### PR TITLE
chore(release): prepare core for open-source publish (packaging, metadata, Biome)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
         run: npm ci
         working-directory: core
 
+      - name: Lint
+        run: npm run lint
+        working-directory: core
+
       - name: Typecheck
         run: npm run typecheck
         working-directory: core

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ The full local loop is fast:
 ```bash
 cd core
 npm install
+npm run lint           # biome check (format + lint, read-only); `npm run format` to fix
 npm run typecheck      # tsc --noEmit (covers src, test, examples)
 npm test               # vitest --run
 ```
@@ -30,7 +31,7 @@ Tests use faux models by default, so they validate serving mechanics without net
 ```text
 1. git checkout -b feature/<thing>
 2. ... change code, iterate locally ...
-3. cd core && npm run typecheck && npm test
+3. cd core && npm run lint && npm run typecheck && npm test
 4. git push -u origin feature/<thing>
 5. gh pr create --base main           # fill in the PR template
 6. CI green → merge (see "Merge strategy")
@@ -50,9 +51,10 @@ git fetch --prune origin
 
 A PR is mergeable only when, in `core/`:
 
+- `npm run lint` is clean (Biome format + lint; run `npm run format` to auto-fix),
 - `npm run typecheck` is clean (TypeScript with `noUnusedLocals`/`noUnusedParameters`),
 - `npm test` passes,
-- CI (`Core checks`, Node 26) is green.
+- CI (`Core checks`, Node 22.19 / 24 / 26) is green.
 
 Add or update the smallest relevant tests that prove the change. Reusable SPEC conformance lives in `core/test/spec-conformance.ts`; one-off product-scenario scripts should be run and then deleted, not committed.
 

--- a/core/LICENSE
+++ b/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 the fastagent authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,48 @@
+# @kid7st/fastagent
+
+**Flask/WSGI for agents.** Turn an existing agent folder — `AGENTS.md` + `skills/` — into a running capability without rewriting it, in either posture:
+
+- **Embed into an existing product** — call the agent from your own route (Astro/Next/Hono/Lambda), wired to your session store, your auth, your host.
+- **Serve as a standalone agent service** — webhook handler, scheduled worker, Slack/Telegram bot, API endpoint, or cloud-hosted agent.
+
+Engine-, model-, and host-neutral. Built on the [pi](https://www.npmjs.com/package/@earendil-works/pi-agent-core) harness; implements the locked [Agent Handler SPEC v0.1](https://github.com/kid7st/fastagent/blob/main/docs/SPEC.md).
+
+> Requires Node ≥ 22.19. Ships compiled JavaScript + type declarations; no build step in consuming projects.
+
+## Embed (library)
+
+```ts
+import { createPiAgentFromDefinition, resolveModel, createInvokeHandler } from "@kid7st/fastagent";
+
+// folder → agent, with your own session store / auth / tools injected
+const { agent } = await createPiAgentFromDefinition("./agent", {
+  model: resolveModel("openai-codex/gpt-5.5"),
+  // sessions, env, lease, getApiKeyAndHeaders, tools — all optional injection points
+});
+
+// createInvokeHandler is a Fetch handler: mount it in any host route
+export const POST = createInvokeHandler(agent);
+```
+
+`agent.invoke(scope, prompt)` returns an `AsyncIterable<AgentEvent>` (text deltas, tool events, a terminal `completed`/`failed`). Consume it as a stream, or buffer it with `collect()`.
+
+## Serve / deploy (CLI)
+
+```bash
+fastagent init my-agent && cd my-agent
+fastagent dev                 # local HTTP/SSE on :8787
+fastagent build               # → a self-contained artifact
+fastagent start .fastagent/build
+```
+
+## Documentation
+
+Full docs, design, and the SPEC live in the repository:
+
+- [Quickstart](https://github.com/kid7st/fastagent/blob/main/docs/quickstart.md)
+- [Agent Handler SPEC v0.1](https://github.com/kid7st/fastagent/blob/main/docs/SPEC.md)
+- [Core design](https://github.com/kid7st/fastagent/blob/main/docs/core-design.md)
+
+## License
+
+[MIT](./LICENSE)

--- a/core/biome.json
+++ b/core/biome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "files": {
+    "includes": ["src/**/*.ts", "test/**/*.ts", "examples/**/*.ts"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "javascript": {
+    "formatter": { "quoteStyle": "double", "semicolons": "always", "trailingCommas": "all" }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": { "recommended": true }
+  },
+  "assist": {
+    "actions": {
+      "source": { "organizeImports": "off" }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["test/**/*.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": { "noExplicitAny": "off" },
+          "style": { "noNonNullAssertion": "off" }
+        }
+      }
+    }
+  ]
+}

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -21,6 +21,7 @@
         "fastagent": "dist/cli.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.5.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"
       },
@@ -504,6 +505,181 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.0.tgz",
+      "integrity": "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.0",
+        "@biomejs/cli-darwin-x64": "2.5.0",
+        "@biomejs/cli-linux-arm64": "2.5.0",
+        "@biomejs/cli-linux-arm64-musl": "2.5.0",
+        "@biomejs/cli-linux-x64": "2.5.0",
+        "@biomejs/cli-linux-x64-musl": "2.5.0",
+        "@biomejs/cli-win32-arm64": "2.5.0",
+        "@biomejs/cli-win32-x64": "2.5.0"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.0.tgz",
+      "integrity": "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.0.tgz",
+      "integrity": "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.0.tgz",
+      "integrity": "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.0.tgz",
+      "integrity": "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.0.tgz",
+      "integrity": "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.0.tgz",
+      "integrity": "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.0.tgz",
+      "integrity": "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.0.tgz",
+      "integrity": "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,7 +1,19 @@
 {
   "name": "@kid7st/fastagent",
   "version": "0.1.0",
-  "description": "Reference implementation of the Agent Handler contract: fan in pi AgentHarness events into the SPEC event stream.",
+  "description": "Flask/WSGI for agents: serve or embed an existing agent folder (AGENTS.md + skills/) as a production capability. Engine-, model-, and host-neutral.",
+  "keywords": [
+    "agent",
+    "ai-agent",
+    "llm",
+    "agents.md",
+    "agent-skills",
+    "mcp",
+    "agent-serving",
+    "sse",
+    "pi",
+    "fastagent"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -25,16 +37,21 @@
     "fastagent": "./dist/cli.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "LICENSE",
+    "README.md"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
+    "prebuild": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "tsc -p tsconfig.build.json",
     "prepack": "npm run build",
     "test": "vitest --run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src test examples",
+    "format": "biome check --write src test examples"
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "^0.79.8",
@@ -46,6 +63,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.5.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/core/src/agent.ts
+++ b/core/src/agent.ts
@@ -5,13 +5,7 @@
  * (`@earendil-works/pi-*` may only appear under engines/).
  */
 
-export type Json =
-  | null
-  | boolean
-  | number
-  | string
-  | Json[]
-  | { [k: string]: Json };
+export type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
 
 /** Base64-encoded image reference. */
 export interface ImageRef {

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -129,7 +129,9 @@ async function runTool(): Promise<void> {
   // run here either; surface that collision instead of silently testing the wrong implementation.
   const { tools, collisions } = mergeDiscoveredTools(resolveTools(config, toolDir), discovered.tools);
   for (const c of [...discovered.collisions, ...collisions]) {
-    console.error(`[fastagent] warn: tool "${c.name}" (${c.source}) is shadowed by a default/config tool — not mounted`);
+    console.error(
+      `[fastagent] warn: tool "${c.name}" (${c.source}) is shadowed by a default/config tool — not mounted`,
+    );
   }
   const tool = tools.find((t) => t.name === name);
   if (!tool) {
@@ -160,7 +162,9 @@ async function runInit(): Promise<void> {
   if (created.length > 0) console.error(`  created: ${created.join(", ")}`);
   if (skipped.length > 0) console.error(`  kept existing: ${skipped.join(", ")}`);
   if (intoNonEmpty) {
-    console.error(`  note: scaffolded into a non-empty directory; for a clean start, run \`fastagent init <name>\` (a fresh subdir)`);
+    console.error(
+      `  note: scaffolded into a non-empty directory; for a clean start, run \`fastagent init <name>\` (a fresh subdir)`,
+    );
   }
   for (const w of warnings) console.error(`[fastagent] warn: ${w}`);
 
