### PR TITLE
feat(start): fastagent start — run a built artifact in production posture

### DIFF
--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -5,24 +5,27 @@
  *
  *   fastagent dev   [dir] — assemble + serve a local HTTP channel (iteration)
  *   fastagent build [dir] — compile a self-contained artifact (core-design §10.3)
- * Next: `start` (production posture, runs an artifact).
+ *   fastagent start [dir] — run a built artifact in production posture (core-design §10.4)
  *
  * Process-level side effects (proxy dispatcher, .env loading) belong here — the CLI
  * is the application entry point.
  */
 import { createServer } from "node:http";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
 import { createInvokeHandler } from "./channels/http.ts";
+import { probeAuthSource } from "./engines/pi/auth.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/create.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
+import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
 
 function usage(code: number): never {
   console.error(`usage:
   fastagent dev   [dir] [--port N] [--model provider/modelId] [--global-skills]
   fastagent build [dir] [--out dir] [--model provider/modelId] [--global-skills] [--force]
+  fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
 
   dev    assemble the agent in dir (default .) and serve a local HTTP channel.
          model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
@@ -36,7 +39,13 @@ function usage(code: number): never {
          wholesale (built to a temp dir, then published atomically); an in-tree --out must
          be under .fastagent/, else use an out-of-tree path with --force.
          --global-skills   materialize the machine's global skills into the artifact
-         --force           allow an --out OUTSIDE the source tree (it will be replaced)`);
+         --force           allow an --out OUTSIDE the source tree (it will be replaced)
+  start  run a built artifact (default dir .) in production posture: model/http come from
+         the artifact's fastagent.json; skills are the artifact (never global).
+         model precedence: --model > FASTAGENT_MODEL > manifest.model
+         port precedence:  --port > PORT env > manifest.http.port > 8787
+         sessions: --sessions-dir > FASTAGENT_SESSIONS_DIR > ./fastagent-sessions
+                   (kept OUTSIDE the artifact so a redeploy never wipes conversations)`);
   process.exit(code);
 }
 
@@ -46,6 +55,7 @@ const { positionals, values } = parseArgs({
     port: { type: "string" },
     model: { type: "string" },
     out: { type: "string" },
+    "sessions-dir": { type: "string" },
     force: { type: "boolean" },
     "global-skills": { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -59,16 +69,24 @@ const globalSkills = values["global-skills"] ?? false;
 
 if (command === "dev") await runDev();
 else if (command === "build") await runBuild();
+else if (command === "start") await runStart();
 else usage(1);
+
+/** Parse + range-check a port string (CLI flag or env). Invalid → exit 1 (argument error). */
+function parsePort(value: string | undefined, source: string): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0 || n > 65535) {
+    console.error(`invalid ${source} "${value}": must be an integer 0-65535`);
+    process.exit(1);
+  }
+  return n;
+}
 
 async function runDev(): Promise<void> {
   // Validate flags before any assembly work: argument errors must fail instantly,
   // not after the startup report. (config's http.port is range-checked by loadConfig.)
-  const portFlag = values.port === undefined ? undefined : Number(values.port);
-  if (portFlag !== undefined && (!Number.isInteger(portFlag) || portFlag < 0 || portFlag > 65535)) {
-    console.error(`invalid --port "${values.port}": must be an integer 0-65535`);
-    process.exit(1);
-  }
+  const portFlag = parsePort(values.port, "--port");
   loadDotEnv(dir);
   // Node's fetch does not honor HTTPS_PROXY by itself; route through the local proxy
   // so blocked providers are reachable (reads HTTP(S)_PROXY/NO_PROXY from the env).
@@ -105,11 +123,7 @@ async function runDev(): Promise<void> {
   }
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 
-  const port = portFlag ?? config.http?.port ?? 8787;
-  createServer(createInvokeHandler(agent)).listen(port, () => {
-    console.error(`[fastagent] http channel on :${port}`);
-    console.error(`  curl -N -X POST localhost:${port}/invoke -d '{"session":"s1","text":"hi"}'`);
-  });
+  serve(agent, portFlag ?? config.http?.port ?? 8787);
 }
 
 async function runBuild(): Promise<void> {
@@ -131,6 +145,60 @@ async function runBuild(): Promise<void> {
     `[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}${globalSkills ? " (incl. global)" : ""}`,
   );
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
+}
+
+async function runStart(): Promise<void> {
+  const portFlag = parsePort(values.port, "--port");
+  loadDotEnv(dir); // env API keys + an optional PORT/FASTAGENT_MODEL override
+  // Same proxy/undici setup as dev (see runDev): route fetch through the local proxy and
+  // keep fetch + dispatcher on the same undici implementation.
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+  installUndiciFetch();
+
+  const { agent, definition, manifest, modelSpec, sessionsDir } = await createPiAgentFromArtifact(dir, {
+    model: values.model,
+    sessionsDir: values["sessions-dir"] ? resolve(values["sessions-dir"]) : undefined,
+  }).catch(failStartup);
+
+  const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
+  const authSource = await probeAuthSource(provider);
+
+  console.error(`[fastagent] start:    ${dir}`);
+  console.error(`[fastagent] model:    ${modelSpec}`);
+  console.error(`[fastagent] auth:     ${authSource === "none" ? "(none found)" : `${authSource} (${provider})`}`);
+  console.error(`[fastagent] agents:   ${definition.instructions ? "AGENTS.md" : "(none)"}`);
+  console.error(`[fastagent] skills:   ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
+  console.error(`[fastagent] sessions: ${sessionsDir}`);
+  // Visible footgun guard: a sessions dir inside the artifact is wiped by a redeploy that
+  // replaces the artifact wholesale. Warn, don't block (running in place is legitimate).
+  const rel = relative(dir, sessionsDir);
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) {
+    console.error(
+      `[fastagent] warn: sessions dir is INSIDE the artifact; a redeploy that replaces the artifact ` +
+        `will wipe conversations — use --sessions-dir to place them outside.`,
+    );
+  }
+  reportDefinitionWarnings(definition.collisions, definition.diagnostics);
+
+  serve(agent, portFlag ?? parsePort(process.env.PORT, "PORT env") ?? manifest.http?.port ?? 8787);
+}
+
+/**
+ * Bind the HTTP channel, with a clean message instead of a raw stack on a listen failure
+ * (the common case being EADDRINUSE — a port already in use). A listen error is a startup
+ * problem, not a bug, so it exits like {@link failStartup} rather than crashing unhandled.
+ */
+function serve(agent: Parameters<typeof createInvokeHandler>[0], port: number): void {
+  const server = createServer(createInvokeHandler(agent));
+  server.on("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EADDRINUSE") console.error(`port ${port} is already in use; choose another with --port`);
+    else console.error(`cannot bind http channel on :${port}: ${error.message}`);
+    process.exit(1);
+  });
+  server.listen(port, () => {
+    console.error(`[fastagent] http channel on :${port}`);
+    console.error(`  curl -N -X POST localhost:${port}/invoke -d '{"session":"s1","text":"hi"}'`);
+  });
 }
 
 /** .env (secrets) → process.env. Only a missing file is normal; surface anything else. */

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -72,15 +72,22 @@ else if (command === "build") await runBuild();
 else if (command === "start") await runStart();
 else usage(1);
 
