### PR TITLE
feat(init): default to a complete agent (instructions + tool) + auto npm install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ core/
 │   └── engines/pi/              # the pi reference implementation
 │       ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
 │       ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
-│       ├── init.ts              # `init`: scaffold a minimal runnable workspace
+│       ├── init.ts              # `init`: scaffold a runnable agent (complete by default; --minimal)
 │       ├── dev.ts               # `dev` opener: open a workspace → agent (authoring posture)
 │       ├── build.ts             # `build`: compile a workspace → self-contained artifact
 │       ├── start.ts             # `start` opener: run a built artifact (production posture)

--- a/core/package.json
+++ b/core/package.json
@@ -18,7 +18,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "fastagent": "./dist/cli.js"

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -13,6 +13,7 @@
  * Process-level side effects (proxy dispatcher, .env loading) belong here — the CLI
  * is the application entry point.
  */
+import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { parseArgs } from "node:util";
@@ -30,7 +31,7 @@ import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
 
 function usage(code: number): never {
   console.error(`usage:
-  fastagent init   [dir]
+  fastagent init   [dir] [--minimal] [--no-install]
   fastagent models
   fastagent tool   <name> '<json-args>' [dir]
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--global-skills]
@@ -41,8 +42,11 @@ function usage(code: number): never {
          model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
          --global-skills   also load the machine's global skills (~/.pi/agent/skills,
                            ~/.agents/skills); default is definition-only (dev == deployed)
-  init   scaffold a minimal runnable workspace in dir (default .): AGENTS.md, an example
-         skill, fastagent.config.mjs, .gitignore. Refuses to overwrite an existing workspace.
+  init   scaffold a runnable agent in dir (default .) and run npm install. Default is a
+         complete agent: AGENTS.md, a skill, tools/word-count.ts (a code tool), config,
+         package.json, .npmrc, .gitignore. Refuses to overwrite an existing workspace.
+         --minimal      markdown-only (no package.json/tool/install) — a prompt+skills agent
+         --no-install   scaffold but skip npm install
   models list the available "provider/modelId" specs (use one with --model or in the config).
   tool   run one tool (from tools/ or config.tools) directly with JSON args — no model, no
          server, no tokens. Fast feedback while authoring: fastagent tool add '{"a":2,"b":3}'
@@ -73,6 +77,8 @@ const { positionals, values } = parseArgs({
     "sessions-dir": { type: "string" },
     force: { type: "boolean" },
     "global-skills": { type: "boolean" },
+    minimal: { type: "boolean" },
+    "no-install": { type: "boolean" },
     help: { type: "boolean", short: "h" },
   },
 });
@@ -139,23 +145,48 @@ async function runTool(): Promise<void> {
 }
 
 async function runInit(): Promise<void> {
-  const { created, skipped, intoNonEmpty, warnings } = await scaffoldWorkspace(dir).catch(failStartup);
-  console.error(`[fastagent] initialized ${dir}`);
+  const minimal = values.minimal ?? false;
+  const { complete, created, skipped, intoNonEmpty, warnings } = await scaffoldWorkspace(dir, { minimal }).catch(
+    failStartup,
+  );
+  console.error(`[fastagent] initialized ${dir}${complete ? "" : " (minimal)"}`);
   if (created.length > 0) console.error(`  created: ${created.join(", ")}`);
   if (skipped.length > 0) console.error(`  kept existing: ${skipped.join(", ")}`);
   if (intoNonEmpty) {
     console.error(`  note: scaffolded into a non-empty directory; for a clean start, run \`fastagent init <name>\` (a fresh subdir)`);
   }
   for (const w of warnings) console.error(`[fastagent] warn: ${w}`);
+
+  // A complete agent has a tool that imports @kid7st/fastagent, so its deps must be installed.
+  // Run `npm install` for the developer (the package is public; users handling a private package
+  // will have run `npm login`). --no-install skips it; --minimal has no deps at all. A kept
+  // (pre-existing) package.json is not ours, so we do not install over it.
+  const willInstall = complete && !values["no-install"] && created.includes("package.json");
+  let installFailed = false;
+  if (willInstall) {
+    console.error(`[fastagent] installing dependencies (npm install)…`);
+    installFailed = (await npmInstall(dir)) !== 0;
+    if (installFailed) console.error(`[fastagent] warn: npm install failed — run it manually in ${dir} before \`fastagent dev\``);
+  }
+
+  // Next steps act on the scaffolded dir. For a named target (`fastagent init my-agent`) lead with
+  // a `cd` so bare `fastagent dev` (which defaults to .) is correct. Credentials are NOT mentioned
+  // here — `dev`/`start` prompt for them in context when missing (reportAuth); front-loading an
+  // instruction a newcomer can't act on yet is noise.
   console.error(`  next steps:`);
