### PR TITLE
refactor: address architecture-audit findings (port naming + cleanup visibility)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .fastagent/
 *.log
 .DS_Store
+.brooks-lint-history.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ core/
 │       ├── definition.ts        # AGENTS.md + skills loading and bundling
 │       ├── config.ts            # fastagent.config.ts loading + model/precedence
 │       ├── auth.ts              # pi OAuth / env auth resolution
-│       └── sessions.ts          # SessionStore port + in-memory/jsonl backends
+│       └── sessions.ts          # PiSessionStore port + in-memory/jsonl backends
 ├── test/                        # vitest; faux models by default
 └── examples/                    # library + config usage
 docs/                            # SPEC, design, positioning
@@ -45,7 +45,7 @@ docs/                            # SPEC, design, positioning
 
 - **The contract is engine-neutral.** `core/src/agent.ts` must not import any engine (`@earendil-works/pi-*` only under `core/src/engines/`).
 - **Fail visibly.** Errors must surface; no swallowed exceptions, no silent fallbacks. On the invoke path, failures become `failed` events (SPEC MUST 2), never thrown iteration errors.
-- **Stateless invoke.** Each invoke builds a fresh harness and discards it; durable state lives behind `SessionStore`. Do not introduce in-process session state.
+- **Stateless invoke.** Each invoke builds a fresh harness and discards it; durable state lives behind `PiSessionStore`. Do not introduce in-process session state.
 - **Public surface is scoped on purpose.** `core/src/index.ts` exports only the supported surface. pi-coupled internals (L0 `createPiAgentFromHarness`, `piHarnessFactory`, assembly helpers) are intentionally not exported — import them from their modules for tests/custom wiring, do not re-export them.
 - **The artifact is the truth.** Deployment behavior must come from the bundled definition, not the builder machine's global state.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Public surface tiers:
 |---|---|---|
 | Contract | `Agent`, `AgentEvent`, `collect`, `createInvokeHandler` | Intended to remain stable within SPEC v0.1 |
 | Pi assembly ladder | `createPiAgentFromWorkspace`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
-| Injection ports | `SessionStore`, `inMemorySessionStore`/`jsonlSessionStore`, `AuthResolver`, `Lease`, `piDefaultTools`/`piReadOnlyTools` | Public because the ladder options reference them |
+| Injection ports | `PiSessionStore`, `inMemorySessionStore`/`jsonlSessionStore`, `AuthResolver`, `Lease`, `piDefaultTools`/`piReadOnlyTools` | Public because the ladder options reference them |
 | Not exported | L0 `createPiAgentFromHarness`, `piHarnessFactory`, prompt/config assembly internals | Internal modules only; they expose pi's engine shape and are not a compatibility promise |
 
 ## Build order

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -64,7 +64,7 @@ import type { AuthResolver } from "./auth.ts";
 import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
 import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, piHarnessFactory } from "./harness.ts";
-import { type SessionStore, inMemorySessionStore, jsonlSessionStore } from "./sessions.ts";
+import { type PiSessionStore, inMemorySessionStore, jsonlSessionStore } from "./sessions.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 
 // ── §1 tools: pi's real built-in core coding tools (engine assets) ───────────
