### PR TITLE
refactor(http): make the invoke handler Fetch-shaped; add nodeListener bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Public surface tiers:
 
 | Tier | Examples | Stability |
 |---|---|---|
-| Contract | `Agent`, `AgentEvent`, `collect`, `createInvokeHandler` | Intended to remain stable within SPEC v0.1 |
+| Contract | `Agent`, `AgentEvent`, `collect` | Intended to remain stable within SPEC v0.1 |
+| Channels (reference) | `createInvokeHandler`, `nodeListener` | Reference HTTP/SSE channel, outside the SPEC contract (invoke is not a wire protocol). The handler is **Fetch-shaped** (`(Request) => Promise<Response>`); shape may still change pre-1.0 |
 | Pi assembly ladder | `createPiAgentFromWorkspace`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
 | Injection ports | `PiSessionStore`, `inMemorySessionStore`/`jsonlSessionStore`, `AuthResolver`, `Lease`, `piDefaultTools`/`piReadOnlyTools` | Public because the ladder options reference them |
 | Not exported | L0 `createPiAgentFromHarness`, `piHarnessFactory`, prompt/config assembly internals | Internal modules only; they expose pi's engine shape and are not a compatibility promise |

--- a/core/src/channels/http.ts
+++ b/core/src/channels/http.ts
@@ -1,85 +1,174 @@
 /**
- * Minimal HTTP channel handler (pure, testable): fans the single invoke stream out to SSE.
- *   - POST /invoke {session,text} → text/event-stream, one `data:` line per AgentEvent;
- *   - client disconnect → iterator.return() → invoke cancellation (SPEC MUST 3);
- *   - concurrent same-session requests → the agent's fail-fast lease (invoke.ts) makes
- *     the second one receive `failed{session busy}`.
+ * HTTP/SSE channel: fan one invoke stream out to Server-Sent Events.
+ *
+ * The handler is **Fetch-shaped** (`(Request) => Promise<Response>`) on purpose: that is the
+ * cross-runtime form every embedding host speaks (Next/Astro/Hono/Bun/Deno/Cloudflare), so the
+ * same handler mounts inside an existing app's own route. It is path-agnostic — the host owns the
+ * route; this handler only turns a POST body `{session,text}` into an SSE stream. Cancellation,
+ * backpressure, and the body cap are all native to the web stream primitives:
+ *   - consumer cancels the response body (client disconnect) → ReadableStream.cancel() →
+ *     iterator.return() → invoke cancellation (SPEC MUST 3);
+ *   - pull-based ReadableStream applies backpressure (next event is pulled when wanted);
+ *   - concurrent same-session requests → the agent's fail-fast lease (invoke.ts) makes the second
+ *     receive `failed{session busy}`.
+ *
+ * `nodeListener` is the thin node:http adapter (used by the standalone `fastagent dev/start`
+ * server). The SSE logic lives once in the Fetch handler; node:http is just transport.
  */
+import { Readable } from "node:stream";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Agent } from "../agent.ts";
 
 /** Request body cap — prompts are text (+ base64 images later); 1 MiB is generous for v1. */
 const MAX_BODY_BYTES = 1 << 20;
 
