### PR TITLE
cleanup: harden config/tests and make public docs English-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # fastagent
 
-agent serving 的 WSGI —— 把现成 agent 定义(`AGENTS.md` + `skills/`)零重写编译/部署成 production 服务,引擎/模型/云中立。
+WSGI for agent serving: turn an existing agent definition (`AGENTS.md` + `skills/`) into a production service without rewriting it. Engine-neutral, model-neutral, and cloud-neutral.
 
-这是按锁定的 [Agent Handler SPEC v0.1](docs/SPEC.md) **从头重建**的仓库(弃旧 `fastagent-mono`,不背兼容)。
+This repository is a from-scratch implementation of the locked [Agent Handler SPEC v0.1](docs/SPEC.md). It does not carry compatibility baggage from older experiments.
 
-## 文档(`docs/`)
+## Documentation
 
-| 文档 | 内容 |
+| Document | Purpose |
 |---|---|
-| [SPEC.md](docs/SPEC.md) | **Agent Handler 协议**(契约层,引擎中立)。`status: locked` v0.1 |
-| [core-design.md](docs/core-design.md) | core 参考实现设计(用 pi 实现 SPEC)+ §0.5 N×M×K 分层口径 |
-| [session.md](docs/session.md) | **session-admin 标准**(草案):event-sourced DAG + 三层解耦(fork / 回退)。`status: design` |
-| [fastagent.md](docs/fastagent.md) | 索引 / 产品定位概览 |
-| [positioning.md](docs/positioning.md) · [comparisons.md](docs/comparisons.md) | 战略定位 / 竞品对比 |
+| [SPEC.md](docs/SPEC.md) | **Agent Handler protocol**: the engine-neutral contract layer. `status: locked` v0.1 |
+| [core-design.md](docs/core-design.md) | The pi-based reference implementation of the SPEC, plus the N × M × K layering model |
+| [session.md](docs/session.md) | Draft session-admin model: event-sourced conversation DAG, fork, and navigation. `status: design` |
+| [fastagent.md](docs/fastagent.md) | Product index and positioning overview |
+| [positioning.md](docs/positioning.md) · [comparisons.md](docs/comparisons.md) | Strategic positioning and competitive analysis |
 
-## 构建顺序
+## Build order
 
