### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 the fastagent authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Public surface tiers:
 
 1. **core** (`core/`) — implement the SPEC in code: the reference `invoke` implementation fans pi's two-port harness into one event stream.
 2. **Adapters on both sides** — N-side triggers/channels and K-side hosts/target adapters.
+
+## License
+
+[MIT](LICENSE).

--- a/core/package.json
+++ b/core/package.json
@@ -2,6 +2,7 @@
   "name": "@fastagent/core",
   "version": "0.1.0",
   "description": "Reference implementation of the Agent Handler contract: fan in pi AgentHarness events into the SPEC event stream.",
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=26"


### PR DESCRIPTION
## Summary

License the project under MIT.

- add `LICENSE` (MIT)
- set `core/package.json` `"license": "MIT"`
- link the license from the README

## Validation

- [x] `npm run typecheck` in `core/`
- [x] `npm test` in `core/` (69 passed)
- [x] docs/metadata only; no behavior change
