### PR TITLE
feat(init): fastagent init — scaffold a minimal runnable workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ core/
 │   └── engines/pi/              # the pi reference implementation
 │       ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
 │       ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
+│       ├── init.ts              # `init`: scaffold a minimal runnable workspace
 │       ├── dev.ts               # `dev` opener: open a workspace → agent (authoring posture)
 │       ├── build.ts             # `build`: compile a workspace → self-contained artifact
 │       ├── start.ts             # `start` opener: run a built artifact (production posture)

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -88,6 +88,11 @@ async function runInit(): Promise<void> {
   }
   for (const w of warnings) console.error(`[fastagent] warn: ${w}`);
   console.error(`  next steps:`);
+  // The .env / config / `fastagent dev` steps all act on the scaffolded dir. When init targeted a
+  // non-cwd dir (e.g. `fastagent init my-agent`, the recommended clean-start flow), lead with a
+  // `cd` so every step — including bare `fastagent dev` (which defaults its dir to .) — is correct.
+  const rel = relative(process.cwd(), dir);
+  if (rel !== "") console.error(`    cd ${rel}`);
   console.error(`    1. credentials — run \`pi login\`, or add a key to .env (e.g. OPENAI_API_KEY=...)`);
   console.error(`    2. optional   — edit fastagent.config.mjs to choose your model`);
   console.error(`    3. fastagent dev   # serve locally and iterate`);

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -79,10 +79,14 @@ else if (command === "start") await runStart();
 else usage(1);
 
 async function runInit(): Promise<void> {
-  const { created, skipped } = await scaffoldWorkspace(dir).catch(failStartup);
+  const { created, skipped, intoNonEmpty, warnings } = await scaffoldWorkspace(dir).catch(failStartup);
   console.error(`[fastagent] initialized ${dir}`);
   if (created.length > 0) console.error(`  created: ${created.join(", ")}`);
   if (skipped.length > 0) console.error(`  kept existing: ${skipped.join(", ")}`);
+  if (intoNonEmpty) {
+    console.error(`  note: scaffolded into a non-empty directory; for a clean start, run \`fastagent init <name>\` (a fresh subdir)`);
+  }
+  for (const w of warnings) console.error(`[fastagent] warn: ${w}`);
   console.error(`  next steps:`);
   console.error(`    1. credentials — run \`pi login\`, or add a key to .env (e.g. OPENAI_API_KEY=...)`);
   console.error(`    2. optional   — edit fastagent.config.mjs to choose your model`);

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -3,6 +3,7 @@
  * fastagent CLI — the consumer of fastagent.config.ts (product entry point,
  * replacing hand-written entry scripts).
  *
+ *   fastagent init  [dir] — scaffold a minimal runnable workspace
  *   fastagent dev   [dir] — assemble + serve a local HTTP channel (iteration)
  *   fastagent build [dir] — compile a self-contained artifact (core-design §10.3)
  *   fastagent start [dir] — run a built artifact in production posture (core-design §10.4)
@@ -19,10 +20,12 @@ import { probeAuthSource } from "./engines/pi/auth.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
+import { scaffoldWorkspace } from "./engines/pi/init.ts";
 import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
 
 function usage(code: number): never {
   console.error(`usage:
+  fastagent init  [dir]
   fastagent dev   [dir] [--port N] [--model provider/modelId] [--global-skills]
   fastagent build [dir] [--out dir] [--model provider/modelId] [--global-skills] [--force]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
@@ -31,6 +34,8 @@ function usage(code: number): never {
          model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
          --global-skills   also load the machine's global skills (~/.pi/agent/skills,
                            ~/.agents/skills); default is definition-only (dev == deployed)
+  init   scaffold a minimal runnable workspace in dir (default .): AGENTS.md, an example
+         skill, fastagent.config.mjs, .gitignore. Refuses to overwrite an existing workspace.
   build  compile dir into a self-contained, relocatable artifact (default out:
          .fastagent/build): the source tree + materialized skills + manifest, minus
          node_modules/.git and anything .gitignore/.fastagentignore excludes (honored
@@ -67,10 +72,22 @@ const [command, dirArg] = positionals;
 const dir = resolve(dirArg ?? ".");
 const globalSkills = values["global-skills"] ?? false;
 
-if (command === "dev") await runDev();
+if (command === "init") await runInit();
+else if (command === "dev") await runDev();
 else if (command === "build") await runBuild();
 else if (command === "start") await runStart();
 else usage(1);
+
+async function runInit(): Promise<void> {
+  const { created, skipped } = await scaffoldWorkspace(dir).catch(failStartup);
+  console.error(`[fastagent] initialized ${dir}`);
+  if (created.length > 0) console.error(`  created: ${created.join(", ")}`);
+  if (skipped.length > 0) console.error(`  kept existing: ${skipped.join(", ")}`);
+  console.error(`  next steps:`);
+  console.error(`    1. credentials — run \`pi login\`, or add a key to .env (e.g. OPENAI_API_KEY=...)`);
+  console.error(`    2. optional   — edit fastagent.config.mjs to choose your model`);
+  console.error(`    3. fastagent dev   # serve locally and iterate`);
+}
 
 /**
  * Parse + range-check a port string (CLI flag or env). Empty/whitespace (e.g. `PORT=` in an

--- a/core/src/engines/pi/definition.ts
+++ b/core/src/engines/pi/definition.ts
@@ -171,8 +171,12 @@ export async function ensureStateDirSelfIgnored(stateDir: string): Promise<void>
  *
  * An existing-but-unreadable file fails visibly — silently building with no rules could
  * ship files the author meant to exclude.
+ *
+ * Exported (module-internal, not on the public surface) so other commands can ask the exact
+ * question the build will answer — e.g. `init` checks whether `.env` will be excluded from the
+ * artifact using THIS matcher, so its advisory matches what `build` actually ships.
  */
-async function loadRootIgnore(dir: string): Promise<Ignore | undefined> {
+export async function loadRootIgnore(dir: string): Promise<Ignore | undefined> {
   let rules = "";
   for (const name of [".gitignore", ".fastagentignore"]) {
     try {

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -16,8 +16,17 @@
  *
  * Node composition-root module: writes template files; no engine import beyond the default
  * model string in the config template (folded-M — lift if a second engine ever scaffolds).
+ *
+ * Scope boundary (deliberate — do not keep hardening past it): init is best-effort atomic for
+ * ORDINARY inputs (a missing or normal target dir). It guards the common, recoverable cases —
+ * never overwrites an existing workspace, preflights non-directory/symlink scaffold parents, and
+ * rolls back a partial write. It does NOT defend against every pathological pre-existing state of
+ * the target (TOCTOU races, read-only dirs, FIFOs, mid-write disk-full, …): this is a local
+ * scaffolding command on the developer's own machine, where such a failure is surfaced and
+ * recovered by deleting the dir and retrying. Hardening past this line is an open-ended edge
+ * factory for negligible benefit; stop here.
  */
-import { access, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { access, lstat, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { loadRootIgnore } from "./definition.ts";
 
@@ -128,9 +137,12 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
     }
   }
   for (const rel of parents) {
-    const st = await stat(join(dir, rel)).catch(() => undefined);
+    // lstat, NOT stat: a symlink at a scaffold parent (e.g. `skills` → another dir) must be
+    // REJECTED, not followed — following it would write the scaffold OUTSIDE the requested dir.
+    // This matches build, which also does not follow in-tree symlinks (definition.ts planShipSet).
+    const st = await lstat(join(dir, rel)).catch(() => undefined);
     if (st && !st.isDirectory()) {
-      throw new Error(`cannot scaffold: "${rel}" exists and is not a directory (remove it, or init elsewhere)`);
+      throw new Error(`cannot scaffold: "${rel}" exists and is not a directory (a regular file or symlink) — remove it, or init elsewhere`);
     }
   }
 

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -17,7 +17,7 @@
  * Node composition-root module: writes template files; no engine import beyond the default
  * model string in the config template (folded-M — lift if a second engine ever scaffolds).
  */
-import { access, mkdir, readdir, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { loadRootIgnore } from "./definition.ts";
 
@@ -114,21 +114,49 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
   // toward `init <name>` (a fresh subdir) when scaffolding into an existing/non-empty dir.
   const intoNonEmpty = (await readdir(dir).catch(() => [] as string[])).length > 0;
 
+  // Preflight the parent directories every scaffold file needs (e.g. `skills`,
+  // `skills/house-style`). A pre-existing NON-directory there would make mkdir fail mid-loop
+  // with ENOTDIR — AFTER the first file is written — leaving a half-scaffold that the identity
+  // guard then blocks on retry. Detect it BEFORE any write, with a clear message; the dir is
+  // left untouched and the user can retry after fixing it.
+  const parents = new Set<string>();
+  for (const file of FILES) {
+    let p = dirname(file.rel);
+    while (p !== "." && p !== "") {
+      parents.add(p);
+      p = dirname(p);
+    }
+  }
+  for (const rel of parents) {
+    const st = await stat(join(dir, rel)).catch(() => undefined);
+    if (st && !st.isDirectory()) {
+      throw new Error(`cannot scaffold: "${rel}" exists and is not a directory (remove it, or init elsewhere)`);
+    }
+  }
+
   await mkdir(dir, { recursive: true });
   const created: string[] = [];
   const skipped: string[] = [];
-  for (const file of FILES) {
-    const abs = join(dir, file.rel);
-    await mkdir(dirname(abs), { recursive: true });
-    try {
-      // wx: never clobber. The identity files are guaranteed absent (guard above); the rest
-      // (e.g. a pre-existing .gitignore) are kept on EEXIST instead of overwritten.
-      await writeFile(abs, file.content, { flag: "wx" });
-      created.push(file.rel);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") skipped.push(file.rel);
-      else throw error;
+  try {
+    for (const file of FILES) {
+      const abs = join(dir, file.rel);
+      await mkdir(dirname(abs), { recursive: true });
+      try {
+        // wx: never clobber. The identity files are guaranteed absent (guard above); the rest
+        // (e.g. a pre-existing .gitignore) are kept on EEXIST instead of overwritten.
+        await writeFile(abs, file.content, { flag: "wx" });
+        created.push(file.rel);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") skipped.push(file.rel);
+        else throw error;
+      }
     }
+  } catch (error) {
+    // Roll back files written THIS run (guard + wx guarantee they are ours, not pre-existing)
+    // so an unexpected mid-write failure never leaves a half-scaffold that blocks retry. Empty
+    // dirs we may have created are harmless and left as-is.
+    for (const rel of created.reverse()) await rm(join(dir, rel), { force: true }).catch(() => {});
+    throw error;
   }
 
   // Security wiring is the .gitignore's whole job here: `fastagent build` excludes secrets ONLY

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -17,8 +17,9 @@
  * Node composition-root module: writes template files; no engine import beyond the default
  * model string in the config template (folded-M — lift if a second engine ever scaffolds).
  */
-import { access, mkdir, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import ignore from "ignore";
 
 const AGENTS_MD = `# Assistant
 
@@ -77,6 +78,10 @@ export interface ScaffoldResult {
   created: string[];
   /** Files that already existed and were kept untouched (e.g. a pre-existing .gitignore). */
   skipped: string[];
+  /** True if the target already had content before this run (init into an existing/non-empty dir). */
+  intoNonEmpty: boolean;
+  /** Non-fatal advisories the caller MUST surface (e.g. a kept .gitignore that does not ignore .env). */
+  warnings: string[];
 }
 
 async function exists(p: string): Promise<boolean> {
@@ -105,6 +110,10 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
     );
   }
 
+  // Was the target non-empty BEFORE we wrote anything? (missing dir = empty). Used to nudge
+  // toward `init <name>` (a fresh subdir) when scaffolding into an existing/non-empty dir.
+  const intoNonEmpty = (await readdir(dir).catch(() => [] as string[])).length > 0;
+
   await mkdir(dir, { recursive: true });
   const created: string[] = [];
   const skipped: string[] = [];
@@ -121,5 +130,19 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
       else throw error;
     }
   }
-  return { dir, created, skipped };
+
+  // Security wiring is the .gitignore's whole job here: `fastagent build` excludes secrets ONLY
+  // via .gitignore/.fastagentignore (it does not special-case .env — core-design §10.1). If we
+  // KEPT a pre-existing .gitignore that does not ignore .env, the scaffold's secret line silently
+  // did not take effect while next-steps still tells the user to create .env → build could ship it.
+  // Warn with the exact fix; do NOT silently mutate the user's file (non-destructive contract +
+  // §10.1 "security is the user's responsibility; fastagent informs").
+  const warnings: string[] = [];
+  const gitignore = await readFile(join(dir, ".gitignore"), "utf8").catch(() => "");
+  if (!ignore().add(gitignore).ignores(".env")) {
+    warnings.push(
+      `your .gitignore does not ignore ".env" — add it, or \`fastagent build\` may ship secrets into the artifact`,
+    );
+  }
+  return { dir, created, skipped, intoNonEmpty, warnings };
 }

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -1,0 +1,125 @@
+/**
+ * Init: scaffold a minimal, runnable fastagent workspace — the lowest-barrier dev unit.
+ *
+ * The scaffold is markdown-only (zero npm dependencies): AGENTS.md + one example skill +
+ * fastagent.config.mjs + .gitignore. It runs immediately under `fastagent dev` once the
+ * developer has model credentials. Code-tool agents (a `package.json` + a tool module) are a
+ * separate, opt-in step — this command deliberately scaffolds the no-dependency unit so the
+ * first run never blocks on `npm install`.
+ *
+ * Two scaffold conventions worth noting:
+ *   - AGENTS.md is kept a CLEAN persona (no meta "edit me" instructions) because it IS the
+ *     system prompt; the "what to edit next" guidance is printed to the console instead.
+ *   - .gitignore lists `.env` so the "secrets are the user's responsibility" model
+ *     (definition.ts / core-design §10.1) is wired up correctly from the first commit —
+ *     build honors .gitignore, so a gitignored .env never ships in the artifact.
+ *
+ * Node composition-root module: writes template files; no engine import beyond the default
+ * model string in the config template (folded-M — lift if a second engine ever scaffolds).
+ */
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+const AGENTS_MD = `# Assistant
+
+You are a concise, helpful assistant. Answer directly and skip filler.
+
+When the user asks you to write or edit prose, consult the house-style skill first.
+`;
+
+const SKILL_MD = `---
+name: house-style
+description: The house writing style. Consult before writing or editing any prose for the user.
+---
+# House style
+
+- Prefer short sentences and the active voice.
+- Avoid marketing adjectives ("seamless", "powerful", "robust").
+- Lead with the answer; put caveats after.
+`;
+
+const CONFIG_MJS = `// fastagent.config.mjs — deployment choices only (model / tools / http).
+// Your agent's identity and behavior live in AGENTS.md + skills/, never here.
+// Model precedence: \`--model\` flag > FASTAGENT_MODEL env > this default.
+// Change "model" to a "provider/modelId" you have access to.
+export default {
+  model: "openai-codex/gpt-5.5",
+  http: { port: 8787 },
+};
+`;
+
+const GITIGNORE = `# secrets — never commit, never ship in the build artifact
+.env
+
+# dependencies (reinstalled at deploy)
+node_modules/
+
+# fastagent machine state (dev sessions + build output)
+.fastagent/
+`;
+
+interface ScaffoldFile {
+  rel: string;
+  content: string;
+}
+
+/** The files init writes, in report order. AGENTS.md + config are guarded (never overwritten). */
+const FILES: ScaffoldFile[] = [
+  { rel: "AGENTS.md", content: AGENTS_MD },
+  { rel: join("skills", "house-style", "SKILL.md"), content: SKILL_MD },
+  { rel: "fastagent.config.mjs", content: CONFIG_MJS },
+  { rel: ".gitignore", content: GITIGNORE },
+];
+
+export interface ScaffoldResult {
+  dir: string;
+  /** Files written by this run (relative paths). */
+  created: string[];
+  /** Files that already existed and were kept untouched (e.g. a pre-existing .gitignore). */
+  skipped: string[];
+}
+
+async function exists(p: string): Promise<boolean> {
+  return access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+/**
+ * Scaffold a minimal runnable workspace into {@link dir} (created if missing). Refuses to
+ * overwrite an existing agent identity (AGENTS.md or any fastagent.config.*) — that means the
+ * dir is already a workspace, and clobbering it would destroy authored content. Other files
+ * that already exist (.gitignore, the example skill) are kept, not overwritten.
+ */
+export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
+  // Guard on the identity files: their presence means "already a workspace". Fail visibly
+  // rather than overwrite authored content.
+  const configNames = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"];
+  const conflicts: string[] = [];
+  if (await exists(join(dir, "AGENTS.md"))) conflicts.push("AGENTS.md");
+  for (const name of configNames) if (await exists(join(dir, name))) conflicts.push(name);
+  if (conflicts.length > 0) {
+    throw new Error(
+      `"${dir}" already has ${conflicts.join(", ")} — init refuses to overwrite an existing workspace`,
+    );
+  }
+
+  await mkdir(dir, { recursive: true });
+  const created: string[] = [];
+  const skipped: string[] = [];
+  for (const file of FILES) {
+    const abs = join(dir, file.rel);
+    await mkdir(dirname(abs), { recursive: true });
+    try {
+      // wx: never clobber. The identity files are guaranteed absent (guard above); the rest
+      // (e.g. a pre-existing .gitignore) are kept on EEXIST instead of overwritten.
+      await writeFile(abs, file.content, { flag: "wx" });
+      created.push(file.rel);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") skipped.push(file.rel);
+      else throw error;
+    }
+  }
+  return { dir, created, skipped };
+}

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -137,6 +137,11 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
   await mkdir(dir, { recursive: true });
   const created: string[] = [];
   const skipped: string[] = [];
+  const warnings: string[] = [];
+  // ONE rollback scope covering ALL post-write work (the write loop AND the advisory read):
+  // any failure after the first write removes files written THIS run (guard + wx guarantee they
+  // are ours), so scaffoldWorkspace is atomic — success or the dir left as it was (retryable).
+  // Empty dirs we may have created are harmless and left as-is.
   try {
     for (const file of FILES) {
       const abs = join(dir, file.rel);
@@ -151,31 +156,29 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
         else throw error;
       }
     }
+
+    // Security wiring is the .gitignore's whole job here: `fastagent build` excludes secrets ONLY
+    // via .gitignore/.fastagentignore (it does not special-case .env — core-design §10.1). If we
+    // KEPT a pre-existing .gitignore that does not ignore .env, the scaffold's secret line silently
+    // did not take effect while next-steps still tells the user to create .env → build could ship it.
+    // Warn with the exact fix; do NOT silently mutate the user's file (non-destructive contract +
+    // §10.1 "security is the user's responsibility; fastagent informs").
+    //
+    // Use the EXACT matcher build uses (loadRootIgnore: .gitignore + .fastagentignore, fa last,
+    // case-sensitive) so the advisory matches what the artifact will actually ship — a hand-rolled
+    // check diverges (misses .fastagentignore `!.env`, or a case-mismatched `.ENV`) and gives false
+    // assurance, the dangerous direction. This read can throw on an existing-but-unreadable ignore
+    // file (loadRootIgnore fails visibly); keeping it INSIDE the rollback scope means such a throw
+    // still leaves no half-scaffold.
+    const rootIgnore = await loadRootIgnore(dir);
+    if (!rootIgnore?.ignores(".env")) {
+      warnings.push(
+        `your .gitignore/.fastagentignore does not exclude ".env" — add it, or \`fastagent build\` may ship secrets into the artifact`,
+      );
+    }
   } catch (error) {
-    // Roll back files written THIS run (guard + wx guarantee they are ours, not pre-existing)
-    // so an unexpected mid-write failure never leaves a half-scaffold that blocks retry. Empty
-    // dirs we may have created are harmless and left as-is.
     for (const rel of created.reverse()) await rm(join(dir, rel), { force: true }).catch(() => {});
     throw error;
-  }
-
-  // Security wiring is the .gitignore's whole job here: `fastagent build` excludes secrets ONLY
-  // via .gitignore/.fastagentignore (it does not special-case .env — core-design §10.1). If we
-  // KEPT a pre-existing .gitignore that does not ignore .env, the scaffold's secret line silently
-  // did not take effect while next-steps still tells the user to create .env → build could ship it.
-  // Warn with the exact fix; do NOT silently mutate the user's file (non-destructive contract +
-  // §10.1 "security is the user's responsibility; fastagent informs").
-  //
-  // Use the EXACT matcher build uses (loadRootIgnore: .gitignore + .fastagentignore, fa last,
-  // case-sensitive) so the advisory matches what the artifact will actually ship — a hand-rolled
-  // check diverges (misses .fastagentignore `!.env`, or a case-mismatched `.ENV`) and gives false
-  // assurance, the dangerous direction.
-  const warnings: string[] = [];
-  const rootIgnore = await loadRootIgnore(dir);
-  if (!rootIgnore?.ignores(".env")) {
-    warnings.push(
-      `your .gitignore/.fastagentignore does not exclude ".env" — add it, or \`fastagent build\` may ship secrets into the artifact`,
-    );
   }
   return { dir, created, skipped, intoNonEmpty, warnings };
 }

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -17,9 +17,9 @@
  * Node composition-root module: writes template files; no engine import beyond the default
  * model string in the config template (folded-M — lift if a second engine ever scaffolds).
  */
-import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import ignore from "ignore";
+import { loadRootIgnore } from "./definition.ts";
 
 const AGENTS_MD = `# Assistant
 
@@ -137,11 +137,16 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
   // did not take effect while next-steps still tells the user to create .env → build could ship it.
   // Warn with the exact fix; do NOT silently mutate the user's file (non-destructive contract +
   // §10.1 "security is the user's responsibility; fastagent informs").
+  //
+  // Use the EXACT matcher build uses (loadRootIgnore: .gitignore + .fastagentignore, fa last,
+  // case-sensitive) so the advisory matches what the artifact will actually ship — a hand-rolled
+  // check diverges (misses .fastagentignore `!.env`, or a case-mismatched `.ENV`) and gives false
+  // assurance, the dangerous direction.
   const warnings: string[] = [];
-  const gitignore = await readFile(join(dir, ".gitignore"), "utf8").catch(() => "");
-  if (!ignore().add(gitignore).ignores(".env")) {
+  const rootIgnore = await loadRootIgnore(dir);
+  if (!rootIgnore?.ignores(".env")) {
     warnings.push(
-      `your .gitignore does not ignore ".env" — add it, or \`fastagent build\` may ship secrets into the artifact`,
+      `your .gitignore/.fastagentignore does not exclude ".env" — add it, or \`fastagent build\` may ship secrets into the artifact`,
     );
   }
   return { dir, created, skipped, intoNonEmpty, warnings };

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -22,6 +22,9 @@ export {
   type CreatePiAgentFromDefinitionOptions,
 } from "./engines/pi/create.ts";
 
+// pi reference implementation — init (scaffold a minimal runnable workspace).
+export { scaffoldWorkspace, type ScaffoldResult } from "./engines/pi/init.ts";
+
 // pi reference implementation — dev (open a workspace into an agent, authoring posture).
 // The command opener that composes over L2; sibling of createPiAgentFromArtifact (start).
 export {

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
-import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, readdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -67,6 +67,15 @@ describe("init: scaffoldWorkspace", () => {
     await expect(scaffoldWorkspace(dir)).rejects.toThrow(/"skills" exists and is not a directory/);
     // no half-scaffold: AGENTS.md was never written, so a retry is not blocked by the guard
     expect(await exists(join(dir, "AGENTS.md"))).toBe(false);
+  });
+
+  it("rejects a symlinked scaffold parent (does not follow it and write outside the workspace)", async () => {
+    const external = await freshDir(); // a dir OUTSIDE the workspace
+    const dir = await freshDir();
+    await symlink(external, join(dir, "skills")); // `skills` is a symlink → must be rejected, not followed
+    await expect(scaffoldWorkspace(dir)).rejects.toThrow(/"skills" exists and is not a directory/);
+    expect(await exists(join(dir, "AGENTS.md"))).toBe(false); // nothing written in the workspace
+    expect(await readdir(external)).toEqual([]); // and nothing escaped into the symlink target
   });
 
   it("rolls back the scaffold when the .env advisory read throws (unreadable ignore file), keeping retry clean", async () => {

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -48,6 +48,14 @@ describe("init: scaffoldWorkspace", () => {
     expect(intoNonEmpty).toBe(false);
   });
 
+  it("preflights blocking parent paths: a file named `skills` fails BEFORE writing AGENTS.md (retryable)", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, "skills"), "i am a file, not a dir\n"); // blocks skills/house-style/
+    await expect(scaffoldWorkspace(dir)).rejects.toThrow(/"skills" exists and is not a directory/);
+    // no half-scaffold: AGENTS.md was never written, so a retry is not blocked by the guard
+    expect(await exists(join(dir, "AGENTS.md"))).toBe(false);
+  });
+
   it("refuses to overwrite an existing workspace (AGENTS.md or a config), leaving it intact", async () => {
     const dir = await freshDir();
     await writeFile(join(dir, "AGENTS.md"), "# My real agent\n");

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createPiAgentFromWorkspace, loadAgentDefinition, scaffoldWorkspace } from "../src/index.ts";
 
 const freshDir = () => mkdtemp(join(tmpdir(), "fa-init-"));
@@ -10,6 +12,17 @@ async function exists(p: string): Promise<boolean> {
     () => true,
     () => false,
   );
+}
+
+const CLI = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+/** Run `fastagent <args>` from `cwd` to completion; return stderr (the [fastagent] report stream). */
+function cliInit(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, ...args], { cwd });
+    let stderr = "";
+    child.stderr.on("data", (d) => (stderr += String(d)));
+    child.on("close", () => resolve(stderr));
+  });
 }
 
 describe("init: scaffoldWorkspace", () => {
@@ -56,6 +69,15 @@ describe("init: scaffoldWorkspace", () => {
     expect(await exists(join(dir, "AGENTS.md"))).toBe(false);
   });
 
+  it("rolls back the scaffold when the .env advisory read throws (unreadable ignore file), keeping retry clean", async () => {
+    const dir = await freshDir();
+    await mkdir(join(dir, ".fastagentignore")); // a dir where a file is expected → loadRootIgnore throws
+    await expect(scaffoldWorkspace(dir)).rejects.toThrow(/cannot read .*\.fastagentignore/);
+    // the advisory read sits inside the rollback scope → the scaffolded AGENTS.md was removed,
+    // so a retry is not blocked by the overwrite guard
+    expect(await exists(join(dir, "AGENTS.md"))).toBe(false);
+  });
+
   it("refuses to overwrite an existing workspace (AGENTS.md or a config), leaving it intact", async () => {
     const dir = await freshDir();
     await writeFile(join(dir, "AGENTS.md"), "# My real agent\n");
@@ -65,6 +87,17 @@ describe("init: scaffoldWorkspace", () => {
     const dir2 = await freshDir();
     await writeFile(join(dir2, "fastagent.config.ts"), "export default {};\n");
     await expect(scaffoldWorkspace(dir2)).rejects.toThrow(/already has fastagent\.config\.ts/);
+  });
+
+  it("prints a `cd <dir>` step for a named target so the dev/.env/config steps are correct", async () => {
+    const base = await freshDir();
+    // init into a subdir from `base` as cwd: the next steps must lead with `cd my-agent`.
+    const named = await cliInit(["init", "my-agent"], base);
+    expect(named).toMatch(/cd my-agent/);
+    // init into cwd (default .): no cd step, bare `fastagent dev` is already correct.
+    const cwd = await cliInit(["init"], await freshDir());
+    expect(cwd).not.toMatch(/cd /);
+    expect(cwd).toMatch(/fastagent dev/);
   });
 
   it("keeps a pre-existing .gitignore; warns when it does not ignore .env (build could ship secrets)", async () => {

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -15,11 +15,14 @@ async function exists(p: string): Promise<boolean> {
 describe("init: scaffoldWorkspace", () => {
   it("scaffolds a workspace that loads and assembles offline (init → dev is self-contained)", async () => {
     const dir = await freshDir();
-    const { created, skipped } = await scaffoldWorkspace(dir);
+    const { created, skipped, intoNonEmpty, warnings } = await scaffoldWorkspace(dir);
     expect(created.sort()).toEqual(
       ["AGENTS.md", ".gitignore", "fastagent.config.mjs", join("skills", "house-style", "SKILL.md")].sort(),
     );
     expect(skipped).toEqual([]);
+    // fresh empty dir, and our own .gitignore ignores .env → no advisories
+    expect(intoNonEmpty).toBe(false);
+    expect(warnings).toEqual([]);
 
     // The scaffold is a valid definition: AGENTS.md + the example skill, no diagnostics/collisions.
     const def = await loadAgentDefinition(dir);
@@ -37,11 +40,12 @@ describe("init: scaffoldWorkspace", () => {
     expect(await readFile(join(dir, ".gitignore"), "utf8")).toContain(".env");
   });
 
-  it("creates a non-existent target dir", async () => {
+  it("creates a non-existent target dir (counts as empty, no non-empty note)", async () => {
     const base = await freshDir();
     const target = join(base, "nested", "agent");
-    await scaffoldWorkspace(target);
+    const { intoNonEmpty } = await scaffoldWorkspace(target);
     expect(await exists(join(target, "AGENTS.md"))).toBe(true);
+    expect(intoNonEmpty).toBe(false);
   });
 
   it("refuses to overwrite an existing workspace (AGENTS.md or a config), leaving it intact", async () => {
@@ -55,12 +59,22 @@ describe("init: scaffoldWorkspace", () => {
     await expect(scaffoldWorkspace(dir2)).rejects.toThrow(/already has fastagent\.config\.ts/);
   });
 
-  it("keeps a pre-existing non-identity file (.gitignore), still scaffolds the rest", async () => {
+  it("keeps a pre-existing .gitignore; warns when it does not ignore .env (build could ship secrets)", async () => {
     const dir = await freshDir();
-    await writeFile(join(dir, ".gitignore"), "custom\n");
-    const { created, skipped } = await scaffoldWorkspace(dir);
+    await writeFile(join(dir, ".gitignore"), "custom\n"); // no .env rule
+    const { created, skipped, intoNonEmpty, warnings } = await scaffoldWorkspace(dir);
     expect(skipped).toEqual([".gitignore"]);
     expect(created).toContain("AGENTS.md");
-    expect(await readFile(join(dir, ".gitignore"), "utf8")).toBe("custom\n"); // user's kept
+    expect(await readFile(join(dir, ".gitignore"), "utf8")).toBe("custom\n"); // kept, NOT mutated
+    expect(intoNonEmpty).toBe(true); // the dir already had the .gitignore
+    expect(warnings).toEqual([expect.stringMatching(/does not ignore "\.env"/)]);
+  });
+
+  it("does not warn when a kept .gitignore already covers .env", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, ".gitignore"), "node_modules/\n*.env\n"); // *.env covers .env
+    const { skipped, warnings } = await scaffoldWorkspace(dir);
+    expect(skipped).toEqual([".gitignore"]);
+    expect(warnings).toEqual([]);
   });
 });

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -67,12 +67,38 @@ describe("init: scaffoldWorkspace", () => {
     expect(created).toContain("AGENTS.md");
     expect(await readFile(join(dir, ".gitignore"), "utf8")).toBe("custom\n"); // kept, NOT mutated
     expect(intoNonEmpty).toBe(true); // the dir already had the .gitignore
-    expect(warnings).toEqual([expect.stringMatching(/does not ignore "\.env"/)]);
+    expect(warnings).toEqual([expect.stringMatching(/does not exclude "\.env"/)]);
   });
 
   it("does not warn when a kept .gitignore already covers .env", async () => {
     const dir = await freshDir();
     await writeFile(join(dir, ".gitignore"), "node_modules/\n*.env\n"); // *.env covers .env
+    const { skipped, warnings } = await scaffoldWorkspace(dir);
+    expect(skipped).toEqual([".gitignore"]);
+    expect(warnings).toEqual([]);
+  });
+
+  // The advisory must mirror build's matcher (loadRootIgnore: .gitignore + .fastagentignore,
+  // fa last, case-SENSITIVE), or it gives false assurance in the dangerous direction.
+  it("warns on a case-mismatched rule (.ENV does not exclude .env under build's case-sensitive matcher)", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, ".gitignore"), ".ENV\n"); // wrong case → build (ignorecase:false) ships .env
+    const { warnings } = await scaffoldWorkspace(dir);
+    expect(warnings).toEqual([expect.stringMatching(/does not exclude "\.env"/)]);
+  });
+
+  it("warns when .fastagentignore re-includes .env (applied last, authoritative — build ships it)", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, ".gitignore"), ".env\n"); // git excludes it …
+    await writeFile(join(dir, ".fastagentignore"), "!.env\n"); // … but fa un-excludes it (last wins)
+    const { warnings } = await scaffoldWorkspace(dir);
+    expect(warnings).toEqual([expect.stringMatching(/does not exclude "\.env"/)]);
+  });
+
+  it("does not warn when .fastagentignore excludes .env though the kept .gitignore does not (combined matcher)", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, ".gitignore"), "node_modules/\n"); // kept, NO .env rule
+    await writeFile(join(dir, ".fastagentignore"), ".env\n"); // fa covers it → build excludes
     const { skipped, warnings } = await scaffoldWorkspace(dir);
     expect(skipped).toEqual([".gitignore"]);
     expect(warnings).toEqual([]);

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createPiAgentFromWorkspace, loadAgentDefinition, scaffoldWorkspace } from "../src/index.ts";
+
+const freshDir = () => mkdtemp(join(tmpdir(), "fa-init-"));
+async function exists(p: string): Promise<boolean> {
+  return access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+describe("init: scaffoldWorkspace", () => {
+  it("scaffolds a workspace that loads and assembles offline (init → dev is self-contained)", async () => {
+    const dir = await freshDir();
+    const { created, skipped } = await scaffoldWorkspace(dir);
+    expect(created.sort()).toEqual(
+      ["AGENTS.md", ".gitignore", "fastagent.config.mjs", join("skills", "house-style", "SKILL.md")].sort(),
+    );
+    expect(skipped).toEqual([]);
+
+    // The scaffold is a valid definition: AGENTS.md + the example skill, no diagnostics/collisions.
+    const def = await loadAgentDefinition(dir);
+    expect(def.instructions).toContain("concise");
+    expect(def.skills.map((s) => s.name)).toEqual(["house-style"]);
+    expect(def.diagnostics).toEqual([]);
+    expect(def.collisions).toEqual([]);
+
+    // dev assembly works with zero edits and zero network (model is resolved from the registry).
+    const { agent, modelSpec } = await createPiAgentFromWorkspace(dir);
+    expect(typeof agent.invoke).toBe("function");
+    expect(modelSpec).toBe("openai-codex/gpt-5.5");
+
+    // .gitignore wires up the "secrets are the user's responsibility" model from the start.
+    expect(await readFile(join(dir, ".gitignore"), "utf8")).toContain(".env");
+  });
+
+  it("creates a non-existent target dir", async () => {
+    const base = await freshDir();
+    const target = join(base, "nested", "agent");
+    await scaffoldWorkspace(target);
+    expect(await exists(join(target, "AGENTS.md"))).toBe(true);
+  });
+
+  it("refuses to overwrite an existing workspace (AGENTS.md or a config), leaving it intact", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, "AGENTS.md"), "# My real agent\n");
+    await expect(scaffoldWorkspace(dir)).rejects.toThrow(/already has AGENTS\.md .* refuses to overwrite/);
+    expect(await readFile(join(dir, "AGENTS.md"), "utf8")).toBe("# My real agent\n"); // untouched
+
+    const dir2 = await freshDir();
+    await writeFile(join(dir2, "fastagent.config.ts"), "export default {};\n");
+    await expect(scaffoldWorkspace(dir2)).rejects.toThrow(/already has fastagent\.config\.ts/);
+  });
+
+  it("keeps a pre-existing non-identity file (.gitignore), still scaffolds the rest", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, ".gitignore"), "custom\n");
+    const { created, skipped } = await scaffoldWorkspace(dir);
+    expect(skipped).toEqual([".gitignore"]);
+    expect(created).toContain("AGENTS.md");
+    expect(await readFile(join(dir, ".gitignore"), "utf8")).toBe("custom\n"); // user's kept
+  });
+});


