### PR TITLE
refactor(pi): extract the dev opener to dev.ts; create.ts = reusable ladder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,11 @@ core/
 │   ├── cli.ts                   # `fastagent dev` entry point (process side effects live here)
 │   ├── index.ts                 # the public API surface (see README "API stability")
 │   └── engines/pi/              # the pi reference implementation
-│       ├── create.ts            # L1–L3 assembly ladder + engine assets/prompt
+│       ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
 │       ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
+│       ├── dev.ts               # `dev` opener: open a workspace → agent (authoring posture)
+│       ├── build.ts             # `build`: compile a workspace → self-contained artifact
+│       ├── start.ts             # `start` opener: run a built artifact (production posture)
 │       ├── harness.ts           # pi harness wiring (factory)
 │       ├── definition.ts        # AGENTS.md + skills loading and bundling
 │       ├── config.ts            # fastagent.config.ts loading + model/precedence

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -17,8 +17,8 @@ import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher }
 import { createInvokeHandler } from "./channels/http.ts";
 import { probeAuthSource } from "./engines/pi/auth.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
-import { createPiAgentFromWorkspace } from "./engines/pi/create.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
+import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
 import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
 
 function usage(code: number): never {

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -3,21 +3,18 @@
  * (Division of labor: invoke.ts decides HOW a turn runs, request time; this
  * module decides WHAT parts an agent is assembled from, configuration time.)
  *
- * Organized as the engine-asset parts plus the assembly ladder that consumes them:
+ * Organized as the engine-asset parts plus the reusable assembly ladder that consumes them:
  *
  *   §1 tools   — pi default/read-only toolsets (engine assets)
  *   §2 prompt  — four-segment systemPrompt assembly (pure functions)
- *   §3 ladder  — the single place where a pi agent gets put together.
+ *   §3 ladder  — the reusable rungs that put a pi agent together (L0–L2).
  *
  * Ladder naming rule: `From<source>` marks INDIRECTION — that rung derives its
- * inputs from the named source (a workspace, a definition folder, engine wiring).
- * L1 carries no suffix: its inputs are given directly as typed options — it is the
- * canonical constructor every other rung ultimately calls. Each rung also has a
- * semantic verb — what its fold actually does — used as its label below:
+ * inputs from the named source (a definition folder, engine wiring). L1 carries no
+ * suffix: its inputs are given directly as typed options — it is the canonical
+ * constructor every other rung ultimately calls. Each rung also has a semantic verb —
+ * what its fold actually does — used as its label below:
  *
- *   L3  createPiAgentFromWorkspace(dir, options)        (this file)     [OPEN]
- *       "Open the deployment site" (definition + fastagent.config.ts + .env):
- *       config.ts loads/resolves, then L2. For the CLI and config-driven embedding.
  *   L2  createPiAgentFromDefinition(dir, options)       (this file)     [LOAD]
  *       "Load the portable agent definition": definition.ts loads, §2 assembles,
  *       then L1. For folder-based embedding.
@@ -28,34 +25,43 @@
  *       "Adapt engine wiring to the Agent contract": adds only the concurrency/
  *       stream shell. For tests and fully custom wiring.
  *
+ * Above L2 sit the COMMAND OPENERS — not ladder rungs, but command-posture
+ * compositions that open a source, resolve model/tools, inject K-wiring, then call L2:
+ *   createPiAgentFromWorkspace (dev.ts, authoring posture) and
+ *   createPiAgentFromArtifact (start.ts, production posture). They live in their own
+ *   command modules (alongside build.ts) so dev/build/start stay symmetric and create.ts
+ *   stays the pure REUSABLE ladder. The openers own command policy (config/manifest
+ *   precedence, the .fastagent state dir vs external sessions, --global-skills); the
+ *   ladder owns engine assembly.
+ *
  * Each rung only calls the one below; options narrow as you go up (L2 owns
- * systemPrompt/skills itself — they come from the definition; L3 owns model/tools —
- * they come from the config resolution, so their options deliberately do not
- * accept them).
+ * systemPrompt/skills itself — they come from the definition; the openers own model/tools —
+ * they come from the config/manifest resolution, so L2's options deliberately do not
+ * accept them as the openers' job).
  *
  * Two ladder-wide rules, written down so the per-rung choices stay explainable:
  *
- * 1. L0 is the odd rung out: L1–L3 fold *configuration
+ * 1. L0 is the odd rung out: L1–L2 fold *configuration
  *    inputs* (files → values → closures); L0 adapts *behavior* (pi's two ports →
  *    SPEC stream + concurrency discipline) — strictly an Adapter. It joins the
  *    create… family by NAME because it is a legitimate entry point (discoverability),
  *    but lives in invoke.ts because its body IS the turn mechanism (cohesion).
  *
- * 2. An injection point climbs only as high as the last rung whose persona owns
- *    the decision, then stops:
+ * 2. An injection point climbs only as high as the last persona who owns the
+ *    decision, then stops:
  *      - sessions / lease (deployment backends)  → reach L2 (embedding developer);
- *        L3 picks its own default (jsonl under .fastagent/) without exposing a choice;
+ *        the openers pick their own default (dev: jsonl under .fastagent/; start: jsonl
+ *        outside the artifact) without exposing a choice;
  *      - base / raw skillPaths (definition-assembly) → stop at L2 (L2 owns prompt/skill mounting);
  *      - retryClassifier (engine adaptation)     → stays at L0 (custom-wiring persona);
- *      - L3 exposes only what an operator may say: the model flag, and `globalSkills`
- *        (a semantic authoring-scope toggle — "include the machine's global skills" —
- *        not raw skillPaths; raw paths stay an L2/embedder concern).
- *    KNOWN DEBT: "L3 accepts no K" is a v1 line, not an invariant — sessions/env ARE
- *    deployment choices semantically. When backend #2 lands (DDB / sandbox env),
- *    this boundary must be re-cut: either config grows K keys (L3 inherits them)
- *    or L3 options grow K overrides. Decide from real backends; do not pre-wire.
+ *      - an opener exposes only what an operator may say: the model flag, and (dev)
+ *        `globalSkills` (a semantic authoring-scope toggle, not raw skillPaths; raw
+ *        paths stay an L2/embedder concern).
+ *    KNOWN DEBT: "the openers accept no K" is a v1 line, not an invariant — sessions/env
+ *    ARE deployment choices semantically. When backend #2 lands (DDB / sandbox env),
+ *    this boundary must be re-cut: either config grows K keys (the openers inherit them)
+ *    or opener options grow K overrides. Decide from real backends; do not pre-wire.
  */
-import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
@@ -63,10 +69,10 @@ import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { createCodingTools, createReadOnlyTools } from "@earendil-works/pi-coding-agent";
 import type { Agent } from "../../agent.ts";
 import type { AuthResolver } from "./auth.ts";
-import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { type LoadedDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored, loadAgentDefinition } from "./definition.ts";
+import type { FastagentConfig } from "./config.ts";
+import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, piHarnessFactory } from "./harness.ts";
-import { type PiSessionStore, inMemorySessionStore, jsonlSessionStore } from "./sessions.ts";
+import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 
 // ── §1 tools: pi's real built-in core coding tools (engine assets) ───────────
