### PR TITLE
refactor(pi): migrate to 0.80 Models collection (auth + model registry)

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -12,12 +12,15 @@ Engine-, model-, and host-neutral. Built on the [pi](https://www.npmjs.com/packa
 ## Embed (library)
 
 ```ts
-import { createPiAgentFromDefinition, resolveModel, createInvokeHandler } from "@kid7st/fastagent";
+import { createPiAgentFromDefinition, createPiModels, resolveModel, createInvokeHandler } from "@kid7st/fastagent";
 
-// folder → agent, with your own session store / auth / tools injected
+// One Models collection owns model resolution + auth (pi OAuth file → env vars).
+const models = createPiModels();
+// folder → agent, with your own session store / models / tools injected
 const { agent } = await createPiAgentFromDefinition("./agent", {
-  model: resolveModel("openai-codex/gpt-5.5"),
-  // sessions, env, lease, getApiKeyAndHeaders, tools — all optional injection points
+  models,
+  model: resolveModel(models, "openai-codex/gpt-5.5"),
+  // sessions, env, lease, models, tools — all optional injection points
 });
 
 // createInvokeHandler is a Fetch handler: mount it in any host route

--- a/core/examples/definition.ts
+++ b/core/examples/definition.ts
@@ -11,8 +11,7 @@
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
-import { getModel } from "@earendil-works/pi-ai";
-import { createPiAgentFromDefinition, piDefaultTools } from "../src/index.ts";
+import { createPiAgentFromDefinition, createPiModels, piDefaultTools, resolveModel } from "../src/index.ts";
 import lookupOrderTool from "./agent/lookup-order-tool.ts";
 
 // install() aligns fetch with the dispatcher (same undici impl) — see cli.ts for why.
@@ -21,8 +20,10 @@ installUndiciFetch();
 
 // Custom code tool = explicit import + injection (type-checked, refactor-safe; no magic directory).
 const dir = join(dirname(fileURLToPath(import.meta.url)), "agent");
+const models = createPiModels();
 const { agent, definition } = await createPiAgentFromDefinition(dir, {
-  model: getModel("openai-codex", "gpt-5.5"),
+  models,
+  model: resolveModel(models, "openai-codex/gpt-5.5"),
   tools: [...piDefaultTools(dir), lookupOrderTool],
 });
 

--- a/core/examples/local.ts
+++ b/core/examples/local.ts
@@ -12,8 +12,7 @@
  */
 import { createInterface } from "node:readline/promises";
 import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
-import { getModel } from "@earendil-works/pi-ai";
-import { AgentFailure, collect, createPiAgent, type AgentEvent } from "../src/index.ts";
+import { AgentFailure, collect, createPiAgent, createPiModels, resolveModel, type AgentEvent } from "../src/index.ts";
 
 // Process-level network config belongs to the application entry: Node's fetch does not
 // honor HTTPS_PROXY by itself; the local proxy is required to reach blocked providers.
@@ -21,8 +20,11 @@ import { AgentFailure, collect, createPiAgent, type AgentEvent } from "../src/in
 setGlobalDispatcher(new EnvHttpProxyAgent());
 installUndiciFetch();
 
+// One Models collection owns model resolution + auth; the model must come from it.
+const models = createPiModels();
 const agent = createPiAgent({
-  model: getModel("openai-codex", "gpt-5.5"),
+  models,
+  model: resolveModel(models, "openai-codex/gpt-5.5"),
   systemPrompt: "You are a concise, helpful assistant. Keep answers short.",
 });
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.8",
-        "@earendil-works/pi-ai": "^0.79.2",
-        "@earendil-works/pi-coding-agent": "^0.79.8",
+        "@earendil-works/pi-agent-core": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.2",
+        "@earendil-works/pi-coding-agent": "^0.80.2",
         "@octokit/webhooks-methods": "^6.0.0",
         "@octokit/webhooks-types": "^7.6.1",
         "chokidar": "^5.0.0",
@@ -140,13 +140,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
-      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
-        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/core": "^3.24.6",
         "@smithy/signature-v4": "^5.4.6",
@@ -159,13 +159,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
-      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -175,13 +175,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.48",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
-      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
         "@smithy/node-http-handler": "^4.7.6",
@@ -193,13 +193,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz",
-      "integrity": "sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.7",
-        "@smithy/types": "^4.14.4",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -207,20 +207,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.53.tgz",
-      "integrity": "sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==",
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/credential-provider-env": "^3.972.46",
-        "@aws-sdk/credential-provider-http": "^3.972.48",
-        "@aws-sdk/credential-provider-login": "^3.972.52",
-        "@aws-sdk/credential-provider-process": "^3.972.46",
-        "@aws-sdk/credential-provider-sso": "^3.972.52",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
         "@smithy/types": "^4.14.3",
@@ -231,14 +231,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.52.tgz",
-      "integrity": "sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -248,18 +248,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.55.tgz",
-      "integrity": "sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.46",
-        "@aws-sdk/credential-provider-http": "^3.972.48",
-        "@aws-sdk/credential-provider-ini": "^3.972.53",
-        "@aws-sdk/credential-provider-process": "^3.972.46",
-        "@aws-sdk/credential-provider-sso": "^3.972.52",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-ini": "^3.972.56",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
         "@smithy/types": "^4.14.3",
@@ -270,13 +270,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
-      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -286,15 +286,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.52.tgz",
-      "integrity": "sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/token-providers": "3.1066.0",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/token-providers": "3.1074.0",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -304,14 +304,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1066.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1066.0.tgz",
-      "integrity": "sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==",
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -321,14 +321,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.52.tgz",
-      "integrity": "sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/nested-clients": "^3.997.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -338,12 +338,12 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.21.tgz",
-      "integrity": "sha512-mVC0hOmwGJmNFezZ+wM8Sqfap/LjsMavEf2Evl0YWrLAcrdZOEdjnY8nRvgakVViWJSGm2eJxLuPVHGdeV06kA==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.22.tgz",
+      "integrity": "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -353,12 +353,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.17.tgz",
-      "integrity": "sha512-tdbnXbw73ww62ABWP0G0Z/euvFowEEvAoi/zG4NaZo7HJFpfGho/Z65HyVzkJLT1cMsUregr4pTyxljlarT0wA==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.18.tgz",
+      "integrity": "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -368,13 +368,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.28.tgz",
-      "integrity": "sha512-SCW06Zjugn86pq7+dxGnFcyWJuEWHT753HTU/Vj/OzVxP+NoShwdAr4ynxAcvWL883OgRVbSqW3ohnjIxwXjjw==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.31.tgz",
+      "integrity": "sha512-ps1rumU1LybSFHaW9dTDgkhCMJLVaedEY78kKSzUDDY+b9974/g6aiaYYA0U9WV0oL4CJCJrVWG+EZ/qr4or7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
         "@smithy/signature-v4": "^5.4.6",
@@ -386,16 +386,16 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.20.tgz",
-      "integrity": "sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==",
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.20",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.34",
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
         "@smithy/node-http-handler": "^4.7.6",
@@ -407,13 +407,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz",
-      "integrity": "sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.7",
-        "@smithy/types": "^4.14.4",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -421,12 +421,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.34.tgz",
-      "integrity": "sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==",
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/types": "^3.973.13",
         "@smithy/signature-v4": "^5.4.6",
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
-      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
-      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -478,13 +478,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
-      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
-        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -685,12 +684,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.8.tgz",
-      "integrity": "sha512-8m5fcqRpoGpq3QY0I/tFXROSTmPwBb1dAuzYZO3XYgjsdCokkRMAGRjA9P8s/UD6Jy9yy69lyE4H6sz/5A1TmQ==",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
+      "integrity": "sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.8",
+        "@earendil-works/pi-ai": "^0.80.2",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -700,9 +699,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.8.tgz",
-      "integrity": "sha512-ZpSwaD7oNpsjn9vtEatZQNT9PSdDJXi6rFeY5Qv+OHQGFDKlmcrfJE4ypm4SAc/fBECPs4Rdi3l+YjVtXYrkKw==",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
+      "integrity": "sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -725,15 +724,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.8.tgz",
-      "integrity": "sha512-wr9oTS/yrwURDXnYrONQgFgV7QDlwslXL/rvKU5X7TRtrGxIhippsRApXqYlRwSeMjb2YzgHMfZ/kAhOqrzoFQ==",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.2.tgz",
+      "integrity": "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.8",
-        "@earendil-works/pi-ai": "^0.79.8",
-        "@earendil-works/pi-tui": "^0.79.8",
+        "@earendil-works/pi-agent-core": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.2",
+        "@earendil-works/pi-tui": "^0.80.2",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1196,11 +1195,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.8.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.8",
+        "@earendil-works/pi-ai": "^0.80.2",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1210,8 +1209,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.8.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1227,15 +1226,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.8.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -2661,18 +2660,6 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@octokit/webhooks-methods": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
@@ -3056,13 +3043,13 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.7",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.7.tgz",
-      "integrity": "sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.4",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3070,13 +3057,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.9.tgz",
-      "integrity": "sha512-ZlfJ/4Fa3jYb+3eaohPfG9utX9HmdhFNcFtpoGAhUhdynAOmGXtmigbi7eEiONKM+ykHw8RwKuDEb85Lx7t7fA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.7",
-        "@smithy/types": "^4.14.4",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3084,13 +3071,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.7.tgz",
-      "integrity": "sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.7",
-        "@smithy/types": "^4.14.4",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3124,13 +3111,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.7.tgz",
-      "integrity": "sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.7",
-        "@smithy/types": "^4.14.4",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3138,9 +3125,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.4",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.4.tgz",
-      "integrity": "sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3355,18 +3342,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3527,43 +3502,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4171,21 +4109,6 @@
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "license": "MIT"
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4371,21 +4294,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "anynum": "^1.0.0"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4691,21 +4599,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/yaml": {

--- a/core/package.json
+++ b/core/package.json
@@ -58,9 +58,9 @@
     "format": "biome check --write src test examples"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "^0.79.8",
-    "@earendil-works/pi-ai": "^0.79.2",
-    "@earendil-works/pi-coding-agent": "^0.79.8",
+    "@earendil-works/pi-agent-core": "^0.80.2",
+    "@earendil-works/pi-ai": "^0.80.2",
+    "@earendil-works/pi-coding-agent": "^0.80.2",
     "@octokit/webhooks-methods": "^6.0.0",
     "@octokit/webhooks-types": "^7.6.1",
     "chokidar": "^5.0.0",

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -24,10 +24,10 @@ import { createInvokeHandler } from "./channels/http.ts";
 import { text } from "./channels/respond.ts";
 import { type Routes, parseRouteKey, router, serveNode } from "./host/node.ts";
 import { loadChannels } from "./engines/pi/channel.ts";
-import { probeAuthSource } from "./engines/pi/auth.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
 import { fastagentVersion } from "./engines/pi/version.ts";
 import { listModels, loadConfig } from "./engines/pi/config.ts";
+import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 import {
   type LoadedDefinition,
   defaultGlobalSkillPaths,
@@ -122,7 +122,7 @@ else usage(1);
 
 /** `fastagent models`: print every registered "provider/modelId" to stdout (pipe-friendly). */
 function runModels(): void {
-  for (const spec of listModels()) console.log(spec);
+  for (const spec of listModels(createPiModels())) console.log(spec);
 }
 
 /**
@@ -281,9 +281,9 @@ function parsePort(value: string | undefined, source: string): number | undefine
  */
 async function reportAuth(modelSpec: string): Promise<void> {
   const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
-  const source = await probeAuthSource(provider);
-  console.error(`[fastagent] auth:   ${source === "none" ? "(none found)" : `${source} (${provider})`}`);
-  if (source === "none") {
+  const source = await probeAuthSource(createPiModels(), modelSpec);
+  console.error(`[fastagent] auth:   ${source === undefined ? "(none found)" : `${source} (${provider})`}`);
+  if (source === undefined) {
     // Lead with `pi login`: the default model (openai-codex) is OAuth-only, and we cannot name
     // the right env var (it is provider-specific and pi-ai's mapping is not exported). Keep the
     // env path generic so we never advertise a key that can't satisfy the probed provider.

--- a/core/src/engines/pi/auth.ts
+++ b/core/src/engines/pi/auth.ts
@@ -1,41 +1,27 @@
 /**
- * Auth resolution for the pi engine (the harness's `getApiKeyAndHeaders` injection).
+ * Auth for the pi engine: a {@link CredentialStore} over pi's local credentials
+ * file (`~/.pi/agent/auth.json`), consumed by the `Models` collection (see
+ * models.ts). pi 0.80 made auth first-class: providers carry their own
+ * `ProviderAuth`, the collection resolves per request through a `CredentialStore`
+ * (stored credentials) plus an `AuthContext` (ambient env vars). This module
+ * supplies the store; env fallback is upstream-automatic.
  *
- * This is **reusable pi engine wiring**, hence it lives in engines/pi — not in examples.
- * Process-level global side effects (e.g. the undici proxy dispatcher) do NOT belong
- * here: those are the application entry point's responsibility.
+ * The on-disk file IS the `CredentialStore` shape: a `Record<providerId, Credential>`
+ * where each `Credential` is `{type:"oauth",...}` or `{type:"api_key",...}`.
+ * So reading is a parse-and-index; fastagent never logs in (that is the pi CLI's
+ * job), so writes are intentionally NOT persisted — see {@link piCredentialStore}.
+ *
+ * Process-level global side effects (e.g. the undici proxy dispatcher) do NOT
+ * belong here: those are the application entry point's responsibility.
  */
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { getEnvApiKey } from "@earendil-works/pi-ai";
-
-export type Auth = { apiKey: string; headers?: Record<string, string> } | undefined;
-/**
- * The parameter is just { provider } — all auth resolution needs; still assignable
- * wherever pi expects `(model: Model) => …` (contravariance).
- */
-export type AuthResolver = (model: { provider: string }) => Promise<Auth>;
+import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
 
 /** pi's local credentials file (written by the pi CLI). */
 const PI_AUTH_PATH = join(homedir(), ".pi", "agent", "auth.json");
 
-/** Resolve from environment variables (e.g. OPENAI_API_KEY / ANTHROPIC_API_KEY). */
-export const envAuth: AuthResolver = (model) => {
-  const apiKey = getEnvApiKey(model.provider);
-  return Promise.resolve(apiKey ? { apiKey } : undefined);
-};
-
-/**
- * Resolve from pi's OAuth credentials file (`~/.pi/agent/auth.json`, consuming
- * coding-plan tokens). The access token is returned directly as apiKey — pi-ai's
- * providers auto-detect OAuth tokens (anthropic `sk-ant-oat` / openai-codex JWT)
- * and set the Bearer auth plus required request headers themselves.
- *
- * Note: **no token refresh** (expired → undefined; the user re-logs-in via pi).
- * Coupled to the pi CLI credentials format — an out-of-the-box convenience, not a
- * core contract.
- */
 export interface PiAuthOptions {
   /**
    * Sink for non-fatal auth anomalies (unreadable/corrupt credentials file).
@@ -45,9 +31,25 @@ export interface PiAuthOptions {
   warn?: (message: string) => void;
 }
 
-export function piOAuthAuth(authPath: string = PI_AUTH_PATH, options: PiAuthOptions = {}): AuthResolver {
+/**
+ * A read-only `CredentialStore` backed by pi's `~/.pi/agent/auth.json`.
+ *
+ * `read` parses the file and returns the provider's stored credential (OAuth
+ * coding-plan token or `api_key` entry). Missing file / missing entry = not
+ * configured (the collection then falls back to ambient env vars); a corrupt
+ * file is surfaced via `warn` (fail visibly) and treated as not configured.
+ *
+ * **Writes are not persisted.** The pi CLI owns login/logout and token
+ * persistence; fastagent only reads. `modify` therefore runs the caller's
+ * function against the freshly-read credential and returns the result WITHOUT
+ * writing back — so an upstream OAuth refresh still produces a valid token for
+ * the in-flight request (a strict improvement over the old reader, which failed
+ * on an expired token), it just is not saved. `delete` is a no-op.
+ */
+export function piCredentialStore(authPath: string = PI_AUTH_PATH, options: PiAuthOptions = {}): CredentialStore {
   const warn = options.warn ?? ((message: string) => console.warn(message));
-  return (model) => {
+
+  const read = (providerId: string): Promise<Credential | undefined> => {
     let raw: string;
     try {
       raw = readFileSync(authPath, "utf8");
@@ -58,7 +60,7 @@ export function piOAuthAuth(authPath: string = PI_AUTH_PATH, options: PiAuthOpti
       }
       return Promise.resolve(undefined);
     }
-    let creds: Record<string, { type?: string; access?: unknown; expires?: unknown }>;
+    let creds: Record<string, Credential>;
     try {
       creds = JSON.parse(raw);
     } catch {
@@ -67,33 +69,23 @@ export function piOAuthAuth(authPath: string = PI_AUTH_PATH, options: PiAuthOpti
       warn(`[fastagent] corrupt auth file ${authPath}; run pi to re-login`);
       return Promise.resolve(undefined);
     }
-    const cred = creds[model.provider];
-    if (cred?.type === "oauth" && typeof cred.access === "string") {
-      if (typeof cred.expires === "number" && cred.expires < Date.now()) {
-        // Expired ≠ not configured: surface it, or the root cause hides behind a
-        // downstream "missing API key".
-        warn(`[fastagent] pi OAuth token for "${model.provider}" expired; run pi to re-login`);
-        return Promise.resolve(undefined);
-      }
-      return Promise.resolve({ apiKey: cred.access });
+    const cred = creds[providerId];
+    // Guard the discriminator: a foreign/old entry must read as not-configured,
+    // not crash auth resolution downstream.
+    if (cred && (cred.type === "oauth" || cred.type === "api_key")) {
+      return Promise.resolve(cred);
     }
     return Promise.resolve(undefined);
   };
-}
 
-/** Default resolution: try pi OAuth (coding plan) first, then fall back to env vars. */
-export function resolvePiAuth(authPath?: string, options?: PiAuthOptions): AuthResolver {
-  const oauth = piOAuthAuth(authPath, options);
-  return async (model) => (await oauth(model)) ?? envAuth(model);
-}
-
-/**
- * Which source of the DEFAULT chain ({@link resolvePiAuth}: OAuth → env) currently has
- * credentials for `provider`. Reporting-only (e.g. the `start` startup line); mirrors the
- * default chain order, warns suppressed (the live resolver surfaces anomalies per invoke).
- */
-export async function probeAuthSource(provider: string, authPath?: string): Promise<"oauth" | "env" | "none"> {
-  if (await piOAuthAuth(authPath, { warn: () => {} })({ provider })) return "oauth";
-  if (await envAuth({ provider })) return "env";
-  return "none";
+  return {
+    read,
+    async modify(providerId, fn) {
+      // Non-persisting: run against current, return the result, do not write.
+      return fn(await read(providerId));
+    },
+    delete() {
+      return Promise.resolve();
+    },
+  };
 }

--- a/core/src/engines/pi/auth.ts
+++ b/core/src/engines/pi/auth.ts
@@ -8,15 +8,18 @@
  *
  * The on-disk file IS the `CredentialStore` shape: a `Record<providerId, Credential>`
  * where each `Credential` is `{type:"oauth",...}` or `{type:"api_key",...}`.
- * So reading is a parse-and-index; fastagent never logs in (that is the pi CLI's
- * job), so writes are intentionally NOT persisted — see {@link piCredentialStore}.
+ * Reading is a parse-and-index; writing is the OAuth-refresh path — `Models.getAuth`
+ * runs token refresh inside `modify`, so the rotated credential MUST be persisted
+ * or the next request/restart reads a refresh token the provider already
+ * invalidated (see {@link piCredentialStore}). fastagent still never initiates
+ * login: that is the pi CLI's job.
  *
  * Process-level global side effects (e.g. the undici proxy dispatcher) do NOT
  * belong here: those are the application entry point's responsibility.
  */
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
 
 /** pi's local credentials file (written by the pi CLI). */
@@ -31,61 +34,119 @@ export interface PiAuthOptions {
   warn?: (message: string) => void;
 }
 
+/** Type-guard a parsed entry to a known `Credential`; foreign/old entries → undefined. */
+function asCredential(value: unknown): Credential | undefined {
+  if (value && typeof value === "object") {
+    const type = (value as { type?: unknown }).type;
+    if (type === "oauth" || type === "api_key") return value as Credential;
+  }
+  return undefined;
+}
+
 /**
- * A read-only `CredentialStore` backed by pi's `~/.pi/agent/auth.json`.
+ * A `CredentialStore` backed by pi's `~/.pi/agent/auth.json`.
  *
  * `read` parses the file and returns the provider's stored credential (OAuth
  * coding-plan token or `api_key` entry). Missing file / missing entry = not
  * configured (the collection then falls back to ambient env vars); a corrupt
  * file is surfaced via `warn` (fail visibly) and treated as not configured.
  *
- * **Writes are not persisted.** The pi CLI owns login/logout and token
- * persistence; fastagent only reads. `modify` therefore runs the caller's
- * function against the freshly-read credential and returns the result WITHOUT
- * writing back — so an upstream OAuth refresh still produces a valid token for
- * the in-flight request (a strict improvement over the old reader, which failed
- * on an expired token), it just is not saved. `delete` is a no-op.
+ * **Writes persist.** pi 0.80 resolves OAuth by refreshing the token inside
+ * `modify`, and the provider rotates its refresh token on every refresh — so the
+ * rotated credential is written back atomically (temp file + rename, mode 0600),
+ * preserving every other provider's entry. Without this the on-disk refresh
+ * token goes stale after the first refresh and later requests/restarts fail with
+ * 401 until the user re-runs `pi` login. `delete` removes a provider's entry.
+ * fastagent never initiates login (that is the pi CLI's job); it only persists
+ * the upstream refresh and an explicit logout.
+ *
+ * Mutual exclusion is per-provider and in-process (a promise chain): concurrent
+ * requests in a long-running `start`/`dev` cannot double-refresh a rotated token.
+ * Cross-process safety is best-effort — the atomic rename prevents torn writes,
+ * and pi's double-checked expiry under `modify` collapses redundant refreshes.
  */
 export function piCredentialStore(authPath: string = PI_AUTH_PATH, options: PiAuthOptions = {}): CredentialStore {
   const warn = options.warn ?? ((message: string) => console.warn(message));
 
-  const read = (providerId: string): Promise<Credential | undefined> => {
+  // Read the whole on-disk record. ENOENT = empty (not configured / pre-login);
+  // a corrupt parse is surfaced via `warn`. `onCorrupt` lets the write path turn
+  // an unreadable/corrupt file into a hard failure so a persist never clobbers
+  // other providers' credentials by overwriting a file it could not parse.
+  const readRecord = (onCorrupt: (message: string) => void): Record<string, unknown> => {
     let raw: string;
     try {
       raw = readFileSync(authPath, "utf8");
     } catch (error) {
-      // Missing file = not configured (normal). Anything else must be visible.
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         warn(`[fastagent] cannot read ${authPath}: ${(error as Error).message}`);
+        onCorrupt(`cannot read ${authPath}: ${(error as Error).message}`);
       }
-      return Promise.resolve(undefined);
+      return {};
     }
-    let creds: Record<string, Credential>;
     try {
-      creds = JSON.parse(raw);
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
     } catch {
-      // Corrupt credentials are an anomaly, not "not configured" — warn so the
-      // root cause is diagnosable instead of a confusing downstream auth failure.
       warn(`[fastagent] corrupt auth file ${authPath}; run pi to re-login`);
-      return Promise.resolve(undefined);
+      onCorrupt(`corrupt auth file ${authPath}`);
+      return {};
     }
-    const cred = creds[providerId];
-    // Guard the discriminator: a foreign/old entry must read as not-configured,
-    // not crash auth resolution downstream.
-    if (cred && (cred.type === "oauth" || cred.type === "api_key")) {
-      return Promise.resolve(cred);
-    }
-    return Promise.resolve(undefined);
+  };
+
+  // Atomic write: a fresh temp file (mode 0600 — never widen secret perms) then
+  // rename over the target, so a concurrent `read` sees one complete version.
+  const persist = (record: Record<string, unknown>): void => {
+    mkdirSync(dirname(authPath), { recursive: true });
+    const tmp = `${authPath}.${process.pid}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+    renameSync(tmp, authPath);
+  };
+
+  // Serialize tasks per provider id (the only write path is `modify`/`delete`).
+  const chains = new Map<string, Promise<unknown>>();
+  const enqueue = <T>(providerId: string, task: () => Promise<T>): Promise<T> => {
+    const previous = chains.get(providerId) ?? Promise.resolve();
+    const next = (async () => {
+      await previous.catch(() => {});
+      return task();
+    })();
+    chains.set(
+      providerId,
+      next.catch(() => {}),
+    );
+    return next;
   };
 
   return {
-    read,
-    async modify(providerId, fn) {
-      // Non-persisting: run against current, return the result, do not write.
-      return fn(await read(providerId));
+    read(providerId) {
+      // Display/status read: a corrupt file is not "not configured", but it must
+      // not crash resolution — warn (above) and report unconfigured.
+      const record = readRecord(() => {});
+      return Promise.resolve(asCredential(record[providerId]));
     },
-    delete() {
-      return Promise.resolve();
+    modify(providerId, fn) {
+      return enqueue(providerId, async () => {
+        const record = readRecord((message) => {
+          throw new Error(message); // never overwrite an unreadable/corrupt file
+        });
+        const current = asCredential(record[providerId]);
+        const next = await fn(current);
+        if (next !== undefined) {
+          record[providerId] = next;
+          persist(record);
+        }
+        return next ?? current;
+      });
+    },
+    delete(providerId) {
+      return enqueue(providerId, async () => {
+        const record = readRecord((message) => {
+          throw new Error(message);
+        });
+        if (!(providerId in record)) return;
+        delete record[providerId];
+        persist(record);
+      });
     },
   };
 }

--- a/core/src/engines/pi/build.ts
+++ b/core/src/engines/pi/build.ts
@@ -15,6 +15,7 @@
 import { mkdir, mkdtemp, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
+import { createPiModels } from "./models.ts";
 import { fastagentVersion } from "./version.ts";
 import {
   type LoadedDefinition,
@@ -87,7 +88,7 @@ export async function buildPiArtifact(
   }
   // Validate against the registry now, so a typo fails the build instead of being frozen
   // into the manifest and only failing later at start.
-  resolveModel(model);
+  resolveModel(createPiModels(), model);
 
   // Structural guard (the ONLY one): the output must not be the source or contain it — we
   // read src and publish over outDir, so out ⊇ src would destroy the input. realpath so a

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -46,6 +46,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
+import { createPiModels } from "./models.ts";
 import { defaultGlobalSkillPaths, loadAgentDefinition } from "./definition.ts";
 import { loadTools, mergeDiscoveredTools, type ToolCollision } from "./tool.ts";
 
@@ -75,7 +76,8 @@ export async function buildChatRuntime(
         `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
       );
     }
-    const model = resolveModel(modelSpec);
+    // Resolution only; chat's auth/login rides pi's native TUI machinery (see header).
+    const model = resolveModel(createPiModels(), modelSpec);
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(cwd, {
       env,

--- a/core/src/engines/pi/config.ts
+++ b/core/src/engines/pi/config.ts
@@ -29,7 +29,7 @@ import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { getModel, getModels, getProviders } from "@earendil-works/pi-ai";
+import type { Models } from "@earendil-works/pi-ai";
 import type { AnyModel } from "./harness.ts";
 
 export interface FastagentConfig {
@@ -118,15 +118,19 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   return { config: c, path };
 }
 
-/** Resolve "provider/modelId" → a pi Model. Unknown specs throw a clear error (getModel returns undefined). */
-export function resolveModel(spec: string): AnyModel {
+/**
+ * Resolve "provider/modelId" → a pi Model from the given collection. Unknown
+ * specs throw a clear error. The model is looked up in `models` so the harness
+ * resolves its auth from the same collection.
+ */
+export function resolveModel(models: Models, spec: string): AnyModel {
   const slash = spec.indexOf("/");
   if (slash < 1 || slash === spec.length - 1) {
     throw new Error(`model must be "provider/modelId" (e.g. "openai-codex/gpt-5.5"), got "${spec}"`);
   }
   const provider = spec.slice(0, slash);
   const modelId = spec.slice(slash + 1);
-  const model = getModel(provider as never, modelId as never) as AnyModel | undefined;
+  const model = models.getModel(provider, modelId) as AnyModel | undefined;
   if (!model) {
     throw new Error(
       `unknown model "${spec}" (provider "${provider}" / id "${modelId}" not in registry); run \`fastagent models\` to list available specs`,
@@ -136,14 +140,14 @@ export function resolveModel(spec: string): AnyModel {
 }
 
 /**
- * All registered "provider/modelId" specs, sorted — the discovery list behind `fastagent models`.
- * Sourced from pi-ai's registry (getProviders × getModels), so it stays in sync with what
- * {@link resolveModel} accepts. Pure (no IO); the CLI prints it to stdout.
+ * All registered "provider/modelId" specs in `models`, sorted — the discovery
+ * list behind `fastagent models`. Sourced from the same collection {@link resolveModel}
+ * accepts, so they stay in sync. Pure (no IO); the CLI prints it to stdout.
  */
-export function listModels(): string[] {
+export function listModels(models: Models): string[] {
   const specs: string[] = [];
-  for (const provider of getProviders()) {
-    for (const model of getModels(provider)) specs.push(`${provider}/${model.id}`);
+  for (const provider of models.getProviders()) {
+    for (const model of provider.getModels()) specs.push(`${provider.id}/${model.id}`);
   }
   return specs.sort();
 }

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -67,11 +67,12 @@ import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { createCodingTools } from "@earendil-works/pi-coding-agent";
+import type { Models } from "@earendil-works/pi-ai";
 import type { Agent } from "../../agent.ts";
-import type { AuthResolver } from "./auth.ts";
 import type { FastagentConfig } from "./config.ts";
 import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, piHarnessFactory } from "./harness.ts";
+import { createPiModels } from "./models.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 
@@ -183,6 +184,12 @@ export function assembleSystemPrompt(options: AssembleSystemPromptOptions): stri
 /** L1 options, grouped by the two-axis model (core-design §6.1). */
 export interface CreatePiAgentOptions {
   // ── M: what the agent is ───────────────────────────────────────────────
+  /**
+   * Provider collection for model requests + auth. Defaults to {@link createPiModels}
+   * (built-in providers; pi OAuth file then env vars). Inject a custom collection
+   * to change providers or auth. {@link model} must belong to it (same provider id).
+   */
+  models?: Models;
   model: AnyModel;
   /**
    * The FINAL assembled prompt (see §2 for assembly from parts), or a
@@ -199,9 +206,6 @@ export interface CreatePiAgentOptions {
   env?: ExecutionEnv;
   /** Single-writer lease. Defaults to in-process fail-fast inProcessLease(). */
   lease?: Lease;
-  // ── auth: how it reaches the provider ──────────────────────────────────
-  /** Auth resolution. Defaults to resolvePiAuth() (pi OAuth first, then env vars). */
-  getApiKeyAndHeaders?: AuthResolver;
 }
 
 /** L1: batteries-included assembly. */
@@ -211,11 +215,11 @@ export function createPiAgent(options: CreatePiAgentOptions): Agent {
     harnessFactory: piHarnessFactory({
       sessions: options.sessions ?? inMemorySessionStore(),
       env: options.env ?? new NodeExecutionEnv({ cwd: process.cwd() }),
+      models: options.models ?? createPiModels(),
       model: options.model,
       systemPrompt: options.systemPrompt,
       tools: options.tools,
       skills: options.skills,
-      getApiKeyAndHeaders: options.getApiKeyAndHeaders,
     }),
   });
 }
@@ -228,6 +232,8 @@ export function createPiAgent(options: CreatePiAgentOptions): Agent {
  */
 export interface CreatePiAgentFromDefinitionOptions {
   // ── M ──────────────────────────────────────────────────────────────────
+  /** Provider collection for model requests + auth. Defaults to {@link createPiModels}. */
+  models?: Models;
   model: AnyModel;
   /** Override the base prompt (segment ①). Defaults to piBasePrompt({tools}) (engine-inherited). */
   base?: string;
@@ -239,8 +245,6 @@ export interface CreatePiAgentFromDefinitionOptions {
   sessions?: PiSessionStore;
   env?: ExecutionEnv;
   lease?: Lease;
-  // ── auth ───────────────────────────────────────────────────────────────
-  getApiKeyAndHeaders?: AuthResolver;
 }
 
 /**
@@ -257,6 +261,7 @@ export async function createPiAgentFromDefinition(
   const base = options.base ?? piBasePrompt({ tools });
   const agent = createPiAgent({
     // M — assembled here from the definition (no spread: every field deliberate)
+    models: options.models,
     model: options.model,
     // Factory, not a string: re-assembled per invoke so `date` is the date of the
     // turn, not of agent creation (long-running deployments would otherwise serve
@@ -276,7 +281,6 @@ export async function createPiAgentFromDefinition(
     sessions: options.sessions,
     env,
     lease: options.lease,
-    getApiKeyAndHeaders: options.getApiKeyAndHeaders,
   });
   return { agent, definition };
 }

--- a/core/src/engines/pi/dev.ts
+++ b/core/src/engines/pi/dev.ts
@@ -27,6 +27,7 @@ import type { Agent } from "../../agent.ts";
 import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
 import { createPiAgentFromDefinition, piDefaultTools, resolveTools } from "./create.ts";
 import { type LoadedDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored } from "./definition.ts";
+import { createPiModels } from "./models.ts";
 import { jsonlSessionStore } from "./sessions.ts";
 import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 
@@ -87,8 +88,10 @@ export async function createPiAgentFromWorkspace(
   const stateDir = join(dir, ".fastagent");
   await mkdir(stateDir, { recursive: true });
   await ensureStateDirSelfIgnored(stateDir);
+  const models = createPiModels();
   const { agent, definition } = await createPiAgentFromDefinition(dir, {
-    model: resolveModel(modelSpec),
+    models,
+    model: resolveModel(models, modelSpec),
     tools,
     // Definition-only by default (the agent is its folder); globals are an explicit
     // authoring-fidelity opt-in, never the deploy path (see create.ts ladder rule 2 + core-design §6).

--- a/core/src/engines/pi/harness.ts
+++ b/core/src/engines/pi/harness.ts
@@ -14,8 +14,7 @@
  */
 import { AgentHarness } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
-import type { Model } from "@earendil-works/pi-ai";
-import { type AuthResolver, resolvePiAuth } from "./auth.ts";
+import type { Model, Models } from "@earendil-works/pi-ai";
 import type { PiSessionStore } from "./sessions.ts";
 
 /**
@@ -37,6 +36,12 @@ export interface PiHarnessFactoryOptions {
   /** Session persistence (see sessions.ts). Continuity = same backing store + same session id. */
   sessions: PiSessionStore;
   env: ExecutionEnv;
+  /**
+   * Provider collection used for all model requests; resolves auth through the
+   * providers' own `ProviderAuth`. {@link model} must belong to this collection
+   * (same provider id) for its auth to be in scope.
+   */
+  models: Models;
   model: AnyModel;
   tools?: AgentTool[];
   /**
@@ -46,8 +51,6 @@ export interface PiHarnessFactoryOptions {
   systemPrompt?: string | (() => string);
   /** Skills visible to the model / explicitly invokable (injected as harness resources). */
   skills?: Skill[];
-  /** Model auth resolution. Defaults to {@link resolvePiAuth}: pi OAuth (~/.pi/agent/auth.json) first, then env vars. */
-  getApiKeyAndHeaders?: AuthResolver;
 }
 
 /**
@@ -61,11 +64,11 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
     return new AgentHarness({
       env: options.env,
       session,
+      models: options.models,
       model: options.model,
       tools: options.tools,
       systemPrompt: typeof systemPrompt === "function" ? systemPrompt() : systemPrompt,
       resources: options.skills ? { skills: options.skills } : undefined,
-      getApiKeyAndHeaders: options.getApiKeyAndHeaders ?? resolvePiAuth(),
     });
   };
 }

--- a/core/src/engines/pi/models.ts
+++ b/core/src/engines/pi/models.ts
@@ -1,0 +1,55 @@
+/**
+ * The pi `Models` collection — the single hub that owns BOTH model resolution
+ * (provider/modelId lookup) AND auth (per-request credential resolution).
+ *
+ * pi 0.80 folded the old split — a global model registry (`getModel`/`getModels`)
+ * plus a harness-injected `getApiKeyAndHeaders` callback — into one `Models`
+ * object built from provider factories. Providers carry their own `ProviderAuth`,
+ * so auth resolves through the collection (`Models.getAuth`), not a side channel.
+ *
+ * fastagent builds one `Models` per opener (dev/start) and threads it into the
+ * harness alongside the selected `model`; the two must come from the same
+ * collection so the selected model's provider auth is in scope.
+ */
+import { type Models, defaultProviderAuthContext } from "@earendil-works/pi-ai";
+import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import { type PiAuthOptions, piCredentialStore } from "./auth.ts";
+
+export interface CreatePiModelsOptions extends PiAuthOptions {
+  /** Override pi's credentials file path (`~/.pi/agent/auth.json`). */
+  authPath?: string;
+}
+
+/**
+ * A `Models` with every built-in pi provider registered, wired to fastagent's
+ * default auth:
+ * - **stored credentials** from pi's `~/.pi/agent/auth.json` (OAuth coding-plan
+ *   tokens or `api_key` entries) via {@link piCredentialStore}, and
+ * - **ambient env vars** (e.g. `ANTHROPIC_API_KEY`) via pi's default auth context.
+ *
+ * Resolution order is upstream-owned: a stored credential owns the provider;
+ * env is consulted only when nothing is stored. This mirrors the pre-0.80
+ * default (`resolvePiAuth`: OAuth first, then env) — and additionally gains
+ * upstream OAuth token refresh, which the old reader did not do.
+ */
+export function createPiModels(options: CreatePiModelsOptions = {}): Models {
+  return builtinModels({
+    credentials: piCredentialStore(options.authPath, { warn: options.warn }),
+    authContext: defaultProviderAuthContext(),
+  });
+}
+
+/**
+ * Which source currently satisfies auth for `spec` — a startup diagnostic
+ * (dev/start print it). Returns the upstream `AuthResult.source` label
+ * (e.g. "OAuth", "ANTHROPIC_API_KEY") or undefined when unconfigured.
+ * Reporting-only; never throws (a failed OAuth refresh reports unconfigured).
+ */
+export async function probeAuthSource(models: Models, spec: string): Promise<string | undefined> {
+  const slash = spec.indexOf("/");
+  if (slash < 1) return undefined;
+  const model = models.getModel(spec.slice(0, slash), spec.slice(slash + 1));
+  if (!model) return undefined;
+  const auth = await models.getAuth(model).catch(() => undefined);
+  return auth?.source;
+}

--- a/core/src/engines/pi/start.ts
+++ b/core/src/engines/pi/start.ts
@@ -25,11 +25,11 @@
 import { mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Agent } from "../../agent.ts";
-import type { AuthResolver } from "./auth.ts";
 import { type ArtifactManifest, MANIFEST_FILE } from "./build.ts";
 import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
 import { createPiAgentFromDefinition, piDefaultTools, resolveTools } from "./create.ts";
 import { type LoadedDefinition, ensureStateDirSelfIgnored } from "./definition.ts";
+import { createPiModels } from "./models.ts";
 import { jsonlSessionStore } from "./sessions.ts";
 import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 
@@ -89,8 +89,6 @@ export interface CreatePiAgentFromArtifactOptions {
    * dir, not the artifact). Self-gitignored on create.
    */
   sessionsDir?: string;
-  /** Model auth resolution. Defaults to the L2 default (resolvePiAuth: pi OAuth → env vars). */
-  getApiKeyAndHeaders?: AuthResolver;
 }
 
 /**
@@ -139,14 +137,15 @@ export async function createPiAgentFromArtifact(
   const toolCollisions = [...discovered.collisions, ...crossCollisions];
   const defaultNames = new Set(piDefaultTools(artifactDir).map((t) => t.name));
   const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
+  const models = createPiModels();
   const { agent, definition } = await createPiAgentFromDefinition(artifactDir, {
-    model: resolveModel(modelSpec),
+    models,
+    model: resolveModel(models, modelSpec),
     // Code tools shipped in fastagent.config.* (appended after pi defaults); model/http are
     // already frozen in the manifest, but tools are functions and only live in the config file.
     tools,
     // Continuity from an external store, reconstructed per invoke (SPEC portable conformance).
     sessions: jsonlSessionStore({ dir: sessionsDir, cwd: artifactDir }),
-    getApiKeyAndHeaders: options.getApiKeyAndHeaders,
   });
   return { agent, definition, manifest, config, modelSpec, sessionsDir, toolNames, toolCollisions };
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -110,12 +110,9 @@ export {
   inMemorySessionStore,
   jsonlSessionStore,
 } from "./engines/pi/sessions.ts";
-export {
-  type Auth,
-  type AuthResolver,
-  type PiAuthOptions,
-  envAuth,
-  piOAuthAuth,
-  probeAuthSource,
-  resolvePiAuth,
-} from "./engines/pi/auth.ts";
+// pi reference implementation — auth + the Models collection (model resolution +
+// per-request auth). createPiModels builds the default collection (built-in
+// providers; pi OAuth file → env vars); piCredentialStore is the auth.json reader.
+export { type PiAuthOptions, piCredentialStore } from "./engines/pi/auth.ts";
+export { type CreatePiModelsOptions, createPiModels, probeAuthSource } from "./engines/pi/models.ts";
+export type { Models } from "@earendil-works/pi-ai";

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -112,7 +112,8 @@ export {
 } from "./engines/pi/sessions.ts";
 // pi reference implementation — auth + the Models collection (model resolution +
 // per-request auth). createPiModels builds the default collection (built-in
-// providers; pi OAuth file → env vars); piCredentialStore is the auth.json reader.
+// providers; pi OAuth file → env vars); piCredentialStore is the auth.json store
+// (reads credentials; persists the upstream OAuth refresh).
 export { type PiAuthOptions, piCredentialStore } from "./engines/pi/auth.ts";
 export { type CreatePiModelsOptions, createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 export type { Models } from "@earendil-works/pi-ai";

--- a/core/test/auth.test.ts
+++ b/core/test/auth.test.ts
@@ -13,7 +13,7 @@ async function authFile(contents: string): Promise<string> {
   return path;
 }
 
-describe("piCredentialStore (read-only auth.json reader; fail-visibly discipline)", () => {
+describe("piCredentialStore (read-write auth.json store; fail-visibly discipline)", () => {
   it("missing file → undefined, no warning (normal not-configured)", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const cred = await piCredentialStore("/nonexistent/auth.json").read("anthropic");
@@ -61,20 +61,63 @@ describe("piCredentialStore (read-only auth.json reader; fail-visibly discipline
     expect(await piCredentialStore(path).read("anthropic")).toBeUndefined();
   });
 
-  it("modify does NOT persist (pi CLI owns writes) but returns the function's result", async () => {
-    const original = { anthropic: { type: "oauth", access: "old", expires: 1 } };
-    const path = await authFile(JSON.stringify(original));
+  it("modify persists the rotated credential and returns it (next request reads the new token)", async () => {
+    const path = await authFile(
+      JSON.stringify({ anthropic: { type: "oauth", access: "old", refresh: "r0", expires: 1 } }),
+    );
     const store = piCredentialStore(path);
-    const next = { type: "oauth", access: "refreshed", refresh: "r", expires: 2 } as const;
+    const next = { type: "oauth", access: "refreshed", refresh: "r1", expires: 2 } as const;
     const result = await store.modify("anthropic", async () => next);
-    expect(result).toEqual(next); // refreshed token is usable for the in-flight request
-    expect(JSON.parse(await readFile(path, "utf8"))).toEqual(original); // file untouched
+    expect(result).toEqual(next); // usable for the in-flight request
+    expect(await store.read("anthropic")).toEqual(next); // persisted: a later read sees the rotated token
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ anthropic: next });
   });
 
-  it("delete is a no-op (read-only store)", async () => {
-    const path = await authFile(JSON.stringify({ anthropic: { type: "oauth", access: "x", expires: 1 } }));
+  it("modify preserves other providers' entries (writes only the target key)", async () => {
+    const openai = { type: "api_key", key: "sk-openai" };
+    const path = await authFile(
+      JSON.stringify({ openai, anthropic: { type: "oauth", access: "old", refresh: "r0", expires: 1 } }),
+    );
+    const next = { type: "oauth", access: "new", refresh: "r1", expires: 2 } as const;
+    await piCredentialStore(path).modify("anthropic", async () => next);
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ openai, anthropic: next });
+  });
+
+  it("modify returns current unchanged when fn returns undefined (no write)", async () => {
+    const current = { type: "oauth", access: "live", refresh: "r", expires: Date.now() + 60_000 };
+    const path = await authFile(JSON.stringify({ anthropic: current }));
+    const result = await piCredentialStore(path).modify("anthropic", async () => undefined);
+    expect(result).toEqual(current);
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ anthropic: current });
+  });
+
+  it("modify refuses to overwrite a corrupt file (fail visibly, not clobber)", async () => {
+    const path = await authFile("{not valid json");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      piCredentialStore(path).modify("anthropic", async () => ({
+        type: "oauth",
+        access: "x",
+        refresh: "r",
+        expires: 1,
+      })),
+    ).rejects.toThrow(/corrupt auth file/);
+    expect(await readFile(path, "utf8")).toBe("{not valid json"); // untouched
+  });
+
+  it("delete removes the provider's entry, preserving the rest", async () => {
+    const openai = { type: "api_key", key: "sk" };
+    const path = await authFile(
+      JSON.stringify({ openai, anthropic: { type: "oauth", access: "x", refresh: "r", expires: 1 } }),
+    );
     const store = piCredentialStore(path);
+    await store.delete("anthropic");
+    expect(await store.read("anthropic")).toBeUndefined();
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ openai });
+  });
+
+  it("delete of a missing entry / file is a no-op that does not create the file", async () => {
+    const store = piCredentialStore("/nonexistent/dir/auth.json");
     await expect(store.delete("anthropic")).resolves.toBeUndefined();
-    expect(await store.read("anthropic")).toBeDefined(); // still there
   });
 });

--- a/core/test/auth.test.ts
+++ b/core/test/auth.test.ts
@@ -1,76 +1,80 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { piOAuthAuth, probeAuthSource } from "../src/index.ts";
-
-const model = { provider: "anthropic" };
+import { piCredentialStore } from "../src/index.ts";
 
 afterEach(() => vi.restoreAllMocks());
 
-describe("piOAuthAuth (silent-failure discipline)", () => {
+async function authFile(contents: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "fa-auth-"));
+  const path = join(dir, "auth.json");
+  await writeFile(path, contents);
+  return path;
+}
+
+describe("piCredentialStore (read-only auth.json reader; fail-visibly discipline)", () => {
   it("missing file → undefined, no warning (normal not-configured)", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const auth = await piOAuthAuth("/nonexistent/auth.json")(model);
-    expect(auth).toBeUndefined();
+    const cred = await piCredentialStore("/nonexistent/auth.json").read("anthropic");
+    expect(cred).toBeUndefined();
     expect(warn).not.toHaveBeenCalled();
   });
 
   it("corrupt JSON → undefined, but warns (diagnosable root cause)", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-auth-"));
-    const path = join(dir, "auth.json");
-    await writeFile(path, "{not valid json");
+    const path = await authFile("{not valid json");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const auth = await piOAuthAuth(path)(model);
-    expect(auth).toBeUndefined();
+    const cred = await piCredentialStore(path).read("anthropic");
+    expect(cred).toBeUndefined();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("corrupt auth file"));
   });
 
   it("injected warn sink routes warnings to the injected logger without touching console", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-auth-"));
-    const path = join(dir, "auth.json");
-    await writeFile(path, "{not valid json");
+    const path = await authFile("{not valid json");
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const messages: string[] = [];
-
-    const auth = await piOAuthAuth(path, { warn: (m) => messages.push(m) })(model);
-
-    expect(auth).toBeUndefined();
+    const cred = await piCredentialStore(path, { warn: (m) => messages.push(m) }).read("anthropic");
+    expect(cred).toBeUndefined();
     expect(messages[0]).toContain("corrupt auth file");
     expect(consoleWarn).not.toHaveBeenCalled();
   });
 
-  it("valid oauth credential returns access token as apiKey; expired credential returns undefined with warning instead of silently degrading", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-auth-"));
-    const path = join(dir, "auth.json");
-    await writeFile(
-      path,
-      JSON.stringify({
-        anthropic: { type: "oauth", access: "tok-live", expires: Date.now() + 60_000 },
-      }),
-    );
-    expect(await piOAuthAuth(path)(model)).toEqual({ apiKey: "tok-live" });
-
-    await writeFile(path, JSON.stringify({ anthropic: { type: "oauth", access: "tok-old", expires: Date.now() - 1 } }));
-    const messages: string[] = [];
-    expect(await piOAuthAuth(path, { warn: (m) => messages.push(m) })(model)).toBeUndefined();
-    expect(messages[0]).toContain("expired"); // root cause surfaced, not buried under "missing API key"
-  });
-});
-
-describe("probeAuthSource (startup credential report; dev + start)", () => {
-  it("reports oauth when the credentials file has a live token for the provider", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-probe-"));
-    const path = join(dir, "auth.json");
-    await writeFile(
-      path,
-      JSON.stringify({ anthropic: { type: "oauth", access: "tok", expires: Date.now() + 60_000 } }),
-    );
-    expect(await probeAuthSource("anthropic", path)).toBe("oauth");
+  it("returns the stored oauth credential verbatim (upstream owns refresh/expiry)", async () => {
+    const oauth = { type: "oauth", access: "tok-live", refresh: "r", expires: Date.now() + 60_000 };
+    const path = await authFile(JSON.stringify({ anthropic: oauth }));
+    expect(await piCredentialStore(path).read("anthropic")).toEqual(oauth);
   });
 
-  it("reports none when neither the credentials file nor env provides a key", async () => {
-    // a provider with no env-var mapping + a nonexistent auth file → deterministically none
-    expect(await probeAuthSource("no-such-provider", "/nonexistent/auth.json")).toBe("none");
+  it("returns api_key credentials (incl. provider-scoped env) — auth.json's other discriminator", async () => {
+    const apiKey = { type: "api_key", key: "sk-x", env: { CLOUDFLARE_ACCOUNT_ID: "acc" } };
+    const path = await authFile(JSON.stringify({ cloudflare: apiKey }));
+    expect(await piCredentialStore(path).read("cloudflare")).toEqual(apiKey);
+  });
+
+  it("foreign/unknown discriminator reads as not-configured (does not crash resolution)", async () => {
+    const path = await authFile(JSON.stringify({ anthropic: { type: "legacy", token: "x" } }));
+    expect(await piCredentialStore(path).read("anthropic")).toBeUndefined();
+  });
+
+  it("missing provider entry → undefined", async () => {
+    const path = await authFile(JSON.stringify({ openai: { type: "api_key", key: "sk" } }));
+    expect(await piCredentialStore(path).read("anthropic")).toBeUndefined();
+  });
+
+  it("modify does NOT persist (pi CLI owns writes) but returns the function's result", async () => {
+    const original = { anthropic: { type: "oauth", access: "old", expires: 1 } };
+    const path = await authFile(JSON.stringify(original));
+    const store = piCredentialStore(path);
+    const next = { type: "oauth", access: "refreshed", refresh: "r", expires: 2 } as const;
+    const result = await store.modify("anthropic", async () => next);
+    expect(result).toEqual(next); // refreshed token is usable for the in-flight request
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual(original); // file untouched
+  });
+
+  it("delete is a no-op (read-only store)", async () => {
+    const path = await authFile(JSON.stringify({ anthropic: { type: "oauth", access: "x", expires: 1 } }));
+    const store = piCredentialStore(path);
+    await expect(store.delete("anthropic")).resolves.toBeUndefined();
+    expect(await store.read("anthropic")).toBeDefined(); // still there
   });
 });

--- a/core/test/config.test.ts
+++ b/core/test/config.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { createPiAgentFromWorkspace, listModels, resolveModel } from "../src/index.ts";
+import { createPiAgentFromWorkspace, createPiModels, listModels, resolveModel } from "../src/index.ts";
 import { loadConfig, resolveModelSpec } from "../src/engines/pi/config.ts";
 import { resolveTools } from "../src/engines/pi/create.ts";
 
@@ -11,7 +11,8 @@ const fixtures = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 
 describe("config: listModels (fastagent models discovery)", () => {
   it("lists well-formed provider/modelId specs, sorted, that resolveModel accepts", () => {
-    const specs = listModels();
+    const models = createPiModels();
+    const specs = listModels(models);
     expect(specs.length).toBeGreaterThan(0);
     // every entry is a "provider/modelId" and round-trips through resolveModel (the list is the
     // discovery surface for exactly what --model / config accepts).
@@ -19,7 +20,7 @@ describe("config: listModels (fastagent models discovery)", () => {
       // provider (no slash) + "/" + non-empty modelId (which MAY contain slashes, e.g.
       // cloudflare-ai-gateway/workers-ai/@cf/...); resolveModel splits on the first slash.
       expect(spec).toMatch(/^[^/]+\/.+$/);
-      expect(() => resolveModel(spec)).not.toThrow();
+      expect(() => resolveModel(models, spec)).not.toThrow();
     }
     expect(specs).toEqual([...specs].sort()); // sorted
     expect(specs).toContain("openai-codex/gpt-5.5"); // the spec used across the repo
@@ -100,14 +101,15 @@ describe("config: resolveTools (append-after-defaults semantics)", () => {
 
 describe("config: resolveModel", () => {
   it('parses "provider/modelId"', () => {
-    const m = resolveModel("openai-codex/gpt-5.5");
+    const m = resolveModel(createPiModels(), "openai-codex/gpt-5.5");
     expect(m.provider).toBe("openai-codex");
     expect(m.id).toBe("gpt-5.5");
   });
 
   it("bad format / unknown model throws a clear error", () => {
-    expect(() => resolveModel("no-slash")).toThrow(/provider\/modelId/);
-    expect(() => resolveModel("nope/nothing")).toThrow(/unknown model/);
+    const models = createPiModels();
+    expect(() => resolveModel(models, "no-slash")).toThrow(/provider\/modelId/);
+    expect(() => resolveModel(models, "nope/nothing")).toThrow(/unknown model/);
   });
 });
 

--- a/core/test/conformance.test.ts
+++ b/core/test/conformance.test.ts
@@ -7,19 +7,21 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
-import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, type FauxResponseStep } from "@earendil-works/pi-ai";
 import { inMemorySessionStore, jsonlSessionStore, type PiSessionStore } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
 
 function piAgent(responses: FauxResponseStep[], sessions: PiSessionStore = inMemorySessionStore()) {
-  const faux = registerFauxProvider();
+  const { faux, models } = makeFaux();
   faux.setResponses(responses);
   return createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
       sessions,
       env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
       model: faux.getModel(),
       systemPrompt: "test",
     }),
@@ -32,11 +34,12 @@ describeSpecConformance("pi reference implementation (faux model, full L0 compos
   failing: () => piAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })]),
 
   hanging: (onCleanup) => {
-    const faux = registerFauxProvider();
+    const { faux, models } = makeFaux();
     faux.setResponses([fauxAssistantMessage("a long answer that streams out slowly")]);
     const inner = piHarnessFactory({
       sessions: inMemorySessionStore(),
       env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
       model: faux.getModel(),
       systemPrompt: "test",
     });

--- a/core/test/definition.test.ts
+++ b/core/test/definition.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { makeFaux } from "./faux.ts";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { access, mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -147,7 +148,7 @@ describe("create: createPiAgentFromDefinition (directory → agent)", () => {
   it("assembled systemPrompt reaches the model; skills are injected as resources; read tool is present by default", async () => {
     let seenSystemPrompt: string | undefined;
     let seenTools: string[] = [];
-    const faux = registerFauxProvider();
+    const { faux, models } = makeFaux();
     faux.setResponses([
       (context) => {
         seenSystemPrompt = context.systemPrompt;
@@ -157,6 +158,7 @@ describe("create: createPiAgentFromDefinition (directory → agent)", () => {
     ]);
 
     const { agent, definition } = await createPiAgentFromDefinition(fixtureDir, {
+      models,
       model: faux.getModel(),
       skillPaths: [], // hermetic: do not scan this dev machine's real globals
     });

--- a/core/test/faux.ts
+++ b/core/test/faux.ts
@@ -1,0 +1,19 @@
+/**
+ * Test faux model wiring for pi 0.80's `Models` collections.
+ *
+ * pi 0.80 removed the global `registerFauxProvider()` registry; faux providers
+ * now live in explicit `Models` collections. This helper restores the old
+ * one-call ergonomics: build a `Models` with a single faux provider registered,
+ * and return both so tests can pass `models` + `faux.getModel()` to a harness.
+ */
+import { type Models, type RegisterFauxProviderOptions, createModels, fauxProvider } from "@earendil-works/pi-ai";
+
+export function makeFaux(options?: RegisterFauxProviderOptions): {
+  faux: ReturnType<typeof fauxProvider>;
+  models: Models;
+} {
+  const faux = fauxProvider(options);
+  const models = createModels();
+  models.setProvider(faux.provider);
+  return { faux, models };
+}

--- a/core/test/http.test.ts
+++ b/core/test/http.test.ts
@@ -3,18 +3,20 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { EventEmitter } from "node:events";
 import type { AddressInfo } from "node:net";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
-import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, type FauxResponseStep } from "@earendil-works/pi-ai";
 import { createInvokeHandler, nodeListener, inMemorySessionStore, type Agent, type AgentEvent } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { makeFaux } from "./faux.ts";
 
 function makeAgent(responses: FauxResponseStep[]): Agent {
-  const faux = registerFauxProvider();
+  const { faux, models } = makeFaux();
   faux.setResponses(responses);
   return createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
       sessions: inMemorySessionStore(),
       env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
       model: faux.getModel(),
       systemPrompt: "test",
     }),

--- a/core/test/invoke.test.ts
+++ b/core/test/invoke.test.ts
@@ -1,16 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { AgentHarness, InMemorySessionRepo, type AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
-import {
-  fauxAssistantMessage,
-  fauxToolCall,
-  registerFauxProvider,
-  Type,
-  type FauxResponseStep,
-} from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxToolCall, Type, type FauxResponseStep } from "@earendil-works/pi-ai";
 import { inMemorySessionStore, inProcessLease, type AgentEvent } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { makeFaux } from "./faux.ts";
 
 /** An echo tool for the tool-call path. */
 const echoTool: AgentTool = {
@@ -29,13 +24,14 @@ const echoTool: AgentTool = {
 
 /** An agent bound to a faux model + shared store (→ continuity). Open-or-create per invoke. */
 function makeAgent(responses: FauxResponseStep[]) {
-  const faux = registerFauxProvider();
+  const { faux, models } = makeFaux();
   faux.setResponses(responses);
   const sessions = inMemorySessionStore();
   const agent = createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
       sessions,
       env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
       model: faux.getModel(),
       tools: [echoTool],
       systemPrompt: "test",
@@ -106,12 +102,13 @@ describe("invoke fan-in", () => {
     const env = new NodeExecutionEnv({ cwd: process.cwd() });
     const agent = createPiAgentFromHarness({
       harnessFactory: async (sessionId: string) => {
-        const faux = registerFauxProvider();
+        const { faux, models } = makeFaux();
         faux.setResponses([fauxAssistantMessage("a long answer streamed out")]);
         const session = await repo.create({ id: sessionId });
         const harness = new AgentHarness({
           env,
           session,
+          models,
           model: faux.getModel(),
           systemPrompt: "test",
         });
@@ -139,10 +136,10 @@ describe("invoke fan-in", () => {
     const env = new NodeExecutionEnv({ cwd: process.cwd() });
     const agent = createPiAgentFromHarness({
       harnessFactory: async (sessionId: string) => {
-        const faux = registerFauxProvider();
+        const { faux, models } = makeFaux();
         faux.setResponses([fauxAssistantMessage("done")]);
         const session = await repo.create({ id: sessionId });
-        const harness = new AgentHarness({ env, session, model: faux.getModel(), systemPrompt: "test" });
+        const harness = new AgentHarness({ env, session, models, model: faux.getModel(), systemPrompt: "test" });
         harness.abort = async () => {
           throw new Error("abort blew up"); // simulate an idle abort rejecting
         };
@@ -166,7 +163,7 @@ describe("invoke fan-in", () => {
 describe("prompt.images passthrough (SPEC §4)", () => {
   it("images reach the model context with the prompt", async () => {
     let seen: unknown;
-    const faux = registerFauxProvider({ models: [{ id: "faux-vision", input: ["text", "image"] }] });
+    const { faux, models } = makeFaux({ models: [{ id: "faux-vision", input: ["text", "image"] }] });
     faux.setResponses([
       (context) => {
         seen = context.messages;
@@ -177,6 +174,7 @@ describe("prompt.images passthrough (SPEC §4)", () => {
       harnessFactory: piHarnessFactory({
         sessions: inMemorySessionStore(),
         env: new NodeExecutionEnv({ cwd: process.cwd() }),
+        models,
         model: faux.getModel(),
         systemPrompt: "test",
       }),
@@ -248,7 +246,7 @@ describe("lease + setup robustness", () => {
 
   it("createPiAgentFromHarness wraps invoke with the injected lease (acquire…release)", async () => {
     const calls: string[] = [];
-    const faux = registerFauxProvider();
+    const { faux, models } = makeFaux();
     faux.setResponses([fauxAssistantMessage("ok")]);
     const agent = createPiAgentFromHarness({
       lease: {
@@ -260,6 +258,7 @@ describe("lease + setup robustness", () => {
       harnessFactory: piHarnessFactory({
         sessions: inMemorySessionStore(),
         env: new NodeExecutionEnv({ cwd: process.cwd() }),
+        models,
         model: faux.getModel(),
         systemPrompt: "test",
       }),
@@ -294,12 +293,13 @@ describe("lease + setup robustness", () => {
 describe("systemPrompt factory (re-evaluated per invoke)", () => {
   it("harnessFactory calls the factory each time so time-sensitive segments are not frozen at creation time", async () => {
     let calls = 0;
-    const faux = registerFauxProvider();
+    const { faux, models } = makeFaux();
     faux.setResponses([fauxAssistantMessage("a"), fauxAssistantMessage("b")]);
     const agent = createPiAgentFromHarness({
       harnessFactory: piHarnessFactory({
         sessions: inMemorySessionStore(),
         env: new NodeExecutionEnv({ cwd: process.cwd() }),
+        models,
         model: faux.getModel(),
         systemPrompt: () => `prompt v${++calls}`,
       }),
@@ -313,7 +313,7 @@ describe("systemPrompt factory (re-evaluated per invoke)", () => {
 
 describe("retryClassifier injection (failed.retryable policy is replaceable)", () => {
   it("injected policy overrides the default string heuristic", async () => {
-    const faux = registerFauxProvider();
+    const { faux, models } = makeFaux();
     // "weird custom failure" does not match the default regex, so the default would be retryable:false
     faux.setResponses([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "weird custom failure" })]);
     const agent = createPiAgentFromHarness({
@@ -321,6 +321,7 @@ describe("retryClassifier injection (failed.retryable policy is replaceable)", (
       harnessFactory: piHarnessFactory({
         sessions: inMemorySessionStore(),
         env: new NodeExecutionEnv({ cwd: process.cwd() }),
+        models,
         model: faux.getModel(),
         systemPrompt: "test",
       }),

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -4,19 +4,21 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
-import { fauxAssistantMessage, registerFauxProvider, type FauxResponseStep } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, type FauxResponseStep } from "@earendil-works/pi-ai";
 import { inMemorySessionStore, jsonlSessionStore, type AgentEvent, type PiSessionStore } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { makeFaux } from "./faux.ts";
 
 /** Agent over an injected store (the store is the variable under test). */
 function makeAgent(sessions: PiSessionStore, responses: FauxResponseStep[]) {
-  const faux = registerFauxProvider();
+  const { faux, models } = makeFaux();
   faux.setResponses(responses);
   return createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
       sessions,
       env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
       model: faux.getModel(),
       systemPrompt: "test",
     }),

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -86,11 +86,13 @@ A product team is building a SaaS in Astro (with their own auth and Postgres) an
 
 ```ts
 // src/lib/agent.ts
-import { createPiAgentFromDefinition, resolveModel } from "@kid7st/fastagent";
+import { createPiAgentFromDefinition, createPiModels, resolveModel } from "@kid7st/fastagent";
 import { postgresSessionStore } from "./sessions"; // your adapter
 
+const models = createPiModels();
 export const { agent } = await createPiAgentFromDefinition("./agent", {
-  model: resolveModel(process.env.FASTAGENT_MODEL ?? "openai-codex/gpt-5.5"),
+  models,
+  model: resolveModel(models, process.env.FASTAGENT_MODEL ?? "openai-codex/gpt-5.5"),
   sessions: postgresSessionStore,
 });
 
@@ -119,7 +121,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 };
 ```
 
-The embed entry point is `createPiAgentFromDefinition` (L2): point at the folder, pass a resolved model (`resolveModel("provider/modelId")`) and your own K ports (sessions/env/lease/auth), and inject tools explicitly. There is deliberately no separate embed opener — L2 already gives folder + K injection + a fully replaceable toolset (pass an app-specific set to drop the default coding tools).
+The embed entry point is `createPiAgentFromDefinition` (L2): point at the folder, pass a `Models` collection plus a resolved model (`resolveModel(models, "provider/modelId")`) and your own K ports (sessions/env/lease), and inject tools explicitly. Auth rides the `Models` collection (model resolution + per-request credentials in one object); inject a custom one to change providers or credentials. There is deliberately no separate embed opener — L2 already gives folder + K injection + a fully replaceable toolset (pass an app-specific set to drop the default coding tools).
 
 One build, one deploy, one auth, your database. The transport-neutral `invoke` contract (no bundled HTTP framework) is what lets the agent live inside the host's own route. This is the demo that makes the abstract positioning concrete — and the sweet spot is explicit: a relatively *light* agent feature (interactive/generation/trigger-response) in a *TS/Node* product with an *existing stack*. A *heavy* agent (long autonomy, swarm, sandbox isolation, many channels) tilts back toward Flue's batteries-included path even as a feature.
 

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -268,7 +268,7 @@ Run a built agent in **production posture**. Differences from `dev`:
 |---|---|---|
 | config | executes `fastagent.config.ts` | reads the artifact's `fastagent.json` for the frozen model/http; runs from the artifact (cwd = artifact). config.ts ships in the artifact for code tools (needs `npm ci`); the strict no-`.ts`-at-runtime posture is a later hardening |
 | skills | definition-only (+ `--global-skills`) | artifact is the truth; **never scans globals** |
-| auth | pi OAuth → env | pluggable `AuthResolver` (§10.5); default still pi OAuth → env |
+| auth | pi OAuth → env | pluggable `Models` collection (§10.5); default still pi OAuth → env |
 | sessions | jsonl under `.fastagent/sessions` | jsonl **outside** the artifact (jsonl now; external/DDB later) |
 | model | `--model > FASTAGENT_MODEL > config` | `--model > FASTAGENT_MODEL > manifest.model` |
 | port | `--port > config` | `--port > PORT env > manifest.http.port > 8787` |
@@ -277,20 +277,20 @@ Run a built agent in **production posture**. Differences from `dev`:
 
 **Sessions live OUTSIDE the artifact** (the M/K split): the artifact is immutable and replaced wholesale on redeploy, so conversational state (K) kept inside it would be wiped on every deploy and every container restart. The default is the shell-cwd-relative, visible `./fastagent-sessions/` (precedence `--sessions-dir > FASTAGENT_SESSIONS_DIR > <cwd>/fastagent-sessions`), self-gitignored, **never** the artifact's own `.fastagent/`. The cwd-relative default's only footgun (continuity bound to launch dir) is loud (the resolved absolute path is in the startup report) and absent in containers (fixed `WORKDIR`); a sessions dir resolving inside the artifact emits a visible warning. dev keeps sessions under `<workspace>/.fastagent/` because the dev "artifact" is the mutable workspace itself — a deliberate difference, not an inconsistency.
 
-**Startup report (minimal observable surface):** `start` logs the run dir, model, **auth source** (`env (<KEY>)` or `oauth (<provider>)`), `AGENTS.md` presence, the **loaded skills** (enumerable), the session backend, and the bound port. It does **not** enumerate authored context files: they are ambient (§10.1a), so the only meaningful, bounded list is skills. This mirrors the `dev` startup report.
+**Startup report (minimal observable surface):** `start` logs the run dir, model, **auth source** (pi's resolved label + provider, e.g. `OAuth (anthropic)` or `ANTHROPIC_API_KEY (anthropic)`), `AGENTS.md` presence, the **loaded skills** (enumerable), the session backend, and the bound port. It does **not** enumerate authored context files: they are ambient (§10.1a), so the only meaningful, bounded list is skills. This mirrors the `dev` startup report.
 
 ### 10.5 Auth at runtime (env key or OAuth)
 
-Auth is a pluggable `AuthResolver`; `start` is **not** env-only. Two deploy-appropriate sources:
+Auth rides the pi `Models` collection, not a side channel; `start` is **not** env-only. Since pi 0.80 a `Models` (built by `createPiModels` → `builtinModels`) owns both model resolution and per-request auth: each provider carries its own `ProviderAuth`, resolved against a `CredentialStore` (stored credentials) plus an `AuthContext` (ambient env vars). Two deploy-appropriate sources, both upstream-native:
 
 | Source | Use | Refresh |
 |---|---|---|
-| env API key (`envAuth`) | simplest, stateless, metered API billing | none |
-| OAuth from a credential store | run a deployed agent on a Claude Pro/Max or ChatGPT subscription | required |
+| env API key (pi default `AuthContext`) | simplest, stateless, metered API billing | none |
+| OAuth from a credential store | run a deployed agent on a Claude Pro/Max or ChatGPT subscription | upstream-owned |
 
-Feasibility is confirmed in pi: `pi-ai`'s `getOAuthApiKey()` auto-refreshes and returns updated credentials, and `pi-coding-agent`'s `AuthStorage` does file-locked auto-refresh-and-persist. The current `piOAuthAuth` reads `~/.pi/agent/auth.json` and does **not** refresh — a refresh-capable resolver is needed for runtime OAuth.
+Resolution order is upstream-owned and matches the pre-0.80 default: a stored credential owns the provider; env is consulted only when nothing is stored. fastagent supplies `piCredentialStore`, a **read-only** `CredentialStore` over `~/.pi/agent/auth.json` (the file IS the store shape: `Record<providerId, Credential>` with `type:"oauth"`/`type:"api_key"`). The pi CLI owns login/logout and token persistence, so `piCredentialStore.modify` does **not** write back — an upstream OAuth refresh still produces a valid token for the in-flight request (a strict improvement over the old non-refreshing reader), it just is not persisted.
 
-Constraint: OAuth refresh tokens are single-use, so refresh must be serialized and the new credentials persisted back to the store. **Single machine/container**: a file-backed `AuthStorage` (its file lock) is sufficient — in scope for v1. **Multi-instance**: a credential broker with row-locked refresh over a shared store (the ketchup `worker_credentials` pattern) — same `AuthResolver` seam, deferred with the K-axis backends.
+Constraint, for a future persisting store: OAuth refresh tokens are single-use, so refresh must be serialized and the new credentials persisted back. **Single machine/container**: a file-backed store with a file lock suffices — pi's own `AuthStorage` already does file-locked auto-refresh-and-persist, available if fastagent wants persistence. **Multi-instance**: a credential broker with row-locked refresh over a shared store (the ketchup `worker_credentials` pattern) — same `CredentialStore` seam, injected via `createPiModels`'s collection, deferred with the K-axis backends.
 
 ### 10.6 Container recipe (v1, documented not generated)
 


### PR DESCRIPTION
## What

Upgrade `@earendil-works/pi-*` to **0.80.2** and migrate the 0.80 breaking change: pi folded the global model registry (`getModel`/`getModels`/`getProviders`) and the harness-injected `getApiKeyAndHeaders` callback into a single **`Models` collection** — providers carry their own `ProviderAuth`, resolved against a `CredentialStore` + `AuthContext`.

This is a forced migration: the old root-entrypoint APIs were removed (not just moved to `/compat`), and the harness now requires `models: Models`.

## Changes

| Area | Change |
|---|---|
| `engines/pi/models.ts` (new) | `createPiModels()` = `builtinModels()` wired to fastagent auth (auth.json store + default env `AuthContext`); `probeAuthSource` returns the upstream resolved source label |
| `engines/pi/auth.ts` (rewrite) | Replace the `AuthResolver` machinery (`resolvePiAuth`/`envAuth`/`piOAuthAuth`) with `piCredentialStore`, a **read-only** `CredentialStore` over `~/.pi/agent/auth.json` |
| `harness`/`create`/`dev`/`start` | Thread `models: Models` + `model` through the ladder; drop the `getApiKeyAndHeaders` option |
| `config.ts` | `resolveModel(models, spec)` / `listModels(models)` operate on a collection instead of the removed globals |
| `test/faux.ts` (new) | Restore one-call faux ergonomics over `createModels` + `fauxProvider` (`registerFauxProvider` was removed); `auth.test.ts` now covers `piCredentialStore` |
| docs | README / comparisons / core-design §10.5 updated to the `Models` API |

## Capability upgrades (inherited)

- **OAuth token refresh** — the old reader did not refresh (expired → request failed); upstream providers now refresh on demand for the in-flight request.
- **`api_key` credentials from auth.json** — reads `type:"api_key"` entries (incl. provider-scoped env like Cloudflare), not just OAuth.
- **More accurate startup auth report** — real source label (`OAuth (anthropic)` / `ANTHROPIC_API_KEY (anthropic)`) instead of `oauth`/`env`/`none`.

## Design decisions (need review)

1. **`piCredentialStore` does not persist (`modify` is non-writing).** The pi CLI owns login/refresh/persistence; fastagent only reads. This avoids server-side writes to `~/.pi` global state and whole-file RMW races. Trade-off: an expired token is re-refreshed per invoke (not cached). A persisting store (pi's file-locked `AuthStorage`) is available if we later want cross-invoke reuse. Documented in `core-design.md §10.5`.
2. **Public API surface break** (per `CONTRIBUTING.md` review tier): `resolveModel`/`listModels` now take `Models`; the `getApiKeyAndHeaders` option is removed; auth exports change to `piCredentialStore` + `createPiModels`. Unavoidable — upstream removed the underlying APIs.

## Verification

- `npm run typecheck` ✅
- `npm test` — 181 passed ✅
- `npm run lint` ✅
- Runtime smoke: `fastagent models` lists the full built-in catalog
