### PR TITLE
chore: cleanup scan — drop dead loadConfig branch + doc-map fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ The stable design center is the Agent Handler contract (`docs/SPEC.md`). The ref
 |---|---|
 | `docs/SPEC.md` | The locked v0.1 Agent Handler contract. Do not change its semantics without an explicit decision. |
 | `docs/core-design.md` | The pi reference implementation and current architecture. |
+| `docs/fastagent.md` | Product overview and documentation index (landing page; `status: design`). |
 | `docs/session.md` | Draft session-admin model (not implemented; do not treat as built). |
 | `docs/positioning.md`, `docs/comparisons.md` | Strategy and competitive framing. |
 | `CONTRIBUTING.md` | The full GitHub workflow (branch model, PR loop, merge strategy, review tiers). |

--- a/core/src/engines/pi/config.ts
+++ b/core/src/engines/pi/config.ts
@@ -61,56 +61,55 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     throw new Error(`${dir}: multiple fastagent config files found; keep exactly one (${found.map((p) => basename(p)).join(", ")})`);
   }
 
-  for (const path of found) {
-    const mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
-    const config = mod.default;
-    if (!config || typeof config !== "object") {
-      throw new Error(`${path}: must default-export defineConfig({...})`);
-    }
-    const c = config as FastagentConfig;
-    // Unknown keys throw: defineConfig only type-protects .ts authors; a typo in a
-    // .js/.mjs config (`modle:`) must not silently degrade to zero-config.
-    for (const key of Object.keys(c)) {
-      if (key !== "model" && key !== "tools" && key !== "http") {
-        throw new Error(`${path}: unknown key "${key}" (valid keys: model, tools, http)`);
-      }
-    }
-    if (c.model !== undefined && typeof c.model !== "string") {
-      throw new Error(`${path}: "model" must be a "provider/modelId" string`);
-    }
-    if (c.tools !== undefined && !Array.isArray(c.tools)) {
-      throw new Error(`${path}: "tools" must be an array of AgentTool`);
-    }
-    if (c.tools !== undefined) {
-      for (const [i, tool] of c.tools.entries()) {
-        if (!tool || typeof tool !== "object") {
-          throw new Error(`${path}: "tools[${i}]" must be an AgentTool object`);
-        }
-        const candidate = tool as { name?: unknown; execute?: unknown };
-        if (typeof candidate.name !== "string" || typeof candidate.execute !== "function") {
-          throw new Error(`${path}: "tools[${i}]" must have string "name" and function "execute"`);
-        }
-      }
-    }
-    if (c.http !== undefined && (typeof c.http !== "object" || c.http === null)) {
-      throw new Error(`${path}: "http" must be an object`);
-    }
-    // Same typo discipline one level down: { http: { porrt } } must not silently
-    // fall back to the default port.
-    for (const key of Object.keys(c.http ?? {})) {
-      if (key !== "port") {
-        throw new Error(`${path}: unknown key "http.${key}" (valid keys: port)`);
-      }
-    }
-    if (
-      c.http?.port !== undefined &&
-      (typeof c.http.port !== "number" || !Number.isInteger(c.http.port) || c.http.port < 0 || c.http.port > 65535)
-    ) {
-      throw new Error(`${path}: "http.port" must be an integer 0-65535`);
-    }
-    return { config: c, path };
+  // Exactly one config file at this point (0 and >1 handled above).
+  const path = found[0]!;
+  const mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
+  const config = mod.default;
+  if (!config || typeof config !== "object") {
+    throw new Error(`${path}: must default-export defineConfig({...})`);
   }
-  throw new Error(`${dir}: failed to load fastagent config`);
+  const c = config as FastagentConfig;
+  // Unknown keys throw: defineConfig only type-protects .ts authors; a typo in a
+  // .js/.mjs config (`modle:`) must not silently degrade to zero-config.
+  for (const key of Object.keys(c)) {
+    if (key !== "model" && key !== "tools" && key !== "http") {
+      throw new Error(`${path}: unknown key "${key}" (valid keys: model, tools, http)`);
+    }
+  }
+  if (c.model !== undefined && typeof c.model !== "string") {
+    throw new Error(`${path}: "model" must be a "provider/modelId" string`);
+  }
+  if (c.tools !== undefined && !Array.isArray(c.tools)) {
+    throw new Error(`${path}: "tools" must be an array of AgentTool`);
+  }
+  if (c.tools !== undefined) {
+    for (const [i, tool] of c.tools.entries()) {
+      if (!tool || typeof tool !== "object") {
+        throw new Error(`${path}: "tools[${i}]" must be an AgentTool object`);
+      }
+      const candidate = tool as { name?: unknown; execute?: unknown };
+      if (typeof candidate.name !== "string" || typeof candidate.execute !== "function") {
+        throw new Error(`${path}: "tools[${i}]" must have string "name" and function "execute"`);
+      }
+    }
+  }
+  if (c.http !== undefined && (typeof c.http !== "object" || c.http === null)) {
+    throw new Error(`${path}: "http" must be an object`);
+  }
+  // Same typo discipline one level down: { http: { porrt } } must not silently
+  // fall back to the default port.
+  for (const key of Object.keys(c.http ?? {})) {
+    if (key !== "port") {
+      throw new Error(`${path}: unknown key "http.${key}" (valid keys: port)`);
+    }
+  }
+  if (
+    c.http?.port !== undefined &&
+    (typeof c.http.port !== "number" || !Number.isInteger(c.http.port) || c.http.port < 0 || c.http.port > 65535)
+  ) {
+    throw new Error(`${path}: "http.port" must be an integer 0-65535`);
+  }
+  return { config: c, path };
 }
 
 /** Resolve "provider/modelId" → a pi Model. Unknown specs throw a clear error (getModel returns undefined). */


### PR DESCRIPTION
Pre-existing cleanup from the project-wide refactor/cleanup scan (the part that lives on `main`, independent of the open `feat/fastagent-build` PR — zero file overlap with it).

## Changes
- **refactor(config)**: `loadConfig` iterated a single-element array (`found.length` 0 and >1 are handled above), so the loop always returned on iteration 1 and the trailing `throw "failed to load…"` was unreachable. Replaced with a direct single-path read. Behavior unchanged; covered by existing config tests.
- **docs**: added `docs/fastagent.md` (product overview / docs index, linked from README) to the AGENTS.md source-of-truth table — it was missing, leaving the doc map inconsistent.

## Scan findings deliberately NOT in this PR
- **`definition.ts` stale comment + build-time gitignore duplication**: live only on the `feat/fastagent-build` branch (`build.ts` does not exist on `main`). Will be addressed in a follow-up PR once that branch merges.
- **Un-exporting `defaultRetryClassifier` / `AssembleSystemPromptOptions`**: declined. On closer look these are not dead code — they are the composable default and the parameter type of the L0/assembly surface used by tests and custom wiring. Removing `export` would shrink the module surface for no benefit.
- **`docs/session.md`**: kept — it is the intentional, AGENTS-mapped roadmap draft, not residue.

## Verification
`npm run typecheck` clean; `npm test` 71 passed.