@@ -190,7 +190,7 @@ export interface CreatePiAgentOptions {
   skills?: Skill[];
   // ── K: where/how it runs ───────────────────────────────────────────────
   /** Session persistence. Defaults to in-memory (embedding/tests); inject jsonlSessionStore for restart-surviving continuity. */
-  sessions?: SessionStore;
+  sessions?: PiSessionStore;
   /** Tool execution environment. Defaults to local NodeExecutionEnv (cwd); production injects sandbox/e2b. */
   env?: ExecutionEnv;
   /** Single-writer lease. Defaults to in-process fail-fast inProcessLease(). */
@@ -232,7 +232,7 @@ export interface CreatePiAgentFromDefinitionOptions {
   /** Extra skills mount directories (see LoadAgentDefinitionOptions.skillPaths). */
   skillPaths?: string[];
   // ── K ──────────────────────────────────────────────────────────────────
-  sessions?: SessionStore;
+  sessions?: PiSessionStore;
   env?: ExecutionEnv;
   lease?: Lease;
   // ── auth ───────────────────────────────────────────────────────────────

--- a/core/src/engines/pi/harness.ts
+++ b/core/src/engines/pi/harness.ts
@@ -7,7 +7,7 @@
  * pi continuity wiring: open-or-create delivers "same session, multi-turn memory".
  *
  * Under the stateless design the harness is discarded after each use; continuity
- * comes from **persisting the session (SessionStore) and re-opening it per invoke** — pi's
+ * comes from **persisting the session (PiSessionStore) and re-opening it per invoke** — pi's
  * prompt() runs buildContext() (getPathToRoot + buildSessionContext), folding the
  * historical entries back into context. This is SPEC portable conformance
  * (no location dependence) made concrete.
@@ -16,7 +16,7 @@ import { AgentHarness } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
 import type { Model } from "@earendil-works/pi-ai";
 import { type AuthResolver, resolvePiAuth } from "./auth.ts";
-import type { SessionStore } from "./sessions.ts";
+import type { PiSessionStore } from "./sessions.ts";
 
 /**
  * pi's Model with the API-shape generic erased — fastagent only passes models
@@ -34,7 +34,7 @@ export type PiHarnessFactory = (session: string) => AgentHarness | Promise<Agent
 
 export interface PiHarnessFactoryOptions {
   /** Session persistence (see sessions.ts). Continuity = same backing store + same session id. */
-  sessions: SessionStore;
+  sessions: PiSessionStore;
   env: ExecutionEnv;
   model: AnyModel;
   tools?: AgentTool[];

--- a/core/src/engines/pi/invoke.ts
+++ b/core/src/engines/pi/invoke.ts
@@ -268,16 +268,19 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         // Both cancel (generator return → finally) and normal completion pass here.
         // Cleanup MUST NOT throw: an abort()/unsub() exception after the terminal
         // was yielded would make iteration throw, polluting an already-closed
-        // event stream (violating SPEC MUST 2 / MUST 3).
+        // event stream (violating SPEC MUST 2 / MUST 3). So we contain the throw
+        // here — but a cleanup failure is abnormal (resource/abort regression), so
+        // surface it visibly instead of swallowing it (fail visibly). A pluggable
+        // sink can replace console.warn once the production logging seam exists.
         try {
           unsub();
-        } catch {
-          // ignore
+        } catch (error) {
+          console.warn(`[fastagent] harness unsubscribe failed during cleanup: ${String(error)}`);
         }
         try {
           await harness.abort();
-        } catch {
-          // ignore
+        } catch (error) {
+          console.warn(`[fastagent] harness abort failed during cleanup: ${String(error)}`);
         }
       }
     } finally {

--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -1,11 +1,16 @@
 /**
  * Session persistence — the K-axis port and its first two backends.
  *
- * SessionStore is the consumer-owned port: exactly what the harness factory needs
+ * PiSessionStore is the consumer-owned port: exactly what the harness factory needs
  * (open-or-create by opaque session id) and nothing more. pi's full SessionRepo
  * surface (list/open/create/delete/fork, backend-specific create options) stays
  * behind the adapters — the invoke path never needs it, and backend-specific
  * requirements (jsonl's `cwd`) stay out of the port.
+ *
+ * The name carries the `Pi` prefix on purpose: `openOrCreate` returns pi's `Session`,
+ * so this port is pi-coupled, not an engine-neutral persistence contract. A neutral
+ * session-log port (see docs/session.md) would be a separate abstraction, justified
+ * only once a second engine provides the real requirement.
  *
  * Continuity contract: same backing store + same session id = same conversation.
  *   - in-memory: continuity bound to the store INSTANCE (gone on restart; tests/embedding);
@@ -20,12 +25,12 @@ import type { Session } from "@earendil-works/pi-agent-core";
 import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 /** What fastagent needs from a session backend: open-or-create by opaque id. */
-export interface SessionStore {
+export interface PiSessionStore {
   openOrCreate(sessionId: string): Promise<Session>;
 }
 
 /** In-process store (pi InMemorySessionRepo). Continuity lives and dies with the instance. */
-export function inMemorySessionStore(): SessionStore {
+export function inMemorySessionStore(): PiSessionStore {
   const repo = new InMemorySessionRepo();
   return {
     async openOrCreate(sessionId) {
@@ -41,7 +46,7 @@ export function inMemorySessionStore(): SessionStore {
  * `cwd` is recorded in session metadata (pi associates sessions with a project
  * directory); defaults to process.cwd().
  */
-export function jsonlSessionStore(options: { dir: string; cwd?: string }): SessionStore {
+export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSessionStore {
   const cwd = options.cwd ?? process.cwd();
   const repo = new JsonlSessionRepo({
     fs: new NodeExecutionEnv({ cwd }),

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -64,7 +64,7 @@ export {
 } from "./engines/pi/invoke.ts";
 export type { AnyModel } from "./engines/pi/harness.ts";
 export {
-  type SessionStore,
+  type PiSessionStore,
   inMemorySessionStore,
   jsonlSessionStore,
 } from "./engines/pi/sessions.ts";

--- a/core/test/conformance.test.ts
+++ b/core/test/conformance.test.ts
@@ -8,12 +8,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
-import { inMemorySessionStore, jsonlSessionStore, type SessionStore } from "../src/index.ts";
+import { inMemorySessionStore, jsonlSessionStore, type PiSessionStore } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
 
-function piAgent(responses: FauxResponseStep[], sessions: SessionStore = inMemorySessionStore()) {
+function piAgent(responses: FauxResponseStep[], sessions: PiSessionStore = inMemorySessionStore()) {
   const faux = registerFauxProvider();
   faux.setResponses(responses);
   return createPiAgentFromHarness({

--- a/core/test/invoke.test.ts
+++ b/core/test/invoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AgentHarness, InMemorySessionRepo, type AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
@@ -148,8 +148,15 @@ describe("invoke fan-in", () => {
     });
 
     // iteration must not throw, and the tail is still completed
-    const events = await drain(agent.invoke({ session: "sg" }, { text: "hi" }));
-    expect(events.at(-1)).toEqual({ type: "completed" });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const events = await drain(agent.invoke({ session: "sg" }, { text: "hi" }));
+      expect(events.at(-1)).toEqual({ type: "completed" });
+      // the swallowed-to-stream cleanup error is still surfaced visibly (fail visibly)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("abort blew up"));
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -5,12 +5,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
-import { jsonlSessionStore, type AgentEvent, type SessionStore } from "../src/index.ts";
+import { jsonlSessionStore, type AgentEvent, type PiSessionStore } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 
 /** Agent over an injected store (the store is the variable under test). */
-function makeAgent(sessions: SessionStore, responses: FauxResponseStep[]) {
+function makeAgent(sessions: PiSessionStore, responses: FauxResponseStep[]) {
   const faux = registerFauxProvider();
   faux.setResponses(responses);
   return createPiAgentFromHarness({

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -137,7 +137,7 @@ The protocol treats an Agent as a black box. The following concerns are injected
 
 | Injection | Meaning |
 |---|---|
-| Session storage | `SessionStore` such as jsonl, Postgres, or DynamoDB |
+| Session storage | an external session store such as jsonl, Postgres, or DynamoDB |
 | Tool execution environment | local process, sandbox, E2B, etc. |
 | Model selection | injected by implementation/assembly |
 | Tools and agent definition loading | assembly-layer concerns |

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -132,7 +132,7 @@ Code tools are different: they are TypeScript/JavaScript modules with dependenci
 
 ## 7. Sessions and statelessness
 
-Each `invoke` creates a fresh harness bound to the requested session and discards it after the turn. Conversation continuity comes from reopening the session from a `SessionStore`:
+Each `invoke` creates a fresh harness bound to the requested session and discards it after the turn. Conversation continuity comes from reopening the session from a `PiSessionStore` (pi-coupled: it returns pi's `Session`):
 
 - L1 default: `inMemorySessionStore()` for embedding/tests.
 - L3 default: `jsonlSessionStore()` under `.fastagent/sessions` for restart-surviving local dev.

--- a/docs/session.md
+++ b/docs/session.md
@@ -79,11 +79,11 @@ The important rule is that `navigate` and `fork` belong to the generic DAG core,
 
 Current core already implements the minimum needed for linear session continuity:
 
-- `SessionStore` in `core/src/engines/pi/sessions.ts` is intentionally smaller than this draft: it only needs `openOrCreate(sessionId)` for the pi harness factory.
+- `PiSessionStore` in `core/src/engines/pi/sessions.ts` is intentionally smaller than this draft: it only needs `openOrCreate(sessionId)` for the pi harness factory, and it is pi-coupled (returns pi's `Session`) on purpose.
 - `jsonlSessionStore` provides restart-surviving continuity for `fastagent dev`.
 - `inProcessLease` prevents same-session concurrent writes inside one process.
 
-This draft describes the next layer above that minimum: portable fork/navigation and a richer storage seam. To avoid a naming conflict, the future append/read/pointer backend is called `SessionLogStore` here, not `SessionStore`.
+This draft describes the next layer above that minimum: portable fork/navigation and a richer storage seam. The future engine-neutral append/read/pointer backend is called `SessionLogStore` here to keep it distinct from the pi-coupled `PiSessionStore` that exists today.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

Triage of the Brooks-Lint architecture audit. Two findings are clean wins consistent with our own conventions and are fixed here; the other two conflict with deliberate prior decisions and are deferred with reasons.

### Fixed

- **SessionStore → PiSessionStore** (Stable Abstractions). `openOrCreate` returns pi's `Session`, so the port is pi-coupled — and `core/src/index.ts`'s own naming convention says pi-coupled exports carry `pi`/`Pi`. The rename makes the coupling honest and frees the neutral name for a future engine-neutral session-log port. Factory names (`inMemorySessionStore` / `jsonlSessionStore`, which name the backend) are unchanged. Docs updated; SPEC §9 de-specified to generic wording (it must stay engine-neutral).
- **Cleanup visibility** (fail visibly). `unsub()` / `harness.abort()` exceptions were swallowed to avoid poisoning the already-terminal stream (SPEC MUST 2/3). They are still contained, but now logged via `console.warn`. The existing MUST-2 cleanup test now also asserts the warning is emitted. No new injection point: a pluggable sink waits for the production logging seam to avoid a single-use abstraction.

Also gitignores `.brooks-lint-history.json` (tool artifact, not a deliverable).

### Deferred (with reasons)

- **Async `Lease.tryAcquire`** — declined for now. The sync interface is deliberate: no `await` sits between acquire and entering `try`, so cancellation always releases in `finally` (no deadlock class). Making it async reopens that window. Our design already states the cross-process distributed lock is a **separate future port**, not this in-process fail-fast floor. With one implementation and no DDB/AgentCore backend yet, making it async is speculative generality. Revisit when the real distributed backend lands.
- **L2 artifact-only default** — real issue, but the clean fix reverses a decision we already flipped once (dev defaults to scanning global skills for local-pi fidelity). Reversing it again is exactly the flip-flop our working rules say to stop and surface rather than silently patch. The deterministic-load guarantee belongs to the future `fastagent start` (it will pass definition-only); decided as part of `build`/`start`, not patched here.

## Validation

- [x] `npm run typecheck` in `core/`
- [x] `npm test` in `core/` (69 passed)