-  // The .env / config / `fastagent dev` steps all act on the scaffolded dir. When init targeted a
-  // non-cwd dir (e.g. `fastagent init my-agent`, the recommended clean-start flow), lead with a
-  // `cd` so every step — including bare `fastagent dev` (which defaults its dir to .) — is correct.
   const rel = relative(process.cwd(), dir);
   if (rel !== "") console.error(`    cd ${rel}`);
-  console.error(`    1. credentials — authenticate with \`pi login\`, or set the provider's API key in .env`);
-  console.error(`    2. optional   — edit fastagent.config.mjs to choose your model`);
-  console.error(`    3. fastagent dev   # serve locally and iterate`);
+  if (complete && (values["no-install"] || installFailed)) console.error(`    npm install`);
+  console.error(`    fastagent dev   # serve locally and iterate`);
+}
+
+/** Run `npm install` in `cwd` (inherit stdio so the user sees progress). Returns the exit code. */
+function npmInstall(cwd: string): Promise<number> {
+  return new Promise((resolveCode) => {
+    const child = spawn("npm", ["install"], { cwd, stdio: "inherit" });
+    child.on("close", (code) => resolveCode(code ?? 1));
+    child.on("error", () => resolveCode(1)); // npm not on PATH, etc.
+  });
 }
 
 /**

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -1,41 +1,43 @@
 /**
- * Init: scaffold a minimal, runnable fastagent workspace — the lowest-barrier dev unit.
+ * Init: scaffold a runnable fastagent workspace.
  *
- * The scaffold is markdown-only (zero npm dependencies): AGENTS.md + one example skill +
- * fastagent.config.mjs + .gitignore. It runs immediately under `fastagent dev` once the
- * developer has model credentials. Code-tool agents (a `package.json` + a tool module) are a
- * separate, opt-in step — this command deliberately scaffolds the no-dependency unit so the
- * first run never blocks on `npm install`.
+ * Default = a COMPLETE agent (instructions + a skill + a code tool): AGENTS.md, a house-style
+ * skill, tools/word-count.ts (defineTool), fastagent.config.mjs, package.json (ESM + the
+ * @kid7st/fastagent + zod deps), .npmrc (scope registry), .gitignore. A complete agent is
+ * instructions + tools, so that is what `init` produces; the CLI then runs `npm install`.
  *
- * Two scaffold conventions worth noting:
- *   - AGENTS.md is kept a CLEAN persona (no meta "edit me" instructions) because it IS the
- *     system prompt; the "what to edit next" guidance is printed to the console instead.
+ * `--minimal` = the markdown-only unit (AGENTS.md + skill + config + .gitignore): zero npm
+ * dependencies, no package.json, no install — for a pure prompt+skills agent.
+ *
+ * Scaffold conventions:
+ *   - AGENTS.md is a CLEAN persona (no meta "edit me" text) because it IS the system prompt;
+ *     "what to do next" is printed to the console by the CLI, not baked into a file.
+ *   - tools/ is auto-discovered (filename = tool name), so the config needs no `tools: []`.
  *   - .gitignore lists `.env` so the "secrets are the user's responsibility" model
- *     (definition.ts / core-design §10.1) is wired up correctly from the first commit —
- *     build honors .gitignore, so a gitignored .env never ships in the artifact.
+ *     (core-design §10.1) is wired up from the first commit (build honors .gitignore).
  *
- * Node composition-root module: writes template files; no engine import beyond the default
- * model string in the config template (folded-M — lift if a second engine ever scaffolds).
+ * Node composition-root module: writes template files (the CLI handles `npm install`).
  *
  * Scope boundary (deliberate — do not keep hardening past it): init is best-effort atomic for
- * ORDINARY inputs (a missing or normal target dir). It guards the common, recoverable cases —
- * never overwrites an existing workspace, preflights non-directory/symlink scaffold parents, and
- * rolls back a partial write. It does NOT defend against every pathological pre-existing state of
- * the target (TOCTOU races, read-only dirs, FIFOs, mid-write disk-full, …): this is a local
- * scaffolding command on the developer's own machine, where such a failure is surfaced and
- * recovered by deleting the dir and retrying. Hardening past this line is an open-ended edge
- * factory for negligible benefit; stop here.
+ * ORDINARY inputs. It guards the common, recoverable cases — never overwrites an existing
+ * workspace, preflights non-directory/symlink scaffold parents, and rolls back a partial write.
+ * It does NOT defend against every pathological pre-existing target state (TOCTOU, read-only
+ * dirs, FIFOs, mid-write disk-full, …): a local scaffolding command recovered by delete-and-retry.
  */
 import { access, lstat, mkdir, readdir, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { loadRootIgnore } from "./definition.ts";
 
-const AGENTS_MD = `# Assistant
+/** Identity persona (clean — it is the system prompt). The complete variant references the tool. */
+function agentsMd(minimal: boolean): string {
+  const toolLine = minimal ? "" : "\nWhen the user asks how long a piece of text is, use the word-count tool.\n";
+  return `# Assistant
 
 You are a concise, helpful assistant. Answer directly and skip filler.
 
 When the user asks you to write or edit prose, consult the house-style skill first.
-`;
+${toolLine}`;
+}
 
 const SKILL_MD = `---
 name: house-style
@@ -48,14 +50,35 @@ description: The house writing style. Consult before writing or editing any pros
 - Lead with the answer; put caveats after.
 `;
 
