### PR TITLE
feat(init): scaffold .env.example documenting optional env knobs

### DIFF
--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -15,6 +15,9 @@
  *   - tools/ is auto-discovered (filename = tool name), so the config needs no `tools: []`.
  *   - .gitignore lists `.env` so the "secrets are the user's responsibility" model
  *     (core-design §10.1) is wired up from the first commit (build honors .gitignore).
+ *   - .env.example documents the (optional) env knobs and is committable (only `.env` is ignored);
+ *     it is all-commented and states the default model uses OAuth (`pi login`), not an API key, so
+ *     it never implies a key is required.
  *
  * Node composition-root module: writes template files (the CLI handles `npm install`).
  *
@@ -91,6 +94,29 @@ node_modules/
 .fastagent/
 `;
 
+// All-commented: copying to .env sets nothing by accident, and every knob is optional. Auth leads
+// with `pi login` because the default model (openai-codex) is OAuth-only — never imply an API key.
+const ENV_EXAMPLE = `# Environment for this agent. Copy to .env (gitignored) and uncomment what you need.
+# Everything here is OPTIONAL — the defaults work without a .env.
+
+# --- Model auth ---
+# The default model (openai-codex) signs in with OAuth, not an API key: run \`pi login\` once.
+# Switch to an API-key provider? Set its key here — the variable name is provider-specific
+# (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY). Run \`fastagent models\` to see available specs.
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+
+# --- Model selection (overrides fastagent.config) ---
+# Precedence: --model flag > FASTAGENT_MODEL > config.
+# FASTAGENT_MODEL=openai-codex/gpt-5.5
+
+# --- Serving (fastagent start) ---
+# Port precedence: --port > PORT > config.http.port > 8787
+# PORT=8787
+# Where conversations persist (default: ./fastagent-sessions)
+# FASTAGENT_SESSIONS_DIR=./fastagent-sessions
+`;
+
 /** package.json for the complete (code-tool) agent: ESM + the deps a defineTool tool imports. */
 function packageJson(name: string): string {
   return `${JSON.stringify(
@@ -155,6 +181,7 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
     { rel: join("skills", "house-style", "SKILL.md"), content: SKILL_MD },
     { rel: "fastagent.config.mjs", content: CONFIG_MJS },
     { rel: ".gitignore", content: GITIGNORE },
+    { rel: ".env.example", content: ENV_EXAMPLE },
   ];
   if (!minimal) {
     files.push(

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -39,9 +39,19 @@ describe("init: scaffoldWorkspace", () => {
         "package.json",
         ".npmrc",
         ".gitignore",
+        ".env.example",
       ]),
     );
     expect(warnings).toEqual([]);
+
+    // .env.example documents env knobs without misleading: all-commented (sets nothing), and it
+    // states the default model uses OAuth (`pi login`), never implying an API key is required.
+    const envExample = await readFile(join(dir, ".env.example"), "utf8");
+    expect(envExample).toMatch(/pi login/);
+    expect(envExample).toMatch(/OAuth, not an API key/);
+    for (const line of envExample.split("\n")) {
+      if (line.trim() !== "") expect(line.startsWith("#")).toBe(true); // every non-blank line is a comment
+    }
 
     // package.json is ESM with the tool's deps; the tool imports the package + names from its file.
     const pkg = JSON.parse(await readFile(join(dir, "package.json"), "utf8"));
@@ -62,7 +72,7 @@ describe("init: scaffoldWorkspace", () => {
     const { complete, created } = await scaffoldWorkspace(dir, { minimal: true });
     expect(complete).toBe(false);
     expect(created.sort()).toEqual(
-      ["AGENTS.md", ".gitignore", "fastagent.config.mjs", join("skills", "house-style", "SKILL.md")].sort(),
+      ["AGENTS.md", ".gitignore", ".env.example", "fastagent.config.mjs", join("skills", "house-style", "SKILL.md")].sort(),
     );
     expect(await exists(join(dir, "package.json"))).toBe(false);
     expect(await exists(join(dir, "tools"))).toBe(false);

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,6 +30,7 @@ my-agent/
 ├── tools/word-count.ts          # a code tool (defineTool) — auto-discovered
 ├── fastagent.config.mjs         # deployment choices: model, http port
 ├── package.json                 # ESM + the @kid7st/fastagent + zod deps
+├── .env.example                 # optional env knobs (model/keys/port) — copy to .env
 └── .gitignore / .npmrc
 ```
 


### PR DESCRIPTION
Adds a committable, all-commented `.env.example` to `fastagent init` (only `.env` is gitignored).

It documents the optional env knobs (`FASTAGENT_MODEL`, provider API keys, `PORT`, `FASTAGENT_SESSIONS_DIR`) **without misleading**: the default model `openai-codex` is OAuth-only, so auth leads with `pi login`, and the file never implies an API key is required. Every line is a comment, so copying to `.env` sets nothing by accident.

- Added to both the complete and `--minimal` scaffolds.
- Tests: file created in both variants, all-commented, states the OAuth-not-a-key default.
- Quickstart scaffold tree updated.

No public API surface / contract / SPEC change (`scaffoldWorkspace` signature unchanged).
