### PR TITLE
refactor: drop speculative piReadOnlyTools (YAGNI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Public surface tiers:
 | Contract | `Agent`, `AgentEvent`, `collect` | Intended to remain stable within SPEC v0.1 |
 | Channels (reference) | `createInvokeHandler`, `nodeListener` | Reference HTTP/SSE channel, outside the SPEC contract (invoke is not a wire protocol). The handler is **Fetch-shaped** (`(Request) => Promise<Response>`); shape may still change pre-1.0 |
 | Pi assembly ladder | `createPiAgentFromWorkspace`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
-| Injection ports | `PiSessionStore`, `inMemorySessionStore`/`jsonlSessionStore`, `AuthResolver`, `Lease`, `piDefaultTools`/`piReadOnlyTools` | Public because the ladder options reference them |
+| Injection ports | `PiSessionStore`, `inMemorySessionStore`/`jsonlSessionStore`, `AuthResolver`, `Lease`, `piDefaultTools` | Public because the ladder options reference them |
 | Not exported | L0 `createPiAgentFromHarness`, `piHarnessFactory`, prompt/config assembly internals | Internal modules only; they expose pi's engine shape and are not a compatibility promise |
 
 ## Build order

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -5,7 +5,7 @@
  *
  * Organized as the engine-asset parts plus the reusable assembly ladder that consumes them:
  *
- *   §1 tools   — pi default/read-only toolsets (engine assets)
+ *   §1 tools   — pi default toolset (engine asset)
  *   §2 prompt  — four-segment systemPrompt assembly (pure functions)
  *   §3 ladder  — the reusable rungs that put a pi agent together (L0–L2).
  *
@@ -66,7 +66,7 @@ import { join } from "node:path";
 import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
-import { createCodingTools, createReadOnlyTools } from "@earendil-works/pi-coding-agent";
+import { createCodingTools } from "@earendil-works/pi-coding-agent";
 import type { Agent } from "../../agent.ts";
 import type { AuthResolver } from "./auth.ts";
 import type { FastagentConfig } from "./config.ts";
@@ -84,19 +84,14 @@ import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 //     match local pi verbatim.
 //   - **The tool layer is not the security boundary**: isolation is the K-side
 //     ExecutionEnv/sandbox's job (local = the user's own machine; AgentCore = microVM).
-//     Locking down for public exposure = explicitly passing `tools` (e.g.
-//     piReadOnlyTools) — a deployment posture, not the default.
+//     Locking down for public exposure = explicitly passing a restricted `tools`
+//     list — a deployment posture, not the default.
 //   - pi tools take injectable operations (BashOperations etc.); a future sandbox
 //     adapter swaps operations rather than being locked to local fs.
 
 /** pi's core default toolset (read/bash/edit/write, matching pi defaults), rooted at cwd. */
 export function piDefaultTools(cwd: string): AgentTool[] {
   return createCodingTools(cwd) as AgentTool[];
-}
-
-/** Read-only subset (read/grep/find/ls) for locked-down postures such as public exposure. */
-export function piReadOnlyTools(cwd: string): AgentTool[] {
-  return createReadOnlyTools(cwd) as AgentTool[];
 }
 
 /**
@@ -236,7 +231,7 @@ export interface CreatePiAgentFromDefinitionOptions {
   model: AnyModel;
   /** Override the base prompt (segment ①). Defaults to piBasePrompt({tools}) (engine-inherited). */
   base?: string;
-  /** Override tools. Defaults to piDefaultTools (full pi toolset, fidelity; lock down with piReadOnlyTools or a custom list). */
+  /** Override tools. Defaults to piDefaultTools (full pi toolset, fidelity; lock down with a custom list). */
   tools?: AgentTool[];
   /** Extra skills mount directories (see LoadAgentDefinitionOptions.skillPaths). */
   skillPaths?: string[];

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -73,11 +73,7 @@ export {
 // pi reference implementation — engine assets (prompt base + toolsets, in create.ts).
 // Internal assembly helpers (assembleSystemPrompt, resolveTools) are NOT public:
 // the ladder rungs own assembly; embedders compose via L1/L2/L3.
-export {
-  piBasePrompt,
-  piDefaultTools,
-  piReadOnlyTools,
-} from "./engines/pi/create.ts";
+export { piBasePrompt, piDefaultTools } from "./engines/pi/create.ts";
 
 // pi reference implementation — config subsystem.
 // loadConfig is internal (L3 owns config loading); resolveModel bridges a

--- a/core/test/definition.test.ts
+++ b/core/test/definition.test.ts
@@ -13,7 +13,6 @@ import {
   loadAgentDefinition,
   piBasePrompt,
   piDefaultTools,
-  piReadOnlyTools,
   type CreatePiAgentFromDefinitionOptions,
 } from "../src/index.ts";
 // bundleAgentDefinition is internal (not re-exported): import it from its module.
@@ -177,16 +176,12 @@ describe("create: createPiAgentFromDefinition (directory → agent)", () => {
 });
 
 describe("create: toolset (real pi tools, fidelity)", () => {
-  it("piDefaultTools are pi core four tools (same as pi default); piReadOnlyTools is the read-only subset", () => {
+  it("piDefaultTools are pi core four tools (same as pi default)", () => {
     expect(
       piDefaultTools(fixtureDir)
         .map((t) => t.name)
         .sort(),
     ).toEqual(["bash", "edit", "read", "write"]);
-    const ro = piReadOnlyTools(fixtureDir).map((t) => t.name);
-    expect(ro).not.toContain("bash");
-    expect(ro).not.toContain("write");
-    expect(ro).toContain("read");
   });
 
   it("pi's read tool can read the fixture (same behavior as local pi)", async () => {

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -119,7 +119,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 };
 ```
 
-The embed entry point is `createPiAgentFromDefinition` (L2): point at the folder, pass a resolved model (`resolveModel("provider/modelId")`) and your own K ports (sessions/env/lease/auth), and inject tools explicitly. There is deliberately no separate embed opener — L2 already gives folder + K injection + a fully replaceable toolset (pass `piReadOnlyTools(dir)` or an app-specific set to drop the default coding tools).
+The embed entry point is `createPiAgentFromDefinition` (L2): point at the folder, pass a resolved model (`resolveModel("provider/modelId")`) and your own K ports (sessions/env/lease/auth), and inject tools explicitly. There is deliberately no separate embed opener — L2 already gives folder + K injection + a fully replaceable toolset (pass an app-specific set to drop the default coding tools).
 
 One build, one deploy, one auth, your database. The transport-neutral `invoke` contract (no bundled HTTP framework) is what lets the agent live inside the host's own route. This is the demo that makes the abstract positioning concrete — and the sweet spot is explicit: a relatively *light* agent feature (interactive/generation/trigger-response) in a *TS/Node* product with an *existing stack*. A *heavy* agent (long autonomy, swarm, sandbox isolation, many channels) tilts back toward Flue's batteries-included path even as a feature.
 


### PR DESCRIPTION
## What

Remove `piReadOnlyTools` and its plumbing entirely.

## Why

It had **no internal caller** — no command, opener, or example wired it; only its own unit test exercised it. The read-only deployment posture is a genuinely rare need, and L2's `tools` option already accepts any restricted toolset (`createPiAgentFromDefinition(dir, { tools })`), so a dedicated export is speculative public surface. YAGNI: re-add it from a real requirement if one appears.

## Changes

- `core/src/engines/pi/create.ts` — remove the function + the `createReadOnlyTools` import; update the §1 toolset stance/header comments and the L2 `tools` doc.
- `core/src/index.ts` — drop the public export.
- `core/test/definition.test.ts` — drop the read-only-subset assertions (keep the `piDefaultTools` ones).
- `README.md` / `docs/comparisons.md` — drop `piReadOnlyTools` from the public-surface table and the embed example.

## Surface note

This narrows the public API (removes one exported symbol). Pre-1.0, no internal callers, no known external users. Flagging for the public-surface review tier per CONTRIBUTING.

## Verification

`npm run typecheck` ✓ · `npm run lint` ✓ · `npm test` ✓ (160 passed)