### PR TITLE
feat(embed): add createPiAgentForEmbed — workspace conveniences + K injection

### DIFF
--- a/core/src/engines/pi/dev.ts
+++ b/core/src/engines/pi/dev.ts
@@ -24,11 +24,12 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { Agent } from "../../agent.ts";
-import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { createPiAgentFromDefinition, piDefaultTools, resolveTools } from "./create.ts";
+import type { FastagentConfig } from "./config.ts";
+import { createPiAgentFromDefinition } from "./create.ts";
 import { type LoadedDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored } from "./definition.ts";
 import { jsonlSessionStore } from "./sessions.ts";
-import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import type { ToolCollision } from "./tool.ts";
+import { resolveWorkspace } from "./workspace.ts";
 
 export interface CreatePiAgentFromWorkspaceOptions {
   /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -68,19 +69,10 @@ export async function createPiAgentFromWorkspace(
   /** Discovered tools dropped on a name clash with a default/config tool (surfaced, not silent). */
   toolCollisions: ToolCollision[];
 }> {
-  const { config, path: configPath }: LoadedConfig = await loadConfig(dir);
-  const modelSpec = resolveModelSpec(options.model, config);
-  if (!modelSpec) {
-    throw new Error(
-      `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
-    );
-  }
-  // Discover tools/ and merge with pi defaults + config.tools (existing win name clashes).
-  const discovered = await loadTools(dir);
-  const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
-  const toolCollisions = [...discovered.collisions, ...crossCollisions];
-  const defaultNames = new Set(piDefaultTools(dir).map((t) => t.name));
-  const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
+  // M side (model + tools + config) is the shared workspace resolution; dev adds only K + state.
+  const { config, configPath, modelSpec, model, tools, toolNames, toolCollisions } = await resolveWorkspace(dir, {
+    model: options.model,
+  });
   // The dev opener owns workspace state: .fastagent/ (machine state — gitignored, deletable,
   // rebuildable) is created HERE, not in the CLI, so library callers get the same
   // self-gitignored dir (vite/next-style).
@@ -88,7 +80,7 @@ export async function createPiAgentFromWorkspace(
   await mkdir(stateDir, { recursive: true });
   await ensureStateDirSelfIgnored(stateDir);
   const { agent, definition } = await createPiAgentFromDefinition(dir, {
-    model: resolveModel(modelSpec),
+    model,
     tools,
     // Definition-only by default (the agent is its folder); globals are an explicit
     // authoring-fidelity opt-in, never the deploy path (see create.ts ladder rule 2 + core-design §6).

--- a/core/src/engines/pi/embed.ts
+++ b/core/src/engines/pi/embed.ts
@@ -1,0 +1,86 @@
+/**
+ * Embed: open a workspace folder into an agent in PRODUCTION-EMBED posture (`createPiAgentForEmbed`).
+ *
+ * This is the blessed entry point for putting an agent inside an app you already have (a Next/Astro/
+ * Hono route, a Slack/webhook worker). It is the third opener beside dev.ts (authoring) and start.ts
+ * (standalone artifact), and it exists to close one specific gap: neither existing API gave BOTH the
+ * workspace conveniences (config-driven model resolution + `tools/` discovery) AND K-axis injection.
+ *
+ *   | opener                         | reads config/discovers tools | K injection | side effects            |
+ *   |--------------------------------|------------------------------|-------------|-------------------------|
+ *   | createPiAgentFromWorkspace (dev)| yes                         | no          | creates `.fastagent/`   |
+ *   | createPiAgentFromDefinition (L2)| no (you pass model object)  | yes         | none                    |
+ *   | createPiAgentForEmbed (here)    | yes                         | **yes**     | **none**                |
+ *
+ * Why a separate opener and not a flag on the dev opener: the two differ on the K default and on
+ * side effects, which is fundamental, not cosmetic. The dev opener defaults sessions to jsonl under
+ * a `.fastagent/` directory it CREATES in the workspace (authoring continuity). Embedding into a
+ * host app must not litter the host's project, so this opener creates nothing and leaves the K
+ * defaults to the ladder (in-memory sessions, local exec env, in-process lease, pi auth) — you
+ * inject your production session store / lease / env / auth instead.
+ *
+ * Tools note: like dev, the resolved toolset includes pi's default coding tools (read/bash/edit/
+ * write) plus config.tools and discovered `tools/`. A production embed that should not expose shell/
+ * filesystem tools must narrow them (config.tools with piReadOnlyTools, or an empty/app-specific
+ * set) — a safety profile decision that lives in the workspace config, not in this opener.
+ */
+import type { Agent } from "../../agent.ts";
+import type { FastagentConfig } from "./config.ts";
+import { createPiAgentFromDefinition } from "./create.ts";
+import type { LoadedDefinition } from "./definition.ts";
+import type { AnyModel } from "./harness.ts";
+import type { AuthResolver } from "./auth.ts";
+import type { Lease } from "./invoke.ts";
+import type { PiSessionStore } from "./sessions.ts";
+import type { ToolCollision } from "./tool.ts";
+import { resolveWorkspace } from "./workspace.ts";
+import type { ExecutionEnv } from "@earendil-works/pi-agent-core";
+
+export interface CreatePiAgentForEmbedOptions {
+  /** Model spec override (e.g. "openai-codex/gpt-5.5"). Precedence: this > FASTAGENT_MODEL > config.model. */
+  model?: string;
+  // ── K: where/how it runs — inject your production infrastructure ─────────
+  /** Session persistence. Default (unset): in-memory (no side effects); inject your durable store. */
+  sessions?: PiSessionStore;
+  /** Tool execution environment. Default (unset): local NodeExecutionEnv(cwd: dir); inject a sandbox. */
+  env?: ExecutionEnv;
+  /** Single-writer lease. Default (unset): in-process fail-fast; inject a distributed lease for multi-instance. */
+  lease?: Lease;
+  /** Auth resolution. Default (unset): pi OAuth then env vars; inject your secret/key resolver. */
+  getApiKeyAndHeaders?: AuthResolver;
+}
+
+/**
+ * "Point at a workspace folder → embeddable agent": reads the workspace config (model + tools), then
+ * builds the agent with your injected K ports (anything left unset falls back to the ladder default).
+ * Creates no files. Returns the assembled agent plus what was resolved, so the host can surface
+ * diagnostics/collisions. Throws a clear error when no model source is set.
+ */
+export async function createPiAgentForEmbed(
+  dir: string,
+  options: CreatePiAgentForEmbedOptions = {},
+): Promise<{
+  agent: Agent;
+  definition: LoadedDefinition;
+  config: FastagentConfig;
+  configPath?: string;
+  modelSpec: string;
+  model: AnyModel;
+  toolNames: string[];
+  toolCollisions: ToolCollision[];
+}> {
+  const { config, configPath, modelSpec, model, tools, toolNames, toolCollisions } = await resolveWorkspace(dir, {
+    model: options.model,
+  });
+  const { agent, definition } = await createPiAgentFromDefinition(dir, {
+    model,
+    tools,
+    // K: pass through; undefined → the ladder's default (in-memory / local env / in-process lease /
+    // pi auth). Unlike dev, nothing is materialized on disk.
+    sessions: options.sessions,
+    env: options.env,
+    lease: options.lease,
+    getApiKeyAndHeaders: options.getApiKeyAndHeaders,
+  });
+  return { agent, definition, config, configPath, modelSpec, model, toolNames, toolCollisions };
+}

--- a/core/src/engines/pi/workspace.ts
+++ b/core/src/engines/pi/workspace.ts
@@ -1,0 +1,59 @@
+/**
+ * Workspace resolution: the shared M-side of opening a workspace folder into an agent.
+ *
+ * Both the dev opener (dev.ts, authoring posture) and the embed opener (embed.ts, production-embed
+ * posture) need the SAME "point at a folder, read its config" work: resolve the model (flag > env >
+ * config), discover and merge tools (pi defaults + config.tools + `tools/`), and report what was
+ * assembled. They differ ONLY on the K axis (sessions/env/lease/auth) and side effects — which is
+ * exactly what stays OUT of here.
+ *
+ * resolveWorkspace is pure M + read-only IO: it loads config and imports tool modules, but it does
+ * NOT touch the K axis and does NOT create directories or write anything. The caller owns K and any
+ * side effects (dev creates `.fastagent/`; embed creates nothing).
+ */
+import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
+import { piDefaultTools, resolveTools } from "./create.ts";
+import type { AnyModel } from "./harness.ts";
+import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+
+export interface ResolveWorkspaceOptions {
+  /** Model spec override (e.g. a CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
+  model?: string;
+}
+
+export interface ResolvedWorkspace {
+  config: FastagentConfig;
+  /** Config file path; undefined when running zero-config. */
+  configPath?: string;
+  /** The resolved "provider/modelId" spec actually in use. */
+  modelSpec: string;
+  /** The model object (M), ready for the assembly ladder. */
+  model: AnyModel;
+  /** pi defaults + config.tools + discovered `tools/`, name clashes resolved (existing win). */
+  tools: AgentTool[];
+  /** Non-default tool names in effect: config.tools + discovered tools/. */
+  toolNames: string[];
+  /** Discovered tools dropped on a name clash with a default/config tool (surfaced, not silent). */
+  toolCollisions: ToolCollision[];
+}
+
+/**
+ * Resolve a workspace folder to its model + tools (and the config behind them). No K, no side
+ * effects. Throws a clear error when no model source is set (fail visibly at startup).
+ */
+export async function resolveWorkspace(dir: string, options: ResolveWorkspaceOptions = {}): Promise<ResolvedWorkspace> {
+  const { config, path: configPath } = await loadConfig(dir);
+  const modelSpec = resolveModelSpec(options.model, config);
+  if (!modelSpec) {
+    throw new Error(
+      `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
+    );
+  }
+  const discovered = await loadTools(dir);
+  const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
+  const toolCollisions = [...discovered.collisions, ...crossCollisions];
+  const defaultNames = new Set(piDefaultTools(dir).map((t) => t.name));
+  const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
+  return { config, configPath, modelSpec, model: resolveModel(modelSpec), tools, toolNames, toolCollisions };
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -44,6 +44,15 @@ export {
   type CreatePiAgentFromWorkspaceOptions,
 } from "./engines/pi/dev.ts";
 
+// pi reference implementation — embed (open a workspace into an agent, production-embed posture).
+// Reads the workspace config (model + tools) like dev, but injects K (sessions/env/lease/auth) like
+// L2 and creates no files — the blessed entry point for embedding an agent into an existing app.
+export {
+  createPiAgentForEmbed,
+  type CreatePiAgentForEmbedOptions,
+} from "./engines/pi/embed.ts";
+export type { ExecutionEnv } from "@earendil-works/pi-agent-core";
+
 // pi reference implementation — definition domain (load).
 // bundleAgentDefinition is intentionally NOT exported: it does a destructive `rm -rf
 // outDir` and the overwrite guard lives in buildPiArtifact, the public build entry point.

--- a/core/test/embed.test.ts
+++ b/core/test/embed.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { access, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createPiAgentForEmbed, inMemorySessionStore } from "../src/index.ts";
+
+/** A minimal workspace folder: AGENTS.md + an optional config. */
+async function makeWorkspace(config?: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "fa-embed-ws-"));
+  await writeFile(join(dir, "AGENTS.md"), "# Embed Bot\nYou are a test agent.\n");
+  if (config !== undefined) await writeFile(join(dir, "fastagent.config.mjs"), config);
+  return dir;
+}
+
+describe("createPiAgentForEmbed", () => {
+  it("reads the workspace config (model) and returns an embeddable agent", async () => {
+    const dir = await makeWorkspace(`export default { model: "openai-codex/gpt-5.5" };`);
+    const result = await createPiAgentForEmbed(dir);
+
+    expect(result.modelSpec).toBe("openai-codex/gpt-5.5");
+    expect(result.configPath).toMatch(/fastagent\.config\.mjs$/);
+    expect(result.definition.instructions).toBeDefined(); // AGENTS.md loaded
+    expect(typeof result.agent.invoke).toBe("function");
+  });
+
+  it("lets the embedder override the model spec without a config", async () => {
+    const dir = await makeWorkspace(); // no config file
+    const result = await createPiAgentForEmbed(dir, { model: "openai-codex/gpt-5.5" });
+    expect(result.modelSpec).toBe("openai-codex/gpt-5.5");
+    expect(result.configPath).toBeUndefined();
+  });
+
+  it("accepts injected K ports (no model object required)", async () => {
+    const dir = await makeWorkspace(`export default { model: "openai-codex/gpt-5.5" };`);
+    // The point of the opener: config convenience AND K injection in one call.
+    const result = await createPiAgentForEmbed(dir, {
+      model: "openai-codex/gpt-5.5",
+      sessions: inMemorySessionStore(),
+    });
+    expect(typeof result.agent.invoke).toBe("function");
+  });
+
+  it("creates no .fastagent state directory (unlike the dev opener)", async () => {
+    const dir = await makeWorkspace(`export default { model: "openai-codex/gpt-5.5" };`);
+    await createPiAgentForEmbed(dir);
+    await expect(access(join(dir, ".fastagent"))).rejects.toThrow(); // ENOENT: nothing materialized
+  });
+
+  it("fails visibly when no model source is set", async () => {
+    const dir = await makeWorkspace(`export default {};`); // config present but no model
+    const saved = process.env.FASTAGENT_MODEL;
+    delete process.env.FASTAGENT_MODEL;
+    try {
+      await expect(createPiAgentForEmbed(dir)).rejects.toThrow(/missing model/);
+    } finally {
+      if (saved !== undefined) process.env.FASTAGENT_MODEL = saved;
+    }
+  });
+});


