### PR TITLE
feat(github): log the turn lifecycle to stderr (start/done/failed)

### DIFF
--- a/core/src/channels/github.ts
+++ b/core/src/channels/github.ts
@@ -89,11 +89,18 @@ export function githubChannel(agent: Agent, { secret, on }: GithubChannelOptions
       payload: payload as unknown as Schema, // trust boundary: the verified body is a GitHub event
     };
 
-    // Fire each turn, return 202; the long-running process runs them to completion. `.catch` is the
-    // only failure sink (server log). Concurrency safety = the engine's per-session lease.
+    // Fire each turn, return 202; the long-running process runs them to completion. The turn lifecycle
+    // is logged to stderr — after the 202 there is no response body, so these lines are the operator's
+    // only signal that a turn ran (and the failure sink that keeps a post-ACK error from going
+    // unhandled). Concurrency safety = the engine's per-session lease.
     for (const { session, text } of on(event)) {
-      void collect(agent.invoke({ session }, { text })).catch((error) =>
-        console.error(`[github] turn failed for ${session}: ${String(error)}`),
+      const label = event.action ? `${event.event}.${event.action}` : event.event;
+      console.error(`[github] turn start: session=${session} event=${label} delivery=${event.deliveryId}`);
+      const startedAt = Date.now();
+      void collect(agent.invoke({ session }, { text })).then(
+        () => console.error(`[github] turn done: session=${session} (${Date.now() - startedAt}ms)`),
+        (error) =>
+          console.error(`[github] turn failed: session=${session} (${Date.now() - startedAt}ms): ${String(error)}`),
       );
     }
     return new Response(null, { status: 202 });

--- a/core/src/channels/github.ts
+++ b/core/src/channels/github.ts
@@ -93,14 +93,22 @@ export function githubChannel(agent: Agent, { secret, on }: GithubChannelOptions
     // is logged to stderr — after the 202 there is no response body, so these lines are the operator's
     // only signal that a turn ran (and the failure sink that keeps a post-ACK error from going
     // unhandled). Concurrency safety = the engine's per-session lease.
-    for (const { session, text } of on(event)) {
-      const label = event.action ? `${event.event}.${event.action}` : event.event;
-      console.error(`[github] turn start: session=${session} event=${label} delivery=${event.deliveryId}`);
+    const intents = on(event);
+    const label = event.action ? `${event.event}.${event.action}` : event.event;
+    for (let i = 0; i < intents.length; i++) {
+      const { session, text } = intents[i] as Intent;
+      // A per-turn correlation id: deliveryId is unique per webhook, the index disambiguates the
+      // multiple turns one delivery can fan out to (session, by contract, recurs across deliveries).
+      // It threads through start/done/failed so a terminal line joins back to its start.
+      const turn = `${event.deliveryId}#${i}`;
+      console.error(`[github] turn start: turn=${turn} session=${session} event=${label}`);
       const startedAt = Date.now();
       void collect(agent.invoke({ session }, { text })).then(
-        () => console.error(`[github] turn done: session=${session} (${Date.now() - startedAt}ms)`),
+        () => console.error(`[github] turn done: turn=${turn} session=${session} (${Date.now() - startedAt}ms)`),
         (error) =>
-          console.error(`[github] turn failed: session=${session} (${Date.now() - startedAt}ms): ${String(error)}`),
+          console.error(
+            `[github] turn failed: turn=${turn} session=${session} (${Date.now() - startedAt}ms): ${String(error)}`,
+          ),
       );
     }
     return new Response(null, { status: 202 });

--- a/core/test/github.test.ts
+++ b/core/test/github.test.ts
@@ -215,8 +215,26 @@ describe("github channel", () => {
     });
     expect((await ch(signed(PR_OPENED.body, PR_OPENED.headers))).status).toBe(202);
     await flush();
-    // The lone failure sink (.catch) ran: logged, and (since it ran) not an unhandled rejection.
-    expect(errors.some((e) => /turn failed for s/.test(e) && /boom/.test(e))).toBe(true);
+    // The failure sink ran: logged with the session, and (since it ran) not an unhandled rejection.
+    expect(errors.some((e) => /turn failed: session=s/.test(e) && /boom/.test(e))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("logs the turn lifecycle (start with trigger source, done) so a fire-and-forget turn is observable", async () => {
+    const errors: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m) => {
+      errors.push(String(m));
+    });
+    const { agent } = recordingAgent(); // resolves normally
+    const ch = githubChannel(agent, {
+      secret: SECRET,
+      on: (e) => (e.event === "pull_request" ? [{ session: "s", text: "x" }] : []),
+    });
+    expect((await ch(signed(PR_OPENED.body, PR_OPENED.headers))).status).toBe(202);
+    await flush();
+    // start names the session + the trigger source (event.action), done confirms completion.
+    expect(errors.some((e) => /turn start: session=s/.test(e) && /event=pull_request\.opened/.test(e))).toBe(true);
+    expect(errors.some((e) => /turn done: session=s/.test(e))).toBe(true);
     spy.mockRestore();
   });
 });

