### PR TITLE
fix(sessions): reconcile interrupted tool calls on reopen

### DIFF
--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -21,12 +21,67 @@
  * via pi's repos; the invoke path itself stays disk-free.
  */
 import { InMemorySessionRepo } from "@earendil-works/pi-agent-core";
-import type { Session } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, Session } from "@earendil-works/pi-agent-core";
 import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 /** What fastagent needs from a session backend: open-or-create by opaque id. */
 export interface PiSessionStore {
   openOrCreate(sessionId: string): Promise<Session>;
+}
+
+/**
+ * Crash-safety reconciliation, run on every OPEN of an existing session.
+ *
+ * A turn that dies mid tool-execution leaves the session with an assistant tool_use that
+ * has no matching tool result: pi persists the assistant message at `message_end` — BEFORE
+ * the tool runs — and `buildSessionContext` does not repair the gap. The next turn would
+ * then hand the provider an `assistant(tool_use) -> user` sequence that Anthropic/OpenAI
+ * reject, so a retry after a crash fails outright (the session is "poisoned"). We append an
+ * honest "interrupted" error tool result for each dangling call, restoring a valid transcript
+ * so the next turn proceeds and the model can re-decide.
+ *
+ * Tool side-effect idempotency stays the tool's responsibility (SPEC §6); this only restores
+ * transcript validity, it does not promise the interrupted tool ran exactly once. Dangling
+ * calls are assumed to belong to the leaf turn (the only turn a crash can interrupt), so the
+ * appended results land at the leaf, immediately after that assistant message.
+ *
+ * The synthetic result has three audiences, so it splits them deliberately:
+ *   - `content` is read by the MODEL next turn (and may be relayed to the end user). It stays
+ *     neutral and decision-guiding. It must NOT say "aborted" — pi uses that for a user
+ *     cancellation, and the model would read it as "the user dropped this" and abandon work
+ *     the user actually wants. It must NOT leak infra detail ("process restarted"/"crash")
+ *     — that text can surface to the end user and reads as an outage.
+ *   - `details` carries the operational marker for developers (logs/session inspection); it is
+ *     never sent to the provider (`transform-messages` forwards only `content`).
+ */
+async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
+  const { messages } = await session.buildContext();
+  const settled = new Set<string>();
+  for (const m of messages) {
+    if (m.role === "toolResult") settled.add(m.toolCallId);
+  }
+  for (const m of messages) {
+    if (m.role !== "assistant") continue;
+    for (const block of m.content) {
+      if (block.type !== "toolCall" || settled.has(block.id)) continue;
+      const result: AgentMessage = {
+        role: "toolResult",
+        toolCallId: block.id,
+        toolName: block.name,
+        content: [
+          {
+            type: "text",
+            text: "This tool call did not complete and its result is unavailable. Re-run it if the result is still needed.",
+          },
+        ],
+        details: { fastagent: "interrupted-tool-call" },
+        isError: true,
+        timestamp: Date.now(),
+      };
+      await session.appendMessage(result);
+      settled.add(block.id); // a malformed message could repeat an id; never append twice
+    }
+  }
 }
 
 /** In-process store (pi InMemorySessionRepo). Continuity lives and dies with the instance. */
@@ -35,7 +90,10 @@ export function inMemorySessionStore(): PiSessionStore {
   return {
     async openOrCreate(sessionId) {
       const existing = (await repo.list()).find((m) => m.id === sessionId);
-      return existing ? repo.open(existing) : repo.create({ id: sessionId });
+      if (!existing) return repo.create({ id: sessionId });
+      const session = await repo.open(existing);
+      await reconcileInterruptedToolCalls(session);
+      return session;
     },
   };
 }
@@ -60,7 +118,10 @@ export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSes
       // Scope the lookup to this store's cwd: pi groups sessions by project dir,
       // and two stores sharing a sessionsRoot must not open each other's sessions.
       const existing = (await repo.list({ cwd })).find((m) => m.id === id);
-      return existing ? repo.open(existing) : repo.create({ id, cwd });
+      if (!existing) return repo.create({ id, cwd });
+      const session = await repo.open(existing);
+      await reconcileInterruptedToolCalls(session);
+      return session;
     },
   };
 }