-1. **core**(`core/`)—— 先把 SPEC 用代码实现(`invoke` 参考实现:fan-in pi 双口 → 单流)。
-2. **两端扩展** —— N triggers(channel)/ K hosts(target adapter)。
+1. **core** (`core/`) — implement the SPEC in code: the reference `invoke` implementation fans pi's two-port harness into one event stream.
+2. **Adapters on both sides** — N-side triggers/channels and K-side hosts/target adapters.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ This repository is a from-scratch implementation of the locked [Agent Handler SP
 | [fastagent.md](docs/fastagent.md) | Product index and positioning overview |
 | [positioning.md](docs/positioning.md) · [comparisons.md](docs/comparisons.md) | Strategic positioning and competitive analysis |
 
+## API stability
+
+This repository is pre-1.0. The stable design center is the Agent Handler contract in [SPEC.md](docs/SPEC.md). The pi reference implementation is intentionally exported for early embedding and testing, but low-level pi escape hatches may change while `build`, `start`, and the first target adapters land.
+
+Public surface tiers:
+
+| Tier | Examples | Stability |
+|---|---|---|
+| Contract | `Agent`, `AgentEvent`, `collect`, `createInvokeHandler` | Intended to remain stable within SPEC v0.1 |
+| Pi assembly ladder | `createPiAgentFromWorkspace`, `createPiAgentFromDefinition`, `createPiAgent`, `createPiAgentFromHarness` | Usable now, may tighten before 1.0 |
+| Pi internals / escape hatches | prompt/tool helpers, auth/session/lease helpers | Exposed for early adopters and tests; not a long-term compatibility promise yet |
+
 ## Build order
 
 1. **core** (`core/`) — implement the SPEC in code: the reference `invoke` implementation fans pi's two-port harness into one event stream.

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@fastagent/core",
       "version": "0.1.0",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.0",
-        "@earendil-works/pi-ai": "^0.79.0",
-        "@earendil-works/pi-coding-agent": "^0.79.0",
+        "@earendil-works/pi-agent-core": "^0.79.2",
+        "@earendil-works/pi-ai": "^0.79.2",
+        "@earendil-works/pi-coding-agent": "^0.79.2",
         "undici": "^8.4.1"
       },
       "bin": {
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.19.tgz",
-      "integrity": "sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.12",
@@ -152,12 +152,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.45.tgz",
-      "integrity": "sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -168,12 +168,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.47",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.47.tgz",
-      "integrity": "sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
@@ -186,13 +186,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
-      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz",
+      "integrity": "sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -200,19 +200,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.51.tgz",
-      "integrity": "sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.53.tgz",
+      "integrity": "sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/credential-provider-env": "^3.972.45",
-        "@aws-sdk/credential-provider-http": "^3.972.47",
-        "@aws-sdk/credential-provider-login": "^3.972.50",
-        "@aws-sdk/credential-provider-process": "^3.972.45",
-        "@aws-sdk/credential-provider-sso": "^3.972.50",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/nested-clients": "^3.997.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
@@ -224,13 +224,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.50.tgz",
-      "integrity": "sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.52.tgz",
+      "integrity": "sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -241,17 +241,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.53.tgz",
-      "integrity": "sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.55.tgz",
+      "integrity": "sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.45",
-        "@aws-sdk/credential-provider-http": "^3.972.47",
-        "@aws-sdk/credential-provider-ini": "^3.972.51",
-        "@aws-sdk/credential-provider-process": "^3.972.45",
-        "@aws-sdk/credential-provider-sso": "^3.972.50",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.53",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
@@ -263,12 +263,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.45.tgz",
-      "integrity": "sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -279,14 +279,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.50.tgz",
-      "integrity": "sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.52.tgz",
+      "integrity": "sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
-        "@aws-sdk/token-providers": "3.1064.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/token-providers": "3.1066.0",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -297,13 +297,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1064.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1064.0.tgz",
-      "integrity": "sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==",
+      "version": "3.1066.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1066.0.tgz",
+      "integrity": "sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -314,13 +314,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.50.tgz",
-      "integrity": "sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.52.tgz",
+      "integrity": "sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -361,12 +361,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.27.tgz",
-      "integrity": "sha512-V/IgUogQm/NSGlNglDCkREirQXgjyrrq64vPt5qcRTGhEJJwPcUB3RyYE6iZ63WNGp4Ezc+JtVRA4QlSbhDvVQ==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.28.tgz",
+      "integrity": "sha512-SCW06Zjugn86pq7+dxGnFcyWJuEWHT753HTU/Vj/OzVxP+NoShwdAr4ynxAcvWL883OgRVbSqW3ohnjIxwXjjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
@@ -379,15 +379,15 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.18.tgz",
-      "integrity": "sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==",
+      "version": "3.997.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.20.tgz",
+      "integrity": "sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.34",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
@@ -400,13 +400,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
-      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz",
+      "integrity": "sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
-      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
+      "version": "3.996.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.34.tgz",
+      "integrity": "sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.12",
@@ -503,12 +503,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.0.tgz",
-      "integrity": "sha512-jQOtYjRGZ7+XC/olw9euLd2V03vkAPO8u0sSnQoLbyOQZz66dEBZrklTESk34Sf3AaeBSua28wjZR48ch1aXJQ==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.2.tgz",
+      "integrity": "sha512-52+ckc76+gantwr1QCHiCCuMFHCSWa/DSsUkOUzumLwbLYEiSM3Zd+HmvY7DXwL6Frlrrz1w2pVU+mfGbitrTw==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.0",
+        "@earendil-works/pi-ai": "^0.79.2",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -518,9 +518,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.0.tgz",
-      "integrity": "sha512-D/2aDoe9vcCbqAztALQcKkdqXGuaQcqAzLm8LfUhNaorwoIHkwnaAuDVlo+OkF5clpEwS8Z1bk2o8NiSrwEdsA==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.2.tgz",
+      "integrity": "sha512-ydZ19dWqhw4KrkKXtLByFXdNPusRTpXYAElbnCMX0iSX+m59+SUJG0RgEQ6H7sIIV6LvGSEnnQsP6tm1vwcrLA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -542,15 +542,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.0.tgz",
-      "integrity": "sha512-pZoXk65vFR3dAzzmPNWEX61aHnT6+BaVhTyFDQAs1DyumaMeWpvzRV9ZrGxqlbVLwhrq+0LnXbaqDAFkhe2+MQ==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.2.tgz",
+      "integrity": "sha512-RAB5NvI3qw3E991iigPfeE5lqUTmsDGwlqmpqDlCqBDYNCJFJXuCJfNhyBe6/kAI1seYIheHYu5BA0q8adUqgA==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.0",
-        "@earendil-works/pi-ai": "^0.79.0",
-        "@earendil-works/pi-tui": "^0.79.0",
+        "@earendil-works/pi-agent-core": "^0.79.2",
+        "@earendil-works/pi-ai": "^0.79.2",
+        "@earendil-works/pi-tui": "^0.79.2",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1012,11 +1012,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.0.tgz",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.2.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.0",
+        "@earendil-works/pi-ai": "^0.79.2",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1026,8 +1026,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.0.tgz",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.2.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1042,15 +1042,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.0.tgz",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.2.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -2825,9 +2825,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -2873,12 +2873,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -3289,13 +3283,13 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
-      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "version": "3.24.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.7.tgz",
+      "integrity": "sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.14.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3303,13 +3297,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
-      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.9.tgz",
+      "integrity": "sha512-ZlfJ/4Fa3jYb+3eaohPfG9utX9HmdhFNcFtpoGAhUhdynAOmGXtmigbi7eEiONKM+ykHw8RwKuDEb85Lx7t7fA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3317,13 +3311,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
-      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.7.tgz",
+      "integrity": "sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3357,13 +3351,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
-      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.7.tgz",
+      "integrity": "sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.6",
-        "@smithy/types": "^4.14.3",
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3371,9 +3365,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
-      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.4.tgz",
+      "integrity": "sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3571,6 +3565,18 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -4232,9 +4238,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4244,7 +4250,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -4374,16 +4379,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/core/package.json
+++ b/core/package.json
@@ -19,9 +19,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "^0.79.0",
-    "@earendil-works/pi-ai": "^0.79.0",
-    "@earendil-works/pi-coding-agent": "^0.79.0",
+    "@earendil-works/pi-agent-core": "^0.79.2",
+    "@earendil-works/pi-ai": "^0.79.2",
+    "@earendil-works/pi-coding-agent": "^0.79.2",
     "undici": "^8.4.1"
   },
   "devDependencies": {

--- a/core/src/engines/pi/config.ts
+++ b/core/src/engines/pi/config.ts
@@ -23,7 +23,7 @@
  * a runnable zero-config agent (model via --model / FASTAGENT_MODEL).
  */
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { getModel } from "@earendil-works/pi-ai";
@@ -54,9 +54,14 @@ export interface LoadedConfig {
  * a file with the wrong shape throws (fail visibly).
  */
 export async function loadConfig(dir: string): Promise<LoadedConfig> {
-  for (const name of ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"]) {
-    const path = join(dir, name);
-    if (!existsSync(path)) continue;
+  const names = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"];
+  const found = names.map((name) => join(dir, name)).filter((path) => existsSync(path));
+  if (found.length === 0) return { config: {} };
+  if (found.length > 1) {
+    throw new Error(`${dir}: multiple fastagent config files found; keep exactly one (${found.map((p) => basename(p)).join(", ")})`);
+  }
+
+  for (const path of found) {
     const mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
     const config = mod.default;
     if (!config || typeof config !== "object") {
@@ -76,6 +81,17 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     if (c.tools !== undefined && !Array.isArray(c.tools)) {
       throw new Error(`${path}: "tools" must be an array of AgentTool`);
     }
+    if (c.tools !== undefined) {
+      for (const [i, tool] of c.tools.entries()) {
+        if (!tool || typeof tool !== "object") {
+          throw new Error(`${path}: "tools[${i}]" must be an AgentTool object`);
+        }
+        const candidate = tool as { name?: unknown; execute?: unknown };
+        if (typeof candidate.name !== "string" || typeof candidate.execute !== "function") {
+          throw new Error(`${path}: "tools[${i}]" must have string "name" and function "execute"`);
+        }
+      }
+    }
     if (c.http !== undefined && (typeof c.http !== "object" || c.http === null)) {
       throw new Error(`${path}: "http" must be an object`);
     }
@@ -94,7 +110,7 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     }
     return { config: c, path };
   }
-  return { config: {} };
+  throw new Error(`${dir}: failed to load fastagent config`);
 }
 
 /** Resolve "provider/modelId" → a pi Model. Unknown specs throw a clear error (getModel returns undefined). */

--- a/core/src/engines/pi/definition.ts
+++ b/core/src/engines/pi/definition.ts
@@ -137,8 +137,8 @@ export async function loadAgentDefinition(
  * (definition wins); losers are not bundled.
  * Note: **custom code tools are out of bundling scope** — they are code (with npm
  * dependencies); their deployment unit is "project + deps" via the project's normal
- * build/deploy (explicit `tools:` injection). The standards-track for declarative
- * tool mounting is `.mcp.json` (MCP, a future knife).
+ * build/deploy (explicit `tools:` injection). Declarative MCP tool mounting via
+ * `.mcp.json` is future support, not implemented today.
  */
 export async function bundleAgentDefinition(
   srcDir: string,

--- a/core/test/config.test.ts
+++ b/core/test/config.test.ts
@@ -19,7 +19,8 @@ describe("config: loadConfig", () => {
   });
 
   it("missing config file returns zero-config with undefined path", async () => {
-    const { config, path } = await loadConfig("/tmp");
+    const dir = await mkdtemp(join(tmpdir(), "fa-config-empty-"));
+    const { config, path } = await loadConfig(dir);
     expect(config).toEqual({});
     expect(path).toBeUndefined();
   });
@@ -75,13 +76,19 @@ describe("config: resolveModel", () => {
 
 describe("L3: createPiAgentFromWorkspace (config-driven assembly boundary on the engine side)", () => {
   it("assembles config + definition and returns everything the entrypoint needs; flag beats config", async () => {
-    const dir = join(fixtures, "configured");
+    const dir = await mkdtemp(join(tmpdir(), "fa-ws-configured-"));
+    await writeFile(join(dir, "AGENTS.md"), "# Test Agent\nBe concise.\n");
+    await writeFile(
+      join(dir, "fastagent.config.mjs"),
+      `export default { model: "openai-codex/gpt-5.5", http: { port: 9999 } };`,
+    );
+
     const ws = await createPiAgentFromWorkspace(dir);
     expect(ws.modelSpec).toBe("openai-codex/gpt-5.5"); // from config
-    expect(ws.configPath).toMatch(/fastagent\.config\.ts$/);
+    expect(ws.configPath).toMatch(/fastagent\.config\.mjs$/);
     expect(ws.config.http?.port).toBe(9999);
     expect(typeof ws.agent.invoke).toBe("function");
-    expect(ws.definition.dir).toContain("configured");
+    expect(ws.definition.dir).toBe(dir);
 
     const overridden = await createPiAgentFromWorkspace(dir, { model: "openai-codex/gpt-5.4" });
     expect(overridden.modelSpec).toBe("openai-codex/gpt-5.4"); // flag wins

--- a/core/test/config.test.ts
+++ b/core/test/config.test.ts
@@ -48,6 +48,19 @@ describe("config: loadConfig", () => {
     await writeFile(join(dir, "fastagent.config.mjs"), `export default { http: { porrt: 9999 } };`);
     await expect(loadConfig(dir)).rejects.toThrow(/unknown key "http\.porrt"/);
   });
+
+  it("multiple config files throw instead of silently choosing one", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
+    await writeFile(join(dir, "fastagent.config.js"), `export default { model: "openai-codex/gpt-5.5" };`);
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.4" };`);
+    await expect(loadConfig(dir)).rejects.toThrow(/multiple fastagent config files/);
+  });
+
+  it("invalid custom tool entries throw during config load", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { tools: [{}] };`);
+    await expect(loadConfig(dir)).rejects.toThrow(/tools\[0\].*name.*execute/);
+  });
 });
 
 describe("config: resolveTools (append-after-defaults semantics)", () => {

--- a/core/test/definition.test.ts
+++ b/core/test/definition.test.ts
@@ -35,7 +35,8 @@ describe("definition: loadAgentDefinition", () => {
   });
 
   it("missing AGENTS.md / skills returns undefined instructions and empty skills without throwing", async () => {
-    const def = await loadAgentDefinition("/tmp", { skillPaths: [] }); // a directory with no definition
+    const dir = await mkdtemp(join(tmpdir(), "fa-empty-definition-"));
+    const def = await loadAgentDefinition(dir, { skillPaths: [] });
     expect(def.instructions).toBeUndefined();
     expect(def.skills).toEqual([]);
   });

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,27 +1,26 @@
 ---
-title: Agent Handler — 协议规范
+title: Agent Handler — Protocol Specification
 type: spec
 status: locked
 version: 0.1
 updated: 2026-06-09
-share_link: https://qsort.me/neypsf87
-share_updated: 2026-06-08T16:43:43+08:00
 ---
 
 # Agent Handler — Protocol Specification v0.1 (locked)
 
-> agent 层的 handler 约定,对标 Web 的 fetch handler。一个函数 + 几条 MUST,让任意 **Caller** 驱动任意 **Agent**,而无需知道对方的引擎、模型、wire 或部署形态。
+> A handler contract for the agent layer, analogous to Web fetch handlers: one function plus a small set of MUSTs so any **Caller** can drive any **Agent** without knowing its engine, model, wire protocol, or deployment shape.
 >
-> 关键词 MUST / MUST NOT / SHOULD / MAY 按 RFC 2119 解释。本规范是引擎中立的协议层,不依赖任何具体实现。
+> The keywords MUST, MUST NOT, SHOULD, and MAY are to be interpreted as described in RFC 2119. This specification is engine-neutral and does not depend on any implementation.
 
 ## 1. Overview
 
-三个角色:
-- **Agent**:实现 `invoke` 的对象。接收一次调用,跑一个 turn,流式产出事件。对 Caller 是黑盒。
-- **Caller**:发起调用的一方——channel / trigger / CLI / 对外 wire adapter(A2A、ACP)。
-- **Middleware**:同时是 Caller 和 Agent——包装下游 Agent,暴露同一接口(auth / 预算 / 日志)。
+There are three roles:
 
-`invoke` 不对外。对外 wire 是 HTTP / A2A / ACP;`invoke` 是 Caller 与 Agent 之间的内部约定。
+- **Agent**: an object that implements `invoke`. It receives one call, runs one turn, and streams events. It is a black box to the Caller.
+- **Caller**: the party that initiates an invocation — a channel, trigger, CLI, or external wire adapter such as A2A or ACP.
+- **Middleware**: both a Caller and an Agent — it wraps a downstream Agent while exposing the same interface for auth, budgets, logging, etc.
+
+`invoke` is not an external wire protocol. HTTP, A2A, ACP, or any custom transport can sit outside it; `invoke` is the internal contract between Callers and Agents.
 
 ## 2. The Agent Handler
 
@@ -31,19 +30,19 @@ interface Agent {
 }
 ```
 
-一个 turn = 一次 `invoke`。返回一个异步事件流;buffered 是它的退化(§7)。
+One turn = one `invoke`. The result is one async event stream; buffered consumption is a degeneration of that stream (§7).
 
-返回类型 MUST 是 `AsyncIterable`(`async function*`、`ReadableStream` 等任意实现皆可)。
+The return type MUST be `AsyncIterable`; `async function*`, `ReadableStream`, and equivalent implementations are all valid.
 
 ## 3. Scope
 
 ```ts
 interface Scope {
-  session: string;          // 会话锚:跨 invoke 连接上下文
+  session: string;          // Conversation anchor across invocations.
 }
 ```
 
-`session` 是 opaque 字符串,由 Caller 拥有;同一逻辑会话的多次 turn MUST 复用同一 `session`。其余字段(身份、来源、约束等)是扩展,见 §8。
+`session` is an opaque string owned by the Caller. Multiple turns in the same logical conversation MUST reuse the same `session`. Additional fields such as identity, source, and constraints are extensions (§8).
 
 ## 4. Prompt
 
@@ -52,7 +51,7 @@ interface Prompt { text: string; images?: ImageRef[]; }
 interface ImageRef { mimeType: string; data: string; }   // base64
 ```
 
-不支持 `images` 的 Agent 忽略它。
+Agents that do not support `images` ignore it.
 
 ## 5. AgentEvent
 
@@ -61,51 +60,51 @@ type AgentEvent =
   | { type: "text";         delta: string }
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended";   id: string; isError: boolean; content: Json }
-  | { type: "completed";    data?: Json }                        // 终局:成功
-  | { type: "failed";       details: string; retryable: boolean }; // 终局:失败
+  | { type: "completed";    data?: Json }                        // Terminal: success
+  | { type: "failed";       details: string; retryable: boolean }; // Terminal: failure
 
 type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
 ```
 
-- 所有文本走 `text` delta;`completed` 是纯终局信号,不重复全文。
-- `completed.data` 仅在引擎能产出结构化结果时附带。
-- 事件 MUST 可 JSON 序列化。
+- All textual output is emitted as `text` deltas; `completed` is only a terminal success signal and does not repeat the full text.
+- `completed.data` is present only when the engine produces structured data.
+- Every event MUST be JSON-serializable.
 
 ## 6. Conformance
 
-一次 `invoke` 的流 MUST 恰好以下列三者之一终止:
+An `invoke` stream MUST end in exactly one of the following three ways:
 
-- **(a) `completed`** — 成功;
-- **(b) `failed`** — 失败;
-- **(c) 被 Caller 取消** — 无终局事件。
+- **(a) `completed`** — success;
+- **(b) `failed`** — failure;
+- **(c) Caller cancellation** — no terminal event.
 
-下面的 MUST 是这个三分法在两个角色上的展开。
+The following MUSTs spell out that trichotomy for both roles.
 
 ### Agent MUST
 
-1. **终局唯一**:当 Caller 消费到流自然结束(未取消)时,最后一个事件 MUST 是 `completed` 或 `failed` 之一,其后无任何事件。对应 (a)/(b)。
-2. **失败即事件,不 throw**:Agent MUST NOT 让 `invoke` 的迭代抛出异常;所有失败 MUST 表现为一个 `failed` 事件。这是终局集对消费者闭合的前提——失败只有一条通道。
-3. **响应 cancel**:当 Caller 停止消费(`for-await` break / 迭代器 `return()` / `ReadableStream` 的 `reader.cancel()`)时,Agent MUST 尽快中止在飞的模型/工具调用并释放资源;此时不要求、也不期望发终局事件。对应 (c)。
+1. **Exactly one terminal**: when the Caller consumes the stream to natural completion (without cancelling), the last event MUST be either `completed` or `failed`, and no event may follow it. This corresponds to (a)/(b).
+2. **Failures are events, not thrown iteration errors**: an Agent MUST NOT let iteration of `invoke` throw. Every failure MUST be represented as a `failed` event. This keeps the terminal set closed for consumers: failure has exactly one channel.
+3. **Respond to cancellation**: when the Caller stops consuming (`for-await` break, iterator `return()`, or `ReadableStream` `reader.cancel()`), the Agent MUST promptly abort in-flight model/tool work and release resources. In this case a terminal event is neither required nor expected. This corresponds to (c).
 
 ### Caller MUST
 
-4. **前向兼容**:终局集 `{ completed, failed }` 冻结,不可扩展;新增事件 MUST 是非终局的。**终局消费者**(消费流以得到结果的 Caller)MUST 忽略 `type` 未知的非终局事件。
-5. **中继转发**:作为 **Middleware** 转发下游流的 Caller MUST 原样透传未知的非终局事件,MUST NOT 丢弃——「忽略」只适用于终局消费者,不适用于中继者。否则下游引擎新增的事件会在中继跳被吞掉,破坏 MUST 4 想保证的前向兼容。
+4. **Forward compatibility**: the terminal set `{ completed, failed }` is frozen and not extensible. New event types MUST be non-terminal. A **terminal consumer** (a Caller consuming the stream to obtain a result) MUST ignore unknown non-terminal events.
+5. **Relay passthrough**: a Caller acting as **Middleware** and relaying a downstream stream MUST pass unknown non-terminal events through unchanged, and MUST NOT drop them. “Ignore” applies to terminal consumers only, not to relays; otherwise a downstream engine adding a new event type would be broken by the relay hop, defeating MUST 4.
 
-### Portable conformance(可选;声明"可 serverless 部署"的 Agent 额外满足)
+### Portable conformance (optional; required for Agents claiming serverless portability)
 
-6. **无位置依赖**:MUST NOT 依赖"同一 `session` 的多次 `invoke` 落在同一进程/实例";会话状态须可从外部重建。常驻有状态 Agent 不满足此项,但仍是合规的 Agent Handler。
+6. **No location dependence**: the Agent MUST NOT require multiple invocations with the same `session` to land in the same process or instance. Session state must be reconstructible from external state. A resident stateful Agent can still conform to Agent Handler, but it does not satisfy portable conformance.
 
-### 显式不保证(避免误读)
+### Explicit non-guarantees
 
-协议**不**保证下列两点,实现/消费者 MUST NOT 依赖它们:
+The protocol does **not** guarantee the following; implementations and consumers MUST NOT rely on them:
 
-- **`tool_started` / `tool_ended` 配对**:常态下两者按 `id` 成对、`ended` 跟在对应 `started` 后;但取消 (c) 时可能留下悬空的 `tool_started`。渲染 tool UI 的消费者须容忍悬空 started。
-- **`failed.retryable` 的会话洁净度**:`retryable: true` 只表示"值得用同一 `session` 重发",**不**保证失败的 turn 对会话状态是原子的——半跑的 turn 可能已写入 entry / 跑过带副作用的 tool。重试的副作用安全是引擎/工具的责任(§9),不在协议层兑现。
+- **`tool_started` / `tool_ended` pairing**: normally these events are paired by `id`, and `tool_ended` follows the matching `tool_started`; after cancellation (c), a dangling `tool_started` may remain. Tool UIs must tolerate dangling starts.
+- **Session cleanliness of `failed.retryable`**: `retryable: true` means “worth re-sending with the same `session`”. It does **not** guarantee that the failed turn was atomic with respect to session state. A partial turn may have already appended entries or run side-effecting tools. Retry side-effect safety belongs to the engine/tools, not to the protocol (§9).
 
 ## 7. Buffered
 
-不需要流式的 Caller 用一行 helper 退化成 buffered(caller-side,不属协议):
+A Caller that does not need streaming can reduce the stream to a buffered result with a caller-side helper; this helper is not part of the protocol:
 
 ```ts
 async function collect(events: AsyncIterable<AgentEvent>): Promise<{ text: string; data?: Json }> {
@@ -115,51 +114,51 @@ async function collect(events: AsyncIterable<AgentEvent>): Promise<{ text: strin
     else if (e.type === "completed") return { text, data: e.data };
     else if (e.type === "failed") throw new AgentFailure(e.details, e.retryable);
   }
-  throw new Error("stream ended without a terminal event"); // 违反 MUST 1
+  throw new Error("stream ended without a terminal event"); // violates MUST 1
 }
 ```
 
 ## 8. Extension points
 
-核心保持最小;以下通过加 `scope` 字段 / 加非终局事件 / 加可选参数 / Middleware 挂上:
+The core stays small. The following extensions attach through additional `scope` fields, new non-terminal events, optional parameters, or Middleware:
 
-| 扩展 | 怎么挂 |
+| Extension | Attachment point |
 |---|---|
-| 身份 / 多租户 | `scope.principal`(如 `{ type, issuer, subject }`) |
-| 触发来源 / trace | `scope.source` 等标识性字段 |
-| 执行约束(deadline / budget) | Middleware(`budget_exceeded` 由 Middleware 产出 `failed`) |
-| 中途 steering | **(扩展,非 v0.1 核心签名)** `invoke` 增加可选第三参 `input?: AsyncIterable<Prompt>`,把输入塞进正在跑的 turn(对应 pi `steer/followUp/nextTurn`)。注:愿意丢弃当前 turn 的「换个方向」用 cancel + 同 `session` 重新 invoke 即可,无需此扩展 |
-| thinking / citation / artifact 流 | 新增非终局 `AgentEvent` type |
-| 失败细分 | `failed.code?` |
+| Identity / multi-tenancy | `scope.principal`, e.g. `{ type, issuer, subject }` |
+| Source / trace | `scope.source` and other identifying fields |
+| Execution constraints such as deadline / budget | Middleware; for example, `budget_exceeded` becomes a `failed` event produced by Middleware |
+| Mid-turn steering | **Extension, not part of the v0.1 core signature**: add an optional third parameter `input?: AsyncIterable<Prompt>` to `invoke` and feed input into the in-flight turn, corresponding to pi `steer` / `followUp` / `nextTurn`. If the desired behavior is “discard the current turn and go another way”, use cancel + a new `invoke` with the same `session`; no steering extension is required. |
+| Thinking / citations / artifact streaming | Add new non-terminal `AgentEvent` types |
+| Failure subdivision | Add `failed.code?` |
 
 ## 9. Dependency inversion
 
-协议把 Agent 当黑盒。以下全在黑盒内、由实现注入,规范不规定:
+The protocol treats an Agent as a black box. The following concerns are injected inside that black box and are not specified here:
 
-| 注入项 | 说明 |
+| Injection | Meaning |
 |---|---|
-| 会话状态存到哪 | SessionStore(jsonl / pg / ddb) |
-| 工具在哪个 env 跑 | 执行环境(local / sandbox / e2b) |
-| 用哪个 model | 注入 |
-| 有哪些 tools / 加载什么 agent 定义 | 装配层注入 |
+| Session storage | `SessionStore` such as jsonl, Postgres, or DynamoDB |
+| Tool execution environment | local process, sandbox, E2B, etc. |
+| Model selection | injected by implementation/assembly |
+| Tools and agent definition loading | assembly-layer concerns |
 
 ## 10. Out of scope
 
-- **Wire / transport**:对外用 A2A / ACP / 自定义 HTTP;Agent Handler 是它们内部调到的那一层。
-- **引擎内部**:turn loop / tool / model / context 管理。
-- **agent 定义格式**:`AGENTS.md` / Agent Skills / MCP consume 既有标准,不另立。
-- **打包 / 部署**:OCI / target runtime,consume OCI / ADP。
-- **Task 编排**:长任务状态机 / Artifact 版本 = 上层(A2A Task / workflow),用 Caller 造,不进协议。
+- **Wire / transport**: expose the Agent through A2A, ACP, HTTP, or any custom transport; Agent Handler is the internal layer they call.
+- **Engine internals**: turn loop, tool execution, model calls, and context management.
+- **Agent definition format**: consume existing standards such as `AGENTS.md`, Agent Skills, and MCP; do not invent a parallel format.
+- **Packaging / deployment**: consume OCI and target runtime conventions.
+- **Task orchestration**: long-running task state machines and artifact versions belong to upper layers such as A2A Tasks or userland workflows.
 
-## 11. 与既有标准的关系
+## 11. Relationship to existing standards
 
-| 层 | Web | agent |
+| Layer | Web | Agent |
 |---|---|---|
-| 对外 wire | HTTP | A2A / ACP |
-| gateway 约定 | fetch handler `(Request)=>Response` | **Agent Handler `invoke(scope, prompt)=>AsyncIterable<AgentEvent>`** |
-| 引擎/app 内部 | 框架/业务 | agent 引擎 |
+| External wire | HTTP | A2A / ACP |
+| Gateway contract | fetch handler `(Request) => Response` | **Agent Handler `invoke(scope, prompt) => AsyncIterable<AgentEvent>`** |
+| Engine/app internals | frameworks / application code | agent engine |
 
-## 最小示例
+## Minimal example
 
 ```ts
 async function* invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
@@ -178,10 +177,11 @@ async function* invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> 
   }
 }
 
-// 流式
+// Streaming
 for await (const e of agent.invoke({ session: "s1" }, { text: "triage issue #42" })) {
   if (e.type === "text") process.stdout.write(e.delta);
 }
-// buffered
+
+// Buffered
 const { text } = await collect(agent.invoke({ session: "s1" }, { text: "…" }));
 ```

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,157 +1,81 @@
 ---
-title: fastagent — 竞品深度对比
+title: fastagent — Competitive comparisons
 type: competitive-analysis
 status: design
-updated: 2026-06-05
+updated: 2026-06-11
 ---
 
-# 竞品深度对比:Flue / OpenClaw / Claude SDK / OpenCode / pi
+# Competitive comparisons
 
-> 索引 [fastagent](fastagent.md) · 同目录 [positioning](positioning.md) · [core-design](core-design.md)
+FastAgent sits in the serving layer for existing markdown-native agents. The closest neighboring projects occupy adjacent layers.
 
-> 战略矩阵见 [positioning.md](positioning.md)。本文逐项拆解 + 一个 worked example。
+## Overview
 
-## 总览:framework ↔ product × markdown ↔ code
+| Project | What it is | Agent definition | Neutrality | Web analogy |
+|---|---|---|---|---|
+| **FastAgent** | Serving contract + reference implementation + deployment toolchain | Existing markdown definition + config | Engine/model/host neutral by design | WSGI + gunicorn + deployment toolchain |
+| **Flue** | Code-first agent harness framework | TypeScript workflows | Partly neutral, but framework-shaped | Astro/Next-style framework |
+| **OpenClaw** | Self-hosted personal assistant product | Markdown-native assistant config | Product-shaped, not a neutral serving layer | WordPress-like product |
+| **Claude Agent SDK hosting** | SDK + hosting guidance | Claude Code projects | Claude-locked | Vendor SDK hosting |
+| **OpenCode `serve`** | Headless server for OpenCode | OpenCode projects | OpenCode-locked | Product server |
+| **pi** | Harness engine and coding agent | Engine/runtime layer | The reference engine FastAgent builds on | Werkzeug-like engine substrate |
 
-```
-                      product / app
-                            │
-            OpenClaw  ●     │   ● OpenCode serve(锁引擎的 server)
-        (个人助理产品)      │
-                            │
-  markdown ─────────────────┼───────────────── code-first
-   native                   │
-                            │
-          fastagent  ●      │      ● Flue
-     (定义 → 任意 target)    │   (TS 写 agent)
-                            │
-              serving 契约 / framework
-```
+## Flue
 
-| | 它是什么 | agent 怎么定义 | 你拿它干嘛 | 中立? | Web 类比 |
-|---|---|---|---|---|---|
-| **OpenClaw** | **产品**(个人多渠道助理) | markdown(SOUL/AGENTS/skills) | 自托管 + 定制**这一个** app | 半 | WordPress |
-| **fastagent** | **serving 契约 + 实现 + 工具链** | markdown 定义 + config | 把**任意**定义部署成**任意**形态、**任意** target | **全中立** | **WSGI + gunicorn / Vercel** |
-| **Flue** | **框架** | code-first(TS) | 写 agent → build → 部署 | 引擎半锁 | Astro / Next |
-| **Claude Agent SDK** | **SDK + hosting** | Claude Code 文件夹 | 把 Claude Code 跑成服务 | **锁 Claude** | —— |
-| **OpenCode `serve`** | **产品 server** | OpenCode | 跑 OpenCode 的 HTTP server | **锁 OpenCode** | —— |
+Flue is a code-first harness framework. You write workflows in TypeScript, use typed schemas, and select sandbox/connectors as first-class concepts.
 
----
+FastAgent differs in the entry point:
 
-## Flue(Astro 团队)
-
-- 自称 **"The Agent Harness Framework"**——核心卖点是**自带 harness**(`@flue/runtime`);模型层用 pi-ai。
-- **编程模型 = workflow-centric**:`.flue/workflows/*.ts` 写 `run({init, payload})` 编排,可用 valibot schema 拿 typed 结构化结果。
-- **Sandbox 是一等公民、真差异化**:默认虚拟 sandbox(just-bash)+ 丰富 connector(Daytona/E2B/Modal/Vercel/CF)+ `local()` 给 CI。
-- **部署目标**:Node / Cloudflare Workers / GitHub Actions / GitLab CI。`flue build` 出 artifact 再部署(两步)。
-
-**和 fastagent 的哲学分叉(都直面竞争,非零和)**:
-
-| | Flue | fastagent |
+| Axis | Flue | FastAgent |
 |---|---|---|
-| agent 是什么 | 你**用 TS 写**的 | 你**用 markdown vibe** 的定义文件夹 |
-| 入口 | code-first | markdown-native,代码是逃生舱 |
-| 与标准 | 自成 runtime API | **consume AGENTS.md/Skills/MCP;对外 consume A2A/ACP,不另立** |
-| 调用契约 | Flue 私有 API | **Agent Handler:`invoke(scope, prompt) => AsyncIterable<AgentEvent>`(引擎中立,见 [SPEC](SPEC.md))** |
-| 跨 runtime | 虚拟 sandbox **抹平**环境 | **无状态 core + env 注入 + target adapter**,让同一定义编译到异构 runtime |
-| build/deploy | 分两步 | `deploy` 端到端一条命令 |
+| Agent authoring | Write TypeScript workflows | Reuse an existing `AGENTS.md` + `skills/` folder |
+| Primary user | Engineers writing agents as code | People who already created useful markdown-native agents |
+| Contract | Flue runtime API | Agent Handler `invoke(scope, prompt) => AsyncIterable<AgentEvent>` |
+| Runtime strategy | Framework/sandbox abstraction | Stateless core + injected env/session + target adapters |
+| Deployment | Build/run in supported targets | Build/start/deploy existing definitions across targets |
 
-> 有意思:Flue 用**虚拟 sandbox 抹平环境**(占栈更深、自带 harness+sandbox),fastagent 用**无状态 core + env 注入**让引擎/target 解耦、保持中立。两种"run anywhere"哲学。Flue 吃不到「已 vibe 出 markdown 定义、不想写 TS」的人——那是 fastagent 的 wedge。
-
----
+Flue is a real competitor when the user wants code-first workflow control. FastAgent's wedge is the opposite: do not rewrite the agent.
 
 ## OpenClaw
 
-- **不是框架,是产品**:_"the product is the assistant."_ 你自托管的个人 AI 助理,单用户、always-on。
-- **markdown-native**:SOUL.md + AGENTS.md + skills/(和 Claude Code 同一套)。
-- **渠道狂魔**:WhatsApp/Telegram/Slack/Discord/Signal/iMessage/飞书/微信… 20+,加语音 + Canvas UI。
-- **成熟度高**:OpenAI/GitHub/NVIDIA/Vercel 赞助、MIT、安全边界完善、插件 SDK + MCP。
+OpenClaw validates a related need: markdown-native, multi-channel, self-hosted assistants are useful. But OpenClaw is a product; the product is the assistant.
 
-**三条战略读数:**
-1. **验证**:重量级玩家真金白银验证了"markdown 定义 + 多渠道 + 自托管"是真需求。
-2. **威胁/边界**:**别去拼渠道**。OpenClaw 锁死 app 形态 = 个人助理;在"做更好的助理"上必输。
-3. **差异化**:**OpenClaw 是可以用 fastagent 来 build 的东西。** 你是 serving 层,它是 WordPress——前提是**别做成更差的 WordPress**。
+FastAgent should not compete on being the best personal assistant. It is the serving layer someone could use to build OpenClaw-like products for arbitrary definitions and targets.
 
-**真实重叠 vs 分歧**:重叠只有"个人多渠道助理"这一格;fastagent 的跨 runtime 部署 / 多 target / A2A 网络 / 云端自主,OpenClaw 根本不做。
+## Claude Agent SDK hosting and OpenCode serve
 
----
+These are the most important platform-absorption examples:
 
-## Claude Agent SDK & OpenCode `serve`(平台吸收的两个真身)
+- Claude Agent SDK hosting shows how to run Claude Code programmatically or as a hosted service, but it locks the Claude engine/model path.
+- OpenCode `serve` exposes OpenCode as a headless HTTP server, but it locks the OpenCode product.
 
-这两个最该正视——它们正在做"把 agent 跑成服务",而且已经发布:
+FastAgent only exists if neutrality matters: the same serving/deployment path should work across different coding-agent artifacts, engines, models, and hosts.
 
-- **Claude Agent SDK**:`query()` programmatic + headless `-p` + 官方《Hosting the Agent SDK》(subprocess 架构、session 持久化、scaling、multi-tenant Docker/K8s)。**但 subprocess 是 `claude` CLI——锁 Claude 引擎、锁模型。**
-- **OpenCode `serve`**:headless HTTP server + OpenAPI 3.1 + 自动生成 SDK + 多 client。**但它是 OpenCode 这个产品的 server——锁 OpenCode。**
+## pi
 
-**fastagent 的唯一立足点 = 它们锁死的那条轴:中立。** 同样"把 agent 变服务",fastagent 不锁引擎/模型/云/coding-agent。它们一个版本就能把"把文件夹跑成服务"做掉(平台吸收),但**做不到中立**——这是开放层的唯一持久防线,也是 fastagent 存在的全部理由。
+pi is not the competitor; it is the first engine substrate.
 
----
+FastAgent builds on `pi-agent-core`'s `AgentHarness`, not the TUI-oriented `pi-coding-agent` `AgentSession`. The reference implementation adapts pi's two ports — `prompt()` final value plus `subscribe()` event side-channel — into the single Agent Handler event stream.
 
-## pi(pi-agent-core / pi-coding-agent)
+FastAgent should avoid rebuilding pi's harness. Its value is the contract, assembly/deployment shape, and host portability around the harness.
 
-**不是竞品,是参考实现的底座(Werkzeug + gunicorn 那层的引擎)。** fastagent 建在 **pi-agent-core 的 `AgentHarness`**(不是 pi-coding-agent 的 `AgentSession`,后者是 TUI 封装、拖文件系统耦合)。pi 给的:`AgentHarness`(turn loop / `prompt()=>AssistantMessage` buffered / subscribe / hooks / compaction)、`ExecutionEnv = FileSystem & Shell`、`SessionRepo`、`AgentTool`/`Skill`、整套事件。
+## Worked example: GitHub issue triage
 
-fastagent **建在它上,不重造**:把 pi 的双口(`prompt` buffered + `subscribe`)fan-in 成 [SPEC](SPEC.md) 的单一事件流;对 pi 的依赖收敛到一个 translator(pi 事件→`AgentEvent`)。详 [core-design.md §4](core-design.md)。
+Imagine an agent definition that triages new GitHub issues by reading issue content, choosing labels, commenting, and assigning an owner. The core agent behavior can live in `AGENTS.md` and a skill either way.
 
----
+With Flue, the natural wrapper is a TypeScript workflow running in CI or a configured sandbox.
 
-## Worked example:GitHub issue 自动三连
-
-"三连" = 新 issue 一开,自动:① 打标签 ② 发评论 ③ 指派。**关键:三连逻辑两个框架都写在 markdown(AGENTS.md + skill),agent 用 `gh` CLI 执行——差别只在触发/装配/部署。**
-
-### Flue(惯用 = CI workflow)
+With FastAgent, the natural wrapper is a channel adapter:
 
 ```ts
-// src/workflows/triage.ts
-export async function run({ init, payload }: FlueContext) {
-  const agent = createAgent(() => ({
-    model: 'anthropic/claude-sonnet-4-6',
-    sandbox: local({ env: { GH_TOKEN: process.env.GH_TOKEN } }),  // CI runner 即环境
-  }));
-  const session = await (await init(agent)).session();
-  const { data } = await session.skill('issue-triage', {
-    args: { repo: payload.repo, issue: payload.issue },
-    result: v.object({ labels: v.array(v.string()), commented: v.boolean(), assignee: v.nullable(v.string()) }),
-  });
-  return data;
-}
+const result = await collect(agent.invoke(
+  { session: `gh-${repo}-${issue}` },
+  { text: `Triage issue #${issue} in ${repo}.` },
+));
 ```
-GitHub Actions 里 `npx flue run triage`。**没有"部署"步骤——CI runner 就是运行环境。**
 
-### fastagent(惯用 = 常驻 webhook channel;API 为示意)
+The same Agent Handler can be exposed through HTTP, a webhook adapter, A2A, a scheduled job, or a target runtime such as AgentCore. The markdown agent stays the same; the serving shell changes.
 
-> 下面是 channel adapter 调 `invoke` 的形状示意。对外这个 channel 可暴露成普通 HTTP webhook,或一个 A2A endpoint;agent 逻辑仍在 markdown 定义里,与 Flue 一字不差。
+## Summary
 
-```ts
-// fastagent/app.ts(production source:用户拥有、进 git)
-export default defineApp(async (ctx) => ({
-  agent: ctx.default,                       // 复用默认 agent 定义;bash 继承部署环境的 GH_TOKEN
-  channels: [githubWebhook({
-    name: "github",
-    onIssueOpened: (agent) => async (repo, issue) => {
-      const { text } = await collect(agent.invoke(
-        { session: `gh-${repo}-${issue}` },             // scope:核心只 session
-        { text: `Triage issue #${issue} in ${repo}.` }, // prompt
-      ));                                                // 单流 → collect 退化成 buffered
-      return text;
-    },
-  })],
-}));
-```
-`fastagent deploy --target agentcore`(或 `fly` / `workers`)→ 一条命令编译 + 部署 → webhook/endpoint 指向它。
-
-### 对照
-
-| 环节 | Flue | fastagent |
-|---|---|---|
-| 触发模型 | 事件→CI 跑一次(serverless) | webhook→常驻/serverless invoke |
-| 三连逻辑 | markdown skill | **完全一样** |
-| `gh` 鉴权 | `local()` 显式注 env | bash 继承部署环境 |
-| 上线 | `git push`(无部署步骤) | `deploy --target`(一条命令,任意 runtime) |
-| 跨 runtime | Node / Workers / CI | **AgentCore / Lambda / Fly / Workers / E2B(无状态 core 支撑)** |
-
-**本质**:agent 本身两边几乎相同(都是 AGENTS.md + skill + bash/gh,共享 Claude-Code DNA);**分歧全在外壳**——Flue 包成 typed/可编排 workflow,fastagent 包成可部署任意 runtime 的 serving。事件驱动 Flue 的 CI 更顺手;长期在线 + 跨 runtime 部署 + 中立是 fastagent 甜区。
-
-### fastagent 架构上本来就 multi-target
-
-`invoke` 是单流不动点(buffered 用 `collect` 退化),适配不同进程模型:① CLI 一次性 `invoke` 进 GitHub Action(≈ `flue run`);② 常驻 webhook channel;③ **AgentCore 部署本就是 serverless**(每 invocation `InvokeAgentRuntime` 现起 runtime)。能跑 ③ 的前提正是 [core-design §4](core-design.md) 的**无状态多-session 工厂**——这也是别人(Claude SDK / OpenCode 的有状态常驻设计)结构上吃不到 AgentCore 的原因。
+FastAgent wins only where “existing markdown-native agent definition → running service on any target” is the job. If the user wants to write a new agent in code, use a framework. If the user wants a finished assistant product, use a product. If the user wants neutral serving/deployment for agent folders, FastAgent owns that layer.

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -7,7 +7,7 @@ updated: 2026-06-05
 
 # 竞品深度对比:Flue / OpenClaw / Claude SDK / OpenCode / pi
 
-> 索引 [[fastagent]] · 同目录 [[positioning]] · [[core-design]]
+> 索引 [fastagent](fastagent.md) · 同目录 [positioning](positioning.md) · [core-design](core-design.md)
 
 > 战略矩阵见 [positioning.md](positioning.md)。本文逐项拆解 + 一个 worked example。
 
@@ -52,7 +52,7 @@ updated: 2026-06-05
 | agent 是什么 | 你**用 TS 写**的 | 你**用 markdown vibe** 的定义文件夹 |
 | 入口 | code-first | markdown-native,代码是逃生舱 |
 | 与标准 | 自成 runtime API | **consume AGENTS.md/Skills/MCP;对外 consume A2A/ACP,不另立** |
-| 调用契约 | Flue 私有 API | **Agent Handler:`invoke(scope, prompt) => AsyncIterable<AgentEvent>`(引擎中立,见 [[SPEC]])** |
+| 调用契约 | Flue 私有 API | **Agent Handler:`invoke(scope, prompt) => AsyncIterable<AgentEvent>`(引擎中立,见 [SPEC](SPEC.md))** |
 | 跨 runtime | 虚拟 sandbox **抹平**环境 | **无状态 core + env 注入 + target adapter**,让同一定义编译到异构 runtime |
 | build/deploy | 分两步 | `deploy` 端到端一条命令 |
 
@@ -91,7 +91,7 @@ updated: 2026-06-05
 
 **不是竞品,是参考实现的底座(Werkzeug + gunicorn 那层的引擎)。** fastagent 建在 **pi-agent-core 的 `AgentHarness`**(不是 pi-coding-agent 的 `AgentSession`,后者是 TUI 封装、拖文件系统耦合)。pi 给的:`AgentHarness`(turn loop / `prompt()=>AssistantMessage` buffered / subscribe / hooks / compaction)、`ExecutionEnv = FileSystem & Shell`、`SessionRepo`、`AgentTool`/`Skill`、整套事件。
 
-fastagent **建在它上,不重造**:把 pi 的双口(`prompt` buffered + `subscribe`)fan-in 成 [[SPEC]] 的单一事件流;对 pi 的依赖收敛到一个 translator(pi 事件→`AgentEvent`)。详 [core-design.md §4](core-design.md)。
+fastagent **建在它上,不重造**:把 pi 的双口(`prompt` buffered + `subscribe`)fan-in 成 [SPEC](SPEC.md) 的单一事件流;对 pi 的依赖收敛到一个 translator(pi 事件→`AgentEvent`)。详 [core-design.md §4](core-design.md)。
 
 ---
 

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -1,328 +1,173 @@
 ---
-title: fastagent - 核心设计(参考实现)
+title: fastagent — Core design
 type: design-doc
 status: design
 updated: 2026-06-11
 ---
 
-# fastagent - 核心设计(参考实现)
+# fastagent core design
 
-> 索引 [fastagent](fastagent.md) · 协议 [SPEC](SPEC.md) · 同目录 [positioning](positioning.md) · [comparisons](comparisons.md)
+This document describes the current pi-based reference implementation of the [Agent Handler SPEC](SPEC.md). The code source of truth is `core/`.
 
-> **契约层已抽到 [SPEC](SPEC.md)(Agent Handler 协议,引擎中立)。本文只讲 fastagent 的参考实现--怎么用 pi 实现那个协议 + 怎么部署到任意 runtime。代码真相在 `core/`。**
+FastAgent is WSGI for agent serving: a small internal handler contract plus a reference implementation and deployment tooling around existing agent definitions.
 
-## 0. 定位:三件套
+## 1. Layering: N × M × K
 
-> **fastagent = agent serving 的 WSGI**(对外易懂的说法;技术宗谱是 ASGI / fetch handler,见 [SPEC](SPEC.md))。一套把「触发源 / 部署 target / agent 引擎」三方解耦的 serving 契约,加一个建在 pi 上的参考实现,加一条「指向文件夹就部署到任意 runtime」的工具链。
+FastAgent aims to collapse **N triggers × M agents × K hosts** into additive seams. Those seams live at different layers:
 
-| fastagent 层 | 干什么 | web 世界对应 | 在哪定义 |
-|---|---|---|---|
-| **契约层** | Agent Handler:`invoke(scope, prompt) => AsyncIterable<AgentEvent>` | **fetch handler / ASGI** | **[SPEC](SPEC.md)** |
-| **参考实现层** | 建在 pi-agent-core 上,把协议跑起来 | Werkzeug + gunicorn | 本文 §3-5 |
-| **工具链层** | 指向 agent 定义文件夹 → 编译 → 部署到任意 target | Vercel + Buildpacks | 本文 §6 |
-
-核心发明是**契约层**(那套 primitives);参考实现和工具链让它好用、先活下来。fastagent 占的是 **gateway 那一格,不是 Flask**--它不是让你写 agent 的框架(agent 是 pi 引擎 + 你的 markdown 定义),是让现成 agent 能被服务/部署的中立层。
-
-## 0.5 core 设计目标:N×M×K 的分层口径(定稿)
-
-产品目标是把 **N triggers × M agents × K hosts** 从相乘塌成相加。但三个轴不是一个契约扁下来的,是三道缝,分属不同层--**core 只直接管 N×M**:
-
-| 轴 | 由什么解耦 | 在哪一层 |
+| Axis | What decouples it | Layer |
 |---|---|---|
-| **N×M**(trigger ↔ agent)| `invoke` 的签名 + 事件([SPEC](SPEC.md))| **core / 契约** |
-| **M**(引擎多样)| invoke 是黑盒接口 + 装配层注入(定义装载 → `LoadedDefinition` → 装配出 `Agent`)| core(依赖反转)|
-| **K**(host 多样)| invoke 的无状态性质(SPEC MUST「无位置依赖」)+ `SessionStore`/`ExecutionEnv` 注入,使 host 可替换;真正"编译到某 runtime" = target adapter | K 的*可*解耦在 core,K 的解耦*动作*在工具链层(SPEC §10 out of scope)|
+| N × M: trigger ↔ agent | Agent Handler `invoke(scope, prompt) => AsyncIterable<AgentEvent>` | SPEC / core contract |
+| M: engine diversity | the Agent is a black box; definitions/config are assembled into an Agent | core dependency inversion |
+| K: host diversity | stateless `invoke`, injected `ExecutionEnv`, sessions, and leases | core provides hooks; target adapters do host work |
 
-精确口径:**`invoke` 是 N×M 的窄腰;core 的无状态不变量 + DI 注入点,是让「×K」可被上层塌掉的钩子;K 本身的塌缩(target adapter)不在 core、不在 SPEC。** core = 对引擎中立、且被约束成 host-可移植的 serving 契约,不是"N×M×K 三轴契约"。
+The SPEC directly owns N × M. K portability is enabled by core invariants, but each host still needs real target-adapter work.
 
-对位 wedge/moat:N×M(invoke 契约)= **wedge**(忠实、无新机制、可复制);×K(target adapter)= **moat**(逐 runtime 啤异构,工程积累)。
+## 2. Agent definitions and prompt assembly
 
-## 1. 用户与空缺(发生点)
+FastAgent consumes existing definition artifacts:
 
-**触发时刻**:用户用 coding agent(Claude Code / pi / Codex)vibe 出了一个 agent 定义文件夹(`AGENTS.md` + `skills/`),想让它「在我不盯着时也干活」--收 webhook、定时巡检、随时在 Telegram 找得到。**这一刻本地交互式工具模式必然失效。**
-
-**覆盖地图(谁锁死/缺失什么轴)**:
-
-| 现有实现 | 在哪轴掉链子 |
-|---|---|
-| pi / Claude Code / Codex | 常驻、机器触发、多租户、部署 全缺 |
-| Claude Agent SDK + Hosting | **锁 Claude 引擎** |
-| OpenCode `serve` | **锁 OpenCode 这个 agent** |
-| ACP | 假设人在环 + editor 提供环境;是 IDE 协议非 serving |
-| A2A | 假设 agent 已是 running endpoint,不管你怎么变出 endpoint |
-| ADP / Ninetrix / Agent Executor | 要写新 manifest 重定义,不消费现成文件夹 |
-| Flue | code-first,吃不到「已 vibe 出 markdown 定义、不想写代码」的人 |
-| Hermes Agent / OpenClaw | 常驻多-channel 个人 agent 产品:N 轴做得全(Telegram/Discord/cron...),但**垂直一体、锁自家引擎/定义**,不消费现成 AGENTS.md、非中立 serving 层 |
-
-**空缺 = 消费现成 markdown 定义、引擎/target/云中立、机器触发的跨 runtime 部署**。没有一个现有方案落在这。
-
-**试金石(也是 search→MVP 的 exit condition)**:能否一条命令把一个现成 `AGENTS.md`+`skills` 部署到 **AWS AgentCore**(serverless、每 invocation 现起 runtime、session 外置)并跑通一次 invoke。AgentCore 最难、最能证伪 core 是否真无状态;做穿它 = 设计成立。
-
-## 2. 概念框架(对齐业界)
-
-业界 2025-26 已收敛:**Agent = Model + Harness**,Harness = model 之外的一切(含 turn loop、tools、sandbox、memory、permissions)。
-
-术语校准:
-- 业界的 **harness**(含 loop)= **pi 的 `AgentHarness`**。Hermes Agent(Nous)、OpenClaw、Claude Code 同为「harness + 捆绑 serving」的垂直产品形态。
-- 你 vibe 出的 `AGENTS.md`+`skills` 文件夹,本文称 **agent 定义(agent definition)**,**不叫 harness**--它是"内容/定义",不是执行系统。
-
-**prompt 层的精确口径(定稿;AGENTS.md ≠ system prompt)**。最终发给模型的 system prompt 是 harness **组装**的产物,四段式(pi/Claude Code 同构,已验证 pi 源码):
-
-| 段 | 内容 | 谁拥有 |
-|---|---|---|
-| 1 base prompt | 身份、工具使用规范、行为准则(质量大头) | **引擎 binding 资产,继承自引擎**(pi binding → `piBasePrompt`,镜像 pi 的、按实际 tools 参数化、去 pi-TUI 文档段;claude/codex 引擎的 SDK 内部自带组装,binding 无需注入。理由:定义作者在该引擎下 vibe 出 AGENTS.md,换 base = 行为漂移、违背忠实性。可配置覆盖) |
-| 2 instructions | **AGENTS.md 的内容**,被包成 `<project_instructions>` 注入 | **agent 定义**(定义装载 `definition.ts` 读出) |
-| 3 skills listing | `<available_skills>` 列表,指引模型按需读 SKILL.md(需 read 工具才真可用) | 定义(定义装载读出)+ prompt 组装格式化 |
-| 4 env context | date / cwd | harness 生成 |
-
-即:**AGENTS.md = 项目级指令("README for agents"),只是注入物 2;定义装载的产出是 instructions + skills,不是 systemPrompt;最终 systemPrompt 由 prompt 组装(`assembleSystemPrompt`)产出。**
-
-标准已分四层,fastagent 在每层的姿态:
-
-| 层 | 事实标准 | fastagent |
-|---|---|---|
-| 内容/定义 | AGENTS.md · Agent Skills · MCP | **consume** |
-| 调用(editor↔agent) | ACP | 可选 channel(见 §6) |
-| 调用(agent↔agent) | A2A | consume(见 §6) |
-| **serving(触发源↔agent)** | **空** | **Agent Handler([SPEC](SPEC.md))= 这一层的 gateway** |
-| 打包/部署 | OCI · ADP | target adapter 输出(见 §6) |
-
-## 3. 契约 = [SPEC](SPEC.md)
-
-契约层不在本文重复定义--见 [SPEC](SPEC.md)。要点(供下文实现参照):
-
-```ts
-interface Agent { invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent>; }
+```txt
+workspace/
+├── AGENTS.md
+├── skills/
+├── fastagent.config.ts
+└── .fastagent/          # generated machine state, ignored by git
 ```
-- 一个 turn = 一次 `invoke`,返回单一异步事件流(`text` / `tool_*` / `completed` / `failed`)。
-- `Scope` 核心只 `session`;buffered 是 `collect()` 退化;3+1 条 MUST(终局唯一 / cancel-cleanup / 忽略未知非终局 / 可选 portable 无位置依赖)。
-- **引擎中立**:任何引擎只要把"跑一个 turn"包成这个流就合规。fastagent 是用 **pi** 实现它的参考实现。
 
-## 4. 参考实现:用 pi 实现 Agent Handler
+`AGENTS.md` is not the full system prompt. The pi reference implementation assembles the final prompt from four segments:
 
-**底座 = `AgentHarness`(pi-agent-core),不是 `AgentSession`(pi-coding-agent)。** 后者是 TUI 封装,绑 SettingsManager/ResourceLoader/ExtensionRunner + 直接读盘。`AgentHarness` 宿主中立,只要 `env` + `session` + `tools` + `model` + `systemPrompt`。
+| Segment | Source | Owner |
+|---|---|---|
+| base prompt | pi engine binding (`piBasePrompt`) | engine asset |
+| project instructions | `AGENTS.md`, wrapped in `<project_instructions>` | agent definition |
+| skills listing | loaded skills, formatted for progressive disclosure | agent definition |
+| environment context | date and cwd | runtime assembly |
 
-pi 的 `AgentHarness` 有**两个口**:`prompt(text) => Promise<AssistantMessage>`(buffered 终值)+ `subscribe(piEvent)`(事件旁路)。SPEC 的**单一事件流**,就是把这两个口 **fan-in** 成一个 async generator:
+`assembleSystemPrompt` is pure: callers provide date/cwd. L2 uses a factory so long-running processes re-evaluate time-sensitive context per invocation.
+
+## 3. pi reference implementation
+
+The reference implementation is built on `pi-agent-core` `AgentHarness`, not the TUI-oriented `pi-coding-agent` session wrapper.
+
+pi exposes two useful ports:
+
+- `harness.prompt(...) -> Promise<AssistantMessage>` for the final buffered result,
+- `harness.subscribe(...)` for streaming side-channel events.
+
+FastAgent fans those into one SPEC stream:
 
 ```ts
-// invoke(scope, prompt) 的参考实现(与代码同步,见 engines/pi/invoke.ts):把 pi 双口 fan-in 成单流
-async function* invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
-  const release = lease.tryAcquire(scope.session);          // 单写者,fail-fast(见 §6.6)
-  if (!release) { yield failedBusy(); return; }             // "session busy",不排队
+async function* invoke(scope, prompt) {
+  const release = lease.tryAcquire(scope.session);
+  if (!release) { yield busyFailedEvent; return; }
   try {
-    const harness = await harnessFactory(scope.session);      // 每 invoke 现起,open-or-create session
+    const harness = await harnessFactory(scope.session);
     const queue = new EventQueue<AgentEvent>();
-    const unsub = harness.subscribe(pe => queue.push(toAgentEvent(pe))); // pi event → AgentEvent
+    const unsub = harness.subscribe((event) => queue.push(toAgentEvent(event)));
     try {
-      const run = harness.prompt(prompt.text, { images: prompt.images });
-      yield* queue.drainUntil(run);                         // text / tool_* 边跑边 yield
-      yield toTerminal(await run);  // completed / failed -- MUST inspect resolved message 的 stopReason
+      const run = harness.prompt(prompt.text, toPiPromptOptions(prompt));
+      yield* queue.drainUntil(run);
+      yield toTerminal(await run);
     } finally {
-      unsub(); await harness.abort();                       // 清理绝不抛(MUST 2/3)
+      unsub();
+      await harness.abort();
     }
   } finally {
-    release();                                              // cancel/正常结束都释放
+    release();
   }
 }
 ```
 
-**关键点:**
-- **单一 translator**:`toAgentEvent`(pi 事件 → `AgentEvent`)+ `toTerminal`(pi `AssistantMessage` → `completed`/`failed`)。对 pi 的全部依赖收敛到这一处。SPEC 坍成单流后,旧版的"两个 translator + 双 seam"也坍成"一个 generator fan-in 双口"。
-- **`failed` 以 stopReason 为准,不只靠 catch**:pi 的 `prompt()` 在模型错误/abort 时**不一定 throw**--常态是 resolve 一个 `stopReason: "error" | "aborted"` 的 `AssistantMessage`。所以 `toTerminal(await run)` MUST inspect resolved message 的 `stopReason`(`error`/`aborted` → `failed`);外层 `try/catch` 只兑底真正的 throw。光靠 catch 会漏掉一整类失败,违反 SPEC MUST 1。
-- **无状态多-session**:pi 是「1 harness = 1 session」;fastagent 要服务无数 session,所以**每 invoke 现起一个绑该 session 的 harness,用完即弃**。唯一活态 = 在飞的 turn,两次 invoke 之间没有不可重建的东西。**这是能 serverless、能部署 AgentCore 的最硬地基。**
-- **cancel 落地**:消费者 `break` → generator 收到 `return()` → `finally` 跑 `harness.abort()` + `lease.release()`。SPEC MUST 2 天然由 async generator 的 cleanup 兑现。
+The real implementation catches setup/runtime errors and converts them to `failed` events so iteration does not throw (SPEC MUST 2). Cleanup errors are intentionally prevented from poisoning an already-terminal stream.
 
-实现层注入点(协议看不到,见 [SPEC](SPEC.md) §9 依赖反转)--**已实现的实际签名**:
+## 4. Assembly ladder
+
+The pi implementation exposes four entry points. Each upper rung delegates downward.
+
+| Rung | Function | Meaning |
+|---|---|---|
+| L3 `[OPEN]` | `createPiAgentFromWorkspace(dir, { model? })` | load workspace config + definition; used by CLI |
+| L2 `[LOAD]` | `createPiAgentFromDefinition(dir, options)` | load `AGENTS.md` + skills, assemble prompt, then L1 |
+| L1 `[ASSEMBLE]` | `createPiAgent(options)` | assemble from typed parts: model, prompt, tools, sessions, env, auth |
+| L0 `[ADAPT]` | `createPiAgentFromHarness({ harnessFactory })` | adapt pi harness wiring into the Agent Handler stream |
+
+Naming rule: `From<source>` means inputs are derived from that source. No suffix (`createPiAgent`) means typed parts are supplied directly.
+
+L0 lives in `invoke.ts` because its body is the request-time turn mechanism; L1–L3 live in `create.ts` because they are configuration-time assembly.
+
+## 5. Config v1
+
+`fastagent.config.ts` currently has three keys:
 
 ```ts
-// 低层：引擎接线被打包进 harnessFactory（PiHarnessFactory）；lease = 进程内 fail-fast 单写者（§6.6）
-createPiAgentFromHarness({ harnessFactory: (session: string) => AgentHarness, lease?: Lease }): Agent
-// 中层:batteries-included(sessions/env/auth/lease 全有默认、可覆盖)
-createPiAgent({ model, systemPrompt?, tools?, skills?, sessions?, env?, getApiKeyAndHeaders?, lease? }): Agent
-// 高层:指向文件夹(装载定义 + 组装 prompt + 默认工具)
-createPiAgentFromDefinition(dir, { model, ... }): Promise<{ agent, definition }>
-// 顶层:指向 workspace(定义 + fastagent.config.ts):装载 config → 解析 model/tools → L2
-createPiAgentFromWorkspace(dir, { model? }): Promise<{ agent, definition, config, configPath?, modelSpec }>
+export default defineConfig({
+  model: "provider/modelId",
+  tools: [myTool],
+  http: { port: 8787 },
+});
 ```
 
-四级返回同一契约类型 **`Agent`**(做 IO 的 L2/L3 另附装载产物--`LoadedDefinition` / config--供 caller surface 诊断)--消费者永远拿到同型的 Agent,不感知装配级别。跨进程 lease 仍 deferred(§8);middleware 未建(无消费者)。model 来源是配置非定义(AGENTS.md 不讲用哪个 LLM),见 §6 装配点归类。
+Semantics:
 
-## 5. 坍缩:实现真正发明了什么
+- `model` is the repo default; precedence is CLI `--model` > `FASTAGENT_MODEL` > config.
+- `tools` are custom code tools appended after pi defaults; they never replace defaults.
+- `http.port` configures the built-in dev HTTP channel.
 
-连续审查把实现从「~12 个概念」坍缩到 **几项发明 + 其余 pi 透传**:
+Deliberately not in v1: session/env backend selection, auth overrides, base prompt overrides, and skill-path overrides. Those remain library API escape hatches until real hosting backends shape the config surface.
 
-1. **把 pi 双口 fan-in 成 SPEC 单流**(+ 单一 event/terminal translator)
-2. **无状态多-session 编排**(每 invoke 现起 harness,用完即弃)
-3. **单写者 lease**(独立 `Lease` 端口;进程内 fail-fast 已落地,跨进程后端待 K 刀;pi 无)
-4. **请求级 middleware + 依赖反转 adapter 架构**
+## 6. Tools and skills
 
-删除清单(每条过 R5):
+Skills are markdown/file assets. By default, local dev loads:
 
-| 删除 | 理由 |
-|---|---|
-| Capability / fit-check | `ExecutionEnv` 是 monolithic 的,"有 fs 没 shell" 的 env 不存在 → false precision |
-| fastagent `Tool` / `ToolContext` | 退化成 pi `AgentTool`,零 delta |
-| Budget(核心概念) | 是 middleware;只在 `failed` 上体现 |
-| 结构化失败分类(transient/fatal/content_filter) | 引擎不提供这个区分度;`failed.retryable` 足够 |
+- definition-local `skills/`,
+- global pi skills: `~/.pi/agent/skills`,
+- cross-tool global skills: `~/.agents/skills`.
 
-> **实现薄,而且应该薄**。价值在协议 + 部署 DX,不在概念量。
+Definition-local skills win name collisions because the deployable unit is authoritative. Collisions are surfaced as diagnostics, not swallowed.
 
-## 6. 部署:三层所有权 + 跨 runtime 编译
+`bundleAgentDefinition` is the build-time step that materializes the winning skill folders into a self-contained artifact. Dropped skills are removed on rebuild so the artifact is the truth.
 
-**文件结构按「谁拥有 / 是否进 git / 是否可重建」分三层:**
+Code tools are different: they are TypeScript/JavaScript modules with dependencies. FastAgent does not auto-load a magic `tools/` directory. Projects explicitly import and inject code tools through config or library APIs. Declarative MCP tool mounting via `.mcp.json` is future support, not implemented today.
 
-```
-工作区根/
-├── AGENTS.md / skills/               # 1 agent 定义:标准、可移植、fastagent 只读;定义装载(definition.ts)读盘产出 LoadedDefinition
-├── fastagent.config.ts · 自定义代码 · .env   # 2 production source:用户拥有、可见、进 git(机密走 .env)
-└── .fastagent/                       # 3 machine state:fastagent 生成、gitignore、可删可重建
-```
+## 7. Sessions and statelessness
 
-### 6.1 装配点参数归类(定稿,二维)
+Each `invoke` creates a fresh harness bound to the requested session and discards it after the turn. Conversation continuity comes from reopening the session from a `SessionStore`:
 
-装配点 = `create.ts` 的 L0–L3 梯子(L0 住 invoke.ts),**产物是实现 invoke 契约的 `Agent`**。每个参数按两条轴归位--**概念归属**(M=agent 是什么 / K=在哪怎么跑 / auth=凭什么连)决定该谁负责;**来源**(定义/配置/host)决定谁来填。三个产出层中,**定义装载(definition.ts)与 config 装载(config.ts)已建成;target adapter 未建--K 侧参数仍是默认值**。
+- L1 default: `inMemorySessionStore()` for embedding/tests.
+- L3 default: `jsonlSessionStore()` under `.fastagent/sessions` for restart-surviving local dev.
 
-| 参数 | 概念归属 | 来源 |
-|---|---|---|
-| `instructions`(→ systemPrompt 的一段) | M | **定义**(AGENTS.md 正文 → 定义装载;见 §2 prompt 四段式) |
-| base prompt(→ systemPrompt 骨架) | M | **引擎 binding 资产**(继承自引擎:pi→piBasePrompt;配置可覆盖) |
-| `tools` / skills | M | **定义**(skills/ → 定义装载; `.mcp.json` is future MCP support, not implemented today) |
-| `model` | M | **配置**(fastagent.config / env;AGENTS.md 不讲用哪个 LLM) |
-| `sessions`(SessionStore) | K | **已落地第一个持久后端**:jsonlSessionStore(dev 默认落 `.fastagent/sessions/`)+ inMemorySessionStore;config 选后端仍 deferred(等后端 #2)+ **host**(target adapter 接线实现) |
-| `env`(ExecutionEnv) | K | **配置**选环境 + **host**(target adapter 接线实现) |
-| `lease` | K | **配置**策略/TTL + **host**(target adapter 接线实现) |
-| `getApiKeyAndHeaders` | auth(横切) | **配置/secrets**(.env / vault) |
+This gives the reference implementation portable conformance in miniature: two separate instances sharing the same external store can continue the same session.
 
-```
-定义文件 ─(definition.ts)→ instructions, skills(systemPrompt=prompt 组装产出) ┐
-配置 ─(fastagent.config + .env)→ model, 后端选择, secrets   ├→ createPiAgent → agent ←(N: channel 调 invoke,不是装配参数)
-host ─(target adapter)→ sessions/env/lease 的实现接线            ┘
+Full fork/navigation session-admin is a separate draft: see [session](session.md).
+
+## 8. Same-session concurrency
+
+Core provides only a corruption-prevention floor: one in-flight turn per session.
+
+If a second invocation arrives for the same session while one is already running, it immediately yields:
+
+```ts
+{ type: "failed", retryable: true, details: "session busy: ..." }
 ```
 
-注:**定义装载只产出「定义推导」那一格**(instructions + skills);model 是配置项,不在 AGENTS.md 里。
+Core does not queue. Dedupe, retry, user-visible “busy” messages, and steering are channel-level decisions because only the channel understands the trigger semantics.
 
-### 6.2 config v1(定稿,已实现)
+## 9. HTTP channel
 
-`fastagent.config.ts` = `defineConfig({ model, tools, http })` --**只有 3 个键**,每个都过「一句话讲得清 + 有近期故事」门槛:`model`="provider/modelId" 字符串;`tools`=追加在 pi 默认工具后的自定义工具数组(即「无入口部署下 code tools 的归宿」);`http.port`。优先级 CLI flag > `FASTAGENT_MODEL` > config;无 config = zero-config 跑默认。**刻意不进 v1**:sessions/env 选型(K 轴,等 hosting 刀由真实后端定形状)、base/auth/skillPaths 覆盖(默认几乎总是对的,留库 API 作逃生舱)。选 .ts 非 yaml(旧版教训):tools 是代码需 import、类型补全、生态收敛(vite/next 同款);toolchain 要声明式数据时构建期执行 config 取 resolved 值。红线:config 只描述部署选择,绝不描述 agent 身份/行为。消费者 = **L3(`createPiAgentFromWorkspace`,config 驱动装配的收口);CLI(`fastagent dev`,已实现)经 L3 消费,自身只留进程副作用/展示/起服务;`build`/`start` 随后--业界 dev/build/start 三连,恰好对上 dev-server / bundleAgentDefinition / 跑产物)。
+`createInvokeHandler(agent)` implements the minimal dev HTTP channel:
 
-### 6.3 tools/skills 挂载口径(定稿;参照 agentskills.io 规范 + pi/Claude Code 实现)
+- `POST /invoke { session, text }`,
+- SSE output with one `data:` line per `AgentEvent`,
+- request body cap by real bytes,
+- client disconnect calls `iterator.return()` to trigger invoke cleanup.
 
-- **skills 发现位置是 client 约定,规范不定**。pi 的层级:user 全局(`~/.pi/agent/skills`,先加载)→ 项目(`.pi/skills`)→ 额外 skillPaths(settings/extensions);碰撞先到者赢 + 发 collision 诊断。
-- **fastagent 的口径(经忠实性推导翻转过一次,定稿)**:缺省 `skillPaths = defaultGlobalSkillPaths()`(`~/.pi/agent/skills` + `~/.agents/skills`)--**默认加载全局,忠实 pi 本地体验**。高级控制:`skillPaths: []` = 只扫定义内;自定义数组 = 精确选装。
-- **部署路径必经 `bundleAgentDefinition`(一键部署的「编译」阶段,非可选 dev 工具)**:把胜出的全局/额外 skills 整夹物化进自包含产物 → **服务器完整复现本地体验**(这是产品承诺)。运行时默认扫全局只是本地 dev 便利;服务器上 home 不存在自然为空只是兜底,**产物才是真相**。skills(纯文件)拷贝即自包含;**code tools 不在打包范围**(见下条)。
-- **碰撞**:定义内 skills 赢(部署单元是权威),先到者赢 + surface `collisions`(不吞)。机制同 pi、优先级取向不同(pi 是 user 先,我们是 definition 先--部署单元不同)。
-- **默认工具 = pi 核心集(read/bash/edit/write),忠实性口径(经场景推导翻转过一次,定稿)**:直接用 pi-coding-agent 的工厂(`createCodingTools`),工具名/描述/行为与 pi 本地逐字一致--定义作者是带全套工具 vibe 的,砍工具 = 行为漂移(同 base prompt 逻辑)。**工具层不是安全边界**:隔离是 K 侧 ExecutionEnv/sandbox 的职责(本地=用户自己的机器;AgentCore=microVM);对公网收紧 = 显式传 `tools`(如 `piReadOnlyTools`),是部署姿态非默认。渐进披露三级(discovery/activation/execution)随之全部开箱可用。pi 工具的 operations 可注入(BashOperations 等),未来 sandbox adapter 换 operations 即可。
-- **打包机制(bundleAgentDefinition)**:运行时只扫定义内的规则不变;dev 在**构建时**用 `bundleAgentDefinition(src, out, {skillPaths})` 把全局/额外挂载的**胜出** skill 整夹(含 scripts/references/assets)物化进产物,部署单元自包含、可直接再装载。败者不进包。
-- **自定义 tools = 代码,显式 `tools:` 注入,不做魔法目录。** 模式:项目里的普通 TS 模块实现 `AgentTool`,显式 import + `tools: [...piDefaultTools(cwd), myTool]`(示例 examples/lookup-order-tool.ts)。理由:(a) tool 是代码,开发者已在代码里,显式 import 型检/可重构,魔法目录只省一行 import;(b) 假对称违反分层--定义夹=标准可移植数据,tools=代码属 layer-2;(c) bundle 拷源文件不带 npm 依赖,自包含是假的。无用户入口的部署下声明 tools 的归宿 = `fastagent.config.ts`(config 刀);声明式/可移植的挂工具 = **MCP**(`.mcp.json`,future support, not implemented today)。进程内 code tools 无跨引擎标准,fastagent-on-pi 用 pi `AgentTool`。**pi extensions(含全局自定义 tools)不自动加载**:其契约绑 TUI 宿主(ctx.ui/commands/渲染),headless 无对应物;桥 = 把 `pi.registerTool({...})` 的参数搬成项目 tool 模块(形状几乎相同)。
-- spec 的 `allowed-tools`(实验性)暂不实现;`.mcp.json`(MCP tools) is future support, not implemented today.
+The HTTP channel consumes only the neutral `Agent` contract.
 
-### 6.4 跨 runtime 编译(工具链层的真工程)
+## 10. Current open work
 
-同一份 agent 定义,target adapter 编译成适配不同 runtime 的部署产物。难点不是 wire,是**异构 target 的进程/env/session 模型全不同**:
-
-| target | 进程模型 | env 供给 | session |
-|---|---|---|---|
-| AgentCore | serverless,现起即弃 | OCI 内 | 外置(DDB) |
-| Lambda | 无状态,冷启动 | 容器 | 外置 |
-| Fly | 常驻进程 | 本地 fs | 本地/外置 |
-| Workers | V8 isolate,无 Node fs | 受限 | 外置 |
-| E2B | sandbox | 远程 | 外置 |
-
-让同一份定义跑在这些上面,靠的正是 §4 的**无状态 invoke + env 注入 + session 外置(SessionStore)+ target adapter**。SPEC 的 portable conformance(无位置依赖)正是为此而设。这是 ACP 结构上不碰(它把 env 留给 client)、而 fastagent 必须做的--也是「没人能部署到 AgentCore」的技术核心。**部署 DX 是 wedge(可复制),无状态跨 runtime 解耦是 moat(工程积累)。**
-
-**两处非正交耦合(诚实标注,别被 N+M+K 的算术骗了)**:
-
-1. **M⊥K 是假设出来的,不免费**:§5 删 capability/fit-check 等于假设 `ExecutionEnv` 同质。Workers 没 Node fs--要 shell/fs 的 agent 跑不上去。撞 Workers 时这个假设要还债。
-2. **N⊥K 不干净**:cron 要 host 给调度器,webhook 要 host 给公网 ingress;特定 (trigger, host) 对需要特定 host 基建(AgentCore 为此开 EventBridge + API Gateway)。N×K 不是自由组合,这块耦合压在 target adapter 层。
-
-即:N×M 是真窄腰(干净塌缩);×K 是工程上逐 host 啤出来的近似正交,不是协议白送。
-
-**对外 wire(consume 标准,不另立)**:invoke 不对外。
-- **A2A**(agent↔agent):consume--暴露 Agent Card,把 invoke 的单流 fan-out 到 A2A 的 event queue(`for await (e of invoke) eventQueue.push(toTaskUpdate(e))`);终局 → final Message/Task。Task 状态机/Artifact 在 adapter + userland,不进 core。`scope.session` ≙ A2A `contextId`,`completed.data` ≙ Artifact。
-- **ACP**(editor):可选 channel,但 ACP 角色倒置(client 提供 env / human-in-loop),agent 要切「委托 env」模式,独立分支非主路。
-- **webhook/cron**(serving 主入口):无标准,channel adapter 自定义 → invoke。
-
-> SPEC 的单流(AsyncIterable)天然适配 A2A 的 push executor(`for await` 转 push)--比旧版"buffered + 旁路 subscribe"喂得更顺。
-
-## 6.5 session 模型:tree / fork / 回退如何跨 host 可移植(定稿)
-
-**session = 一棵持久化的 entry 树 + 一个 leaf 指针**(沿用 pi 的 `SessionStorage`:append-only entry 带 `parentId` + `LeafEntry`)。**turn = 一次 invoke = 沿 leaf 向前追加一节**,所以 `session : invoke = 1 : 多`。「长程对话」是错觉:每 invoke 无状态、用完即弃;连续性靠 SessionStore 持久化 entry 树、下次 `open` + 回放 `getPathToRoot(leaf)` 重建上下文(满足 SPEC portable conformance)。
-
-> ✅ 连续性已接:`engines/pi` 的 `piHarnessFactory` 每 invoke **open-or-create**(已有则 open、harness 经 buildContext 看到历史;否则 create)。连续性契约 = **同一 backing store + 同一 session id**:jsonlSessionStore 跨进程重启仍连续(磁盘是真相;`fastagent dev` 默认),in-memory 需复用同一实例。详见 [session](session.md)。
-
-**回退 / 重试 / regenerate = session 管理,不进 invoke**(SPEC §10:编排 = 上层):
-- **回退** = 把 leaf 移回某 entry(pi `navigateTree`);被甩的 turn 成死分支,不删(可选 `summarize` 留痕)。
-- **干净重试** = 先回退到失败 turn 的 start 边界(SPEC §6 警告 `retryable` 非原子,半跑的 turn 可能已 append entry / 跑过带副作用 tool),**再** invoke。
-- **regenerate** = 在某 user message 处 fork。
-
-**业界对照(2026 调研):**
-
-| 系统 | 历史形状 | fork 机制 | 节点寻址 |
-|---|---|---|---|
-| AWS AgentCore | 扁平事件日志(actor, session) | 无(线性) | 无 |
-| Claude Agent SDK | 线性 transcript + leaf | **fork → 新 session id**(leaf 处复制历史) | 无(只能 leaf) |
-| OpenAI Responses | DAG(`previous_response_id`) | 多响应指向同一 prev_id | 有(节点在调用里) |
-| LangGraph | 树(checkpoint 的 parent 链) | `update_state` / 从 `checkpoint_id` replay | 有(checkpoint_id) |
-| pi | 树 + leaf | fork / `navigateTree` | 有(任意 entry) |
-
-**结论(定稿):**
-
-1. **树是 SessionStore 的逻辑,不是 host 的能力。** host 只需提供三原语:`durable append + read(history) + single-writer(lock)`;从扁平 entry 读 `parentId` 即重建树。
-2. **fork / 回退跨 host 可移植。** 凡能 append+read+锁的后端(jsonl / pg / ddb / **AgentCore**)都能模拟。两策略:**森林**(每 host session 保持线性,分支 = 新 session id + 我们自存的 "forked-from" 边;顺 AgentCore 纹理、Claude 同款)作 floor;**树进 payload**(整棵树编码进 entry,复刻 pi)作可选优化--注意 AgentCore 的长期语义抽取会把死分支也吃进"记忆",用它时**只当短期事件存储**。唯一做不到的极端 host:既隐藏历史、又只能 leaf 线性追加、且无分支原语(AgentCore 不是)。
-3. **入口在 session-admin 面,不进 `Scope`。** fork **返回新 session id**(Claude 同款),不把 node-id 塞进 invoke。理由是**契约卫生,不是存储做不到**:node-in-scope 会(a)被忽略时静默 append-to-leaf → 写坏对话;(b)隐藏分支落点(caller 跟 A、新 turn 落 B)。invoke 永远只有一个普适动词「续接此 session」,降级永不静默。
-4. **定位**:这把「分支 / 回退」从「只有树引擎才有的奢侈品」变成 fastagent 在**任意 host 上统一提供**的可移植 capability--AgentCore 这种最硬的 host 也能给到分支语义,正是试金石要证的「无状态可移植」。它属于 **×K 的 moat**(逐后端啤 SessionStore 的工程),不是协议白送。
-
-> 展开为独立标准草案 [session](session.md)(event-sourced DAG + 三层解耦:1 Consumer API / 2 DAG core / 3a Host adapter · 3b Engine adapter)。
-
-## 6.6 同 session 并发:core 只留 fail-fast 地板,UX 在 channel(定稿)
-
-> 这一节是从第一性原理重新推导的结果:先问「同 session 并发是真需求还是假需求」,再决定机制。曾错走一步:默认 FIFO 串队 lease--把一个症状当成一种需求解了。
-
-**同 session = 同一段对话线程;同 session 并发 invoke = 同一对话同时有两个 turn 在跑。** 它由这些场景产生:
-
-| # | 场景 | 本质 | 理想 UX | 对的机制 |
-|---|---|---|---|---|
-| 1 | 用户手抖/超时重发(double-submit / client retry / 刷新) | 重复意图 | 去重 / 忽略第二个 / 幂等 | dedupe / 幂等键 |
-| 2 | 用户连发("做 X"...紧接"还有 Y") | 一个用户追加/改主意 | 第二条注入在飞 turn 或排成 follow-up | **steering**(SPEC §8,已 defer) |
-| 3 | 多端/群聊(多人同时说) | 多参与者的真·两个 turn | 串行进连贯 transcript + 等待方"忙"反馈 | 串行 + 反馈 |
-| 4 | webhook 风暴(同一 issue 连续触发) | 机器重复/最新态 | 合并 / debounce | coalesce / latest-wins |
-| 5 | 失败后重试 | 替换不是叠加 | 替换原 turn(且原已结束) | 多数非真并发 |
-
-**归并成三类,「FIFO 串跑两遍」只契合一类且不完整:**
-- **A 重复意图(1/4/5)** → 该去重/合并,**绝不该跑两遍**(跑两遍 = 同一意图产生两条回复)。
-- **B 单用户连发(2)** → 该 **steering**(第二条修饰/排在第一条上,agent 感知),不是两个独立 turn 抢跑。
-- **C 多参与者(3)** → 该 **串行 + 给等待方反馈**(连 C 都需要"你在排队"这个反馈)。
-
-**分层决策:**
-1. **invoke 本质是"跑一个 turn",turn 之间的并发编排在 invoke 之上**(channel/caller 的事)。
-2. **谁知道该 dedupe/steer/queue/reject?是 channel**--它知 trigger 语义(HTTP 幂等键、聊天 steering、webhook debounce)。core 不知,也不该替它定。
-3. **场景 B 的正解是 steering 输入流**(SPEC §8 第三参),不是 lease。
-
-**所以 core 的唯一职责 = 一个「不写坏」的、最小且显式的地板。辙选 fail-fast 而非 queue:**
-
-> 同 session 已有在飞 turn 时,第二个 invoke **立即** yield `failed{ retryable:true, details:"session busy" }`。
-
-- **正确**:无交错写、无死锁(根本不排队,自然没有"排队中被 cancel"的槽泄漏)、无无界队列;
-- **显式**(fail visibly):不再有"隐形挂住"的请求;
-- **把 UX 决策推给 caller**:channel 自己决定重试/去重/显示"忙"/串行;
-- 正好对上 SPEC `failed{retryable}` 语义。
-
-需要"串行带反馈"的 channel(如群聊 Slack adapter),自己在 channel 层按 thread 排队即可--它做排队比在 async generator 的 `await`(在 try 外)里做安全得多。
-
-**一句话**:同 session 并发的大多数是"重复"或"steering",不是"两个真 turn";core 不用 FIFO 串跑去糊弄所有场景,只留一个显式的 fail-fast 地板,把 UX 交给 channel,把单用户连发交给将来的 steering。这也把死锁从设计上去掉了--不是修 lease,是不该有那个排队 lease。
-
-## 7. 不变量(实现的法律)
-
-1. 参考实现把 pi 的双口 fan-in 成 SPEC 单流;对 pi 的依赖收敛到 `toAgentEvent` + `toTerminal` 两个 translator。
-2. **IO 政策(精确化)**:invoke 路径(invoke/harness)永不碰盘;运行时读定义(definition.ts 的 load)只经 `ExecutionEnv`(可移植);build-time(bundle)与 Node 组合根模块(config/auth/sessions)可直接用 node fs。错误通道约定:env 层 Result → load/config 层 throw(启动期响亮失败)→ auth 层 undefined(未配置)+ warn(异常)→ invoke 边界 failed 事件(SPEC 强制)。非致命加载发现(diagnostics/collisions)作为数据返回由 caller surface。
-3. 无状态:每 invoke 现起 harness,用完即弃;耐久状态全在 `SessionStore` 后(满足 SPEC portable conformance)。
-4. 对外 consume 标准(A2A/ACP/OCI),不另立 wire;invoke 不对外、不对齐任何 wire 数据模型。
-5. Task 编排 / Artifact 版本 / 长任务查询 = app 层(adapter + userland),不进 core。
-
-## 8. 边界与开放问题
-
-- **autonomy 安全(无人在环授权 / runaway 边界 / escalation)= v2 纵深**,不是第一性发生点。用户此刻的痛是「部署不了」,不是「不安全」;部署通了之后它才成为下一道缝(也正是 vision 里「狂徒锁链」的落点)。
-- **「成为标准」是上行期权,不是 base case。** Agent Handler 技术上够格当 agent serving 的 gateway 标准,但事实标准要生态采纳,而大厂在出竞品标准(A2A / Agent Executor)。所以:把协议设计成开放可采纳的形状(已做,见 [SPEC](SPEC.md)),产品价值赌「参考实现 + 部署 DX 够好用」,采纳是 huge upside。
-- **pi 失败有三条路径,translator 以 stopReason 为准**:(1)`prompt()` reject(少数,由 catch 兑);(2)resolve 带 `stopReason: error/aborted` 的 message(常态,`toTerminal` 检查);(3)subscribe 的 `AssistantMessageEvent{type:"error"}`。以 resolved message 的 stopReason 为准产出 `failed`,catch 只兑底路径(1)。
-- **lease**:进程内 fail-fast「session busy」地板已落地(见 §6.6 场景推导 + 决策)。**跨进程/多实例的分布式锁仍 deferred**(到有远程 SessionStore + 多实例/AgentCore 时再做)。
-- 还没钉死的微决策:`retryable` 判定已抽成可注入 `RetryClassifier`(L0 选项;默认字符串启发式,终解仍待 pi 导出结构化分类);分布式 lease 最小形状(独立 `Lease` 端口,非 SessionStore 方法);`EventQueue.drainUntil` 的 backpressure;非流式引擎的 `text` 退化(发一个大 delta)。
+- `fastagent build`: create deterministic artifact-only bundles.
+- `fastagent start`: run artifact-only production posture.
+- AgentCore target adapter with external sessions and distributed locking.
+- Production observability/logging for cleanup anomalies without violating SPEC terminal discipline.
+- Engine #2, which will prove which pi-specific seams should become engine-neutral abstractions.

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -9,17 +9,17 @@ share_updated: 2026-06-08T16:43:10+08:00
 
 # fastagent - 核心设计(参考实现)
 
-> 索引 [[fastagent]] · 协议 [[SPEC]] · 同目录 [[positioning]] · [[comparisons]]
+> 索引 [fastagent](fastagent.md) · 协议 [SPEC](SPEC.md) · 同目录 [positioning](positioning.md) · [comparisons](comparisons.md)
 
-> **契约层已抽到 [[SPEC]](Agent Handler 协议,引擎中立)。本文只讲 fastagent 的参考实现--怎么用 pi 实现那个协议 + 怎么部署到任意 runtime。代码真相在 `core/`。**
+> **契约层已抽到 [SPEC](SPEC.md)(Agent Handler 协议,引擎中立)。本文只讲 fastagent 的参考实现--怎么用 pi 实现那个协议 + 怎么部署到任意 runtime。代码真相在 `core/`。**
 
 ## 0. 定位:三件套
 
-> **fastagent = agent serving 的 WSGI**(对外易懂的说法;技术宗谱是 ASGI / fetch handler,见 [[SPEC]])。一套把「触发源 / 部署 target / agent 引擎」三方解耦的 serving 契约,加一个建在 pi 上的参考实现,加一条「指向文件夹就部署到任意 runtime」的工具链。
+> **fastagent = agent serving 的 WSGI**(对外易懂的说法;技术宗谱是 ASGI / fetch handler,见 [SPEC](SPEC.md))。一套把「触发源 / 部署 target / agent 引擎」三方解耦的 serving 契约,加一个建在 pi 上的参考实现,加一条「指向文件夹就部署到任意 runtime」的工具链。
 
 | fastagent 层 | 干什么 | web 世界对应 | 在哪定义 |
 |---|---|---|---|
-| **契约层** | Agent Handler:`invoke(scope, prompt) => AsyncIterable<AgentEvent>` | **fetch handler / ASGI** | **[[SPEC]]** |
+| **契约层** | Agent Handler:`invoke(scope, prompt) => AsyncIterable<AgentEvent>` | **fetch handler / ASGI** | **[SPEC](SPEC.md)** |
 | **参考实现层** | 建在 pi-agent-core 上,把协议跑起来 | Werkzeug + gunicorn | 本文 §3-5 |
 | **工具链层** | 指向 agent 定义文件夹 → 编译 → 部署到任意 target | Vercel + Buildpacks | 本文 §6 |
 
@@ -31,7 +31,7 @@ share_updated: 2026-06-08T16:43:10+08:00
 
 | 轴 | 由什么解耦 | 在哪一层 |
 |---|---|---|
-| **N×M**(trigger ↔ agent)| `invoke` 的签名 + 事件([[SPEC]])| **core / 契约** |
+| **N×M**(trigger ↔ agent)| `invoke` 的签名 + 事件([SPEC](SPEC.md))| **core / 契约** |
 | **M**(引擎多样)| invoke 是黑盒接口 + 装配层注入(定义装载 → `LoadedDefinition` → 装配出 `Agent`)| core(依赖反转)|
 | **K**(host 多样)| invoke 的无状态性质(SPEC MUST「无位置依赖」)+ `SessionStore`/`ExecutionEnv` 注入,使 host 可替换;真正"编译到某 runtime" = target adapter | K 的*可*解耦在 core,K 的解耦*动作*在工具链层(SPEC §10 out of scope)|
 
@@ -86,12 +86,12 @@ share_updated: 2026-06-08T16:43:10+08:00
 | 内容/定义 | AGENTS.md · Agent Skills · MCP | **consume** |
 | 调用(editor↔agent) | ACP | 可选 channel(见 §6) |
 | 调用(agent↔agent) | A2A | consume(见 §6) |
-| **serving(触发源↔agent)** | **空** | **Agent Handler([[SPEC]])= 这一层的 gateway** |
+| **serving(触发源↔agent)** | **空** | **Agent Handler([SPEC](SPEC.md))= 这一层的 gateway** |
 | 打包/部署 | OCI · ADP | target adapter 输出(见 §6) |
 
-## 3. 契约 = [[SPEC]]
+## 3. 契约 = [SPEC](SPEC.md)
 
-契约层不在本文重复定义--见 [[SPEC]]。要点(供下文实现参照):
+契约层不在本文重复定义--见 [SPEC](SPEC.md)。要点(供下文实现参照):
 
 ```ts
 interface Agent { invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent>; }
@@ -134,7 +134,7 @@ async function* invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> 
 - **无状态多-session**:pi 是「1 harness = 1 session」;fastagent 要服务无数 session,所以**每 invoke 现起一个绑该 session 的 harness,用完即弃**。唯一活态 = 在飞的 turn,两次 invoke 之间没有不可重建的东西。**这是能 serverless、能部署 AgentCore 的最硬地基。**
 - **cancel 落地**:消费者 `break` → generator 收到 `return()` → `finally` 跑 `harness.abort()` + `lease.release()`。SPEC MUST 2 天然由 async generator 的 cleanup 兑现。
 
-实现层注入点(协议看不到,见 [[SPEC]] §9 依赖反转)--**已实现的实际签名**:
+实现层注入点(协议看不到,见 [SPEC](SPEC.md) §9 依赖反转)--**已实现的实际签名**:
 
 ```ts
 // 低层：引擎接线被打包进 harnessFactory（PiHarnessFactory）；lease = 进程内 fail-fast 单写者（§6.6）
@@ -250,7 +250,7 @@ host ─(target adapter)→ sessions/env/lease 的实现接线            ┘
 
 **session = 一棵持久化的 entry 树 + 一个 leaf 指针**(沿用 pi 的 `SessionStorage`:append-only entry 带 `parentId` + `LeafEntry`)。**turn = 一次 invoke = 沿 leaf 向前追加一节**,所以 `session : invoke = 1 : 多`。「长程对话」是错觉:每 invoke 无状态、用完即弃;连续性靠 SessionStore 持久化 entry 树、下次 `open` + 回放 `getPathToRoot(leaf)` 重建上下文(满足 SPEC portable conformance)。
 
-> ✅ 连续性已接:`engines/pi` 的 `piHarnessFactory` 每 invoke **open-or-create**(已有则 open、harness 经 buildContext 看到历史;否则 create)。连续性契约 = **同一 backing store + 同一 session id**:jsonlSessionStore 跨进程重启仍连续(磁盘是真相;`fastagent dev` 默认),in-memory 需复用同一实例。详见 [[session]]。
+> ✅ 连续性已接:`engines/pi` 的 `piHarnessFactory` 每 invoke **open-or-create**(已有则 open、harness 经 buildContext 看到历史;否则 create)。连续性契约 = **同一 backing store + 同一 session id**:jsonlSessionStore 跨进程重启仍连续(磁盘是真相;`fastagent dev` 默认),in-memory 需复用同一实例。详见 [session](session.md)。
 
 **回退 / 重试 / regenerate = session 管理,不进 invoke**(SPEC §10:编排 = 上层):
 - **回退** = 把 leaf 移回某 entry(pi `navigateTree`);被甩的 turn 成死分支,不删(可选 `summarize` 留痕)。
@@ -274,7 +274,7 @@ host ─(target adapter)→ sessions/env/lease 的实现接线            ┘
 3. **入口在 session-admin 面,不进 `Scope`。** fork **返回新 session id**(Claude 同款),不把 node-id 塞进 invoke。理由是**契约卫生,不是存储做不到**:node-in-scope 会(a)被忽略时静默 append-to-leaf → 写坏对话;(b)隐藏分支落点(caller 跟 A、新 turn 落 B)。invoke 永远只有一个普适动词「续接此 session」,降级永不静默。
 4. **定位**:这把「分支 / 回退」从「只有树引擎才有的奢侈品」变成 fastagent 在**任意 host 上统一提供**的可移植 capability--AgentCore 这种最硬的 host 也能给到分支语义,正是试金石要证的「无状态可移植」。它属于 **×K 的 moat**(逐后端啤 SessionStore 的工程),不是协议白送。
 
-> 展开为独立标准草案 [[session]](event-sourced DAG + 三层解耦:1 Consumer API / 2 DAG core / 3a Host adapter · 3b Engine adapter)。
+> 展开为独立标准草案 [session](session.md)(event-sourced DAG + 三层解耦:1 Consumer API / 2 DAG core / 3a Host adapter · 3b Engine adapter)。
 
 ## 6.6 同 session 并发:core 只留 fail-fast 地板,UX 在 channel(定稿)
 
@@ -324,7 +324,7 @@ host ─(target adapter)→ sessions/env/lease 的实现接线            ┘
 ## 8. 边界与开放问题
 
 - **autonomy 安全(无人在环授权 / runaway 边界 / escalation)= v2 纵深**,不是第一性发生点。用户此刻的痛是「部署不了」,不是「不安全」;部署通了之后它才成为下一道缝(也正是 vision 里「狂徒锁链」的落点)。
-- **「成为标准」是上行期权,不是 base case。** Agent Handler 技术上够格当 agent serving 的 gateway 标准,但事实标准要生态采纳,而大厂在出竞品标准(A2A / Agent Executor)。所以:把协议设计成开放可采纳的形状(已做,见 [[SPEC]]),产品价值赌「参考实现 + 部署 DX 够好用」,采纳是 huge upside。
+- **「成为标准」是上行期权,不是 base case。** Agent Handler 技术上够格当 agent serving 的 gateway 标准,但事实标准要生态采纳,而大厂在出竞品标准(A2A / Agent Executor)。所以:把协议设计成开放可采纳的形状(已做,见 [SPEC](SPEC.md)),产品价值赌「参考实现 + 部署 DX 够好用」,采纳是 huge upside。
 - **pi 失败有三条路径,translator 以 stopReason 为准**:(1)`prompt()` reject(少数,由 catch 兑);(2)resolve 带 `stopReason: error/aborted` 的 message(常态,`toTerminal` 检查);(3)subscribe 的 `AssistantMessageEvent{type:"error"}`。以 resolved message 的 stopReason 为准产出 `failed`,catch 只兑底路径(1)。
 - **lease**:进程内 fail-fast「session busy」地板已落地(见 §6.6 场景推导 + 决策)。**跨进程/多实例的分布式锁仍 deferred**(到有远程 SessionStore + 多实例/AgentCore 时再做)。
 - 还没钉死的微决策:`retryable` 判定已抽成可注入 `RetryClassifier`(L0 选项;默认字符串启发式,终解仍待 pi 导出结构化分类);分布式 lease 最小形状(独立 `Lease` 端口,非 SessionStore 方法);`EventQueue.drainUntil` 的 backpressure;非流式引擎的 `text` 退化(发一个大 delta)。

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -3,8 +3,6 @@ title: fastagent - 核心设计(参考实现)
 type: design-doc
 status: design
 updated: 2026-06-11
-share_link: https://qsort.me/e7yv5ox2
-share_updated: 2026-06-08T16:43:10+08:00
 ---
 
 # fastagent - 核心设计(参考实现)
@@ -175,7 +173,7 @@ createPiAgentFromWorkspace(dir, { model? }): Promise<{ agent, definition, config
 
 ```
 工作区根/
-├── AGENTS.md / skills/ / .mcp.json   # 1 agent 定义:标准、可移植、fastagent 只读;定义装载(definition.ts)读盘产出 LoadedDefinition
+├── AGENTS.md / skills/               # 1 agent 定义:标准、可移植、fastagent 只读;定义装载(definition.ts)读盘产出 LoadedDefinition
 ├── fastagent.config.ts · 自定义代码 · .env   # 2 production source:用户拥有、可见、进 git(机密走 .env)
 └── .fastagent/                       # 3 machine state:fastagent 生成、gitignore、可删可重建
 ```
@@ -188,7 +186,7 @@ createPiAgentFromWorkspace(dir, { model? }): Promise<{ agent, definition, config
 |---|---|---|
 | `instructions`(→ systemPrompt 的一段) | M | **定义**(AGENTS.md 正文 → 定义装载;见 §2 prompt 四段式) |
 | base prompt(→ systemPrompt 骨架) | M | **引擎 binding 资产**(继承自引擎:pi→piBasePrompt;配置可覆盖) |
-| `tools` / skills | M | **定义**(skills/ + .mcp.json → 定义装载) |
+| `tools` / skills | M | **定义**(skills/ → 定义装载; `.mcp.json` is future MCP support, not implemented today) |
 | `model` | M | **配置**(fastagent.config / env;AGENTS.md 不讲用哪个 LLM) |
 | `sessions`(SessionStore) | K | **已落地第一个持久后端**:jsonlSessionStore(dev 默认落 `.fastagent/sessions/`)+ inMemorySessionStore;config 选后端仍 deferred(等后端 #2)+ **host**(target adapter 接线实现) |
 | `env`(ExecutionEnv) | K | **配置**选环境 + **host**(target adapter 接线实现) |
@@ -203,11 +201,11 @@ host ─(target adapter)→ sessions/env/lease 的实现接线            ┘
 
 注:**定义装载只产出「定义推导」那一格**(instructions + skills);model 是配置项,不在 AGENTS.md 里。
 
-### 6.3 config v1(定稿,已实现)
+### 6.2 config v1(定稿,已实现)
 
 `fastagent.config.ts` = `defineConfig({ model, tools, http })` --**只有 3 个键**,每个都过「一句话讲得清 + 有近期故事」门槛:`model`="provider/modelId" 字符串;`tools`=追加在 pi 默认工具后的自定义工具数组(即「无入口部署下 code tools 的归宿」);`http.port`。优先级 CLI flag > `FASTAGENT_MODEL` > config;无 config = zero-config 跑默认。**刻意不进 v1**:sessions/env 选型(K 轴,等 hosting 刀由真实后端定形状)、base/auth/skillPaths 覆盖(默认几乎总是对的,留库 API 作逃生舱)。选 .ts 非 yaml(旧版教训):tools 是代码需 import、类型补全、生态收敛(vite/next 同款);toolchain 要声明式数据时构建期执行 config 取 resolved 值。红线:config 只描述部署选择,绝不描述 agent 身份/行为。消费者 = **L3(`createPiAgentFromWorkspace`,config 驱动装配的收口);CLI(`fastagent dev`,已实现)经 L3 消费,自身只留进程副作用/展示/起服务;`build`/`start` 随后--业界 dev/build/start 三连,恰好对上 dev-server / bundleAgentDefinition / 跑产物)。
 
-### 6.2 tools/skills 挂载口径(定稿;参照 agentskills.io 规范 + pi/Claude Code 实现)
+### 6.3 tools/skills 挂载口径(定稿;参照 agentskills.io 规范 + pi/Claude Code 实现)
 
 - **skills 发现位置是 client 约定,规范不定**。pi 的层级:user 全局(`~/.pi/agent/skills`,先加载)→ 项目(`.pi/skills`)→ 额外 skillPaths(settings/extensions);碰撞先到者赢 + 发 collision 诊断。
 - **fastagent 的口径(经忠实性推导翻转过一次,定稿)**:缺省 `skillPaths = defaultGlobalSkillPaths()`(`~/.pi/agent/skills` + `~/.agents/skills`)--**默认加载全局,忠实 pi 本地体验**。高级控制:`skillPaths: []` = 只扫定义内;自定义数组 = 精确选装。
@@ -215,8 +213,8 @@ host ─(target adapter)→ sessions/env/lease 的实现接线            ┘
 - **碰撞**:定义内 skills 赢(部署单元是权威),先到者赢 + surface `collisions`(不吞)。机制同 pi、优先级取向不同(pi 是 user 先,我们是 definition 先--部署单元不同)。
 - **默认工具 = pi 核心集(read/bash/edit/write),忠实性口径(经场景推导翻转过一次,定稿)**:直接用 pi-coding-agent 的工厂(`createCodingTools`),工具名/描述/行为与 pi 本地逐字一致--定义作者是带全套工具 vibe 的,砍工具 = 行为漂移(同 base prompt 逻辑)。**工具层不是安全边界**:隔离是 K 侧 ExecutionEnv/sandbox 的职责(本地=用户自己的机器;AgentCore=microVM);对公网收紧 = 显式传 `tools`(如 `piReadOnlyTools`),是部署姿态非默认。渐进披露三级(discovery/activation/execution)随之全部开箱可用。pi 工具的 operations 可注入(BashOperations 等),未来 sandbox adapter 换 operations 即可。
 - **打包机制(bundleAgentDefinition)**:运行时只扫定义内的规则不变;dev 在**构建时**用 `bundleAgentDefinition(src, out, {skillPaths})` 把全局/额外挂载的**胜出** skill 整夹(含 scripts/references/assets)物化进产物,部署单元自包含、可直接再装载。败者不进包。
-- **自定义 tools = 代码,显式 `tools:` 注入,不做魔法目录(定稿;曾实现过 `<dir>/tools/*.ts` 自动加载,审查后删除)**。模式(ketchup 验证):项目里的普通 TS 模块实现 `AgentTool`,显式 import + `tools: [...piDefaultTools(cwd), myTool]`(示例 examples/lookup-order-tool.ts)。**删除自动加载的理由**:(a) tool 是代码,开发者已在代码里,显式 import 型检/可重构,魔法目录只省一行 import;(b) 假对称违反分层--定义夹=标准可移植数据,tools=代码属 layer-2;(c) bundle 拷源文件不带 npm 依赖,自包含是假的。无用户入口的部署下声明 tools 的归宿 = `fastagent.config.ts`(config 刀);声明式/可移植的挂工具 = **MCP**(`.mcp.json`,未来一刀)。进程内 code tools 无跨引擎标准,fastagent-on-pi 用 pi `AgentTool`。**pi extensions(含全局自定义 tools)不自动加载**:其契约绑 TUI 宿主(ctx.ui/commands/渲染),headless 无对应物;桥 = 把 `pi.registerTool({...})` 的参数搬成项目 tool 模块(形状几乎相同)。
-- spec 的 `allowed-tools`(实验性)暂不实现;`.mcp.json`(MCP tools)未来一刀。
+- **自定义 tools = 代码,显式 `tools:` 注入,不做魔法目录。** 模式:项目里的普通 TS 模块实现 `AgentTool`,显式 import + `tools: [...piDefaultTools(cwd), myTool]`(示例 examples/lookup-order-tool.ts)。理由:(a) tool 是代码,开发者已在代码里,显式 import 型检/可重构,魔法目录只省一行 import;(b) 假对称违反分层--定义夹=标准可移植数据,tools=代码属 layer-2;(c) bundle 拷源文件不带 npm 依赖,自包含是假的。无用户入口的部署下声明 tools 的归宿 = `fastagent.config.ts`(config 刀);声明式/可移植的挂工具 = **MCP**(`.mcp.json`,future support, not implemented today)。进程内 code tools 无跨引擎标准,fastagent-on-pi 用 pi `AgentTool`。**pi extensions(含全局自定义 tools)不自动加载**:其契约绑 TUI 宿主(ctx.ui/commands/渲染),headless 无对应物;桥 = 把 `pi.registerTool({...})` 的参数搬成项目 tool 模块(形状几乎相同)。
+- spec 的 `allowed-tools`(实验性)暂不实现;`.mcp.json`(MCP tools) is future support, not implemented today.
 
 ### 6.4 跨 runtime 编译(工具链层的真工程)
 

--- a/docs/fastagent.md
+++ b/docs/fastagent.md
@@ -8,56 +8,55 @@ domain: https://fastagent.sh
 
 # FastAgent
 
-> 把你用 Claude Code / Codex vibe 出来的 **agent 定义**(`AGENTS.md` + `skills/`),**零重写**编译、部署成 production 服务——webhook 服务 / 定时 worker / Telegram·Slack bot / 云端常驻 agent,落到任意 runtime(AgentCore / Lambda / Fly / Workers)。
->
-> **agent serving 的 WSGI。** 一套把「触发源 / 部署 target / agent 引擎」三方解耦的 serving 契约(`invoke`)+ 建在 pi 上的参考实现 + 「指向文件夹就部署到任意地方」的工具链。三件套对位:**WSGI(契约)· Werkzeug+gunicorn(实现=pi)· Vercel+Buildpacks(部署)**。引擎/模型/云全中立。
+FastAgent is WSGI for agent serving: it turns an existing agent definition — `AGENTS.md` plus `skills/` — into a production service without rewriting the agent.
 
-## Why this product (AI wedge)
+The product has three pieces:
 
-**触发时刻**:用户对一个本地 agent 满意之后,迟早想要它**在我不盯着的时候也干活**——定时巡检、收 webhook、随时在 Telegram 找得到。就在这一刻,本地工具模式(pi / Claude Code / Codex)必然失效。
+1. **Contract** — the [Agent Handler SPEC](SPEC.md): `invoke(scope, prompt) => AsyncIterable<AgentEvent>`.
+2. **Reference implementation** — a pi-based engine binding that fans pi's harness events into the SPEC stream.
+3. **Deployment toolchain** — point at a folder, build an artifact, and run it on a target runtime.
 
-**今天的缺口**:每个 coding-agent 用户都已攒下 agent 定义文件夹(`AGENTS.md` + `skills/` + 标准 markdown),却**没有一条不重写就能把它变成 production 服务的路**。这个 artifact 正在成为 agent 的事实创作形态(AGENTS.md / Agent Skills / MCP 标准 2025–26 收敛中),而"部署这个 artifact"无人认领——serving 这层的「触发源↔agent」中立契约是空的(ACP=editor、A2A=agent 网络,都不填)。
+FastAgent is not an agent-writing framework. The agent already exists as markdown-native definition files created in tools such as pi, Claude Code, or Codex. FastAgent serves and deploys that artifact.
 
-**AI wedge**:fastagent **消费标准、不另立格式**,于是你 vibe 出来的文件夹**零重写**就是部署产物——`point-at-folder → live service`。这是 code-first 框架(Flue)结构上吃不到的人群,也是成品助理(OpenClaw)主动放弃的通用性。
+## Why this product exists
 
-**防御**:不锁模型 / 不锁云 / 不锁某个 coding agent。平台吸收**已是现实**(Claude Agent SDK + 官方《Hosting》文档、OpenCode `serve`),但它们都锁自己的引擎。开放中立是唯一持久防线——正是 WSGI 当年靠中立把 N×M 适配收敛成 N+M 的方式。
+The trigger moment is simple: a developer has a local agent they like, then wants it to work while they are not watching — receive webhooks, run on a schedule, answer from Telegram/Slack, or live behind an API endpoint.
+
+Local interactive tools do not solve that serving problem. Cloud/platform offerings increasingly do, but they usually lock one engine, one model provider, or one host. FastAgent's durable bet is neutrality across:
+
+- agent definitions (`AGENTS.md`, Agent Skills, future MCP support),
+- engines (pi first; other engines later),
+- channels/triggers,
+- deployment targets.
 
 ## Product boundary
 
-FastAgent is the product unit in this repository: a neutral agent-serving contract (`invoke`), a pi-based reference implementation, and a deployment toolchain for turning existing agent definitions into services on any runtime.
+FastAgent owns the serving layer:
 
-## Design summary
+- **In scope:** the Agent Handler contract, the pi reference implementation, local dev, build/start, and target adapters.
+- **Out of scope:** inventing a new agent definition format, replacing the harness engine, building a full workflow/task orchestration product, or becoming a code-first agent framework.
 
-> **Conclusion: FastAgent is agent-serving WSGI (contract + reference implementation + deployment toolchain), not a Flask-style application framework.** The supporting design rationale lives in the documents below.
+You can build products such as multi-channel assistants or A2A task systems on top of FastAgent, but those products are not FastAgent itself.
 
-### 文档导航(本目录)
+## Documentation
 
-| 文档 | 内容 |
+| Document | Purpose |
 |---|---|
-| [SPEC](SPEC.md) | **Agent Handler 协议规范**(契约层,引擎中立):`invoke(scope, prompt) => AsyncIterable<AgentEvent>`、5 事件、3+1 MUST、宗 ASGI、对标 fetch handler |
-| [positioning](positioning.md) | 战略定位:用户需求 / 市场 / 生态位 / 竞品矩阵 / 历史类比 / SWOT / 明确不做什么 |
-| [core-design](core-design.md) | 核心设计:agent serving 的 WSGI(契约层/实现层分清)、pi 双口 fan-in 成 SPEC 单流(toAgentEvent/toTerminal 两 translator)、无状态多-session(每 invoke 现起 harness)、装配点二维归类、tools/skills 挂载、config v1、对外 consume A2A/ACP、跨 runtime 编译 |
-| [comparisons](comparisons.md) | Flue / OpenClaw / pi 深度对比 + "GitHub issue 三连" worked example |
+| [SPEC](SPEC.md) | Locked v0.1 Agent Handler contract |
+| [core-design](core-design.md) | The pi reference implementation and current core architecture |
+| [positioning](positioning.md) | Product strategy, wedge, risks, and boundaries |
+| [comparisons](comparisons.md) | Comparison with Flue, OpenClaw, Claude Agent SDK, OpenCode, and pi |
+| [session](session.md) | Draft session-admin model for fork/navigation beyond linear invoke |
 
-### 关键结论速记
+## Current status
 
-- **占 WSGI 那一格,不是 Flask。** fastagent 不是写 agent 的框架(agent = pi 引擎 + 你的 markdown 定义),是让现成 agent 能被服务/部署的中立层。三件套:WSGI(契约)· Werkzeug+gunicorn(参考实现=pi)· Vercel+Buildpacks(部署工具链)。
-- **invoke = agent serving 的 WSGI 位**:不对外(对外是 HTTP/A2A/ACP),是「触发源/target/引擎」三方解耦的中立契约。WSGI 不对外,invoke 不对外恰恰证明它在 WSGI 位,不是反例。
-- **对 pi 的依赖收敛到两个 translator**(`toAgentEvent` 流内事件 + `toTerminal` 终局):非 pi 引擎实现同样的映射就能提供 invoke。早期「AgentObservation 8 语义」设计已坍缩进 SPEC 的 5 事件单流。
-- **建在 `AgentHarness`(pi-agent-core),不是 `AgentSession`(TUI 封装)**:前者 `prompt()=>AssistantMessage` buffered,是 invoke 天然底座。
-- **无状态多-session**(实现为 `createPiAgentFromHarness`/`createPiAgent`):每 invoke 现起一个绑 session 的 harness,用完即弃;唯一活态是"在飞的 turn"。能 serverless、部署 AgentCore 的地基。
-- **真空缺 = markdown-native + 引擎/target/云中立的跨 runtime 部署**:试金石 = 一条命令把现成 `AGENTS.md`+`skills` 部署到 AgentCore 跑通。没人做到(Claude SDK 锁 Claude、OpenCode serve 锁 OpenCode、ADP 要写新 manifest)。
-- **对外 consume 标准,不另立 wire**:A2A(agent 网络,只在 Message 层)/ ACP(editor,角色倒置→只能可选 channel)/ webhook(主入口无标准,自定义)。invoke 不对齐 A2A 数据模型(pi-shaped),双 seam 喂 A2A 的 push executor。
-- **术语校准**:业界 Agent = Model + Harness,harness 含 turn loop = pi 的 `AgentHarness`;你的 `AGENTS.md`+`skills` 文件夹本文称 **agent 定义**,不叫 harness。
-- **护城河**:契约设计 + **无状态跨 runtime 解耦**(moat,工程积累)+ 部署 DX(wedge,可复制)+ 开放中立。
-- **两个悬顶风险(已是现实)**:薄层感知价值薄;平台吸收(Claude Agent SDK Hosting / OpenCode serve 已发生)。中立是唯一持久防线;「成为标准」是上行期权,不是 base case。
+Core v0.1 local development is closed:
 
-### ⚠️ 状态与边界
+- SPEC reference implementation over pi,
+- L0–L3 assembly ladder,
+- HTTP/SSE channel,
+- `fastagent dev`,
+- persistent jsonl sessions under `.fastagent/sessions`,
+- executable SPEC conformance tests.
 
-- [core-design](core-design.md) is the implementation-design source of truth; the code source of truth is `core/`.
-- **"跨人/跨项目/跨组织调度"** 是你**用 fastagent 造出来的一类 app**(A2A Task 层 / workflow,framework 之上),不是 framework 本身——三件套在"组织级 Agent 协作"场景的落点,不与"serving 的 WSGI"产品形态冲突。
-- **autonomy 安全(狂徒锁链落点)= v2 纵深**,不是第一性发生点;部署通了之后才成为下一道缝。
-
-## 现状
-
-core v0.1 本地 dev 链路已闭合:SPEC 参考实现(pi 双口 fan-in)、L0–L3 装配阶梯、HTTP/SSE channel、`fastagent dev`、持久 session(jsonl,重启存活)。下一步:`build`/`start`,再到 AgentCore target adapter(试金石)。
+Next product step: `fastagent build` and `fastagent start`, then an AgentCore target adapter.

--- a/docs/fastagent.md
+++ b/docs/fastagent.md
@@ -1,18 +1,9 @@
 ---
-type: unit-page
-unit: fastagent
-scope: product
-entity: ai-creator-llc
-created: 2026-05-27
-last_updated: 2026-06-05
-archived: false
+title: FastAgent
+type: product-overview
+status: design
+updated: 2026-06-11
 domain: https://fastagent.sh
-repos:
-  - Sukitly/fastagent-mono # 已弃;代码真相在本 repo core/(从头重建,不背兼容)
-owners:
-  - alex
-  - vincent
-  - shuqian
 ---
 
 # FastAgent
@@ -31,19 +22,13 @@ owners:
 
 **防御**:不锁模型 / 不锁云 / 不锁某个 coding agent。平台吸收**已是现实**(Claude Agent SDK + 官方《Hosting》文档、OpenCode `serve`),但它们都锁自己的引擎。开放中立是唯一持久防线——正是 WSGI 当年靠中立把 N×M 适配收敛成 N+M 的方式。
 
-## 与 kua.ai 三件套的边界
+## Product boundary
 
-讨论中明确了三个概念的边界:
+FastAgent is the product unit in this repository: a neutral agent-serving contract (`invoke`), a pi-based reference implementation, and a deployment toolchain for turning existing agent definitions into services on any runtime.
 
-- **狂徒锁链** = 权限 / 决策边界 / 谁能做什么 + 给非技术人安全感
-- **主职智能** = AI 增强每个人的主职业状态, 不把人训练成全才
-- **FastAgent** = agent serving 的 WSGI(`invoke` 契约)+ 参考实现 + 部署工具链;把现成 agent 定义编译/部署到任意 runtime 的中立 serving 层
+## Design summary
 
-三者不同层, 在"组织级 Agent 协作"场景汇合。FastAgent 是其中**唯一**当前 product unit 化的部分; 狂徒锁链 / 主职智能 是 vision-level 概念, 跨多 product 体现。
-
-## 设计探索 (2026-06 session)
-
-> 一串 from-scratch 设计 + 读透 pi / ACP / A2A 真实 API 的 session。**结论:产品形态是 agent serving 的 WSGI(契约 + 参考实现 + 部署工具链),不是 Flask 式应用框架。** 完整推导见下面三篇。
+> **Conclusion: FastAgent is agent-serving WSGI (contract + reference implementation + deployment toolchain), not a Flask-style application framework.** The supporting design rationale lives in the documents below.
 
 ### 文档导航(本目录)
 
@@ -69,7 +54,7 @@ owners:
 
 ### ⚠️ 状态与边界
 
-- 本设计以 [core-design](core-design.md) 为权威口径;代码真相在本 repo 的 `core/`(旧 `fastagent-mono`已弃,不背兼容)。
+- [core-design](core-design.md) is the implementation-design source of truth; the code source of truth is `core/`.
 - **"跨人/跨项目/跨组织调度"** 是你**用 fastagent 造出来的一类 app**(A2A Task 层 / workflow,framework 之上),不是 framework 本身——三件套在"组织级 Agent 协作"场景的落点,不与"serving 的 WSGI"产品形态冲突。
 - **autonomy 安全(狂徒锁链落点)= v2 纵深**,不是第一性发生点;部署通了之后才成为下一道缝。
 

--- a/docs/fastagent.md
+++ b/docs/fastagent.md
@@ -49,10 +49,10 @@ owners:
 
 | 文档 | 内容 |
 |---|---|
-| [[SPEC]] | **Agent Handler 协议规范**(契约层,引擎中立):`invoke(scope, prompt) => AsyncIterable<AgentEvent>`、5 事件、3+1 MUST、宗 ASGI、对标 fetch handler |
-| [[positioning]] | 战略定位:用户需求 / 市场 / 生态位 / 竞品矩阵 / 历史类比 / SWOT / 明确不做什么 |
-| [[core-design]] | 核心设计:agent serving 的 WSGI(契约层/实现层分清)、pi 双口 fan-in 成 SPEC 单流(toAgentEvent/toTerminal 两 translator)、无状态多-session(每 invoke 现起 harness)、装配点二维归类、tools/skills 挂载、config v1、对外 consume A2A/ACP、跨 runtime 编译 |
-| [[comparisons]] | Flue / OpenClaw / pi 深度对比 + "GitHub issue 三连" worked example |
+| [SPEC](SPEC.md) | **Agent Handler 协议规范**(契约层,引擎中立):`invoke(scope, prompt) => AsyncIterable<AgentEvent>`、5 事件、3+1 MUST、宗 ASGI、对标 fetch handler |
+| [positioning](positioning.md) | 战略定位:用户需求 / 市场 / 生态位 / 竞品矩阵 / 历史类比 / SWOT / 明确不做什么 |
+| [core-design](core-design.md) | 核心设计:agent serving 的 WSGI(契约层/实现层分清)、pi 双口 fan-in 成 SPEC 单流(toAgentEvent/toTerminal 两 translator)、无状态多-session(每 invoke 现起 harness)、装配点二维归类、tools/skills 挂载、config v1、对外 consume A2A/ACP、跨 runtime 编译 |
+| [comparisons](comparisons.md) | Flue / OpenClaw / pi 深度对比 + "GitHub issue 三连" worked example |
 
 ### 关键结论速记
 
@@ -69,7 +69,7 @@ owners:
 
 ### ⚠️ 状态与边界
 
-- 本设计以 [[core-design]] 为权威口径;代码真相在本 repo 的 `core/`(旧 `fastagent-mono`已弃,不背兼容)。
+- 本设计以 [core-design](core-design.md) 为权威口径;代码真相在本 repo 的 `core/`(旧 `fastagent-mono`已弃,不背兼容)。
 - **"跨人/跨项目/跨组织调度"** 是你**用 fastagent 造出来的一类 app**(A2A Task 层 / workflow,framework 之上),不是 framework 本身——三件套在"组织级 Agent 协作"场景的落点,不与"serving 的 WSGI"产品形态冲突。
 - **autonomy 安全(狂徒锁链落点)= v2 纵深**,不是第一性发生点;部署通了之后才成为下一道缝。
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -3,8 +3,6 @@ title: fastagent — 战略定位
 type: product-positioning
 status: design
 updated: 2026-06-05
-share_link: https://qsort.me/fjlg0unp
-share_updated: 2026-06-08T16:43:28+08:00
 ---
 
 # fastagent 战略定位

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,123 +1,81 @@
 ---
-title: fastagent — 战略定位
+title: fastagent — Positioning
 type: product-positioning
 status: design
-updated: 2026-06-05
+updated: 2026-06-11
 ---
 
-# fastagent 战略定位
+# fastagent positioning
 
-> 索引 [fastagent](fastagent.md) · 同目录 [core-design](core-design.md) · [comparisons](comparisons.md)
+## North star
 
-> 多角度盘点:用户需求 / 市场 / 生态位 / 竞品 / 历史类比 / SWOT。诚实优先,风险摆台面。
+You already have an agent: a folder with `AGENTS.md`, `skills/`, and standard markdown assets. FastAgent should let you point at that folder and turn it into a production service — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent — without rewriting the agent.
 
-## 北极星
+FastAgent is WSGI for agent serving: a neutral `invoke` contract plus a pi-based reference implementation plus a deployment toolchain.
 
-> **你已经把 agent vibe 出来了——它是你的 `AGENTS.md` + `skills/` 文件夹(一份 agent 定义)。fastagent 不碰它,加一份 config 就把它编译、部署成 production 服务:webhook 服务、定时 worker、Telegram/Slack bot、云端常驻 agent——落到任意 runtime(AgentCore / Lambda / Fly / Workers)。一份可移植定义,任意 target,引擎/模型/云全中立。**
+It is **not**:
 
-fastagent = **agent serving 的 WSGI**:把「触发源 / 部署 target / agent 引擎」三方解耦的中立契约(`invoke`)+ 建在 pi 上的参考实现 + 「指向文件夹就部署」的工具链。**不是** Flask 式应用框架(你不在它里面写 agent,agent 是 pi 引擎 + 你的 markdown 定义),**不是** code-first SDK,**不是** batteries-included 产品。
+- a code-first agent SDK,
+- a new agent definition format,
+- a batteries-included assistant product,
+- a replacement for the harness engine.
 
-> 术语:业界 **Agent = Model + Harness**,harness 含 turn loop = pi 的 `AgentHarness`。你的 `AGENTS.md`+`skills` 文件夹本文称 **agent 定义**,不叫 harness。
+## Primary user wedge
 
----
+The sharpest user segment is the developer or power user who already has useful agent definition folders and wants them to run when they are not present.
 
-## 1. 真实用户需求
-
-收紧的触发点:
-
-> 用户对一个本地 agent 满意之后,迟早想要它**在我不盯着的时候也干活**——定时巡检、收 webhook、Telegram 随时找得到。**就在这一刻,本地工具模式(pi/Claude Code)必然失效,fastagent 成为唯一的路。**
-
-| 人群 | 需求强度 | 契合 | 风险 |
-|---|---|---|---|
-| **A. 个人/power user**:攒了有用的 agent 定义,想让它自己跑 | 中,人群巨大且在涨 | **最高**,markdown-native 正中 | 很多人满足于本地按需跑,deploy 需求比人群浅 |
-| **B. 团队把 agent 做进产品**:要 typed 输出/auth/可观测/上自家 infra | 高,有钱 | 中,但他们**会写代码**,更可能用 SDK | 竞争最激烈,markdown 优势最弱 |
-| **C. indie hacker 做 agent 产品** | 高,重 DX | 中,和 Flue 抢同批人 | 直接撞 Flue |
-
-**最锐、竞争最少、最契合的是 A 的"零重写把文件夹变成 always-on 服务、跑在任意地方"。** 诚实警告:deploy 需求的**深度可能比定义-文件夹人群规模浅**——叙事必须咬住"我不在时它要干活"这个本地模式必然崩的时刻,而非泛泛"productionize"。
-
-## 2. 市场
-
-- **agent 框架市场已很挤**:LangGraph / Vercel AI SDK / Mastra / CrewAI / OpenAI Agents SDK / Cloudflare Agents …… 绝大多数是 **code-first 编排**。
-- **"部署/serving agent"作为 framing**:基本是**基础设施厂商自留地**(Cloudflare Agents/DO、Vercel、AWS AgentCore)——锁进它们的云。
-- **markdown-native + 跨 runtime 中立这一格**:产品侧有 OpenClaw,**serving 契约层几乎空白**。真空。
-- **serving 层的契约标准是空的**:ACP=editor↔agent(假设人在环 + editor 提供环境)、A2A=agent↔agent 网络(假设已是 running endpoint),**两个都不填「触发源↔agent」的 serving 砖缝**。webhook/cron 这个 serving 主入口干脆无标准。
-- **时机对**:AGENTS.md / Agent Skills / MCP 正在 2025–26 收敛;每个 coding agent 都在产出定义文件夹,**这个 artifact 正在变成事实标准,而"部署它"无人认领。**
-
-**最大威胁 — 平台吸收(已是现实,不是未来)**:
-- **Claude Agent SDK + 官方《Hosting the Agent SDK》** 已经在教你把 Claude Code 跑成生产服务(subprocess、session、scaling、multi-tenant)——但**锁 Claude 引擎**。
-- **OpenCode `serve`**(163K stars)已是 headless HTTP server + OpenAPI——但**锁 OpenCode**。
-
-**唯一持久防线 = 开放、跨厂商、跨 host、跨引擎**:吃任何 coding agent 的定义、部署到任何 host、不绑任何模型/云/引擎。开放不是美德,是生存策略——WSGI 当年正是靠中立把 N×M 适配收敛成 N+M 活下来。
-
-## 3. 生态位:盟友多、敌人少的水平层
-
-```
-模型层          Anthropic/OpenAI … + pi-ai(provider 抽象)
-引擎层(harness)  pi-agent-core —— turn loop / env / sessions / tools / events   ← 参考实现底座
-serving 契约层   ★ fastagent(invoke = WSGI;markdown-native、引擎/target 中立)  ← 我们在这
-对外 wire 层     HTTP / A2A(agent 网络)/ ACP(editor) —— consume,不另立
-target 层        Node / Fly / CF Workers / AWS AgentCore / Lambda / E2B —— 跨 runtime 编译,正交可插
-产品/app 层      OpenClaw(成品) | A2A Task 编排 | 用契约造出来的东西
-```
-
-**不和 pi 竞争(是它客户),不和 host 竞争(target 它们),不和标准竞争(consume 它们)。** 同层对手只有 Flue,部分重叠 OpenClaw。押注:`invoke` 像 WSGI 一样把「agent 行为 ⊥ 怎么被触发/服务/host」解耦,让 channel/target/wire adapter 在它周围生长。
-
-## 4. 竞品矩阵
-
-| | 层 | agent 怎么定义 | 自带引擎? | 锁厂商/云/引擎? | 主用户 | 动词 |
-|---|---|---|---|---|---|---|
-| **pi-agent-core** | 引擎 | (引擎本身) | —— | 否 | 框架作者 | 跑一个 turn |
-| **fastagent** | **serving 契约+实现+工具链** | **markdown 定义 + config** | 否(用 pi) | **否** | 有定义的人 | **把文件夹变服务、部署任意 target** |
-| **Flue** | 框架 | code-first(TS) | 半(自带 harness) | 否 | 工程师 | 写 agent 再部署 |
-| **OpenClaw** | 产品 | markdown | 是(整套) | 半(是个产品) | 想要助理的人 | 自托管+定制这 app |
-| **Claude Agent SDK** | SDK + hosting | Claude Code 文件夹 | 是 | **是(Anthropic)** | Claude 用户 | 把 Claude Code 跑成服务 |
-| **OpenCode `serve`** | 产品 server | OpenCode | 是 | **是(OpenCode)** | OpenCode 用户 | 跑 OpenCode server |
-| **ACP** | 协议(editor↔agent) | —— | —— | 否 | editor/agent 作者 | IDE 连 agent |
-| **A2A** | 协议(agent↔agent) | —— | —— | 否 | agent 作者 | agent 网络互调 |
-| **AWS AgentCore** | host runtime | (任意,要适配) | —— | **是(AWS)** | AWS 用户 | serverless 跑 agent |
-
-两条结构性差异化:**(a) 唯一 markdown-native + 引擎/模型/云全中立的 serving 层;(b) serving 这层的契约(WSGI 位)目前没人立——ACP/A2A 都在隔壁场景,大厂方案都锁自己生态。**
-
-详细的 Flue / OpenClaw / Claude SDK / OpenCode 拆解见 [comparisons.md](comparisons.md)。
-
-## 5. 历史类比(把定位讲活)
-
-| 类比 | 映射 | 教训 |
+| Segment | Fit | Risk |
 |---|---|---|
-| **① WSGI / PEP-333**(身份,最深) | `invoke` = agent serving 的 WSGI:不对外(对外是 HTTP/A2A/ACP),是「触发源/target/引擎」之间谁都不拥有的中立砖缝。WSGI 把 server⊥app 解耦,催生 gunicorn/uWSGI + Flask/Django 在一个契约周围繁荣 | **agent serving 还没有 WSGI(ACP=editor、A2A=网络都不填);谁立成契约,谁定义这一层** |
-| **② Werkzeug + gunicorn**(参考实现) | pi(`AgentHarness`/`ExecutionEnv`/`SessionRepo`)= 引擎;fastagent 参考实现 = 把契约跑起来的那层 | **先有好用的实现,标准才水到渠成**——不是反过来 |
-| **③ Vercel / Buildpacks**(部署 DX) | "指向我的文件夹 → 零配置编译 → 跑在任意 runtime + URL/channel" | 体感北极星;**但我们是开源 + 开放 target,不锁平台** |
-| **④ TanStack**(架构风格) | `@fastagent/core`(headless `invoke` 单流 = AsyncIterable<AgentEvent>)+ `channel-*`/`target-*` 野蛮生长 | 拥有 headless 中立原语 + 端到端类型,让 adapter 生态生长 |
-| **⑤ Flask**(只剩哲学姿态) | micro / 可组合 / 你装配 / 不 batteries-included / 开放中立 | **保留哲学,但 fastagent 占 WSGI 那格、不是 Flask 那格**——它不是让你写 app 的框架 |
+| Individual/power user with useful local agent definitions | Highest fit: markdown-native, zero rewrite | Deployment need may be shallower than the number of people creating agent folders |
+| Teams building agents into products | Real need, budget, infra expectations | They can write code and may prefer SDKs/frameworks |
+| Indie hackers building agent products | Strong deployment/DX need | Directly overlaps more with code-first frameworks such as Flue |
 
-> 关键修正:旧定位说"我们是 Flask"——错。Flask 是 build-time 应用框架(你用它写 app);fastagent 是 ship-time serving 层(app 已经是你的 markdown + pi)。**fastagent 站在 Flask 下游,占 WSGI 那一格。**
+The story must focus on the moment where local tooling breaks: “I need this agent to act while I am away.” Generic “productionize your agent” is weaker.
 
-## 6. SWOT 与两个悬顶风险
+## Market read
 
-| | |
+Most agent frameworks are code-first orchestration layers: LangGraph, Vercel AI SDK, Mastra, CrewAI, OpenAI Agents SDK, Cloudflare Agents, and similar systems.
+
+Most “agent serving” offerings are owned by infrastructure or platform vendors and naturally pull users into that platform.
+
+The open gap is:
+
+> markdown-native + engine-neutral + target-neutral serving for existing agent definitions.
+
+ACP and A2A are important standards, but they sit next to this gap:
+
+- ACP assumes an editor/client environment and human-in-the-loop interaction.
+- A2A assumes an already-running agent endpoint.
+- Neither specifies how a trigger invokes an arbitrary local agent definition as a deployable service.
+
+## Competitive moat
+
+The moat is not code volume. The engine is pi. The durable value is:
+
+1. a small, engine-neutral serving contract,
+2. stateless multi-session execution that can move across hosts,
+3. target adapters that encode hard runtime differences,
+4. deployment DX good enough to feel obvious.
+
+The technical proof point is AgentCore: if an existing `AGENTS.md` + `skills/` folder can be deployed to AgentCore and handle one invocation with external session state, the stateless design is real.
+
+## Threats
+
+1. **Thin-layer perception.** Users may ask why this is more than “pi plus a few scripts.” The answer must be visceral DX: point at a folder, get a running service.
+2. **Platform absorption.** Claude Agent SDK hosting and OpenCode serve already show that platforms will absorb “run my agent as a service.” FastAgent wins only if its neutrality across engines/models/hosts matters enough.
+3. **Standards fragmentation.** FastAgent consumes standards rather than inventing new ones, but the ecosystem may still fragment across several incompatible standards.
+
+## Boundaries
+
+| Boundary | Why |
 |---|---|
-| **S** | 唯一 markdown-native + 全中立的 serving 层(真空);serving 契约位无人立;无状态跨 runtime 解耦是工程壁垒;契约小而开放,盟友多敌人少 |
-| **W** | 薄层 = **感知价值薄**("为啥不直接 pi + 几个脚本");deploy 需求**深度可能浅**;"我们是什么"难讲 |
-| **O** | 成为 agent serving 的事实"部署契约"(像 WSGI 之于 Python web);adapter 生态社区化生长;随 AGENTS.md/Skills/MCP/A2A 一起赢;**做穿 AgentCore = 证明无状态设计 payoff** |
-| **T** | **平台吸收已发生**(Claude Agent SDK Hosting / OpenCode serve);Flue 同层更快执行;大厂出竞品契约标准(A2A / Agent Executor);**标准不收敛** → "consume 标准"变"consume 5 个互不兼容标准" |
+| Do not compete with OpenClaw on channels/product UX | FastAgent is a layer for building OpenClaw-like products, not the product itself |
+| Do not become a code-first SDK | The wedge is “your folder is the agent” |
+| Do not invent a parallel agent definition format | Consume `AGENTS.md`, Agent Skills, and MCP rather than competing with them |
+| Do not own Task orchestration in core | A2A Tasks/workflows belong above the Agent Handler contract |
+| Do not rebuild the harness engine | pi owns the turn loop; FastAgent serves and deploys it |
+| Do not weld channels or targets into core | Core owns the contract; adapters own external wires and host-specific deployment |
 
-**最该正视的两个:**
+## One-line summary
 
-1. **感知价值薄,是薄层的原罪。** WSGI/Flask 早期也被骂"不就是加几个装饰器"。破法只有一个:**DX 好到产生"原来这么简单"的情绪**——`point-at-folder → deploy anywhere` 必须丝滑到像魔法。契约干净是必要,**上手体感才是充分**。
-2. **平台吸收是悬顶之剑,而且剑已出鞘。** Claude Agent SDK Hosting、OpenCode serve 已经在做"把 agent 跑成服务"——但都锁自己引擎。你赢的唯一方式:那天到来时,你已是**跨所有模型、所有云、所有 coding agent 的开放中立层**,而它们只能锁自己的生态。
-
-## 7. 明确不做什么(边界)
-
-| 边界 | 为什么 |
-|---|---|
-| **不和 OpenClaw 拼渠道** | 那是 OpenClaw 主场;在"做更好的私人助理"上必输。我们是你**用来造** OpenClaw-like 的层 |
-| **不变 code-first SDK** | 那是 Flue 主场。差异化是"你的文件夹就是 agent",一旦让人 code agent 就蒸发 |
-| **不另立 wire / 不造平行 agent 格式** | 内容层 consume AGENTS.md/Skills/MCP;对外 wire consume A2A/ACP/OCI。`invoke` 是**内部**契约,不对外、不对齐任何单一 wire 数据模型 |
-| **不做 Task 编排层** | A2A 的 Task 状态机 / Artifact 版本 / 长任务查询 = **app 层**(adapter + userland),不进 core。"跨人/跨组织调度"是用 fastagent 造的 app,不是 framework |
-| **不重造 harness 引擎** | 建在 pi 上。拥有 turn loop = 永久追前沿、零定位收益 |
-| **不把 channel/target 焊进 core** | core 拥有**契约**不拥有**实现**。守住"小核、你装配"(WSGI/TanStack)的承诺 |
-| **不靠对齐单一引擎换便利** | 事件流归一(`AgentEvent`)+ 终局归一(`completed`/`failed`)让 invoke 引擎中立——这是"可被任意引擎实现"的前提,不能为贴 pi 牺牲 |
-
-## 一句话收口
-
-> 护城河不是代码量(引擎是 pi 的),是**契约设计 + 无状态跨 runtime 解耦 + 部署 DX + 开放中立**。fastagent 赌的是:**agent serving 缺一个 WSGI,而它正好长在这个位置——让一代人觉得"把 vibe 出来的 agent 定义变成线上服务、跑在任意地方,就该这么简单"。** 「成为事实标准」是 huge upside,不是 base case;base case 是参考实现 + 部署 DX 本身够好用(WSGI 也是先有 gunicorn 好用)。
+FastAgent bets that agent serving needs a WSGI-like neutral layer: small enough to implement everywhere, useful enough to make “deploy this existing agent folder anywhere” feel like the default path.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -9,7 +9,7 @@ share_updated: 2026-06-08T16:43:28+08:00
 
 # fastagent 战略定位
 
-> 索引 [[fastagent]] · 同目录 [[core-design]] · [[comparisons]]
+> 索引 [fastagent](fastagent.md) · 同目录 [core-design](core-design.md) · [comparisons](comparisons.md)
 
 > 多角度盘点:用户需求 / 市场 / 生态位 / 竞品 / 历史类比 / SWOT。诚实优先,风险摆台面。
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -7,9 +7,9 @@ updated: 2026-06-09
 
 # Session — fastagent session-admin 标准(草案)
 
-> 索引 [[fastagent]] · 协议 [[SPEC]] · 实现 [[core-design]]
+> 索引 [fastagent](fastagent.md) · 协议 [SPEC](SPEC.md) · 实现 [core-design](core-design.md)
 
-> **`invoke`(见 [[SPEC]])让对话向前长一节;session-admin 管对话的树:读历史 / fork / 回退。两个正交面。** 本文定义后者——一个 event-sourced DAG + 分层解耦。`status: design`,**不冻进 locked SPEC**(SPEC §10:Task 编排/长任务状态 = 上层)。它是 fastagent 的标准扩展(moat),会演进;接口待第一个要分支/回退的 channel/UI 拉动再定型。
+> **`invoke`(见 [SPEC](SPEC.md))让对话向前长一节;session-admin 管对话的树:读历史 / fork / 回退。两个正交面。** 本文定义后者——一个 event-sourced DAG + 分层解耦。`status: design`,**不冻进 locked SPEC**(SPEC §10:Task 编排/长任务状态 = 上层)。它是 fastagent 的标准扩展(moat),会演进;接口待第一个要分支/回退的 channel/UI 拉动再定型。
 
 ## 1. 心智模型:Git for conversations(minus merge)
 
@@ -171,5 +171,5 @@ interface SessionStore {
 ## 9. 与 core / SPEC 的关系 + N×M×K 对齐
 
 - **invoke(SPEC)**:`scope.session` 保持 opaque string = 沿 current 线性续接。**session-admin 不进 invoke / 不进 `Scope`。**
-- **core([[core-design]] §6.5)**:已记录"tree/fork 跨 host 可移植"结论;本文是其展开。
+- **core([core-design](core-design.md) §6.5)**:已记录"tree/fork 跨 host 可移植"结论;本文是其展开。
 - **N×M×K**:N(①)、K(③a)是**现在就标准化**的缝;M 的"中立核 ②"现在就立(因薄 host 缝),但 M 的"引擎适配 ③b"**只分模块、不冻接口**——M 轴真正的可换引擎,等第二个引擎兑现。

--- a/docs/session.md
+++ b/docs/session.md
@@ -1,175 +1,100 @@
 ---
-title: Session — fastagent session-admin 标准(草案)
+title: Session — fastagent session-admin draft
 type: design-doc
-status: design
-updated: 2026-06-09
+status: draft
+updated: 2026-06-11
 ---
 
-# Session — fastagent session-admin 标准(草案)
+# Session-admin draft
 
-> 索引 [fastagent](fastagent.md) · 协议 [SPEC](SPEC.md) · 实现 [core-design](core-design.md)
+The Agent Handler [SPEC](SPEC.md) defines one operation: `invoke` advances a conversation by one turn. Session-admin is a separate, higher-level surface for inspecting and moving through the conversation tree: history, fork, and navigation.
 
-> **`invoke`(见 [SPEC](SPEC.md))让对话向前长一节;session-admin 管对话的树:读历史 / fork / 回退。两个正交面。** 本文定义后者——一个 event-sourced DAG + 分层解耦。`status: design`,**不冻进 locked SPEC**(SPEC §10:Task 编排/长任务状态 = 上层)。它是 fastagent 的标准扩展(moat),会演进;接口待第一个要分支/回退的 channel/UI 拉动再定型。
+This document is a draft. It is not part of the locked v0.1 SPEC and is not fully implemented in core today.
 
-## 1. 心智模型:Git for conversations(minus merge)
+## Mental model
 
-session 的结构 = **event sourcing**(只追加日志 + 状态靠 fold 派生)+ **Git 的对象模型**(节点带 parent 指针成 DAG + 一个可移动的 current 指针)。pi 的 session、LangGraph 的 checkpointer 都是这个范式的实例;Git 是原型。**我们 codify 的是这个通用范式,不是某一家的实现。**
+A portable conversation session is an event-sourced DAG:
 
-| Git | 本标准(中立) | 说明 |
-|---|---|---|
-| commit(不可变 + parent) | `entry`(id, parentId) | 不叫 commit——无内容寻址/staging |
-| HEAD | `current` 指针 | 可指任意节点(≈detached HEAD)|
-| reflog(HEAD 移动入日志) | 指针移动 = 追加一条 entry | 只追加,不破坏性改 |
-| checkout/reset(移 HEAD) | `navigate(id)` | 不借 checkout/reset(重载、劝退)|
-| branch / 新 ref | `fork(id?)` → 新 session id | fork 双语境都精确、不过度承诺 |
-| git log(沿 parent 路径) | `getHistory()` | 对话语境用 history |
-| checkout 投影成工作区 | **projection**(引擎特有,见 §6b) | entries → 模型上下文 |
-| merge / rebase | **不引入** | 对话是树,无 merge;引入=制造落空预期 |
+- entries are append-only,
+- each entry has a parent pointer,
+- a current pointer selects the active path,
+- history is derived by walking from current to root,
+- fork creates a new session id from an existing prefix,
+- navigation moves the current pointer without deleting old branches.
 
-**偏差(别过拟合 Git)**:① 无 merge(对话是树,单 parent);② current 可指任意节点;③ 非内容寻址(用时间序 id)。
+The closest analogy is Git for conversations, minus merge/rebase.
 
-## 2. 分层:为什么是这几层(逐层被什么力逼出)
+| Git | Session-admin concept |
+|---|---|
+| commit | immutable `Entry` with `id` and `parentId` |
+| HEAD | current pointer |
+| reflog | pointer moves as append-only entries |
+| branch | `fork(id?) -> new session id` |
+| log | active-path history |
 
-中间那块**永远存在**(consumer 与 host 之间总要有人做树逻辑)。真正的问题是中间切不切。下面是逐层的存在理由——**注意 ② 的理由与引擎数量无关**。
-
-```
-┌─ ① Consumer API(×N:caller / channel / UI)────────────────┐
-│ current() / navigate(id) / fork(id?) / getHistory() /      │  opaque id + 中立 kind/preview
-│ capabilities()                                             │
-└────────────────────────────────────────────────────────────┘
-              ▲ 用(只见 id/kind/preview,不见 payload)
-┌─ ② DAG core(引擎中立,fastagent 自有,写一次)─────────────┐
-│ Entry{id,parentId,kind,payload} + append-only 不变量        │  ← 由「薄 host 缝 + 复用 pi 树」
-│ + 纯图逻辑:getPathToRoot / fork-prefix / navigate(移指针) │     逼出,与引擎数量无关
-└────────────────────────────────────────────────────────────┘
-   ▲ 扁平存储原语(K)              ▲ 解释 payload(M,模块非冻结接口)
-┌─ ③a Host adapter(薄)──────┐   ┌─ ③b Engine 模块(pi 特有)────┐
-│ append / getEntries /       │   │ payload 语义 + 两个 projection │
-│ getEntry / get·setPointer / │   │  · model-context(给 invoke)  │
-│ lease   (payload opaque)    │   │  · display(产 kind+preview)   │
-│ jsonl / pg / ddb / AgentCore│   │ 把 turn 产出包成 payload       │
-└─────────────────────────────┘   └────────────────────────────────┘
-```
-
-**① Consumer**——被 ×N 逼出:多 channel/UI 要一个稳定、可理解的面。与引擎数量无关,现在就需要。
-
-**③a Host(薄)**——被 ×K 逼出:多 host 要一个**好实现**的存储缝。与引擎数量无关,现在就需要。
-
-**② DAG core(中立)**——被 **「薄 host 缝 + 复用 pi 树」** 逼出,**不是被 M 多样性逼出**:要 host 缝薄(只 `append/get/pointer/lease`),图逻辑(`getPathToRoot`/fork/navigate)就**必须**落在 host 之上的 fastagent 里;要复用 pi 的树,这层就是"pi 树逻辑 + 架到薄 host 缝上的胶水"。**所以 ② 现在就该有——这就是"守住 host 缝薄"的必然产物。**
-
-**③b Engine(pi 特有)**——**是模块边界,不是冻结接口**:
-- **分离(现在做,零成本)**:projection/payload 是 pi 特有的;放进单独模块、`②` 不 import pi,使 ② 可审计地保持中立。
-- **冻接口(现在不做)**:只有 pi 一个样本,**不定义 EngineAdapter 契约**(就是我们否过的"从单例抽象")。引擎 #2 来时共同形状才浮现,那时再抽。
-
-> **红线:`navigate` / `fork` 在 ②(纯图操作),绝不下放给 ③b。** 一旦下放,leaf-only/线性引擎就给不了任意节点 navigate,跨 host 可移植的 moat 蒸发。③b 只解释 payload。
-
-## 3. 数据模型:Entry(② 拥有)
-
-```ts
-interface Entry {
-  id: string;                 // opaque,可寻址(navigate/fork 靶点;getHistory 返回)
-  parentId: string | null;    // 父链 → DAG;root 为 null
-  kind: EntryKind;            // 中立元数据,由 ③b 打;② 图操作 + ① 渲染靠它
-  payload: Json;              // 只有 ③b(引擎)解释;对 ②/③a/① opaque
-  preview?: string;           // ③b 产的中立可显示摘要,供 ① 渲染(payload 仍 opaque)
-  timestamp: string;
-}
-
-type EntryKind =
-  | "turn_input"    // 可 fork-before 的边界(≈ user message)
-  | "turn_output"   // assistant / tool 产出
-  | "pointer_move"  // 指针移动(navigate 追加的,payload 记 targetId)
-  | "meta";         // 模型/工具变更、compaction、branch_summary 等
-```
-
-**不变量(event sourcing,跨 host 可移植的根):**
-1. **只追加,不修改、不删除。** 死分支留在日志里,只是不在活跃路径上。
-2. **指针移动也是一条 entry**(`kind:"pointer_move"`)。回退/navigate = 追加,不破坏历史。
-3. **状态靠 fold 派生**:current = 重放日志最后一次 pointer-effect;活跃对话 = 从 current 沿 parentId 到 root。
-
-## 4. ① Consumer API
+## Proposed consumer API
 
 ```ts
 interface SessionAdmin {
   current(session: string): Promise<string | null>;
-  navigate(session: string, entryId: string): Promise<void>;  // 移指针(纯)
-  fork(session: string, entryId?: string): Promise<string>;   // → 新 session id(缺省从 current)
-  getHistory(session: string): Promise<Entry[]>;              // 活跃路径(payload opaque)
+  navigate(session: string, entryId: string): Promise<void>;
+  fork(session: string, entryId?: string): Promise<string>;
+  getHistory(session: string): Promise<Entry[]>;
   capabilities(session: string): Promise<{ fork: boolean; navigate: boolean }>;
 }
 ```
 
-- **opaque id**:用 `getHistory` 的 `entry.id` 作 navigate/fork 靶点;靠 `kind` 判断合法靶点(如只在 `turn_input` 处 fork-before)。
-- **payload 不解释**:UI 用 `kind` + `preview` 渲染。
-- **fork 返回新 session id**(Claude SDK 同款);**绝不把 node-id 塞进 `Scope`**——契约卫生:那会在被忽略时静默 append-to-leaf 写坏对话、并隐藏分支落点。
-- 变更操作(navigate/fork)在 lease 下执行(见 §6a / §7)。
+The `Scope` passed to `invoke` remains unchanged: it only contains the opaque `session` string. Node ids do not go into `Scope`; doing so would make unsupported branching silently append to the wrong place.
 
-## 5. ② DAG core(引擎中立,写一次)
-
-纯图逻辑,跑在薄 ③a 之上,**不 import 任何引擎**:
-
-- `getPathToRoot(current)`:沿 parentId 到 root,反转 → 活跃路径。
-- `fork-prefix`:取靶点前缀路径,写入**新 session**(新 id,记 `parentSession` 血缘)。
-- `navigate`:**纯移指针**——追加一条 `pointer_move` entry + 更新 current。**不做摘要**(branch-summary 是 ③b 的独立 enrichment,见 §6b),否则 ② 被 pi 污染。
-- `capabilities` 推导:依 ③a 能力给出 fork/navigate 是否可用。
-
-**moat 命根**:这些逻辑是 fastagent 的、只要求 ③a 提供 `append+read+lock`,所以任意 host 都拿到全树。
-
-## 6. Adapter
-
-### 6a Host / storage adapter(K)— SessionLogStore 薄原语,payload opaque
+## Proposed entry model
 
 ```ts
-interface SessionLogStore {
-  append(session: string, entry: Entry): Promise<void>;
-  getEntries(session: string): Promise<Entry[]>;        // 扁平,全部
-  getEntry(session: string, id: string): Promise<Entry | undefined>;
-  getPointer(session: string): Promise<string | null>;
-  setPointer(session: string, id: string | null): Promise<void>;
-  lease(session: string): Promise<{ release(): Promise<void> }>;  // 跨进程单写者
+interface Entry {
+  id: string;
+  parentId: string | null;
+  kind: EntryKind;
+  payload: Json;
+  preview?: string;
+  timestamp: string;
 }
+
+type EntryKind = "turn_input" | "turn_output" | "pointer_move" | "meta";
 ```
 
-- **只做存储,不做图遍历**(`getPathToRoot` 在 ②,避免图逻辑下泄到每个 host)。
-- **pointer 双源**:日志是**真相**(重放 `pointer_move`),`getPointer/setPointer` 标量是 **O(1) 缓存**;不变量 `标量 == replay(日志)`。
-- **payload 当 opaque Json** 存取。
-- **lease 守 ② 的所有 mutation**(invoke 的 append + navigate + fork),不只 invoke。
-- 实例:jsonl / pg / ddb / **AgentCore**(只当**短期事件存储**,避开其长期语义抽取把死分支吃进"记忆")。
+`payload` is opaque to the generic DAG layer. Engine-specific modules interpret it and produce display previews or model-context projections.
 
-### 6b Engine 模块(M)— 解释 payload,不碰图逻辑
+## Layering
 
-**职责 = 把 payload 翻译给所有上层**(模块,非冻结接口):
+Session-admin splits into three concerns:
 
-1. **包 payload**:把 turn 产出包成 entry payload,交给 ② 落盘(② 负责 id/parentId/append)。
-2. **打 `kind` + `preview`**(display projection):② 图操作靠 kind,① 渲染靠 kind+preview。
-3. **model-context projection**:把 ② 给的活跃路径折成自己的模型上下文(含 compaction、branch_summary 解释——全引擎特有,② 不懂)。
-4. **branch-summary enrichment(可选)**:navigate 离开一条分支时,若要"留痕",由 ③b 生成一条 `kind:"meta"` 的摘要 entry,作为**独立 append**,**不焊进 `②.navigate`**。
+1. **Consumer API** — stable surface for channels/UIs.
+2. **DAG core** — engine-neutral graph logic: active path, fork-prefix, navigate, capabilities.
+3. **Adapters**:
+   - **Host/storage adapter** (`SessionLogStore`) — append/read/pointer/lease over jsonl, Postgres, DynamoDB, AgentCore, etc.
+   - **Engine module** — interprets payload and projects entries back into the engine's model context.
 
-接入形态(因引擎而异,正因如此不冻接口):
-- **pi**:② 在 pi 的 `SessionStorage` 层接入——payload = pi `SessionTreeEntry`,`kind` 由 `entry.type`/`message.role` 映射(user→`turn_input`,assistant→`turn_output`,leaf→`pointer_move`,其余→`meta`)。
-- **claude / opencode(未来)**:经 transcript 捕获把产出喂给 ②。
+The important rule is that `navigate` and `fork` belong to the generic DAG core, not to an engine module. Engines interpret payload; they do not own graph movement.
 
-> ③b **不实现** navigate/fork(红线)。
+## Relationship to current core
 
-## 7. 审阅留下的不变量与张力(实现的法律)
+Current core already implements the minimum needed for linear session continuity:
 
-1. **navigate 纯粹**:② 只移指针;一切 pi 特有的离场摘要在 ③b,作独立 append。
-2. **payload 单向 opaque**:只有 ③b 解释;②/③a/① 只碰 `id/parentId/kind/preview`。
-3. **pointer 真相在日志**,③a 标量是缓存,维持 `标量 == replay(日志)`。
-4. **lease 守全部 ② mutation**;fork 牵涉两 session(读源前缀 + 写新 id)。
-5. **② 中立是一个赌注,不是证明**:只有 pi 一个样本,`kind` 分类法很可能照 pi 描的;真中立只有引擎 #2 能证伪。好在便宜可逆——赌错只重画 ③b,② 不动。
+- `SessionStore` in `core/src/engines/pi/sessions.ts` is intentionally smaller than this draft: it only needs `openOrCreate(sessionId)` for the pi harness factory.
+- `jsonlSessionStore` provides restart-surviving continuity for `fastagent dev`.
+- `inProcessLease` prevents same-session concurrent writes inside one process.
 
-## 8. 开放问题
+This draft describes the next layer above that minimum: portable fork/navigation and a richer storage seam. To avoid a naming conflict, the future append/read/pointer backend is called `SessionLogStore` here, not `SessionStore`.
 
-- **`kind` 最小集**:`{turn_input, turn_output, pointer_move, meta}` 够不够 ② 图操作 + ① 渲染?
-- **path 读取 O(n)**:② 在扁平 entry 上走 parentId,远程 store 每次 O(n) 读 → 全量载入+缓存(pi 式)/ 物化活跃路径 / 可选 host 侧 path 读。v1 先全量载入。
-- **lease 形状 + 争用策略**:navigate/fork 与在飞 turn 冲突时阻塞 or fail-fast(retryable)?TTL + fencing 防僵尸持有者。
-- **payload stance A vs B**:A(现选)= opaque,session 与引擎绑定,存储跨 host 可移植。B(未来期权)= 标准化 message schema(consume A2A / AG-UI),跨引擎/UI 互解释——大承诺,等消费者拉动。
-- **连续性已接**(§6b 的最小落地):`engines/pi` 的 `piHarnessFactory` 每 invoke **open-or-create**——已有 session 则 `open`(harness 经 `buildContext` = `getPathToRoot` + projection 看到历史),否则 `create`。连续性契约 = 同一 backing store + 同一 session id(jsonlSessionStore 跨进程重启仍连续,in-memory 需复用实例)。这是我们第一次实际碰本标准:`open`=读 substrate,`buildContext`=projection。
-- **并发单写者已接(进程内,fail-fast)**:`createPiAgentFromHarness` 默认 `inProcessLease()`——同 session 已有在飞 turn 时第二个 invoke 立即 `failed{retryable}`("session busy"),**不排队**。这是 **invoke 编排层**只防写坏的地板,不是 §6a host substrate 的 `lease`;dedupe/排队/steering 是 channel/上层决策。**跨进程分布式锁仍 deferred**。尚未接:navigate / fork / 跨进程 lease。
+## Open questions
 
-## 9. 与 core / SPEC 的关系 + N×M×K 对齐
+- Is `{ turn_input, turn_output, pointer_move, meta }` enough for UI rendering and graph operations?
+- Should remote stores materialize active paths, or is full-log read acceptable for v1?
+- What is the distributed lease shape: fail-fast, blocking, TTL, fencing?
+- Should payloads remain engine-bound forever, or should FastAgent eventually standardize a cross-engine message schema?
 
-- **invoke(SPEC)**:`scope.session` 保持 opaque string = 沿 current 线性续接。**session-admin 不进 invoke / 不进 `Scope`。**
-- **core([core-design](core-design.md) §6.5)**:已记录"tree/fork 跨 host 可移植"结论;本文是其展开。
-- **N×M×K**:N(①)、K(③a)是**现在就标准化**的缝;M 的"中立核 ②"现在就立(因薄 host 缝),但 M 的"引擎适配 ③b"**只分模块、不冻接口**——M 轴真正的可换引擎,等第二个引擎兑现。
+## Non-goals for v0.1
+
+- No session-admin API in the Agent Handler SPEC.
+- No node id in `Scope`.
+- No merge/rebase semantics.
+- No attempt to define a stable engine adapter before a second engine exists.

--- a/docs/session.md
+++ b/docs/session.md
@@ -117,10 +117,10 @@ interface SessionAdmin {
 
 ## 6. Adapter
 
-### 6a Host / storage adapter(K)— 薄原语,payload opaque
+### 6a Host / storage adapter(K)— SessionLogStore 薄原语,payload opaque
 
 ```ts
-interface SessionStore {
+interface SessionLogStore {
   append(session: string, entry: Entry): Promise<void>;
   getEntries(session: string): Promise<Entry[]>;        // 扁平,全部
   getEntry(session: string, id: string): Promise<Entry | undefined>;


### PR DESCRIPTION
## Summary

This applies the cleanup scan findings in ordered commits:

- make tests hermetic (no /tmp assumptions, no repo-local `.fastagent` state under fixtures)
- fail visibly on ambiguous config files and invalid JS/MJS tool entries
- translate README + SPEC to English
- replace Obsidian-style wiki links with GitHub Markdown links
- prune process residue/internal metadata from docs and align MCP/session wording
- rewrite remaining public docs in English and reduce duplicated positioning prose
- document API stability tiers instead of pretending low-level pi escape hatches are stable
- update actions/checkout and pi packages

## Validation

- [x] `npm run typecheck` in `core/`
- [x] `npm test` in `core/` (69 passed)
- [x] repository grep for Chinese characters in public md/ts/json/yml/yaml returned no matches