-/** Parse + range-check a port string (CLI flag or env). Invalid → exit 1 (argument error). */
+/**
+ * Parse + range-check a port string (CLI flag or env). Empty/whitespace (e.g. `PORT=` in an
+ * env file) is treated as "not set" → undefined, so the `??` precedence chain falls through to
+ * the next source instead of binding port 0 (an ephemeral port) — `Number("")` is 0. A
+ * non-empty but non-decimal/out-of-range value is an argument error → exit 1. Strict `^\d+$`
+ * (not `Number`) rejects hex/exponent/negative/whitespace coercion quirks.
+ */
 function parsePort(value: string | undefined, source: string): number | undefined {
   if (value === undefined) return undefined;
-  const n = Number(value);
-  if (!Number.isInteger(n) || n < 0 || n > 65535) {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  if (!/^\d+$/.test(trimmed) || Number(trimmed) > 65535) {
     console.error(`invalid ${source} "${value}": must be an integer 0-65535`);
     process.exit(1);
   }
-  return n;
+  return Number(trimmed);
 }
 
 async function runDev(): Promise<void> {

--- a/core/src/engines/pi/auth.ts
+++ b/core/src/engines/pi/auth.ts
@@ -86,3 +86,14 @@ export function resolvePiAuth(authPath?: string, options?: PiAuthOptions): AuthR
   const oauth = piOAuthAuth(authPath, options);
   return async (model) => (await oauth(model)) ?? envAuth(model);
 }
+
+/**
+ * Which source of the DEFAULT chain ({@link resolvePiAuth}: OAuth → env) currently has
+ * credentials for `provider`. Reporting-only (e.g. the `start` startup line); mirrors the
+ * default chain order, warns suppressed (the live resolver surfaces anomalies per invoke).
+ */
+export async function probeAuthSource(provider: string, authPath?: string): Promise<"oauth" | "env" | "none"> {
+  if (await piOAuthAuth(authPath, { warn: () => {} })({ provider })) return "oauth";
+  if (await envAuth({ provider })) return "env";
+  return "none";
+}

--- a/core/src/engines/pi/build.ts
+++ b/core/src/engines/pi/build.ts
@@ -43,7 +43,8 @@ export interface BuildPiArtifactOptions {
   force?: boolean;
 }
 
-const MANIFEST_FILE = "fastagent.json";
+/** The reserved manifest filename inside an artifact (written by build, read by start). */
+export const MANIFEST_FILE = "fastagent.json";
 
 /**
  * Compile {@link srcDir} into a self-contained artifact at {@link outDir}. Resolves +

--- a/core/src/engines/pi/start.ts
+++ b/core/src/engines/pi/start.ts
@@ -1,0 +1,138 @@
+/**
+ * Start: run a built artifact in production posture (core-design §10.4).
+ *
+ * `start` is the deploy-time sibling of L3 `createPiAgentFromWorkspace` (dev). Both are thin
+ * orchestrations over L2 `createPiAgentFromDefinition` — NOT a new ladder rung (the M-assembly
+ * ladder is L0–L3; this only injects production K-wiring into L2). The two differ only in
+ * where their inputs come from and which K defaults they pick:
+ *
+ *   | concern  | dev (L3, from workspace)        | start (from artifact, here)            |
+ *   |----------|----------------------------------|-----------------------------------------|
+ *   | model    | config.model                     | manifest.model (frozen at build)        |
+ *   | tools    | loadConfig → resolveTools        | loadConfig → resolveTools (same)        |
+ *   | skills   | definition-only (+ --global)     | definition-only (artifact is the truth) |
+ *   | sessions | jsonl under <ws>/.fastagent/      | jsonl OUTSIDE the artifact (see below)   |
+ *
+ * Sessions live OUTSIDE the immutable artifact on purpose (the M/K split, core-design §10.1):
+ * the artifact is relocatable and replaced wholesale on redeploy, so conversational state (K)
+ * kept inside it would be wiped on every deploy and on every container restart. Default is the
+ * shell-cwd-relative, visible `./fastagent-sessions/` (override: `sessionsDir` /
+ * FASTAGENT_SESSIONS_DIR) — never the artifact's own `.fastagent/`.
+ *
+ * Node composition-root module (IO policy, see definition.ts): reads the manifest/config and
+ * sets up the session dir on disk; the invoke path itself stays disk-free.
+ */
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Agent } from "../../agent.ts";
+import type { AuthResolver } from "./auth.ts";
+import { type ArtifactManifest, MANIFEST_FILE } from "./build.ts";
+import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
+import { createPiAgentFromDefinition, resolveTools } from "./create.ts";
+import { type LoadedDefinition, ensureStateDirSelfIgnored } from "./definition.ts";
+import { jsonlSessionStore } from "./sessions.ts";
+
+/**
+ * Read + validate `<artifactDir>/fastagent.json`. The manifest is machine-generated, so this
+ * validates only the runtime-relevant fields (engine/model/http) and tolerates extra keys
+ * (forward-compat with newer builds). A missing file means "not a built artifact" — fail
+ * visibly with the fix, rather than a confusing downstream error.
+ */
+export async function loadManifest(artifactDir: string): Promise<ArtifactManifest> {
+  const path = join(artifactDir, MANIFEST_FILE);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`no ${MANIFEST_FILE} in "${artifactDir}": not a built artifact (run \`fastagent build\` first)`);
+    }
+    throw new Error(`cannot read ${path}: ${(error as Error).message}`);
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error(`${path}: invalid JSON (corrupt artifact manifest)`);
+  }
+  if (!data || typeof data !== "object") {
+    throw new Error(`${path}: must be a JSON object`);
+  }
+  const m = data as Record<string, unknown>;
+  // engine identifies who can run the artifact; a non-pi artifact must not be silently served.
+  if (m.engine !== "pi") {
+    throw new Error(`${path}: engine "${String(m.engine)}" is not runnable by this build (expected "pi")`);
+  }
+  if (typeof m.model !== "string" || m.model === "") {
+    throw new Error(`${path}: "model" must be a non-empty "provider/modelId" string`);
+  }
+  if (m.http !== undefined) {
+    const http = m.http as Record<string, unknown> | null;
+    if (typeof http !== "object" || http === null) {
+      throw new Error(`${path}: "http" must be an object`);
+    }
+    const port = http.port;
+    if (port !== undefined && (typeof port !== "number" || !Number.isInteger(port) || port < 0 || port > 65535)) {
+      throw new Error(`${path}: "http.port" must be an integer 0-65535`);
+    }
+  }
+  return data as ArtifactManifest;
+}
+
+export interface CreatePiAgentFromArtifactOptions {
+  /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > manifest.model. */
+  model?: string;
+  /**
+   * Session store directory. Precedence: this > FASTAGENT_SESSIONS_DIR > `<cwd>/fastagent-sessions`.
+   * MUST resolve outside the artifact (the default is cwd-relative, and cwd is the shell launch
+   * dir, not the artifact). Self-gitignored on create.
+   */
+  sessionsDir?: string;
+  /** Model auth resolution. Defaults to the L2 default (resolvePiAuth: pi OAuth → env vars). */
+  getApiKeyAndHeaders?: AuthResolver;
+}
+
+/**
+ * Assemble a production agent from a built artifact: load the manifest (frozen model/http) and
+ * the shipped config (code tools), resolve the model/sessions, then L2 with production wiring.
+ * Returns everything an entry point needs to report what it assembled. Throws on a missing/bad
+ * artifact or model (fail visibly at startup).
+ */
+export async function createPiAgentFromArtifact(
+  artifactDir: string,
+  options: CreatePiAgentFromArtifactOptions = {},
+): Promise<{
+  agent: Agent;
+  definition: LoadedDefinition;
+  manifest: ArtifactManifest;
+  config: FastagentConfig;
+  /** The resolved "provider/modelId" spec actually in use. */
+  modelSpec: string;
+  /** Absolute session store directory in use (for the startup report). */
+  sessionsDir: string;
+}> {
+  const manifest = await loadManifest(artifactDir);
+  // config.ts ships in the artifact for code tools (model/http come from the manifest).
+  const { config } = await loadConfig(artifactDir);
+  const modelSpec = resolveModelSpec(options.model, { model: manifest.model });
+  if (!modelSpec) {
+    // Unreachable in practice (loadManifest guarantees a non-empty model); kept as a visible floor.
+    throw new Error(`missing model: artifact manifest has no model and none was provided via --model/FASTAGENT_MODEL`);
+  }
+  const sessionsDir =
+    options.sessionsDir ?? process.env.FASTAGENT_SESSIONS_DIR ?? join(process.cwd(), "fastagent-sessions");
+  // The session dir is runtime state outside the artifact: create + self-gitignore it (so a
+  // start run inside a git repo does not show conversations as untracked).
+  await mkdir(sessionsDir, { recursive: true });
+  await ensureStateDirSelfIgnored(sessionsDir);
+  const { agent, definition } = await createPiAgentFromDefinition(artifactDir, {
+    model: resolveModel(modelSpec),
+    // Code tools shipped in fastagent.config.* (appended after pi defaults); model/http are
+    // already frozen in the manifest, but tools are functions and only live in the config file.
+    tools: resolveTools(config, artifactDir),
+    // Continuity from an external store, reconstructed per invoke (SPEC portable conformance).
+    sessions: jsonlSessionStore({ dir: sessionsDir, cwd: artifactDir }),
+    getApiKeyAndHeaders: options.getApiKeyAndHeaders,
+  });
+  return { agent, definition, manifest, config, modelSpec, sessionsDir };
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -42,6 +42,14 @@ export {
   type BuildPiArtifactOptions,
 } from "./engines/pi/build.ts";
 
+// pi reference implementation — start (run a built artifact in production posture).
+// Deploy-time sibling of L3 createPiAgentFromWorkspace; both are thin orchestrations over L2.
+export {
+  createPiAgentFromArtifact,
+  loadManifest,
+  type CreatePiAgentFromArtifactOptions,
+} from "./engines/pi/start.ts";
+
 // pi reference implementation — engine assets (prompt base + toolsets, in create.ts).
 // Internal assembly helpers (assembleSystemPrompt, resolveTools) are NOT public:
 // the ladder rungs own assembly; embedders compose via L1/L2/L3.
@@ -82,5 +90,6 @@ export {
   type PiAuthOptions,
   envAuth,
   piOAuthAuth,
+  probeAuthSource,
   resolvePiAuth,
 } from "./engines/pi/auth.ts";

--- a/core/test/start.test.ts
+++ b/core/test/start.test.ts
@@ -1,8 +1,47 @@
 import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildPiArtifact, createPiAgentFromArtifact, loadManifest } from "../src/index.ts";
