### PR TITLE
refactor(api): shrink root exports to the supported public surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ This repository is a from-scratch implementation of the locked [Agent Handler SP
 
 ## API stability
 
-This repository is pre-1.0. The stable design center is the Agent Handler contract in [SPEC.md](docs/SPEC.md). The pi reference implementation is intentionally exported for early embedding and testing, but low-level pi escape hatches may change while `build`, `start`, and the first target adapters land.
+This repository is pre-1.0. The stable design center is the Agent Handler contract in [SPEC.md](docs/SPEC.md). The root export (`@fastagent/core`) is deliberately scoped to the supported public surface; pi-coupled internals are not exported and may change freely while `build`, `start`, and the first target adapters land.
 
 Public surface tiers:
 
 | Tier | Examples | Stability |
 |---|---|---|
 | Contract | `Agent`, `AgentEvent`, `collect`, `createInvokeHandler` | Intended to remain stable within SPEC v0.1 |
-| Pi assembly ladder | `createPiAgentFromWorkspace`, `createPiAgentFromDefinition`, `createPiAgent`, `createPiAgentFromHarness` | Usable now, may tighten before 1.0 |
-| Pi internals / escape hatches | prompt/tool helpers, auth/session/lease helpers | Exposed for early adopters and tests; not a long-term compatibility promise yet |
+| Pi assembly ladder | `createPiAgentFromWorkspace`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
+| Injection ports | `SessionStore`, `inMemorySessionStore`/`jsonlSessionStore`, `AuthResolver`, `Lease`, `piDefaultTools`/`piReadOnlyTools` | Public because the ladder options reference them |
+| Not exported | L0 `createPiAgentFromHarness`, `piHarnessFactory`, prompt/config assembly internals | Internal modules only; they expose pi's engine shape and are not a compatibility promise |
 
 ## Build order
 

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -34,41 +34,35 @@ export {
   type SkillCollision,
 } from "./engines/pi/definition.ts";
 
-// pi reference implementation — engine assets & prompt assembly (in create.ts)
+// pi reference implementation — engine assets (prompt base + toolsets, in create.ts).
+// Internal assembly helpers (assembleSystemPrompt, resolveTools) are NOT public:
+// the ladder rungs own assembly; embedders compose via L1/L2/L3.
 export {
   piBasePrompt,
-  assembleSystemPrompt,
-  type AssembleSystemPromptOptions,
   piDefaultTools,
   piReadOnlyTools,
-  resolveTools,
 } from "./engines/pi/create.ts";
 
-// pi reference implementation — config subsystem
+// pi reference implementation — config subsystem.
+// loadConfig is internal (L3 owns config loading); resolveModel bridges a
+// "provider/modelId" string to a model for L1/L2 embedders.
 export {
   defineConfig,
-  loadConfig,
   resolveModel,
   type FastagentConfig,
-  type LoadedConfig,
 } from "./engines/pi/config.ts";
 
-// pi reference implementation — low-level building blocks (escape hatch; L0)
+// pi reference implementation — injection ports referenced by the ladder options.
+// L0 (createPiAgentFromHarness) and the pi harness-factory wiring are deliberately
+// NOT exported: they expose pi's two-port shape and would pin the engine-coupled
+// surface as a public promise before engine #2 exists. Reach them via internal
+// modules for custom wiring/tests.
 export {
-  createPiAgentFromHarness,
-  type CreatePiAgentFromHarnessOptions,
   type Lease,
   type Release,
   inProcessLease,
-  type RetryClassifier,
-  defaultRetryClassifier,
 } from "./engines/pi/invoke.ts";
-export {
-  piHarnessFactory,
-  type AnyModel,
-  type PiHarnessFactory,
-  type PiHarnessFactoryOptions,
-} from "./engines/pi/harness.ts";
+export type { AnyModel } from "./engines/pi/harness.ts";
 export {
   type SessionStore,
   inMemorySessionStore,

--- a/core/test/config.test.ts
+++ b/core/test/config.test.ts
@@ -3,8 +3,9 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { createPiAgentFromWorkspace, loadConfig, resolveModel, resolveTools } from "../src/index.ts";
-import { resolveModelSpec } from "../src/engines/pi/config.ts";
+import { createPiAgentFromWorkspace, resolveModel } from "../src/index.ts";
+import { loadConfig, resolveModelSpec } from "../src/engines/pi/config.ts";
+import { resolveTools } from "../src/engines/pi/create.ts";
 
 const fixtures = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 

--- a/core/test/conformance.test.ts
+++ b/core/test/conformance.test.ts
@@ -8,13 +8,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
-import {
-  createPiAgentFromHarness,
-  inMemorySessionStore,
-  jsonlSessionStore,
-  piHarnessFactory,
-  type SessionStore,
-} from "../src/index.ts";
+import { inMemorySessionStore, jsonlSessionStore, type SessionStore } from "../src/index.ts";
+import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
 
 function piAgent(responses: FauxResponseStep[], sessions: SessionStore = inMemorySessionStore()) {

--- a/core/test/definition.test.ts
+++ b/core/test/definition.test.ts
@@ -7,7 +7,6 @@ import { mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { FileError, err } from "@earendil-works/pi-agent-core";
 import {
-  assembleSystemPrompt,
   bundleAgentDefinition,
   collect,
   createPiAgentFromDefinition,
@@ -18,6 +17,7 @@ import {
   piReadOnlyTools,
   type CreatePiAgentFromDefinitionOptions,
 } from "../src/index.ts";
+import { assembleSystemPrompt } from "../src/engines/pi/create.ts";
 
 const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "agent");
 const extraSkillsDir = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "extra-skills");

--- a/core/test/http.test.ts
+++ b/core/test/http.test.ts
@@ -7,8 +7,9 @@ import {
   registerFauxProvider,
   type FauxResponseStep,
 } from "@earendil-works/pi-ai";
-import { createPiAgentFromHarness, inMemorySessionStore, piHarnessFactory, type Agent, type AgentEvent } from "../src/index.ts";
-import { createInvokeHandler } from "../src/index.ts";
+import { createInvokeHandler, inMemorySessionStore, type Agent, type AgentEvent } from "../src/index.ts";
+import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 
 async function startServer(responses: FauxResponseStep[]) {
   const faux = registerFauxProvider();

--- a/core/test/invoke.test.ts
+++ b/core/test/invoke.test.ts
@@ -8,7 +8,9 @@ import {
   Type,
   type FauxResponseStep,
 } from "@earendil-works/pi-ai";
-import { createPiAgentFromHarness, inMemorySessionStore, inProcessLease, piHarnessFactory, type AgentEvent } from "../src/index.ts";
+import { inMemorySessionStore, inProcessLease, type AgentEvent } from "../src/index.ts";
+import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 
 /** An echo tool for the tool-call path. */
 const echoTool: AgentTool = {

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -5,13 +5,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
-import {
-  createPiAgentFromHarness,
-  jsonlSessionStore,
-  piHarnessFactory,
-  type AgentEvent,
-  type SessionStore,
-} from "../src/index.ts";
+import { jsonlSessionStore, type AgentEvent, type SessionStore } from "../src/index.ts";
+import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 
 /** Agent over an injected store (the store is the variable under test). */
 function makeAgent(sessions: SessionStore, responses: FauxResponseStep[]) {


### PR DESCRIPTION
## Summary

Shrink `@fastagent/core`'s root export to the supported public surface while the repo is still pre-1.0 with no external consumers.

Removed from the root export (kept in their own modules):

- L0 `createPiAgentFromHarness` and `CreatePiAgentFromHarnessOptions`
- `piHarnessFactory`, `PiHarnessFactory`, `PiHarnessFactoryOptions`
- `RetryClassifier`, `defaultRetryClassifier`
- `assembleSystemPrompt`, `AssembleSystemPromptOptions`
- `resolveTools`
- `loadConfig`, `LoadedConfig`

Kept public: the Agent Handler contract, `collect`/`createInvokeHandler`, the L1/L2/L3 ladder, definition/bundle helpers, ladder-referenced injection ports (`SessionStore`, `Lease`, `AuthResolver`, `AnyModel`), and useful bridges (`resolveModel`, `piBasePrompt`, `piDefaultTools`/`piReadOnlyTools`).

Rationale: L0 + `piHarnessFactory` expose pi's two-port engine shape; the others are assembly internals. Exporting them would pin an engine-coupled compatibility promise before engine #2 exists.

Tests now import internal building blocks from their own modules instead of through `index.ts` (matching the existing `resolveModelSpec` precedent), removing a layering smell where tests reached internals via the public door.

## Validation

- [x] `npm run typecheck` in `core/` (examples + tests included)
- [x] `npm test` in `core/` (69 passed)
- [x] README API-stability tiers updated to reflect the smaller surface