--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -43,14 +43,20 @@ export interface PiSessionStore {
  * Tool side-effect idempotency stays the tool's responsibility (SPEC §6); this only restores
  * transcript validity, it does not promise the interrupted tool ran exactly once.
  *
+ * Pairing is TURN-LOCAL, never transcript-global: a tool_use is paired only by a toolResult
+ * that FOLLOWS it (append-only — a result always lands after the assistant that requested it).
+ * tool-call ids are not guaranteed unique across turns (model-neutral: a local/custom model may
+ * restart ids at `call-1` each response), so matching against the whole transcript would falsely
+ * "settle" the leaf's call against an earlier turn's identical id and skip the repair.
+ *
  * Append-only logs can only repair a gap AT THE LEAF: the last assistant message followed by
  * nothing but its own toolResults. Appending a missing result there yields a valid
  * `assistant -> toolResults` run. We reconcile on every open, before any later turn is
  * appended, so a crash gap is always at the leaf — but we ENFORCE that rather than assume it:
- * an unmatched call sitting behind later history (which appending cannot repair) is surfaced
- * via `console.warn` and left untouched, never "fixed" with an orphaned result that would only
- * make the transcript worse. (Unreachable in the current single-leaf, reconcile-on-open design;
- * the guard exists for forks/navigation or pre-fix poisoned sessions.)
+ * a leaf call sitting behind later history (which appending cannot repair) is surfaced via
+ * `console.warn` and left untouched, never "fixed" with an orphaned result that would only make
+ * the transcript worse. (Unreachable in the current single-leaf, reconcile-on-open design; the
+ * guard exists for forks/navigation or pre-fix poisoned sessions.)
  *
  * The synthetic result has three audiences, so it splits them deliberately:
  *   - `content` is read by the MODEL next turn (and may be relayed to the end user). It stays
@@ -64,51 +70,46 @@ export interface PiSessionStore {
 async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
   const { messages } = await session.buildContext();
 
-  const settled = new Set<string>();
-  for (const m of messages) {
-    if (m.role === "toolResult") settled.add(m.toolCallId);
-  }
-
-  // Every unmatched tool_use across the transcript, tagged with its message index.
-  const unmatched: { idx: number; id: string; name: string }[] = [];
-  messages.forEach((m, idx) => {
-    if (m.role !== "assistant") return;
-    for (const block of m.content) {
-      if (block.type === "toolCall" && !settled.has(block.id)) {
-        unmatched.push({ idx, id: block.id, name: block.name });
-      }
-    }
-  });
-  if (unmatched.length === 0) return;
-
-  // The leaf turn = the last assistant message followed by nothing but its own toolResults.
-  // Only unmatched calls belonging to it can be repaired by appending (see the doc comment).
-  let leafAssistantIdx = -1;
+  // Leaf turn = the last assistant message.
+  let leafIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i]?.role === "assistant") {
-      leafAssistantIdx = i;
+      leafIdx = i;
       break;
     }
   }
-  const leafIsAtTail =
-    leafAssistantIdx !== -1 && messages.slice(leafAssistantIdx + 1).every((m) => m.role === "toolResult");
+  const leaf = leafIdx === -1 ? undefined : messages[leafIdx];
+  if (leaf?.role !== "assistant") return; // no assistant turn yet (also narrows `leaf`)
 
-  const atLeaf = unmatched.filter((u) => leafIsAtTail && u.idx === leafAssistantIdx);
-  const notAtLeaf = unmatched.filter((u) => !(leafIsAtTail && u.idx === leafAssistantIdx));
+  // Turn-local pairing: only toolResults that FOLLOW the leaf can pair its calls. Using the
+  // tail (not the whole transcript) is what makes this robust to ids reused across turns.
+  const tail = messages.slice(leafIdx + 1);
+  const paired = new Set<string>();
+  for (const m of tail) {
+    if (m.role === "toolResult") paired.add(m.toolCallId);
+  }
+  const dangling = leaf.content.filter(
+    (block): block is Extract<typeof block, { type: "toolCall" }> =>
+      block.type === "toolCall" && !paired.has(block.id),
+  );
+  if (dangling.length === 0) return; // leaf has no tool_use, or all of them are already paired
 
