### PR TITLE
docs: reposition vs Flue/Eve — embed-first, agent-as-a-feature, Flask not framework

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -16,10 +16,10 @@ The sharpest distinction is not feature count or neutrality — it is *what you 
 | | Eve / Flue | FastAgent |
 |---|---|---|
 | Assumes you are building | an agent **product/platform** (the agent is the thing) | a product with an agent **feature** (the agent is one capability) |
-| Posture | **move into their world** (their routing, db, project layout, deploy) | **embed into your world** (one contract + injected ports inside your stack) |
-| Verb | **deploy** an agent | **embed** an agent capability |
+| Posture | **move into their world** (their routing, db, project layout, deploy) | **compose into your world** (one contract + injected ports, either in your app or as a thin service/channel) |
+| Integration surface | full project/framework/platform | library API, route handler, webhook/channel adapter, or standalone service |
 
-Most teams that need an agent are not building an agent platform; they are adding an agent feature to a SaaS/web/app. That **agent-as-a-feature** majority is where FastAgent fits and where full frameworks create friction.
+Most teams that need an agent are not building an agent platform; they are adding an agent feature to a SaaS/web/app or channel. That **agent-as-a-feature** majority is where FastAgent fits and where full frameworks create friction.
 
 ## Overview
 
@@ -53,9 +53,9 @@ So FastAgent's old differentiators mostly collapse against Flue:
 | Built on open pi | Flue is also built on pi |
 | Markdown-native, serve coding-agent artifacts | Flue is too, with more mature AI-first DX |
 | **Zero-rewrite, just point at a folder** | Only this remains — but the delta is thin: Flue needs a ~10-line `createAgent` + project layout; FastAgent needs a config |
-| **Library, not framework** (transport-neutral `invoke`, no imposed structure) | The one structural difference: Flue is a full framework (imposes routing/db/project layout); FastAgent is a contract + injected ports you embed into your own stack |
+| **Library/thin service, not framework** (transport-neutral `invoke`, no imposed structure) | The one structural difference: Flue is a full framework (imposes routing/db/project layout); FastAgent is a contract + injected ports you compose into your stack or run as a thin channel/service |
 
-The honest difference is **agent-as-a-feature vs agent-as-the-product**: Flue wants to be your app framework; FastAgent wants to be one capability inside your app. Even pairing Flue with Astro — same team, same Vite — still yields *two frameworks to stitch*, because Flue's value is owning the application, not embedding into one. That is the structural seam FastAgent owns; resource parity (a funded Astro team vs a small project) means FastAgent cannot win on framework breadth, only on this posture.
+The honest difference is **agent-as-a-feature vs agent-as-the-product**: Flue wants to be your app framework; FastAgent wants to be one capability inside your app or channel. Even pairing Flue with Astro — same team, same Vite — still yields *two frameworks to stitch*, because Flue's value is owning the application, not serving one capability with minimal surface area. That is the structural seam FastAgent owns; resource parity (a funded Astro team vs a small project) means FastAgent cannot win on framework breadth, only on this posture.
 
 ## OpenClaw
 
@@ -74,7 +74,7 @@ FastAgent only exists if neutrality matters: the same serving/embedding path sho
 
 ## pi
 
-pi is not the competitor; it is the first engine substrate — and the one **Flue also builds on**. FastAgent uses `pi-agent-core`'s `AgentHarness`, adapting pi's two ports (`prompt()` final value + `subscribe()` events) into the single Agent Handler event stream. FastAgent should avoid rebuilding pi's harness; its value is the contract, the embed/assembly shape, and host portability around the harness.
+pi is not the competitor; it is the first engine substrate — and the one **Flue also builds on**. FastAgent's serving/embedding path uses `pi-agent-core`'s `AgentHarness`, adapting pi's two ports (`prompt()` final value + `subscribe()` events) into the single Agent Handler event stream. The `fastagent chat` dev command is intentionally pi-specific and uses pi's interactive session lifecycle for TUI fidelity; it does not change the serving contract. FastAgent should avoid rebuilding pi's harness; its value is the contract, the embed/assembly shape, and host portability around the harness.
 
 ## Worked example: an agent feature in an Astro product
 