+
+const CLI = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+
+/** Run the CLI to completion (for paths that exit, e.g. an invalid argument). */
+function cliRunToExit(args: string[], env: NodeJS.ProcessEnv = {}): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, ...args], { env: { ...process.env, ...env } });
+    let stderr = "";
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("close", (code) => resolve({ code, stderr }));
+  });
+}
+
+/** Run the CLI until it logs the http-channel line; return the bound port, then kill it. */
+function cliBoundPort(args: string[], env: NodeJS.ProcessEnv = {}): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], { env: { ...process.env, ...env } });
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`timeout before binding; stderr:\n${stderr}`));
+    }, 8000);
+    child.stderr.on("data", (d) => {
+      stderr += String(d);
+      const m = stderr.match(/http channel on :(\d+)/);
+      if (m) {
+        clearTimeout(timer);
+        child.kill("SIGKILL");
+        resolve(Number(m[1]));
+      }
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`exited (code ${code}) before binding; stderr:\n${stderr}`));
+    });
+  });
+}
 
 /** A minimal workspace, then build it into an artifact — the input `start` consumes. */
 async function makeArtifact(opts: { config?: string } = {}): Promise<{ artifact: string }> {
@@ -115,6 +154,37 @@ describe("start: createPiAgentFromArtifact", () => {
       if (saved !== undefined) process.env.HOME = saved;
       else delete process.env.HOME;
     }
+  });
+
+  it("empty PORT env falls through to the manifest port (not listen(0))", async () => {
+    // The bug: Number("") === 0, so `PORT=` (empty) used to bind an ephemeral port. A random
+    // manifest port proves fall-through: the bound port can only match it if `PORT=` was
+    // treated as unset (no --port given, so the manifest is the next source).
+    const manifestPort = 19000 + Math.floor(Math.random() * 10000);
+    const ws = await mkdtemp(join(tmpdir(), "fa-start-port-ws-"));
+    await writeFile(join(ws, "AGENTS.md"), "# Bot\n");
+    await writeFile(
+      join(ws, "fastagent.config.mjs"),
+      `export default { model: "openai-codex/gpt-5.5", http: { port: ${manifestPort} } };`,
+    );
+    const artifact = await mkdtemp(join(tmpdir(), "fa-start-port-art-"));
+    await buildPiArtifact(ws, artifact, { force: true });
+    const bound = await cliBoundPort(["start", artifact, "--sessions-dir", await freshSessions()], { PORT: "" });
+    expect(bound).toBe(manifestPort);
+  });
+
+  it("rejects a non-decimal port (strict parse, not Number coercion) with a clean exit", async () => {
+    const { artifact } = await makeArtifact();
+    const { code, stderr } = await cliRunToExit([
+      "start",
+      artifact,
+      "--port",
+      "0x50",
+      "--sessions-dir",
+      await freshSessions(),
+    ]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/invalid --port "0x50": must be an integer 0-65535/);
   });
 
   it("appends code tools shipped in the artifact's config", async () => {

--- a/core/test/start.test.ts
+++ b/core/test/start.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildPiArtifact, createPiAgentFromArtifact, loadManifest } from "../src/index.ts";
+
+/** A minimal workspace, then build it into an artifact — the input `start` consumes. */
+async function makeArtifact(opts: { config?: string } = {}): Promise<{ artifact: string }> {
+  const ws = await mkdtemp(join(tmpdir(), "fa-start-ws-"));
+  await writeFile(join(ws, "AGENTS.md"), "# Start Bot\n");
+  await mkdir(join(ws, "skills", "s1"), { recursive: true });
+  await writeFile(join(ws, "skills", "s1", "SKILL.md"), "---\nname: s1\ndescription: A skill.\n---\nBody.\n");
+  await writeFile(
+    join(ws, "fastagent.config.mjs"),
+    opts.config ?? `export default { model: "openai-codex/gpt-5.5", http: { port: 9100 } };`,
+  );
+  const artifact = await mkdtemp(join(tmpdir(), "fa-start-art-"));
+  await buildPiArtifact(ws, artifact, { force: true });
+  return { artifact };
+}
+
+const freshSessions = () => mkdtemp(join(tmpdir(), "fa-start-sess-"));
+
+describe("start: loadManifest", () => {
+  it("reads the manifest a build wrote", async () => {
+    const { artifact } = await makeArtifact();
+    const m = await loadManifest(artifact);
+    expect(m.engine).toBe("pi");
+    expect(m.model).toBe("openai-codex/gpt-5.5");
+    expect(m.http).toEqual({ port: 9100 });
+  });
+
+  it("fails visibly when the dir is not a built artifact (no fastagent.json)", async () => {
+    const empty = await mkdtemp(join(tmpdir(), "fa-start-empty-"));
+    await expect(loadManifest(empty)).rejects.toThrow(/not a built artifact .*fastagent build/);
+  });
+
+  it("rejects a corrupt manifest, a non-pi engine, and a missing model", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-start-bad-"));
+    await writeFile(join(dir, "fastagent.json"), "{ not json");
+    await expect(loadManifest(dir)).rejects.toThrow(/invalid JSON/);
+
+    await writeFile(join(dir, "fastagent.json"), JSON.stringify({ engine: "claude", model: "x/y" }));
+    await expect(loadManifest(dir)).rejects.toThrow(/engine "claude" is not runnable/);
+
+    await writeFile(join(dir, "fastagent.json"), JSON.stringify({ engine: "pi" }));
+    await expect(loadManifest(dir)).rejects.toThrow(/"model" must be a non-empty/);
+
+    await writeFile(join(dir, "fastagent.json"), JSON.stringify({ engine: "pi", model: "x/y", http: { port: 70000 } }));
+    await expect(loadManifest(dir)).rejects.toThrow(/http\.port.*0-65535/);
+  });
+});
+
+describe("start: createPiAgentFromArtifact", () => {
+  it("assembles an agent from the artifact: manifest model, definition, external sessions dir", async () => {
+    const { artifact } = await makeArtifact();
+    const sessionsDir = await freshSessions();
+    const { agent, definition, manifest, modelSpec, sessionsDir: used } = await createPiAgentFromArtifact(artifact, {
+      sessionsDir,
+    });
+    expect(typeof agent.invoke).toBe("function");
+    expect(modelSpec).toBe("openai-codex/gpt-5.5");
+    expect(manifest.engine).toBe("pi");
+    expect(definition.instructions).toContain("Start Bot");
+    expect(definition.skills.map((s) => s.name)).toEqual(["s1"]);
+    expect(used).toBe(sessionsDir);
+    // the session dir is self-gitignored so a start inside a repo hides runtime state
+    expect(await readFile(join(sessionsDir, ".gitignore"), "utf8")).toBe("*\n");
+  });
+
+  it("model precedence: --model option beats the frozen manifest model", async () => {
+    const { artifact } = await makeArtifact();
+    const { modelSpec } = await createPiAgentFromArtifact(artifact, {
+      model: "openai-codex/gpt-5.4",
+      sessionsDir: await freshSessions(),
+    });
+    expect(modelSpec).toBe("openai-codex/gpt-5.4");
+  });
+
+  it("FASTAGENT_SESSIONS_DIR is used when no explicit dir is passed", async () => {
+    const { artifact } = await makeArtifact();
+    const envDir = await freshSessions();
+    const saved = process.env.FASTAGENT_SESSIONS_DIR;
+    process.env.FASTAGENT_SESSIONS_DIR = envDir;
+    try {
+      const { sessionsDir } = await createPiAgentFromArtifact(artifact, {});
+      expect(sessionsDir).toBe(envDir);
+    } finally {
+      if (saved !== undefined) process.env.FASTAGENT_SESSIONS_DIR = saved;
+      else delete process.env.FASTAGENT_SESSIONS_DIR;
+    }
+  });
+
+  it("fails visibly on a bad --model spec (validated against the registry)", async () => {
+    const { artifact } = await makeArtifact();
+    await expect(
+      createPiAgentFromArtifact(artifact, { model: "nope/nothing", sessionsDir: await freshSessions() }),
+    ).rejects.toThrow(/unknown model/);
+  });
+
+  it("runs definition-only: a global skill on the machine is never loaded", async () => {
+    const home = await mkdtemp(join(tmpdir(), "fa-start-home-"));
+    await mkdir(join(home, ".pi", "agent", "skills", "global-skill"), { recursive: true });
+    await writeFile(
+      join(home, ".pi", "agent", "skills", "global-skill", "SKILL.md"),
+      "---\nname: global-skill\ndescription: A global skill.\n---\nGlobal.\n",
+    );
+    const { artifact } = await makeArtifact();
+    const saved = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      const { definition } = await createPiAgentFromArtifact(artifact, { sessionsDir: await freshSessions() });
+      expect(definition.skills.map((s) => s.name)).toEqual(["s1"]); // artifact is the truth, never global
+    } finally {
+      if (saved !== undefined) process.env.HOME = saved;
+      else delete process.env.HOME;
+    }
+  });
+
+  it("appends code tools shipped in the artifact's config", async () => {
+    // A config.ts so loadConfig accepts a single config file; the tool must survive into the agent.
+    const ws = await mkdtemp(join(tmpdir(), "fa-start-tools-ws-"));
+    await writeFile(join(ws, "AGENTS.md"), "# Bot\n");
+    await writeFile(
+      join(ws, "fastagent.config.ts"),
+      `export default { model: "openai-codex/gpt-5.5", tools: [{ name: "ping", description: "d", parameters: {}, execute: async () => "pong" }] };\n`,
+    );
+    const artifact = await mkdtemp(join(tmpdir(), "fa-start-tools-art-"));
+    await buildPiArtifact(ws, artifact, { force: true });
+    const { config } = await createPiAgentFromArtifact(artifact, { sessionsDir: await freshSessions() });
+    expect(config.tools?.map((t) => t.name)).toEqual(["ping"]);
+  });
+});

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -257,12 +257,14 @@ Run a built agent in **production posture**. Differences from `dev`:
 |---|---|---|
 | config | executes `fastagent.config.ts` | reads the artifact's `fastagent.json` for the frozen model/http; runs from the artifact (cwd = artifact). config.ts ships in the artifact for code tools (needs `npm ci`); the strict no-`.ts`-at-runtime posture is a later hardening |
 | skills | definition-only (+ `--global-skills`) | artifact is the truth; **never scans globals** |