-  if (notAtLeaf.length > 0) {
-    // Behind later history: appending cannot repair it. Surface, do not silently corrupt.
+  // Reconcilable only if nothing but the leaf's own toolResults follows it. If a later turn
+  // already sits after the gap (a broken invariant — we reconcile before any later turn is
+  // appended), appending cannot repair it; surface instead of adding an orphan.
+  if (tail.some((m) => m.role !== "toolResult")) {
     console.warn(
       `[fastagent] unmatched tool_use is not at the session leaf; leaving it unreconciled ` +
-        `(an append-only log cannot repair a mid-history gap): toolCallIds=${notAtLeaf.map((u) => u.id).join(",")}`,
+        `(an append-only log cannot repair a mid-history gap): toolCallIds=${dangling.map((b) => b.id).join(",")}`,
     );
+    return;
   }
 
-  for (const { id, name } of atLeaf) {
+  for (const block of dangling) {
     const result: AgentMessage = {
       role: "toolResult",
-      toolCallId: id,
-      toolName: name,
+      toolCallId: block.id,
+      toolName: block.name,
       content: [
         {
           type: "text",

--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -49,14 +49,13 @@ export interface PiSessionStore {
  * restart ids at `call-1` each response), so matching against the whole transcript would falsely
  * "settle" the leaf's call against an earlier turn's identical id and skip the repair.
  *
- * Append-only logs can only repair a gap AT THE LEAF: the last assistant message followed by
- * nothing but its own toolResults. Appending a missing result there yields a valid
- * `assistant -> toolResults` run. We reconcile on every open, before any later turn is
- * appended, so a crash gap is always at the leaf — but we ENFORCE that rather than assume it:
- * a leaf call sitting behind later history (which appending cannot repair) is surfaced via
- * `console.warn` and left untouched, never "fixed" with an orphaned result that would only make
- * the transcript worse. (Unreachable in the current single-leaf, reconcile-on-open design; the
- * guard exists for forks/navigation or pre-fix poisoned sessions.)
+ * Append-only logs can only repair a gap AT THE LEAF (the last assistant followed by nothing but
+ * its own toolResults): appending the missing result there yields a valid `assistant -> toolResults`
+ * run. We still scan EVERY assistant turn-locally so a gap that is NOT at the leaf — an earlier
+ * assistant's call, or a leaf call already followed by later history — is surfaced via `console.warn`
+ * rather than silently ignored or "fixed" with an orphaned result that appending cannot place
+ * correctly. (Mid-history gaps are unreachable in the reconcile-on-open design — we reconcile before
+ * any later turn is appended — so the guard exists for forks/navigation or pre-fix sessions.)
  *
  * The synthetic result has three audiences, so it splits them deliberately:
  *   - `content` is read by the MODEL next turn (and may be relayed to the end user). It stays
@@ -70,7 +69,7 @@ export interface PiSessionStore {
 async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
   const { messages } = await session.buildContext();
 
-  // Leaf turn = the last assistant message.
+  // The leaf is the last assistant; only its gap can be repaired by appending (append-only log).
   let leafIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i]?.role === "assistant") {
@@ -78,38 +77,46 @@ async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
       break;
     }
   }
-  const leaf = leafIdx === -1 ? undefined : messages[leafIdx];
-  if (leaf?.role !== "assistant") return; // no assistant turn yet (also narrows `leaf`)
+  if (leafIdx === -1) return; // no assistant turn yet
+  const leafReparable = messages.slice(leafIdx + 1).every((m) => m.role === "toolResult");
 
-  // Turn-local pairing: only toolResults that FOLLOW the leaf can pair its calls. Using the
-  // tail (not the whole transcript) is what makes this robust to ids reused across turns.
-  const tail = messages.slice(leafIdx + 1);
-  const paired = new Set<string>();
-  for (const m of tail) {
-    if (m.role === "toolResult") paired.add(m.toolCallId);
-  }
-  const dangling = leaf.content.filter(
-    (block): block is Extract<typeof block, { type: "toolCall" }> =>
-      block.type === "toolCall" && !paired.has(block.id),
-  );
-  if (dangling.length === 0) return; // leaf has no tool_use, or all of them are already paired
+  // Scan EVERY assistant turn-locally: a tool_use is paired only by the toolResults that
+  // immediately follow it (up to the next non-toolResult). Turn-local windows are robust to
+  // ids reused across turns; scanning every turn (not only the leaf) lets a mid-history gap be
+  // surfaced rather than silently ignored.
+  const toRepair: { id: string; name: string }[] = [];
+  const orphaned: string[] = [];
+  messages.forEach((m, idx) => {
+    if (m.role !== "assistant") return;
+    const paired = new Set<string>();
+    for (let j = idx + 1; j < messages.length; j++) {
+      const next = messages[j];
+      if (next?.role !== "toolResult") break;
+      paired.add(next.toolCallId);
+    }
+    for (const block of m.content) {
+      if (block.type !== "toolCall" || paired.has(block.id)) continue;
+      // The leaf's gap (last assistant, followed only by its own results) is repairable by
+      // appending. Any earlier gap is mid-history: an append-only log cannot fix it.
+      if (idx === leafIdx && leafReparable) toRepair.push({ id: block.id, name: block.name });
+      else orphaned.push(block.id);
+    }
+  });
 
-  // Reconcilable only if nothing but the leaf's own toolResults follows it. If a later turn
-  // already sits after the gap (a broken invariant — we reconcile before any later turn is
-  // appended), appending cannot repair it; surface instead of adding an orphan.
-  if (tail.some((m) => m.role !== "toolResult")) {
+  if (orphaned.length > 0) {
+    // Behind later history: a result appended at the end arrives too late. Surface, do not add an
+    // orphan. Unreachable in the reconcile-on-open design; the guard is for forks/pre-fix sessions.
     console.warn(
       `[fastagent] unmatched tool_use is not at the session leaf; leaving it unreconciled ` +
-        `(an append-only log cannot repair a mid-history gap): toolCallIds=${dangling.map((b) => b.id).join(",")}`,
+        `(an append-only log cannot repair a mid-history gap): toolCallIds=${orphaned.join(",")}`,
     );
-    return;
   }
 
-  for (const block of dangling) {
+  for (const { id, name } of toRepair) {
     const result: AgentMessage = {
       role: "toolResult",
-      toolCallId: block.id,
-      toolName: block.name,
+      toolCallId: id,
+      toolName: name,
       content: [
         {
           type: "text",

--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -41,9 +41,16 @@ export interface PiSessionStore {
  * so the next turn proceeds and the model can re-decide.
  *
  * Tool side-effect idempotency stays the tool's responsibility (SPEC §6); this only restores
- * transcript validity, it does not promise the interrupted tool ran exactly once. Dangling
- * calls are assumed to belong to the leaf turn (the only turn a crash can interrupt), so the
- * appended results land at the leaf, immediately after that assistant message.
+ * transcript validity, it does not promise the interrupted tool ran exactly once.
+ *
+ * Append-only logs can only repair a gap AT THE LEAF: the last assistant message followed by
+ * nothing but its own toolResults. Appending a missing result there yields a valid
+ * `assistant -> toolResults` run. We reconcile on every open, before any later turn is
+ * appended, so a crash gap is always at the leaf — but we ENFORCE that rather than assume it:
+ * an unmatched call sitting behind later history (which appending cannot repair) is surfaced
+ * via `console.warn` and left untouched, never "fixed" with an orphaned result that would only
+ * make the transcript worse. (Unreachable in the current single-leaf, reconcile-on-open design;
+ * the guard exists for forks/navigation or pre-fix poisoned sessions.)
  *
  * The synthetic result has three audiences, so it splits them deliberately:
  *   - `content` is read by the MODEL next turn (and may be relayed to the end user). It stays
@@ -56,31 +63,63 @@ export interface PiSessionStore {
  */
 async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
   const { messages } = await session.buildContext();
+
   const settled = new Set<string>();
   for (const m of messages) {
     if (m.role === "toolResult") settled.add(m.toolCallId);
   }
-  for (const m of messages) {
-    if (m.role !== "assistant") continue;
+
+  // Every unmatched tool_use across the transcript, tagged with its message index.
+  const unmatched: { idx: number; id: string; name: string }[] = [];
+  messages.forEach((m, idx) => {
+    if (m.role !== "assistant") return;
     for (const block of m.content) {
-      if (block.type !== "toolCall" || settled.has(block.id)) continue;
-      const result: AgentMessage = {
-        role: "toolResult",
-        toolCallId: block.id,
-        toolName: block.name,
-        content: [
-          {
-            type: "text",
-            text: "This tool call did not complete and its result is unavailable. Re-run it if the result is still needed.",
-          },
-        ],
-        details: { fastagent: "interrupted-tool-call" },
-        isError: true,
-        timestamp: Date.now(),
-      };
-      await session.appendMessage(result);
-      settled.add(block.id); // a malformed message could repeat an id; never append twice
+      if (block.type === "toolCall" && !settled.has(block.id)) {
+        unmatched.push({ idx, id: block.id, name: block.name });
+      }
     }
+  });
+  if (unmatched.length === 0) return;
+
+  // The leaf turn = the last assistant message followed by nothing but its own toolResults.
+  // Only unmatched calls belonging to it can be repaired by appending (see the doc comment).
+  let leafAssistantIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") {
+      leafAssistantIdx = i;
+      break;
+    }
+  }
+  const leafIsAtTail =
+    leafAssistantIdx !== -1 && messages.slice(leafAssistantIdx + 1).every((m) => m.role === "toolResult");
+
+  const atLeaf = unmatched.filter((u) => leafIsAtTail && u.idx === leafAssistantIdx);
+  const notAtLeaf = unmatched.filter((u) => !(leafIsAtTail && u.idx === leafAssistantIdx));
+
+  if (notAtLeaf.length > 0) {
+    // Behind later history: appending cannot repair it. Surface, do not silently corrupt.
+    console.warn(
+      `[fastagent] unmatched tool_use is not at the session leaf; leaving it unreconciled ` +
+        `(an append-only log cannot repair a mid-history gap): toolCallIds=${notAtLeaf.map((u) => u.id).join(",")}`,
+    );
+  }
+
+  for (const { id, name } of atLeaf) {
+    const result: AgentMessage = {
+      role: "toolResult",
+      toolCallId: id,
+      toolName: name,
+      content: [
+        {
+          type: "text",
+          text: "This tool call did not complete and its result is unavailable. Re-run it if the result is still needed.",
+        },
+      ],
+      details: { fastagent: "interrupted-tool-call" },
+      isError: true,
+      timestamp: Date.now(),
+    };
+    await session.appendMessage(result);
   }
 }
 

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -178,9 +178,9 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
     expect(messages.some((m: any) => m.role === "toolResult")).toBe(false);
   });
 
-  it("an unmatched call behind later history is surfaced, not silently appended (fail visibly)", async () => {
-    // A gap that is NOT at the leaf (a later turn already sits after the dangling call) cannot
-    // be repaired by appending to an append-only log; appending would only add an orphan.
+  it("a leaf call behind later history is surfaced, not silently appended (fail visibly)", async () => {
+    // The leaf's dangling call is followed by a later turn (a user prompt) rather than only its
+    // own results, so appending to an append-only log cannot repair it; surface instead.
     const store = inMemorySessionStore();
     const s = await store.openOrCreate("mid-history");
     await s.appendMessage({ role: "user", content: [{ type: "text", text: "run it" }], timestamp: Date.now() } as any);
@@ -191,11 +191,6 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
     } as any);
     // a later turn lands after the dangling call without it ever being reconciled
     await s.appendMessage({ role: "user", content: [{ type: "text", text: "still there?" }], timestamp: Date.now() } as any);
-    await s.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "sorry, failed" }],
-      provider: "faux", model: "faux", stopReason: "error", usage: { input: 0, output: 0 }, timestamp: Date.now(),
-    } as any);
 
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
@@ -206,6 +201,46 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it("pairing is turn-local: a reused tool-call id from an earlier turn does not mask a leaf gap", async () => {
+    // tool-call ids are not globally unique (a model may restart at call-1 each turn). An earlier
+    // *completed* call-1 must NOT make a later crashed call-1 look already paired.
+    const store = inMemorySessionStore();
+    const s = await store.openOrCreate("reused-id");
+    // turn 1: call-1 ran and completed
+    await s.appendMessage({ role: "user", content: [{ type: "text", text: "first" }], timestamp: Date.now() } as any);
+    await s.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "a" } }],
+      provider: "faux", model: "faux", stopReason: "toolUse", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+    } as any);
+    await s.appendMessage({
+      role: "toolResult", toolCallId: "call-1", toolName: "echo",
+      content: [{ type: "text", text: "a" }], isError: false, timestamp: Date.now(),
+    } as any);
+    await s.appendMessage({
+      role: "assistant", content: [{ type: "text", text: "done turn 1" }],
+      provider: "faux", model: "faux", stopReason: "stop", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+    } as any);
+    // turn 2: call-1 reused, crashed before its result
+    await s.appendMessage({ role: "user", content: [{ type: "text", text: "second" }], timestamp: Date.now() } as any);
+    await s.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "b" } }],
+      provider: "faux", model: "faux", stopReason: "toolUse", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+    } as any);
+
+    const reopened = await store.openOrCreate("reused-id"); // open -> reconcile
+    const { messages } = await reopened.buildContext();
+    // the leaf call-1 must be repaired despite the earlier paired call-1 (turn-local pairing)
+    const interrupted = messages.filter(
+      (m: any) => m.role === "toolResult" && m.details?.fastagent === "interrupted-tool-call",
+    );
+    expect(interrupted).toHaveLength(1);
+    expect((interrupted[0] as any).toolCallId).toBe("call-1");
+    // and the leaf is now valid: its call has a following result
+    expect(messages.at(-1)).toMatchObject({ role: "toolResult", toolCallId: "call-1", isError: true });
   });
 });
 

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
-import { jsonlSessionStore, type AgentEvent, type PiSessionStore } from "../src/index.ts";
+import { inMemorySessionStore, jsonlSessionStore, type AgentEvent, type PiSessionStore } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 
@@ -102,6 +102,84 @@ describe("jsonlSessionStore (persistent sessions, first K-axis backend)", () => 
     expect(JSON.stringify(other)).not.toContain("hunter2"); // B cannot see A same-named session
   });
 
