### PR TITLE
feat(dev): --global-skills opt-in + available-but-not-loaded report

### DIFF
--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -16,12 +16,15 @@ import { parseArgs } from "node:util";
 import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
 import { createInvokeHandler } from "./channels/http.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/create.ts";
+import { defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
 
 function usage(code: number): never {
-  console.error(`usage: fastagent dev [dir] [--port N] [--model provider/modelId]
+  console.error(`usage: fastagent dev [dir] [--port N] [--model provider/modelId] [--global-skills]
 
   dev   assemble the agent definition in dir (default .) and start a local HTTP channel
-        model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts`);
+        model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
+        --global-skills   also load the machine's global skills (~/.pi/agent/skills,
+                          ~/.agents/skills); default is definition-only (dev == deployed)`);
   process.exit(code);
 }
 
@@ -30,6 +33,7 @@ const { positionals, values } = parseArgs({
   options: {
     port: { type: "string" },
     model: { type: "string" },
+    "global-skills": { type: "boolean" },
     help: { type: "boolean", short: "h" },
   },
 });
@@ -62,8 +66,10 @@ try {
 setGlobalDispatcher(new EnvHttpProxyAgent());
 installUndiciFetch();
 
+const globalSkills = values["global-skills"] ?? false;
 const { agent, definition, config, configPath, modelSpec } = await createPiAgentFromWorkspace(dir, {
   model: values.model,
+  globalSkills,
 }).catch((error: unknown) => {
   // User-fixable startup problems (missing model / bad config / broken definition)
   // are thrown as plain `Error` with actionable messages — print just the message.
@@ -77,7 +83,21 @@ console.error(`[fastagent] dir:    ${definition.dir}`);
 console.error(`[fastagent] config: ${configPath ?? "(zero-config)"}`);
 console.error(`[fastagent] model:  ${modelSpec}`);
 console.error(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);
-console.error(`[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
+const loadedSkills = definition.skills.map((s) => s.name);
+console.error(
+  `[fastagent] skills: ${loadedSkills.join(", ") || "(none)"}${globalSkills ? " (incl. global)" : ""}`,
+);
+if (!globalSkills) {
+  // Definition-only by default: surface globals that exist on this machine but were
+  // NOT loaded, so dropped skills are visible at dev time (not discovered at deploy).
+  // A separate scan (dev-only diagnostic); the agent itself stays definition-only.
+  const withGlobals = await loadAgentDefinition(dir, { skillPaths: defaultGlobalSkillPaths() }).catch(() => undefined);
+  const available = (withGlobals?.skills ?? []).map((s) => s.name).filter((n) => !loadedSkills.includes(n));
+  if (available.length > 0) {
+    console.error(`[fastagent] ${available.length} global skill(s) available but not loaded: ${available.join(", ")}`);
+    console.error(`            use in dev: --global-skills | ship: copy into skills/ (or build --global-skills)`);
+  }
+}
 for (const c of definition.collisions) {
   console.error(`[fastagent] warn: skill "${c.name}" collision — using ${c.winnerPath}, ignoring ${c.loserPath}`);
 }

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -45,9 +45,11 @@
  *    the decision, then stops:
  *      - sessions / lease (deployment backends)  → reach L2 (embedding developer);
  *        L3 picks its own default (jsonl under .fastagent/) without exposing a choice;
- *      - base / skillPaths (definition-assembly) → stop at L2 (L2 owns prompt/skill mounting);
+ *      - base / raw skillPaths (definition-assembly) → stop at L2 (L2 owns prompt/skill mounting);
  *      - retryClassifier (engine adaptation)     → stays at L0 (custom-wiring persona);
- *      - L3 exposes only what an operator may say per the config red line (today: the model flag).
+ *      - L3 exposes only what an operator may say: the model flag, and `globalSkills`
+ *        (a semantic authoring-scope toggle — "include the machine's global skills" —
+ *        not raw skillPaths; raw paths stay an L2/embedder concern).
  *    KNOWN DEBT: "L3 accepts no K" is a v1 line, not an invariant — sessions/env ARE
  *    deployment choices semantically. When backend #2 lands (DDB / sandbox env),
  *    this boundary must be re-cut: either config grows K keys (L3 inherits them)
@@ -62,7 +64,7 @@ import { createCodingTools, createReadOnlyTools } from "@earendil-works/pi-codin
 import type { Agent } from "../../agent.ts";
 import type { AuthResolver } from "./auth.ts";
 import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
+import { type LoadedDefinition, defaultGlobalSkillPaths, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, piHarnessFactory } from "./harness.ts";
 import { type PiSessionStore, inMemorySessionStore, jsonlSessionStore } from "./sessions.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
@@ -286,6 +288,13 @@ export async function createPiAgentFromDefinition(
 export interface CreatePiAgentFromWorkspaceOptions {
   /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
   model?: string;
+  /**
+   * Also load the machine's global skills (`~/.pi/agent/skills`, `~/.agents/skills`) on top of
+   * the definition's own `skills/`. Default false = definition-only, so dev mirrors deployment.
+   * This is an authoring-fidelity opt-in (e.g. `fastagent dev --global-skills`); to ship a global
+   * skill, materialize it into the artifact (build --global-skills) — do not rely on this at deploy.
+   */
+  globalSkills?: boolean;
 }
 
 /**
@@ -325,6 +334,9 @@ export async function createPiAgentFromWorkspace(
   const { agent, definition } = await createPiAgentFromDefinition(dir, {
     model: resolveModel(modelSpec),
     tools: resolveTools(config, dir),
+    // Definition-only by default (the agent is its folder); globals are an explicit
+    // authoring-fidelity opt-in, never the deploy path (see ladder rule 2 + §6).
+    skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
     // Sessions persist under the state dir: `fastagent dev` restarts keep
     // conversations — faithful to local pi, which persists sessions too.
     sessions: jsonlSessionStore({ dir: join(stateDir, "sessions"), cwd: dir }),

--- a/core/test/config.test.ts
+++ b/core/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -114,6 +114,30 @@ describe("L3: createPiAgentFromWorkspace (config-driven assembly boundary on the
     await createPiAgentFromWorkspace(dir);
     const { readFile } = await import("node:fs/promises");
     expect(await readFile(join(dir, ".fastagent", ".gitignore"), "utf8")).toBe("*\n");
+  });
+
+  it("globalSkills opt-in loads the machine's global skills; default stays definition-only", async () => {
+    // Point homedir at a temp dir holding one global skill, so defaultGlobalSkillPaths
+    // resolves to it (hermetic: does not depend on the test machine's real ~/.pi).
+    const home = await mkdtemp(join(tmpdir(), "fa-home-"));
+    await mkdir(join(home, ".pi", "agent", "skills", "global-greeter"), { recursive: true });
+    await writeFile(
+      join(home, ".pi", "agent", "skills", "global-greeter", "SKILL.md"),
+      "---\nname: global-greeter\ndescription: A global greeter skill.\n---\nSay hi.\n",
+    );
+    const dir = await mkdtemp(join(tmpdir(), "fa-ws-"));
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };`);
+    const savedHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      const off = await createPiAgentFromWorkspace(dir);
+      expect(off.definition.skills.map((s) => s.name)).not.toContain("global-greeter"); // definition-only
+      const on = await createPiAgentFromWorkspace(dir, { globalSkills: true });
+      expect(on.definition.skills.map((s) => s.name)).toContain("global-greeter"); // opt-in loads it
+    } finally {
+      if (savedHome !== undefined) process.env.HOME = savedHome;
+      else delete process.env.HOME;
+    }
   });
 
   it("missing every model source throws a clear startup error (fail visibly)", async () => {


### PR DESCRIPTION
## Summary

Close the dev-side gap left by the definition-only default (the work that actually belonged to dev, not build/start).

- **L3 `globalSkills` toggle**: `createPiAgentFromWorkspace` gains a semantic `globalSkills` option (default `false` = definition-only, so dev mirrors deployment). Maps to `skillPaths` = `defaultGlobalSkillPaths()` vs `[]`. Raw skillPaths stays an L2 concern; L3 exposes only the operator-level toggle (ladder rule updated).
- **`fastagent dev --global-skills`**: loads the machine global skills for authoring fidelity (ephemeral; changes no artifact).
- **available-but-not-loaded report**: in the default definition-only mode, dev lists global skills that exist but were not loaded, with the one-liners to use them (`--global-skills`) or ship them (copy into `skills/` / `build --global-skills`). A dropped skill is visible at dev time, not at deploy.

Deferred (belongs to start): `start` always definition-only.

## Validation

- [x] `npm run typecheck` in `core/`
- [x] `npm test` in `core/` (71 passed; +1 hermetic globalSkills test via temp HOME)
- [x] smoke-verified the dev startup report in both modes