-| auth | pi OAuth → env | pluggable `AuthResolver` (§10.5) |
-| sessions | jsonl under `.fastagent/sessions` | persistent store (jsonl now; external/DDB later) |
+| auth | pi OAuth → env | pluggable `AuthResolver` (§10.5); default still pi OAuth → env |
+| sessions | jsonl under `.fastagent/sessions` | jsonl **outside** the artifact (jsonl now; external/DDB later) |
 | model | `--model > FASTAGENT_MODEL > config` | `--model > FASTAGENT_MODEL > manifest.model` |
 | port | `--port > config` | `--port > PORT env > manifest.http.port > 8787` |
 
-`start` reuses **L2** (`createPiAgentFromDefinition`) with production wiring injected — no new ladder rung — which is exactly what L2's injection points exist for. It depends on zero builder-machine state.
+`start` reuses **L2** (`createPiAgentFromDefinition`) with production wiring injected — no new ladder rung — which is exactly what L2's injection points exist for. It depends on zero builder-machine state. The entry point is `createPiAgentFromArtifact(artifactDir, options)` (in `engines/pi/start.ts`): a deploy-time orchestration sibling of L3 `createPiAgentFromWorkspace`, not a ladder rung. It reads `fastagent.json` (frozen model/http) + the shipped `fastagent.config.*` (code tools), resolves the model/sessions, then calls L2.
+
+**Sessions live OUTSIDE the artifact** (the M/K split): the artifact is immutable and replaced wholesale on redeploy, so conversational state (K) kept inside it would be wiped on every deploy and every container restart. The default is the shell-cwd-relative, visible `./fastagent-sessions/` (precedence `--sessions-dir > FASTAGENT_SESSIONS_DIR > <cwd>/fastagent-sessions`), self-gitignored, **never** the artifact's own `.fastagent/`. The cwd-relative default's only footgun (continuity bound to launch dir) is loud (the resolved absolute path is in the startup report) and absent in containers (fixed `WORKDIR`); a sessions dir resolving inside the artifact emits a visible warning. dev keeps sessions under `<workspace>/.fastagent/` because the dev "artifact" is the mutable workspace itself — a deliberate difference, not an inconsistency.
 
 **Startup report (minimal observable surface):** `start` logs the run dir, model, **auth source** (`env (<KEY>)` or `oauth (<provider>)`), `AGENTS.md` presence, the **loaded skills** (enumerable), the session backend, and the bound port. It does **not** enumerate authored context files: they are ambient (§10.1a), so the only meaningful, bounded list is skills. This mirrors the `dev` startup report.
 