-/** Write honoring backpressure; waits for drain OR close (never hangs on a dead socket). */
-async function writeWithBackpressure(res: ServerResponse, chunk: string): Promise<void> {
-  if (res.destroyed) return; // connection already gone; caller's loop exits via done/destroyed check
-  if (res.write(chunk)) return;
-  await new Promise<void>((resolve) => {
-    const done = () => {
-      res.off("drain", done);
-      res.off("close", done);
-      resolve();
-    };
-    res.once("drain", done);
-    res.once("close", done);
-  });
+const encoder = new TextEncoder();
+const textHeaders = { "content-type": "text/plain" };
+
+function text(body: string, status: number): Response {
+  return new Response(body, { status, headers: textHeaders });
 }
 
-export function createInvokeHandler(agent: Agent) {
-  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
-    if (req.method !== "POST" || req.url !== "/invoke") {
-      res.writeHead(404, { "content-type": "text/plain" }).end("POST /invoke\n");
-      return;
+/** Read the request body with a hard byte cap (counts real bytes, not JS characters). */
+async function readBodyCapped(req: Request, max: number): Promise<{ text: string } | { tooLarge: true }> {
+  if (!req.body) return { text: "" };
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    if (received > max) {
+      await reader.cancel();
+      return { tooLarge: true };
     }
+    chunks.push(value);
+  }
+  const buf = new Uint8Array(received);
+  let offset = 0;
+  for (const c of chunks) {
+    buf.set(c, offset);
+    offset += c.byteLength;
+  }
+  return { text: new TextDecoder().decode(buf) };
+}
 
-    const chunks: Buffer[] = [];
-    let received = 0;
-    for await (const chunk of req) {
-      const buf = chunk as Buffer; // no setEncoding → chunks are Buffers; count real bytes
-      received += buf.length;
-      if (received > MAX_BODY_BYTES) {
-        res.writeHead(413, { "content-type": "text/plain" }).end("body too large\n");
-        return;
-      }
-      chunks.push(buf);
-    }
+/**
+ * Fetch-shaped invoke handler. Mount it at any route in the host app; it accepts POST only.
+ * Returns SSE (`text/event-stream`) with one `data:` line per AgentEvent.
+ */
+export function createInvokeHandler(agent: Agent): (req: Request) => Promise<Response> {
+  return async (req) => {
+    if (req.method !== "POST") return text("POST only\n", 405);
+
+    const body = await readBodyCapped(req, MAX_BODY_BYTES);
+    if ("tooLarge" in body) return text("body too large\n", 413);
+
     let payload: unknown;
     try {
-      payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      payload = JSON.parse(body.text);
     } catch {
-      res.writeHead(400, { "content-type": "text/plain" }).end("invalid json\n");
-      return;
+      return text("invalid json\n", 400);
     }
-    const { session, text } = (payload ?? {}) as { session?: unknown; text?: unknown };
-    if (typeof session !== "string" || typeof text !== "string") {
-      res.writeHead(400, { "content-type": "text/plain" }).end('need { "session": string, "text": string }\n');
-      return;
+    const { session, text: promptText } = (payload ?? {}) as { session?: unknown; text?: unknown };
+    if (typeof session !== "string" || typeof promptText !== "string") {
+      return text('need { "session": string, "text": string }\n', 400);
     }
 
-    res.writeHead(200, {
-      "content-type": "text/event-stream",
-      "cache-control": "no-cache",
-      connection: "keep-alive",
+    // Take the iterator explicitly so the stream's cancel() (consumer disconnect) can return() it
+    // and run invoke's cancellation cleanup (SPEC MUST 3). pull = backpressure: the next event is
+    // produced only when the consumer wants it.
+    const iterator = agent.invoke({ session }, { text: promptText })[Symbol.asyncIterator]();
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const { value, done } = await iterator.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(value)}\n\n`));
+      },
+      async cancel() {
+        await iterator.return?.();
+      },
     });
 
-    // Take the iterator explicitly: on client disconnect, return() it so invoke
-    // runs its cancellation cleanup (SPEC MUST 3). The signal must be the RESPONSE's
-    // "close" — req "close" fires when the request message ends (Node ≥15), i.e.
-    // right after the body is consumed, NOT on socket teardown; listening there
-    // either cancels every request or never fires (covered by the disconnect test).
-    // res "close" also fires after normal end — return() on a finished generator
-    // is a no-op, so no special-casing.
-    const iterator = agent.invoke({ session }, { text })[Symbol.asyncIterator]();
-    res.on("close", () => void iterator.return?.());
-    try {
-      while (true) {
-        const { value, done } = await iterator.next();
-        if (done || res.destroyed) break;
-        await writeWithBackpressure(res, `data: ${JSON.stringify(value)}\n\n`);
-      }
-    } finally {
-      res.end();
-    }
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
+    });
   };
+}
+
+/**
+ * node:http adapter for a Fetch handler. Bridges IncomingMessage → Request and pumps the
+ * Response body back to ServerResponse with backpressure; a client disconnect (`res` close)
+ * cancels both the request signal and the response stream (→ invoke cancellation).
+ */
+export function nodeListener(
+  handler: (req: Request) => Promise<Response>,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    void pump(handler, req, res);
+  };
+}
+
+async function pump(
+  handler: (req: Request) => Promise<Response>,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const controller = new AbortController();
+  res.on("close", () => controller.abort());
+
+  const method = req.method ?? "GET";
+  const hasBody = method !== "GET" && method !== "HEAD";
+  const headers = new Headers();
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (Array.isArray(v)) for (const vv of v) headers.append(k, vv);
+    else if (v != null) headers.set(k, v);
+  }
+
+  let response: Response;
+  try {
+    const request = new Request(`http://${req.headers.host ?? "localhost"}${req.url ?? "/"}`, {
+      method,
+      headers,
+      body: hasBody ? (Readable.toWeb(req) as unknown as ReadableStream<Uint8Array>) : undefined,
+      duplex: "half",
+      signal: controller.signal,
+    } as RequestInit & { duplex: "half" });
+    response = await handler(request);
+  } catch (error) {
+    if (!res.headersSent) res.writeHead(500, textHeaders);
+    res.end(`internal error: ${(error as Error).message}\n`);
+    return;
+  }
+
+  const outHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    outHeaders[key] = value;
+  });
+  res.writeHead(response.status, outHeaders);
+
+  if (!response.body) {
+    res.end();
+    return;
+  }
+  const reader = response.body.getReader();
+  res.on("close", () => void reader.cancel());
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done || res.destroyed) break;
+      if (!res.write(value)) await new Promise<void>((resolve) => res.once("drain", resolve));
+    }
+  } finally {
+    if (!res.destroyed) res.end();
+  }
 }

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -19,7 +19,7 @@ import { createServer } from "node:http";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
-import { createInvokeHandler } from "./channels/http.ts";
+import { createInvokeHandler, nodeListener } from "./channels/http.ts";
 import { probeAuthSource } from "./engines/pi/auth.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
 import { listModels, loadConfig } from "./engines/pi/config.ts";