-const CONFIG_MJS = `// fastagent.config.mjs — deployment choices only (model / tools / http).
-// Your agent's identity and behavior live in AGENTS.md + skills/, never here.
+const TOOL_TS = `import { defineTool, z } from "@kid7st/fastagent";
+
+// A code tool: filename (word-count.ts) is the tool name. tools/ is auto-discovered,
+// so it needs no registration in fastagent.config. Test it directly with:
+//   fastagent tool word-count '{"text":"hello there world"}'
+export default defineTool({
+  description: "Count the words and characters in a piece of text.",
+  input: z.object({ text: z.string().describe("The text to measure") }),
+  async execute({ text }) {
+    const trimmed = text.trim();
+    return { words: trimmed ? trimmed.split(/\\s+/).length : 0, characters: text.length };
+  },
+});
+`;
+
+const CONFIG_MJS = `// fastagent.config.mjs — deployment choices only (model / http; code tools auto-discover from tools/).
+// Your agent's identity and behavior live in AGENTS.md + skills/ + tools/, never here.
 // Model precedence: \`--model\` flag > FASTAGENT_MODEL env > this default.
-// Change "model" to a "provider/modelId" you have access to.
+// Change "model" to a "provider/modelId" you have access to (\`fastagent models\` lists them).
 export default {
   model: "openai-codex/gpt-5.5",
   http: { port: 8787 },
 };
+`;
+
+const NPMRC = `; @kid7st/fastagent is published to GitHub Packages.
+; This maps the @kid7st scope to that registry; authenticate with a GitHub token
+; (read:packages) in your user ~/.npmrc — never commit the token.
+@kid7st:registry=https://npm.pkg.github.com
 `;
 
 const GITIGNORE = `# secrets — never commit, never ship in the build artifact