### PR DESCRIPTION
Adds the blessed embed entry point you sketched: read the workspace config (model + tools) **and** inject your production K (sessions/env/lease/auth) in one call, with no disk side effects.

## ⚠️ Review tier
Public API addition (new exports: `createPiAgentForEmbed`, `CreatePiAgentForEmbedOptions`, `ExecutionEnv` type). **Wait for review.**

## The gap it closes
| opener | reads config / discovers tools | K injection | side effects |
|---|---|---|---|
| `createPiAgentFromWorkspace` (dev) | yes | **no** | creates `.fastagent/` |
| `createPiAgentFromDefinition` (L2) | **no** (pass a model object) | yes | none |
| **`createPiAgentForEmbed` (new)** | **yes** | **yes** | **none** |

```ts
const { agent } = await createPiAgentForEmbed("./agent", {
  model: "openai-codex/gpt-5.5",   // optional; else from config / FASTAGENT_MODEL
  sessions: postgresSessionStore,   // K: your DB
  lease: redisLease,                // K: multi-instance lock
  env: sandboxEnv,                  // K: sandbox execution
  getApiKeyAndHeaders: myAuth,      // auth: your secrets
});
```

## Why a separate opener, not a flag on the dev opener
Surfaced before coding: the two differ **fundamentally**, not cosmetically. The dev opener defaults sessions to jsonl under a `.fastagent/` dir it **creates in the workspace**; embedding into a host app must not litter the project. So embed creates nothing and leaves K defaults to the ladder (in-memory / local env / in-process lease / pi auth). Same "unset sessions" → two different defaults ⇒ two postures.

## Changes
- **New** `embed.ts`: `createPiAgentForEmbed(dir, options)`.
- **Extract** `workspace.ts` `resolveWorkspace()`: shared M-side resolution (config + model + tools), pure, no K, no side effects. The dev opener now reuses it (removes the duplicated resolution logic); embed reuses it too.
- **Export** the new opener + options type + `ExecutionEnv` (for sandbox injection).

## Scope notes
- This only exposes **injection points** for K (the port interfaces already exist and L2 already accepts them). It does **not** ship concrete K adapters (Postgres session / Redis lease) — those wait for a real backend requirement to fix their shape.
- Like dev, the resolved toolset includes pi default coding tools; a production embed that must not expose shell/fs tools narrows them via config (`piReadOnlyTools` / app-specific set) — a safety-profile decision, separate from this PR.

## Verification (Node 26)
- `npm run typecheck` clean
- `npm test` → 164 passed (5 new embed tests + dev opener refactor, no regression)
- `npm run build` clean