### PR TITLE
fix: lower package runtime floor to Node 22.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,12 @@ permissions:
 
 jobs:
   core:
-    name: Core checks
+    name: Core checks (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22.19.0', '24', '26']
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -19,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '26'
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: core/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  core:
-    name: Core checks (Node ${{ matrix.node-version }})
+  test:
+    name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,3 +38,15 @@ jobs:
       - name: Test
         run: npm test
         working-directory: core
+
+  # Stable-named aggregate gate: this is the branch-protection required check.
+  # Keeping a fixed name (independent of the matrix) means adding/removing Node
+  # versions never requires editing branch protection.
+  core-checks:
+    name: Core checks
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all matrix jobs to pass
+        run: '[ "${{ needs.test.result }}" = "success" ]'

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ This repository is a from-scratch implementation of the locked [Agent Handler SP
 
 (A per-project `.npmrc` is only read when you run npm from within that project, and a global `npm i -g` is usually run from elsewhere — so the user config is the reliable place. If you commit a project `.npmrc`, keep only the registry line there and supply the token via env / `~/.npmrc`; never commit the token.)
 
-Then install (requires Node ≥ 26):
+Then install (requires Node ≥ 22.19):
 
 ```bash
 npm i -g @kid7st/fastagent   # the `fastagent` CLI on PATH
 npm i @kid7st/fastagent      # the library (defineConfig, the Agent contract, …) for code-tool agents
 ```
 
-The package ships compiled JavaScript + type declarations (`dist/`); the repository itself runs the TypeScript sources directly under Node 26.
+The package ships compiled JavaScript + type declarations (`dist/`). The runtime floor follows pi's packages (`node >=22.19.0`); no build step is required in consuming projects.
 
 **New here? Start with the [Quickstart](docs/quickstart.md)** — from an installed CLI to a running, deployable agent in a few minutes.
 

--- a/core/examples/local.ts
+++ b/core/examples/local.ts
@@ -5,7 +5,7 @@
  * handled by createPiAgent's defaults (dev batteries-included); this file only owns
  * two **application-level** concerns: the process-level proxy and which model to use.
  *
- * Run (Node 26 executes .ts natively):
+ * Run (Node >=22.19 executes .ts natively):
  *   node examples/local.ts "say hi in 3 words"   # one-shot
  *   node examples/local.ts                        # REPL; same session keeps memory; /exit to quit
  *   node examples/local.ts --busy-demo            # concurrent same-session → one runs, one "session busy"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -25,7 +25,7 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": ">=26"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/core/package.json
+++ b/core/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=26"
+    "node": ">=22.19.0"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/core/tsconfig.build.json
+++ b/core/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  // Publish build only (dev still runs the .ts sources directly via Node 26). Emits .js + .d.ts
+  // Publish build only. Emits .js + .d.ts
   // to dist/, which is what the package ships — Node refuses to type-strip .ts under node_modules,
   // so consumers must receive compiled JavaScript. rewriteRelativeImportExtensions rewrites the
   // source's explicit `./x.ts` import specifiers to `./x.js` in the output.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ From an installed CLI to a running, deployable agent in a few minutes. Everythin
 
 ## Prerequisites
 
-- **Node ≥ 26** (`node -v`). The package ships compiled JavaScript; Node runs it directly, no build step on your side.
+- **Node ≥ 22.19** (`node -v`). The package ships compiled JavaScript; consuming projects do not need a build step for FastAgent itself.
 - **The `fastagent` CLI** — see [Install](../README.md#install): `npm i -g @kid7st/fastagent`, with the `@kid7st` scope registry + a GitHub token in your `~/.npmrc`.
 - **Model credentials** — either `pi login` (OAuth) or a provider API key in the workspace's `.env` (e.g. `OPENAI_API_KEY=…`). Run `fastagent models` to list the available `provider/modelId` specs.
 
@@ -94,7 +94,7 @@ fastagent build                  # → .fastagent/build : a self-contained, relo
 fastagent start .fastagent/build # run it in production posture
 ```
 
-`build` compiles the workspace (instructions + skills + tools + config) into an artifact whose manifest freezes the model and http port. `start` runs that artifact with sessions kept **outside** it (so a redeploy never wipes conversations). To deploy: copy the artifact directory anywhere with Node ≥ 26, run `npm ci`, then `fastagent start`.
+`build` compiles the workspace (instructions + skills + tools + config) into an artifact whose manifest freezes the model and http port. `start` runs that artifact with sessions kept **outside** it (so a redeploy never wipes conversations). To deploy: copy the artifact directory anywhere with Node ≥ 22.19, run `npm ci`, then `fastagent start`.
 
 ## Where next
 


### PR DESCRIPTION
FastAgent ships compiled JavaScript and pi's packages require Node >=22.19.0, so requiring Node 26 for consumers is unnecessarily restrictive for embed/service usage in existing apps and cloud hosts.

## Changes
- Set package `engines.node` to `>=22.19.0` and sync package-lock.
- Update README/quickstart/runtime docs from Node >=26 to Node >=22.19.
- Remove a stale build-config comment implying package consumers need Node 26.
- Align the local .ts example wording with the new floor.
- Run CI on Node 22.19, 24, and 26 so the declared runtime floor is enforced.

## Verification
Local (Node 26):
- `cd core && npm run build`
- `cd core && npm run typecheck`
- `cd core && npm test`

CI will validate the actual Node 22.19 floor.