### PR TITLE
feat(channels): webhook channel + the background port (N-axis)

### DIFF
--- a/core/src/channels/background.ts
+++ b/core/src/channels/background.ts
@@ -28,10 +28,11 @@ export type BackgroundRunner = (task: () => Promise<void>) => void;
  * use it. Multi-instance / crash-durable runners (queue + worker, a platform's async invocation)
  * are host-specific and live outside core.
  *
- * The task is started on a microtask (not synchronously), so the caller's path — e.g. a webhook
- * returning 202 — finishes before the turn begins, and a task that throws *synchronously* becomes a
- * tracked rejection instead of propagating out of `background()` (which would otherwise turn a
- * post-ACK failure into a pre-ACK error). `drain()` awaits all in-flight tasks — call it on SIGTERM
+ * The task is started on a macrotask (setImmediate), so the caller's response — e.g. a webhook 202,
+ * written in a microtask continuation — lands before the turn begins, and a task that throws
+ * *synchronously* becomes a tracked rejection instead of propagating out of `background()` (which
+ * would otherwise turn a post-ACK failure into a pre-ACK error). `drain()` awaits all in-flight
+ * tasks — call it on SIGTERM
  * before exiting. A task failure is settled (not propagated) so one cannot wedge the drain, and is
  * surfaced via `onTaskError` (default console.error: fail visibly, never swallow).
  */
@@ -43,10 +44,19 @@ export function createTrackedBackground(options: { onTaskError?: (error: unknown
     options.onTaskError ?? ((error: unknown) => console.error(`[fastagent] background task failed: ${String(error)}`));
   const inFlight = new Set<Promise<void>>();
   const background: BackgroundRunner = (task) => {
-    // Start on a microtask: keeps the task off the caller's synchronous frame (the ACK path) and
-    // turns a synchronous throw inside `task` into a tracked rejection routed to onTaskError.
-    const p = Promise.resolve()
-      .then(task)
+    // Start on a macrotask (setImmediate), not synchronously and not a microtask: the caller's
+    // response — e.g. a webhook 202, whose write is a microtask continuation — lands BEFORE the
+    // turn begins, so the turn's synchronous prefix never delays the ACK. A synchronous throw inside
+    // `task` is captured (routed to onTaskError), never escaping `background()` as a pre-ACK failure.
+    const p = new Promise<void>((resolve, reject) => {
+      setImmediate(() => {
+        try {
+          resolve(task());
+        } catch (error) {
+          reject(error);
+        }
+      });
+    })
       .catch(onTaskError)
       .finally(() => inFlight.delete(p));
     inFlight.add(p);

--- a/core/src/channels/background.ts
+++ b/core/src/channels/background.ts
@@ -28,9 +28,12 @@ export type BackgroundRunner = (task: () => Promise<void>) => void;
  * use it. Multi-instance / crash-durable runners (queue + worker, a platform's async invocation)
  * are host-specific and live outside core.
  *
- * `drain()` awaits all in-flight tasks — call it on SIGTERM before exiting. A task that throws is
- * settled (not propagated) so one failure cannot wedge the drain, and is surfaced via `onTaskError`
- * (default console.error: fail visibly, never swallow).
+ * The task is started on a microtask (not synchronously), so the caller's path — e.g. a webhook
+ * returning 202 — finishes before the turn begins, and a task that throws *synchronously* becomes a
+ * tracked rejection instead of propagating out of `background()` (which would otherwise turn a
+ * post-ACK failure into a pre-ACK error). `drain()` awaits all in-flight tasks — call it on SIGTERM
+ * before exiting. A task failure is settled (not propagated) so one cannot wedge the drain, and is
+ * surfaced via `onTaskError` (default console.error: fail visibly, never swallow).
  */
 export function createTrackedBackground(options: { onTaskError?: (error: unknown) => void } = {}): {
   background: BackgroundRunner;
@@ -40,7 +43,10 @@ export function createTrackedBackground(options: { onTaskError?: (error: unknown
     options.onTaskError ?? ((error: unknown) => console.error(`[fastagent] background task failed: ${String(error)}`));
   const inFlight = new Set<Promise<void>>();
   const background: BackgroundRunner = (task) => {
-    const p = task()
+    // Start on a microtask: keeps the task off the caller's synchronous frame (the ACK path) and
+    // turns a synchronous throw inside `task` into a tracked rejection routed to onTaskError.
+    const p = Promise.resolve()
+      .then(task)
       .catch(onTaskError)
       .finally(() => inFlight.delete(p));
     inFlight.add(p);

--- a/core/src/channels/background.ts
+++ b/core/src/channels/background.ts
@@ -28,7 +28,8 @@ export type BackgroundRunner = (task: () => Promise<void>) => void;
  * use it. Multi-instance / crash-durable runners (queue + worker, a platform's async invocation)
  * are host-specific and live outside core.
  *
- * The task is started on a macrotask (setImmediate), so the caller's response — e.g. a webhook 202,
+ * The task is started on a macrotask (`setTimeout(…, 0)` — portable, unlike Node's `setImmediate`), so
+ * the caller's response — e.g. a webhook 202,
  * written in a microtask continuation — lands before the turn begins, and a task that throws
  * *synchronously* becomes a tracked rejection instead of propagating out of `background()` (which
  * would otherwise turn a post-ACK failure into a pre-ACK error). `drain()` awaits all in-flight
@@ -44,18 +45,19 @@ export function createTrackedBackground(options: { onTaskError?: (error: unknown
     options.onTaskError ?? ((error: unknown) => console.error(`[fastagent] background task failed: ${String(error)}`));
   const inFlight = new Set<Promise<void>>();
   const background: BackgroundRunner = (task) => {
-    // Start on a macrotask (setImmediate), not synchronously and not a microtask: the caller's
-    // response — e.g. a webhook 202, whose write is a microtask continuation — lands BEFORE the
-    // turn begins, so the turn's synchronous prefix never delays the ACK. A synchronous throw inside
-    // `task` is captured (routed to onTaskError), never escaping `background()` as a pre-ACK failure.
+    // Start on a macrotask (setTimeout 0 — portable across runtimes, unlike Node's setImmediate),
+    // not synchronously and not a microtask: the caller's response — e.g. a webhook 202, whose write
+    // is a microtask continuation — lands BEFORE the turn begins, so the turn's synchronous prefix
+    // never delays the ACK. A synchronous throw inside `task` is captured (routed to onTaskError),
+    // never escaping `background()` as a pre-ACK failure.
     const p = new Promise<void>((resolve, reject) => {
-      setImmediate(() => {
+      setTimeout(() => {
         try {
           resolve(task());
         } catch (error) {
           reject(error);
         }
-      });
+      }, 0);
     })
       .catch(onTaskError)
       .finally(() => inFlight.delete(p));

--- a/core/src/channels/background.ts
+++ b/core/src/channels/background.ts
@@ -1,0 +1,52 @@
+/**
+ * The `background` port (Caller-side): run a task to completion AFTER the caller has detached
+ * (e.g. a webhook that already returned 202).
+ *
+ * It is the symmetric twin of the Agent-side dependency-inversion ports (sessions/env/lease/
+ * auth): the Agent has host dependencies injected into it, and so does a Caller — its execution
+ * lifetime. It lives OUTSIDE the invoke contract (adds no scope field, no event, no invoke
+ * parameter; the Agent never sees it) and is NOT Middleware. In WSGI/ASGI terms it is the
+ * server's background-task / lifespan layer, not the app callable.
+ *
+ * NOT a universal tax: only ACK-early channels (webhook-like) need it. Channels whose caller
+ * awaits the result (SSE, buffered embed, CLI) get liveness for free from the open connection /
+ * blocked request and never touch this port.
+ */
+
+/**
+ * Run `task` to completion after the caller has detached. The implementation MUST carry a
+ * completion guarantee: `(t) => void t()` is ILLEGAL — once the response is sent the runtime may
+ * reclaim the process and the task dies mid-flight. The completion guarantee is the entire reason
+ * this port exists; how it is honored (track in-flight, durable queue, host primitive) is the
+ * host's choice.
+ */
+export type BackgroundRunner = (task: () => Promise<void>) => void;
+
+/**
+ * Reference single-instance {@link BackgroundRunner}: track in-flight tasks so a graceful shutdown
+ * can drain them instead of killing turns mid-flight. Channel-agnostic — any ACK-early channel can
+ * use it. Multi-instance / crash-durable runners (queue + worker, a platform's async invocation)
+ * are host-specific and live outside core.
+ *
+ * `drain()` awaits all in-flight tasks — call it on SIGTERM before exiting. A task that throws is
+ * settled (not propagated) so one failure cannot wedge the drain, and is surfaced via `onTaskError`
+ * (default console.error: fail visibly, never swallow).
+ */
+export function createTrackedBackground(options: { onTaskError?: (error: unknown) => void } = {}): {
+  background: BackgroundRunner;
+  drain: () => Promise<void>;
+} {
+  const onTaskError =
+    options.onTaskError ?? ((error: unknown) => console.error(`[fastagent] background task failed: ${String(error)}`));
+  const inFlight = new Set<Promise<void>>();
+  const background: BackgroundRunner = (task) => {
+    const p = task()
+      .catch(onTaskError)
+      .finally(() => inFlight.delete(p));
+    inFlight.add(p);
+  };
+  return {
+    background,
+    drain: () => Promise.allSettled([...inFlight]).then(() => undefined),
+  };
+}

--- a/core/src/channels/webhook.ts
+++ b/core/src/channels/webhook.ts
@@ -7,8 +7,12 @@
  * works with any Agent. The per-platform glue (verify, parse, map, optional delivery) is the
  * {@link WebhookBinding} the caller supplies.
  *
+ * `parse` returns one of three outcomes so a binding can act, ignore, or reject a delivery (real
+ * webhooks send many event types and redeliveries; an ignored/duplicate one must be ACKed 2xx, not
+ * 4xx, or the provider retries it).
+ *
  * Two failure planes:
- *   - pre-ACK: parse/verify rejects → 4xx on the request;
+ *   - pre-ACK: parse rejects (bad/unauthorized) → 4xx; parse throws (unexpected fault) → 400;
  *   - post-ACK: the turn fails → `binding.onError` out-of-band (the 202 already went out).
  *
  * Delivery is OPTIONAL: a "fat" agent posts its own result via tools (e.g. `gh pr review`), so the
@@ -20,10 +24,26 @@ import type { BackgroundRunner } from "./background.ts";
 
 const textHeaders = { "content-type": "text/plain" };
 
+/**
+ * What `parse` decided about a delivery:
+ *   - `invoke` — run the agent on `event` (→ 202);
+ *   - `ignore` — valid but no work (a duplicate, or an event type this binding doesn't handle) → 200
+ *     no-op; the delivery is ACKed so the provider doesn't retry it;
+ *   - `reject` — bad/unauthorized request → 4xx (default 401).
+ */
+export type WebhookOutcome<E> =
+  | { action: "invoke"; event: E }
+  | { action: "ignore" }
+  | { action: "reject"; status?: number };
+
 /** Per-platform glue. One impl per platform (GitHub, Slack, generic callback). */
 export interface WebhookBinding<E> {
-  /** Verify the request (signature, etc.) and parse it into an event, or null to reject (→ 401). */
-  parse(req: Request): Promise<E | null>;
+  /**
+   * Verify the request (signature, etc.) and classify it: invoke / ignore / reject (see
+   * {@link WebhookOutcome}). Throwing signals an unexpected fault (unreadable body) → 400; an
+   * expected bad/unauthorized request is `{ action: "reject" }`, not a throw.
+   */
+  parse(req: Request): Promise<WebhookOutcome<E>>;
   /** Map the event to an invocation. `scope.session` is derived from the payload. */
   toInvocation(event: E): { scope: Scope; prompt: Prompt };
   /**
@@ -48,16 +68,21 @@ export function createWebhookHandler<E>(
   return async (req) => {
     if (req.method !== "POST") return new Response("POST only\n", { status: 405, headers: textHeaders });
 
-    let parsed: E | null;
+    let outcome: WebhookOutcome<E>;
     try {
-      parsed = await binding.parse(req);
+      outcome = await binding.parse(req);
     } catch (error) {
-      // parse/verify throwing is a fault in the request (bad signature shape, unreadable body),
-      // not a deliberately rejected webhook — answer with 400, before any ACK.
+      // parse throwing is an UNEXPECTED fault (unreadable body, etc.), not a deliberate reject —
+      // answer 400, before any ACK. An expected bad request is `{ action: "reject" }` below.
       return new Response(`bad request: ${(error as Error).message}\n`, { status: 400, headers: textHeaders });
     }
-    if (parsed === null) return new Response("rejected\n", { status: 401, headers: textHeaders });
-    const event = parsed;
+    // A valid-but-skipped delivery (duplicate / unhandled event type) MUST be ACKed 2xx, or the
+    // provider keeps retrying it; only a bad/unauthorized request gets 4xx.
+    if (outcome.action === "reject") {
+      return new Response("rejected\n", { status: outcome.status ?? 401, headers: textHeaders });
+    }
+    if (outcome.action === "ignore") return new Response(null, { status: 200 });
+    const { event } = outcome;
 
     const { scope, prompt } = binding.toInvocation(event);
 

--- a/core/src/channels/webhook.ts
+++ b/core/src/channels/webhook.ts
@@ -1,0 +1,78 @@
+/**
+ * Webhook channel: turn an inbound webhook (GitHub, Slack, a generic callback, …) into one agent
+ * turn. The ACK-early N topology — acknowledge the delivery immediately (202), then run the turn
+ * via the `background` port and let the result reach the user out-of-band.
+ *
+ * Consumes ONLY the Agent contract (+ collect + the background port). Zero engine coupling: it
+ * works with any Agent. The per-platform glue (verify, parse, map, optional delivery) is the
+ * {@link WebhookBinding} the caller supplies.
+ *
+ * Two failure planes:
+ *   - pre-ACK: parse/verify rejects → 4xx on the request;
+ *   - post-ACK: the turn fails → `binding.onError` out-of-band (the 202 already went out).
+ *
+ * Delivery is OPTIONAL: a "fat" agent posts its own result via tools (e.g. `gh pr review`), so the
+ * binding need deliver nothing; a "thin" agent returns text the binding posts in `deliver`.
+ */
+import type { Agent, Prompt, Scope } from "../agent.ts";
+import { AgentFailure, collect, type CollectResult } from "../collect.ts";
+import type { BackgroundRunner } from "./background.ts";
+
+const textHeaders = { "content-type": "text/plain" };
+
+/** Per-platform glue. One impl per platform (GitHub, Slack, generic callback). */
+export interface WebhookBinding<E> {
+  /** Verify the request (signature, etc.) and parse it into an event, or null to reject (→ 401). */
+  parse(req: Request): Promise<E | null>;
+  /** Map the event to an invocation. `scope.session` is derived from the payload. */
+  toInvocation(event: E): { scope: Scope; prompt: Prompt };
+  /**
+   * Deliver the result out-of-band (OPTIONAL). Omit it when the agent posts its own result via
+   * tools; provide it for a thin agent whose text/data the binding posts back.
+   */
+  deliver?(event: E, result: CollectResult): Promise<void>;
+  /** Deliver a turn failure out-of-band (OPTIONAL). `retryable` is the platform-retry signal. */
+  onError?(event: E, failure: AgentFailure): Promise<void>;
+}
+
+/**
+ * Fetch-shaped webhook handler. Mount at any route; POST only. ACKs `202` immediately and runs the
+ * turn via `background`; the result reaches the user through the agent's own tools and/or
+ * `binding.deliver`.
+ */
+export function createWebhookHandler<E>(
+  agent: Agent,
+  binding: WebhookBinding<E>,
+  background: BackgroundRunner,
+): (req: Request) => Promise<Response> {
+  return async (req) => {
+    if (req.method !== "POST") return new Response("POST only\n", { status: 405, headers: textHeaders });
+
+    let parsed: E | null;
+    try {
+      parsed = await binding.parse(req);
+    } catch (error) {
+      // parse/verify throwing is a fault in the request (bad signature shape, unreadable body),
+      // not a deliberately rejected webhook — answer with 400, before any ACK.
+      return new Response(`bad request: ${(error as Error).message}\n`, { status: 400, headers: textHeaders });
+    }
+    if (parsed === null) return new Response("rejected\n", { status: 401, headers: textHeaders });
+    const event = parsed;
+
+    const { scope, prompt } = binding.toInvocation(event);
+
+    // ACK-early: hand the turn to the host's background runner, which MUST run it to completion.
+    background(async () => {
+      try {
+        const result = await collect(agent.invoke(scope, prompt)); // buffered + terminal discipline
+        await binding.deliver?.(event, result);
+      } catch (error) {
+        if (error instanceof AgentFailure)
+          await binding.onError?.(event, error); // a turn failure
+        else throw error; // a real bug → the background runner's error sink (fail visibly)
+      }
+    });
+
+    return new Response(null, { status: 202 });
+  };
+}

--- a/core/src/channels/webhook.ts
+++ b/core/src/channels/webhook.ts
@@ -67,9 +67,12 @@ export function createWebhookHandler<E>(
         const result = await collect(agent.invoke(scope, prompt)); // buffered + terminal discipline
         await binding.deliver?.(event, result);
       } catch (error) {
-        if (error instanceof AgentFailure)
-          await binding.onError?.(event, error); // a turn failure
-        else throw error; // a real bug → the background runner's error sink (fail visibly)
+        // A turn failure with an onError handler is delivered out-of-band. WITHOUT a handler it must
+        // still be visible: rethrow so it reaches the background runner's error sink, same as a real
+        // bug — never swallow it (fail visibly). For a fat agent this is the case where the agent
+        // crashed before posting anything, so the failure especially must not vanish.
+        if (error instanceof AgentFailure && binding.onError) await binding.onError(event, error);
+        else throw error;
       }
     });
 

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -15,6 +15,11 @@ export { collect, AgentFailure, type CollectResult } from "./collect.ts";
 // createInvokeHandler is Fetch-shaped ((Request) => Promise<Response>) so it mounts in any host
 // route; nodeListener bridges it onto node:http for the standalone server.
 export { createInvokeHandler, nodeListener } from "./channels/http.ts";
+// Webhook channel (N): the ACK-early topology — 202 now, run the turn via the `background` port,
+// deliver out-of-band. Consumes only the Agent contract. `background` is the Caller-side host port
+// (execution lifetime); createTrackedBackground is the single-instance reference impl.
+export { createWebhookHandler, type WebhookBinding } from "./channels/webhook.ts";
+export { type BackgroundRunner, createTrackedBackground } from "./channels/background.ts";
 
 // pi reference implementation — reusable assembly ladder (L1/L2; L0 below)
 export {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -18,7 +18,7 @@ export { createInvokeHandler, nodeListener } from "./channels/http.ts";
 // Webhook channel (N): the ACK-early topology — 202 now, run the turn via the `background` port,
 // deliver out-of-band. Consumes only the Agent contract. `background` is the Caller-side host port
 // (execution lifetime); createTrackedBackground is the single-instance reference impl.
-export { createWebhookHandler, type WebhookBinding } from "./channels/webhook.ts";
+export { createWebhookHandler, type WebhookBinding, type WebhookOutcome } from "./channels/webhook.ts";
 export { type BackgroundRunner, createTrackedBackground } from "./channels/background.ts";
 
 // pi reference implementation — reusable assembly ladder (L1/L2; L0 below)

--- a/core/test/webhook.test.ts
+++ b/core/test/webhook.test.ts
@@ -167,4 +167,18 @@ describe("createTrackedBackground", () => {
     expect(errors).toHaveLength(1);
     expect((errors[0] as Error).message).toBe("task boom");
   });
+
+  it("a synchronously-thrown task is captured (not propagated out of background) and tracked", async () => {
+    const errors: unknown[] = [];
+    const { background, drain } = createTrackedBackground({ onTaskError: (e) => errors.push(e) });
+    // A task that throws synchronously (before returning a promise) must not escape background() —
+    // otherwise the webhook handler would reject pre-ACK (500) instead of ACKing and tracking it.
+    const syncThrow = (() => {
+      throw new Error("sync boom");
+    }) as () => Promise<void>;
+    expect(() => background(syncThrow)).not.toThrow();
+    await expect(drain()).resolves.toBeUndefined();
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("sync boom");
+  });
 });

--- a/core/test/webhook.test.ts
+++ b/core/test/webhook.test.ts
@@ -32,7 +32,7 @@ function recordingBinding(parse?: WebhookBinding<Ev>["parse"]): {
 } {
   const calls = { deliver: [] as CollectResult[], onError: [] as AgentFailure[], invocations: [] as Ev[] };
   const binding: WebhookBinding<Ev> = {
-    parse: parse ?? (async (req) => (await req.json()) as Ev),
+    parse: parse ?? (async (req) => ({ action: "invoke", event: (await req.json()) as Ev })),
     toInvocation(e) {
       calls.invocations.push(e);
       return { scope: { session: e.session }, prompt: { text: e.text } };
@@ -112,7 +112,7 @@ describe("webhook channel", () => {
     const agent = fauxAgent([{ type: "failed", details: "model exploded", retryable: true }]);
     const binding: WebhookBinding<Ev> = {
       async parse(req) {
-        return (await req.json()) as Ev;
+        return { action: "invoke", event: (await req.json()) as Ev };
       },
       toInvocation: (e) => ({ scope: { session: e.session }, prompt: { text: e.text } }),
       // no onError — the failure must still be visible
@@ -129,12 +129,21 @@ describe("webhook channel", () => {
     expect((errors[0] as AgentFailure).details).toBe("model exploded");
   });
 
-  it("parse → null rejects with 401 and never invokes", async () => {
-    const { binding, calls } = recordingBinding(async () => null);
+  it("a reject outcome answers 4xx (default 401) and never invokes", async () => {
+    const { binding, calls } = recordingBinding(async () => ({ action: "reject" }));
     const bg = captureBackground();
     const handler = createWebhookHandler(fauxAgent([]), binding, bg.background);
     const res = await handler(post({ nope: true }));
     expect(res.status).toBe(401);
+    expect(calls.invocations).toHaveLength(0);
+  });
+
+  it("an ignore outcome ACKs 2xx (200) and never invokes — so a deduped/unhandled delivery is not retried", async () => {
+    const { binding, calls } = recordingBinding(async () => ({ action: "ignore" }));
+    const bg = captureBackground();
+    const handler = createWebhookHandler(fauxAgent([]), binding, bg.background);
+    const res = await handler(post({ duplicate: true }));
+    expect(res.status).toBe(200);
     expect(calls.invocations).toHaveLength(0);
   });
 
@@ -152,7 +161,7 @@ describe("webhook channel", () => {
     const agent = fauxAgent([{ type: "completed" }]);
     const binding: WebhookBinding<Ev> = {
       async parse(req) {
-        return (await req.json()) as Ev;
+        return { action: "invoke", event: (await req.json()) as Ev };
       },
       toInvocation: (e) => ({ scope: { session: e.session }, prompt: { text: e.text } }),
       // no deliver, no onError — the agent owns its output

--- a/core/test/webhook.test.ts
+++ b/core/test/webhook.test.ts
@@ -166,6 +166,19 @@ describe("webhook channel", () => {
 });
 
 describe("createTrackedBackground", () => {
+  it("starts the task on a macrotask so the caller's response lands first", async () => {
+    const order: string[] = [];
+    const { background, drain } = createTrackedBackground();
+    background(async () => {
+      order.push("task");
+    });
+    order.push("after-background"); // synchronous code after background() returns
+    await Promise.resolve(); // a microtask (stands in for the response write) must run before the task
+    order.push("microtask");
+    await drain();
+    expect(order).toEqual(["after-background", "microtask", "task"]);
+  });
+
   it("runs tasks and drain() awaits in-flight work", async () => {
     const { background, drain } = createTrackedBackground();
     let done = false;

--- a/core/test/webhook.test.ts
+++ b/core/test/webhook.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentFailure,
+  type Agent,
+  type AgentEvent,
+  type BackgroundRunner,
+  type CollectResult,
+  createTrackedBackground,
+  createWebhookHandler,
+  type WebhookBinding,
+} from "../src/index.ts";
+
+/** A faux Agent (contract-only, no engine) that yields the given events — proves the channel
+ *  works against any Agent, not just the pi implementation. */
+function fauxAgent(events: AgentEvent[]): Agent {
+  return {
+    async *invoke() {
+      for (const e of events) yield e;
+    },
+  };
+}
+
+interface Ev {
+  session: string;
+  text: string;
+}
+
+/** A binding that records deliver/onError calls; parse defaults to reading {session,text}. */
+function recordingBinding(parse?: WebhookBinding<Ev>["parse"]): {
+  binding: WebhookBinding<Ev>;
+  calls: { deliver: CollectResult[]; onError: AgentFailure[]; invocations: Ev[] };
+} {
+  const calls = { deliver: [] as CollectResult[], onError: [] as AgentFailure[], invocations: [] as Ev[] };
+  const binding: WebhookBinding<Ev> = {
+    parse: parse ?? (async (req) => (await req.json()) as Ev),
+    toInvocation(e) {
+      calls.invocations.push(e);
+      return { scope: { session: e.session }, prompt: { text: e.text } };
+    },
+    async deliver(_e, r) {
+      calls.deliver.push(r);
+    },
+    async onError(_e, f) {
+      calls.onError.push(f);
+    },
+  };
+  return { binding, calls };
+}
+
+/** A background runner that captures the task instead of running it, so a test can assert the
+ *  202 is returned BEFORE the turn runs (ACK-early), then run the task explicitly. */
+function captureBackground(): { background: BackgroundRunner; run: () => Promise<void> } {
+  let task: (() => Promise<void>) | undefined;
+  return {
+    background: (t) => {
+      task = t;
+    },
+    run: () => {
+      if (!task) throw new Error("no background task was scheduled");
+      return task();
+    },
+  };
+}
+
+function post(body: unknown): Request {
+  return new Request("http://app/hook", { method: "POST", body: JSON.stringify(body) });
+}
+
+describe("webhook channel", () => {
+  it("rejects non-POST with 405", async () => {
+    const { binding } = recordingBinding();
+    const handler = createWebhookHandler(fauxAgent([]), binding, captureBackground().background);
+    const res = await handler(new Request("http://app/hook", { method: "GET" }));
+    expect(res.status).toBe(405);
+  });
+
+  it("ACKs 202 and runs the turn AFTER responding (ACK-early)", async () => {
+    const agent = fauxAgent([{ type: "text", delta: "looks good" }, { type: "completed" }]);
+    const { binding, calls } = recordingBinding();
+    const bg = captureBackground();
+    const handler = createWebhookHandler(agent, binding, bg.background);
+
+    const res = await handler(post({ session: "pr-1", text: "review" }));
+    expect(res.status).toBe(202);
+    // The turn has NOT run yet — the binding only ACKed.
+    expect(calls.deliver).toHaveLength(0);
+    expect(calls.invocations).toEqual([{ session: "pr-1", text: "review" }]);
+
+    await bg.run(); // now the host runs the deferred turn
+    expect(calls.deliver).toEqual([{ text: "looks good", data: undefined }]);
+    expect(calls.onError).toHaveLength(0);
+  });
+
+  it("a turn failure goes to onError out-of-band (not deliver)", async () => {
+    const agent = fauxAgent([{ type: "failed", details: "model exploded", retryable: true }]);
+    const { binding, calls } = recordingBinding();
+    const bg = captureBackground();
+    const handler = createWebhookHandler(agent, binding, bg.background);
+
+    const res = await handler(post({ session: "pr-2", text: "review" }));
+    expect(res.status).toBe(202);
+    await bg.run();
+
+    expect(calls.deliver).toHaveLength(0);
+    expect(calls.onError).toHaveLength(1);
+    expect(calls.onError[0]).toBeInstanceOf(AgentFailure);
+    expect(calls.onError[0]?.details).toBe("model exploded");
+    expect(calls.onError[0]?.retryable).toBe(true);
+  });
+
+  it("parse → null rejects with 401 and never invokes", async () => {
+    const { binding, calls } = recordingBinding(async () => null);
+    const bg = captureBackground();
+    const handler = createWebhookHandler(fauxAgent([]), binding, bg.background);
+    const res = await handler(post({ nope: true }));
+    expect(res.status).toBe(401);
+    expect(calls.invocations).toHaveLength(0);
+  });
+
+  it("parse throwing answers 400 (a request fault, before any ACK)", async () => {
+    const { binding } = recordingBinding(async () => {
+      throw new Error("bad signature");
+    });
+    const handler = createWebhookHandler(fauxAgent([]), binding, captureBackground().background);
+    const res = await handler(post({}));
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("bad signature");
+  });
+
+  it("delivery is optional: a fat agent that posts via tools needs no deliver/onError", async () => {
+    const agent = fauxAgent([{ type: "completed" }]);
+    const binding: WebhookBinding<Ev> = {
+      async parse(req) {
+        return (await req.json()) as Ev;
+      },
+      toInvocation: (e) => ({ scope: { session: e.session }, prompt: { text: e.text } }),
+      // no deliver, no onError — the agent owns its output
+    };
+    const bg = captureBackground();
+    const handler = createWebhookHandler(agent, binding, bg.background);
+    const res = await handler(post({ session: "pr-3", text: "review" }));
+    expect(res.status).toBe(202);
+    await expect(bg.run()).resolves.toBeUndefined(); // no throw with deliver/onError absent
+  });
+});
+
+describe("createTrackedBackground", () => {
+  it("runs tasks and drain() awaits in-flight work", async () => {
+    const { background, drain } = createTrackedBackground();
+    let done = false;
+    background(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      done = true;
+    });
+    expect(done).toBe(false); // not awaited synchronously
+    await drain();
+    expect(done).toBe(true);
+  });
+
+  it("a throwing task is surfaced via onTaskError and does not wedge drain", async () => {
+    const errors: unknown[] = [];
+    const { background, drain } = createTrackedBackground({ onTaskError: (e) => errors.push(e) });
+    background(async () => {
+      throw new Error("task boom");
+    });
+    await expect(drain()).resolves.toBeUndefined();
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("task boom");
+  });
+});

--- a/core/test/webhook.test.ts
+++ b/core/test/webhook.test.ts
@@ -108,6 +108,27 @@ describe("webhook channel", () => {
     expect(calls.onError[0]?.retryable).toBe(true);
   });
 
+  it("a turn failure with no onError handler surfaces via the runner's error sink (not swallowed)", async () => {
+    const agent = fauxAgent([{ type: "failed", details: "model exploded", retryable: true }]);
+    const binding: WebhookBinding<Ev> = {
+      async parse(req) {
+        return (await req.json()) as Ev;
+      },
+      toInvocation: (e) => ({ scope: { session: e.session }, prompt: { text: e.text } }),
+      // no onError — the failure must still be visible
+    };
+    const errors: unknown[] = [];
+    const { background, drain } = createTrackedBackground({ onTaskError: (e) => errors.push(e) });
+    const handler = createWebhookHandler(agent, binding, background);
+
+    const res = await handler(post({ session: "pr-4", text: "review" }));
+    expect(res.status).toBe(202);
+    await drain();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(AgentFailure);
+    expect((errors[0] as AgentFailure).details).toBe("model exploded");
+  });
+
   it("parse → null rejects with 401 and never invokes", async () => {
     const { binding, calls } = recordingBinding(async () => null);
     const bg = captureBackground();

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -224,9 +224,18 @@ const { agent } = await createPiAgentFromArtifact(process.cwd());
 const { background, drain } = createTrackedBackground();
 
 const server = createServer(nodeListener(createWebhookHandler(agent, callbackBinding, background)));
-process.on("SIGTERM", async () => { server.close(); await drain(); process.exit(0); });
+process.on("SIGTERM", async () => {
+  server.closeIdleConnections?.(); // drop idle keep-alive sockets so close() does not hang
+  await new Promise<void>((r) => server.close(() => r())); // let in-flight requests send their 202 (they enqueue their task first)
+  await drain(); // ordering matters: drain AFTER close, so no late request enqueues a task past the snapshot
+  process.exit(0);
+});
 server.listen(8787);
 ```
+
+The `close → drain` order is the point: draining before the listener is closed can miss a task
+from a request still mid-`parse` when the signal arrived. Production-grade graceful shutdown
+(keep-alive handling, a hard timeout) is host-specific; this shows only the ordering.
 
 ## 10. Build it as a family, not a one-off
 

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -205,11 +205,19 @@ const { background, drain } = createTrackedBackground();
 
 // shape (shipped in core/src/channels/background.ts):
 const background: BackgroundRunner = (task) => {
-  // Start on a microtask: keeps the task off the caller's synchronous frame (the ACK path), and
-  // turns a synchronous throw inside `task` into a tracked rejection routed to onTaskError
-  // instead of escaping as a pre-ACK failure.
-  const p = Promise.resolve()
-    .then(task)
+  // Start on a macrotask (setImmediate): the caller's response (e.g. a webhook 202, written in a
+  // microtask continuation) lands before the turn begins, so the turn's synchronous prefix never
+  // delays the ACK. A synchronous throw inside `task` is captured (routed to onTaskError), never
+  // escaping as a pre-ACK failure.
+  const p = new Promise<void>((resolve, reject) => {
+    setImmediate(() => {
+      try {
+        resolve(task());
+      } catch (error) {
+        reject(error);
+      }
+    });
+  })
     .catch(onTaskError) // default: console.error — fail visibly, never swallow
     .finally(() => inFlight.delete(p));
   inFlight.add(p);

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -215,11 +215,16 @@ const { background, drain } = createTrackedBackground(); // + optional { onTaskE
 ```
 
 Behavior (impl: `core/src/channels/background.ts`): each task starts on a **macrotask**
-(`setImmediate`) so the caller's response — e.g. a webhook `202`, written in a microtask
-continuation — lands before the turn begins; a synchronous throw inside the task is captured and
-routed to `onTaskError` (default `console.error` — fail visibly, never swallow); `drain()` awaits
-all in-flight tasks. Strict ACK-first latency *under load* is the durable runner's job, not this
-in-process one (§12).
+(`setTimeout(…, 0)` — portable across runtimes, not Node's `setImmediate`) so the caller's response —
+e.g. a webhook `202`, written in a microtask continuation — lands before the turn begins; a
+synchronous throw inside the task is captured and routed to `onTaskError` (default `console.error` —
+fail visibly, never swallow); `drain()` awaits all in-flight tasks. Strict ACK-first latency *under
+load* is the durable runner's job, not this in-process one (§12).
+
+`createTrackedBackground` assumes a **long-running process** (it runs the task after the response
+and drains on shutdown), so it fits Node/Deno/Bun *servers*. A **request-scoped serverless** runtime
+(Cloudflare Workers, Deno Deploy) freezes after the response, so provide your own runner there — e.g.
+one backed by `ctx.waitUntil(task())` — satisfying the same `BackgroundRunner` completion guarantee.
 
 The wrong impl, for contrast:
 

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -1,0 +1,297 @@
+---
+title: Webhook channel & the `background` port (N-axis)
+type: design-doc
+status: implemented
+updated: 2026-06-22
+---
+
+# Webhook channel & the `background` port
+
+> Engineer handoff for the first non-SSE channel. **N-axis only.** It defines the
+> webhook channel and the single new Caller-side port the channel surfaces
+> (`background`). It does **not** design hosts (fly.io / AgentCore) — those *fill*
+> `background` and are K-face work. The locked `Agent` / `invoke` contract (SPEC v0.1)
+> is untouched.
+>
+> **Status:** shipped in core — `createWebhookHandler`, `WebhookBinding`,
+> `BackgroundRunner`, `createTrackedBackground` (`core/src/channels/webhook.ts` +
+> `background.ts`), exercised by `core/test/webhook.test.ts`. `deliver`/`onError` are
+> **optional** (§5/§7): a fat agent posts its own result via tools.
+
+## 1. Why this, why now
+
+`serve` is the strategic core (build an agent → deploy it to the cloud → it acts while
+you are away). The webhook is the canonical "agent acts on an external trigger" channel.
+
+It is also the **seam test**: the SSE channel already proved a Caller can consume the
+`Agent` contract alone; the webhook is the second N, and it surfaces something SSE hid —
+that a Caller has its own host dependency (execution lifetime). Building it validates
+that the N axis composes on contracts, and pins down the one port that was missing from
+the catalog.
+
+## 2. Where it sits
+
+```
+webhook.ts (N) ─────────┐
+                        ├──► @kid7st/fastagent contracts (Agent, collect, BackgroundRunner, …)
+background impl (K) ────┘                ▲
+                                         │
+server.ts (composition root) ────────────┘   only this file knows all three of N/M/K
+```
+
+The channel imports **only** the contract. The host fills `background`. **Neither imports
+the other.** The composition root (`server.ts` = `main`) wires a concrete N + M + K — that
+is its job, and it is the one place allowed to import all three (core's own `cli.ts` does
+exactly this).
+
+## 3. The consumption topology this channel is
+
+The webhook is the **ACK-early** topology: the caller does not wait for the result.
+
+| Consumption | Caller waits for the result? | Needs `background`? | Stays alive via |
+|---|---|---|---|
+| SSE chat (`createInvokeHandler`) | yes (connection open) | **no** | the open connection |
+| Buffered embed (`await collect` in a route) | yes (request blocks) | **no** | the awaited request |
+| CLI (`for await`) | yes (process runs) | **no** | the process |
+| Queue worker (`await collect`, then ack) | yes | **no** | worker + visibility timeout |
+| **Webhook (`202`, deliver out-of-band)** | **no** | **yes** | **`background`** |
+
+The discriminator is **"does the caller await the result"**, not "is the turn long". A
+caller that blocks on the result gets liveness for free; a caller that ACKs early and
+finishes later must re-acquire it. `background` is therefore **not a universal tax** — only
+ACK-early channels declare it. SSE/embed/CLI never import it.
+
+## 4. The `background` port (new, Caller-side)
+
+A new port, added to core's public surface alongside the Agent-side ports
+(`PiSessionStore`, `Lease`, `AuthResolver`, `ExecutionEnv`).
+
+```ts
+/**
+ * Run a task to completion AFTER the caller has detached (e.g. a webhook that already
+ * returned 202). The host provides this; the channel only declares it.
+ *
+ * CONTRACT: the implementation MUST run `task` to completion under normal operation.
+ * `(t) => void t()` is ILLEGAL — it carries no completion guarantee; the moment the
+ * response is sent the runtime may reclaim the process and the task dies mid-flight.
+ * The completion guarantee is the entire reason this port exists.
+ */
+export type BackgroundRunner = (task: () => Promise<void>) => void;
+```
+
+Placement, stated so nobody re-files it:
+
+- It is **not** an `invoke` extension (it adds no `scope` field, no event, no `invoke`
+  parameter; `agent.invoke` is byte-identical with or without it; the agent never sees it).
+- It is **not** Middleware (Middleware *is* the invoke contract — invoke in, invoke out;
+  "detach early, finish later" cannot be expressed inside a stream-someone-consumes).
+- It **is** the Caller-side twin of SPEC §9 dependency inversion. §9 documents the
+  Agent-side injected ports; `background` is the same idea on the Caller side. It lives
+  **outside** the invoke contract, in the deployment/execution-model layer SPEC §10 keeps
+  out of scope. In WSGI/ASGI terms it is the server's background-task / lifespan layer, not
+  the app callable.
+
+Naming: the call site (`background(() => work)`) is read by many channel authors whose
+intent is "do this after I ACK"; the completion guarantee is enforced for the few host
+implementers by the contract above + the reference impl in §8, not by the name.
+
+**v1 scope of the port:** the task is an opaque closure. This is correct for in-process
+hosts. A durable, cross-instance host (the work must survive *this* instance dying) cannot
+serialize a closure — that reshapes the port to carry `{ scope, prompt, delivery }` data
+and re-invoke on a worker. That reshape is **K-face**, deferred (§12).
+
+## 5. The channel interface
+
+```ts
+// webhook.ts — userland N. Imports ONLY contracts.
+import {
+  collect, AgentFailure,
+  type Agent, type Scope, type Prompt, type Json, type BackgroundRunner,
+} from "@kid7st/fastagent";
+
+/** Per-platform glue (generic callback, Slack, GitHub, …). One impl per platform. */
+export interface WebhookBinding<E> {
+  /** Verify signature + parse the request into an event, or null to reject (→ 4xx). */
+  parse(req: Request): Promise<E | null>;
+  /** Map the event to an invocation. `scope.session` is derived from the payload. */
+  toInvocation(event: E): { scope: Scope; prompt: Prompt };
+  /**
+   * Deliver the result out-of-band (OPTIONAL). Omit it when the agent posts its own result via
+   * tools (e.g. `gh pr review`); provide it for a thin agent whose text/data the binding posts.
+   */
+  deliver?(event: E, result: { text: string; data?: Json }): Promise<void>;
+  /** Deliver a turn failure out-of-band (OPTIONAL). `retryable` is the platform-retry signal. */
+  onError?(event: E, failure: AgentFailure): Promise<void>;
+}
+
+export function createWebhookHandler<E>(
+  agent: Agent,
+  binding: WebhookBinding<E>,
+  background: BackgroundRunner,
+): (req: Request) => Promise<Response> {
+  return async (req) => {
+    const event = await binding.parse(req);            // failure plane #1: pre-ACK
+    if (!event) return new Response("rejected\n", { status: 401 });
+
+    const { scope, prompt } = binding.toInvocation(event);
+
+    background(async () => {                            // failure plane #2: post-ACK, out-of-band
+      try {
+        const result = await collect(agent.invoke(scope, prompt)); // buffered + terminal discipline
+        await binding.deliver?.(event, result);
+      } catch (e) {
+        if (e instanceof AgentFailure) await binding.onError?.(event, e); // a turn failure
+        else throw e;                                                   // a real bug → host error path
+      }
+    });
+
+    return new Response(null, { status: 202 });        // Accepted; work runs via background
+  };
+}
+```
+
+The handler is **Fetch-shaped** (`(Request) => Promise<Response>`), like
+`createInvokeHandler`, so it mounts in any host route; `nodeListener` bridges it to
+`node:http` for the standalone server.
+
+## 6. The discipline (the rules that make it host-neutral)
+
+1. **ACK / run split.** Respond `202` immediately; the turn runs via `background`. Never
+   block the response on the turn, and never run the turn synchronously hoping the platform
+   waits.
+2. **Delivery is out-of-band.** The HTTP response is only an acknowledgement. The result
+   reaches the user through `binding.deliver` (and failures through `binding.onError`).
+3. **Never bake the runtime lifecycle into the channel.** No `void task()`, no assuming a
+   long-running process. The channel's only contact with execution lifetime is the
+   `background` port; *how* it is fulfilled is the host's problem.
+4. **Buffered consumption.** Use `collect`. Drop to the raw `invoke` stream only if a
+   channel genuinely needs partial output on failure (rare; webhooks want atomic
+   success-or-fail).
+
+## 7. Cross-cutting behaviors (decided here so they are not rediscovered)
+
+**Two failure planes.** Pre-ACK (`parse`/verify) failures answer the HTTP request directly
+(`4xx`). Post-ACK (turn) failures cannot use the original response (already `202`) — they go
+out-of-band via `onError`. Retry of a post-ACK failure is the binding's call (re-POST a
+callback, re-enqueue, or rely on the platform's own redelivery); `AgentFailure.retryable`
+is the signal that it is worth retrying with the same `session`.
+
+**Same-session concurrency is not the dedup tool.** Two turns for the same `session` at once
+→ the second yields `failed{retryable:true}` ("session busy"), surfaced as a thrown
+`AgentFailure` through `collect`. The channel's correct response is retry/re-enqueue
+(channel policy). This is the *concurrency floor*, not idempotency.
+
+**Dedup / idempotency is channel-owned, before `invoke`.** Webhooks redeliver; an
+at-most-once channel must dedup on the platform's **delivery id** (which the binding has),
+*before* calling `invoke` — not via the Lease (busy ≠ duplicate) and not via the agent.
+v1 leaves dedup to the binding; a shared idempotency store may later become its own port
+(do not add it now — §12).
+
+**`Scope` is sufficient for serve.** `scope.session` (opaque, channel-derived) is enough
+for a served, single-tenant-per-deployment agent. Multi-tenant principal threading is an
+embed-phase concern, and is deferred not only as a `Scope` field but because it would have
+no path to tools/env today (tools receive only `ToolContext{ signal }`).
+
+## 8. Reference host (single-instance) — `createTrackedBackground`
+
+The simplest **correct** `background`: track in-flight tasks so a graceful shutdown drains
+them instead of killing turns mid-flight. Channel-agnostic (any ACK-early channel can use
+it); depends only on the port type.
+
+```ts
+import type { BackgroundRunner } from "@kid7st/fastagent";
+
+export function createTrackedBackground(): { background: BackgroundRunner; drain: () => Promise<void> } {
+  const inFlight = new Set<Promise<void>>();
+  const background: BackgroundRunner = (task) => {
+    const p = task().finally(() => inFlight.delete(p));
+    inFlight.add(p);
+  };
+  return { background, drain: () => Promise.allSettled([...inFlight]).then(() => {}) };
+}
+```
+
+The wrong impl, for contrast:
+
+```ts
+const background: BackgroundRunner = (task) => void task(); // ✗ no completion guarantee
+// 202 already sent → SIGTERM / process.exit cuts the running turn mid tool-call. The bug is
+// 100% here in the host's background impl, not in the channel and not in invoke.
+```
+
+Multi-instance / crash-durable `background` (queue + worker, AgentCore async invocation) is
+**K-face**, out of scope for this doc.
+
+## 9. Composition root example
+
+```ts
+// server.ts — wires one N + one M + one K.
+import { createServer } from "node:http";
+import { createPiAgentFromArtifact, nodeListener } from "@kid7st/fastagent"; // M assembly + transport
+import { createWebhookHandler } from "./webhook.ts";                         // N
+import { callbackBinding } from "./callback-binding.ts";                     // N glue (per platform)
+import { createTrackedBackground } from "./tracked-background.ts";           // K (single-instance)
+
+const { agent } = await createPiAgentFromArtifact(process.cwd());
+const { background, drain } = createTrackedBackground();
+
+const server = createServer(nodeListener(createWebhookHandler(agent, callbackBinding, background)));
+process.on("SIGTERM", async () => { server.close(); await drain(); process.exit(0); });
+server.listen(8787);
+```
+
+## 10. Build it as a family, not a one-off
+
+Reusable core (`createWebhookHandler` + `background`) + **per-platform bindings**. Ship a
+generic **callback** binding first (cleanest: a shared-secret header, `{ session, text,
+callbackUrl }` in, result POSTed back); Slack / GitHub bindings follow the same interface.
+
+```ts
+// callback-binding.ts
+import type { WebhookBinding } from "./webhook.ts";
+interface Ev { session: string; text: string; callbackUrl: string }
+
+export const callbackBinding: WebhookBinding<Ev> = {
+  async parse(req) {
+    if (req.headers.get("x-secret") !== process.env.WEBHOOK_SECRET) return null;
+    const b = (await req.json()) as Partial<Ev>;
+    return b.session && b.text && b.callbackUrl ? (b as Ev) : null;
+  },
+  toInvocation: (e) => ({ scope: { session: e.session }, prompt: { text: e.text } }),
+  deliver: (e, r) =>
+    fetch(e.callbackUrl, { method: "POST", body: JSON.stringify({ ok: true, ...r }) }).then(() => {}),
+  onError: (e, f) =>
+    fetch(e.callbackUrl, { method: "POST", body: JSON.stringify({ ok: false, error: f.details, retryable: f.retryable }) }).then(() => {}),
+};
+```
+
+## 11. Acceptance criteria (definition of done)
+
+- `webhook.ts` imports **only** contract symbols — zero `Pi*`, zero host imports.
+- The handler returns `202` **before** any turn work runs.
+- The generic callback binding round-trips: `POST` → `202` → out-of-band delivery carrying
+  the result `{ text, data? }`.
+- Failure paths: a turn failure reaches `onError` (out-of-band); a parse/verify failure
+  returns `4xx` (on the request).
+- The same handler runs **unchanged** against two different `background` impls
+  (`createTrackedBackground` + a stub queue runner) — proving the seam is the only N↔K
+  contact point.
+- `createTrackedBackground` drains in-flight turns on `SIGTERM` — no dropped turns.
+
+## 12. Non-goals / open questions (explicitly deferred)
+
+- **Durable / cross-instance `background`.** A closure cannot cross a process; a crash-durable
+  host reshapes the port to carry `{ scope, prompt, delivery }` data + re-invoke on a worker.
+  K-face.
+- **A shared idempotency/dedup store** as its own port. Surfaced (§7) but not built; wait for
+  a real backend.
+- **Multi-tenant principal threading.** Embed-phase; needs a path to tools/env, not just a
+  `Scope` field.
+- **Streaming + detached** (e.g. a self-editing Slack message: `background` + the raw stream).
+  Real but not v1.
+
+## Core change this implies
+
+Add `BackgroundRunner` to the package's public port surface (Caller-side), re-exported from
+the root like the other ports. No change to `agent.ts` or the locked SPEC. Optional: a SPEC
+§9 note that Callers, like Agents, have injected host capabilities.

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -255,12 +255,24 @@ export const callbackBinding: WebhookBinding<Ev> = {
     return b.session && b.text && b.callbackUrl ? (b as Ev) : null;
   },
   toInvocation: (e) => ({ scope: { session: e.session }, prompt: { text: e.text } }),
-  deliver: (e, r) =>
-    fetch(e.callbackUrl, { method: "POST", body: JSON.stringify({ ok: true, ...r }) }).then(() => {}),
-  onError: (e, f) =>
-    fetch(e.callbackUrl, { method: "POST", body: JSON.stringify({ ok: false, error: f.details, retryable: f.retryable }) }).then(() => {}),
+  deliver: async (e, r) => {
+    const res = await fetch(e.callbackUrl, { method: "POST", body: JSON.stringify({ ok: true, ...r }) });
+    if (!res.ok) throw new Error(`callback POST failed: ${res.status}`); // fetch does NOT reject on 4xx/5xx; surface it
+  },
+  onError: async (e, f) => {
+    const res = await fetch(e.callbackUrl, {
+      method: "POST",
+      body: JSON.stringify({ ok: false, error: f.details, retryable: f.retryable }),
+    });
+    if (!res.ok) throw new Error(`callback POST failed: ${res.status}`);
+  },
 };
 ```
+
+> The §9/§10 samples are **illustrative** — they show the wiring and the binding shape, not a
+> production HTTP client. Concerns like request timeouts, retry/backoff, and SSRF allowlisting of
+> `callbackUrl` are the binding author's, per platform; only the essentials (a `res.ok` check so a
+> failed delivery is not silently lost) are shown here.
 
 ## 11. Acceptance criteria (definition of done)
 

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -106,10 +106,20 @@ and re-invoke on a worker. That reshape is **K-face**, deferred (§12).
 // You implement WebhookBinding; core ships createWebhookHandler (core/src/channels/webhook.ts).
 import type { Agent, AgentFailure, BackgroundRunner, Json, Prompt, Scope } from "@kid7st/fastagent";
 
+/**
+ * What `parse` decided about a delivery: act on it, ACK-and-skip it, or reject it. Real webhooks
+ * send many event types and redeliveries, so a skipped/duplicate one must be ACKed 2xx (not 4xx) or
+ * the provider keeps retrying.
+ */
+export type WebhookOutcome<E> =
+  | { action: "invoke"; event: E }          // run the agent → 202
+  | { action: "ignore" }                     // valid, no work (duplicate / unhandled event type) → 200
+  | { action: "reject"; status?: number };   // bad/unauthorized → 4xx (default 401)
+
 /** Per-platform glue (generic callback, Slack, GitHub, …). One impl per platform. */
 export interface WebhookBinding<E> {
-  /** Verify signature + parse the request into an event, or null to reject (→ 4xx). */
-  parse(req: Request): Promise<E | null>;
+  /** Verify the request and classify it (invoke / ignore / reject). Throwing = unexpected fault → 400. */
+  parse(req: Request): Promise<WebhookOutcome<E>>;
   /** Map the event to an invocation. `scope.session` is derived from the payload. */
   toInvocation(event: E): { scope: Scope; prompt: Prompt };
   /**
@@ -129,9 +139,11 @@ export function createWebhookHandler<E>(
 ): (req: Request) => Promise<Response>;
 ```
 
-Behavior (the authoritative impl is `core/src/channels/webhook.ts`): a non-POST is `405`; a
-`parse` returning `null` is `401` and a `parse` that throws is `400` (failure plane #1, pre-ACK);
-otherwise it ACKs `202` and runs the turn via `background`. On a turn failure it calls
+Behavior (the authoritative impl is `core/src/channels/webhook.ts`): a non-POST is `405`; `parse`
+classifies the delivery — `reject` → 4xx (default 401), `ignore` → 200 no-op (ACK a duplicate or an
+unhandled event type so the provider stops retrying), `invoke` → ACK `202` and run the turn via
+`background`; a `parse` that *throws* is an unexpected fault → 400 (failure plane #1, pre-ACK). On a
+turn failure it calls
 `binding.onError` — or, when no `onError` is installed, **rethrows** the `AgentFailure` so it reaches
 the background runner's error sink rather than being swallowed (fail-visible). The handler is
 **Fetch-shaped** (`(Request) => Promise<Response>`), like `createInvokeHandler`, so it mounts in any
@@ -165,9 +177,11 @@ is the signal that it is worth retrying with the same `session`.
 (channel policy). This is the *concurrency floor*, not idempotency.
 
 **Dedup / idempotency is channel-owned, before `invoke`.** Webhooks redeliver; an
-at-most-once channel must dedup on the platform's **delivery id** (which the binding has),
-*before* calling `invoke` — not via the Lease (busy ≠ duplicate) and not via the agent.
-v1 leaves dedup to the binding; a shared idempotency store may later become its own port
+at-most-once channel dedups on the platform's **delivery id** (which the binding has) inside
+`parse`, returning `{ action: "ignore" }` for a duplicate so it is ACKed 2xx (not retried) without
+running the agent — not via the Lease (busy ≠ duplicate) and not via the agent. The same `ignore`
+outcome is how a binding ACKs event types it does not handle. v1 leaves the dedup *store* to the
+binding; a shared idempotency store may later become its own port
 (do not add it now — §12).
 
 **`Scope` is sufficient for serve.** `scope.session` (opaque, channel-derived) is enough
@@ -250,9 +264,14 @@ interface Ev { session: string; text: string; callbackUrl: string }
 
 export const callbackBinding: WebhookBinding<Ev> = {
   async parse(req) {
-    if (req.headers.get("x-secret") !== process.env.WEBHOOK_SECRET) return null;
-    const b = (await req.json()) as Partial<Ev>;
-    return b.session && b.text && b.callbackUrl ? (b as Ev) : null;
+    if (req.headers.get("x-secret") !== process.env.WEBHOOK_SECRET) return { action: "reject", status: 401 };
+    const b = (await req.json()) as Record<string, unknown>;
+    // Validate TYPES, not just truthiness: a non-string field cast to Ev would crash downstream
+    // (the session store calls string methods; fetch(callbackUrl) fails post-ACK).
+    if (typeof b.session !== "string" || typeof b.text !== "string" || typeof b.callbackUrl !== "string") {
+      return { action: "reject", status: 400 };
+    }
+    return { action: "invoke", event: { session: b.session, text: b.text, callbackUrl: b.callbackUrl } };
   },
   toInvocation: (e) => ({ scope: { session: e.session }, prompt: { text: e.text } }),
   deliver: async (e, r) => {

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -103,11 +103,8 @@ and re-invoke on a worker. That reshape is **K-face**, deferred (§12).
 ## 5. The channel interface
 
 ```ts
-// webhook.ts — userland N. Imports ONLY contracts.
-import {
-  collect, AgentFailure,
-  type Agent, type Scope, type Prompt, type Json, type BackgroundRunner,
-} from "@kid7st/fastagent";
+// You implement WebhookBinding; core ships createWebhookHandler (core/src/channels/webhook.ts).
+import type { Agent, AgentFailure, BackgroundRunner, Json, Prompt, Scope } from "@kid7st/fastagent";
 
 /** Per-platform glue (generic callback, Slack, GitHub, …). One impl per platform. */
 export interface WebhookBinding<E> {
@@ -124,35 +121,21 @@ export interface WebhookBinding<E> {
   onError?(event: E, failure: AgentFailure): Promise<void>;
 }
 
+// Shipped by core — you implement only the WebhookBinding above. Signature:
 export function createWebhookHandler<E>(
   agent: Agent,
   binding: WebhookBinding<E>,
   background: BackgroundRunner,
-): (req: Request) => Promise<Response> {
-  return async (req) => {
-    const event = await binding.parse(req);            // failure plane #1: pre-ACK
-    if (!event) return new Response("rejected\n", { status: 401 });
-
-    const { scope, prompt } = binding.toInvocation(event);
-
-    background(async () => {                            // failure plane #2: post-ACK, out-of-band
-      try {
-        const result = await collect(agent.invoke(scope, prompt)); // buffered + terminal discipline
-        await binding.deliver?.(event, result);
-      } catch (e) {
-        if (e instanceof AgentFailure) await binding.onError?.(event, e); // a turn failure
-        else throw e;                                                   // a real bug → host error path
-      }
-    });
-
-    return new Response(null, { status: 202 });        // Accepted; work runs via background
-  };
-}
+): (req: Request) => Promise<Response>;
 ```
 
-The handler is **Fetch-shaped** (`(Request) => Promise<Response>`), like
-`createInvokeHandler`, so it mounts in any host route; `nodeListener` bridges it to
-`node:http` for the standalone server.
+Behavior (the authoritative impl is `core/src/channels/webhook.ts`): a non-POST is `405`; a
+`parse` returning `null` is `401` and a `parse` that throws is `400` (failure plane #1, pre-ACK);
+otherwise it ACKs `202` and runs the turn via `background`. On a turn failure it calls
+`binding.onError` — or, when no `onError` is installed, **rethrows** the `AgentFailure` so it reaches
+the background runner's error sink rather than being swallowed (fail-visible). The handler is
+**Fetch-shaped** (`(Request) => Promise<Response>`), like `createInvokeHandler`, so it mounts in any
+host route; `nodeListener` bridges it to `node:http` for the standalone server.
 
 ## 6. The discipline (the rules that make it host-neutral)
 
@@ -201,29 +184,17 @@ the port type. Its shape:
 
 ```ts
 import { createTrackedBackground } from "@kid7st/fastagent";
-const { background, drain } = createTrackedBackground();
 
-// shape (shipped in core/src/channels/background.ts):
-const background: BackgroundRunner = (task) => {
-  // Start on a macrotask (setImmediate): the caller's response (e.g. a webhook 202, written in a
-  // microtask continuation) lands before the turn begins, so the turn's synchronous prefix never
-  // delays the ACK. A synchronous throw inside `task` is captured (routed to onTaskError), never
-  // escaping as a pre-ACK failure.
-  const p = new Promise<void>((resolve, reject) => {
-    setImmediate(() => {
-      try {
-        resolve(task());
-      } catch (error) {
-        reject(error);
-      }
-    });
-  })
-    .catch(onTaskError) // default: console.error — fail visibly, never swallow
-    .finally(() => inFlight.delete(p));
-  inFlight.add(p);
-};
-// drain() = Promise.allSettled([...inFlight]); call it on SIGTERM before exiting.
+const { background, drain } = createTrackedBackground(); // + optional { onTaskError }
+// pass `background` to createWebhookHandler; call `drain()` on SIGTERM before exiting.
 ```
+
+Behavior (impl: `core/src/channels/background.ts`): each task starts on a **macrotask**
+(`setImmediate`) so the caller's response — e.g. a webhook `202`, written in a microtask
+continuation — lands before the turn begins; a synchronous throw inside the task is captured and
+routed to `onTaskError` (default `console.error` — fail visibly, never swallow); `drain()` awaits
+all in-flight tasks. Strict ACK-first latency *under load* is the durable runner's job, not this
+in-process one (§12).
 
 The wrong impl, for contrast:
 
@@ -241,10 +212,13 @@ Multi-instance / crash-durable `background` (queue + worker, AgentCore async inv
 ```ts
 // server.ts — wires one N + one M + one K.
 import { createServer } from "node:http";
-import { createPiAgentFromArtifact, nodeListener } from "@kid7st/fastagent"; // M assembly + transport
-import { createWebhookHandler } from "./webhook.ts";                         // N
-import { callbackBinding } from "./callback-binding.ts";                     // N glue (per platform)
-import { createTrackedBackground } from "./tracked-background.ts";           // K (single-instance)
+import {
+  createPiAgentFromArtifact, // M assembly
+  nodeListener, // transport
+  createWebhookHandler, // N channel (shipped by core)
+  createTrackedBackground, // K runner (shipped by core)
+} from "@kid7st/fastagent";
+import { callbackBinding } from "./callback-binding.ts"; // N glue (per platform — you write this)
 
 const { agent } = await createPiAgentFromArtifact(process.cwd());
 const { background, drain } = createTrackedBackground();
@@ -262,7 +236,7 @@ callbackUrl }` in, result POSTed back); Slack / GitHub bindings follow the same 
 
 ```ts
 // callback-binding.ts
-import type { WebhookBinding } from "./webhook.ts";
+import type { WebhookBinding } from "@kid7st/fastagent";
 interface Ev { session: string; text: string; callbackUrl: string }
 
 export const callbackBinding: WebhookBinding<Ev> = {

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -194,21 +194,27 @@ no path to tools/env today (tools receive only `ToolContext{ signal }`).
 
 ## 8. Reference host (single-instance) — `createTrackedBackground`
 
-The simplest **correct** `background`: track in-flight tasks so a graceful shutdown drains
-them instead of killing turns mid-flight. Channel-agnostic (any ACK-early channel can use
-it); depends only on the port type.
+Core ships this as `createTrackedBackground` (import it; you do not write it). The simplest
+**correct** `background`: track in-flight tasks so a graceful shutdown drains them instead of
+killing turns mid-flight. Channel-agnostic (any ACK-early channel can use it); depends only on
+the port type. Its shape:
 
 ```ts
-import type { BackgroundRunner } from "@kid7st/fastagent";
+import { createTrackedBackground } from "@kid7st/fastagent";
+const { background, drain } = createTrackedBackground();
 
-export function createTrackedBackground(): { background: BackgroundRunner; drain: () => Promise<void> } {
-  const inFlight = new Set<Promise<void>>();
-  const background: BackgroundRunner = (task) => {
-    const p = task().finally(() => inFlight.delete(p));
-    inFlight.add(p);
-  };
-  return { background, drain: () => Promise.allSettled([...inFlight]).then(() => {}) };
-}
+// shape (shipped in core/src/channels/background.ts):
+const background: BackgroundRunner = (task) => {
+  // Start on a microtask: keeps the task off the caller's synchronous frame (the ACK path), and
+  // turns a synchronous throw inside `task` into a tracked rejection routed to onTaskError
+  // instead of escaping as a pre-ACK failure.
+  const p = Promise.resolve()
+    .then(task)
+    .catch(onTaskError) // default: console.error — fail visibly, never swallow
+    .finally(() => inFlight.delete(p));
+  inFlight.add(p);
+};
+// drain() = Promise.allSettled([...inFlight]); call it on SIGTERM before exiting.
 ```
 
 The wrong impl, for contrast:

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -100,6 +100,17 @@ hosts. A durable, cross-instance host (the work must survive *this* instance dyi
 serialize a closure — that reshapes the port to carry `{ scope, prompt, delivery }` data
 and re-invoke on a worker. That reshape is **K-face**, deferred (§12).
 
+**v1 registers synchronously.** `background` returns `void`, and the handler ACKs `202` as soon as
+it returns. This is correct for a runner whose handoff is synchronous (the in-process reference
+adds the task to a set). A runner whose handoff is **async** — e.g. it must enqueue to a durable
+store *before* the task is accepted — needs `background` to surface acceptance so the handler ACKs
+only after the task is durably accepted (a failed handoff → non-2xx → the provider retries, instead
+of a silently lost webhook). That is a **non-breaking** widening to `(task) => void | Promise<void>`
+that the handler `await`s; it lands **with the durable runner (K-face, §12)**, not before — there is
+no async-handoff runner today, and building the contract for one that does not exist is exactly the
+speculative surface this project avoids. The v1 contract is therefore: *the runner registers
+synchronously.*
+
 ## 5. The channel interface
 
 ```ts


### PR DESCRIPTION
## What

The second N-axis channel, beside SSE: a **webhook** channel, plus the Caller-side **`background`** port it surfaces.

- `core/src/channels/webhook.ts` — `createWebhookHandler(agent, binding, background)` + `WebhookBinding<E>`
- `core/src/channels/background.ts` — `BackgroundRunner` (the port) + `createTrackedBackground` (single-instance reference impl with `drain()`)
- `core/src/index.ts` — exports the above
- `core/test/webhook.test.ts` — 8 tests
- `docs/webhook.md` — design + status

## Why

Webhooks are the **ACK-early** topology: acknowledge the delivery immediately (202), run the turn in the background, deliver the result out-of-band (the agent posts via its own tools, e.g. `gh pr review`, or the binding delivers).

This surfaces a port SSE hid: **a Caller also has a host dependency — its execution lifetime.** `BackgroundRunner` is that Caller-side port, the symmetric twin of the Agent-side dependency-inversion ports (sessions/env/lease/auth). It lives **outside** the locked `invoke` contract and is **not** Middleware (in WSGI/ASGI terms: the server's background-task layer, not the app callable). Its contract is a **completion guarantee** — `(t) => void t()` is illegal.

It is **not** a universal tax: only ACK-early channels declare it. SSE/embed/CLI get liveness free from the open connection / blocked request and never touch it.

## Design notes

- The channel consumes **only** the `Agent` contract (+ `collect`) — zero engine coupling; the webhook test runs against a hand-rolled faux `Agent`, proving it works with any engine, not just pi.
- `deliver`/`onError` are **optional**: a *fat* agent that posts its own result via tools needs neither; a *thin* agent returns text the binding posts.
- Two failure planes: pre-ACK parse/verify → 4xx on the request; post-ACK turn failure → `onError` out-of-band.

## Surface

Public API addition (`createWebhookHandler`, `WebhookBinding`, `BackgroundRunner`, `createTrackedBackground`). The locked SPEC v0.1 / `agent.ts` are untouched. Flagging for the public-surface review tier.

## Not in this PR

The GitHub-reviewer product (`apps/`) that consumes this channel — follows separately as the N×M×K vertical slice.

## Verification

`npm run typecheck` ✓ · `npm run lint` ✓ · `npm test` ✓ (168 passed, +8 new)