### PR TITLE
fix(http): resolve SSE backpressure wait on socket close, not just drain

### DIFF
--- a/core/src/channels/http.ts
+++ b/core/src/channels/http.ts
@@ -166,7 +166,21 @@ async function pump(
     for (;;) {
       const { done, value } = await reader.read();
       if (done || res.destroyed) break;
-      if (!res.write(value)) await new Promise<void>((resolve) => res.once("drain", resolve));
+      // Backpressure: wait for drain, but ALSO resolve on close. If the client disconnects after
+      // write() returned false, Node never emits 'drain' on the closed socket, so waiting on 'drain'
+      // alone would suspend pump() forever (leaking the request/stream) even though the close handler
+      // cancelled the reader.
+      if (!res.write(value)) {
+        await new Promise<void>((resolve) => {
+          const done = () => {
+            res.off("drain", done);
+            res.off("close", done);
+            resolve();
+          };
+          res.once("drain", done);
+          res.once("close", done);
+        });
+      }
     }
   } finally {
     if (!res.destroyed) res.end();

--- a/core/test/http.test.ts
+++ b/core/test/http.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { EventEmitter } from "node:events";
 import type { AddressInfo } from "node:net";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
@@ -227,5 +228,54 @@ describe("nodeListener (standalone server bridge)", () => {
       server.closeAllConnections();
       await new Promise<void>((r) => server.close(() => r()));
     }
+  });
+});
+
+describe("nodeListener backpressure", () => {
+  /** Minimal IncomingMessage: GET (no body) so the bridge needs no request stream. */
+  function fakeReq(): IncomingMessage {
+    const req = new EventEmitter() as unknown as IncomingMessage & { method: string; url: string; headers: Record<string, string> };
+    req.method = "GET";
+    req.url = "/invoke";
+    req.headers = { host: "localhost" };
+    return req;
+  }
+  /** Minimal ServerResponse whose write() always signals backpressure (returns false). */
+  function fakeRes() {
+    const res = new EventEmitter() as unknown as ServerResponse & { ended: boolean; destroyed: boolean };
+    res.destroyed = false;
+    (res as { ended: boolean }).ended = false;
+    (res as unknown as { headersSent: boolean }).headersSent = false;
+    (res as unknown as { writeHead: () => ServerResponse }).writeHead = () => res;
+    (res as unknown as { write: () => boolean }).write = () => false; // always backpressure
+    (res as unknown as { end: () => void }).end = () => {
+      (res as { ended: boolean }).ended = true;
+    };
+    return res as ServerResponse & { ended: boolean; destroyed: boolean };
+  }
+
+  it("client close during backpressure ends pump (no leak; regression for drain-only wait)", async () => {
+    // An endless SSE stream so pump always has more to write and parks on backpressure.
+    const handler = async (): Promise<Response> => {
+      const stream = new ReadableStream<Uint8Array>({
+        pull(c) {
+          c.enqueue(new TextEncoder().encode("data: x\n\n"));
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/event-stream" } });
+    };
+    const req = fakeReq();
+    const res = fakeRes();
+    nodeListener(handler)(req, res);
+
+    // Let pump start, write once (→ false), and suspend on the backpressure wait.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(res.ended).toBe(false);
+
+    res.emit("close"); // client disconnects WHILE parked on backpressure (no 'drain' will ever come)
+
+    // With drain+close wait, pump resumes, the cancelled reader yields done, and finally runs end().
+    await new Promise((r) => setTimeout(r, 20));
+    expect(res.ended).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes a resource leak in the node:http SSE bridge surfaced by review on #35.

## Bug
`nodeListener`'s `pump()` backpressure wait listened only for `drain`:
```ts
if (!res.write(value)) await new Promise((resolve) => res.once("drain", resolve));
```
If a slow client disconnects **after** `res.write()` returned `false`, Node never emits `drain` on the closed socket, so `pump()` stays suspended forever — leaking the request and response stream, even though the close handler already cancelled the reader (the loop can't reach the next `read()`).

Regression introduced when the SSE logic moved into the Fetch handler (#35): the old `writeWithBackpressure` resolved on **either** `drain` **or** `close`.

## Fix
Wait on `drain` + `close` (cleaning up both listeners on resolve), so a mid-backpressure disconnect promptly unwinds `pump()`.

## Test
Adds a fake-`ServerResponse` regression test: `write()` always returns `false`, an endless SSE stream parks `pump()` on backpressure, then `emit('close')` — asserts `pump` runs to completion (`end()` called) instead of hanging. With the old drain-only wait this test would time out.

## Verification (Node 26)
- `npm run typecheck` clean
- `npm test` → 160 passed
- Review tier: fix, self-merge after green CI.