### PR TITLE
docs(quickstart): from-zero getting-started guide (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ npm i @kid7st/fastagent      # the library (defineConfig, the Agent contract, �
 
 The package ships compiled JavaScript + type declarations (`dist/`); the repository itself runs the TypeScript sources directly under Node 26.
 
+**New here? Start with the [Quickstart](docs/quickstart.md)** — from an installed CLI to a running, deployable agent in a few minutes.
+
 ## Documentation
 
 | Document | Purpose |
 |---|---|
+| [quickstart.md](docs/quickstart.md) | **Quickstart**: scaffold → run → add a tool → build/start, end to end |
 | [SPEC.md](docs/SPEC.md) | **Agent Handler protocol**: the engine-neutral contract layer. `status: locked` v0.1 |
 | [core-design.md](docs/core-design.md) | The pi-based reference implementation of the SPEC, plus the N × M × K layering model |
 | [session.md](docs/session.md) | Draft session-admin model: event-sourced conversation DAG, fork, and navigation. `status: design` |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,99 @@
+---
+title: Quickstart
+type: doc
+status: current
+---
+
+# Quickstart
+
+From an installed CLI to a running, deployable agent in a few minutes. Everything here runs locally.
+
+## Prerequisites
+
+- **Node ≥ 26** (`node -v`). The package ships compiled JavaScript; Node runs it directly, no build step on your side.
+- **The `fastagent` CLI** — see [Install](../README.md#install): `npm i -g @kid7st/fastagent`, with the `@kid7st` scope registry + a GitHub token in your `~/.npmrc`.
+- **Model credentials** — either `pi login` (OAuth) or a provider API key in the workspace's `.env` (e.g. `OPENAI_API_KEY=…`). Run `fastagent models` to list the available `provider/modelId` specs.
+
+## 1. Scaffold an agent
+
+```bash
+fastagent init my-agent
+cd my-agent
+```
+
+`init` writes a complete agent (instructions **+ a tool**) and runs `npm install`:
+
+```
+my-agent/
+├── AGENTS.md                    # the agent's instructions (its system prompt)
+├── skills/house-style/SKILL.md  # an on-demand skill
+├── tools/word-count.ts          # a code tool (defineTool) — auto-discovered
+├── fastagent.config.mjs         # deployment choices: model, http port
+├── package.json                 # ESM + the @kid7st/fastagent + zod deps
+└── .gitignore / .npmrc
+```
+
+For a pure prompt+skills agent with no code and no dependencies, use `fastagent init my-agent --minimal`.
+
+## 2. Run it
+
+```bash
+fastagent dev
+```
+
+The startup report shows the model, auth source, loaded skills, and tools. If it prints `auth: (none found)`, set credentials (see prerequisites) and re-run. Then send a turn:
+
+```bash
+curl -N -X POST localhost:8787/invoke \
+  -H 'content-type: application/json' \
+  -d '{"session":"s1","text":"How many words are in: the quick brown fox jumps"}'
+```
+
+The response is a stream of Server-Sent Events — `text` deltas, `tool_started` / `tool_ended` when the model calls a tool, and a terminal `completed`. The scaffolded agent calls its `word-count` tool here:
+
+```
+data: {"type":"tool_started","name":"word-count","args":{"text":"the quick brown fox jumps"}}
+data: {"type":"tool_ended","isError":false,"content":{"details":{"words":5,"characters":25}}}
+data: {"type":"completed"}
+```
+
+Reuse the same `session` value to continue a conversation; conversations persist under `.fastagent/sessions`, so a `dev` restart keeps them.
+
+## 3. Add a tool
+
+A tool is a file in `tools/`; the **filename is the tool name**, and `tools/` is auto-discovered — no registration in the config. Drop in `tools/reverse.ts`:
+
+```ts
+import { defineTool, z } from "@kid7st/fastagent";
+
+export default defineTool({
+  description: "Reverse a string.",
+  input: z.object({ text: z.string() }),
+  async execute({ text }) {
+    return { reversed: [...text].reverse().join("") };
+  },
+});
+```
+
+Test it directly — no model, no server, no tokens:
+
+```bash
+fastagent tool reverse '{"text":"hello"}'
+# → { "reversed": "olleh" }
+```
+
+Restart `fastagent dev` and the model can call `reverse`. Mention the tool in `AGENTS.md` so the model knows when to use it. (`input` is a [Zod](https://zod.dev) schema: the args are validated before `execute`, and an invalid call is reported back to the model, not a crash.)
+
+## 4. Build and run the artifact
+
+```bash
+fastagent build                  # → .fastagent/build : a self-contained, relocatable artifact
+fastagent start .fastagent/build # run it in production posture
+```
+
+`build` compiles the workspace (instructions + skills + tools + config) into an artifact whose manifest freezes the model and http port. `start` runs that artifact with sessions kept **outside** it (so a redeploy never wipes conversations). To deploy: copy the artifact directory anywhere with Node ≥ 26, run `npm ci`, then `fastagent start`.
+
+## Where next
+
+- [SPEC](SPEC.md) — the Agent Handler contract (`invoke(scope, prompt) => AsyncIterable<AgentEvent>`) the whole thing rests on.
+- [core-design](core-design.md) — the pi reference implementation, the N × M × K layering, and the build/start deployment model.


### PR DESCRIPTION
A runnable one-pager (scaffold → run → add a tool → build/start), verified end-to-end against the published package. Adds `docs/quickstart.md` + README links. Closes review gap #2. Docs tier.