### PR TITLE
refactor(pi): share the .fastagent self-gitignore writer + fix stale skill-ignore comment

### DIFF
--- a/core/src/engines/pi/build.ts
+++ b/core/src/engines/pi/build.ts
@@ -16,7 +16,7 @@ import { mkdir, mkdtemp, readFile, realpath, rename, rm, stat, writeFile } from 
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { type LoadedDefinition, bundleAgentDefinition, defaultGlobalSkillPaths } from "./definition.ts";
+import { type LoadedDefinition, bundleAgentDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored } from "./definition.ts";
 
 /** The `fastagent.json` manifest written into the artifact. Pure data (no `.ts`). */
 export interface ArtifactManifest {
@@ -135,11 +135,7 @@ export async function buildPiArtifact(
   // An in-tree build creates <src>/.fastagent; self-gitignore it (same as the L3 dev path in
   // create.ts), so a build-first workspace doesn't show the artifact/staging as untracked.
   if (!outsideSource) {
-    await writeFile(join(srcReal, ".fastagent", ".gitignore"), "*\n", { flag: "wx" }).catch(
-      (e: NodeJS.ErrnoException) => {
-        if (e.code !== "EEXIST") throw e;
-      },
-    );
+    await ensureStateDirSelfIgnored(join(srcReal, ".fastagent"));
   }
   const staging = await mkdtemp(join(stagingParent, ".fa-build-"));
   try {

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -55,7 +55,7 @@
  *    this boundary must be re-cut: either config grows K keys (L3 inherits them)
  *    or L3 options grow K overrides. Decide from real backends; do not pre-wire.
  */
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
@@ -64,7 +64,7 @@ import { createCodingTools, createReadOnlyTools } from "@earendil-works/pi-codin
 import type { Agent } from "../../agent.ts";
 import type { AuthResolver } from "./auth.ts";
 import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { type LoadedDefinition, defaultGlobalSkillPaths, loadAgentDefinition } from "./definition.ts";
+import { type LoadedDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, piHarnessFactory } from "./harness.ts";
 import { type PiSessionStore, inMemorySessionStore, jsonlSessionStore } from "./sessions.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
@@ -328,9 +328,7 @@ export async function createPiAgentFromWorkspace(
   // callers of L3 get the same self-gitignored dir (vite/next-style).
   const stateDir = join(dir, ".fastagent");
   await mkdir(stateDir, { recursive: true });
-  await writeFile(join(stateDir, ".gitignore"), "*\n", { flag: "wx" }).catch((e: NodeJS.ErrnoException) => {
-    if (e.code !== "EEXIST") throw e;
-  });
+  await ensureStateDirSelfIgnored(stateDir);
   const { agent, definition } = await createPiAgentFromDefinition(dir, {
     model: resolveModel(modelSpec),
     tools: resolveTools(config, dir),

--- a/core/src/engines/pi/definition.ts
+++ b/core/src/engines/pi/definition.ts
@@ -24,7 +24,7 @@
  *   - non-fatal load findings (bad skill files, name collisions) are returned as
  *     data (diagnostics/collisions) for the caller to surface — visible, not fatal.
  */
-import { copyFile, mkdir, readFile, readdir, realpath } from "node:fs/promises";
+import { copyFile, mkdir, readFile, readdir, realpath, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import ignore, { type Ignore } from "ignore";
@@ -146,6 +146,19 @@ function isHardExcluded(name: string): boolean {
 }
 
 /**
+ * Self-ignore a `.fastagent` state dir: write `<stateDir>/.gitignore` = "*" (idempotent —
+ * an existing one is kept). Layer-3 machine state (dev sessions, build staging/artifacts) is
+ * gitignored, deletable, and rebuildable, so a workspace that only runs dev/build never shows
+ * it as untracked. The caller creates the dir; this only drops the marker. Shared by the L3
+ * dev path (create.ts) and an in-tree build (build.ts) so the marker stays in one place.
+ */
+export async function ensureStateDirSelfIgnored(stateDir: string): Promise<void> {
+  await writeFile(join(stateDir, ".gitignore"), "*\n", { flag: "wx" }).catch((e: NodeJS.ErrnoException) => {
+    if (e.code !== "EEXIST") throw e;
+  });
+}
+
+/**
  * Load the build root's exclude rules into ONE flat matcher: `.gitignore` then
  * `.fastagentignore` (fa last → authoritative on conflicts), applied artifact-relative to
  * the whole tree. Deliberately FLAT — we read only the ROOT files, not nested .gitignore
@@ -252,7 +265,7 @@ async function executeShipPlan(plan: ShipPlan, outDir: string): Promise<void> {
  *     package.json, …) is copied via the ignore-aware walk, EXCLUDING skills/;
  *   - outDir/skills/ is produced from the RESOLVED skill model: each WINNING skill
  *     (definition.skills — local AND mounted, treated uniformly) is materialized to
- *     skills/<name> via the same walk (its own + ancestor .gitignore honored). Names are
+ *     skills/<name> via the same walk (its own root .gitignore honored). Names are
  *     unique after dedup, so destinations never collide; collision losers and non-loaded
  *     skills simply never appear.
  *


### PR DESCRIPTION
The cleanup-scan findings that lived only on the `feat/fastagent-build` branch (now on `main` after #14). Follow-up to #15.

## Changes
- **refactor(pi)**: the L3 dev path (`create.ts`) and an in-tree build (`build.ts`) each wrote an identical `<dir>/.fastagent/.gitignore` = `"*"` marker (`wx` + swallow `EEXIST`). Extracted `ensureStateDirSelfIgnored` into `definition.ts` (which already owns the `.fastagent` hard-exclude knowledge) and call it from both.
- **docs/comment**: fixed a stale comment in `bundleAgentDefinition` — skill materialization honors the skill's OWN root `.gitignore` only (flat-root design; the dir-skill branch already says so), not "its own + ancestor", which the ignore rewrite removed.

## Verification
`npm run typecheck` clean; `npm test` 116 passed.
