### PR TITLE
chore(release): core 0.2.0

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Flask/WSGI for agents: serve or embed an existing agent folder (AGENTS.md + skills/) as a production capability. Engine-, model-, and host-neutral.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Bump `core/package.json` to 0.2.0 to publish the **webhook channel + background port** (PR #41).

New public API since 0.1.0:
- `createWebhookHandler`, `WebhookBinding`, `WebhookOutcome`
- `BackgroundRunner`, `createTrackedBackground`

Minor bump: additive surface, no breaking change to the SPEC-stable `Agent` contract.

After merge: `gh release create v0.2.0` triggers `publish.yml` → GitHub Packages. (Unblocks the github-reviewer app, the first real consumer of the published webhook channel.)