### PR TITLE
feat(cli): first-run onboarding — dev auth report (#4) + fastagent models (#7)

### DIFF
--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -116,6 +116,22 @@ function parsePort(value: string | undefined, source: string): number | undefine
   return Number(trimmed);
 }
 
+/**
+ * Report which source provides the model's credentials — and, when none is found, surface a
+ * remediation hint at STARTUP (dev and start alike) rather than letting the agent fail silently
+ * at first invoke. Non-blocking: you may be iterating on prompts, or set credentials afterward.
+ */
+async function reportAuth(modelSpec: string): Promise<void> {
+  const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
+  const source = await probeAuthSource(provider);
+  console.error(`[fastagent] auth:   ${source === "none" ? "(none found)" : `${source} (${provider})`}`);
+  if (source === "none") {
+    console.error(
+      `[fastagent] warn: no credentials for "${provider}" — run \`pi login\`, or set the provider API key in .env (e.g. OPENAI_API_KEY); invokes will fail until then`,
+    );
+  }
+}
+
 async function runDev(): Promise<void> {
   // Validate flags before any assembly work: argument errors must fail instantly,
   // not after the startup report. (config's http.port is range-checked by loadConfig.)
@@ -138,6 +154,7 @@ async function runDev(): Promise<void> {
   console.error(`[fastagent] dir:    ${definition.dir}`);
   console.error(`[fastagent] config: ${configPath ?? "(zero-config)"}`);
   console.error(`[fastagent] model:  ${modelSpec}`);
+  await reportAuth(modelSpec);
   console.error(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);
   const loadedSkills = definition.skills.map((s) => s.name);
   console.error(
@@ -193,14 +210,11 @@ async function runStart(): Promise<void> {
     sessionsDir: values["sessions-dir"] ? resolve(values["sessions-dir"]) : undefined,
   }).catch(failStartup);
 
-  const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
-  const authSource = await probeAuthSource(provider);
-
-  console.error(`[fastagent] start:    ${dir}`);
-  console.error(`[fastagent] model:    ${modelSpec}`);
-  console.error(`[fastagent] auth:     ${authSource === "none" ? "(none found)" : `${authSource} (${provider})`}`);
-  console.error(`[fastagent] agents:   ${definition.instructions ? "AGENTS.md" : "(none)"}`);
-  console.error(`[fastagent] skills:   ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
+  console.error(`[fastagent] start:  ${dir}`);
+  console.error(`[fastagent] model:  ${modelSpec}`);
+  await reportAuth(modelSpec);
+  console.error(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);
+  console.error(`[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
   console.error(`[fastagent] sessions: ${sessionsDir}`);
   // Visible footgun guard: a sessions dir inside the artifact is wiped by a redeploy that
   // replaces the artifact wholesale. Warn, don't block (running in place is legitimate).

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -4,6 +4,7 @@
  * replacing hand-written entry scripts).
  *
  *   fastagent init  [dir] — scaffold a minimal runnable workspace
+ *   fastagent models      — list available "provider/modelId" specs
  *   fastagent dev   [dir] — assemble + serve a local HTTP channel (iteration)
  *   fastagent build [dir] — compile a self-contained artifact (core-design §10.3)
  *   fastagent start [dir] — run a built artifact in production posture (core-design §10.4)
@@ -18,6 +19,7 @@ import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher }
 import { createInvokeHandler } from "./channels/http.ts";
 import { probeAuthSource } from "./engines/pi/auth.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
+import { listModels } from "./engines/pi/config.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
 import { scaffoldWorkspace } from "./engines/pi/init.ts";
@@ -25,8 +27,9 @@ import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
 
 function usage(code: number): never {
   console.error(`usage:
-  fastagent init  [dir]
-  fastagent dev   [dir] [--port N] [--model provider/modelId] [--global-skills]
+  fastagent init   [dir]
+  fastagent models
+  fastagent dev    [dir] [--port N] [--model provider/modelId] [--global-skills]
   fastagent build [dir] [--out dir] [--model provider/modelId] [--global-skills] [--force]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
 
@@ -36,6 +39,7 @@ function usage(code: number): never {
                            ~/.agents/skills); default is definition-only (dev == deployed)
   init   scaffold a minimal runnable workspace in dir (default .): AGENTS.md, an example
          skill, fastagent.config.mjs, .gitignore. Refuses to overwrite an existing workspace.
+  models list the available "provider/modelId" specs (use one with --model or in the config).
   build  compile dir into a self-contained, relocatable artifact (default out:
          .fastagent/build): the source tree + materialized skills + manifest, minus
          node_modules/.git and anything .gitignore/.fastagentignore excludes (honored
@@ -73,10 +77,16 @@ const dir = resolve(dirArg ?? ".");
 const globalSkills = values["global-skills"] ?? false;
 
 if (command === "init") await runInit();
+else if (command === "models") runModels();
 else if (command === "dev") await runDev();
 else if (command === "build") await runBuild();
 else if (command === "start") await runStart();
 else usage(1);
+
+/** `fastagent models`: print every registered "provider/modelId" to stdout (pipe-friendly). */
+function runModels(): void {
+  for (const spec of listModels()) console.log(spec);
+}
 
 async function runInit(): Promise<void> {
   const { created, skipped, intoNonEmpty, warnings } = await scaffoldWorkspace(dir).catch(failStartup);

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -103,7 +103,7 @@ async function runInit(): Promise<void> {
   // `cd` so every step — including bare `fastagent dev` (which defaults its dir to .) — is correct.
   const rel = relative(process.cwd(), dir);
   if (rel !== "") console.error(`    cd ${rel}`);
-  console.error(`    1. credentials — run \`pi login\`, or add a key to .env (e.g. OPENAI_API_KEY=...)`);
+  console.error(`    1. credentials — authenticate with \`pi login\`, or set the provider's API key in .env`);
   console.error(`    2. optional   — edit fastagent.config.mjs to choose your model`);
   console.error(`    3. fastagent dev   # serve locally and iterate`);
 }
@@ -136,8 +136,11 @@ async function reportAuth(modelSpec: string): Promise<void> {
   const source = await probeAuthSource(provider);
   console.error(`[fastagent] auth:   ${source === "none" ? "(none found)" : `${source} (${provider})`}`);
   if (source === "none") {
+    // Lead with `pi login`: the default model (openai-codex) is OAuth-only, and we cannot name
+    // the right env var (it is provider-specific and pi-ai's mapping is not exported). Keep the
+    // env path generic so we never advertise a key that can't satisfy the probed provider.
     console.error(
-      `[fastagent] warn: no credentials for "${provider}" — run \`pi login\`, or set the provider API key in .env (e.g. OPENAI_API_KEY); invokes will fail until then`,
+      `[fastagent] warn: no credentials for "${provider}" — authenticate with \`pi login\`, or set the provider's API key in .env; invokes will fail until then`,
     );
   }
 }

--- a/core/src/engines/pi/config.ts
+++ b/core/src/engines/pi/config.ts
@@ -26,7 +26,7 @@ import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { getModel } from "@earendil-works/pi-ai";
+import { getModel, getModels, getProviders } from "@earendil-works/pi-ai";
 import type { AnyModel } from "./harness.ts";
 
 export interface FastagentConfig {
@@ -122,9 +122,24 @@ export function resolveModel(spec: string): AnyModel {
   const modelId = spec.slice(slash + 1);
   const model = getModel(provider as never, modelId as never) as AnyModel | undefined;
   if (!model) {
-    throw new Error(`unknown model "${spec}" (provider "${provider}" / id "${modelId}" not in registry)`);
+    throw new Error(
+      `unknown model "${spec}" (provider "${provider}" / id "${modelId}" not in registry); run \`fastagent models\` to list available specs`,
+    );
   }
   return model;
+}
+
+/**
+ * All registered "provider/modelId" specs, sorted — the discovery list behind `fastagent models`.
+ * Sourced from pi-ai's registry (getProviders × getModels), so it stays in sync with what
+ * {@link resolveModel} accepts. Pure (no IO); the CLI prints it to stdout.
+ */
+export function listModels(): string[] {
+  const specs: string[] = [];
+  for (const provider of getProviders()) {
+    for (const model of getModels(provider)) specs.push(`${provider}/${model.id}`);
+  }
+  return specs.sort();
 }
 
 /** Model selection precedence: CLI flag > FASTAGENT_MODEL env var > config default. All absent = undefined (caller errors). */

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -73,6 +73,7 @@ export {
 export {
   defineConfig,
   resolveModel,
+  listModels,
   type FastagentConfig,
 } from "./engines/pi/config.ts";
 

--- a/core/test/auth.test.ts
+++ b/core/test/auth.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { piOAuthAuth } from "../src/index.ts";
+import { piOAuthAuth, probeAuthSource } from "../src/index.ts";
 
 const model = { provider: "anthropic" };
 
@@ -58,5 +58,19 @@ describe("piOAuthAuth (silent-failure discipline)", () => {
     const messages: string[] = [];
     expect(await piOAuthAuth(path, { warn: (m) => messages.push(m) })(model)).toBeUndefined();
     expect(messages[0]).toContain("expired"); // root cause surfaced, not buried under "missing API key"
+  });
+});
+
+describe("probeAuthSource (startup credential report; dev + start)", () => {
+  it("reports oauth when the credentials file has a live token for the provider", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-probe-"));
+    const path = join(dir, "auth.json");
+    await writeFile(path, JSON.stringify({ anthropic: { type: "oauth", access: "tok", expires: Date.now() + 60_000 } }));
+    expect(await probeAuthSource("anthropic", path)).toBe("oauth");
+  });
+
+  it("reports none when neither the credentials file nor env provides a key", async () => {
+    // a provider with no env-var mapping + a nonexistent auth file → deterministically none
+    expect(await probeAuthSource("no-such-provider", "/nonexistent/auth.json")).toBe("none");
   });
 });

--- a/core/test/config.test.ts
+++ b/core/test/config.test.ts
@@ -3,11 +3,28 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { createPiAgentFromWorkspace, resolveModel } from "../src/index.ts";
+import { createPiAgentFromWorkspace, listModels, resolveModel } from "../src/index.ts";
 import { loadConfig, resolveModelSpec } from "../src/engines/pi/config.ts";
 import { resolveTools } from "../src/engines/pi/create.ts";
 
 const fixtures = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+
+describe("config: listModels (fastagent models discovery)", () => {
+  it("lists well-formed provider/modelId specs, sorted, that resolveModel accepts", () => {
+    const specs = listModels();
+    expect(specs.length).toBeGreaterThan(0);
+    // every entry is a "provider/modelId" and round-trips through resolveModel (the list is the
+    // discovery surface for exactly what --model / config accepts).
+    for (const spec of specs) {
+      // provider (no slash) + "/" + non-empty modelId (which MAY contain slashes, e.g.
+      // cloudflare-ai-gateway/workers-ai/@cf/...); resolveModel splits on the first slash.
+      expect(spec).toMatch(/^[^/]+\/.+$/);
+      expect(() => resolveModel(spec)).not.toThrow();
+    }
+    expect(specs).toEqual([...specs].sort()); // sorted
+    expect(specs).toContain("openai-codex/gpt-5.5"); // the spec used across the repo
+  });
+});
 
 describe("config: loadConfig", () => {
   it("loads the fastagent.config.ts default export, including tools passthrough", async () => {


### PR DESCRIPTION
## What

Two first-run onboarding gaps from the from-zero review, batched because both are small, CLI-only, and independent of publishing (#1):

- **#4 — auth preflight + onboarding.** `dev` now probes and reports the model credential source, consistent with `start`; both surface a remediation hint when none is found, instead of failing silently at the first invoke.
- **#7 — model discovery.** `fastagent models` lists every valid `provider/modelId`; the "unknown model" error now points at it (error → discovery).

## Changes

- `reportAuth(modelSpec)` (cli.ts): probe + print the `auth:` line; warn with the fix (`pi login`, or a provider key in `.env`) when none. Non-blocking. `runDev` now calls it (was missing); `runStart` uses it too (was inline, without the hint).
- `listModels()` (config.ts): enumerate pi-ai's registry (`getProviders` × `getModels`) into sorted `provider/modelId` specs — stays in sync with what `resolveModel` accepts. `fastagent models` prints them to stdout (pipe-friendly). The "unknown model" error references the command.
- Exports: `listModels`, `probeAuthSource` (already), via index.ts.
- Tests: `probeAuthSource` (oauth / none) had no coverage; `listModels` (every spec round-trips through `resolveModel`; model ids may contain slashes, e.g. `cloudflare-ai-gateway/workers-ai/@cf/…`).

## Verification

- `npm run typecheck` clean; `npm test` 142 passed.
- Smoke: `dev` → `auth: oauth (openai-codex)`; no creds → `(none found)` + warn. `fastagent models` lists 966 specs; `--model bad/nope` → "unknown model … run `fastagent models`".

## Out of scope

A dedicated `fastagent login` (`pi login` is the path today).