@@ -68,28 +91,47 @@ node_modules/
 .fastagent/
 `;
 
+/** package.json for the complete (code-tool) agent: ESM + the deps a defineTool tool imports. */
+function packageJson(name: string): string {
+  return `${JSON.stringify(
+    {
+      name,
+      private: true,
+      type: "module",
+      dependencies: { "@kid7st/fastagent": "^0.1.0", zod: "^4.0.0" },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+/** Sanitize a directory basename into a valid npm package name (lowercase, safe chars). */
+function toPackageName(dir: string): string {
+  const base = basename(resolve(dir)).toLowerCase().replace(/[^a-z0-9._-]/g, "-").replace(/^[._-]+/, "");
+  return base || "agent";
+}
+
 interface ScaffoldFile {
   rel: string;
   content: string;
 }
 
-/** The files init writes, in report order. AGENTS.md + config are guarded (never overwritten). */
-const FILES: ScaffoldFile[] = [
-  { rel: "AGENTS.md", content: AGENTS_MD },
-  { rel: join("skills", "house-style", "SKILL.md"), content: SKILL_MD },
-  { rel: "fastagent.config.mjs", content: CONFIG_MJS },
-  { rel: ".gitignore", content: GITIGNORE },
-];
+export interface ScaffoldOptions {
+  /** Scaffold the markdown-only unit (no package.json, no tool, no install) instead of a complete agent. */
+  minimal?: boolean;
+}
 
 export interface ScaffoldResult {
   dir: string;
+  /** Whether a complete (code-tool) agent was scaffolded (false for --minimal). */
+  complete: boolean;
   /** Files written by this run (relative paths). */
   created: string[];
   /** Files that already existed and were kept untouched (e.g. a pre-existing .gitignore). */
   skipped: string[];
   /** True if the target already had content before this run (init into an existing/non-empty dir). */
   intoNonEmpty: boolean;
-  /** Non-fatal advisories the caller MUST surface (e.g. a kept .gitignore that does not ignore .env). */
+  /** Non-fatal advisories the caller MUST surface. */
   warnings: string[];
 }
 
@@ -101,12 +143,27 @@ async function exists(p: string): Promise<boolean> {
 }
 
 /**
- * Scaffold a minimal runnable workspace into {@link dir} (created if missing). Refuses to
- * overwrite an existing agent identity (AGENTS.md or any fastagent.config.*) — that means the
- * dir is already a workspace, and clobbering it would destroy authored content. Other files
- * that already exist (.gitignore, the example skill) are kept, not overwritten.
+ * Scaffold a runnable workspace into {@link dir} (created if missing). Default is a complete
+ * agent (instructions + skill + a code tool + package.json); `--minimal` is markdown-only.
+ * Refuses to overwrite an existing agent identity (AGENTS.md or any fastagent.config.*); other
+ * pre-existing files (.gitignore, package.json, the example skill) are kept, not overwritten.
  */
-export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
+export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = {}): Promise<ScaffoldResult> {
+  const minimal = options.minimal ?? false;
+  const files: ScaffoldFile[] = [
+    { rel: "AGENTS.md", content: agentsMd(minimal) },
+    { rel: join("skills", "house-style", "SKILL.md"), content: SKILL_MD },
+    { rel: "fastagent.config.mjs", content: CONFIG_MJS },
+    { rel: ".gitignore", content: GITIGNORE },
+  ];
+  if (!minimal) {
+    files.push(
+      { rel: join("tools", "word-count.ts"), content: TOOL_TS },
+      { rel: "package.json", content: packageJson(toPackageName(dir)) },
+      { rel: ".npmrc", content: NPMRC },
+    );
+  }
+
   // Guard on the identity files: their presence means "already a workspace". Fail visibly
   // rather than overwrite authored content.
   const configNames = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"];
@@ -114,22 +171,18 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
   if (await exists(join(dir, "AGENTS.md"))) conflicts.push("AGENTS.md");
   for (const name of configNames) if (await exists(join(dir, name))) conflicts.push(name);
   if (conflicts.length > 0) {
-    throw new Error(
-      `"${dir}" already has ${conflicts.join(", ")} — init refuses to overwrite an existing workspace`,
-    );
+    throw new Error(`"${dir}" already has ${conflicts.join(", ")} — init refuses to overwrite an existing workspace`);
   }
 
-  // Was the target non-empty BEFORE we wrote anything? (missing dir = empty). Used to nudge
-  // toward `init <name>` (a fresh subdir) when scaffolding into an existing/non-empty dir.
+  // Was the target non-empty BEFORE we wrote anything? (missing dir = empty).
   const intoNonEmpty = (await readdir(dir).catch(() => [] as string[])).length > 0;
 
-  // Preflight the parent directories every scaffold file needs (e.g. `skills`,
-  // `skills/house-style`). A pre-existing NON-directory there would make mkdir fail mid-loop
-  // with ENOTDIR — AFTER the first file is written — leaving a half-scaffold that the identity
-  // guard then blocks on retry. Detect it BEFORE any write, with a clear message; the dir is
-  // left untouched and the user can retry after fixing it.
+  // Preflight scaffold parent dirs (e.g. `skills`, `tools`): a pre-existing NON-directory there
+  // would make mkdir fail mid-loop (ENOTDIR) AFTER the first write, leaving a half-scaffold the
+  // identity guard then blocks on retry. Detect it BEFORE any write (lstat, not stat: a symlinked
+  // parent must be rejected, not followed outside the dir — matches build's no-follow stance).
   const parents = new Set<string>();
-  for (const file of FILES) {
+  for (const file of files) {
     let p = dirname(file.rel);
     while (p !== "." && p !== "") {
       parents.add(p);
@@ -137,9 +190,6 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
     }
   }
   for (const rel of parents) {
-    // lstat, NOT stat: a symlink at a scaffold parent (e.g. `skills` → another dir) must be
-    // REJECTED, not followed — following it would write the scaffold OUTSIDE the requested dir.
-    // This matches build, which also does not follow in-tree symlinks (definition.ts planShipSet).
     const st = await lstat(join(dir, rel)).catch(() => undefined);
     if (st && !st.isDirectory()) {
       throw new Error(`cannot scaffold: "${rel}" exists and is not a directory (a regular file or symlink) — remove it, or init elsewhere`);
@@ -150,18 +200,14 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
   const created: string[] = [];
   const skipped: string[] = [];
   const warnings: string[] = [];
-  // ONE rollback scope covering ALL post-write work (the write loop AND the advisory read):
-  // any failure after the first write removes files written THIS run (guard + wx guarantee they
-  // are ours), so scaffoldWorkspace is atomic — success or the dir left as it was (retryable).
-  // Empty dirs we may have created are harmless and left as-is.
+  // ONE rollback scope over all post-write work: any failure removes files written THIS run
+  // (guard + wx guarantee they are ours), so scaffoldWorkspace is atomic (retryable on failure).
   try {
-    for (const file of FILES) {
+    for (const file of files) {
       const abs = join(dir, file.rel);
       await mkdir(dirname(abs), { recursive: true });
       try {
-        // wx: never clobber. The identity files are guaranteed absent (guard above); the rest
-        // (e.g. a pre-existing .gitignore) are kept on EEXIST instead of overwritten.
-        await writeFile(abs, file.content, { flag: "wx" });
+        await writeFile(abs, file.content, { flag: "wx" }); // wx: never clobber
         created.push(file.rel);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "EEXIST") skipped.push(file.rel);
@@ -169,28 +215,24 @@ export async function scaffoldWorkspace(dir: string): Promise<ScaffoldResult> {
       }
     }
 
-    // Security wiring is the .gitignore's whole job here: `fastagent build` excludes secrets ONLY
-    // via .gitignore/.fastagentignore (it does not special-case .env — core-design §10.1). If we
-    // KEPT a pre-existing .gitignore that does not ignore .env, the scaffold's secret line silently
-    // did not take effect while next-steps still tells the user to create .env → build could ship it.
-    // Warn with the exact fix; do NOT silently mutate the user's file (non-destructive contract +
-    // §10.1 "security is the user's responsibility; fastagent informs").
-    //
-    // Use the EXACT matcher build uses (loadRootIgnore: .gitignore + .fastagentignore, fa last,
-    // case-sensitive) so the advisory matches what the artifact will actually ship — a hand-rolled
-    // check diverges (misses .fastagentignore `!.env`, or a case-mismatched `.ENV`) and gives false
-    // assurance, the dangerous direction. This read can throw on an existing-but-unreadable ignore
-    // file (loadRootIgnore fails visibly); keeping it INSIDE the rollback scope means such a throw
-    // still leaves no half-scaffold.
+    // Security wiring: `fastagent build` excludes secrets ONLY via .gitignore/.fastagentignore
+    // (core-design §10.1). If a kept .gitignore does not ignore .env, the scaffold's secret line
+    // silently did not take effect. Use the EXACT matcher build uses (loadRootIgnore) so the
+    // advisory matches what ships; it can throw on an unreadable ignore file (kept in the rollback
+    // scope so such a throw leaves no half-scaffold).
     const rootIgnore = await loadRootIgnore(dir);
     if (!rootIgnore?.ignores(".env")) {
       warnings.push(
         `your .gitignore/.fastagentignore does not exclude ".env" — add it, or \`fastagent build\` may ship secrets into the artifact`,
       );
     }
+    // A kept package.json won't carry the tool's deps — the example tool would not resolve.
+    if (!minimal && skipped.includes("package.json")) {
+      warnings.push(`kept your existing package.json — add "@kid7st/fastagent" and "zod" to its dependencies to use code tools`);
+    }
   } catch (error) {
     for (const rel of created.reverse()) await rm(join(dir, rel), { force: true }).catch(() => {});
     throw error;
   }
-  return { dir, created, skipped, intoNonEmpty, warnings };
+  return { dir, complete: !minimal, created, skipped, intoNonEmpty, warnings };
 }

--- a/core/src/engines/pi/tool.ts
+++ b/core/src/engines/pi/tool.ts
@@ -120,12 +120,15 @@ export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; coll
     try {
       mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
     } catch (error) {
-      // The most common cause is a non-ESM workspace: a tool's `import` needs the project's
-      // package.json to set "type": "module". Surface the file + a hint instead of a raw stack.
-      throw new Error(
-        `cannot load tools/${entry.name}: ${(error as Error).message}\n` +
-          `  (a code-tool workspace must be ESM — set "type": "module" in package.json)`,
-      );
+      // Two common causes get a specific hint instead of a raw stack: a missing dependency
+      // (deps not installed — run `npm install`) and a non-ESM workspace (the tool's `import`
+      // needs package.json "type": "module").
+      const e = error as NodeJS.ErrnoException;
+      const hint =
+        e.code === "ERR_MODULE_NOT_FOUND" || /Cannot find (package|module)/.test(e.message)
+          ? `  (a dependency is not installed — run \`npm install\` in the workspace)`
+          : `  (a code-tool workspace must be ESM — set "type": "module" in package.json)`;
+      throw new Error(`cannot load tools/${entry.name}: ${e.message}\n${hint}`);
     }
     const tool = mod.default as Partial<AgentTool> | undefined;
     if (!tool || typeof tool.execute !== "function") {

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -26,31 +26,51 @@ function cliInit(args: string[], cwd: string): Promise<string> {
 }
 
 describe("init: scaffoldWorkspace", () => {
-  it("scaffolds a workspace that loads and assembles offline (init → dev is self-contained)", async () => {
+  it("default scaffolds a COMPLETE agent (instructions + skill + a code tool + package.json)", async () => {
     const dir = await freshDir();
-    const { created, skipped, intoNonEmpty, warnings } = await scaffoldWorkspace(dir);
+    const { complete, created, warnings } = await scaffoldWorkspace(dir);
+    expect(complete).toBe(true);
+    expect(created).toEqual(
+      expect.arrayContaining([
+        "AGENTS.md",
+        join("skills", "house-style", "SKILL.md"),
+        join("tools", "word-count.ts"),
+        "fastagent.config.mjs",
+        "package.json",
+        ".npmrc",
+        ".gitignore",
+      ]),
+    );
+    expect(warnings).toEqual([]);
+
+    // package.json is ESM with the tool's deps; the tool imports the package + names from its file.
+    const pkg = JSON.parse(await readFile(join(dir, "package.json"), "utf8"));
+    expect(pkg.type).toBe("module");
+    expect(pkg.dependencies["@kid7st/fastagent"]).toBeDefined();
+    expect(pkg.dependencies.zod).toBeDefined();
+    expect(await readFile(join(dir, "tools", "word-count.ts"), "utf8")).toContain('from "@kid7st/fastagent"');
+    expect(await readFile(join(dir, ".npmrc"), "utf8")).toContain("npm.pkg.github.com");
+
+    // AGENTS.md + skill load as a definition offline (loadAgentDefinition does not touch tools/).
+    const def = await loadAgentDefinition(dir);
+    expect(def.skills.map((s) => s.name)).toEqual(["house-style"]);
+    expect(def.collisions).toEqual([]);
+  });
+
+  it("--minimal scaffolds the markdown-only unit (no package.json/tool) and assembles fully offline", async () => {
+    const dir = await freshDir();
+    const { complete, created } = await scaffoldWorkspace(dir, { minimal: true });
+    expect(complete).toBe(false);
     expect(created.sort()).toEqual(
       ["AGENTS.md", ".gitignore", "fastagent.config.mjs", join("skills", "house-style", "SKILL.md")].sort(),
     );
-    expect(skipped).toEqual([]);
-    // fresh empty dir, and our own .gitignore ignores .env → no advisories
-    expect(intoNonEmpty).toBe(false);
-    expect(warnings).toEqual([]);
+    expect(await exists(join(dir, "package.json"))).toBe(false);
+    expect(await exists(join(dir, "tools"))).toBe(false);
 
-    // The scaffold is a valid definition: AGENTS.md + the example skill, no diagnostics/collisions.
-    const def = await loadAgentDefinition(dir);
-    expect(def.instructions).toContain("concise");
-    expect(def.skills.map((s) => s.name)).toEqual(["house-style"]);
-    expect(def.diagnostics).toEqual([]);
-    expect(def.collisions).toEqual([]);
-
-    // dev assembly works with zero edits and zero network (model is resolved from the registry).
+    // No tool to import → dev assembles with zero edits and zero network.
     const { agent, modelSpec } = await createPiAgentFromWorkspace(dir);
     expect(typeof agent.invoke).toBe("function");
     expect(modelSpec).toBe("openai-codex/gpt-5.5");
-
-    // .gitignore wires up the "secrets are the user's responsibility" model from the start.
-    expect(await readFile(join(dir, ".gitignore"), "utf8")).toContain(".env");
   });
 
   it("creates a non-existent target dir (counts as empty, no non-empty note)", async () => {
@@ -101,10 +121,10 @@ describe("init: scaffoldWorkspace", () => {
   it("prints a `cd <dir>` step for a named target so the dev/.env/config steps are correct", async () => {
     const base = await freshDir();
     // init into a subdir from `base` as cwd: the next steps must lead with `cd my-agent`.
-    const named = await cliInit(["init", "my-agent"], base);
+    const named = await cliInit(["init", "my-agent", "--no-install"], base);
     expect(named).toMatch(/cd my-agent/);
     // init into cwd (default .): no cd step, bare `fastagent dev` is already correct.
-    const cwd = await cliInit(["init"], await freshDir());
+    const cwd = await cliInit(["init", "--no-install"], await freshDir());
     expect(cwd).not.toMatch(/cd /);
     expect(cwd).toMatch(/fastagent dev/);
   });


### PR DESCRIPTION
## What

A complete agent is **instructions + tools**, so `fastagent init` now produces that by default — not a markdown-only stub. This drops the awkward `--with-tool` framing (tools are the default, not an opt-in) and runs `npm install` for the developer.

```
fastagent init my-agent          # complete: AGENTS.md + skill + tools/word-count.ts + package.json, then npm install
fastagent init my-agent --minimal    # markdown-only: prompt+skills agent, zero deps, no install
fastagent init my-agent --no-install # scaffold complete but skip npm install
```

## Changes

- **init.ts**: default scaffold = `AGENTS.md` + `skills/house-style/SKILL.md` + `tools/word-count.ts` (a `defineTool` tool, auto-discovered — **no config wiring**) + `fastagent.config.mjs` + `package.json` (ESM + `@kid7st/fastagent` + `zod`) + `.npmrc` (the `@kid7st` scope → GitHub Packages) + `.gitignore`. `--minimal` keeps the markdown-only unit.
- **cli.ts**: after a complete scaffold, run `npm install` (the package is published; `--no-install` skips it; `--minimal` has no deps). **Next-steps drop the credentials line** — `dev`/`start` already prompt for credentials in context when missing (reportAuth), so front-loading an instruction a newcomer can't act on yet is noise.
- **tool.ts**: `loadTools` hints `npm install` on a missing-dependency load failure (not just the ESM hint).
- **package.json**: export `./package.json` (tooling/bundlers can read the manifest — closes a small gap surfaced during #1's e2e).

## Verification (real, against the published package)

- `npm run typecheck` clean; `npm test` 147 passed.
- `fastagent init my-agent` → scaffolds + `npm install` (243 pkgs from GitHub Packages) → `fastagent tool word-count '{"text":"hello there big world"}'` → `{words:4, characters:21}` (tool resolves `@kid7st/fastagent` from the auto-installed deps).
- `--minimal` → markdown-only, no package.json/tool, assembles fully offline.

## Decisions baked in (agreed)

- Credentials can't be auto (interactive OAuth / user secret) → not front-loaded; surfaced at dev/start when missing.
- npm i auto-runs (the package is/will be public; users handling a private package have `npm login`'d).
- `--minimal` kept as the zero-dependency escape for pure prompt+skills agents.

Note: adds public API surface (`ScaffoldOptions`, `ScaffoldResult.complete`) → review-gated.