### PR DESCRIPTION
## What

`fastagent init [dir]` scaffolds a minimal, runnable workspace — the lowest-barrier dev unit. Addresses review gap #3 (no scaffolding for a from-zero developer).

The scaffold is **markdown-only / zero-dependency**, so the first run never blocks on `npm install`:

```
<dir>/
├── AGENTS.md                     # a clean persona (it IS the system prompt)
├── skills/house-style/SKILL.md   # demonstrates frontmatter + "consult skill"
├── fastagent.config.mjs          # model / http, with precedence comments
└── .gitignore                    # .env / node_modules / .fastagent
```

It runs under `fastagent dev` with **zero edits** once credentials are set.

## Design choices

- **AGENTS.md is a clean persona** — no meta "edit me" instructions, because AGENTS.md *is* the system prompt; "what to edit next" is printed to the console instead.
- **.gitignore lists `.env`** so the "secrets are the user's responsibility" model (definition.ts / core-design §10.1) is wired up from the first commit — build honors .gitignore, so a gitignored `.env` never ships in the artifact.
- **Overwrite guard**: refuses if `AGENTS.md` or any `fastagent.config.*` exists (already a workspace); other pre-existing files (`.gitignore`) are kept, not clobbered. Creates the target dir if missing.
- Lives in `engines/pi/init.ts` alongside dev/build/start (the only pi coupling is the default model string — folded-M).

## Verification (fully local, self-contained)

- `npm run typecheck` clean; `npm test` 131 passed (4 new).
- `init → dev` loop end-to-end: scaffold → assembles + serves with no edits, no network (model resolved from the registry).
- Re-run refuses to overwrite; pre-existing `.gitignore` kept.

## Review note

Adds **public API surface** (`scaffoldWorkspace`) → review-gated per CONTRIBUTING, not self-merge.

## Next (per the agreed plan)

#5 lower the code-tool barrier (a `--with-tool` / package.json template), then #6 container recipe (§10.6) and #7 `fastagent models`.