+});
+
+describe("crash-safety: reconcile interrupted tool calls on open", () => {
+  /** ids of assistant tool_use blocks that have no matching toolResult (a poisoned transcript). */
+  const danglingToolCalls = (messages: any[]): string[] => {
+    const settled = new Set(messages.filter((m) => m.role === "toolResult").map((m) => m.toolCallId));
+    const out: string[] = [];
+    for (const m of messages) {
+      if (m.role !== "assistant" || !Array.isArray(m.content)) continue;
+      for (const b of m.content) if (b?.type === "toolCall" && !settled.has(b.id)) out.push(b.id);
+    }
+    return out;
+  };
+
+  /** Simulate a turn that died mid tool-execution: assistant(tool_use) persisted, NO result. */
+  async function poison(store: PiSessionStore, id: string) {
+    const s = await store.openOrCreate(id);
+    await s.appendMessage({ role: "user", content: [{ type: "text", text: "run it" }], timestamp: Date.now() } as any);
+    await s.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "x" } }],
+      provider: "faux",
+      model: "faux",
+      stopReason: "toolUse",
+      usage: { input: 0, output: 0 },
+      timestamp: Date.now(),
+    } as any);
+  }
+
+  it("reopening a crashed session repairs the gap with an interrupted error result", async () => {
+    const store = inMemorySessionStore();
+    await poison(store, "crashed");
+
+    const reopened = await store.openOrCreate("crashed"); // open -> reconcile fires
+    const { messages } = await reopened.buildContext();
+
+    expect(danglingToolCalls(messages)).toEqual([]); // no more dangling tool_use
+    const repaired = messages.find((m: any) => m.role === "toolResult" && m.toolCallId === "call-1") as any;
+    expect(repaired.isError).toBe(true);
+    // customer-facing contract: the model-visible text is neutral and decision-guiding,
+    // never "aborted" (cancellation misread) and never leaking infra detail (relayable to users).
+    const text = repaired.content[0].text as string;
+    expect(text).toMatch(/did not complete/i);
+    expect(text).not.toMatch(/abort|crash|restart|process/i);
+    // operational marker lives in details (not sent to the provider), for developer observability.
+    expect(repaired.details).toMatchObject({ fastagent: "interrupted-tool-call" });
+  });
+
+  it("a retry after the crash now completes instead of being rejected by a pairing-validating provider", async () => {
+    const store = inMemorySessionStore();
+    await poison(store, "crashed");
+
+    let contextSeen: any[] = [];
+    const agent = makeAgent(store, [
+      (context) => {
+        contextSeen = context.messages;
+        // Mirror Anthropic/OpenAI: reject an assistant tool_use without a matching tool_result.
+        return danglingToolCalls(context.messages).length > 0
+          ? fauxAssistantMessage("", { stopReason: "error", errorMessage: "400 tool_use without tool_result" })
+          : fauxAssistantMessage("recovered");
+      },
+    ]);
+
+    const events = await drain(agent.invoke({ session: "crashed" }, { text: "are you there?" }));
+    expect(danglingToolCalls(contextSeen)).toEqual([]); // the provider never sees a dangling call
+    expect(events.at(-1)?.type).toBe("completed"); // was "failed" before the reconcile fix
+  });
+
+  it("a clean session is untouched (no spurious results appended)", async () => {
+    const store = inMemorySessionStore();
+    await drain(makeAgent(store, [fauxAssistantMessage("hello")]).invoke({ session: "clean" }, { text: "hi" }));
+    const reopened = await store.openOrCreate("clean");
+    const { messages } = await reopened.buildContext();
+    expect(messages.some((m: any) => m.role === "toolResult")).toBe(false);
+  });
+});
+
+describe("jsonlSessionStore (malicious id)", () => {
   it("malicious session id cannot escape the sessions directory because it is filename-encoded and can round-trip", async () => {
     const root = await mkdtemp(join(tmpdir(), "fa-sessions-"));
     const dir = join(root, "sessions");

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { readdir } from "node:fs/promises";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -176,6 +176,36 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
     const reopened = await store.openOrCreate("clean");
     const { messages } = await reopened.buildContext();
     expect(messages.some((m: any) => m.role === "toolResult")).toBe(false);
+  });
+
+  it("an unmatched call behind later history is surfaced, not silently appended (fail visibly)", async () => {
+    // A gap that is NOT at the leaf (a later turn already sits after the dangling call) cannot
+    // be repaired by appending to an append-only log; appending would only add an orphan.
+    const store = inMemorySessionStore();
+    const s = await store.openOrCreate("mid-history");
+    await s.appendMessage({ role: "user", content: [{ type: "text", text: "run it" }], timestamp: Date.now() } as any);
+    await s.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "x" } }],
+      provider: "faux", model: "faux", stopReason: "toolUse", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+    } as any);
+    // a later turn lands after the dangling call without it ever being reconciled
+    await s.appendMessage({ role: "user", content: [{ type: "text", text: "still there?" }], timestamp: Date.now() } as any);
+    await s.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "sorry, failed" }],
+      provider: "faux", model: "faux", stopReason: "error", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+    } as any);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const reopened = await store.openOrCreate("mid-history"); // open -> reconcile
+      const { messages } = await reopened.buildContext();
+      expect(messages.some((m: any) => m.role === "toolResult")).toBe(false); // NOT appended
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("call-1")); // surfaced instead
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -203,6 +203,34 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
     }
   });
 
