### PR TITLE
refactor(skills): default to definition-only loading

### DIFF
--- a/core/src/engines/pi/definition.ts
+++ b/core/src/engines/pi/definition.ts
@@ -55,10 +55,13 @@ export interface LoadedDefinition {
 }
 
 /**
- * Default global skills directories (pi parity): pi user-level + the cross-tool
- * standard directory. loadSkills skips missing directories → on a dev machine this
- * matches local pi; on a server with no home it is naturally empty (fallback only —
- * the deploy path materializes via bundleAgentDefinition, the artifact is the truth).
+ * The machine's global skills directories (pi user-level + the cross-tool standard
+ * directory). This is an explicit OPT-IN helper, not a default: loading is
+ * definition-only unless a caller passes these in (e.g. `fastagent dev
+ * --global-skills` for local-authoring fidelity, or `fastagent build
+ * --global-skills` to materialize them into the artifact). Keeping it out of the
+ * default makes "your folder is the agent" structural — the same definition loads
+ * the same skills on every machine, and dev behavior equals deployed behavior.
  */
 export function defaultGlobalSkillPaths(): string[] {
   return [join(homedir(), ".pi", "agent", "skills"), join(homedir(), ".agents", "skills")];
@@ -67,12 +70,14 @@ export function defaultGlobalSkillPaths(): string[] {
 export interface LoadAgentDefinitionOptions {
   env?: ExecutionEnv;
   /**
-   * Skills mount directories. **Default = defaultGlobalSkillPaths() (load globals,
-   * faithful to the local pi experience)**; missing directories are skipped.
-   * Advanced control:
-   *   - `skillPaths: []` → definition-only (deterministic deployment posture);
+   * Extra skills mount directories, appended after the definition-local `skills/`.
+   * **Default = [] (definition-only)**: the agent is exactly its folder, so the same
+   * definition is reproducible across machines and dev mirrors deployment. Missing
+   * directories are skipped. Opt in explicitly:
+   *   - `defaultGlobalSkillPaths()` → load the machine's global skills (local-pi
+   *     fidelity during authoring; not portable, so dev/build must pass it on purpose);
    *   - custom array → precise control over what is mounted;
-   *   - to materialize globals into a deployable artifact → bundleAgentDefinition.
+   *   - to ship globals, materialize them into the artifact via bundleAgentDefinition.
    * Collisions: definition-local skills win (the deployable unit is authoritative);
    * first-wins + surfaced collision.
    */
@@ -102,10 +107,11 @@ export async function loadAgentDefinition(
   const instructions = read.ok ? read.value : undefined;
 
   // Definition-local skills first → definition wins collisions (first-wins).
-  // Default appends the global directories (pi parity).
+  // Default is definition-only ([]): "your folder is the agent". Global/extra
+  // mounts are an explicit opt-in (see skillPaths / defaultGlobalSkillPaths).
   const { skills: raw, diagnostics } = await loadSkills(e, [
     join(root, "skills"),
-    ...(options.skillPaths ?? defaultGlobalSkillPaths()),
+    ...(options.skillPaths ?? []),
   ]);
   const byName = new Map<string, Skill>();
   const collisions: SkillCollision[] = [];

--- a/core/test/definition.test.ts
+++ b/core/test/definition.test.ts
@@ -56,11 +56,18 @@ describe("definition: loadAgentDefinition", () => {
     );
   });
 
-  it("default skillPaths are global directories (pi parity): ~/.pi/agent/skills + ~/.agents/skills", () => {
+  it("defaultGlobalSkillPaths() returns the machine global dirs (opt-in helper, not the default): ~/.pi/agent/skills + ~/.agents/skills", () => {
     const paths = defaultGlobalSkillPaths();
     expect(paths).toHaveLength(2);
     expect(paths[0]).toMatch(/\.pi\/agent\/skills$/);
     expect(paths[1]).toMatch(/\.agents\/skills$/);
+  });
+
+  it("defaults to definition-only when skillPaths is omitted (globals are opt-in, not ambient)", async () => {
+    // No skillPaths → must NOT scan the machine's global skills; only the folder's own.
+    const def = await loadAgentDefinition(fixtureDir);
+    expect(def.skills.map((s) => s.name)).toEqual(["season-words"]);
+    expect(def.collisions).toEqual([]);
   });
 
   it("extra skillPaths mount new skills; definition-local skill wins name collisions and surfaces collision info", async () => {

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -118,15 +118,24 @@ Deliberately not in v1: session/env backend selection, auth overrides, base prom
 
 ## 6. Tools and skills
 
-Skills are markdown/file assets. By default, local dev loads:
+Skills are markdown/file assets. Loading is **definition-only by default**: an agent is exactly its folder (`AGENTS.md` + `skills/`). This is the structural form of "your folder is the agent" — the same definition loads the same skills on every machine, and dev behavior equals deployed behavior. Definition-local skills win name collisions (the deployable unit is authoritative); collisions are surfaced as diagnostics, not swallowed.
 
-- definition-local `skills/`,
-- global pi skills: `~/.pi/agent/skills`,
-- cross-tool global skills: `~/.agents/skills`.
+The machine's global skills (`~/.pi/agent/skills`, `~/.agents/skills`, via `defaultGlobalSkillPaths()`) are an **explicit opt-in**, never a silent default. Defaulting to them would make the agent depend on ambient machine state, break reproducibility, and recreate the "works on my machine, breaks deployed" trap fastagent exists to kill.
 
-Definition-local skills win name collisions because the deployable unit is authoritative. Collisions are surfaced as diagnostics, not swallowed.
+### Skills lifecycle across dev / build / start (spec)
 
-`bundleAgentDefinition` is the build-time step that materializes the winning skill folders into a self-contained artifact. Dropped skills are removed on rebuild so the artifact is the truth.
+| Stage | Default | Opt-in to globals |
+|---|---|---|
+| `createPiAgentFromDefinition` (L2) | definition-only | caller passes `skillPaths` |
+| `fastagent dev` | definition-only (dev == deployed) | `--global-skills` (ephemeral: loads globals for local-authoring fidelity this run only; does not change the artifact) |
+| `fastagent build` | definition-only | `--global-skills` materializes the winning globals into the artifact's `skills/` (the deliberate "I want these to ship" action) |
+| `fastagent start` | always definition-only | n/a — the artifact is already self-contained |
+
+`fastagent dev` must not silently drop globals: when run definition-only, it reports which global skills exist but were not loaded, plus the one-liners to use them (`--global-skills`) or ship them (copy into `skills/` / `build --global-skills`). The "what is actually in my agent?" question is thus answered at dev time (cheap), not at deploy time (expensive).
+
+**Red line:** the only way a global skill reaches production is being materialized into the artifact (`build --global-skills` or copied into `skills/`). `fastagent.config.ts` must never carry a machine path like `~/.agents/skills/foo` as a deploy mechanism — that path does not exist on a teammate's machine, CI, or the server, reintroducing the machine-state dependency. Config describes deployment choices, not "go fetch files from a directory on the build machine."
+
+`bundleAgentDefinition` is the build-time step that materializes the resolved skill set into a self-contained artifact. Dropped skills are removed on rebuild so the artifact is the truth.
 
 Code tools are different: they are TypeScript/JavaScript modules with dependencies. FastAgent does not auto-load a magic `tools/` directory. Projects explicitly import and inject code tools through config or library APIs. Declarative MCP tool mounting via `.mcp.json` is future support, not implemented today.
 


### PR DESCRIPTION
## Summary

Make skill loading **definition-only by default**: an agent is exactly its folder. The machine's global skills become an explicit opt-in, never an ambient default.

### Why

Defaulting to global skills makes the agent depend on ambient machine state, breaks reproducibility (same folder → different agent on different machines), and recreates the "works on my machine, breaks deployed" trap fastagent exists to kill. This corrects the earlier "dev loads globals for local-pi fidelity" decision — that call was made before the build/start/deploy lifecycle was in view; with it in view, definition-only is the coherent default. Re-derived from first principles per the working rules (don't silently flip-flop; re-derive).

### Changes

- `loadAgentDefinition` default `skillPaths`: `defaultGlobalSkillPaths()` → `[]`. L2/L3 inherit. `defaultGlobalSkillPaths()` stays as the explicit opt-in helper.
- Documented the dev/build/start skills lifecycle spec in `core-design.md`:
  - `fastagent dev`: definition-only (dev == deployed); `--global-skills` is an ephemeral opt-in for authoring fidelity; dev must report globals that exist-but-were-not-loaded with the one-liners to use/ship them.
  - `fastagent build`: definition-only; `--global-skills` materializes globals into the artifact's `skills/`.
  - `fastagent start`: always definition-only.
  - Red line: config must never carry a machine skill path (`~/.agents/skills/foo`) as a deploy mechanism.
- Regression test: omitted `skillPaths` ⇒ definition-only.

### Deferred (to build/start)

The `--global-skills` flag wiring (dev/build) and the dev "available-but-not-loaded" report are part of the build/start work; this PR sets the default + locks the spec.

## Validation

- [x] `npm run typecheck` in `core/`
- [x] `npm test` in `core/` (70 passed)