@@ -285,7 +287,7 @@ The container is the v1 "machine-state independence" boundary: copy the project,
 
 ## 11. Current open work
 
-- `fastagent build` / `fastagent start` per §10 (container tier first).
+- `fastagent build` / `fastagent start` per §10 are implemented (single-machine tier); the documented container recipe (§10.6) is not yet shipped.
 - Refresh-capable runtime OAuth resolver (§10.5); multi-instance credential broker deferred.
 - Portable data-bundle scoping (§10.2): bundle the source tree under the §10.1 boundary, secret exclusion enforced — lands with the AgentCore target adapter.
 - AgentCore target adapter with external sessions and distributed locking (the async `Lease` port).


### PR DESCRIPTION
## What

Implements `fastagent start` (core-design §10.4): run a self-contained artifact in production posture — the deploy-time counterpart to `fastagent dev`. Closes the build/start half of §10.

## Design (as agreed)

- **Entry point** `createPiAgentFromArtifact(artifactDir, options)` in `engines/pi/start.ts`: a thin deploy-time orchestration over **L2** `createPiAgentFromDefinition` (a sibling of L3 `createPiAgentFromWorkspace`, **not** a new ladder rung). Reads frozen `model`/`http` from `fastagent.json` + code tools from the shipped `fastagent.config.*`, resolves model/sessions, then L2.
- **Sessions live OUTSIDE the artifact** (the M/K split). The artifact is immutable and replaced wholesale on redeploy, so conversational state kept inside it would be wiped on every deploy / container restart. Default is the visible, cwd-relative `./fastagent-sessions/` (`--sessions-dir > FASTAGENT_SESSIONS_DIR > <cwd>/fastagent-sessions`), self-gitignored. A sessions dir resolving inside the artifact emits a visible warning; the resolved absolute path is in the startup report.
- **Precedence**: model `--model > FASTAGENT_MODEL > manifest.model`; port `--port > PORT env > manifest.http.port > 8787`.
- **Skills** are always definition-only (artifact is the truth; never scans globals).

