### PR TITLE
chore(api): export ExecutionEnv; document L2 as the embed entry point

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -100,6 +100,9 @@ export {
   inProcessLease,
 } from "./engines/pi/invoke.ts";
 export type { AnyModel } from "./engines/pi/harness.ts";
+// ExecutionEnv is the K-axis env port referenced by the ladder's `env` option (L1/L2): export the
+// type so embedders can inject a sandbox env without reaching into pi-agent-core directly.
+export type { ExecutionEnv } from "@earendil-works/pi-agent-core";
 export {
   type PiSessionStore,
   inMemorySessionStore,

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -119,7 +119,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 };
 ```
 
-Today, custom session stores use `createPiAgentFromDefinition`, so the embed setup passes a resolved model explicitly. A config-resolving embed opener that also accepts K-axis overrides (sessions/auth/env/lease) is the intended ergonomic follow-up.
+The embed entry point is `createPiAgentFromDefinition` (L2): point at the folder, pass a resolved model (`resolveModel("provider/modelId")`) and your own K ports (sessions/env/lease/auth), and inject tools explicitly. There is deliberately no separate embed opener — L2 already gives folder + K injection + a fully replaceable toolset (pass `piReadOnlyTools(dir)` or an app-specific set to drop the default coding tools).
 
 One build, one deploy, one auth, your database. The transport-neutral `invoke` contract (no bundled HTTP framework) is what lets the agent live inside the host's own route. This is the demo that makes the abstract positioning concrete — and the sweet spot is explicit: a relatively *light* agent feature (interactive/generation/trigger-response) in a *TS/Node* product with an *existing stack*. A *heavy* agent (long autonomy, swarm, sandbox isolation, many channels) tilts back toward Flue's batteries-included path even as a feature.
 


### PR DESCRIPTION
Small follow-up after withdrawing #36 (createPiAgentForEmbed).

## Changes
- **Export `ExecutionEnv`** (type) next to the other ladder injection ports. L2 `createPiAgentFromDefinition` already accepts `env: ExecutionEnv`, but the type was unexported, so embedders couldn't type a sandbox-env injection without importing from pi-agent-core directly.
- **comparisons.md**: state plainly that the embed entry point is L2 (folder + injected K + fully replaceable tools via `tools: piReadOnlyTools(dir)` / app-specific set). Removed the "config-resolving embed opener is the intended follow-up" note.

## Why no embed opener
`createPiAgentForEmbed` (#36) was withdrawn as redundant: it could not narrow the toolset (its `resolveTools` appends config tools after pi defaults rather than replacing them — flagged in #36 review), and it bundled runtime `tools/` discovery, which is an anti-pattern under third-party bundlers. L2 already gives folder + K injection + a replaceable toolset.

## Verification
- `npm run typecheck` clean; `npm run build` clean (`ExecutionEnv` present in dist/index.d.ts).
- Review tier: chore/docs + tiny public-API addition (type export only).