### PR TITLE
fix(build): set explicit rootDir for TS6 compatibility

### DIFF
--- a/core/tsconfig.build.json
+++ b/core/tsconfig.build.json
@@ -8,7 +8,8 @@
     "noEmit": false,
     "rewriteRelativeImportExtensions": true,
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
TypeScript 6 makes the inferred common source directory a hard error (TS5011) on emit, so `npm run build` fails under TS6 while `tsc --noEmit` and tests still pass. CI does not run the build, so this would land silently and only surface at `prepack`/publish.

`rootDir: "src"` is the value TS already inferred — a no-op under TS5, forward-compatible with TS6. Verified `npm run build` exits 0 and emits dist/ under both TS 5.9.3 and TS 6.0.3.

Unblocks the TS6 bump in #31.