@@ -92,14 +92,21 @@ import { agent } from "../../lib/agent.ts"; // createPiAgentFromDefinition('./ag
 export const POST: APIRoute = async ({ request, locals }) => {
   if (!locals.user) return new Response("Unauthorized", { status: 401 }); // your auth
   const { session, text } = await request.json();
-  const stream = new ReadableStream({
-    async start(c) {
-      for await (const e of agent.invoke({ session: `${locals.user.id}:${session}` }, { text }))
-        c.enqueue(`data: ${JSON.stringify(e)}\n\n`);
-      c.close();
+  const iterator = agent.invoke({ session: `${locals.user.id}:${session}` }, { text })[Symbol.asyncIterator]();
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(c) {
+      const { value, done } = await iterator.next();
+      if (done) return c.close();
+      c.enqueue(encoder.encode(`data: ${JSON.stringify(value)}\n\n`));
+    },
+    async cancel() {
+      await iterator.return?.(); // client disconnect/cancel → SPEC MUST 3 cleanup
     },
   });
-  return new Response(stream, { headers: { "content-type": "text/event-stream" } });
+  return new Response(stream, {
+    headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+  });
 };
 ```
 
@@ -107,4 +114,4 @@ One build, one deploy, one auth, your database. The transport-neutral `invoke` c
 
 ## Summary
 
-FastAgent wins where the job is **"embed an agent capability into a product I already have, on a stack I already chose, without adopting a second framework."** If the user is building an agent *product/platform* — or needs heavyweight durable/swarm/sandbox out of the box — Flue (open) or Eve (Vercel) is the better fit. FastAgent's defensible position is the Flask/WSGI one: a minimal, transport-neutral serving contract plus injected ports (session/auth/env/lease), composed into the user's own stack — promising less, but not annexing the user's architecture.
+FastAgent wins where the job is **"turn an existing agent folder into an agent capability — inside my product, or as Slack/webhook/API infrastructure — without adopting a second framework."** If the user is building an agent *product/platform* — or needs heavyweight durable/swarm/sandbox out of the box — Flue (open) or Eve (Vercel) is the better fit. FastAgent's defensible position is the Flask/WSGI one: a minimal, transport-neutral serving contract plus injected ports (session/auth/env/lease), composed into the user's own stack or deployed as a thin service — promising less, but not annexing the user's architecture.

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -2,80 +2,109 @@
 title: fastagent — Competitive comparisons
 type: competitive-analysis
 status: design
-updated: 2026-06-11
+updated: 2026-06-18
 ---
 
 # Competitive comparisons
 
-FastAgent sits in the serving layer for existing markdown-native agents. The closest neighboring projects occupy adjacent layers.
+FastAgent sits in the serving/embedding layer for existing markdown-native agents. The closest neighbors split into two camps: **full agent frameworks/platforms** (Eve, Flue) that you build an agent *product* in, and **adjacent layers** (engines, products, vendor hosting) around the same job.
+
+## The framing that matters: agent-as-a-feature vs agent-as-the-product
+
+The sharpest distinction is not feature count or neutrality — it is *what you are building*:
+
+| | Eve / Flue | FastAgent |
+|---|---|---|
+| Assumes you are building | an agent **product/platform** (the agent is the thing) | a product with an agent **feature** (the agent is one capability) |
+| Posture | **move into their world** (their routing, db, project layout, deploy) | **embed into your world** (one contract + injected ports inside your stack) |
+| Verb | **deploy** an agent | **embed** an agent capability |
+
+Most teams that need an agent are not building an agent platform; they are adding an agent feature to a SaaS/web/app. That **agent-as-a-feature** majority is where FastAgent fits and where full frameworks create friction.
 
 ## Overview
 
-| Project | What it is | Agent definition | Neutrality | Web analogy |
+| Project | What it is | Engine | Neutrality | Web analogy |
 |---|---|---|---|---|
-| **FastAgent** | Serving contract + reference implementation + deployment toolchain | Existing markdown definition + config | Engine/model/host neutral by design | WSGI + gunicorn + deployment toolchain |
-| **Flue** | Code-first agent harness framework | TypeScript workflows | Partly neutral, but framework-shaped | Astro/Next-style framework |
-| **OpenClaw** | Self-hosted personal assistant product | Markdown-native assistant config | Product-shaped, not a neutral serving layer | WordPress-like product |
-| **Claude Agent SDK hosting** | SDK + hosting guidance | Claude Code projects | Claude-locked | Vendor SDK hosting |
-| **OpenCode `serve`** | Headless server for OpenCode | OpenCode projects | OpenCode-locked | Product server |
-| **pi** | Harness engine and coding agent | Engine/runtime layer | The reference engine FastAgent builds on | Werkzeug-like engine substrate |
+| **Eve** (Vercel) | Vertically-integrated agent platform | own harness | Vercel-locked (Sandbox/Workflows/Connect) | agent's **Next.js** |
+| **Flue** (Astro team) | Open full-framework for agentic software | **pi** | Open by default (any model/sandbox/deploy), but full-framework-shaped | agent's **Django** |
+| **FastAgent** | Serving/embedding contract + reference impl + deploy toolchain | **pi** | Engine/model/host neutral; **library, not framework** | agent's **Flask/WSGI** |
+| OpenClaw | Self-hosted personal-assistant product | pi | Product-shaped, not a neutral layer | WordPress-like product |
+| Claude Agent SDK hosting | SDK + hosting guidance | Claude | Claude-locked | Vendor SDK hosting |
+| OpenCode `serve` | Headless server for OpenCode | OpenCode | OpenCode-locked | Product server |
+| pi | Harness engine and coding agent | — | The reference engine FastAgent (and Flue) build on | Werkzeug-like substrate |
 
-## Flue
+**Flue and FastAgent build on the same engine (pi).** Neither has a durable-execution capability the other technically cannot reach — both checkpoint at turn/operation boundaries because pi's turn loop is the shared black box. The difference is product shape, not engine power.
 
-Flue is a code-first harness framework. You write workflows in TypeScript, use typed schemas, and select sandbox/connectors as first-class concepts.
+## Eve (Vercel)
 
-FastAgent differs in the entry point:
+Eve is the vertically-integrated bet: an agent is a directory (`instructions.md` + `tools/` + `skills/` + `channels/` + `subagents/` + `schedules/`), and the Vercel platform supplies everything else — AI Gateway, Sandbox, Workflows (durable), Connect (MCP/auth), Chat SDK (channels). Batteries-included, one-click, and locked to Vercel.
 
-| Axis | Flue | FastAgent |
-|---|---|---|
-| Agent authoring | Write TypeScript workflows | Reuse an existing `AGENTS.md` + `skills/` folder |
-| Primary user | Engineers writing agents as code | People who already created useful markdown-native agents |
-| Contract | Flue runtime API | Agent Handler `invoke(scope, prompt) => AsyncIterable<AgentEvent>` |
-| Runtime strategy | Framework/sandbox abstraction | Stateless core + injected env/session + target adapters |
-| Deployment | Build/run in supported targets | Build/start/deploy existing definitions across targets |
+FastAgent differs on lock-in and posture: Eve makes you write an *eve agent* and run it on *Vercel*; FastAgent serves/embeds an agent you already have, on any host. Eve is a real competitor only when the user is already all-in on Vercel and wants the platform to do everything.
 
-Flue is a real competitor when the user wants code-first workflow control. FastAgent's wedge is the opposite: do not rewrite the agent.
+## Flue (the most direct competitor)
+
+Flue is **not** a code-first workflow tool (an earlier version of this doc was wrong). It is an **open full-framework for agentic software**, built by the Astro team, **on the same pi engine FastAgent uses**. Its stated design principles are: harness-first, **open by default (no lock-in)**, and **AI-first** (built to be used alongside Claude Code/Codex). It ships markdown skills + TypeScript tools + a thin `createAgent`, plus a complete platform: agents (continuing) vs workflows (finite durable runs), sandboxes, subagents, channels (Slack/Teams/Discord/GitHub), MCP, observability, routing (Hono `app.ts`), and a `PersistenceAdapter` database port.
+
+So FastAgent's old differentiators mostly collapse against Flue:
+
+| FastAgent thought its moat was | Against Flue |
+|---|---|
+| Neutral (engine/model/host) | Flue is also open by default — neutrality is **not** exclusive |
+| Built on open pi | Flue is also built on pi |
+| Markdown-native, serve coding-agent artifacts | Flue is too, with more mature AI-first DX |
+| **Zero-rewrite, just point at a folder** | Only this remains — but the delta is thin: Flue needs a ~10-line `createAgent` + project layout; FastAgent needs a config |
+| **Library, not framework** (transport-neutral `invoke`, no imposed structure) | The one structural difference: Flue is a full framework (imposes routing/db/project layout); FastAgent is a contract + injected ports you embed into your own stack |
+
+The honest difference is **agent-as-a-feature vs agent-as-the-product**: Flue wants to be your app framework; FastAgent wants to be one capability inside your app. Even pairing Flue with Astro — same team, same Vite — still yields *two frameworks to stitch*, because Flue's value is owning the application, not embedding into one. That is the structural seam FastAgent owns; resource parity (a funded Astro team vs a small project) means FastAgent cannot win on framework breadth, only on this posture.
 
 ## OpenClaw
 
 OpenClaw validates a related need: markdown-native, multi-channel, self-hosted assistants are useful. But OpenClaw is a product; the product is the assistant.
 
-FastAgent should not compete on being the best personal assistant. It is the serving layer someone could use to build OpenClaw-like products for arbitrary definitions and targets.
+FastAgent should not compete on being the best personal assistant. It is the serving/embedding layer someone could use to build OpenClaw-like products for arbitrary definitions and targets.
 
 ## Claude Agent SDK hosting and OpenCode serve
 
-These are the most important platform-absorption examples:
+These are the platform-absorption examples:
 
-- Claude Agent SDK hosting shows how to run Claude Code programmatically or as a hosted service, but it locks the Claude engine/model path.
+- Claude Agent SDK hosting runs Claude Code programmatically or as a hosted service, but it locks the Claude engine/model path.
 - OpenCode `serve` exposes OpenCode as a headless HTTP server, but it locks the OpenCode product.
 
-FastAgent only exists if neutrality matters: the same serving/deployment path should work across different coding-agent artifacts, engines, models, and hosts.
+FastAgent only exists if neutrality matters: the same serving/embedding path should work across different coding-agent artifacts, engines, models, and hosts.
 
 ## pi
 
-pi is not the competitor; it is the first engine substrate.
+pi is not the competitor; it is the first engine substrate — and the one **Flue also builds on**. FastAgent uses `pi-agent-core`'s `AgentHarness`, adapting pi's two ports (`prompt()` final value + `subscribe()` events) into the single Agent Handler event stream. FastAgent should avoid rebuilding pi's harness; its value is the contract, the embed/assembly shape, and host portability around the harness.
 
-FastAgent builds on `pi-agent-core`'s `AgentHarness`, not the TUI-oriented `pi-coding-agent` `AgentSession`. The reference implementation adapts pi's two ports — `prompt()` final value plus `subscribe()` event side-channel — into the single Agent Handler event stream.
+## Worked example: an agent feature in an Astro product
 
-FastAgent should avoid rebuilding pi's harness. Its value is the contract, assembly/deployment shape, and host portability around the harness.
+A product team is building a SaaS in Astro (with their own auth and Postgres) and wants to add an agent feature.
 
-## Worked example: GitHub issue triage
+**With Flue (or Eve):** the agent is a separate framework/service. You run a Flue project (its `src/agents`, `db.ts`, Hono `app.ts`, build, deploy) alongside the Astro app, and stitch two worlds — Flue's db vs your Postgres, Flue's routing/auth vs Astro's, two deploy units.
 
-Imagine an agent definition that triages new GitHub issues by reading issue content, choosing labels, commenting, and assigning an owner. The core agent behavior can live in `AGENTS.md` and a skill either way.
-
-With Flue, the natural wrapper is a TypeScript workflow running in CI or a configured sandbox.
-
-With FastAgent, the natural wrapper is a channel adapter:
+**With FastAgent:** the agent is one Astro endpoint.
 
 ```ts
-const result = await collect(agent.invoke(
-  { session: `gh-${repo}-${issue}` },
-  { text: `Triage issue #${issue} in ${repo}.` },
-));
+// src/pages/api/agent.ts (Astro SSR endpoint)
+import type { APIRoute } from "astro";
+import { agent } from "../../lib/agent.ts"; // createPiAgentFromDefinition('./agent', { sessions: yourPostgres })
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  if (!locals.user) return new Response("Unauthorized", { status: 401 }); // your auth
+  const { session, text } = await request.json();
+  const stream = new ReadableStream({
+    async start(c) {
+      for await (const e of agent.invoke({ session: `${locals.user.id}:${session}` }, { text }))
+        c.enqueue(`data: ${JSON.stringify(e)}\n\n`);
+      c.close();
+    },
+  });
+  return new Response(stream, { headers: { "content-type": "text/event-stream" } });
+};
 ```
 
-The same Agent Handler can be exposed through HTTP, a webhook adapter, A2A, a scheduled job, or a target runtime such as AgentCore. The markdown agent stays the same; the serving shell changes.
+One build, one deploy, one auth, your database. The transport-neutral `invoke` contract (no bundled HTTP framework) is what lets the agent live inside the host's own route. This is the demo that makes the abstract positioning concrete — and the sweet spot is explicit: a relatively *light* agent feature (interactive/generation/trigger-response) in a *TS/Node* product with an *existing stack*. A *heavy* agent (long autonomy, swarm, sandbox isolation, many channels) tilts back toward Flue's batteries-included path even as a feature.
 
 ## Summary
 
-FastAgent wins only where “existing markdown-native agent definition → running service on any target” is the job. If the user wants to write a new agent in code, use a framework. If the user wants a finished assistant product, use a product. If the user wants neutral serving/deployment for agent folders, FastAgent owns that layer.
+FastAgent wins where the job is **"embed an agent capability into a product I already have, on a stack I already chose, without adopting a second framework."** If the user is building an agent *product/platform* — or needs heavyweight durable/swarm/sandbox out of the box — Flue (open) or Eve (Vercel) is the better fit. FastAgent's defensible position is the Flask/WSGI one: a minimal, transport-neutral serving contract plus injected ports (session/auth/env/lease), composed into the user's own stack — promising less, but not annexing the user's architecture.

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -33,7 +33,7 @@ Most teams that need an agent are not building an agent platform; they are addin
 | OpenCode `serve` | Headless server for OpenCode | OpenCode | OpenCode-locked | Product server |
 | pi | Harness engine and coding agent | — | The reference engine FastAgent (and Flue) build on | Werkzeug-like substrate |
 
-**Flue and FastAgent build on the same engine (pi).** Neither has a durable-execution capability the other technically cannot reach — both checkpoint at turn/operation boundaries because pi's turn loop is the shared black box. The difference is product shape, not engine power.
+**Flue and FastAgent build on the same engine (pi), but not with current durability parity.** Shared pi keeps both under the same engine turn-loop boundary, yet Flue already packages stronger framework-level durability UX (durable workflows/streams, persistence, resume). FastAgent today proves a smaller serving-layer shape: turn-level session continuity, external-session seams, and crash-safe transcript reopen. Deployment-grade durability for long-running agents still depends on target adapters with external sessions and distributed locking.
 
 ## Eve (Vercel)
 

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -85,9 +85,18 @@ A product team is building a SaaS in Astro (with their own auth and Postgres) an
 **With FastAgent:** the agent is one Astro endpoint.
 
 ```ts