## Changes

- `engines/pi/start.ts` (new): `loadManifest` (validates engine/model/http, tolerates extra keys) + `createPiAgentFromArtifact`.
- `engines/pi/auth.ts`: `probeAuthSource` for the startup auth-source line.
- `engines/pi/build.ts`: export `MANIFEST_FILE` (single source for the manifest filename).
- `cli.ts`: `runStart` + a shared `serve()` helper that turns a listen failure (e.g. `EADDRINUSE`) into a clean message + `exit 1` instead of a raw stack. **`runDev` now uses it too**, fixing the pre-existing unhandled-error path.
- `index.ts`: export `createPiAgentFromArtifact`, `loadManifest`, `probeAuthSource`.
- `docs/core-design.md`: §10.4 records the sessions-location decision; §11 marks build/start implemented.
- `test/start.test.ts` (new): manifest read/validation, model precedence, external self-ignored sessions dir, definition-only, shipped code tools (9 cases).

## Verification

- `npm run typecheck` clean; `npm test` 125 passed.
- End-to-end smoke: build→start, manifest-driven port, auth probe, external self-ignored sessions, inside-artifact warning, `--port`/`PORT` override, non-artifact dir clean error, `EADDRINUSE` clean error for both start and dev.

## Review note

Adds **public API surface** (`index.ts` exports) → review-gated per CONTRIBUTING tiers, not self-merge.

## Not in this PR

The §10.6 container recipe (Docker/Podman: image + `CMD fastagent start` + session volume) — follow-up.