### PR TITLE
chore(release): publish @kid7st/fastagent to GitHub Packages (#1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: Publish
 
-# Publish @kid7st/core to GitHub Packages when a GitHub Release is published.
+# Publish @kid7st/fastagent to GitHub Packages when a GitHub Release is published.
 # The release tag is the manual gate; the job re-verifies (typecheck + test) before
 # publishing so a non-green tag never ships. Version comes from core/package.json —
 # bump it before tagging (GitHub Packages rejects re-publishing an existing version).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish
+
+# Publish @kid7st/core to GitHub Packages when a GitHub Release is published.
+# The release tag is the manual gate; the job re-verifies (typecheck + test) before
+# publishing so a non-green tag never ships. Version comes from core/package.json —
+# bump it before tagging (GitHub Packages rejects re-publishing an existing version).
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write # required to publish to GitHub Packages
+
+jobs:
+  publish:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@kid7st'
+          cache: npm
+          cache-dependency-path: core/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is a from-scratch implementation of the locked [Agent Handler SP
 
 ## Install
 
-`@kid7st/core` is published to **GitHub Packages** (private). Consumers authenticate with a GitHub token that has `read:packages`, via an `.npmrc` next to their project:
+`@kid7st/fastagent` is published to **GitHub Packages** (private). Consumers authenticate with a GitHub token that has `read:packages`, via an `.npmrc` next to their project:
 
 ```
 @kid7st:registry=https://npm.pkg.github.com
@@ -16,8 +16,8 @@ This repository is a from-scratch implementation of the locked [Agent Handler SP
 Then install the CLI or the library (requires Node ≥ 26 — the package ships TypeScript sources, run via Node's type stripping; no build step):
 
 ```bash
-npm i -g @kid7st/core   # the `fastagent` CLI on PATH
-npm i @kid7st/core      # the library (defineConfig, Agent contract, …) for code-tool agents
+npm i -g @kid7st/fastagent   # the `fastagent` CLI on PATH
+npm i @kid7st/fastagent      # the library (defineConfig, Agent contract, …) for code-tool agents
 ```
 
 ## Documentation
@@ -32,7 +32,7 @@ npm i @kid7st/core      # the library (defineConfig, Agent contract, …) for co
 
 ## API stability
 
-This repository is pre-1.0. The stable design center is the Agent Handler contract in [SPEC.md](docs/SPEC.md). The root export (`@kid7st/core`) is deliberately scoped to the supported public surface; pi-coupled internals are not exported and may change freely while `build`, `start`, and the first target adapters land.
+This repository is pre-1.0. The stable design center is the Agent Handler contract in [SPEC.md](docs/SPEC.md). The root export (`@kid7st/fastagent`) is deliberately scoped to the supported public surface; pi-coupled internals are not exported and may change freely while `build`, `start`, and the first target adapters land.
 
 Public surface tiers:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ WSGI for agent serving: turn an existing agent definition (`AGENTS.md` + `skills
 
 This repository is a from-scratch implementation of the locked [Agent Handler SPEC v0.1](docs/SPEC.md). It does not carry compatibility baggage from older experiments.
 
+## Install
+
+`@kid7st/core` is published to **GitHub Packages** (private). Consumers authenticate with a GitHub token that has `read:packages`, via an `.npmrc` next to their project:
+
+```
+@kid7st:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Then install the CLI or the library (requires Node ≥ 26 — the package ships TypeScript sources, run via Node's type stripping; no build step):
+
+```bash
+npm i -g @kid7st/core   # the `fastagent` CLI on PATH
+npm i @kid7st/core      # the library (defineConfig, Agent contract, …) for code-tool agents
+```
+
 ## Documentation
 
 | Document | Purpose |
@@ -16,7 +32,7 @@ This repository is a from-scratch implementation of the locked [Agent Handler SP
 
 ## API stability
 
-This repository is pre-1.0. The stable design center is the Agent Handler contract in [SPEC.md](docs/SPEC.md). The root export (`@fastagent/core`) is deliberately scoped to the supported public surface; pi-coupled internals are not exported and may change freely while `build`, `start`, and the first target adapters land.
+This repository is pre-1.0. The stable design center is the Agent Handler contract in [SPEC.md](docs/SPEC.md). The root export (`@kid7st/core`) is deliberately scoped to the supported public surface; pi-coupled internals are not exported and may change freely while `build`, `start`, and the first target adapters land.
 
 Public surface tiers:
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,23 @@ This repository is a from-scratch implementation of the locked [Agent Handler SP
 
 ## Install
 
-`@kid7st/fastagent` is published to **GitHub Packages** (private). Consumers authenticate with a GitHub token that has `read:packages`, via an `.npmrc` next to their project:
+`@kid7st/fastagent` is published to **GitHub Packages** (private), so installs authenticate with a GitHub token that has `read:packages`. Put the scope registry and token in your **user** npm config (`~/.npmrc`) so it applies to both a global CLI install and a project dependency, from any directory:
 
 ```
 @kid7st:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 ```
 
-Then install the CLI or the library (requires Node ≥ 26 — the package ships TypeScript sources, run via Node's type stripping; no build step):
+(A per-project `.npmrc` is only read when you run npm from within that project, and a global `npm i -g` is usually run from elsewhere — so the user config is the reliable place. If you commit a project `.npmrc`, keep only the registry line there and supply the token via env / `~/.npmrc`; never commit the token.)
+
+Then install (requires Node ≥ 26):
 
 ```bash
 npm i -g @kid7st/fastagent   # the `fastagent` CLI on PATH
-npm i @kid7st/fastagent      # the library (defineConfig, Agent contract, …) for code-tool agents
+npm i @kid7st/fastagent      # the library (defineConfig, the Agent contract, …) for code-tool agents
 ```
+
+The package ships compiled JavaScript + type declarations (`dist/`); the repository itself runs the TypeScript sources directly under Node 26.
 
 ## Documentation
 

--- a/core/examples/agent/fastagent.config.ts
+++ b/core/examples/agent/fastagent.config.ts
@@ -4,7 +4,7 @@
  *
  * Run: node ../../src/cli.ts dev .   (real users: fastagent dev)
  */
-import { defineConfig } from "../../src/index.ts"; // real users: from "@fastagent/core"
+import { defineConfig } from "../../src/index.ts"; // real users: from "@kid7st/core"
 import lookupOrderTool from "./lookup-order-tool.ts";
 
 export default defineConfig({

--- a/core/examples/agent/fastagent.config.ts
+++ b/core/examples/agent/fastagent.config.ts
@@ -4,7 +4,7 @@
  *
  * Run: node ../../src/cli.ts dev .   (real users: fastagent dev)
  */
-import { defineConfig } from "../../src/index.ts"; // real users: from "@kid7st/core"
+import { defineConfig } from "../../src/index.ts"; // real users: from "@kid7st/fastagent"
 import lookupOrderTool from "./lookup-order-tool.ts";
 
 export default defineConfig({

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@kid7st/core",
+  "name": "@kid7st/fastagent",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@kid7st/core",
+      "name": "@kid7st/fastagent",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fastagent/core",
+  "name": "@kid7st/core",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fastagent/core",
+      "name": "@kid7st/core",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "@fastagent/core",
+  "name": "@kid7st/core",
   "version": "0.1.0",
   "description": "Reference implementation of the Agent Handler contract: fan in pi AgentHarness events into the SPEC event stream.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kid7st/fastagent.git",
+    "directory": "core"
+  },
   "type": "module",
   "engines": {
     "node": ">=26"
@@ -14,6 +19,12 @@
   },
   "bin": {
     "fastagent": "./src/cli.ts"
+  },
+  "files": [
+    "src"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "vitest --run",

--- a/core/package.json
+++ b/core/package.json
@@ -12,21 +12,26 @@
   "engines": {
     "node": ">=26"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "bin": {
-    "fastagent": "./src/cli.ts"
+    "fastagent": "./dist/cli.js"
   },
   "files": [
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
     "test": "vitest --run",
     "typecheck": "tsc --noEmit"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kid7st/core",
+  "name": "@kid7st/fastagent",
   "version": "0.1.0",
   "description": "Reference implementation of the Agent Handler contract: fan in pi AgentHarness events into the SPEC event stream.",
   "license": "MIT",

--- a/core/tsconfig.build.json
+++ b/core/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  // Publish build only (dev still runs the .ts sources directly via Node 26). Emits .js + .d.ts
+  // to dist/, which is what the package ships — Node refuses to type-strip .ts under node_modules,
+  // so consumers must receive compiled JavaScript. rewriteRelativeImportExtensions rewrites the
+  // source's explicit `./x.ts` import specifiers to `./x.js` in the output.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rewriteRelativeImportExtensions": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -241,7 +241,7 @@ The real axis is **bundled vs runtime-provided**, not "data vs code." Code (skil
 | **local / container** | `start <artifact>` (cwd = artifact) | `npm ci` at deploy installs deps; the artifact carries `package.json` + tool source, not `node_modules` |
 | **AgentCore (later)** | OCI-wrap the same artifact | same |
 
-The artifact = the cleaned source **tree** (AGENTS.md, skills/, authored context, `fastagent.config.ts`, tool source, `package.json`, …) with opted-in globals materialized into `skills/`, **minus** the §10.1 hard excludes (`node_modules`, `.git`, `.fastagent`) and anything `.gitignore`/`.fastagentignore` excludes (honored via the `ignore` library, not git). Secrets are **not** auto-excluded — they are the user's responsibility (§10.1); inject them at runtime and keep them out via .gitignore/.fastagentignore. Pure markdown/skills agents need only `@kid7st/core` to run; code-tool agents add `npm ci`.
+The artifact = the cleaned source **tree** (AGENTS.md, skills/, authored context, `fastagent.config.ts`, tool source, `package.json`, …) with opted-in globals materialized into `skills/`, **minus** the §10.1 hard excludes (`node_modules`, `.git`, `.fastagent`) and anything `.gitignore`/`.fastagentignore` excludes (honored via the `ignore` library, not git). Secrets are **not** auto-excluded — they are the user's responsibility (§10.1); inject them at runtime and keep them out via .gitignore/.fastagentignore. Pure markdown/skills agents need only `@kid7st/fastagent` to run; code-tool agents add `npm ci`.
 
 ### 10.3 `fastagent build`
 

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -241,7 +241,7 @@ The real axis is **bundled vs runtime-provided**, not "data vs code." Code (skil
 | **local / container** | `start <artifact>` (cwd = artifact) | `npm ci` at deploy installs deps; the artifact carries `package.json` + tool source, not `node_modules` |
 | **AgentCore (later)** | OCI-wrap the same artifact | same |
 
-The artifact = the cleaned source **tree** (AGENTS.md, skills/, authored context, `fastagent.config.ts`, tool source, `package.json`, …) with opted-in globals materialized into `skills/`, **minus** the §10.1 hard excludes (`node_modules`, `.git`, `.fastagent`) and anything `.gitignore`/`.fastagentignore` excludes (honored via the `ignore` library, not git). Secrets are **not** auto-excluded — they are the user's responsibility (§10.1); inject them at runtime and keep them out via .gitignore/.fastagentignore. Pure markdown/skills agents need only `@fastagent/core` to run; code-tool agents add `npm ci`.
+The artifact = the cleaned source **tree** (AGENTS.md, skills/, authored context, `fastagent.config.ts`, tool source, `package.json`, …) with opted-in globals materialized into `skills/`, **minus** the §10.1 hard excludes (`node_modules`, `.git`, `.fastagent`) and anything `.gitignore`/`.fastagentignore` excludes (honored via the `ignore` library, not git). Secrets are **not** auto-excluded — they are the user's responsibility (§10.1); inject them at runtime and keep them out via .gitignore/.fastagentignore. Pure markdown/skills agents need only `@kid7st/core` to run; code-tool agents add `npm ci`.
 
 ### 10.3 `fastagent build`
 


### PR DESCRIPTION
## What

#1 (minimal form): make the package resolvable so the things blocked on it — code-tool agents (#5), the quickstart (#2), the container recipe (#6) — can depend on it. Published to **GitHub Packages (private)**, which fits the current team/collaborator audience (consumers authenticate with a GitHub token). A public release stays a separate, later decision.

## Changes

- **Rename `@fastagent/core` → `@kid7st/fastagent`** — GitHub Packages requires the package scope to match the repo owner (`kid7st`). Updated every reference (package.json, lockfile, example config comment, README, core-design §10.2). No source imports use the package name (internal imports are relative `../src/...`), so nothing breaks; typecheck + 142 tests green.
- `package.json`: `repository` (with `directory: core`), `publishConfig.registry` = `https://npm.pkg.github.com`, `files: ["src"]`. No build step — the package ships TypeScript sources, consumed via Node 26 type stripping (the project's existing posture). `npm publish --dry-run` → 17 files, no `test/`/`examples/`.
- `.github/workflows/publish.yml`: on a published GitHub Release, re-verify (typecheck + test) then `npm publish` with `GITHUB_TOKEN` (`packages: write`).
- `README`: an Install section — consumer `.npmrc` + token, CLI (`npm i -g @kid7st/fastagent`) vs library (`npm i @kid7st/fastagent`).

## To actually publish (manual gate, your action)

1. Ensure repo Actions can write packages (Settings → Actions → Workflow permissions; usually default).
2. Bump `core/package.json` version if needed (GitHub Packages rejects re-publishing an existing version).
3. Create a GitHub Release (tag) → the workflow publishes. (Or `npm publish` once manually from `core/` with a token.)

## Unblocks

#2 (quickstart can show real `npm i`), #5 (code-tool scaffold can `import from "@kid7st/fastagent"`), #6 (container `npm ci`).

