### PR TITLE
feat(tool): defineTool + tools/ auto-discovery + fastagent tool runner (#5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ core/
 │       ├── dev.ts               # `dev` opener: open a workspace → agent (authoring posture)
 │       ├── build.ts             # `build`: compile a workspace → self-contained artifact
 │       ├── start.ts             # `start` opener: run a built artifact (production posture)
+│       ├── tool.ts              # defineTool (Zod) + tools/ filesystem discovery
 │       ├── harness.ts           # pi harness wiring (factory)
 │       ├── definition.ts        # AGENTS.md + skills loading and bundling
 │       ├── config.ts            # fastagent.config.ts loading + model/precedence

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -13,10 +13,11 @@
         "@earendil-works/pi-ai": "^0.79.2",
         "@earendil-works/pi-coding-agent": "^0.79.2",
         "ignore": "^7.0.5",
-        "undici": "^8.4.1"
+        "undici": "^8.4.1",
+        "zod": "^4.4.3"
       },
       "bin": {
-        "fastagent": "src/cli.ts"
+        "fastagent": "dist/cli.js"
       },
       "devDependencies": {
         "typescript": "^5.7.0",

--- a/core/package.json
+++ b/core/package.json
@@ -40,7 +40,8 @@
     "@earendil-works/pi-ai": "^0.79.2",
     "@earendil-works/pi-coding-agent": "^0.79.2",
     "ignore": "^7.0.5",
-    "undici": "^8.4.1"
+    "undici": "^8.4.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -23,6 +23,7 @@ import { buildPiArtifact } from "./engines/pi/build.ts";
 import { listModels, loadConfig } from "./engines/pi/config.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
+import { resolveTools } from "./engines/pi/create.ts";
 import { scaffoldWorkspace } from "./engines/pi/init.ts";
 import { loadTools, mergeDiscoveredTools } from "./engines/pi/tool.ts";
 import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
@@ -110,7 +111,13 @@ async function runTool(): Promise<void> {
   loadDotEnv(toolDir); // a tool may read a key from .env
   const { config } = await loadConfig(toolDir).catch(failStartup);
   const discovered = await loadTools(toolDir).catch(failStartup);
-  const { tools } = mergeDiscoveredTools(config.tools ?? [], discovered.tools);
+  // Same tool set dev/start mount (pi defaults + config.tools + discovered, deduped) so the
+  // runner exercises exactly what gets served — a tool shadowed by a default/config tool is not
+  // run here either; surface that collision instead of silently testing the wrong implementation.
+  const { tools, collisions } = mergeDiscoveredTools(resolveTools(config, toolDir), discovered.tools);
+  for (const c of [...discovered.collisions, ...collisions]) {
+    console.error(`[fastagent] warn: tool "${c.name}" (${c.source}) is shadowed by a default/config tool — not mounted`);
+  }
   const tool = tools.find((t) => t.name === name);
   if (!tool) {
     console.error(`unknown tool "${name}". available: ${tools.map((t) => t.name).join(", ") || "(none)"}`);

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -5,6 +5,7 @@
  *
  *   fastagent init  [dir] — scaffold a minimal runnable workspace
  *   fastagent models      — list available "provider/modelId" specs
+ *   fastagent tool  <name> '<json>' [dir] — run one tool directly (no model)
  *   fastagent dev   [dir] — assemble + serve a local HTTP channel (iteration)
  *   fastagent build [dir] — compile a self-contained artifact (core-design §10.3)
  *   fastagent start [dir] — run a built artifact in production posture (core-design §10.4)
@@ -19,16 +20,18 @@ import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher }
 import { createInvokeHandler } from "./channels/http.ts";
 import { probeAuthSource } from "./engines/pi/auth.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
-import { listModels } from "./engines/pi/config.ts";
+import { listModels, loadConfig } from "./engines/pi/config.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
 import { scaffoldWorkspace } from "./engines/pi/init.ts";
+import { loadTools, mergeDiscoveredTools } from "./engines/pi/tool.ts";
 import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
 
 function usage(code: number): never {
   console.error(`usage:
   fastagent init   [dir]
   fastagent models
+  fastagent tool   <name> '<json-args>' [dir]
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--global-skills]
   fastagent build [dir] [--out dir] [--model provider/modelId] [--global-skills] [--force]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
@@ -40,6 +43,8 @@ function usage(code: number): never {
   init   scaffold a minimal runnable workspace in dir (default .): AGENTS.md, an example
          skill, fastagent.config.mjs, .gitignore. Refuses to overwrite an existing workspace.
   models list the available "provider/modelId" specs (use one with --model or in the config).
+  tool   run one tool (from tools/ or config.tools) directly with JSON args — no model, no
+         server, no tokens. Fast feedback while authoring: fastagent tool add '{"a":2,"b":3}'
   build  compile dir into a self-contained, relocatable artifact (default out:
          .fastagent/build): the source tree + materialized skills + manifest, minus
          node_modules/.git and anything .gitignore/.fastagentignore excludes (honored
@@ -78,6 +83,7 @@ const globalSkills = values["global-skills"] ?? false;
 
 if (command === "init") await runInit();
 else if (command === "models") runModels();
+else if (command === "tool") await runTool();
 else if (command === "dev") await runDev();
 else if (command === "build") await runBuild();
 else if (command === "start") await runStart();
@@ -86,6 +92,43 @@ else usage(1);
 /** `fastagent models`: print every registered "provider/modelId" to stdout (pipe-friendly). */
 function runModels(): void {
   for (const spec of listModels()) console.log(spec);
+}
+
+/**
+ * `fastagent tool <name> '<json>' [dir]`: run one tool's body directly with JSON args — no model,
+ * no server, no tokens. The tightest authoring feedback loop. Args are validated by the tool's
+ * own schema (a defineTool tool returns an "Invalid arguments" result the same way the model sees).
+ */
+async function runTool(): Promise<void> {
+  const name = positionals[1];
+  const argsJson = positionals[2] ?? "{}";
+  const toolDir = resolve(positionals[3] ?? ".");
+  if (!name) {
+    console.error(`usage: fastagent tool <name> '<json-args>' [dir]`);
+    process.exit(1);
+  }
+  loadDotEnv(toolDir); // a tool may read a key from .env
+  const { config } = await loadConfig(toolDir).catch(failStartup);
+  const discovered = await loadTools(toolDir).catch(failStartup);
+  const { tools } = mergeDiscoveredTools(config.tools ?? [], discovered.tools);
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) {
+    console.error(`unknown tool "${name}". available: ${tools.map((t) => t.name).join(", ") || "(none)"}`);
+    process.exit(1);
+  }
+  let args: unknown;
+  try {
+    args = JSON.parse(argsJson);
+  } catch {
+    console.error(`invalid JSON args: ${argsJson}`);
+    process.exit(1);
+  }
+  const result = await tool.execute(`cli-${name}`, args).catch(failStartup);
+  const out =
+    result?.details !== undefined
+      ? result.details
+      : (result?.content ?? []).map((c) => ("text" in c ? c.text : "")).join("");
+  console.log(typeof out === "string" ? out : JSON.stringify(out, null, 2));
 }
 
 async function runInit(): Promise<void> {
@@ -159,10 +202,11 @@ async function runDev(): Promise<void> {
   setGlobalDispatcher(new EnvHttpProxyAgent());
   installUndiciFetch();
 
-  const { agent, definition, config, configPath, modelSpec } = await createPiAgentFromWorkspace(dir, {
-    model: values.model,
-    globalSkills,
-  }).catch(failStartup);
+  const { agent, definition, config, configPath, modelSpec, toolNames, toolCollisions } =
+    await createPiAgentFromWorkspace(dir, {
+      model: values.model,
+      globalSkills,
+    }).catch(failStartup);
 
   console.error(`[fastagent] dir:    ${definition.dir}`);
   console.error(`[fastagent] config: ${configPath ?? "(zero-config)"}`);
@@ -184,6 +228,8 @@ async function runDev(): Promise<void> {
       console.error(`            use in dev: --global-skills | ship: copy into skills/ (or build --global-skills)`);
     }
   }
+  if (toolNames.length > 0) console.error(`[fastagent] tools:  ${toolNames.join(", ")}`);
+  reportToolCollisions(toolCollisions);
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 
   serve(agent, portFlag ?? config.http?.port ?? 8787);
@@ -218,16 +264,19 @@ async function runStart(): Promise<void> {
   setGlobalDispatcher(new EnvHttpProxyAgent());
   installUndiciFetch();
 
-  const { agent, definition, manifest, modelSpec, sessionsDir } = await createPiAgentFromArtifact(dir, {
-    model: values.model,
-    sessionsDir: values["sessions-dir"] ? resolve(values["sessions-dir"]) : undefined,
-  }).catch(failStartup);
+  const { agent, definition, manifest, modelSpec, sessionsDir, toolNames, toolCollisions } =
+    await createPiAgentFromArtifact(dir, {
+      model: values.model,
+      sessionsDir: values["sessions-dir"] ? resolve(values["sessions-dir"]) : undefined,
+    }).catch(failStartup);
 
   console.error(`[fastagent] start:  ${dir}`);
   console.error(`[fastagent] model:  ${modelSpec}`);
   await reportAuth(modelSpec);
   console.error(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);
   console.error(`[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
+  if (toolNames.length > 0) console.error(`[fastagent] tools:  ${toolNames.join(", ")}`);
+  reportToolCollisions(toolCollisions);
   console.error(`[fastagent] sessions: ${sessionsDir}`);
   // Visible footgun guard: a sessions dir inside the artifact is wiped by a redeploy that
   // replaces the artifact wholesale. Warn, don't block (running in place is legitimate).
@@ -288,5 +337,11 @@ function reportDefinitionWarnings(
   }
   for (const d of diagnostics) {
     console.error(`[fastagent] warn: ${d.code}: ${d.message} (${d.path})`);
+  }
+}
+
+function reportToolCollisions(collisions: { name: string; source: string }[]): void {
+  for (const c of collisions) {
+    console.error(`[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`);
   }
 }

--- a/core/src/engines/pi/dev.ts
+++ b/core/src/engines/pi/dev.ts
@@ -25,9 +25,10 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { Agent } from "../../agent.ts";
 import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { createPiAgentFromDefinition, resolveTools } from "./create.ts";
+import { createPiAgentFromDefinition, piDefaultTools, resolveTools } from "./create.ts";
 import { type LoadedDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored } from "./definition.ts";
 import { jsonlSessionStore } from "./sessions.ts";
+import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 
 export interface CreatePiAgentFromWorkspaceOptions {
   /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -62,6 +63,10 @@ export async function createPiAgentFromWorkspace(
   configPath?: string;
   /** The resolved "provider/modelId" spec actually in use. */
   modelSpec: string;
+  /** Non-default tool names in effect: config.tools + discovered tools/. */
+  toolNames: string[];
+  /** Discovered tools dropped on a name clash with a default/config tool (surfaced, not silent). */
+  toolCollisions: ToolCollision[];
 }> {
   const { config, path: configPath }: LoadedConfig = await loadConfig(dir);
   const modelSpec = resolveModelSpec(options.model, config);
@@ -70,6 +75,12 @@ export async function createPiAgentFromWorkspace(
       `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
     );
   }
+  // Discover tools/ and merge with pi defaults + config.tools (existing win name clashes).
+  const discovered = await loadTools(dir);
+  const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
+  const toolCollisions = [...discovered.collisions, ...crossCollisions];
+  const defaultNames = new Set(piDefaultTools(dir).map((t) => t.name));
+  const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
   // The dev opener owns workspace state: .fastagent/ (machine state — gitignored, deletable,
   // rebuildable) is created HERE, not in the CLI, so library callers get the same
   // self-gitignored dir (vite/next-style).
@@ -78,7 +89,7 @@ export async function createPiAgentFromWorkspace(
   await ensureStateDirSelfIgnored(stateDir);
   const { agent, definition } = await createPiAgentFromDefinition(dir, {
     model: resolveModel(modelSpec),
-    tools: resolveTools(config, dir),
+    tools,
     // Definition-only by default (the agent is its folder); globals are an explicit
     // authoring-fidelity opt-in, never the deploy path (see create.ts ladder rule 2 + core-design §6).
     skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
@@ -86,5 +97,5 @@ export async function createPiAgentFromWorkspace(
     // faithful to local pi, which persists sessions too.
     sessions: jsonlSessionStore({ dir: join(stateDir, "sessions"), cwd: dir }),
   });
-  return { agent, definition, config, configPath, modelSpec };
+  return { agent, definition, config, configPath, modelSpec, toolNames, toolCollisions };
 }

--- a/core/src/engines/pi/start.ts
+++ b/core/src/engines/pi/start.ts
@@ -28,9 +28,10 @@ import type { Agent } from "../../agent.ts";
 import type { AuthResolver } from "./auth.ts";
 import { type ArtifactManifest, MANIFEST_FILE } from "./build.ts";
 import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { createPiAgentFromDefinition, resolveTools } from "./create.ts";
+import { createPiAgentFromDefinition, piDefaultTools, resolveTools } from "./create.ts";
 import { type LoadedDefinition, ensureStateDirSelfIgnored } from "./definition.ts";
 import { jsonlSessionStore } from "./sessions.ts";
+import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 
 /**
  * Read + validate `<artifactDir>/fastagent.json`. The manifest is machine-generated, so this
@@ -110,6 +111,10 @@ export async function createPiAgentFromArtifact(
   modelSpec: string;
   /** Absolute session store directory in use (for the startup report). */
   sessionsDir: string;
+  /** Non-default tool names in effect: config.tools + discovered tools/. */
+  toolNames: string[];
+  /** Discovered tools dropped on a name clash with a default/config tool. */
+  toolCollisions: ToolCollision[];
 }> {
   const manifest = await loadManifest(artifactDir);
   // config.ts ships in the artifact for code tools (model/http come from the manifest).
@@ -125,14 +130,20 @@ export async function createPiAgentFromArtifact(
   // start run inside a git repo does not show conversations as untracked).
   await mkdir(sessionsDir, { recursive: true });
   await ensureStateDirSelfIgnored(sessionsDir);
+  // Discover tools/ (ships in the artifact as authored context) and merge with config.tools + defaults.
+  const discovered = await loadTools(artifactDir);
+  const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, artifactDir), discovered.tools);
+  const toolCollisions = [...discovered.collisions, ...crossCollisions];
+  const defaultNames = new Set(piDefaultTools(artifactDir).map((t) => t.name));
+  const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
   const { agent, definition } = await createPiAgentFromDefinition(artifactDir, {
     model: resolveModel(modelSpec),
     // Code tools shipped in fastagent.config.* (appended after pi defaults); model/http are
     // already frozen in the manifest, but tools are functions and only live in the config file.
-    tools: resolveTools(config, artifactDir),
+    tools,
     // Continuity from an external store, reconstructed per invoke (SPEC portable conformance).
     sessions: jsonlSessionStore({ dir: sessionsDir, cwd: artifactDir }),
     getApiKeyAndHeaders: options.getApiKeyAndHeaders,
   });
-  return { agent, definition, manifest, config, modelSpec, sessionsDir };
+  return { agent, definition, manifest, config, modelSpec, sessionsDir, toolNames, toolCollisions };
 }

--- a/core/src/engines/pi/tool.ts
+++ b/core/src/engines/pi/tool.ts
@@ -1,0 +1,165 @@
+/**
+ * Tool authoring: `defineTool` (the vibe surface) and `loadTools` (filesystem discovery).
+ *
+ * The two together let a developer add a code tool with no ceremony: drop a file in `tools/`,
+ * default-export `defineTool({...})`, and it is discovered, named from the filename, validated,
+ * and injected — no `name` field, no manual registration in the config.
+ *
+ *   // tools/lookup-order.ts            → tool "lookup-order"
+ *   import { defineTool, z } from "@kid7st/fastagent";
+ *   export default defineTool({
+ *     description: "Look up an order by id.",
+ *     input: z.object({ orderId: z.string() }),
+ *     async execute({ orderId }) { return await db.find(orderId); },  // plain value, auto-wrapped
+ *   });
+ *
+ * defineTool produces a pi `AgentTool` (folded-M): it converts the Zod schema to JSON Schema for
+ * the model, validates the model's arguments before calling `execute` (a validation failure is
+ * returned to the model as an error result, not a crash), and wraps a plain return value into the
+ * pi result shape. The `parameters` field is a plain JSON-Schema object — pi accepts it (the
+ * `TSchema` bound is compile-time only; there is no TypeBox runtime dependency on this path).
+ *
+ * Node composition-root module: `loadTools` dynamically imports the workspace's tool modules
+ * (local files, not node_modules — so Node strips their types); the invoke path stays disk-free.
+ */
+import { readdir } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
+import { z } from "zod";
+
+/** Runtime context passed to a tool's `execute`. Minimal today; reserved for growth (session, …). */
+export interface ToolContext {
+  /** Abort signal for the current turn — honor it to cancel in-flight work on cancellation. */
+  signal?: AbortSignal;
+}
+
+export interface DefineToolOptions<I extends z.ZodType> {
+  /**
+   * Explicit tool name. Usually omitted: a tool in `tools/<name>.ts` is named from its filename
+   * (authoritative). Set this only when injecting programmatically via `config.tools`.
+   */
+  name?: string;
+  /** What the tool does — the text the model reads to decide when to call it. */
+  description: string;
+  /** Input parameters as a Zod schema; `execute` receives the parsed, typed value. */
+  input: I;
+  /**
+   * The tool body. Receives the validated input and a {@link ToolContext}. Return a plain value
+   * (string/object/…) and it is wrapped for the model; return a full `{ content, details }` result
+   * for control over content blocks.
+   */
+  execute: (input: z.infer<I>, ctx: ToolContext) => unknown | Promise<unknown>;
+}
+
+/** Wrap a plain return value into pi's tool-result shape; pass a full result through unchanged. */
+function wrapResult(value: unknown): AgentToolResult<unknown> {
+  if (value && typeof value === "object" && Array.isArray((value as { content?: unknown }).content)) {
+    return value as AgentToolResult<unknown>;
+  }
+  const text = typeof value === "string" ? value : JSON.stringify(value ?? null);
+  return { content: [{ type: "text", text }], details: value };
+}
+
+/**
+ * Define a tool from a Zod input schema and an `execute` body. Returns a pi `AgentTool` with a
+ * JSON-Schema `parameters`, schema-validated arguments, and auto-wrapped results.
+ */
+export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): AgentTool {
+  // Zod → JSON Schema for the model. Drop `$schema` (providers don't need the dialect marker).
+  const { $schema: _drop, ...parameters } = z.toJSONSchema(options.input) as Record<string, unknown>;
+  const tool = {
+    name: options.name ?? "",
+    description: options.description,
+    parameters,
+    async execute(_toolCallId: string, rawParams: unknown, signal?: AbortSignal): Promise<AgentToolResult<unknown>> {
+      const parsed = options.input.safeParse(rawParams);
+      if (!parsed.success) {
+        // Validation failure is reported TO THE MODEL (it can correct and retry), not thrown.
+        const detail = parsed.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ");
+        return { content: [{ type: "text", text: `Invalid arguments: ${detail}` }], details: { error: detail } };
+      }
+      return wrapResult(await options.execute(parsed.data, { signal }));
+    },
+  };
+  return tool as unknown as AgentTool;
+}
+
+/** A discarded same-name tool (within `tools/`, or against an existing tool). Surfaced, never silent. */
+export interface ToolCollision {
+  name: string;
+  source: string;
+}
+
+const TOOL_EXTS = new Set([".ts", ".js", ".mjs"]);
+
+/**
+ * Discover code tools in `<dir>/tools/`: each top-level `*.ts|*.js|*.mjs` is dynamically imported,
+ * its default export taken as the tool, and named from the filename (authoritative). Missing
+ * `tools/` is normal (returns none). A file that does not default-export a tool fails visibly.
+ */
+export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; collisions: ToolCollision[] }> {
+  const toolsDir = join(dir, "tools");
+  let entries;
+  try {
+    entries = await readdir(toolsDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "not_found" || (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { tools: [], collisions: [] };
+    }
+    throw new Error(`cannot read ${toolsDir}: ${(error as Error).message}`);
+  }
+  const byName = new Map<string, AgentTool>();
+  const collisions: ToolCollision[] = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile()) continue;
+    const ext = extname(entry.name);
+    if (!TOOL_EXTS.has(ext) || entry.name.endsWith(".d.ts")) continue;
+    const file = join(toolsDir, entry.name);
+    let mod: { default?: unknown };
+    try {
+      mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
+    } catch (error) {
+      // The most common cause is a non-ESM workspace: a tool's `import` needs the project's
+      // package.json to set "type": "module". Surface the file + a hint instead of a raw stack.
+      throw new Error(
+        `cannot load tools/${entry.name}: ${(error as Error).message}\n` +
+          `  (a code-tool workspace must be ESM — set "type": "module" in package.json)`,
+      );
+    }
+    const tool = mod.default as Partial<AgentTool> | undefined;
+    if (!tool || typeof tool.execute !== "function") {
+      throw new Error(`tools/${entry.name} must default-export defineTool({...})`);
+    }
+    const name = basename(entry.name, ext); // filename is the tool name (authoritative)
+    if (byName.has(name)) {
+      collisions.push({ name, source: `tools/${entry.name}` });
+      continue;
+    }
+    byName.set(name, { ...(tool as AgentTool), name });
+  }
+  return { tools: [...byName.values()], collisions };
+}
+
+/**
+ * Merge already-resolved tools (pi defaults + `config.tools`) with discovered `tools/` tools,
+ * deduping by name. Existing tools win a name clash (a discovered tool may not shadow a default or
+ * a configured one); the dropped discovered tools are surfaced as collisions, never silent.
+ */
+export function mergeDiscoveredTools(
+  existing: AgentTool[],
+  discovered: AgentTool[],
+): { tools: AgentTool[]; collisions: ToolCollision[] } {
+  const names = new Set(existing.map((t) => t.name));
+  const tools = [...existing];
+  const collisions: ToolCollision[] = [];
+  for (const tool of discovered) {
+    if (names.has(tool.name)) {
+      collisions.push({ name: tool.name, source: `tools/${tool.name}` });
+      continue;
+    }
+    names.add(tool.name);
+    tools.push(tool);
+  }
+  return { tools, collisions };
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -25,6 +25,16 @@ export {
 // pi reference implementation — init (scaffold a minimal runnable workspace).
 export { scaffoldWorkspace, type ScaffoldResult } from "./engines/pi/init.ts";
 
+// pi reference implementation — tool authoring: defineTool (+ re-exported z) and tools/ discovery.
+export {
+  defineTool,
+  loadTools,
+  type DefineToolOptions,
+  type ToolContext,
+  type ToolCollision,
+} from "./engines/pi/tool.ts";
+export { z } from "zod";
+
 // pi reference implementation — dev (open a workspace into an agent, authoring posture).
 // The command opener that composes over L2; sibling of createPiAgentFromArtifact (start).
 export {

--- a/core/test/tool.test.ts
+++ b/core/test/tool.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { defineTool, loadTools, z } from "../src/index.ts";
+
+describe("defineTool", () => {
+  it("builds a pi AgentTool: JSON-schema parameters, validated + auto-wrapped execute", async () => {
+    const tool = defineTool({
+      name: "add",
+      description: "Add a and b.",
+      input: z.object({ a: z.number(), b: z.number() }),
+      async execute({ a, b }) {
+        return { sum: a + b }; // plain value
+      },
+    });
+    expect(tool.name).toBe("add");
+    const params = tool.parameters as { type: string; properties: Record<string, unknown>; $schema?: unknown };
+    expect(params.type).toBe("object");
+    expect(Object.keys(params.properties).sort()).toEqual(["a", "b"]);
+    expect(params.$schema).toBeUndefined(); // dialect marker stripped
+
+    // valid args → user value wrapped into pi's result shape
+    const ok = await tool.execute("c1", { a: 2, b: 3 });
+    expect(ok.details).toEqual({ sum: 5 });
+    expect(ok.content[0]).toMatchObject({ type: "text" });
+
+    // invalid args → an error RESULT (reported to the model), not a thrown exception
+    const bad = await tool.execute("c2", { a: "x" });
+    expect(JSON.stringify(bad)).toMatch(/Invalid arguments|expected number/);
+  });
+
+  it("passes a full {content,details} result through unchanged", async () => {
+    const tool = defineTool({
+      name: "raw",
+      description: "d",
+      input: z.object({}),
+      async execute() {
+        return { content: [{ type: "text", text: "hi" }], details: 42 };
+      },
+    });
+    const r = await tool.execute("c", {});
+    expect(r.details).toBe(42);
+    expect(r.content[0]).toMatchObject({ text: "hi" });
+  });
+});
+
+describe("loadTools (filesystem discovery)", () => {
+  it("discovers tools/* and names them from the filename; missing tools/ is empty", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-tools-"));
+    expect((await loadTools(dir)).tools).toEqual([]); // no tools/ dir yet
+
+    await mkdir(join(dir, "tools"));
+    await writeFile(
+      join(dir, "tools", "ping.mjs"),
+      `export default { description: "p", parameters: { type: "object" }, async execute() { return { content: [{ type: "text", text: "pong" }], details: "pong" }; } };`,
+    );
+    const { tools, collisions } = await loadTools(dir);
+    expect(tools.map((t) => t.name)).toEqual(["ping"]); // filename = name
+    expect(collisions).toEqual([]);
+    expect((await tools[0]!.execute("c", {})).details).toBe("pong");
+  });
+
+  it("fails visibly when a tool file does not default-export a tool", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-tools-"));
+    await mkdir(join(dir, "tools"));
+    await writeFile(join(dir, "tools", "bad.mjs"), `export const notDefault = 1;`);
+    await expect(loadTools(dir)).rejects.toThrow(/must default-export defineTool/);
+  });
+});

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -144,7 +144,11 @@ The machine's global skills (`~/.pi/agent/skills`, `~/.agents/skills`, via `defa
 
 `bundleAgentDefinition` is the build-time step that materializes the resolved skill set into a self-contained artifact. Dropped skills are removed on rebuild so the artifact is the truth.
 
-Code tools are different: they are TypeScript/JavaScript modules with dependencies. FastAgent does not auto-load a magic `tools/` directory. Projects explicitly import and inject code tools through config or library APIs. Declarative MCP tool mounting via `.mcp.json` is future support, not implemented today.
+Code tools are TypeScript/JavaScript modules. The vibe path is `defineTool` + filesystem discovery: drop a file in `tools/`, default-export `defineTool({ description, input, execute })`, and it is auto-discovered, named from the filename (authoritative), schema-validated, and injected — no `name` field, no manual registration. `defineTool` takes a Zod `input` schema (re-exported as `z` from the package), converts it to JSON Schema for the model, validates the model's arguments before `execute` (a validation failure becomes an error result the model can correct, not a crash), and wraps a plain return value into pi's result shape.
+
+> Reversal: an earlier draft said "FastAgent does not auto-load a magic `tools/` directory." That rationale conflated dependency installation with registration — they are orthogonal. Vercel's eve (same "agent is a directory" thesis) auto-discovers `tools/` despite tools being TS-with-deps, and it is the bigger DX win (it removes both the `name` field and the wiring). So fastagent now auto-discovers `tools/`.
+
+`config.tools` remains as the programmatic/advanced injection path; discovered tools are merged after pi defaults + `config.tools`, deduped by name (existing win; dropped tools are surfaced, not silent). A code-tool workspace must be ESM (`"type": "module"` in package.json) so a tool's `import` resolves. `fastagent tool <name> '<json>'` runs one tool's body directly — no model, no server, no tokens — the tightest authoring feedback loop. Declarative MCP tool mounting via `.mcp.json` is future support, not implemented today.
 
 ## 7. Sessions and statelessness
 


### PR DESCRIPTION
## What

The vibe path for code tools (#5), informed by Vercel **eve** (same "agent is a directory" thesis). Adding a tool is now: drop a file in `tools/`, default-export `defineTool({...})`. No `name` field, no manual registration, no pi-package imports.

```ts
// tools/lookup-order.ts        → tool "lookup-order"
import { defineTool, z } from "@kid7st/fastagent";   // one import
export default defineTool({
  description: "Look up an order by id.",
  input: z.object({ orderId: z.string() }),
  async execute({ orderId }) { return await db.find(orderId); },  // plain value, auto-wrapped
});
```
```ts
// fastagent.config.mjs — no tools:[] needed; tools/ is auto-discovered
export default { model: "...", http: { port: 8787 } };
```

## Pre-flight spikes (both green, verified before building)

- **pi accepts a plain JSON-Schema `parameters`** — confirmed end-to-end: a tool with a hand-written JSON-Schema `parameters` drove a real model tool-call (`add{a:2,b:3}`). The `TSchema` bound is compile-time only; no TypeBox runtime dependency. → Zod is viable.
- **Compiled JS can dynamic-import a user `.ts`** — Node 26 strips types for files outside `node_modules`. → `tools/` discovery works.

## Changes

- `engines/pi/tool.ts`: `defineTool` (Zod `input` → JSON Schema for the model; validates args before `execute` → a failure is an error *result*, not a crash; wraps plain returns) and `loadTools` (discover `tools/*`, filename = name; missing dir empty; bad export fails visibly with an ESM hint; `mergeDiscoveredTools` dedupes against defaults + `config.tools`, surfacing dropped tools).
- `index.ts`: export `defineTool`/`loadTools`/types + re-export `z`.
- `dev.ts`/`start.ts`: discover `tools/` and merge; report tool names + collisions.
- `cli.ts`: **`fastagent tool <name> '<json>' [dir]`** runs one tool directly — no model, no server, no tokens (tightest feedback loop), with Zod validation feedback.
- `zod ^4` dependency. Docs: core-design §6 reversed (with rationale); AGENTS.md map.

## Verification

- `npm run typecheck` clean; `npm test` 146 passed (+4 tool tests).
- Real tarball install e2e: package-name import works, `fastagent tool add '{"a":2,"b":3}'` → `{sum:5}`; invalid args → schema feedback; `dev` auto-discovers `tools: add` with **no** config wiring.

## Notes

- A code-tool workspace must be ESM (`"type": "module"`) so a tool's `import` resolves — `init --with-tool` (PR B) will scaffold this.
- Adds public API surface (`defineTool`, `z`, `loadTools`) → review-gated.

## Not borrowed from eve (out of scope / against neutrality)

Durable workflows, Vercel Sandbox/Functions, subagents, evals, approval gates, per-tool OAuth — eve's value is integrated Vercel infra; fastagent stays engine/host-neutral. We borrowed the authoring DX, not the platform.