@@ -454,7 +454,18 @@ async function runStart(): Promise<void> {
  * problem, not a bug, so it exits like {@link failStartup} rather than crashing unhandled.
  */
 function serve(agent: Parameters<typeof createInvokeHandler>[0], port: number): void {
-  const server = createServer(createInvokeHandler(agent));
+  // Standalone routing lives in the composition root: only POST /invoke is the agent endpoint;
+  // any other path is a clear 404. The Fetch handler itself stays path-agnostic (the embed case
+  // mounts it at the host's own route).
+  const handler = createInvokeHandler(agent);
+  const server = createServer(
+    nodeListener(async (req) => {
+      if (new URL(req.url).pathname !== "/invoke") {
+        return new Response("POST /invoke\n", { status: 404, headers: { "content-type": "text/plain" } });
+      }
+      return handler(req);
+    }),
+  );
   server.on("error", (error: NodeJS.ErrnoException) => {
     if (error.code === "EADDRINUSE") console.error(`port ${port} is already in use; choose another with --port`);
     else console.error(`cannot bind http channel on :${port}: ${error.message}`);

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -12,7 +12,9 @@ export type { Agent, AgentEvent, ImageRef, Json, Prompt, Scope } from "./agent.t
 export { collect, AgentFailure, type CollectResult } from "./collect.ts";
 
 // Channels (N-side; consume only the Agent contract)
-export { createInvokeHandler } from "./channels/http.ts";
+// createInvokeHandler is Fetch-shaped ((Request) => Promise<Response>) so it mounts in any host
+// route; nodeListener bridges it onto node:http for the standalone server.
+export { createInvokeHandler, nodeListener } from "./channels/http.ts";
 
 // pi reference implementation — reusable assembly ladder (L1/L2; L0 below)
 export {

--- a/core/test/http.test.ts
+++ b/core/test/http.test.ts
@@ -2,19 +2,15 @@ import { describe, expect, it } from "vitest";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
-import {
-  fauxAssistantMessage,
-  registerFauxProvider,
-  type FauxResponseStep,
-} from "@earendil-works/pi-ai";
-import { createInvokeHandler, inMemorySessionStore, type Agent, type AgentEvent } from "../src/index.ts";
+import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
+import { createInvokeHandler, nodeListener, inMemorySessionStore, type Agent, type AgentEvent } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 
-async function startServer(responses: FauxResponseStep[]) {
+function makeAgent(responses: FauxResponseStep[]): Agent {
   const faux = registerFauxProvider();
   faux.setResponses(responses);
-  const agent = createPiAgentFromHarness({
+  return createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
       sessions: inMemorySessionStore(),
       env: new NodeExecutionEnv({ cwd: process.cwd() }),
@@ -22,21 +18,12 @@ async function startServer(responses: FauxResponseStep[]) {
       systemPrompt: "test",
     }),
   });
-  const server = createServer(createInvokeHandler(agent));
-  await new Promise<void>((r) => server.listen(0, r));
-  const port = (server.address() as AddressInfo).port;
-  return {
-    url: `http://localhost:${port}`,
-    async close() {
-      server.closeAllConnections();
-      await new Promise<void>((r) => server.close(() => r()));
-    },
-  };
 }
 
-/** POST /invoke and parse SSE lines into AgentEvent[]. */
-async function invoke(url: string, session: string, text: string): Promise<AgentEvent[]> {
-  const res = await fetch(`${url}/invoke`, { method: "POST", body: JSON.stringify({ session, text }) });
+/** Drive the Fetch handler directly (no server) and parse SSE lines into AgentEvent[]. */
+async function invoke(handler: (req: Request) => Promise<Response>, session: string, text: string): Promise<AgentEvent[]> {
+  const res = await handler(new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session, text }) }));
+  expect(res.headers.get("content-type")).toBe("text/event-stream");
   const body = await res.text();
   return body
     .split("\n\n")
@@ -44,37 +31,35 @@ async function invoke(url: string, session: string, text: string): Promise<Agent
     .map((b) => JSON.parse(b.slice("data: ".length)) as AgentEvent);
 }
 
-describe("http channel (SSE)", () => {
-  it("POST /invoke streams text + completed over SSE", async () => {
-    const srv = await startServer([fauxAssistantMessage("hello over http")]);
-    try {
-      const events = await invoke(srv.url, "s1", "hi");
-      const text = events.filter((e) => e.type === "text").map((e) => (e as any).delta).join("");
-      expect(text).toBe("hello over http");
-      expect(events.at(-1)).toEqual({ type: "completed" });
-    } finally {
-      await srv.close();
-    }
+describe("invoke handler (Fetch/SSE)", () => {
+  it("POST streams text + completed over SSE", async () => {
+    const handler = createInvokeHandler(makeAgent([fauxAssistantMessage("hello over http")]));
+    const events = await invoke(handler, "s1", "hi");
+    const text = events.filter((e) => e.type === "text").map((e) => (e as any).delta).join("");
+    expect(text).toBe("hello over http");
+    expect(events.at(-1)).toEqual({ type: "completed" });
   });
 
-  it("same-session concurrency: one stream completes, the other receives failed 'session busy' over SSE", async () => {
+  it("same-session concurrency: one stream completes, the other receives failed 'session busy'", async () => {
     let started!: () => void;
     const ready = new Promise<void>((r) => (started = r));
     let release!: () => void;
     const gate = new Promise<void>((r) => (release = r));
 
-    const srv = await startServer([
-      async () => {
-        started(); // first turn has entered (lease held)
-        await gate; // park here, stay in flight
-        return fauxAssistantMessage("first");
-      },
-      fauxAssistantMessage("second"),
-    ]);
+    const handler = createInvokeHandler(
+      makeAgent([
+        async () => {
+          started();
+          await gate;
+          return fauxAssistantMessage("first");
+        },
+        fauxAssistantMessage("second"),
+      ]),
+    );
     try {
-      const p1 = invoke(srv.url, "same", "a");
-      await ready; // make sure req1 holds the lease
-      const e2 = await invoke(srv.url, "same", "b"); // must be busy at this point
+      const p1 = invoke(handler, "same", "a");
+      await ready; // req1 holds the lease
+      const e2 = await invoke(handler, "same", "b"); // must be busy now
 
       expect(e2).toHaveLength(1);
       expect(e2[0]).toMatchObject({ type: "failed", retryable: true });
@@ -84,41 +69,45 @@ describe("http channel (SSE)", () => {
       const e1 = await p1;
       expect(e1.at(-1)?.type).toBe("completed");
     } finally {
-      release(); // avoid leaking the gate
-      await srv.close();
+      release();
     }
   });
 
   it("different-session concurrency: both complete", async () => {
-    const srv = await startServer([fauxAssistantMessage("A"), fauxAssistantMessage("B")]);
-    try {
-      const [ea, eb] = await Promise.all([invoke(srv.url, "a", "x"), invoke(srv.url, "b", "y")]);
-      expect(ea.at(-1)?.type).toBe("completed");
-      expect(eb.at(-1)?.type).toBe("completed");
-    } finally {
-      await srv.close();
-    }
+    const handler = createInvokeHandler(makeAgent([fauxAssistantMessage("A"), fauxAssistantMessage("B")]));
+    const [ea, eb] = await Promise.all([invoke(handler, "a", "x"), invoke(handler, "b", "y")]);
+    expect(ea.at(-1)?.type).toBe("completed");
+    expect(eb.at(-1)?.type).toBe("completed");
   });
 
-  it("bad request returns 400; wrong path returns 404", async () => {
-    const srv = await startServer([fauxAssistantMessage("x")]);
-    try {
-      const bad = await fetch(`${srv.url}/invoke`, { method: "POST", body: "{not json" });
-      expect(bad.status).toBe(400);
-      const missing = await fetch(`${srv.url}/invoke`, { method: "POST", body: JSON.stringify({ session: "s" }) });
-      expect(missing.status).toBe(400);
-      const notfound = await fetch(`${srv.url}/other`);
-      expect(notfound.status).toBe(404);
-    } finally {
-      await srv.close();
-    }
+  it("non-POST returns 405; bad/missing body returns 400", async () => {
+    const handler = createInvokeHandler(makeAgent([fauxAssistantMessage("x")]));
+    expect((await handler(new Request("http://app/invoke", { method: "GET" }))).status).toBe(405);
+    expect(
+      (await handler(new Request("http://app/invoke", { method: "POST", body: "{not json" }))).status,
+    ).toBe(400);
+    expect(
+      (await handler(new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s" }) }))).status,
+    ).toBe(400);
   });
 
-  it("client disconnect cancels invoke (generator cleanup runs, SPEC MUST 3)", async () => {
+  it("oversized body returns 413 before invoke and counts real bytes, not JS characters", async () => {
+    const handler = createInvokeHandler(makeAgent([fauxAssistantMessage("x")]));
+    const big = await handler(
+      new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s", text: "x".repeat(2 * 1024 * 1024) }) }),
+    );
+    expect(big.status).toBe(413);
+    // 400k emoji = 400k chars but > 1 MiB in bytes → must be rejected
+    const multibyte = await handler(
+      new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s", text: "🙂".repeat(400_000) }) }),
+    );
+    expect(multibyte.status).toBe(413);
+  });
+
+  it("consumer cancel runs invoke cleanup (SPEC MUST 3)", async () => {
     let cancelled = false;
     let resolveCancelled!: () => void;
     const cancelledSeen = new Promise<void>((r) => (resolveCancelled = r));
-    // Fake agent: slowly streams text; if cancelled before natural completion, finally records evidence
     const fake: Agent = {
       invoke: async function* () {
         let finished = false;
@@ -137,7 +126,86 @@ describe("http channel (SSE)", () => {
         }
       },
     };
-    const server = createServer(createInvokeHandler(fake));
+    const handler = createInvokeHandler(fake);
+    const res = await handler(new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s", text: "hi" }) }));
+    const reader = res.body!.getReader();
+    await reader.read(); // stream has started
+    await reader.cancel(); // consumer disconnects
+    await Promise.race([
+      cancelledSeen,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("invoke was never cancelled after cancel")), 3000)),
+    ]);
+    expect(cancelled).toBe(true);
+  });
+});
+
+describe("nodeListener (standalone server bridge)", () => {
+  async function startServer(agent: Agent) {
+    const handler = createInvokeHandler(agent);
+    // Mirror cli.ts serve(): standalone routing lives in the composition root.
+    const server = createServer(
+      nodeListener(async (req) => {
+        if (new URL(req.url).pathname !== "/invoke") {
+          return new Response("POST /invoke\n", { status: 404, headers: { "content-type": "text/plain" } });
+        }
+        return handler(req);
+      }),
+    );
+    await new Promise<void>((r) => server.listen(0, r));
+    const port = (server.address() as AddressInfo).port;
+    return {
+      url: `http://localhost:${port}`,
+      async close() {
+        server.closeAllConnections();
+        await new Promise<void>((r) => server.close(() => r()));
+      },
+    };
+  }
+
+  it("bridges POST /invoke to SSE; wrong path returns 404", async () => {
+    const srv = await startServer(makeAgent([fauxAssistantMessage("bridged")]));
+    try {
+      const res = await fetch(`${srv.url}/invoke`, { method: "POST", body: JSON.stringify({ session: "s", text: "hi" }) });
+      const body = await res.text();
+      const events = body
+        .split("\n\n")
+        .filter((b) => b.startsWith("data: "))
+        .map((b) => JSON.parse(b.slice("data: ".length)) as AgentEvent);
+      const txt = events.filter((e) => e.type === "text").map((e) => (e as any).delta).join("");
+      expect(txt).toBe("bridged");
+      expect(events.at(-1)?.type).toBe("completed");
+
+      const notfound = await fetch(`${srv.url}/other`);
+      expect(notfound.status).toBe(404);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("client disconnect cancels invoke through the node bridge (SPEC MUST 3)", async () => {
+    let cancelled = false;
+    let resolveCancelled!: () => void;
+    const cancelledSeen = new Promise<void>((r) => (resolveCancelled = r));
+    const fake: Agent = {
+      invoke: async function* () {
+        let finished = false;
+        try {
+          for (let i = 0; i < 10_000; i++) {
+            yield { type: "text", delta: "x" } as AgentEvent;
+            await new Promise((r) => setTimeout(r, 5));
+          }
+          finished = true;
+          yield { type: "completed" } as AgentEvent;
+        } finally {
+          if (!finished) {
+            cancelled = true;
+            resolveCancelled();
+          }
+        }
+      },
+    };
+    const handler = createInvokeHandler(fake);
+    const server = createServer(nodeListener(handler));
     await new Promise<void>((r) => server.listen(0, r));
     const port = (server.address() as AddressInfo).port;
     try {
@@ -148,36 +216,16 @@ describe("http channel (SSE)", () => {
         signal: controller.signal,
       });
       const reader = res.body!.getReader();
-      await reader.read(); // confirm the stream has started
-      controller.abort(); // simulate client disconnect
-      // cleanup must happen within a bounded time; timeout means failure
+      await reader.read();
+      controller.abort(); // client disconnect
       await Promise.race([
         cancelledSeen,
-        new Promise((_, reject) => setTimeout(() => reject(new Error("invoke was never cancelled after client disconnect")), 3000)),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("invoke was never cancelled after disconnect")), 3000)),
       ]);
       expect(cancelled).toBe(true);
     } finally {
       server.closeAllConnections();
       await new Promise<void>((r) => server.close(() => r()));
-    }
-  });
-
-  it("oversized body returns 413 before invoke and counts real bytes, not JS characters", async () => {
-    const srv = await startServer([fauxAssistantMessage("x")]);
-    try {
-      const big = await fetch(`${srv.url}/invoke`, {
-        method: "POST",
-        body: JSON.stringify({ session: "s", text: "x".repeat(2 * 1024 * 1024) }),
-      });
-      expect(big.status).toBe(413);
-      // Multibyte input: 400k emoji is 400k characters but over 1 MiB in bytes, so it must be rejected
-      const multibyte = await fetch(`${srv.url}/invoke`, {
-        method: "POST",
-        body: JSON.stringify({ session: "s", text: "🙂".repeat(400_000) }),
-      });
-      expect(multibyte.status).toBe(413);
-    } finally {
-      await srv.close();
     }
   });
 });


### PR DESCRIPTION
Makes the HTTP channel embed-friendly by switching `createInvokeHandler` to the cross-runtime Fetch shape, with a thin node:http adapter for the standalone server.

## ⚠️ Review tier
Public API change: `createInvokeHandler` shape changes (`(req,res)=>void` → `(Request)=>Promise<Response>`), plus a new `nodeListener` export. Pre-1.0, 3 call sites, no external users — cheapest moment to fix the canonical shape. **Wait for review.**

## Why
The old handler was `node:http` only (`IncomingMessage/ServerResponse`), so it could not mount inside Next/Astro/Hono/Bun/Deno/Cloudflare routes — the embed posture we want to be first-class. Fetch `(Request)=>Response` is the form every embedding host speaks; node:http becomes a one-off adapter. SSE/cancel/backpressure/body-cap logic now lives once.

## Embed usage this unlocks
```ts
// Next.js app/api/agent/route.ts  (or Astro, Hono, Bun, Deno…)
import { createInvokeHandler, createPiAgentFromDefinition } from "@kid7st/fastagent";

const { agent } = await createPiAgentFromDefinition("./agent", { model });
export const POST = createInvokeHandler(agent); // path-agnostic; the host owns the route
```

## Changes
- `createInvokeHandler`: path-agnostic Fetch handler, POST-only (405 otherwise). SSE via a pull-based `ReadableStream` (native backpressure); consumer cancel → `ReadableStream.cancel()` → `iterator.return()` (SPEC MUST 3); byte-capped body (413, counts real bytes).
- `nodeListener(handler)`: node:http bridge — `IncomingMessage`→`Request`, pump `Response.body` with backpressure, `res` close → cancel request signal + stream.
- `cli serve()`: standalone `/invoke` routing + wrong-path 404 move to the composition root (a standalone concern, not a handler concern).
- Tests: drive the Fetch handler directly (no server) for SSE/405/400/413/cancel, plus a `nodeListener` suite for the node bridge, `/invoke` routing + 404, and client-disconnect cancellation.

## Verification (Node 26)
- `npm run typecheck` clean
- `npm test` → 159 passed
- `npm run build` clean

## Scope notes
- Cancellation semantics preserved (SPEC MUST 3), now via the universal `ReadableStream.cancel()` hook instead of `res.on('close')`.
- Not in scope: a separate `createFetchInvokeHandler` name (the handler *is* Fetch now), framework example apps, structured output.