+// src/lib/agent.ts
+import { createPiAgentFromDefinition, resolveModel } from "@kid7st/fastagent";
+import { postgresSessionStore } from "./sessions"; // your adapter
+
+export const { agent } = await createPiAgentFromDefinition("./agent", {
+  model: resolveModel(process.env.FASTAGENT_MODEL ?? "openai-codex/gpt-5.5"),
+  sessions: postgresSessionStore,
+});
+
 // src/pages/api/agent.ts (Astro SSR endpoint)
 import type { APIRoute } from "astro";
-import { agent } from "../../lib/agent.ts"; // createPiAgentFromDefinition('./agent', { sessions: yourPostgres })
+import { agent } from "../../lib/agent.ts";
 
 export const POST: APIRoute = async ({ request, locals }) => {
   if (!locals.user) return new Response("Unauthorized", { status: 401 }); // your auth
@@ -109,6 +118,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
   });
 };
 ```
+
+Today, custom session stores use `createPiAgentFromDefinition`, so the embed setup passes a resolved model explicitly. A config-resolving embed opener that also accepts K-axis overrides (sessions/auth/env/lease) is the intended ergonomic follow-up.
 
 One build, one deploy, one auth, your database. The transport-neutral `invoke` contract (no bundled HTTP framework) is what lets the agent live inside the host's own route. This is the demo that makes the abstract positioning concrete — and the sweet spot is explicit: a relatively *light* agent feature (interactive/generation/trigger-response) in a *TS/Node* product with an *existing stack*. A *heavy* agent (long autonomy, swarm, sandbox isolation, many channels) tilts back toward Flue's batteries-included path even as a feature.
 

--- a/docs/fastagent.md
+++ b/docs/fastagent.md
@@ -2,13 +2,16 @@
 title: FastAgent
 type: product-overview
 status: design
-updated: 2026-06-11
+updated: 2026-06-18
 domain: https://fastagent.sh
 ---
 
 # FastAgent
 
-FastAgent is WSGI for agent serving: it turns an existing agent definition — `AGENTS.md` plus `skills/` — into a production service without rewriting the agent.
+FastAgent is **Flask/WSGI for agents**: it turns an existing agent definition — `AGENTS.md` plus `skills/` — into a running capability without rewriting it, in either mode:
+
+- **Embed** (primary): the agent is one capability inside a product you already have — `createPiAgent(...).invoke(...)` in your own route, wired to your session store, your auth, your host. Library, not framework: it composes into your stack instead of owning the application.
+- **Deploy** (secondary): the agent is a standalone service — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent.
 
 The product has three pieces:
 
@@ -20,9 +23,9 @@ FastAgent is not an agent-writing framework. The agent already exists as markdow
 
 ## Why this product exists
 
-The trigger moment is simple: a developer has a local agent they like, then wants it to work while they are not watching — receive webhooks, run on a schedule, answer from Telegram/Slack, or live behind an API endpoint.
+There are two trigger moments. **Embed:** a developer is building a product (often vibe-coded: their own auth/DB/host) and needs to add an agent *feature* — without adopting a second framework's routing/db/project layout. **Deploy:** a developer has a local agent they like and wants it to work while they are not watching — webhooks, schedules, Telegram/Slack, an API endpoint.
 
-Local interactive tools do not solve that serving problem. Cloud/platform offerings increasingly do, but they usually lock one engine, one model provider, or one host. FastAgent's durable bet is neutrality across:
+Local interactive tools do not solve either problem. Full frameworks (Flue, Eve) solve them by making you build an agent *product* in their world. FastAgent's bet is the opposite posture — a neutral contract you embed into *your* world — plus neutrality across:
 
 - agent definitions (`AGENTS.md`, Agent Skills, future MCP support),
 - engines (pi first; other engines later),
@@ -45,7 +48,7 @@ You can build products such as multi-channel assistants or A2A task systems on t
 | [SPEC](SPEC.md) | Locked v0.1 Agent Handler contract |
 | [core-design](core-design.md) | The pi reference implementation and current core architecture |
 | [positioning](positioning.md) | Product strategy, wedge, risks, and boundaries |
-| [comparisons](comparisons.md) | Comparison with Flue, OpenClaw, Claude Agent SDK, OpenCode, and pi |
+| [comparisons](comparisons.md) | Comparison with Eve, Flue, OpenClaw, Claude Agent SDK, OpenCode, and pi |
 | [session](session.md) | Draft session-admin model for fork/navigation beyond linear invoke |
 
 ## Current status

--- a/docs/fastagent.md
+++ b/docs/fastagent.md
@@ -8,10 +8,10 @@ domain: https://fastagent.sh
 
 # FastAgent
 
-FastAgent is **Flask/WSGI for agents**: it turns an existing agent definition — `AGENTS.md` plus `skills/` — into a running capability without rewriting it, in either mode:
+FastAgent is **Flask/WSGI for agents**: it turns an existing agent definition — `AGENTS.md` plus `skills/` — into a running capability without rewriting it, in either posture:
 
-- **Embed** (primary): the agent is one capability inside a product you already have — `createPiAgent(...).invoke(...)` in your own route, wired to your session store, your auth, your host. Library, not framework: it composes into your stack instead of owning the application.
-- **Deploy** (secondary): the agent is a standalone service — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent.
+- **Embed into an existing product**: the agent is one capability inside a product you already have — `createPiAgent(...).invoke(...)` in your own route, wired to your session store, your auth, your host. Library, not framework: it composes into your stack instead of owning the application.
+- **Serve as a standalone agent service**: the agent runs while you are away — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent.
 
 The product has three pieces:
 
@@ -25,7 +25,7 @@ FastAgent is not an agent-writing framework. The agent already exists as markdow
 
 There are two trigger moments. **Embed:** a developer is building a product (often vibe-coded: their own auth/DB/host) and needs to add an agent *feature* — without adopting a second framework's routing/db/project layout. **Deploy:** a developer has a local agent they like and wants it to work while they are not watching — webhooks, schedules, Telegram/Slack, an API endpoint.
 
-Local interactive tools do not solve either problem. Full frameworks (Flue, Eve) solve them by making you build an agent *product* in their world. FastAgent's bet is the opposite posture — a neutral contract you embed into *your* world — plus neutrality across:
+Local interactive tools do not solve either problem. Full frameworks (Flue, Eve) solve them by making you build an agent *product* in their world. FastAgent's bet is the opposite posture — a neutral contract you embed into *your* world or run as a thin service/channel — plus neutrality across:
 
 - agent definitions (`AGENTS.md`, Agent Skills, future MCP support),
 - engines (pi first; other engines later),

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -9,12 +9,12 @@ updated: 2026-06-18
 
 ## North star
 
-You already have an agent: a folder with `AGENTS.md`, `skills/`, and standard markdown assets. FastAgent turns it into a running capability **without rewriting it**, in either of two modes:
+You already have an agent: a folder with `AGENTS.md`, `skills/`, and standard markdown assets. FastAgent turns it into a running capability **without rewriting it**, in either of two equally valid postures:
 
-- **Embed** (primary, under-served): the agent is one capability inside a product you already have. `createPiAgent(...).invoke(...)` lives in your own route (Astro/Next/Hono endpoint), wired to *your* session store, *your* auth, *your* host. No second framework.
-- **Deploy** (secondary): the agent is a standalone service — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent.
+- **Embed into an existing product**: the agent is one capability inside a product you already have. `createPiAgent(...).invoke(...)` lives in your own route (Astro/Next/Hono endpoint), wired to *your* session store, *your* auth, *your* host. No second framework.
+- **Serve as a standalone agent service**: the agent runs while you are away — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent.
 
-FastAgent is **Flask/WSGI for agents**: a neutral `invoke` contract + injected ports (session/auth/env/lease) + a pi-based reference implementation + a deployment toolchain. Library, not framework — it composes into the user's stack instead of owning the application. The bigger, under-served entry is **agent-as-a-feature** (most teams add an agent to a product; few build an agent platform), and that is exactly the seam full frameworks (Flue, Eve) create friction in.
+FastAgent is **Flask/WSGI for agents**: a neutral `invoke` contract + injected ports (session/auth/env/lease) + a pi-based reference implementation + a deployment toolchain. Library, not framework — it composes into the user's stack **or** runs as a thin standalone service without owning the whole application. The bigger, under-served job is **agent-as-a-feature** (add an agent to a product or channel), not agent-as-a-platform (adopt a full framework to build the whole agent product).
 
 It is **not**:
 
@@ -46,7 +46,7 @@ The remaining code-first orchestration layers (LangGraph, Vercel AI SDK, Mastra,
 
 Because Flue already occupies "markdown-native + neutral + deploy-anywhere full framework," the open gap narrows to:
 
-> **embedding** an existing agent definition as one capability inside a product's own stack — no second framework, no imposed routing/db/project layout, a transport-neutral contract you call from your own route.
+> serving an existing agent definition as one capability — either embedded inside a product's own stack or deployed as a thin standalone service/channel — with no second framework, no imposed routing/db/project layout, and a transport-neutral contract underneath.
 
 ACP and A2A are important standards, but they sit next to this gap:
 
@@ -63,13 +63,13 @@ The moat is not code volume (the engine is pi, which Flue also uses). The durabl
 3. stateless multi-session execution that can move across hosts;
 4. target adapters that encode hard runtime differences.
 
-**Proof point (primary): embed in an Astro/Next route** — one endpoint, injected session/auth, one deploy unit (see [comparisons](comparisons.md)). **Proof point (deploy): AgentCore** — an `AGENTS.md` + `skills/` folder deployed with external session state proves the stateless design.
+**Proof points:** embed in an Astro/Next route — one endpoint, injected session/auth, one deploy unit (see [comparisons](comparisons.md)); and deploy to AgentCore — an `AGENTS.md` + `skills/` folder running as a standalone service with external session state. Both prove the same thing: a small serving contract can either compose into an app or run as its own service.
 
 **Direction (a bet, not yet built): the composability flywheel.** Because each port is a small, stable interface with a conformance suite, writing an adapter for a long-tail stack (your Postgres/Supabase/Convex session store, your auth) becomes an AI-fillable, self-verifiable task. The growth model is not "official builds every N×M×K cell" (unwinnable vs a funded team) but "anyone fills their own cell with an AI agent, and conformance proves it correct." This requires per-port conformance suites + seed adapters + a light registry — not yet built; treat as the intended lever, not a current capability.
 
 ## Threats
 
-1. **Flue (the head-on threat).** Same engine (pi), also neutral/open, markdown-native, AI-first DX, funded Astro team, 1.0 beta. FastAgent cannot win on framework breadth or neutrality (Flue has both). It can only win on **posture**: library-not-framework, embed-not-deploy, no imposed structure. If Flue ships a "point at a folder" mode, even the zero-rewrite delta narrows — the defensible line is then purely embed-vs-own-the-app.
+1. **Flue (the head-on threat).** Same engine (pi), also neutral/open, markdown-native, AI-first DX, funded Astro team, 1.0 beta. FastAgent cannot win on framework breadth or neutrality (Flue has both). It can only win on **posture**: library-not-framework, compose-or-serve without owning the app, no imposed structure. If Flue ships a "point at a folder" mode, even the zero-rewrite delta narrows — the defensible line is then thin serving layer vs full framework ownership.
 2. **Vibe-coding consumer-side headwind.** When AI selects a framework for a new project, batteries-included (Flue/Eve) generates more deterministically than composition (every injected choice is a decision the AI can get wrong). FastAgent should not fight in the "recommend a framework" lane; its AI-distribution bet is the "embed into the folder/stack I already have" trigger, which originates inside the coding agent — and requires AI-first docs (llms.txt / paste-into-agent) plus a zero-decision default path, both currently missing.
 3. **Thin-layer perception.** Users may ask why this is more than “pi plus a few scripts.” The answer is visceral DX: embed one endpoint into your product, or point at a folder and get a running service.
 4. **Platform absorption.** Claude Agent SDK hosting and OpenCode serve show platforms will absorb “run my agent as a service.” FastAgent wins only if neutrality across engines/models/hosts matters enough.
@@ -81,7 +81,7 @@ The moat is not code volume (the engine is pi, which Flue also uses). The durabl
 |---|---|
 | Do not compete with OpenClaw on channels/product UX | FastAgent is a layer for building OpenClaw-like products, not the product itself |
 | Do not become a code-first SDK | The wedge is “your folder is the agent” |
-| Do not become a full framework (own routing/db/project layout) | The wedge is **embed-into-your-stack**, not own-the-app — that is Flue/Eve's lane. Stay library, not framework |
+| Do not become a full framework (own routing/db/project layout) | The wedge is **compose into your stack or serve this folder**, not own-the-app — that is Flue/Eve's lane. Stay library/thin service, not framework |
 | Do not invent a parallel agent definition format | Consume `AGENTS.md`, Agent Skills, and MCP rather than competing with them |
 | Do not own Task orchestration in core | A2A Tasks/workflows belong above the Agent Handler contract |
 | Do not rebuild the harness engine | pi owns the turn loop; FastAgent serves and deploys it |
@@ -89,4 +89,4 @@ The moat is not code volume (the engine is pi, which Flue also uses). The durabl
 
 ## One-line summary
 
-FastAgent bets that the bigger, under-served job is **embedding** an agent as a feature into a product the user already owns — a Flask/WSGI-like neutral contract + injected ports, small enough to drop into any route, composable enough that “add an agent to my stack, or deploy this folder anywhere” feels like the default path — without adopting a second framework or annexing the user's architecture.
+FastAgent bets that the bigger, under-served job is turning an existing agent folder into an **agent feature** — a Flask/WSGI-like neutral contract + injected ports, small enough to drop into any route, deployable enough to run as Slack/webhook/API infrastructure, and composable enough that “add an agent to my stack, or deploy this folder anywhere” feels like the default path — without adopting a second framework or annexing the user's architecture.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -2,16 +2,19 @@
 title: fastagent — Positioning
 type: product-positioning
 status: design
-updated: 2026-06-11
+updated: 2026-06-18
 ---
 
 # fastagent positioning
 
 ## North star
 
-You already have an agent: a folder with `AGENTS.md`, `skills/`, and standard markdown assets. FastAgent should let you point at that folder and turn it into a production service — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent — without rewriting the agent.
+You already have an agent: a folder with `AGENTS.md`, `skills/`, and standard markdown assets. FastAgent turns it into a running capability **without rewriting it**, in either of two modes:
 
-FastAgent is WSGI for agent serving: a neutral `invoke` contract plus a pi-based reference implementation plus a deployment toolchain.
+- **Embed** (primary, under-served): the agent is one capability inside a product you already have. `createPiAgent(...).invoke(...)` lives in your own route (Astro/Next/Hono endpoint), wired to *your* session store, *your* auth, *your* host. No second framework.
+- **Deploy** (secondary): the agent is a standalone service — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent.
+
+FastAgent is **Flask/WSGI for agents**: a neutral `invoke` contract + injected ports (session/auth/env/lease) + a pi-based reference implementation + a deployment toolchain. Library, not framework — it composes into the user's stack instead of owning the application. The bigger, under-served entry is **agent-as-a-feature** (most teams add an agent to a product; few build an agent platform), and that is exactly the seam full frameworks (Flue, Eve) create friction in.
 
 It is **not**:
 
@@ -22,25 +25,28 @@ It is **not**:
 
 ## Primary user wedge
 
-The sharpest user segment is the developer or power user who already has useful agent definition folders and wants them to run when they are not present.
+The sharpest segment is someone who **already has a stack** (their own auth/DB/host) and wants to add an agent **feature** without adopting a second framework. In the vibe-coding era this is no longer enterprise-only — every solo dev has an AI-assembled stack (Supabase + Clerk + Next/Astro + Vercel), so "has a stack, wants to embed" is the default state.
 
 | Segment | Fit | Risk |
 |---|---|---|
-| Individual/power user with useful local agent definitions | Highest fit: markdown-native, zero rewrite | Deployment need may be shallower than the number of people creating agent folders |
-| Teams building agents into products | Real need, budget, infra expectations | They can write code and may prefer SDKs/frameworks |
-| Indie hackers building agent products | Strong deployment/DX need | Directly overlaps more with code-first frameworks such as Flue |
+| **Vibe-coded product needing an agent feature** (esp. TS/Astro/Next, existing stack) | **Highest fit**: embed one endpoint, inject existing session/auth, one deploy unit | Heavy agent needs (long autonomy/swarm/sandbox) tilt back to Flue's batteries-included path |
+| Individual/power user with useful local agent definitions | High fit: markdown-native, zero rewrite | Standalone-deploy need may be shallower than the number of people creating folders |
+| Teams building an agent *product/platform* | Real need, budget | This is Flue/Eve's home turf; FastAgent should not chase it |
 
-The story must focus on the moment where local tooling breaks: “I need this agent to act while I am away.” Generic “productionize your agent” is weaker.
+The story must focus on **"add an agent to the product I already have, on the stack I already chose"** (embed) and **"make this agent act while I am away"** (deploy). Generic “productionize your agent” is weaker, and “build an agent platform” is the wrong fight.
 
 ## Market read
 
-Most agent frameworks are code-first orchestration layers: LangGraph, Vercel AI SDK, Mastra, CrewAI, OpenAI Agents SDK, Cloudflare Agents, and similar systems.
+Two product shapes now own the markdown-native agent space:
 
-Most “agent serving” offerings are owned by infrastructure or platform vendors and naturally pull users into that platform.
+- **Eve** (Vercel): a vertically-integrated platform, batteries-included, locked to Vercel.
+- **Flue** (Astro team): an open full-framework **on the same pi engine FastAgent uses** — markdown-native, neutral (any model/sandbox/deploy), AI-first. Flue is the most direct competitor; it is **not** a code-first workflow tool (an earlier read was wrong). See [comparisons](comparisons.md).
 
-The open gap is:
+The remaining code-first orchestration layers (LangGraph, Vercel AI SDK, Mastra, CrewAI, OpenAI Agents SDK, Cloudflare Agents) sit in a different lane: you script the agent, you don't point at a folder.
 
-> markdown-native + engine-neutral + target-neutral serving for existing agent definitions.
+Because Flue already occupies "markdown-native + neutral + deploy-anywhere full framework," the open gap narrows to:
+
+> **embedding** an existing agent definition as one capability inside a product's own stack — no second framework, no imposed routing/db/project layout, a transport-neutral contract you call from your own route.
 
 ACP and A2A are important standards, but they sit next to this gap:
 
@@ -50,20 +56,24 @@ ACP and A2A are important standards, but they sit next to this gap:
 
 ## Competitive moat
 
-The moat is not code volume. The engine is pi. The durable value is:
+The moat is not code volume (the engine is pi, which Flue also uses). The durable value:
 
-1. a small, engine-neutral serving contract,
-2. stateless multi-session execution that can move across hosts,
-3. target adapters that encode hard runtime differences,
-4. deployment DX good enough to feel obvious.
+1. a small, **transport-neutral** serving contract (`invoke`) with no bundled HTTP framework — so it embeds into the host's own route (Astro/Next/Hono/Lambda), where a full framework would impose its world;
+2. **composability over batteries** (Flask, lib-not-framework): K-axis ports (session/auth/env/lease) injected, so the user wires *their* stack instead of adopting ours — the value the "already has a stack" segment actually wants;
+3. stateless multi-session execution that can move across hosts;
+4. target adapters that encode hard runtime differences.
 
-The technical proof point is AgentCore: if an existing `AGENTS.md` + `skills/` folder can be deployed to AgentCore and handle one invocation with external session state, the stateless design is real.
+**Proof point (primary): embed in an Astro/Next route** — one endpoint, injected session/auth, one deploy unit (see [comparisons](comparisons.md)). **Proof point (deploy): AgentCore** — an `AGENTS.md` + `skills/` folder deployed with external session state proves the stateless design.
+
+**Direction (a bet, not yet built): the composability flywheel.** Because each port is a small, stable interface with a conformance suite, writing an adapter for a long-tail stack (your Postgres/Supabase/Convex session store, your auth) becomes an AI-fillable, self-verifiable task. The growth model is not "official builds every N×M×K cell" (unwinnable vs a funded team) but "anyone fills their own cell with an AI agent, and conformance proves it correct." This requires per-port conformance suites + seed adapters + a light registry — not yet built; treat as the intended lever, not a current capability.
 
 ## Threats
 
-1. **Thin-layer perception.** Users may ask why this is more than “pi plus a few scripts.” The answer must be visceral DX: point at a folder, get a running service.
-2. **Platform absorption.** Claude Agent SDK hosting and OpenCode serve already show that platforms will absorb “run my agent as a service.” FastAgent wins only if its neutrality across engines/models/hosts matters enough.
-3. **Standards fragmentation.** FastAgent consumes standards rather than inventing new ones, but the ecosystem may still fragment across several incompatible standards.
+1. **Flue (the head-on threat).** Same engine (pi), also neutral/open, markdown-native, AI-first DX, funded Astro team, 1.0 beta. FastAgent cannot win on framework breadth or neutrality (Flue has both). It can only win on **posture**: library-not-framework, embed-not-deploy, no imposed structure. If Flue ships a "point at a folder" mode, even the zero-rewrite delta narrows — the defensible line is then purely embed-vs-own-the-app.
+2. **Vibe-coding consumer-side headwind.** When AI selects a framework for a new project, batteries-included (Flue/Eve) generates more deterministically than composition (every injected choice is a decision the AI can get wrong). FastAgent should not fight in the "recommend a framework" lane; its AI-distribution bet is the "embed into the folder/stack I already have" trigger, which originates inside the coding agent — and requires AI-first docs (llms.txt / paste-into-agent) plus a zero-decision default path, both currently missing.
+3. **Thin-layer perception.** Users may ask why this is more than “pi plus a few scripts.” The answer is visceral DX: embed one endpoint into your product, or point at a folder and get a running service.
+4. **Platform absorption.** Claude Agent SDK hosting and OpenCode serve show platforms will absorb “run my agent as a service.” FastAgent wins only if neutrality across engines/models/hosts matters enough.
+5. **Standards fragmentation.** FastAgent consumes standards rather than inventing them, but the ecosystem may still fragment.
 
 ## Boundaries
 
@@ -71,6 +81,7 @@ The technical proof point is AgentCore: if an existing `AGENTS.md` + `skills/` f
 |---|---|
 | Do not compete with OpenClaw on channels/product UX | FastAgent is a layer for building OpenClaw-like products, not the product itself |
 | Do not become a code-first SDK | The wedge is “your folder is the agent” |
+| Do not become a full framework (own routing/db/project layout) | The wedge is **embed-into-your-stack**, not own-the-app — that is Flue/Eve's lane. Stay library, not framework |
 | Do not invent a parallel agent definition format | Consume `AGENTS.md`, Agent Skills, and MCP rather than competing with them |
 | Do not own Task orchestration in core | A2A Tasks/workflows belong above the Agent Handler contract |
 | Do not rebuild the harness engine | pi owns the turn loop; FastAgent serves and deploys it |
@@ -78,4 +89,4 @@ The technical proof point is AgentCore: if an existing `AGENTS.md` + `skills/` f
 
 ## One-line summary
 
-FastAgent bets that agent serving needs a WSGI-like neutral layer: small enough to implement everywhere, useful enough to make “deploy this existing agent folder anywhere” feel like the default path.
+FastAgent bets that the bigger, under-served job is **embedding** an agent as a feature into a product the user already owns — a Flask/WSGI-like neutral contract + injected ports, small enough to drop into any route, composable enough that “add an agent to my stack, or deploy this folder anywhere” feels like the default path — without adopting a second framework or annexing the user's architecture.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -63,7 +63,9 @@ The moat is not code volume (the engine is pi, which Flue also uses). The durabl
 3. stateless multi-session execution that can move across hosts;
 4. target adapters that encode hard runtime differences.
 
-**Proof points:** embed in an Astro/Next route — one endpoint, injected session/auth, one deploy unit (see [comparisons](comparisons.md)); and deploy to AgentCore — an `AGENTS.md` + `skills/` folder running as a standalone service with external session state. Both prove the same thing: a small serving contract can either compose into an app or run as its own service.
+**Proof points today:** embed in an Astro/Next route — one endpoint, injected session/auth, one deploy unit (see [comparisons](comparisons.md)); and `build`/`start` — an `AGENTS.md` + `skills/` folder running as a standalone service with sessions outside the artifact. Both prove the same thing: a small serving contract can either compose into an app or run as its own service.
+
+**Planned target proof:** AgentCore — same artifact shape, external sessions, and distributed locking — remains target-adapter work, not a current capability.
 
 **Direction (a bet, not yet built): the composability flywheel.** Because each port is a small, stable interface with a conformance suite, writing an adapter for a long-tail stack (your Postgres/Supabase/Convex session store, your auth) becomes an AI-fillable, self-verifiable task. The growth model is not "official builds every N×M×K cell" (unwinnable vs a funded team) but "anyone fills their own cell with an AI agent, and conformance proves it correct." This requires per-port conformance suites + seed adapters + a light registry — not yet built; treat as the intended lever, not a current capability.
 


### PR DESCRIPTION
Folds this cycle's strategic turn into the three positioning docs, and fixes a factual error about Flue.

**comparisons.md**: Flue is NOT code-first — it is an open full-framework on the same pi engine, the most direct competitor; neutrality/pi are no longer exclusive to FastAgent. Adds Eve (Vercel, absent before). Adds agent-as-a-feature vs agent-as-the-product framing + an Astro embed worked example.

**positioning.md**: frames FastAgent as two equally valid postures: embed into an existing product, or serve as a standalone agent service (Slack/webhook/schedule/API/cloud agent). Sharpens the moat to transport-neutral serving + composability (Flask, lib-not-framework/thin service); adds Flue and the vibe-coding consumer-side headwind as primary threats; records the composability/conformance flywheel as a direction, not a current capability; new boundary 'do not become a full framework'.

**fastagent.md**: adds the embed/service feature angle to overview and trigger moments.

Docs only (self-merge tier). Hypothesis-level claims (conformance flywheel, market size) are explicitly marked as bets, not built capabilities.