### PR TITLE
feat(chat): `fastagent chat` — the assembled agent in pi's interactive TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ core/
 │       ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
 │       ├── init.ts              # `init`: scaffold a runnable agent (complete by default; --minimal)
 │       ├── dev.ts               # `dev` opener: open a workspace → agent (authoring posture)
+│       ├── chat.ts              # `chat` channel: drive pi's interactive TUI with the assembled agent
 │       ├── build.ts             # `build`: compile a workspace → self-contained artifact
 │       ├── start.ts             # `start` opener: run a built artifact (production posture)
 │       ├── tool.ts              # defineTool (Zod) + tools/ filesystem discovery

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -279,6 +279,11 @@ async function runDev(): Promise<void> {
 /** Open the workspace agent in pi's interactive TUI (the pi-specific `chat` command). */
 async function runChat(): Promise<void> {
   loadDotEnv(dir); // model spec + provider API keys may come from .env
+  // Run the chat process IN the workspace. chat is workspace-scoped, and pi resolves a session's
+  // cwd as `header.cwd ?? process.cwd()`; aligning process.cwd() with the workspace makes that
+  // fallback land on the workspace for every session-replacement path (resume/import/fork/new),
+  // so a cwd-less legacy/imported session never drifts to the launch directory. `dir` is absolute.
+  process.chdir(dir);
   // Lazy-import: chat pulls pi's interactive TUI module graph (InteractiveMode, pi-tui). A static
   // import would load it on EVERY command; headless `start`/`dev` never need it. Runtime hygiene
   // only — the dependency (and install size) is unchanged.

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -25,7 +25,6 @@ import { buildPiArtifact } from "./engines/pi/build.ts";
 import { listModels, loadConfig } from "./engines/pi/config.ts";
 import { type LoadedDefinition, defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
-import { runPiChat } from "./engines/pi/chat.ts";
 import { resolveTools } from "./engines/pi/create.ts";
 import { scaffoldWorkspace } from "./engines/pi/init.ts";
 import { loadTools, mergeDiscoveredTools } from "./engines/pi/tool.ts";
@@ -277,9 +276,13 @@ async function runDev(): Promise<void> {
   runDevSupervisor();
 }
 
-/** Open the workspace agent in pi's interactive TUI (the `chat` channel). */
+/** Open the workspace agent in pi's interactive TUI (the pi-specific `chat` command). */
 async function runChat(): Promise<void> {
   loadDotEnv(dir); // model spec + provider API keys may come from .env
+  // Lazy-import: chat pulls pi's interactive TUI module graph (InteractiveMode, pi-tui). A static
+  // import would load it on EVERY command; headless `start`/`dev` never need it. Runtime hygiene
+  // only — the dependency (and install size) is unchanged.
+  const { runPiChat } = await import("./engines/pi/chat.ts");
   await runPiChat(dir, { model: values.model, globalSkills }).catch(failStartup);
 }
 

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -25,6 +25,7 @@ import { buildPiArtifact } from "./engines/pi/build.ts";
 import { listModels, loadConfig } from "./engines/pi/config.ts";
 import { type LoadedDefinition, defaultGlobalSkillPaths, loadAgentDefinition } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
+import { runPiChat } from "./engines/pi/chat.ts";
 import { resolveTools } from "./engines/pi/create.ts";
 import { scaffoldWorkspace } from "./engines/pi/init.ts";
 import { loadTools, mergeDiscoveredTools } from "./engines/pi/tool.ts";
@@ -36,6 +37,7 @@ function usage(code: number): never {
   fastagent models
   fastagent tool   <name> '<json-args>' [dir]
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--global-skills] [--no-watch]
+  fastagent chat   [dir] [--model provider/modelId] [--global-skills]
   fastagent build [dir] [--out dir] [--model provider/modelId] [--global-skills] [--force]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
 
@@ -43,6 +45,9 @@ function usage(code: number): never {
          model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
          --global-skills   also load the machine's global skills (~/.pi/agent/skills,
                            ~/.agents/skills); default is definition-only (dev == deployed)
+  chat   open the SAME assembled agent in pi's interactive TUI (the real harness, not a
+         crude REPL) — to try it locally before serving. Same model/tool/skill resolution
+         as dev; pi handles login, sessions, and /resume natively.
   init   scaffold a runnable agent in dir (default .) and run npm install. Default is a
          complete agent: AGENTS.md, a skill, tools/word-count.ts (a code tool), config,
          package.json, .npmrc, .gitignore. Refuses to overwrite an existing workspace.
@@ -94,6 +99,7 @@ if (command === "init") await runInit();
 else if (command === "models") runModels();
 else if (command === "tool") await runTool();
 else if (command === "dev") await runDev();
+else if (command === "chat") await runChat();
 else if (command === "build") await runBuild();
 else if (command === "start") await runStart();
 else usage(1);
@@ -269,6 +275,12 @@ async function runDev(): Promise<void> {
   }
   parsePort(values.port, "--port"); // flag-shape check (a non-integer port fails before spawning)
   runDevSupervisor();
+}
+
+/** Open the workspace agent in pi's interactive TUI (the `chat` channel). */
+async function runChat(): Promise<void> {
+  loadDotEnv(dir); // model spec + provider API keys may come from .env
+  await runPiChat(dir, { model: values.model, globalSkills }).catch(failStartup);
 }
 
 /** Assemble the workspace agent and serve it once (the dev worker; also the --no-watch path). */

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -1,0 +1,154 @@
+/**
+ * Chat: open a workspace into pi's interactive TUI (`fastagent chat`).
+ *
+ * `chat` is a CHANNEL, symmetric to the HTTP channel (channels/http.ts): it consumes the SAME
+ * assembled agent that `dev`/`start` serve, but presents it through pi's real interactive TUI
+ * (`InteractiveMode` — editor, streaming render, tool-call display, slash commands, model cycling,
+ * session tree/fork, compaction) instead of HTTP/SSE. We deliberately reuse pi's full TUI rather
+ * than hand-rolling a REPL: a crude line loop would misrepresent the runtime, which IS pi.
+ *
+ * FIDELITY CONTRACT — chat must run the SAME agent dev/start serve, not pi's vanilla discovery.
+ * pi's DefaultResourceLoader would walk AGENTS.md up to the repo root and discover skills under its
+ * own `.pi/skills`/`.agents/skills` convention — neither matches fastagent's "the agent is its
+ * folder" (dir-only AGENTS.md + `skills/` + `tools/`). So we INJECT fastagent's assembly into pi's
+ * session:
+ *   - model      → fromServices({ model })            (fastagent's flag>env>config resolution)
+ *   - prompt     → resourceLoaderOptions.systemPromptOverride (fastagent's exact served prompt;
+ *                  byte-faithful to what HTTP serves — pi's TUI-doc base section is intentionally
+ *                  NOT added, so chat == served)
+ *   - skills     → resourceLoaderOptions.skillsOverride  (fastagent's skills, for invocation)
+ *   - tools      → default coding tools by NAME (pi rebuilds them cwd-bound, keeping its rich TUI
+ *                  rendering) + fastagent's custom tools appended to session state (functional; the
+ *                  prose listing already lives in the injected system prompt)
+ *
+ * Auth/login, model HTTP, and sessions ride pi's native machinery on purpose (the login dialog,
+ * OAuth, and /resume are part of the "real harness" experience this command exists to show).
+ */
+import { dirname, join } from "node:path";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import {
+  type AgentSessionRuntime,
+  type CreateAgentSessionRuntimeFactory,
+  InteractiveMode,
+  SessionManager,
+  createAgentSessionFromServices,
+  createAgentSessionRuntime,
+  createAgentSessionServices,
+  getAgentDir,
+} from "@earendil-works/pi-coding-agent";
+import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
+import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
+import { defaultGlobalSkillPaths, loadAgentDefinition } from "./definition.ts";
+import { loadTools, mergeDiscoveredTools } from "./tool.ts";
+
+export interface RunPiChatOptions {
+  /** Model spec override (the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
+  model?: string;
+  /** Also load the machine's global skills on top of the definition's own (authoring-fidelity opt-in). */
+  globalSkills?: boolean;
+}
+
+/**
+ * Build pi's interactive runtime driven by fastagent's assembled agent (model, prompt, tools,
+ * skills resolved exactly as the dev opener does). Split from {@link runPiChat} so the assembly —
+ * the fidelity-critical part — is inspectable without launching the TUI.
+ */
+export async function buildChatRuntime(
+  dir: string,
+  options: RunPiChatOptions = {},
+  /** Session backend. Defaults to pi's project-scoped store; tests inject SessionManager.inMemory(). */
+  sessionManager?: SessionManager,
+): Promise<AgentSessionRuntime> {
+  const { config }: { config: FastagentConfig } = await loadConfig(dir);
+  const modelSpec = resolveModelSpec(options.model, config);
+  if (!modelSpec) {
+    throw new Error(
+      `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
+    );
+  }
+  const model = resolveModel(modelSpec);
+
+  const env = new NodeExecutionEnv({ cwd: dir });
+  const definition = await loadAgentDefinition(dir, {
+    env,
+    skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
+  });
+
+  // Same tool resolution as the dev opener (defaults + config.tools + discovered tools/, deduped),
+  // then split: defaults go to pi by NAME (rich rendering), customs are appended to session state.
+  const discovered = await loadTools(dir);
+  const { tools } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
+  const defaultNames = piDefaultTools(dir).map((t) => t.name);
+  const customTools = tools.filter((t) => !defaultNames.includes(t.name));
+
+  // fastagent's exact served system prompt (re-evaluated per call so the date stays the turn's).
+  const systemPrompt = (): string =>
+    assembleSystemPrompt({
+      base: piBasePrompt({ tools }),
+      instructions: definition.instructions,
+      instructionsPath: definition.instructions !== undefined ? join(dir, "AGENTS.md") : undefined,
+      skills: definition.skills,
+      date: new Date().toISOString().slice(0, 10),
+      cwd: dir,
+    });
+
+  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+    const services = await createAgentSessionServices({
+      cwd,
+      resourceLoaderOptions: {
+        // Definition-only, like dev/start: suppress pi's machine-global discovery (the developer's
+        // own ~/.pi extensions, slash commands, and global AGENTS.md) so chat runs the SAME agent
+        // that gets served, not the authoring machine's pi setup layered on top.
+        noExtensions: true,
+        noPromptTemplates: true,
+        noContextFiles: true,
+        systemPromptOverride: () => systemPrompt(),
+        // Replace pi's discovered skills with fastagent's resolved skills (so the agent's skills are
+        // invocable and match the prompt's listing). fastagent's Skill (pi-agent-core: content
+        // inline) is reshaped to pi-coding-agent's (read from filePath/baseDir at invocation time).
+        skillsOverride: (base) => ({
+          skills: definition.skills.map((s) => ({
+            name: s.name,
+            description: s.description,
+            filePath: s.filePath,
+            baseDir: dirname(s.filePath),
+            sourceInfo: { path: s.filePath, source: "fastagent", scope: "project", origin: "top-level", baseDir: dirname(s.filePath) },
+            disableModelInvocation: s.disableModelInvocation ?? false,
+          })) as typeof base.skills,
+          diagnostics: base.diagnostics,
+        }),
+      },
+    });
+    const result = await createAgentSessionFromServices({
+      services,
+      sessionManager,
+      sessionStartEvent,
+      model,
+      tools: defaultNames,
+    });
+    return { ...result, services, diagnostics: services.diagnostics };
+  };
+
+  const runtime = await createAgentSessionRuntime(createRuntime, {
+    cwd: dir,
+    agentDir: getAgentDir(),
+    sessionManager: sessionManager ?? SessionManager.create(dir),
+  });
+
+  // Mount fastagent's custom tools functionally. Appended (not replaced) so the default tools keep
+  // pi's built-in rich rendering; the customs' prose already lives in the injected system prompt.
+  if (customTools.length > 0) {
+    runtime.session.agent.state.tools = [...runtime.session.agent.state.tools, ...customTools];
+  }
+  return runtime;
+}
+
+/**
+ * Open the workspace's agent in pi's interactive TUI and run until the user exits. The agent is
+ * fastagent's assembled agent (same model/tools/skills/prompt as dev/start serve); pi's TUI handles
+ * login, rendering, sessions, and /resume natively.
+ */
+export async function runPiChat(dir: string, options: RunPiChatOptions = {}): Promise<void> {
+  const runtime = await buildChatRuntime(dir, options);
+  await new InteractiveMode(runtime, {}).run();
+}

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -25,10 +25,12 @@
  *                  rendering) + fastagent's custom tools registered via pi's customTools path, so
  *                  they survive the TUI rebuilding the session on /new, /resume, and fork
  *
- * Auth/login, model HTTP, and sessions ride pi's native machinery on purpose (the login dialog,
- * OAuth, and /resume are part of the "real harness" experience this command exists to show).
+ * Auth/login, model HTTP, and same-workspace sessions ride pi's native machinery on purpose (the
+ * login dialog, OAuth, and /resume are part of the "real harness" experience this command exists to
+ * show). Cross-workspace session switches are rejected: `.env` is process-global, so one chat TUI is
+ * one workspace; run `fastagent chat <other-dir>` for another workspace.
  */
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   type AgentSessionRuntime,
@@ -111,16 +113,21 @@ export async function buildChatRuntime(
   // pi calls the factory again on /new, /resume, switch, and fork. Dynamic imports for config/tools
   // are cached by Node, so trying to treat same-cwd rebuilds as hot reload would silently produce a
   // half-fresh agent (new AGENTS.md/skills from fs, stale config/tools from ESM cache). Keep chat a
-  // coherent startup snapshot per cwd instead: restart `fastagent chat` to load edits. Different cwd
-  // resumes still assemble that workspace once, so cross-workspace sessions do not mix agents.
-  const assemblies = new Map<string, Promise<Awaited<ReturnType<typeof resolveAssembly>>>>();
+  // coherent startup snapshot instead: restart `fastagent chat` to load edits.
+  //
+  // Also keep chat workspace-scoped. `.env` is process-global and is loaded by the CLI for the
+  // startup workspace; switching the same TUI process to another cwd would either inherit those env
+  // values or require mutating global env at runtime (secrets/leakage footgun). Fail visibly and ask
+  // the user to run a separate `fastagent chat <dir>` for that workspace.
+  const rootCwd = resolve(dir);
+  let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
   const assemblyFor = (cwd: string) => {
-    let cached = assemblies.get(cwd);
-    if (cached === undefined) {
-      cached = resolveAssembly(cwd);
-      assemblies.set(cwd, cached);
+    const activeCwd = resolve(cwd);
+    if (activeCwd !== rootCwd) {
+      throw new Error(`fastagent chat is workspace-scoped: cannot switch to ${activeCwd}; run \`fastagent chat ${activeCwd}\` instead`);
     }
-    return cached;
+    assembly ??= resolveAssembly(rootCwd);
+    return assembly;
   };
 
   const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
@@ -164,16 +171,16 @@ export async function buildChatRuntime(
   };
 
   return createAgentSessionRuntime(createRuntime, {
-    cwd: dir,
+    cwd: rootCwd,
     agentDir: getAgentDir(),
-    sessionManager: sessionManager ?? SessionManager.create(dir),
+    sessionManager: sessionManager ?? SessionManager.create(rootCwd),
   });
 }
 
 /**
  * Open the workspace's agent in pi's interactive TUI and run until the user exits. The agent is
  * fastagent's assembled agent (same model/tools/skills/prompt as dev/start serve); pi's TUI handles
- * login, rendering, sessions, and /resume natively.
+ * login, rendering, and same-workspace sessions natively.
  */
 export async function runPiChat(dir: string, options: RunPiChatOptions = {}): Promise<void> {
   const runtime = await buildChatRuntime(dir, options);

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -16,10 +16,11 @@
  * folder" (dir-only AGENTS.md + `skills/` + `tools/`). So we INJECT fastagent's assembly into pi's
  * session:
  *   - model      → fromServices({ model })            (fastagent's flag>env>config resolution)
- *   - prompt     → resourceLoaderOptions.systemPromptOverride (fastagent's exact served prompt;
- *                  byte-faithful to what HTTP serves — pi's TUI-doc base section is intentionally
- *                  NOT added, so chat == served)
- *   - skills     → resourceLoaderOptions.skillsOverride  (fastagent's skills, for invocation)
+ *   - prompt     → resourceLoaderOptions.systemPromptOverride = fastagent's base + instructions
+ *                  ONLY; pi appends the skill section and env (date/cwd) itself, so including them
+ *                  here would duplicate both. The result equals what dev/start serve (pi's skill/env
+ *                  renderers are the ones assembleSystemPrompt mirrors).
+ *   - skills     → resourceLoaderOptions.skillsOverride  (fastagent's skills, for the section + invocation)
  *   - tools      → default coding tools by NAME (pi rebuilds them cwd-bound, keeping its rich TUI
  *                  rendering) + fastagent's custom tools registered via pi's customTools path, so
  *                  they survive the TUI rebuilding the session on /new, /resume, and fork
@@ -40,7 +41,7 @@ import {
   createAgentSessionServices,
   getAgentDir,
 } from "@earendil-works/pi-coding-agent";
-import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
+import { loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./definition.ts";
 import { loadTools, mergeDiscoveredTools } from "./tool.ts";
@@ -63,52 +64,54 @@ export async function buildChatRuntime(
   /** Session backend. Defaults to pi's project-scoped store; tests inject SessionManager.inMemory(). */
   sessionManager?: SessionManager,
 ): Promise<AgentSessionRuntime> {
-  const { config }: { config: FastagentConfig } = await loadConfig(dir);
-  const modelSpec = resolveModelSpec(options.model, config);
-  if (!modelSpec) {
-    throw new Error(
-      `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
-    );
-  }
-  const model = resolveModel(modelSpec);
-
-  const env = new NodeExecutionEnv({ cwd: dir });
-  const definition = await loadAgentDefinition(dir, {
-    env,
-    skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
-  });
-
-  // Same tool resolution as the dev opener (defaults + config.tools + discovered tools/, deduped),
-  // then split: defaults go to pi by NAME (so pi rebuilds them cwd-bound, keeping rich TUI
-  // rendering); customs go through pi's `customTools` registration path.
-  const discovered = await loadTools(dir);
-  const { tools } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
-  const defaultNames = piDefaultTools(dir).map((t) => t.name);
-  const customTools = tools.filter((t) => !defaultNames.includes(t.name));
-  // Adapt fastagent's AgentTool to pi's ToolDefinition. Registering through the session factory
-  // (below) — not patching session.agent.state afterward — is what makes the customs survive the
-  // TUI rebuilding the session on /new, /resume, and fork. (`parameters` is plain JSON-Schema; pi
-  // accepts it. The extra execute args onUpdate/ctx are unused by fastagent tools.)
-  const customToolDefs = customTools.map((t) => ({
-    name: t.name,
-    label: t.name,
-    description: t.description ?? "",
-    parameters: t.parameters,
-    execute: (id: string, params: unknown, signal: AbortSignal | undefined) => t.execute(id, params, signal),
-  })) as unknown as ToolDefinition[];
-
-  // fastagent's exact served system prompt (re-evaluated per call so the date stays the turn's).
-  const systemPrompt = (): string =>
-    assembleSystemPrompt({
-      base: piBasePrompt({ tools }),
-      instructions: definition.instructions,
-      instructionsPath: definition.instructions !== undefined ? join(dir, "AGENTS.md") : undefined,
-      skills: definition.skills,
-      date: new Date().toISOString().slice(0, 10),
-      cwd: dir,
+  // Resolve the WHOLE fastagent agent INSIDE the factory, keyed on the factory's `cwd` (not the
+  // startup `dir`). pi reuses the factory to rebuild the session on /new, /resume, switch, and
+  // fork, passing that session's cwd. Keying off it means a session resumed from another workspace
+  // assembles THAT workspace's agent (prompt + skills + tools + services all from one cwd) instead
+  // of mixing two; /new also re-reads, so edits made since startup are picked up. The first build
+  // runs synchronously inside createAgentSessionRuntime below, so a missing model still throws at
+  // startup (caught by the CLI's failStartup).
+  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+    const { config } = await loadConfig(cwd);
+    const modelSpec = resolveModelSpec(options.model, config);
+    if (!modelSpec) {
+      throw new Error(
+        `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
+      );
+    }
+    const model = resolveModel(modelSpec);
+    const env = new NodeExecutionEnv({ cwd });
+    const definition = await loadAgentDefinition(cwd, {
+      env,
+      skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
     });
 
-  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+    // Same tool resolution as the dev opener (defaults + config.tools + discovered tools/, deduped),
+    // then split: defaults go to pi by NAME (so pi rebuilds them cwd-bound, keeping rich TUI
+    // rendering); customs go through pi's `customTools` path so they survive /new, /resume, fork.
+    const discovered = await loadTools(cwd);
+    const { tools } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
+    const defaultNames = piDefaultTools(cwd).map((t) => t.name);
+    const customTools = tools.filter((t) => !defaultNames.includes(t.name));
+    // Adapt fastagent's AgentTool to pi's ToolDefinition. (`parameters` is plain JSON-Schema; pi
+    // accepts it. The extra execute args onUpdate/ctx are unused by fastagent tools.)
+    const customToolDefs = customTools.map((t) => ({
+      name: t.name,
+      label: t.name,
+      description: t.description ?? "",
+      parameters: t.parameters,
+      execute: (id: string, params: unknown, signal: AbortSignal | undefined) => t.execute(id, params, signal),
+    })) as unknown as ToolDefinition[];
+
+    // base + instructions ONLY. pi appends the skill section (from skillsOverride) and the env
+    // (date/cwd) itself; including them here would duplicate both — chat must match what dev/start
+    // serve, and pi's renderers are the ones fastagent's assembleSystemPrompt mirrors.
+    const systemPrompt = assembleSystemPrompt({
+      base: piBasePrompt({ tools }),
+      instructions: definition.instructions,
+      instructionsPath: definition.instructions !== undefined ? join(cwd, "AGENTS.md") : undefined,
+    });
+
     const services = await createAgentSessionServices({
       cwd,
       resourceLoaderOptions: {
@@ -118,7 +121,7 @@ export async function buildChatRuntime(
         noExtensions: true,
         noPromptTemplates: true,
         noContextFiles: true,
-        systemPromptOverride: () => systemPrompt(),
+        systemPromptOverride: () => systemPrompt,
         // Replace pi's discovered skills with fastagent's resolved skills (so the agent's skills are
         // invocable and match the prompt's listing). fastagent's Skill (pi-agent-core: content
         // inline) is reshaped to pi-coding-agent's (read from filePath/baseDir at invocation time).

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -47,7 +47,7 @@ import {
 import { loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./definition.ts";
-import { loadTools, mergeDiscoveredTools } from "./tool.ts";
+import { loadTools, mergeDiscoveredTools, type ToolCollision } from "./tool.ts";
 
 export interface RunPiChatOptions {
   /** Model spec override (the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -81,12 +81,14 @@ export async function buildChatRuntime(
       env,
       skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
     });
+    reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 
     // Same tool resolution as the dev opener (defaults + config.tools + discovered tools/, deduped),
     // then split: defaults go to pi by NAME (so pi rebuilds them cwd-bound, keeping rich TUI
     // rendering); customs go through pi's `customTools` path so they survive /new, /resume, fork.
     const discovered = await loadTools(cwd);
-    const { tools } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
+    const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
+    reportToolCollisions([...discovered.collisions, ...crossCollisions]);
     const defaultNames = piDefaultTools(cwd).map((t) => t.name);
     const customTools = tools.filter((t) => !defaultNames.includes(t.name));
     // Adapt fastagent's AgentTool to pi's ToolDefinition. (`parameters` is plain JSON-Schema; pi
@@ -178,6 +180,24 @@ export async function buildChatRuntime(
   });
   enforceWorkspaceScopedSessionSwitches(runtime, rootCwd);
   return runtime;
+}
+
+function reportDefinitionWarnings(
+  collisions: { name: string; winnerPath: string; loserPath: string }[],
+  diagnostics: { code: string; message: string; path: string }[],
+): void {
+  for (const c of collisions) {
+    console.error(`[fastagent] warn: skill "${c.name}" collision — using ${c.winnerPath}, ignoring ${c.loserPath}`);
+  }
+  for (const d of diagnostics) {
+    console.error(`[fastagent] warn: ${d.code}: ${d.message} (${d.path})`);
+  }
+}
+
+function reportToolCollisions(collisions: ToolCollision[]): void {
+  for (const c of collisions) {
+    console.error(`[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`);
+  }
 }
 
 function workspaceScopeError(targetCwd: string): Error {

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -64,14 +64,7 @@ export async function buildChatRuntime(
   /** Session backend. Defaults to pi's project-scoped store; tests inject SessionManager.inMemory(). */
   sessionManager?: SessionManager,
 ): Promise<AgentSessionRuntime> {
-  // Resolve the WHOLE fastagent agent INSIDE the factory, keyed on the factory's `cwd` (not the
-  // startup `dir`). pi reuses the factory to rebuild the session on /new, /resume, switch, and
-  // fork, passing that session's cwd. Keying off it means a session resumed from another workspace
-  // assembles THAT workspace's agent (prompt + skills + tools + services all from one cwd) instead
-  // of mixing two; /new also re-reads, so edits made since startup are picked up. The first build
-  // runs synchronously inside createAgentSessionRuntime below, so a missing model still throws at
-  // startup (caught by the CLI's failStartup).
-  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+  async function resolveAssembly(cwd: string) {
     const { config } = await loadConfig(cwd);
     const modelSpec = resolveModelSpec(options.model, config);
     if (!modelSpec) {
@@ -111,6 +104,27 @@ export async function buildChatRuntime(
       instructions: definition.instructions,
       instructionsPath: definition.instructions !== undefined ? join(cwd, "AGENTS.md") : undefined,
     });
+
+    return { model, definition, defaultNames, customTools, customToolDefs, systemPrompt };
+  }
+
+  // pi calls the factory again on /new, /resume, switch, and fork. Dynamic imports for config/tools
+  // are cached by Node, so trying to treat same-cwd rebuilds as hot reload would silently produce a
+  // half-fresh agent (new AGENTS.md/skills from fs, stale config/tools from ESM cache). Keep chat a
+  // coherent startup snapshot per cwd instead: restart `fastagent chat` to load edits. Different cwd
+  // resumes still assemble that workspace once, so cross-workspace sessions do not mix agents.
+  const assemblies = new Map<string, Promise<Awaited<ReturnType<typeof resolveAssembly>>>>();
+  const assemblyFor = (cwd: string) => {
+    let cached = assemblies.get(cwd);
+    if (cached === undefined) {
+      cached = resolveAssembly(cwd);
+      assemblies.set(cwd, cached);
+    }
+    return cached;
+  };
+
+  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+    const { model, definition, defaultNames, customTools, customToolDefs, systemPrompt } = await assemblyFor(cwd);
 
     const services = await createAgentSessionServices({
       cwd,

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -21,8 +21,8 @@
  *                  NOT added, so chat == served)
  *   - skills     → resourceLoaderOptions.skillsOverride  (fastagent's skills, for invocation)
  *   - tools      → default coding tools by NAME (pi rebuilds them cwd-bound, keeping its rich TUI
- *                  rendering) + fastagent's custom tools appended to session state (functional; the
- *                  prose listing already lives in the injected system prompt)
+ *                  rendering) + fastagent's custom tools registered via pi's customTools path, so
+ *                  they survive the TUI rebuilding the session on /new, /resume, and fork
  *
  * Auth/login, model HTTP, and sessions ride pi's native machinery on purpose (the login dialog,
  * OAuth, and /resume are part of the "real harness" experience this command exists to show).
@@ -34,6 +34,7 @@ import {
   type CreateAgentSessionRuntimeFactory,
   InteractiveMode,
   SessionManager,
+  type ToolDefinition,
   createAgentSessionFromServices,
   createAgentSessionRuntime,
   createAgentSessionServices,
@@ -78,11 +79,23 @@ export async function buildChatRuntime(
   });
 
   // Same tool resolution as the dev opener (defaults + config.tools + discovered tools/, deduped),
-  // then split: defaults go to pi by NAME (rich rendering), customs are appended to session state.
+  // then split: defaults go to pi by NAME (so pi rebuilds them cwd-bound, keeping rich TUI
+  // rendering); customs go through pi's `customTools` registration path.
   const discovered = await loadTools(dir);
   const { tools } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
   const defaultNames = piDefaultTools(dir).map((t) => t.name);
   const customTools = tools.filter((t) => !defaultNames.includes(t.name));
+  // Adapt fastagent's AgentTool to pi's ToolDefinition. Registering through the session factory
+  // (below) — not patching session.agent.state afterward — is what makes the customs survive the
+  // TUI rebuilding the session on /new, /resume, and fork. (`parameters` is plain JSON-Schema; pi
+  // accepts it. The extra execute args onUpdate/ctx are unused by fastagent tools.)
+  const customToolDefs = customTools.map((t) => ({
+    name: t.name,
+    label: t.name,
+    description: t.description ?? "",
+    parameters: t.parameters,
+    execute: (id: string, params: unknown, signal: AbortSignal | undefined) => t.execute(id, params, signal),
+  })) as unknown as ToolDefinition[];
 
   // fastagent's exact served system prompt (re-evaluated per call so the date stays the turn's).
   const systemPrompt = (): string =>
@@ -127,23 +140,17 @@ export async function buildChatRuntime(
       sessionManager,
       sessionStartEvent,
       model,
-      tools: defaultNames,
+      tools: [...defaultNames, ...customTools.map((t) => t.name)],
+      customTools: customToolDefs,
     });
     return { ...result, services, diagnostics: services.diagnostics };
   };
 
-  const runtime = await createAgentSessionRuntime(createRuntime, {
+  return createAgentSessionRuntime(createRuntime, {
     cwd: dir,
     agentDir: getAgentDir(),
     sessionManager: sessionManager ?? SessionManager.create(dir),
   });
-
-  // Mount fastagent's custom tools functionally. Appended (not replaced) so the default tools keep
-  // pi's built-in rich rendering; the customs' prose already lives in the injected system prompt.
-  if (customTools.length > 0) {
-    runtime.session.agent.state.tools = [...runtime.session.agent.state.tools, ...customTools];
-  }
-  return runtime;
 }
 
 /**

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -30,7 +30,7 @@
  * show). Cross-workspace session switches are rejected: `.env` is process-global, so one chat TUI is
  * one workspace; run `fastagent chat <other-dir>` for another workspace.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
@@ -122,10 +122,12 @@ export async function buildChatRuntime(
   // startup workspace; switching the same TUI process to another cwd would either inherit those env
   // values or require mutating global env at runtime (secrets/leakage footgun). Fail visibly and ask
   // the user to run a separate `fastagent chat <dir>` for that workspace.
-  const rootCwd = resolve(dir);
+  const rootCwd = canonicalCwd(dir);
   let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
   const assemblyFor = (cwd: string) => {
-    const activeCwd = resolve(cwd);
+    // Compare canonical paths: process.cwd() (pi's fallback) returns the realpath, so a workspace
+    // reached through a symlink would otherwise mismatch a non-realpath rootCwd.
+    const activeCwd = canonicalCwd(cwd);
     if (activeCwd !== rootCwd) {
       throw workspaceScopeError(activeCwd);
     }
@@ -204,6 +206,16 @@ function workspaceScopeError(targetCwd: string): Error {
   return new Error(`fastagent chat is workspace-scoped: cannot switch to ${targetCwd}; run \`fastagent chat ${targetCwd}\` instead`);
 }
 
+/** Resolve to a canonical (symlink-free) path so comparisons match pi's process.cwd() realpath. */
+function canonicalCwd(p: string): string {
+  const resolved = resolve(p);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved; // a path that doesn't exist (e.g. a foreign workspace cwd) stays as resolved
+  }
+}
+
 function readSessionHeaderCwd(sessionPath: string): string | undefined {
   const resolvedPath = resolve(sessionPath);
   if (!existsSync(resolvedPath)) return undefined;
@@ -211,7 +223,7 @@ function readSessionHeaderCwd(sessionPath: string): string | undefined {
     if (!line.trim()) continue;
     try {
       const entry = JSON.parse(line) as { type?: unknown; cwd?: unknown };
-      if (entry.type === "session") return typeof entry.cwd === "string" ? resolve(entry.cwd) : undefined;
+      if (entry.type === "session") return typeof entry.cwd === "string" ? canonicalCwd(entry.cwd) : undefined;
     } catch {
       // Ignore malformed lines the same way pi's session loader does; no header cwd → caller pins root.
     }
@@ -220,31 +232,32 @@ function readSessionHeaderCwd(sessionPath: string): string | undefined {
 }
 
 /**
- * Keep resume/import inside the chat's single workspace, deciding BEFORE delegating to pi. pi tears
- * down the active session before invoking the runtime factory, so a factory-only guard would leave
- * the TUI on an invalidated session when it rejects. We always pin pi's effective cwd to rootCwd:
- * a session that explicitly records a different workspace is rejected up front, while a session with
- * no cwd (legacy/imported files) runs in the chat workspace instead of falling back to pi's
- * `process.cwd()` (which, when chat was launched from outside <dir>, would itself force a
- * cross-workspace rebuild and tear the live session down).
+ * Keep resume/import inside the chat's single workspace, deciding BEFORE delegating to pi.
+ *
+ * The chat process is chdir'd into rootCwd at startup (see runChat), so pi's `?? process.cwd()`
+ * fallback for a session with no cwd header already resolves to rootCwd on EVERY replacement path
+ * (resume, import, fork, new). The one remaining gap is a session that EXPLICITLY records a
+ * different workspace cwd: pi would bind that foreign cwd and the runtime factory would reject it —
+ * but only AFTER tearing the live session down, leaving the TUI on an invalidated session. Reject
+ * such a switch up front. (fork/new carry no foreign target: fork reopens the current, already
+ * vetted session; new reuses the current cwd.)
  */
 function enforceWorkspaceScopedSessionSwitches(runtime: AgentSessionRuntime, rootCwd: string): void {
-  const pinnedTargetCwd = (sessionPath: string, cwdOverride: string | undefined): string => {
-    const known = cwdOverride !== undefined ? resolve(cwdOverride) : readSessionHeaderCwd(sessionPath);
-    if (known !== undefined && known !== rootCwd) throw workspaceScopeError(known);
-    return rootCwd;
+  const rejectForeignTarget = (sessionPath: string, cwdOverride: string | undefined): void => {
+    const target = cwdOverride !== undefined ? canonicalCwd(cwdOverride) : readSessionHeaderCwd(sessionPath);
+    if (target !== undefined && target !== rootCwd) throw workspaceScopeError(target);
   };
 
   const switchSession = runtime.switchSession.bind(runtime);
   runtime.switchSession = async (...args: Parameters<AgentSessionRuntime["switchSession"]>) => {
-    const [sessionPath, options] = args;
-    return switchSession(sessionPath, { ...options, cwdOverride: pinnedTargetCwd(sessionPath, options?.cwdOverride) });
+    rejectForeignTarget(args[0], args[1]?.cwdOverride);
+    return switchSession(...args);
   };
 
   const importFromJsonl = runtime.importFromJsonl.bind(runtime);
   runtime.importFromJsonl = async (...args: Parameters<AgentSessionRuntime["importFromJsonl"]>) => {
-    const [inputPath, cwdOverride] = args;
-    return importFromJsonl(inputPath, pinnedTargetCwd(inputPath, cwdOverride));
+    rejectForeignTarget(args[0], args[1]);
+    return importFromJsonl(...args);
   };
 }
 

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -142,12 +142,15 @@ export async function buildChatRuntime(
       cwd,
       resourceLoaderOptions: {
         // Definition-only, like dev/start: suppress pi's machine-global discovery (the developer's
-        // own ~/.pi extensions, slash commands, and global AGENTS.md) so chat runs the SAME agent
-        // that gets served, not the authoring machine's pi setup layered on top.
+        // own ~/.pi extensions, slash commands, global AGENTS.md, and APPEND_SYSTEM.md append
+        // prompts) so chat runs the SAME agent that gets served, not the authoring machine's pi
+        // setup layered on top. (noContextFiles covers AGENTS.md context only; the append prompt is
+        // discovered separately and needs its own override.)
         noExtensions: true,
         noPromptTemplates: true,
         noContextFiles: true,
         systemPromptOverride: () => systemPrompt,
+        appendSystemPromptOverride: () => [],
         // Replace pi's discovered skills with fastagent's resolved skills (so the agent's skills are
         // invocable and match the prompt's listing). fastagent's Skill (pi-agent-core: content
         // inline) is reshaped to pi-coding-agent's (read from filePath/baseDir at invocation time).

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -213,34 +213,38 @@ function readSessionHeaderCwd(sessionPath: string): string | undefined {
       const entry = JSON.parse(line) as { type?: unknown; cwd?: unknown };
       if (entry.type === "session") return typeof entry.cwd === "string" ? resolve(entry.cwd) : undefined;
     } catch {
-      // Ignore malformed lines the same way pi's session loader does; no cwd means no preflight.
+      // Ignore malformed lines the same way pi's session loader does; no header cwd → caller pins root.
     }
   }
   return undefined;
 }
 
 /**
- * Reject cross-workspace resume/import BEFORE calling pi's replacement methods. pi tears down the
- * active session before invoking the runtime factory; a factory-only cwd guard would therefore
- * leave the TUI holding an invalidated session on rejection.
+ * Keep resume/import inside the chat's single workspace, deciding BEFORE delegating to pi. pi tears
+ * down the active session before invoking the runtime factory, so a factory-only guard would leave
+ * the TUI on an invalidated session when it rejects. We always pin pi's effective cwd to rootCwd:
+ * a session that explicitly records a different workspace is rejected up front, while a session with
+ * no cwd (legacy/imported files) runs in the chat workspace instead of falling back to pi's
+ * `process.cwd()` (which, when chat was launched from outside <dir>, would itself force a
+ * cross-workspace rebuild and tear the live session down).
  */
 function enforceWorkspaceScopedSessionSwitches(runtime: AgentSessionRuntime, rootCwd: string): void {
-  const assertSameWorkspace = (targetCwd: string | undefined) => {
-    if (targetCwd !== undefined && resolve(targetCwd) !== rootCwd) throw workspaceScopeError(resolve(targetCwd));
+  const pinnedTargetCwd = (sessionPath: string, cwdOverride: string | undefined): string => {
+    const known = cwdOverride !== undefined ? resolve(cwdOverride) : readSessionHeaderCwd(sessionPath);
+    if (known !== undefined && known !== rootCwd) throw workspaceScopeError(known);
+    return rootCwd;
   };
 
   const switchSession = runtime.switchSession.bind(runtime);
   runtime.switchSession = async (...args: Parameters<AgentSessionRuntime["switchSession"]>) => {
     const [sessionPath, options] = args;
-    assertSameWorkspace(options?.cwdOverride ?? readSessionHeaderCwd(sessionPath));
-    return switchSession(...args);
+    return switchSession(sessionPath, { ...options, cwdOverride: pinnedTargetCwd(sessionPath, options?.cwdOverride) });
   };
 
   const importFromJsonl = runtime.importFromJsonl.bind(runtime);
   runtime.importFromJsonl = async (...args: Parameters<AgentSessionRuntime["importFromJsonl"]>) => {
     const [inputPath, cwdOverride] = args;
-    assertSameWorkspace(cwdOverride ?? readSessionHeaderCwd(inputPath));
-    return importFromJsonl(...args);
+    return importFromJsonl(inputPath, pinnedTargetCwd(inputPath, cwdOverride));
   };
 }
 

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -1,11 +1,14 @@
 /**
  * Chat: open a workspace into pi's interactive TUI (`fastagent chat`).
  *
- * `chat` is a CHANNEL, symmetric to the HTTP channel (channels/http.ts): it consumes the SAME
- * assembled agent that `dev`/`start` serve, but presents it through pi's real interactive TUI
- * (`InteractiveMode` — editor, streaming render, tool-call display, slash commands, model cycling,
- * session tree/fork, compaction) instead of HTTP/SSE. We deliberately reuse pi's full TUI rather
- * than hand-rolling a REPL: a crude line loop would misrepresent the runtime, which IS pi.
+ * `chat` is a pi-specific COMMAND, beside dev.ts/start.ts — NOT an engine-neutral channel. The HTTP
+ * channel (channels/http.ts) consumes only the Agent contract (agent.ts), so it works with any
+ * engine; `chat` instead drives pi's full session API (`InteractiveMode` — editor, streaming
+ * render, tool-call display, slash commands, model cycling, session tree/fork, compaction) and
+ * never touches the contract. It HAS to be engine-coupled: the contract is a minimal turn-based
+ * `invoke`, while a real TUI needs the engine's whole session lifecycle — forcing it through the
+ * contract would collapse it to the crude REPL this command exists to avoid. chat trades
+ * neutrality for fidelity, so it lives under engines/pi/ (and is not re-exported from index.ts).
  *
  * FIDELITY CONTRACT — chat must run the SAME agent dev/start serve, not pi's vanilla discovery.
  * pi's DefaultResourceLoader would walk AGENTS.md up to the repo root and discover skills under its

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -30,6 +30,7 @@
  * show). Cross-workspace session switches are rejected: `.env` is process-global, so one chat TUI is
  * one workspace; run `fastagent chat <other-dir>` for another workspace.
  */
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
@@ -124,7 +125,7 @@ export async function buildChatRuntime(
   const assemblyFor = (cwd: string) => {
     const activeCwd = resolve(cwd);
     if (activeCwd !== rootCwd) {
-      throw new Error(`fastagent chat is workspace-scoped: cannot switch to ${activeCwd}; run \`fastagent chat ${activeCwd}\` instead`);
+      throw workspaceScopeError(activeCwd);
     }
     assembly ??= resolveAssembly(rootCwd);
     return assembly;
@@ -170,11 +171,57 @@ export async function buildChatRuntime(
     return { ...result, services, diagnostics: services.diagnostics };
   };
 
-  return createAgentSessionRuntime(createRuntime, {
+  const runtime = await createAgentSessionRuntime(createRuntime, {
     cwd: rootCwd,
     agentDir: getAgentDir(),
     sessionManager: sessionManager ?? SessionManager.create(rootCwd),
   });
+  enforceWorkspaceScopedSessionSwitches(runtime, rootCwd);
+  return runtime;
+}
+
+function workspaceScopeError(targetCwd: string): Error {
+  return new Error(`fastagent chat is workspace-scoped: cannot switch to ${targetCwd}; run \`fastagent chat ${targetCwd}\` instead`);
+}
+
+function readSessionHeaderCwd(sessionPath: string): string | undefined {
+  const resolvedPath = resolve(sessionPath);
+  if (!existsSync(resolvedPath)) return undefined;
+  for (const line of readFileSync(resolvedPath, "utf8").split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line) as { type?: unknown; cwd?: unknown };
+      if (entry.type === "session") return typeof entry.cwd === "string" ? resolve(entry.cwd) : undefined;
+    } catch {
+      // Ignore malformed lines the same way pi's session loader does; no cwd means no preflight.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Reject cross-workspace resume/import BEFORE calling pi's replacement methods. pi tears down the
+ * active session before invoking the runtime factory; a factory-only cwd guard would therefore
+ * leave the TUI holding an invalidated session on rejection.
+ */
+function enforceWorkspaceScopedSessionSwitches(runtime: AgentSessionRuntime, rootCwd: string): void {
+  const assertSameWorkspace = (targetCwd: string | undefined) => {
+    if (targetCwd !== undefined && resolve(targetCwd) !== rootCwd) throw workspaceScopeError(resolve(targetCwd));
+  };
+
+  const switchSession = runtime.switchSession.bind(runtime);
+  runtime.switchSession = async (...args: Parameters<AgentSessionRuntime["switchSession"]>) => {
+    const [sessionPath, options] = args;
+    assertSameWorkspace(options?.cwdOverride ?? readSessionHeaderCwd(sessionPath));
+    return switchSession(...args);
+  };
+
+  const importFromJsonl = runtime.importFromJsonl.bind(runtime);
+  runtime.importFromJsonl = async (...args: Parameters<AgentSessionRuntime["importFromJsonl"]>) => {
+    const [inputPath, cwdOverride] = args;
+    assertSameWorkspace(cwdOverride ?? readSessionHeaderCwd(inputPath));
+    return importFromJsonl(...args);
+  };
 }
 
 /**

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -1,0 +1,43 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { buildChatRuntime } from "../src/engines/pi/chat.ts";
+
+// `chat` must run the SAME agent dev/start serve, presented in pi's TUI — NOT pi's vanilla
+// discovery. buildChatRuntime is split out precisely so that injection is inspectable without a
+// TTY. In-memory sessions keep the test from writing to the machine's pi session store.
+describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's session", () => {
+  it("uses the definition's prompt + skills + tools and the config model, definition-only", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-chat-"));
+    try {
+      await writeFile(join(dir, "AGENTS.md"), "# Test Agent\nMAGIC_CHAT_MARKER_91. Be terse.\n");
+      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await mkdir(join(dir, "skills", "greet"), { recursive: true });
+      await writeFile(
+        join(dir, "skills", "greet", "SKILL.md"),
+        "---\nname: greet\ndescription: How to greet a user.\n---\nSay hi warmly.\n",
+      );
+
+      const rt = await buildChatRuntime(dir, {}, SessionManager.inMemory());
+      try {
+        const st = rt.session.agent.state;
+        // Default coding tools by NAME (pi rebuilds them) and nothing else — definition-only, no
+        // machine-global tools leaked in.
+        expect(st.tools.map((t) => t.name)).toEqual(["read", "bash", "edit", "write"]);
+        // The injected system prompt is fastagent's assembled prompt: the definition's AGENTS.md
+        // content and its skill are present (pi's global AGENTS.md / skills are not).
+        const sp = st.systemPrompt ?? "";
+        expect(sp).toContain("MAGIC_CHAT_MARKER_91");
+        expect(sp).toMatch(/greet/);
+        // The config model resolved (fastagent's, not pi's settings default).
+        expect(st.model).toBeDefined();
+      } finally {
+        rt.session.dispose?.();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildChatRuntime } from "../src/engines/pi/chat.ts";
 
 // `chat` must run the SAME agent dev/start serve, presented in pi's TUI — NOT pi's vanilla
@@ -31,9 +31,31 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
         join(dir, "skills", "greet", "SKILL.md"),
         "---\nname: greet\ndescription: How to greet a user.\n---\nSay hi warmly.\n",
       );
+      await mkdir(join(dir, "skills", "greet-copy"), { recursive: true });
+      await writeFile(
+        join(dir, "skills", "greet-copy", "SKILL.md"),
+        "---\nname: greet\ndescription: Duplicate greet.\n---\nDuplicate.\n",
+      );
+      await mkdir(join(dir, "tools"), { recursive: true });
+      await writeFile(
+        join(dir, "tools", "ping.mjs"),
+        `export default {
+           description: "Discovered ping should be dropped because config.tools wins.",
+           parameters: { type: "object", properties: {} },
+           execute: async () => ({ content: [{ type: "text", text: "stale" }], details: {} }),
+         };\n`,
+      );
 
+      const warnings: string[] = [];
+      const errorSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+        warnings.push(args.map(String).join(" "));
+      });
       const rt = await buildChatRuntime(dir, {}, SessionManager.inMemory());
       try {
+        errorSpy.mockRestore();
+        expect(warnings.some((line) => line.includes('skill "greet" collision'))).toBe(true);
+        expect(warnings.some((line) => line.includes('tool "ping" (tools/ping) dropped'))).toBe(true);
+
         const st = rt.session.agent.state;
         // Default coding tools (rebuilt by pi from names) PLUS the config's custom tool, registered
         // through the session factory — definition-only, nothing machine-global leaked in.
@@ -62,6 +84,7 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
         expect(rebuiltPrompt).toContain("MAGIC_CHAT_MARKER_91");
         expect(rebuiltPrompt).not.toContain("SHOULD_NOT_HOT_RELOAD_IN_CHAT");
       } finally {
+        errorSpy.mockRestore();
         rt.session.dispose?.();
       }
     } finally {

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -93,6 +93,34 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
     }
   });
 
+  it("suppresses pi's machine-global APPEND_SYSTEM.md so chat matches what dev/start serve", async () => {
+    // getAgentDir() honors PI_CODING_AGENT_DIR; point it at a temp agent dir holding an append
+    // prompt. dev/start never read that file, so chat must not either, or fidelity breaks.
+    const dir = await mkdtemp(join(tmpdir(), "fa-chat-append-"));
+    const agentDir = await mkdtemp(join(tmpdir(), "fa-agentdir-"));
+    const prev = process.env.PI_CODING_AGENT_DIR;
+    try {
+      await writeFile(join(dir, "AGENTS.md"), "# Agent\nDEFN_ONLY_MARKER.\n");
+      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(join(agentDir, "APPEND_SYSTEM.md"), "GLOBAL_APPEND_LEAK_MARKER must not reach chat.\n");
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+
+      const rt = await buildChatRuntime(dir, {}, SessionManager.inMemory());
+      try {
+        const sp = rt.session.agent.state.systemPrompt ?? "";
+        expect(sp).toContain("DEFN_ONLY_MARKER"); // fastagent's prompt is there
+        expect(sp).not.toContain("GLOBAL_APPEND_LEAK_MARKER"); // pi's append prompt is suppressed
+      } finally {
+        rt.session.dispose?.();
+      }
+    } finally {
+      if (prev === undefined) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = prev;
+      await rm(dir, { recursive: true, force: true });
+      await rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects cross-workspace session switches because chat env is workspace-scoped", async () => {
     const root = await mkdtemp(join(tmpdir(), "fa-chat-scope-"));
     const dir = join(root, "agent-a");

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -119,6 +119,18 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
         await expect(rt.importFromJsonl(imported, other)).rejects.toThrow(/fastagent chat is workspace-scoped/);
         expect(invalidated).toBe(false);
         expect(rt.cwd).toBe(dir);
+
+        // A legacy/imported session with NO cwd header must run in the chat workspace, not fall back
+        // to pi's process.cwd() (which is this repo here, not `dir`) and trip the cross-workspace
+        // teardown path. It should import successfully and stay pinned to the chat root.
+        const noCwd = join(root, "no-cwd-session.jsonl");
+        await writeFile(
+          noCwd,
+          `${JSON.stringify({ type: "session", version: 3, id: "nocwd", timestamp: new Date().toISOString() })}\n`,
+        );
+        expect(process.cwd()).not.toBe(dir);
+        await expect(rt.importFromJsonl(noCwd)).resolves.toMatchObject({ cancelled: false });
+        expect(rt.cwd).toBe(dir);
       } finally {
         rt.session.dispose?.();
       }

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -68,4 +68,33 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("rejects cross-workspace session switches because chat env is workspace-scoped", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fa-chat-scope-"));
+    const dir = join(root, "agent-a");
+    const other = join(root, "agent-b");
+    const sessionsDir = join(root, "sessions");
+    try {
+      await mkdir(dir, { recursive: true });
+      await mkdir(other, { recursive: true });
+      await writeFile(join(dir, "AGENTS.md"), "# Agent A\n");
+      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(join(other, "AGENTS.md"), "# Agent B\n");
+      await writeFile(join(other, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      const imported = join(root, "other-session.jsonl");
+      await writeFile(
+        imported,
+        `${JSON.stringify({ type: "session", version: 3, id: "other", timestamp: new Date().toISOString(), cwd: other })}\n`,
+      );
+
+      const rt = await buildChatRuntime(dir, {}, SessionManager.create(dir, sessionsDir));
+      try {
+        await expect(rt.importFromJsonl(imported, other)).rejects.toThrow(/fastagent chat is workspace-scoped/);
+      } finally {
+        rt.session.dispose?.();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -7,13 +7,25 @@ import { buildChatRuntime } from "../src/engines/pi/chat.ts";
 
 // `chat` must run the SAME agent dev/start serve, presented in pi's TUI — NOT pi's vanilla
 // discovery. buildChatRuntime is split out precisely so that injection is inspectable without a
-// TTY. In-memory sessions keep the test from writing to the machine's pi session store.
+// TTY. In-memory sessions keep the test from writing to the machine's pi session store. A raw
+// AgentTool via `config.tools` lets the custom-tool path be tested without installing the package.
 describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's session", () => {
-  it("uses the definition's prompt + skills + tools and the config model, definition-only", async () => {
+  it("injects the definition's prompt + skills, the config model, custom tools, definition-only", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-chat-"));
     try {
       await writeFile(join(dir, "AGENTS.md"), "# Test Agent\nMAGIC_CHAT_MARKER_91. Be terse.\n");
-      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(
+        join(dir, "fastagent.config.mjs"),
+        `export default {
+           model: "openai-codex/gpt-5.5",
+           tools: [{
+             name: "ping",
+             description: "Reply pong.",
+             parameters: { type: "object", properties: {} },
+             execute: async () => ({ content: [{ type: "text", text: "pong" }], details: {} }),
+           }],
+         };\n`,
+      );
       await mkdir(join(dir, "skills", "greet"), { recursive: true });
       await writeFile(
         join(dir, "skills", "greet", "SKILL.md"),
@@ -23,16 +35,20 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
       const rt = await buildChatRuntime(dir, {}, SessionManager.inMemory());
       try {
         const st = rt.session.agent.state;
-        // Default coding tools by NAME (pi rebuilds them) and nothing else — definition-only, no
-        // machine-global tools leaked in.
-        expect(st.tools.map((t) => t.name)).toEqual(["read", "bash", "edit", "write"]);
-        // The injected system prompt is fastagent's assembled prompt: the definition's AGENTS.md
-        // content and its skill are present (pi's global AGENTS.md / skills are not).
+        // Default coding tools (rebuilt by pi from names) PLUS the config's custom tool, registered
+        // through the session factory — definition-only, nothing machine-global leaked in.
+        expect(st.tools.map((t) => t.name).sort()).toEqual(["bash", "edit", "ping", "read", "write"]);
+        // The injected system prompt is fastagent's: the definition's AGENTS.md and skill are in it.
         const sp = st.systemPrompt ?? "";
         expect(sp).toContain("MAGIC_CHAT_MARKER_91");
         expect(sp).toMatch(/greet/);
-        // The config model resolved (fastagent's, not pi's settings default).
-        expect(st.model).toBeDefined();
+        expect(st.model).toBeDefined(); // the config model resolved (fastagent's, not pi's default)
+
+        // P1 regression guard: the TUI rebuilds the session on /new (and /resume, fork) via the same
+        // factory. The custom tool must come back — registering through customTools (not patching
+        // state afterward) is what makes that hold.
+        await rt.newSession();
+        expect(rt.session.agent.state.tools.map((t) => t.name)).toContain("ping");
       } finally {
         rt.session.dispose?.();
       }

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -49,11 +49,18 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
         expect((sp.match(/Current working directory/g) ?? []).length).toBe(1);
         expect((sp.match(/<available_skills>/g) ?? []).length).toBe(1);
 
+        // Chat is a coherent startup snapshot per cwd: same-cwd rebuilds (/new, fork) must not
+        // half-refresh only the fs-read pieces while config/tools stay stale in Node's import cache.
+        await writeFile(join(dir, "AGENTS.md"), "# Changed Agent\nSHOULD_NOT_HOT_RELOAD_IN_CHAT.\n");
+
         // P1 regression guard: the TUI rebuilds the session on /new (and /resume, fork) via the same
         // factory. The custom tool must come back — registering through customTools (not patching
         // state afterward) is what makes that hold.
         await rt.newSession();
         expect(rt.session.agent.state.tools.map((t) => t.name)).toContain("ping");
+        const rebuiltPrompt = rt.session.agent.state.systemPrompt ?? "";
+        expect(rebuiltPrompt).toContain("MAGIC_CHAT_MARKER_91");
+        expect(rebuiltPrompt).not.toContain("SHOULD_NOT_HOT_RELOAD_IN_CHAT");
       } finally {
         rt.session.dispose?.();
       }

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -89,7 +89,13 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
 
       const rt = await buildChatRuntime(dir, {}, SessionManager.create(dir, sessionsDir));
       try {
+        let invalidated = false;
+        rt.setBeforeSessionInvalidate(() => {
+          invalidated = true;
+        });
         await expect(rt.importFromJsonl(imported, other)).rejects.toThrow(/fastagent chat is workspace-scoped/);
+        expect(invalidated).toBe(false);
+        expect(rt.cwd).toBe(dir);
       } finally {
         rt.session.dispose?.();
       }

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -43,6 +43,11 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
         expect(sp).toContain("MAGIC_CHAT_MARKER_91");
         expect(sp).toMatch(/greet/);
         expect(st.model).toBeDefined(); // the config model resolved (fastagent's, not pi's default)
+        // Duplication guard: pi appends the skill section + env (date/cwd); the override must carry
+        // only base+instructions, or chat drifts from served and wastes context.
+        expect((sp.match(/Current date/g) ?? []).length).toBe(1);
+        expect((sp.match(/Current working directory/g) ?? []).length).toBe(1);
+        expect((sp.match(/<available_skills>/g) ?? []).length).toBe(1);
 
         // P1 regression guard: the TUI rebuilds the session on /new (and /resume, fork) via the same
         // factory. The custom tool must come back — registering through customTools (not patching

--- a/core/test/chat.test.ts
+++ b/core/test/chat.test.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -116,25 +117,55 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
         rt.setBeforeSessionInvalidate(() => {
           invalidated = true;
         });
+        // A session that EXPLICITLY records another workspace is rejected before pi tears the live
+        // session down — independent of process.cwd().
         await expect(rt.importFromJsonl(imported, other)).rejects.toThrow(/fastagent chat is workspace-scoped/);
         expect(invalidated).toBe(false);
-        expect(rt.cwd).toBe(dir);
-
-        // A legacy/imported session with NO cwd header must run in the chat workspace, not fall back
-        // to pi's process.cwd() (which is this repo here, not `dir`) and trip the cross-workspace
-        // teardown path. It should import successfully and stay pinned to the chat root.
-        const noCwd = join(root, "no-cwd-session.jsonl");
-        await writeFile(
-          noCwd,
-          `${JSON.stringify({ type: "session", version: 3, id: "nocwd", timestamp: new Date().toISOString() })}\n`,
-        );
-        expect(process.cwd()).not.toBe(dir);
-        await expect(rt.importFromJsonl(noCwd)).resolves.toMatchObject({ cancelled: false });
-        expect(rt.cwd).toBe(dir);
+        expect(rt.cwd).toBe(realpathSync(dir)); // runtime cwd is canonical (symlink-free)
       } finally {
         rt.session.dispose?.();
       }
     } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps cwd-less legacy sessions in the chat workspace across import and fork", async () => {
+    // The chat process runs chdir'd into the workspace (runChat); these cases depend on that
+    // invariant, so emulate it here. Without it, a cwd-less session would fall back to pi's
+    // process.cwd() and trip the cross-workspace teardown path on import AND on /fork.
+    const root = await mkdtemp(join(tmpdir(), "fa-chat-legacy-"));
+    const dir = join(root, "agent");
+    const sessionsDir = join(root, "sessions");
+    const originalCwd = process.cwd();
+    try {
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "AGENTS.md"), "# Agent\n");
+      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      // A legacy session: a header with NO cwd, plus one user message entry to fork at.
+      const legacy = join(root, "legacy-session.jsonl");
+      await writeFile(
+        legacy,
+        `${JSON.stringify({ type: "session", version: 3, id: "legacy", timestamp: new Date().toISOString() })}\n` +
+          `${JSON.stringify({ type: "message", id: "m1", parentId: null, timestamp: new Date().toISOString(), message: { role: "user", content: "hi" } })}\n`,
+      );
+
+      process.chdir(dir);
+      const realDir = realpathSync(dir); // pi binds the realpath via process.cwd()
+      const rt = await buildChatRuntime(dir, {}, SessionManager.create(dir, sessionsDir));
+      try {
+        // Import the cwd-less session: no foreign cwd, so it runs in the chat workspace.
+        await expect(rt.importFromJsonl(legacy)).resolves.toMatchObject({ cancelled: false });
+        expect(rt.cwd).toBe(realDir);
+        // Fork at an entry: pi reopens the current (cwd-less) session file without a cwd override.
+        // The chdir invariant keeps that resolving to the chat workspace instead of process.cwd().
+        await expect(rt.fork("m1", { position: "at" })).resolves.toMatchObject({ cancelled: false });
+        expect(rt.cwd).toBe(realDir);
+      } finally {
+        rt.session.dispose?.();
+      }
+    } finally {
+      process.chdir(originalCwd);
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,6 +59,8 @@ data: {"type":"completed"}
 
 Reuse the same `session` value to continue a conversation; conversations persist under `.fastagent/sessions`, so a `dev` restart keeps them.
 
+To try the agent interactively instead of over HTTP, run `fastagent chat`. It opens the **same** assembled agent (same model, tools, skills, instructions) in pi's full interactive TUI — streaming, tool rendering, `/` commands, model switching, session resume — so you can vibe-check what you'll serve without writing a client.
+
 ## 3. Add a tool
 
 A tool is a file in `tools/`; the **filename is the tool name**, and `tools/` is auto-discovered — no registration in the config. Drop in `tools/reverse.ts`:


### PR DESCRIPTION
See commit body. `chat` opens the SAME assembled agent dev/start serve, in pi's full interactive TUI (InteractiveMode) instead of HTTP/SSE — a new channel symmetric to channels/http.ts. Fidelity: driven by fastagent's assembly (model/prompt/skills/tools injected), definition-only (noExtensions/noPromptTemplates/noContextFiles suppress the machine's global pi resources). chat.ts is engine-internal (not in index.ts); no new dependency. buildChatRuntime is split from runPiChat for testability; a test asserts the injection. 154 tests pass.