--- a/core/test/github.test.ts
+++ b/core/test/github.test.ts
@@ -240,4 +240,29 @@ describe("github channel", () => {
     expect(errors.some((e) => /turn done: turn=d1#0 session=s/.test(e))).toBe(true);
     spy.mockRestore();
   });
+
+  it("disambiguates multiple turns from one delivery via the index (d1#0, d1#1)", async () => {
+    const errors: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m) => {
+      errors.push(String(m));
+    });
+    const { agent } = recordingAgent();
+    const ch = githubChannel(agent, {
+      secret: SECRET,
+      // One delivery fans out to two turns (distinct sessions — they run concurrently, no lease clash).
+      on: (e) =>
+        e.event === "pull_request"
+          ? [
+              { session: "a", text: "x" },
+              { session: "b", text: "y" },
+            ]
+          : [],
+    });
+    expect((await ch(signed(PR_OPENED.body, PR_OPENED.headers))).status).toBe(202);
+    await flush();
+    // The index disambiguates the two turns of the same delivery: d1#0 and d1#1, not two d1#0.
+    expect(errors.some((e) => /turn start: turn=d1#0 session=a/.test(e))).toBe(true);
+    expect(errors.some((e) => /turn start: turn=d1#1 session=b/.test(e))).toBe(true);
+    spy.mockRestore();
+  });
 });

--- a/core/test/github.test.ts
+++ b/core/test/github.test.ts
@@ -215,8 +215,8 @@ describe("github channel", () => {
     });
     expect((await ch(signed(PR_OPENED.body, PR_OPENED.headers))).status).toBe(202);
     await flush();
-    // The failure sink ran: logged with the session, and (since it ran) not an unhandled rejection.
-    expect(errors.some((e) => /turn failed: session=s/.test(e) && /boom/.test(e))).toBe(true);
+    // The failure sink ran: logged with the turn correlation id, and (since it ran) not unhandled.
+    expect(errors.some((e) => /turn failed: turn=d1#0 session=s/.test(e) && /boom/.test(e))).toBe(true);
     spy.mockRestore();
   });
 
@@ -232,9 +232,12 @@ describe("github channel", () => {
     });
     expect((await ch(signed(PR_OPENED.body, PR_OPENED.headers))).status).toBe(202);
     await flush();
-    // start names the session + the trigger source (event.action), done confirms completion.
-    expect(errors.some((e) => /turn start: session=s/.test(e) && /event=pull_request\.opened/.test(e))).toBe(true);
-    expect(errors.some((e) => /turn done: session=s/.test(e))).toBe(true);
+    // start carries the per-turn correlation id (deliveryId#index) + trigger source; done repeats the
+    // id so it joins back to its start (the lifecycle log's whole point).
+    expect(errors.some((e) => /turn start: turn=d1#0 session=s/.test(e) && /event=pull_request\.opened/.test(e))).toBe(
+      true,
+    );
+    expect(errors.some((e) => /turn done: turn=d1#0 session=s/.test(e))).toBe(true);
     spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Why

DX gap surfaced by the live E2E: after the channel returns **202**, a fire-and-forget turn produced **no signal on success** — the only way to know it ran was to poll the side effect (the PR). Debugging "my webhook did nothing" meant staring at a black box. (The previous code logged failures only.)

## What

Each fired turn now logs its lifecycle to stderr:

```
[github] turn start: session=<s> event=pull_request.opened delivery=<id>
[github] turn done: session=<s> (1234ms)
[github] turn failed: session=<s> (1234ms): <error>
```

- **start** names the session + trigger source (`event.action`) + delivery id.
- **done** confirms completion with elapsed ms.
- **failed** stays the post-ACK failure sink (keeps a rejection from going unhandled).

Independent of durable execution — the cheapest, highest-DX observability win. Scoped to the github channel (the fire-and-forget path); the http `/invoke` channel already returns its result to the caller.

## Verification

format / typecheck / lint clean; **196 tests** (added a turn-lifecycle test asserting start+done; updated the failure-sink test to the new `session=` message); build clean.