### PR TITLE
docs: add GitHub workflow (CONTRIBUTING, AGENTS, CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Review ownership. Auto-requests a review on the sensitive surfaces named in
+# CONTRIBUTING.md "Review tiers"; it does not block self-merge for low-risk PRs.
+
+# The locked contract and its types.
+/docs/SPEC.md            @kid7st
+/core/src/agent.ts       @kid7st
+
+# The public API surface.
+/core/src/index.ts       @kid7st

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# fastagent — Agent Guide
+
+## What this is
+
+fastagent is WSGI for agent serving: it turns an existing agent definition (`AGENTS.md` + `skills/`) into a production service without rewriting it. Engine-neutral, model-neutral, cloud-neutral.
+
+The stable design center is the Agent Handler contract (`docs/SPEC.md`). The reference implementation is built on pi (`@earendil-works/pi-*`).
+
+## Source of truth
+
+| Document | Purpose |
+|---|---|
+| `docs/SPEC.md` | The locked v0.1 Agent Handler contract. Do not change its semantics without an explicit decision. |
+| `docs/core-design.md` | The pi reference implementation and current architecture. |
+| `docs/session.md` | Draft session-admin model (not implemented; do not treat as built). |
+| `docs/positioning.md`, `docs/comparisons.md` | Strategy and competitive framing. |
+| `CONTRIBUTING.md` | The full GitHub workflow (branch model, PR loop, merge strategy, review tiers). |
+
+Code truth is `core/`.
+
+## Repo map
+
+```
+core/
+├── src/
+│   ├── agent.ts                 # the Agent Handler contract (pure types, no engine import)
+│   ├── collect.ts               # buffered consumption helper
+│   ├── channels/http.ts         # HTTP/SSE channel (consumes only the Agent contract)
+│   ├── cli.ts                   # `fastagent dev` entry point (process side effects live here)
+│   ├── index.ts                 # the public API surface (see README "API stability")
+│   └── engines/pi/              # the pi reference implementation
+│       ├── create.ts            # L1–L3 assembly ladder + engine assets/prompt
+│       ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
+│       ├── harness.ts           # pi harness wiring (factory)
+│       ├── definition.ts        # AGENTS.md + skills loading and bundling
+│       ├── config.ts            # fastagent.config.ts loading + model/precedence
+│       ├── auth.ts              # pi OAuth / env auth resolution
+│       └── sessions.ts          # SessionStore port + in-memory/jsonl backends
+├── test/                        # vitest; faux models by default
+└── examples/                    # library + config usage
+docs/                            # SPEC, design, positioning
+```
+
+## Working rules specific to this repo
+
+- **The contract is engine-neutral.** `core/src/agent.ts` must not import any engine (`@earendil-works/pi-*` only under `core/src/engines/`).
+- **Fail visibly.** Errors must surface; no swallowed exceptions, no silent fallbacks. On the invoke path, failures become `failed` events (SPEC MUST 2), never thrown iteration errors.
+- **Stateless invoke.** Each invoke builds a fresh harness and discards it; durable state lives behind `SessionStore`. Do not introduce in-process session state.
+- **Public surface is scoped on purpose.** `core/src/index.ts` exports only the supported surface. pi-coupled internals (L0 `createPiAgentFromHarness`, `piHarnessFactory`, assembly helpers) are intentionally not exported — import them from their modules for tests/custom wiring, do not re-export them.
+- **The artifact is the truth.** Deployment behavior must come from the bundled definition, not the builder machine's global state.
+
+## GitHub workflow (summary)
+
+Full version: `CONTRIBUTING.md`. The essentials:
+
+1. **Local-first.** Verify locally before opening a PR; do not push to discover bugs in CI.
+   ```bash
+   cd core && npm run typecheck && npm test
+   ```
+2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`.
+3. **Rebase merge by default** (preserve curated commits); squash only to clean up a WIP branch. Merge commits are disabled. `main` enforces linear history; force-push is forbidden.
+4. **Review tiers.** Docs/refactor/tests self-merge after green CI; SPEC, the `Agent` contract, and public API surface wait for review.
+5. **After merge:**
+   ```bash
+   git checkout main && git pull --ff-only && git branch -d <branch> && git fetch --prune origin
+   ```
+
+## Communication
+
+The reader is a senior engineer with full project context. Lead with the conclusion, use tables for structured comparisons, skip obvious reasoning, do not restate, and do not add decorative formatting or meta-narration. Density check: if cutting half the text loses no information, cut it.
+
+优先使用中文回答；面向仓库的产物（代码、注释、文档、commit/PR）一律英文。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to fastagent
+
+This repository follows **GitHub Flow** (single trunk) with a local-first iteration loop. The branch/PR/merge cycle exists to ship verified changes, not to discover bugs in CI.
+
+All repository-facing text — code, comments, docs, commit messages, PR descriptions — is **English**. This is an open-source project for a global audience.
+
+## Branch model
+
+- `main` is the only long-lived branch. It is protected: linear history, required CI, no force-push, no deletion.
+- **Never commit directly to `main`.** Every change lands through a pull request.
+- Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`.
+
+## Local-first iteration
+
+Anything that can be verified locally **must** be verified locally before opening a PR. Pushing speculatively "to see if CI catches it" wastes Actions minutes and pollutes history.
+
+The full local loop is fast:
+
+```bash
+cd core
+npm install
+npm run typecheck      # tsc --noEmit (covers src, test, examples)
+npm test               # vitest --run
+```
+
+Tests use faux models by default, so they validate serving mechanics without network or credentials. A live-model smoke test against a real provider is optional and manual (see `core/examples/`), and requires pi OAuth in `~/.pi/agent/auth.json` plus, behind a proxy, a working `HTTPS_PROXY`.
+
+## Pull request loop
+
+```text
+1. git checkout -b feature/<thing>
+2. ... change code, iterate locally ...
+3. cd core && npm run typecheck && npm test
+4. git push -u origin feature/<thing>
+5. gh pr create --base main           # fill in the PR template
+6. CI green → merge (see "Merge strategy")
+7. After merge: clean up local + remote tracking branches
+```
+
+### After a PR merges
+
+```bash
+git checkout main
+git pull --ff-only
+git branch -d <merged-branch>
+git fetch --prune origin
+```
+
+## Validation before merge
+
+A PR is mergeable only when, in `core/`:
+
+- `npm run typecheck` is clean (TypeScript with `noUnusedLocals`/`noUnusedParameters`),
+- `npm test` passes,
+- CI (`Core checks`, Node 26) is green.
+
+Add or update the smallest relevant tests that prove the change. Reusable SPEC conformance lives in `core/test/spec-conformance.ts`; one-off product-scenario scripts should be run and then deleted, not committed.
+
+## Merge strategy
+
+**Rebase merge is the default**, not squash. This is a deliberate divergence from squash-only workflows: commit messages in this repo are a design asset — each commit explains one decision — and `main` already enforces linear history. Curated, individually meaningful commits should reach `main` intact.
+
+- **Rebase merge** (default): keep the branch's curated, individually meaningful commits.
+- **Squash merge**: collapse a messy WIP branch into one commit before it reaches `main`.
+- **Merge commits are disabled** (they break linear history).
+
+Either way, one branch = one focused change. If a branch grows several unrelated changes, split it into multiple PRs rather than squashing them into an opaque blob.
+
+## Review tiers
+
+This is a small team; review is risk-based, not mandatory on everything.
+
+| Change | Review |
+|---|---|
+| Docs, comments, typos | Self-merge after CI |
+| Semantically-equivalent refactor, added tests | Self-merge after CI |
+| `docs/SPEC.md` (the locked contract), the `Agent` interface, public API surface in `core/src/index.ts` | Wait for review |
+| Anything that deletes a public export or changes error/terminal semantics | Wait for review |
+
+Force-pushing to `main` is forbidden. Long-lived PRs (> ~3 days) should be rebased on `main`.
+
+## Commit and PR messages
+
+- Subject line: `type(scope): summary` (e.g. `fix(config): reject ambiguous config files`).
+- Body: explain the durable *why*, not the editing history. Do not narrate intermediate discussion or "fixed it again" cycles.
+- Do not commit process scaffolding (`*_PLAN.md`, `HANDOFF.md`, `SESSION_*.md`). Fold durable insight into `AGENTS.md` / `README.md` / `docs/`.
+
+## Dependencies
+
+Dependabot opens weekly PRs for npm and GitHub Actions. The pi packages (`@earendil-works/pi-*`) share one monorepo and move together — update them as a group. Re-run `npm run typecheck && npm test` before merging any dependency bump.
+
+The `undici` version is load-bearing for proxy/streaming behavior under Node 26; see the dispatcher comment in `core/src/cli.ts` before changing it.
+
+## Issues
+
+Use the issue forms (`Bug report`, `Feature request`). Bug reports must include a minimal reproduction and the environment (Node version, OS, package version/commit, proxy settings).


### PR DESCRIPTION
## Summary

Add a complete, written GitHub workflow for the repo, adapted from the ketchup `AGENTS.md` workflow section but fitted to a single-package, pre-1.0, open-source library (no Railway/dev/prod/worker).

- **CONTRIBUTING.md** (public, English): GitHub Flow single trunk, branch prefixes, local-first iteration, PR loop, validation commands, review tiers, after-merge cleanup, commit/PR message rules.
- **AGENTS.md** (root, agent-facing): source-of-truth map, repo map, repo-specific invariants (engine-neutral contract, fail-visibly, stateless invoke, scoped public surface, artifact-is-truth), and the workflow essentials.
- **.github/CODEOWNERS**: documents review ownership for `docs/SPEC.md`, the `Agent` contract, and the public API surface.

### Deliberate divergence from ketchup

ketchup mandates squash merge. This repo uses **rebase merge as default** because commit messages here are a design asset (each commit explains one decision) and `main` already enforces linear history. Squash stays available for cleaning up WIP branches.

### Repo settings aligned out-of-band

- merge commits disabled (linear history)
- rebase + squash enabled
- auto-delete merged branches
- allow update-branch

## Validation

- [x] `npm run typecheck` in `core/`
- [x] `npm test` in `core/` (69 passed)
- [x] docs only; no source/behavior change