@@ -173,7 +177,8 @@ async function runInit(): Promise<void> {
   if (willInstall) {
     console.error(`[fastagent] installing dependencies (npm install)…`);
     installFailed = (await npmInstall(dir)) !== 0;
-    if (installFailed) console.error(`[fastagent] warn: npm install failed — run it manually in ${dir} before \`fastagent dev\``);
+    if (installFailed)
+      console.error(`[fastagent] warn: npm install failed — run it manually in ${dir} before \`fastagent dev\``);
   }
 
   // Next steps act on the scaffolded dir. For a named target (`fastagent init my-agent`) lead with
@@ -324,6 +329,7 @@ function runDevSupervisor(): void {
 
   const spawnWorker = (): void => {
     // ipc fd so the worker can signal readiness once it binds; stdio otherwise inherited.
+    // biome-ignore lint/style/noNonNullAssertion: argv[1] is always the script path under a node entry
     const w = spawn(process.execPath, [process.argv[1]!, ...process.argv.slice(2)], {
       stdio: ["inherit", "inherit", "inherit", "ipc"],
       env: { ...process.env, FASTAGENT_DEV_WORKER: "1" },
@@ -377,7 +383,9 @@ function runDevSupervisor(): void {
     timer = setTimeout(triggerReload, 200);
   });
   watcher.on("error", (error) =>
-    console.error(`[fastagent] warn: file watching error (${(error as Error).message}); some edits may need a manual restart`),
+    console.error(
+      `[fastagent] warn: file watching error (${(error as Error).message}); some edits may need a manual restart`,
+    ),
   );
   console.error(`[fastagent] watching for changes — edits restart the dev worker (--no-watch to disable)`);
 
@@ -510,6 +518,8 @@ function reportDefinitionWarnings(
 
 function reportToolCollisions(collisions: { name: string; source: string }[]): void {
   for (const c of collisions) {
-    console.error(`[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`);
+    console.error(
+      `[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`,
+    );
   }
 }

--- a/core/src/engines/pi/build.ts
+++ b/core/src/engines/pi/build.ts
@@ -16,7 +16,12 @@ import { mkdir, mkdtemp, readFile, realpath, rename, rm, stat, writeFile } from 
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { type LoadedDefinition, bundleAgentDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored } from "./definition.ts";
+import {
+  type LoadedDefinition,
+  bundleAgentDefinition,
+  defaultGlobalSkillPaths,
+  ensureStateDirSelfIgnored,
+} from "./definition.ts";
 
 /** The `fastagent.json` manifest written into the artifact. Pure data (no `.ts`). */
 export interface ArtifactManifest {
@@ -65,7 +70,12 @@ export async function buildPiArtifact(
   // The source must exist BEFORE anything is created: the default out is <srcDir>/.fastagent/
   // build, so a typo'd/nonexistent srcDir would otherwise be conjured by the staging mkdir
   // and then "built" into an empty artifact. Fail visibly instead.
-  if (!(await stat(srcDir).then((s) => s.isDirectory(), () => false))) {
+  if (
+    !(await stat(srcDir).then(
+      (s) => s.isDirectory(),
+      () => false,
+    ))
+  ) {
     throw new Error(`source workspace "${srcDir}" does not exist (or is not a directory)`);
   }
   const { config, path: configPath } = await loadConfig(srcDir);
@@ -94,14 +104,14 @@ export async function buildPiArtifact(
     throw new Error(`build output dir must differ from the source workspace (got "${outDir}")`);
   }
   const outToSrc = relative(outReal, srcReal); // src relative to out; ""/".."-prefixed/absolute = not contained
-  if (outToSrc !== "" && outToSrc !== ".." && !outToSrc.startsWith(".." + sep) && !isAbsolute(outToSrc)) {
+  if (outToSrc !== "" && outToSrc !== ".." && !outToSrc.startsWith(`..${sep}`) && !isAbsolute(outToSrc)) {
     throw new Error(`build output dir must not contain the source workspace (got out="${outDir}")`);
   }
   // Location guardrail (not a content judgment): publishing REPLACES outDir wholesale, so an
   // out-of-tree target is where a path typo deletes unrelated data. Allow a target inside the
   // source tree freely; require explicit confirmation (force) for one outside it.
   const srcToOut = relative(srcReal, outReal); // out relative to src; ".."-prefixed/absolute = outside
-  const outsideSource = srcToOut === ".." || srcToOut.startsWith(".." + sep) || isAbsolute(srcToOut);
+  const outsideSource = srcToOut === ".." || srcToOut.startsWith(`..${sep}`) || isAbsolute(srcToOut);
   if (outsideSource && !options.force) {
     throw new Error(
       `build output dir is outside the source workspace (got "${outDir}"); it will be REPLACED wholesale — ` +
@@ -140,15 +150,25 @@ export async function buildPiArtifact(
   }
   const staging = await mkdtemp(join(stagingParent, ".fa-build-"));
   try {
-    const definition = await bundleAgentDefinition(srcDir, staging, {
-      skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
-    }, { skipPaths: [outReal] });
+    const definition = await bundleAgentDefinition(
+      srcDir,
+      staging,
+      {
+        skillPaths: options.globalSkills ? defaultGlobalSkillPaths() : [],
+      },
+      { skipPaths: [outReal] },
+    );
     // fastagent.json is the manifest's reserved name. If a source entry landed at
     // staging/fastagent.json (a file/dir by that name, incl. a case-insensitive alias like
     // FastAgent.json on macOS/Windows), the manifest write would overwrite authored content
     // — reject. Checking the staged path is filesystem-accurate for case-sensitivity, and
     // non-destructive (staging is thrown away on failure).
-    if (await stat(join(staging, MANIFEST_FILE)).then(() => true, () => false)) {
+    if (
+      await stat(join(staging, MANIFEST_FILE)).then(
+        () => true,
+        () => false,
+      )
+    ) {
       throw new Error(
         `"${MANIFEST_FILE}" is reserved for the build manifest; the source ships an entry by that name ` +
           `at the artifact root — rename or exclude it (config goes in fastagent.config.ts/js/mjs)`,
@@ -162,7 +182,10 @@ export async function buildPiArtifact(
     if (
       (config.tools?.length ?? 0) > 0 &&
       configPath !== undefined &&
-      !(await stat(join(staging, basename(configPath))).then(() => true, () => false))
+      !(await stat(join(staging, basename(configPath))).then(
+        () => true,
+        () => false,
+      ))
     ) {
       throw new Error(
         `fastagent.config defines code tools but ${basename(configPath)} is excluded from the artifact ` +

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -160,7 +160,13 @@ export async function buildChatRuntime(
             description: s.description,
             filePath: s.filePath,
             baseDir: dirname(s.filePath),
-            sourceInfo: { path: s.filePath, source: "fastagent", scope: "project", origin: "top-level", baseDir: dirname(s.filePath) },
+            sourceInfo: {
+              path: s.filePath,
+              source: "fastagent",
+              scope: "project",
+              origin: "top-level",
+              baseDir: dirname(s.filePath),
+            },
             disableModelInvocation: s.disableModelInvocation ?? false,
           })) as typeof base.skills,
           diagnostics: base.diagnostics,
@@ -201,12 +207,16 @@ function reportDefinitionWarnings(
 
 function reportToolCollisions(collisions: ToolCollision[]): void {
   for (const c of collisions) {
-    console.error(`[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`);
+    console.error(
+      `[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`,
+    );
   }
 }
 
 function workspaceScopeError(targetCwd: string): Error {
-  return new Error(`fastagent chat is workspace-scoped: cannot switch to ${targetCwd}; run \`fastagent chat ${targetCwd}\` instead`);
+  return new Error(
+    `fastagent chat is workspace-scoped: cannot switch to ${targetCwd}; run \`fastagent chat ${targetCwd}\` instead`,
+  );
 }
 
 /** Resolve to a canonical (symlink-free) path so comparisons match pi's process.cwd() realpath. */

--- a/core/src/engines/pi/config.ts
+++ b/core/src/engines/pi/config.ts
@@ -58,10 +58,13 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   const found = names.map((name) => join(dir, name)).filter((path) => existsSync(path));
   if (found.length === 0) return { config: {} };
   if (found.length > 1) {
-    throw new Error(`${dir}: multiple fastagent config files found; keep exactly one (${found.map((p) => basename(p)).join(", ")})`);
+    throw new Error(
+      `${dir}: multiple fastagent config files found; keep exactly one (${found.map((p) => basename(p)).join(", ")})`,
+    );
   }
 
   // Exactly one config file at this point (0 and >1 handled above).
+  // biome-ignore lint/style/noNonNullAssertion: length checked above — exactly one element here
   const path = found[0]!;
   const mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
   const config = mod.default;

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -132,9 +132,7 @@ export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] 
 export function piBasePrompt(options: { tools?: AgentTool[] } = {}): string {
   const tools = options.tools ?? [];
   const toolsList =
-    tools.length > 0
-      ? tools.map((t) => `- ${t.name}: ${(t.description ?? "").split("\n")[0]}`).join("\n")
-      : "(none)";
+    tools.length > 0 ? tools.map((t) => `- ${t.name}: ${(t.description ?? "").split("\n")[0]}`).join("\n") : "(none)";
   return `You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
 
 Available tools:

--- a/core/src/engines/pi/definition.ts
+++ b/core/src/engines/pi/definition.ts
@@ -110,10 +110,7 @@ export async function loadAgentDefinition(
   // Definition-local skills first → definition wins collisions (first-wins).
   // Default is definition-only ([]): "your folder is the agent". Global/extra
   // mounts are an explicit opt-in (see skillPaths / defaultGlobalSkillPaths).
-  const { skills: raw, diagnostics } = await loadSkills(e, [
-    join(root, "skills"),
-    ...(options.skillPaths ?? []),
-  ]);
+  const { skills: raw, diagnostics } = await loadSkills(e, [join(root, "skills"), ...(options.skillPaths ?? [])]);
   const byName = new Map<string, Skill>();
   const collisions: SkillCollision[] = [];
   for (const skill of raw) {
@@ -297,9 +294,7 @@ export async function bundleAgentDefinition(
   // Production 1 — the authored context tree, EXCLUDING skills/. Skip the build's own dirs
   // (staging / final target) too, so output is never bundled into itself.
   const skipHere = await realpath(outDir).catch(() => resolve(outDir));
-  const skipExtra = await Promise.all(
-    (bundleOpts.skipPaths ?? []).map((p) => realpath(p).catch(() => resolve(p))),
-  );
+  const skipExtra = await Promise.all((bundleOpts.skipPaths ?? []).map((p) => realpath(p).catch(() => resolve(p))));
   const plan = await planShipSet(srcDir, { skip: [skipHere, ...skipExtra, skillsDir] });
   const shipped = new Set(plan.files.map((f) => f.rel));
 

--- a/core/src/engines/pi/harness.ts
+++ b/core/src/engines/pi/harness.ts
@@ -23,6 +23,7 @@ import type { PiSessionStore } from "./sessions.ts";
  * through to the harness, so the generic carries no information. One alias keeps
  * the `any` auditable (tighten here if pi exports a variance-friendly type).
  */
+// biome-ignore lint/suspicious/noExplicitAny: intentional variance-friendly model type, audited at this single point (see above)
 export type AnyModel = Model<any>;
 
 /**

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -133,7 +133,10 @@ function packageJson(name: string): string {
 
 /** Sanitize a directory basename into a valid npm package name (lowercase, safe chars). */
 function toPackageName(dir: string): string {
-  const base = basename(resolve(dir)).toLowerCase().replace(/[^a-z0-9._-]/g, "-").replace(/^[._-]+/, "");
+  const base = basename(resolve(dir))
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/^[._-]+/, "");
   return base || "agent";
 }
 
@@ -219,7 +222,9 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
   for (const rel of parents) {
     const st = await lstat(join(dir, rel)).catch(() => undefined);
     if (st && !st.isDirectory()) {
-      throw new Error(`cannot scaffold: "${rel}" exists and is not a directory (a regular file or symlink) — remove it, or init elsewhere`);
+      throw new Error(
+        `cannot scaffold: "${rel}" exists and is not a directory (a regular file or symlink) — remove it, or init elsewhere`,
+      );
     }
   }
 
@@ -255,7 +260,9 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
     }
     // A kept package.json won't carry the tool's deps — the example tool would not resolve.
     if (!minimal && skipped.includes("package.json")) {
-      warnings.push(`kept your existing package.json — add "@kid7st/fastagent" and "zod" to its dependencies to use code tools`);
+      warnings.push(
+        `kept your existing package.json — add "@kid7st/fastagent" and "zod" to its dependencies to use code tools`,
+      );
     }
   } catch (error) {
     for (const rel of created.reverse()) await rm(join(dir, rel), { force: true }).catch(() => {});

--- a/core/src/engines/pi/invoke.ts
+++ b/core/src/engines/pi/invoke.ts
@@ -236,7 +236,7 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       return;
     }
     try {
-      let harness;
+      let harness: Awaited<ReturnType<PiHarnessFactory>>;
       try {
         harness = await harnessFactory(scope.session);
       } catch (error) {

--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -175,8 +175,5 @@ export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSes
 
 /** Injective filename-safe encoding: [A-Za-z0-9._-] verbatim ("s1" stays "s1"), the rest %-escaped ("%" itself included). */
 function encodeSessionId(id: string): string {
-  return id.replace(
-    /[^A-Za-z0-9._-]/g,
-    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`,
-  );
+  return id.replace(/[^A-Za-z0-9._-]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`);
 }

--- a/core/src/engines/pi/start.ts
+++ b/core/src/engines/pi/start.ts
@@ -132,7 +132,10 @@ export async function createPiAgentFromArtifact(
   await ensureStateDirSelfIgnored(sessionsDir);
   // Discover tools/ (ships in the artifact as authored context) and merge with config.tools + defaults.
   const discovered = await loadTools(artifactDir);
-  const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, artifactDir), discovered.tools);
+  const { tools, collisions: crossCollisions } = mergeDiscoveredTools(
+    resolveTools(config, artifactDir),
+    discovered.tools,
+  );
   const toolCollisions = [...discovered.collisions, ...crossCollisions];
   const defaultNames = new Set(piDefaultTools(artifactDir).map((t) => t.name));
   const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));

--- a/core/src/engines/pi/tool.ts
+++ b/core/src/engines/pi/tool.ts
@@ -22,6 +22,7 @@
  * Node composition-root module: `loadTools` dynamically imports the workspace's tool modules
  * (local files, not node_modules — so Node strips their types); the invoke path stays disk-free.
  */
+import type { Dirent } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -100,7 +101,7 @@ const TOOL_EXTS = new Set([".ts", ".js", ".mjs"]);
  */
 export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; collisions: ToolCollision[] }> {
   const toolsDir = join(dir, "tools");
-  let entries;
+  let entries: Dirent[];
   try {
     entries = await readdir(toolsDir, { withFileTypes: true });
   } catch (error) {

--- a/core/test/auth.test.ts
+++ b/core/test/auth.test.ts
@@ -51,10 +51,7 @@ describe("piOAuthAuth (silent-failure discipline)", () => {
     );
     expect(await piOAuthAuth(path)(model)).toEqual({ apiKey: "tok-live" });
 
-    await writeFile(
-      path,
-      JSON.stringify({ anthropic: { type: "oauth", access: "tok-old", expires: Date.now() - 1 } }),
-    );
+    await writeFile(path, JSON.stringify({ anthropic: { type: "oauth", access: "tok-old", expires: Date.now() - 1 } }));
     const messages: string[] = [];
     expect(await piOAuthAuth(path, { warn: (m) => messages.push(m) })(model)).toBeUndefined();
     expect(messages[0]).toContain("expired"); // root cause surfaced, not buried under "missing API key"
@@ -65,7 +62,10 @@ describe("probeAuthSource (startup credential report; dev + start)", () => {
   it("reports oauth when the credentials file has a live token for the provider", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-probe-"));
     const path = join(dir, "auth.json");
-    await writeFile(path, JSON.stringify({ anthropic: { type: "oauth", access: "tok", expires: Date.now() + 60_000 } }));
+    await writeFile(
+      path,
+      JSON.stringify({ anthropic: { type: "oauth", access: "tok", expires: Date.now() + 60_000 } }),
+    );
     expect(await probeAuthSource("anthropic", path)).toBe("oauth");
   });
 

--- a/core/test/build.test.ts
+++ b/core/test/build.test.ts
@@ -41,7 +41,10 @@ async function makeWorkspace(opts: { config?: string; gitignore?: string } = {})
   await writeFile(join(dir, "node_modules", "left-pad", "index.js"), "module.exports = 1;\n");
   await mkdir(join(dir, ".git"), { recursive: true });
   await writeFile(join(dir, ".git", "HEAD"), "ref: refs/heads/main\n");
-  await writeFile(join(dir, "fastagent.config.mjs"), opts.config ?? `export default { model: "openai-codex/gpt-5.5" };`);
+  await writeFile(
+    join(dir, "fastagent.config.mjs"),
+    opts.config ?? `export default { model: "openai-codex/gpt-5.5" };`,
+  );
   if (opts.gitignore !== undefined) await writeFile(join(dir, ".gitignore"), opts.gitignore);
   return dir;
 }
@@ -50,7 +53,9 @@ const freshOut = () => mkdtemp(join(tmpdir(), "fa-build-out-"));
 
 describe("build: buildPiArtifact", () => {
   it("produces a self-contained artifact: AGENTS.md + skills + authored context + manifest", async () => {
-    const ws = await makeWorkspace({ config: `export default { model: "openai-codex/gpt-5.5", http: { port: 9000 } };` });
+    const ws = await makeWorkspace({
+      config: `export default { model: "openai-codex/gpt-5.5", http: { port: 9000 } };`,
+    });
     const out = await freshOut();
     const { manifest } = await buildOk(ws, out);
 

--- a/core/test/definition.test.ts
+++ b/core/test/definition.test.ts
@@ -178,9 +178,11 @@ describe("create: createPiAgentFromDefinition (directory → agent)", () => {
 
 describe("create: toolset (real pi tools, fidelity)", () => {
   it("piDefaultTools are pi core four tools (same as pi default); piReadOnlyTools is the read-only subset", () => {
-    expect(piDefaultTools(fixtureDir).map((t) => t.name).sort()).toEqual([
-      "bash", "edit", "read", "write",
-    ]);
+    expect(
+      piDefaultTools(fixtureDir)
+        .map((t) => t.name)
+        .sort(),
+    ).toEqual(["bash", "edit", "read", "write"]);
     const ro = piReadOnlyTools(fixtureDir).map((t) => t.name);
     expect(ro).not.toContain("bash");
     expect(ro).not.toContain("write");
@@ -225,8 +227,18 @@ describe("definition: bundleAgentDefinition (materializes extra mounts into a de
     await writeFile(join(src, ".fastagentignore"), "extras/\n"); // exclude the duplicate original
     const out = await mkdtemp(join(tmpdir(), "fa-bundle-out-"));
     await bundleAgentDefinition(src, out, { skillPaths: [join(src, "extras")] }); // must not throw
-    expect(await access(join(out, "skills", "foo", "SKILL.md")).then(() => true, () => false)).toBe(true);
-    expect(await access(join(out, "extras")).then(() => true, () => false)).toBe(false); // no duplicate
+    expect(
+      await access(join(out, "skills", "foo", "SKILL.md")).then(
+        () => true,
+        () => false,
+      ),
+    ).toBe(true);
+    expect(
+      await access(join(out, "extras")).then(
+        () => true,
+        () => false,
+      ),
+    ).toBe(false); // no duplicate
   });
 
   it("rejects skills that materialize to the same artifact path (one case-insensitive guard)", async () => {
@@ -257,7 +269,12 @@ describe("definition: bundleAgentDefinition (materializes extra mounts into a de
     await writeFile(join(src, "skills", "evil", "SKILL.md"), "---\nname: ../../escaped\ndescription: d\n---\nb\n");
     const out = await mkdtemp(join(tmpdir(), "fa-bundle-out-"));
     await expect(bundleAgentDefinition(src, out)).rejects.toThrow(/not a valid directory name/);
-    expect(await access(join(out, "..", "escaped")).then(() => true, () => false)).toBe(false); // nothing escaped
+    expect(
+      await access(join(out, "..", "escaped")).then(
+        () => true,
+        () => false,
+      ),
+    ).toBe(false); // nothing escaped
   });
 
   it("materializes an in-workspace mount outside skills/ into outDir/skills/ (reported == shipped)", async () => {

--- a/core/test/http.test.ts
+++ b/core/test/http.test.ts
@@ -22,8 +22,14 @@ function makeAgent(responses: FauxResponseStep[]): Agent {
 }
 
 /** Drive the Fetch handler directly (no server) and parse SSE lines into AgentEvent[]. */
-async function invoke(handler: (req: Request) => Promise<Response>, session: string, text: string): Promise<AgentEvent[]> {
-  const res = await handler(new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session, text }) }));
+async function invoke(
+  handler: (req: Request) => Promise<Response>,
+  session: string,
+  text: string,
+): Promise<AgentEvent[]> {
+  const res = await handler(
+    new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session, text }) }),
+  );
   expect(res.headers.get("content-type")).toBe("text/event-stream");
   const body = await res.text();
   return body
@@ -36,7 +42,10 @@ describe("invoke handler (Fetch/SSE)", () => {
   it("POST streams text + completed over SSE", async () => {
     const handler = createInvokeHandler(makeAgent([fauxAssistantMessage("hello over http")]));
     const events = await invoke(handler, "s1", "hi");
-    const text = events.filter((e) => e.type === "text").map((e) => (e as any).delta).join("");
+    const text = events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as any).delta)
+      .join("");
     expect(text).toBe("hello over http");
     expect(events.at(-1)).toEqual({ type: "completed" });
   });
@@ -84,23 +93,28 @@ describe("invoke handler (Fetch/SSE)", () => {
   it("non-POST returns 405; bad/missing body returns 400", async () => {
     const handler = createInvokeHandler(makeAgent([fauxAssistantMessage("x")]));
     expect((await handler(new Request("http://app/invoke", { method: "GET" }))).status).toBe(405);
+    expect((await handler(new Request("http://app/invoke", { method: "POST", body: "{not json" }))).status).toBe(400);
     expect(
-      (await handler(new Request("http://app/invoke", { method: "POST", body: "{not json" }))).status,
-    ).toBe(400);
-    expect(
-      (await handler(new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s" }) }))).status,
+      (await handler(new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s" }) })))
+        .status,
     ).toBe(400);
   });
 
   it("oversized body returns 413 before invoke and counts real bytes, not JS characters", async () => {
     const handler = createInvokeHandler(makeAgent([fauxAssistantMessage("x")]));
     const big = await handler(
-      new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s", text: "x".repeat(2 * 1024 * 1024) }) }),
+      new Request("http://app/invoke", {
+        method: "POST",
+        body: JSON.stringify({ session: "s", text: "x".repeat(2 * 1024 * 1024) }),
+      }),
     );
     expect(big.status).toBe(413);
     // 400k emoji = 400k chars but > 1 MiB in bytes → must be rejected
     const multibyte = await handler(
-      new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s", text: "🙂".repeat(400_000) }) }),
+      new Request("http://app/invoke", {
+        method: "POST",
+        body: JSON.stringify({ session: "s", text: "🙂".repeat(400_000) }),
+      }),
     );
     expect(multibyte.status).toBe(413);
   });
@@ -128,7 +142,9 @@ describe("invoke handler (Fetch/SSE)", () => {
       },
     };
     const handler = createInvokeHandler(fake);
-    const res = await handler(new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s", text: "hi" }) }));
+    const res = await handler(
+      new Request("http://app/invoke", { method: "POST", body: JSON.stringify({ session: "s", text: "hi" }) }),
+    );
     const reader = res.body!.getReader();
     await reader.read(); // stream has started
     await reader.cancel(); // consumer disconnects
@@ -166,13 +182,19 @@ describe("nodeListener (standalone server bridge)", () => {
   it("bridges POST /invoke to SSE; wrong path returns 404", async () => {
     const srv = await startServer(makeAgent([fauxAssistantMessage("bridged")]));
     try {
-      const res = await fetch(`${srv.url}/invoke`, { method: "POST", body: JSON.stringify({ session: "s", text: "hi" }) });
+      const res = await fetch(`${srv.url}/invoke`, {
+        method: "POST",
+        body: JSON.stringify({ session: "s", text: "hi" }),
+      });
       const body = await res.text();
       const events = body
         .split("\n\n")
         .filter((b) => b.startsWith("data: "))
         .map((b) => JSON.parse(b.slice("data: ".length)) as AgentEvent);
-      const txt = events.filter((e) => e.type === "text").map((e) => (e as any).delta).join("");
+      const txt = events
+        .filter((e) => e.type === "text")
+        .map((e) => (e as any).delta)
+        .join("");
       expect(txt).toBe("bridged");
       expect(events.at(-1)?.type).toBe("completed");
 
@@ -221,7 +243,9 @@ describe("nodeListener (standalone server bridge)", () => {
       controller.abort(); // client disconnect
       await Promise.race([
         cancelledSeen,
-        new Promise((_, reject) => setTimeout(() => reject(new Error("invoke was never cancelled after disconnect")), 3000)),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("invoke was never cancelled after disconnect")), 3000),
+        ),
       ]);
       expect(cancelled).toBe(true);
     } finally {
@@ -234,7 +258,11 @@ describe("nodeListener (standalone server bridge)", () => {
 describe("nodeListener backpressure", () => {
   /** Minimal IncomingMessage: GET (no body) so the bridge needs no request stream. */
   function fakeReq(): IncomingMessage {
-    const req = new EventEmitter() as unknown as IncomingMessage & { method: string; url: string; headers: Record<string, string> };
+    const req = new EventEmitter() as unknown as IncomingMessage & {
+      method: string;
+      url: string;
+      headers: Record<string, string>;
+    };
     req.method = "GET";
     req.url = "/invoke";
     req.headers = { host: "localhost" };

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -72,7 +72,13 @@ describe("init: scaffoldWorkspace", () => {
     const { complete, created } = await scaffoldWorkspace(dir, { minimal: true });
     expect(complete).toBe(false);
     expect(created.sort()).toEqual(
-      ["AGENTS.md", ".gitignore", ".env.example", "fastagent.config.mjs", join("skills", "house-style", "SKILL.md")].sort(),
+      [
+        "AGENTS.md",
+        ".gitignore",
+        ".env.example",
+        "fastagent.config.mjs",
+        join("skills", "house-style", "SKILL.md"),
+      ].sort(),
     );
     expect(await exists(join(dir, "package.json"))).toBe(false);
     expect(await exists(join(dir, "tools"))).toBe(false);

--- a/core/test/invoke.test.ts
+++ b/core/test/invoke.test.ts
@@ -56,7 +56,10 @@ describe("invoke fan-in", () => {
 
     const events = await drain(agent.invoke({ session: "s1" }, { text: "hi" }));
 
-    const text = events.filter((e) => e.type === "text").map((e) => (e as any).delta).join("");
+    const text = events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as any).delta)
+      .join("");
     expect(text).toBe("hello world");
     expect(events.at(-1)).toEqual({ type: "completed" });
     expect(events.filter((e) => e.type === "completed" || e.type === "failed")).toHaveLength(1);
@@ -266,19 +269,14 @@ describe("lease + setup robustness", () => {
   });
 
   it("same-session concurrency: one completes, the other fail-fasts with 'session busy' (no queue, no reentry)", async () => {
-    const { agent } = makeAgent([
-      fauxAssistantMessage("first"),
-      fauxAssistantMessage("should-not-run"),
-    ]);
+    const { agent } = makeAgent([fauxAssistantMessage("first"), fauxAssistantMessage("should-not-run")]);
     const [ea, eb] = await Promise.all([
       drain(agent.invoke({ session: "x" }, { text: "a" })),
       drain(agent.invoke({ session: "x" }, { text: "b" })),
     ]);
 
     const completed = [ea, eb].filter((es) => es.at(-1)?.type === "completed");
-    const busy = [ea, eb].filter((es) =>
-      es.some((e) => e.type === "failed" && /busy/.test((e as any).details)),
-    );
+    const busy = [ea, eb].filter((es) => es.some((e) => e.type === "failed" && /busy/.test((e as any).details)));
     expect(completed).toHaveLength(1); // exactly one completed
     expect(busy).toHaveLength(1); // exactly one busy
     expect(busy[0]).toHaveLength(1); // the busy one never ran a turn; a single failed event
@@ -286,10 +284,7 @@ describe("lease + setup robustness", () => {
   });
 
   it("busy is transient: same session can be used again after the previous turn completes", async () => {
-    const { agent } = makeAgent([
-      fauxAssistantMessage("first"),
-      fauxAssistantMessage("later"),
-    ]);
+    const { agent } = makeAgent([fauxAssistantMessage("first"), fauxAssistantMessage("later")]);
     await drain(agent.invoke({ session: "y" }, { text: "a" })); // completed serially
     const events = await drain(agent.invoke({ session: "y" }, { text: "b" }));
     expect(events.at(-1)?.type).toBe("completed"); // no longer busy
@@ -320,9 +315,7 @@ describe("retryClassifier injection (failed.retryable policy is replaceable)", (
   it("injected policy overrides the default string heuristic", async () => {
     const faux = registerFauxProvider();
     // "weird custom failure" does not match the default regex, so the default would be retryable:false
-    faux.setResponses([
-      fauxAssistantMessage("x", { stopReason: "error", errorMessage: "weird custom failure" }),
-    ]);
+    faux.setResponses([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "weird custom failure" })]);
     const agent = createPiAgentFromHarness({
       retryClassifier: () => true,
       harnessFactory: piHarnessFactory({
@@ -337,7 +330,6 @@ describe("retryClassifier injection (failed.retryable policy is replaceable)", (
     expect(events.at(-1)).toMatchObject({ type: "failed", retryable: true });
   });
 });
-
 
 describe("inProcessLease (fail-fast single writer)", () => {
   it("occupied session makes the second tryAcquire return null (no queue)", () => {

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -34,9 +34,7 @@ describe("jsonlSessionStore (persistent sessions, first K-axis backend)", () => 
     const dir = await mkdtemp(join(tmpdir(), "fa-sessions-"));
 
     // "process 1":run one turn and persist it
-    const agent1 = makeAgent(jsonlSessionStore({ dir }), [
-      fauxAssistantMessage("the answer is blue"),
-    ]);
+    const agent1 = makeAgent(jsonlSessionStore({ dir }), [fauxAssistantMessage("the answer is blue")]);
     const e1 = await drain(agent1.invoke({ session: "conv" }, { text: "what color?" }));
     expect(e1.at(-1)?.type).toBe("completed");
 
@@ -61,10 +59,12 @@ describe("jsonlSessionStore (persistent sessions, first K-axis backend)", () => 
     const dir = await mkdtemp(join(tmpdir(), "fa-sessions-"));
     const store = jsonlSessionStore({ dir });
 
-    await drain(makeAgent(store, [fauxAssistantMessage("secret hunter2")]).invoke(
-      { session: "A" },
-      { text: "remember the secret" },
-    ));
+    await drain(
+      makeAgent(store, [fauxAssistantMessage("secret hunter2")]).invoke(
+        { session: "A" },
+        { text: "remember the secret" },
+      ),
+    );
     let other: unknown;
     await drain(
       makeAgent(store, [
@@ -101,7 +101,6 @@ describe("jsonlSessionStore (persistent sessions, first K-axis backend)", () => 
 
     expect(JSON.stringify(other)).not.toContain("hunter2"); // B cannot see A same-named session
   });
-
 });
 
 describe("crash-safety: reconcile interrupted tool calls on open", () => {
@@ -187,10 +186,18 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
     await s.appendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "x" } }],
-      provider: "faux", model: "faux", stopReason: "toolUse", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+      provider: "faux",
+      model: "faux",
+      stopReason: "toolUse",
+      usage: { input: 0, output: 0 },
+      timestamp: Date.now(),
     } as any);
     // a later turn lands after the dangling call without it ever being reconciled
-    await s.appendMessage({ role: "user", content: [{ type: "text", text: "still there?" }], timestamp: Date.now() } as any);
+    await s.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "still there?" }],
+      timestamp: Date.now(),
+    } as any);
 
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
@@ -212,12 +219,25 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
     await s.appendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "x" } }],
-      provider: "faux", model: "faux", stopReason: "toolUse", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+      provider: "faux",
+      model: "faux",
+      stopReason: "toolUse",
+      usage: { input: 0, output: 0 },
+      timestamp: Date.now(),
     } as any);
-    await s.appendMessage({ role: "user", content: [{ type: "text", text: "still there?" }], timestamp: Date.now() } as any);
     await s.appendMessage({
-      role: "assistant", content: [{ type: "text", text: "sorry, failed" }],
-      provider: "faux", model: "faux", stopReason: "error", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+      role: "user",
+      content: [{ type: "text", text: "still there?" }],
+      timestamp: Date.now(),
+    } as any);
+    await s.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "sorry, failed" }],
+      provider: "faux",
+      model: "faux",
+      stopReason: "error",
+      usage: { input: 0, output: 0 },
+      timestamp: Date.now(),
     } as any);
 
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -241,22 +261,39 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
     await s.appendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "a" } }],
-      provider: "faux", model: "faux", stopReason: "toolUse", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+      provider: "faux",
+      model: "faux",
+      stopReason: "toolUse",
+      usage: { input: 0, output: 0 },
+      timestamp: Date.now(),
     } as any);
     await s.appendMessage({
-      role: "toolResult", toolCallId: "call-1", toolName: "echo",
-      content: [{ type: "text", text: "a" }], isError: false, timestamp: Date.now(),
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "echo",
+      content: [{ type: "text", text: "a" }],
+      isError: false,
+      timestamp: Date.now(),
     } as any);
     await s.appendMessage({
-      role: "assistant", content: [{ type: "text", text: "done turn 1" }],
-      provider: "faux", model: "faux", stopReason: "stop", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+      role: "assistant",
+      content: [{ type: "text", text: "done turn 1" }],
+      provider: "faux",
+      model: "faux",
+      stopReason: "stop",
+      usage: { input: 0, output: 0 },
+      timestamp: Date.now(),
     } as any);
     // turn 2: call-1 reused, crashed before its result
     await s.appendMessage({ role: "user", content: [{ type: "text", text: "second" }], timestamp: Date.now() } as any);
     await s.appendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call-1", name: "echo", arguments: { value: "b" } }],
-      provider: "faux", model: "faux", stopReason: "toolUse", usage: { input: 0, output: 0 }, timestamp: Date.now(),
+      provider: "faux",
+      model: "faux",
+      stopReason: "toolUse",
+      usage: { input: 0, output: 0 },
+      timestamp: Date.now(),
     } as any);
 
     const reopened = await store.openOrCreate("reused-id"); // open -> reconcile
@@ -279,9 +316,7 @@ describe("jsonlSessionStore (malicious id)", () => {
     const store = jsonlSessionStore({ dir, cwd: root });
     const evil = "../../escape/me";
 
-    const e1 = await drain(
-      makeAgent(store, [fauxAssistantMessage("ok")]).invoke({ session: evil }, { text: "hi" }),
-    );
+    const e1 = await drain(makeAgent(store, [fauxAssistantMessage("ok")]).invoke({ session: evil }, { text: "hi" }));
     expect(e1.at(-1)?.type).toBe("completed");
 
     // only sessions/ is created under root; no escape/ or other path breakout appears

--- a/core/test/spec-conformance.ts
+++ b/core/test/spec-conformance.ts
@@ -32,7 +32,9 @@ export interface ConformanceSubject {
    * `sawHistory` reports whether instance B's turn observed instance A's turn
    * (the subject knows how to probe its own engine's context).
    */
-  pair?(): { a: Agent; b: Agent; sawHistory: () => boolean } | Promise<{ a: Agent; b: Agent; sawHistory: () => boolean }>;
+  pair?():
+    | { a: Agent; b: Agent; sawHistory: () => boolean }
+    | Promise<{ a: Agent; b: Agent; sawHistory: () => boolean }>;
 }
 
 const TERMINAL = new Set(["completed", "failed"]);

--- a/core/test/start.test.ts
+++ b/core/test/start.test.ts
@@ -94,7 +94,13 @@ describe("start: createPiAgentFromArtifact", () => {
   it("assembles an agent from the artifact: manifest model, definition, external sessions dir", async () => {
     const { artifact } = await makeArtifact();
     const sessionsDir = await freshSessions();
-    const { agent, definition, manifest, modelSpec, sessionsDir: used } = await createPiAgentFromArtifact(artifact, {
+    const {
+      agent,
+      definition,
+      manifest,
+      modelSpec,
+      sessionsDir: used,
+    } = await createPiAgentFromArtifact(artifact, {
       sessionsDir,
     });
     expect(typeof agent.invoke).toBe("function");


### PR DESCRIPTION
Open-source readiness for the first version. **The public-registry switch is deliberately NOT in this PR** (that is the final step, per plan); this lands everything else (#2/#3/#5/#6 from the release-readiness review).

## Packaging (#2, #3, #6)
- Ship LICENSE + README in the npm tarball (`files: [dist, LICENSE, README.md]`).
- Add `core/LICENSE` (MIT) and a concise `core/README.md` (embed + serve + doc links).
- User-facing `description` + `keywords` (was an internal one-liner).

## Build hygiene (caught by npm pack smoke, #4)
- `prebuild` cleans `dist/`: a stale build had shipped the **withdrawn** `embed`/`workspace` modules into the tarball (`tsc` does not clean `outDir`). The smoke test caught it.

## Tooling — adopt Biome (#5)
- `biome.json`: format + lint (lineWidth 120, double quotes, semicolons, trailing commas).
- One-time **format baseline** across src/test/examples — no semantic changes (160 tests still pass).
- Fix lint findings: 2 `implicit-any-let` now typed; `useTemplate`; 3 reviewed inline ignores (variance `Model<any>`, `argv[1]!`, `found[0]!` — each justified in place).
- `test/**` override relaxes `noExplicitAny`/`noNonNullAssertion` (mock/faux idioms).
- `organizeImports` assist off (preserve the hand-grouped import blocks).
- `npm run lint` / `npm run format`; **CI runs lint before typecheck**; CONTRIBUTING updated.

## Not in scope (the final publish step)
- Switching `publishConfig.registry` / `publish.yml` from GitHub Packages → public npm.
- README install section (private+token → `npm i`).
- These three are one coupled decision ("switch to public distribution") and land together as the last step.

## Verification
- `npm run lint` clean · `npm run typecheck` clean · `npm test` 160 passed · `npm run build` clean.
- `npm pack --dry-run`: tarball = dist + LICENSE + README (no biome.json, no dead modules).

## Review note
Large diff is mostly the one-time Biome format baseline (mechanical). Substantive changes are confined to: package.json, biome.json, the 2 typed `let`s + 3 inline ignores, CI, CONTRIBUTING, and the two new files.