+  it("a mid-history gap behind a later assistant turn is surfaced, not ignored", async () => {
+    // History: assistant(call-1) -> user -> assistant(error). The dangling call-1 is NOT on the
+    // leaf assistant; scanning every turn (not only the leaf) must still surface it.
+    const store = inMemorySessionStore();
+    const s = await store.openOrCreate("mid-later-assistant");
+    await s.appendMessage({ role: "user", content: [{ type: "text", text: "run it" }], timestamp: Date.now() } as any);
+    await s.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "x" } }],
+      provider: "faux", model: "faux", stopReason: "toolUse", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+    } as any);
+    await s.appendMessage({ role: "user", content: [{ type: "text", text: "still there?" }], timestamp: Date.now() } as any);
+    await s.appendMessage({
+      role: "assistant", content: [{ type: "text", text: "sorry, failed" }],
+      provider: "faux", model: "faux", stopReason: "error", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+    } as any);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const reopened = await store.openOrCreate("mid-later-assistant"); // open -> reconcile
+      const { messages } = await reopened.buildContext();
+      expect(messages.some((m: any) => m.role === "toolResult")).toBe(false); // NOT appended
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("call-1")); // surfaced (leaf has no tool_use)
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("pairing is turn-local: a reused tool-call id from an earlier turn does not mask a leaf gap", async () => {
     // tool-call ids are not globally unique (a model may restart at call-1 each turn). An earlier
     // *completed* call-1 must NOT make a later crashed call-1 look already paired.

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -159,6 +159,8 @@ Each `invoke` creates a fresh harness bound to the requested session and discard
 
 This gives the reference implementation portable conformance in miniature: two separate instances sharing the same external store can continue the same session.
 
+**Crash-safe reopen.** A turn that dies mid tool-execution leaves the session with an assistant `tool_use` whose result was never persisted (pi writes the assistant message at `message_end`, *before* the tools run). The stateless retry path — reopen the session, re-invoke — depends on that transcript staying valid, but pi reconciles nothing (neither `buildSessionContext` nor `convertToLlm`), so the next provider call rejects the dangling `tool_use` and the retry fails: a mid-turn crash poisons the session. So the store reconciles on every open of an *existing* session, appending an honest error tool result for each unmatched call — mirroring pi's own `createErrorToolResult` for aborted calls, at the recovery boundary pi's inline abort path cannot reach (the process was already dead). This restores transcript *validity* only; tool side-effect idempotency stays the tool's responsibility (SPEC §6 non-guarantee). The synthetic result's `content` is model-facing (neutral, decision-guiding, no "aborted" misread, no infra leak); the operational marker lives in `details`, which is never sent to the provider.
+
 Full fork/navigation session-admin is a separate draft: see [session](session.md).
 
 ## 8. Same-session concurrency
@@ -304,3 +306,4 @@ The container is the v1 "machine-state independence" boundary: copy the project,
 - AgentCore target adapter with external sessions and distributed locking (the async `Lease` port).
 - Production observability sink for cleanup anomalies (§3) without violating SPEC terminal discipline.
 - Engine #2, which will prove which pi-specific seams (e.g. `PiSessionStore`) should become engine-neutral abstractions.
+- Crash-safe reopen (§7) is reconciled in fastagent's session store today; the more fundamental fix is upstream in pi's `buildSessionContext` (the single context-rebuild point). If accepted there, the fastagent-layer reconciliation retires.


### PR DESCRIPTION
## Problem

A turn that dies **mid tool-execution** (hard crash: OOM, SIGKILL, container restart) leaves the session with an assistant `tool_use` that has **no matching tool result**. pi persists the assistant message at `message_end` — before the tool runs — and neither `buildSessionContext` nor `convertToLlm` repairs the gap. The next `invoke` then hands the provider an `assistant(tool_use) -> user` sequence that Anthropic/OpenAI reject, so **retrying a crashed turn fails outright; the session is poisoned.**

The stateless "just re-invoke the turn" recovery path silently depends on this not happening, so this is a real **crash-safety bug**, not a missing durable-execution feature. Reproduced end-to-end (a mid-tool abandon leaves `['user','assistant']` with a dangling `call-1`; a pairing-validating provider then returns `failed`).

## Fix

Reconcile on every **open of an existing session** (`reconcileInterruptedToolCalls`): append an honest error tool result for each dangling call, restoring a valid transcript so the next turn proceeds and the model can re-decide.

- Mirrors pi's own remedy for unfinished tool calls (`createErrorToolResult` on graceful abort), applied at the recovery boundary pi's inline path cannot reach (the process was already dead). It is **not** a pi-documented mechanism — pi leaves hard-crash recovery unhandled — but it is convention-aligned, not a foreign invention.
- Tool side-effect idempotency stays the tool's responsibility (SPEC section 6); this only restores transcript **validity**, it does not promise exactly-once.
- The synthetic result splits its audiences: `content` (read by the model, relayable to end users) stays neutral and decision-guiding — never "aborted" (a cancellation misread that makes the model abandon wanted work) and never leaking infra detail; `details` carries a developer marker and is never sent to the provider.

## Scope / review tier

Touches `core/src/engines/pi/sessions.ts` (internal — `PiSessionStore` interface unchanged, helper not exported) + a regression test. Does **not** touch `docs/SPEC.md`, the `Agent` interface, public API in `core/src/index.ts`, or terminal semantics. It does change runtime behavior on session reopen, flagged here for a look.

## Tests

`core/test/sessions.test.ts`: repair appends an interrupted error result and clears the dangling call; a post-crash retry now `completed` (was `failed`); a clean session is untouched; plus the customer-facing content contract (neutral text, no infra leak, structured `details` marker).

Local: `npm run typecheck` clean, `145 passed`.

## Follow-up (not in this PR)

The more fundamental fix point is upstream in pi's `buildSessionContext`; if accepted there, this fastagent-layer reconciliation could be retired.