@@ -95,8 +101,8 @@ export function piReadOnlyTools(cwd: string): AgentTool[] {
 
 /**
  * Materialize the documented `config.tools` semantics: extra tools are APPENDED
- * after pi's defaults, never replacing them. Used by L3; exported for callers
- * assembling manually from a loaded config.
+ * after pi's defaults, never replacing them. Used by the dev/start openers; exported
+ * for callers assembling manually from a loaded config.
  */
 export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] {
   const defaults = piDefaultTools(cwd);
@@ -176,7 +182,10 @@ export function assembleSystemPrompt(options: AssembleSystemPromptOptions): stri
   return prompt;
 }
 
-// ── §3 the assembly ladder: L1 / L2 / L3 (L0 lives in invoke.ts) ─────────────
+// ── §3 the reusable assembly ladder: L1 / L2 (L0 lives in invoke.ts) ─────────
+//
+// The command openers (createPiAgentFromWorkspace in dev.ts, createPiAgentFromArtifact
+// in start.ts) compose OVER L2 and live in their own command modules — see the header.
 
 /** L1 options, grouped by the two-axis model (core-design §6.1). */
 export interface CreatePiAgentOptions {
@@ -279,65 +288,8 @@ export async function createPiAgentFromDefinition(
   return { agent, definition };
 }
 
-/**
- * L3 options. Notably absent by design: `model`/`tools` as objects — at this rung
- * they come from the config resolution (that is the whole point of L3). K/auth
- * overrides are also absent: deployment backends are a library-API concern (use
- * L2/L1) for now — see ladder rule 2 (KNOWN DEBT: re-cut when hosting lands).
- */
-export interface CreatePiAgentFromWorkspaceOptions {
-  /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
-  model?: string;
-  /**
-   * Also load the machine's global skills (`~/.pi/agent/skills`, `~/.agents/skills`) on top of
-   * the definition's own `skills/`. Default false = definition-only, so dev mirrors deployment.
-   * This is an authoring-fidelity opt-in (e.g. `fastagent dev --global-skills`); to ship a global
-   * skill, materialize it into the artifact (build --global-skills) — do not rely on this at deploy.
-   */
-  globalSkills?: boolean;
-}
-
-/**
- * L3: "point at a workspace → agent": the workspace = definition folder +
- * fastagent.config.ts (+ .env handled by the process entry). Loads the config,
- * resolves model (flag > env > config) and tools (append-after-defaults), then L2.
- * Throws a clear error when no model source is set (fail visibly at startup).
- * Returns everything an entry point needs to report what it assembled.
- */
-export async function createPiAgentFromWorkspace(
-  dir: string,
-  options: CreatePiAgentFromWorkspaceOptions = {},
-): Promise<{
-  agent: Agent;
-  definition: LoadedDefinition;
-  config: FastagentConfig;
-  /** Config file path; undefined when running zero-config. */
-  configPath?: string;
-  /** The resolved "provider/modelId" spec actually in use. */
-  modelSpec: string;
-}> {
-  const { config, path: configPath }: LoadedConfig = await loadConfig(dir);
-  const modelSpec = resolveModelSpec(options.model, config);
-  if (!modelSpec) {
-    throw new Error(
-      `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
-    );
-  }
-  // Workspace rung owns workspace state: .fastagent/ (layer-3 machine state —
-  // gitignored, deletable, rebuildable) is created HERE, not in the CLI, so library
-  // callers of L3 get the same self-gitignored dir (vite/next-style).
-  const stateDir = join(dir, ".fastagent");
-  await mkdir(stateDir, { recursive: true });
-  await ensureStateDirSelfIgnored(stateDir);
-  const { agent, definition } = await createPiAgentFromDefinition(dir, {
-    model: resolveModel(modelSpec),
-    tools: resolveTools(config, dir),
-    // Definition-only by default (the agent is its folder); globals are an explicit
-    // authoring-fidelity opt-in, never the deploy path (see ladder rule 2 + §6).
-    skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
-    // Sessions persist under the state dir: `fastagent dev` restarts keep
-    // conversations — faithful to local pi, which persists sessions too.
-    sessions: jsonlSessionStore({ dir: join(stateDir, "sessions"), cwd: dir }),
-  });
-  return { agent, definition, config, configPath, modelSpec };
-}
+// The command OPENERS that compose over L2 live in their own command modules:
+//   dev   → createPiAgentFromWorkspace  (dev.ts)
+//   start → createPiAgentFromArtifact   (start.ts)
+//   build → buildPiArtifact             (build.ts)
+// keeping create.ts the pure reusable ladder (L0–L2 + engine assets). See the header.

--- a/core/src/engines/pi/dev.ts
+++ b/core/src/engines/pi/dev.ts
@@ -1,0 +1,90 @@
+/**
+ * Dev: open a workspace into an agent in AUTHORING posture (`fastagent dev`).
+ *
+ * `dev` is the authoring-time counterpart of `start` (production, `start.ts`). Both are thin
+ * "openers" — open a source → resolve model/tools → inject K-wiring → call L2
+ * `createPiAgentFromDefinition`. They are NOT ladder rungs (the reusable assembly ladder is
+ * L0–L2 in create.ts/invoke.ts); they are command-posture compositions over L2. The two differ
+ * only in their source and K defaults:
+ *
+ *   | concern  | dev (from workspace, here)            | start (from artifact, start.ts)        |
+ *   |----------|----------------------------------------|-----------------------------------------|
+ *   | model    | fastagent.config.ts (flag > env > cfg) | manifest.model (frozen at build)        |
+ *   | tools    | loadConfig → resolveTools              | loadConfig → resolveTools (same)        |
+ *   | skills   | definition-only (+ --global-skills)    | definition-only (artifact is the truth) |
+ *   | sessions | jsonl under <ws>/.fastagent/sessions   | jsonl OUTSIDE the artifact              |
+ *
+ * dev keeps sessions under the workspace's own `.fastagent/` because the dev "artifact" is the
+ * mutable workspace itself — restart-surviving local continuity, faithful to local pi. (start
+ * deliberately differs: its artifact is immutable, so sessions live outside it — see start.ts.)
+ *
+ * Node composition-root module (IO policy, see definition.ts): loads config + sets up the
+ * `.fastagent/` state dir on disk; the invoke path itself stays disk-free.
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { Agent } from "../../agent.ts";
+import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
+import { createPiAgentFromDefinition, resolveTools } from "./create.ts";
+import { type LoadedDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored } from "./definition.ts";
+import { jsonlSessionStore } from "./sessions.ts";
+
+export interface CreatePiAgentFromWorkspaceOptions {
+  /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
+  model?: string;
+  /**
+   * Also load the machine's global skills (`~/.pi/agent/skills`, `~/.agents/skills`) on top of
+   * the definition's own `skills/`. Default false = definition-only, so dev mirrors deployment.
+   * This is an authoring-fidelity opt-in (e.g. `fastagent dev --global-skills`); to ship a global
+   * skill, materialize it into the artifact (build --global-skills) — do not rely on this at deploy.
+   */
+  globalSkills?: boolean;
+}
+
+/**
+ * "Point at a workspace → agent": the workspace = definition folder + fastagent.config.ts (+ .env
+ * handled by the process entry). Loads the config, resolves model (flag > env > config) and tools
+ * (append-after-defaults), then L2. Throws a clear error when no model source is set (fail visibly
+ * at startup). Returns everything an entry point needs to report what it assembled.
+ *
+ * Notably absent from the options by design: `model`/`tools` as objects (they come from the config
+ * resolution — the whole point of this opener) and K/auth overrides (deployment backends are a
+ * library-API concern; use L2/L1 — see create.ts ladder rule 2, KNOWN DEBT: re-cut when hosting lands).
+ */
+export async function createPiAgentFromWorkspace(
+  dir: string,
+  options: CreatePiAgentFromWorkspaceOptions = {},
+): Promise<{
+  agent: Agent;
+  definition: LoadedDefinition;
+  config: FastagentConfig;
+  /** Config file path; undefined when running zero-config. */
+  configPath?: string;
+  /** The resolved "provider/modelId" spec actually in use. */
+  modelSpec: string;
+}> {
+  const { config, path: configPath }: LoadedConfig = await loadConfig(dir);
+  const modelSpec = resolveModelSpec(options.model, config);
+  if (!modelSpec) {
+    throw new Error(
+      `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
+    );
+  }
+  // The dev opener owns workspace state: .fastagent/ (machine state — gitignored, deletable,
+  // rebuildable) is created HERE, not in the CLI, so library callers get the same
+  // self-gitignored dir (vite/next-style).
+  const stateDir = join(dir, ".fastagent");
+  await mkdir(stateDir, { recursive: true });
+  await ensureStateDirSelfIgnored(stateDir);
+  const { agent, definition } = await createPiAgentFromDefinition(dir, {
+    model: resolveModel(modelSpec),
+    tools: resolveTools(config, dir),
+    // Definition-only by default (the agent is its folder); globals are an explicit
+    // authoring-fidelity opt-in, never the deploy path (see create.ts ladder rule 2 + core-design §6).
+    skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
+    // Sessions persist under the state dir: `fastagent dev` restarts keep conversations —
+    // faithful to local pi, which persists sessions too.
+    sessions: jsonlSessionStore({ dir: join(stateDir, "sessions"), cwd: dir }),
+  });
+  return { agent, definition, config, configPath, modelSpec };
+}

--- a/core/src/engines/pi/start.ts
+++ b/core/src/engines/pi/start.ts
@@ -1,12 +1,12 @@
 /**
  * Start: run a built artifact in production posture (core-design §10.4).
  *
- * `start` is the deploy-time sibling of L3 `createPiAgentFromWorkspace` (dev). Both are thin
- * orchestrations over L2 `createPiAgentFromDefinition` — NOT a new ladder rung (the M-assembly
- * ladder is L0–L3; this only injects production K-wiring into L2). The two differ only in
- * where their inputs come from and which K defaults they pick:
+ * `start` is the deploy-time sibling of `createPiAgentFromWorkspace` (dev, dev.ts). Both are thin
+ * command OPENERS over L2 `createPiAgentFromDefinition` — NOT ladder rungs (the reusable ladder is
+ * L0–L2 in create.ts/invoke.ts); they only inject command-posture K-wiring into L2. The two differ
+ * only in where their inputs come from and which K defaults they pick:
  *
- *   | concern  | dev (L3, from workspace)        | start (from artifact, here)            |
+ *   | concern  | dev (from workspace, dev.ts)    | start (from artifact, here)            |
  *   |----------|----------------------------------|-----------------------------------------|
  *   | model    | config.model                     | manifest.model (frozen at build)        |
  *   | tools    | loadConfig → resolveTools        | loadConfig → resolveTools (same)        |

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -14,15 +14,20 @@ export { collect, AgentFailure, type CollectResult } from "./collect.ts";
 // Channels (N-side; consume only the Agent contract)
 export { createInvokeHandler } from "./channels/http.ts";
 
-// pi reference implementation — assembly ladder (L1/L2/L3; L0 below)
+// pi reference implementation — reusable assembly ladder (L1/L2; L0 below)
 export {
   createPiAgent,
   createPiAgentFromDefinition,
-  createPiAgentFromWorkspace,
   type CreatePiAgentOptions,
   type CreatePiAgentFromDefinitionOptions,
-  type CreatePiAgentFromWorkspaceOptions,
 } from "./engines/pi/create.ts";
+
+// pi reference implementation — dev (open a workspace into an agent, authoring posture).
+// The command opener that composes over L2; sibling of createPiAgentFromArtifact (start).
+export {
+  createPiAgentFromWorkspace,
+  type CreatePiAgentFromWorkspaceOptions,
+} from "./engines/pi/dev.ts";
 
 // pi reference implementation — definition domain (load).
 // bundleAgentDefinition is intentionally NOT exported: it does a destructive `rm -rf

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -83,18 +83,25 @@ The real implementation catches setup/runtime errors and converts them to `faile
 
 ## 4. Assembly ladder
 
-The pi implementation exposes four entry points. Each upper rung delegates downward.
+The reusable ladder is three rungs (L0–L2); each upper rung delegates downward.
 
 | Rung | Function | Meaning |
 |---|---|---|
-| L3 `[OPEN]` | `createPiAgentFromWorkspace(dir, { model? })` | load workspace config + definition; used by CLI |
 | L2 `[LOAD]` | `createPiAgentFromDefinition(dir, options)` | load `AGENTS.md` + skills, assemble prompt, then L1 |
 | L1 `[ASSEMBLE]` | `createPiAgent(options)` | assemble from typed parts: model, prompt, tools, sessions, env, auth |
 | L0 `[ADAPT]` | `createPiAgentFromHarness({ harnessFactory })` | adapt pi harness wiring into the Agent Handler stream |
 
 Naming rule: `From<source>` means inputs are derived from that source. No suffix (`createPiAgent`) means typed parts are supplied directly.
 
-L0 lives in `invoke.ts` because its body is the request-time turn mechanism; L1–L3 live in `create.ts` because they are configuration-time assembly.
+L0 lives in `invoke.ts` because its body is the request-time turn mechanism; L1–L2 live in `create.ts` because they are configuration-time assembly.
+
+**Command openers (above L2).** The three CLI commands are thin compositions over L2 that open a source, resolve model/tools, inject command-posture K-wiring, then call L2. They are **not** ladder rungs and live in their own command modules so dev/build/start stay symmetric and `create.ts` stays the pure reusable ladder:
+
+| Command | Function | Module | Posture |
+|---|---|---|---|
+| `dev` | `createPiAgentFromWorkspace(dir, { model?, globalSkills? })` | `dev.ts` | authoring (config.ts, `.fastagent/` sessions) |
+| `start` | `createPiAgentFromArtifact(dir, { model?, sessionsDir? })` | `start.ts` | production (manifest, sessions outside the artifact) |
+| `build` | `buildPiArtifact(src, out, options)` | `build.ts` | compile (produces an artifact, not an Agent) |
 
 ## 5. Config v1
 
@@ -144,7 +151,7 @@ Code tools are different: they are TypeScript/JavaScript modules with dependenci
 Each `invoke` creates a fresh harness bound to the requested session and discards it after the turn. Conversation continuity comes from reopening the session from a `PiSessionStore` (pi-coupled: it returns pi's `Session`):
 
 - L1 default: `inMemorySessionStore()` for embedding/tests.
-- L3 default: `jsonlSessionStore()` under `.fastagent/sessions` for restart-surviving local dev.
+- dev opener default: `jsonlSessionStore()` under `.fastagent/sessions` for restart-surviving local dev.
 
 This gives the reference implementation portable conformance in miniature: two separate instances sharing the same external store can continue the same session.
 
@@ -262,7 +269,7 @@ Run a built agent in **production posture**. Differences from `dev`:
 | model | `--model > FASTAGENT_MODEL > config` | `--model > FASTAGENT_MODEL > manifest.model` |
 | port | `--port > config` | `--port > PORT env > manifest.http.port > 8787` |
 
-`start` reuses **L2** (`createPiAgentFromDefinition`) with production wiring injected — no new ladder rung — which is exactly what L2's injection points exist for. It depends on zero builder-machine state. The entry point is `createPiAgentFromArtifact(artifactDir, options)` (in `engines/pi/start.ts`): a deploy-time orchestration sibling of L3 `createPiAgentFromWorkspace`, not a ladder rung. It reads `fastagent.json` (frozen model/http) + the shipped `fastagent.config.*` (code tools), resolves the model/sessions, then calls L2.
+`start` reuses **L2** (`createPiAgentFromDefinition`) with production wiring injected — no new ladder rung — which is exactly what L2's injection points exist for. It depends on zero builder-machine state. The entry point is `createPiAgentFromArtifact(artifactDir, options)` (in `engines/pi/start.ts`): a deploy-time orchestration sibling of `createPiAgentFromWorkspace` (dev), not a ladder rung. It reads `fastagent.json` (frozen model/http) + the shipped `fastagent.config.*` (code tools), resolves the model/sessions, then calls L2.
 
 **Sessions live OUTSIDE the artifact** (the M/K split): the artifact is immutable and replaced wholesale on redeploy, so conversational state (K) kept inside it would be wiped on every deploy and every container restart. The default is the shell-cwd-relative, visible `./fastagent-sessions/` (precedence `--sessions-dir > FASTAGENT_SESSIONS_DIR > <cwd>/fastagent-sessions`), self-gitignored, **never** the artifact's own `.fastagent/`. The cwd-relative default's only footgun (continuity bound to launch dir) is loud (the resolved absolute path is in the startup report) and absent in containers (fixed `WORKDIR`); a sessions dir resolving inside the artifact emits a visible warning. dev keeps sessions under `<workspace>/.fastagent/` because the dev "artifact" is the mutable workspace itself — a deliberate difference, not an inconsistency.
 

--- a/docs/fastagent.md
+++ b/docs/fastagent.md
@@ -53,7 +53,7 @@ You can build products such as multi-channel assistants or A2A task systems on t
 Core v0.1 local development is closed:
 
 - SPEC reference implementation over pi,
-- L0–L3 assembly ladder,
+- L0–L2 assembly ladder + dev/build/start command openers,
 - HTTP/SSE channel,
 - `fastagent dev`,
 - persistent jsonl sessions under `.fastagent/sessions`,


### PR DESCRIPTION
## What (Direction B)

Make the three CLI commands symmetric. `createPiAgentFromWorkspace` (the dev opener) moves out of `create.ts` into its own `dev.ts`, mirroring `build.ts` and `start.ts`. `create.ts` now holds only the **reusable assembly ladder** (L0–L2) + engine assets (tools/prompt).

## Why

`createPiAgentFromWorkspace` (dev) and `createPiAgentFromArtifact` (start) are conceptual twins — open a source, resolve model/tools, inject K-wiring, call L2 — but were placed asymmetrically: dev as an L3 ladder rung inside `create.ts`, start as a sibling (not a rung) in `start.ts`. They are **command-posture openers**, not pure assembly primitives (they encode config/manifest precedence, sessions location, `--global-skills`). Separating reusable assembly (L0–L2) from command posture (dev/build/start) makes the layering legible:

| Layer | Lives in |
|---|---|
| reusable ladder L0–L2 + assets | `create.ts` (+ L0 in `invoke.ts`) |
| dev opener (authoring) | `dev.ts` |
| build (compile) | `build.ts` |
| start opener (production) | `start.ts` |

## Scope

**Pure refactor — no behavior change, public API unchanged.** `index.ts` re-exports `createPiAgentFromWorkspace` / `CreatePiAgentFromWorkspaceOptions` from `dev.ts` (same names/types). Tests importing via `index.ts` are unaffected.

- `create.ts`: drop L3 (moved to `dev.ts`); rewrite the ladder header (L0–L2 + a "command openers above L2" note); trim now-unused imports.
- `dev.ts` (new): `createPiAgentFromWorkspace` + options, reframed as the authoring-posture opener (twin of start).
- `index.ts`, `cli.ts`: import the dev opener from `dev.ts`.
- `start.ts` header: reference the dev twin without the L3 label.
- Docs: `core-design` §4 (rungs + command-openers table) / §7 wording, `fastagent.md`, AGENTS.md repo map (now lists dev/build/start).

## Verification

`npm run typecheck` clean; `npm test` 127 passed. CLI smoke: `dev` still assembles and binds the config port; `.fastagent/` state dir unchanged.
