### PR TITLE
fix(cli): DX papercuts — --version, init cd path, build .env note

### DIFF
--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -15,6 +15,7 @@
  */
 import { spawn } from "node:child_process";
 import { watch as watchTree } from "chokidar";
+import { existsSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
@@ -25,6 +26,7 @@ import { type Routes, parseRouteKey, router, serveNode } from "./host/node.ts";
 import { loadChannels } from "./engines/pi/channel.ts";
 import { probeAuthSource } from "./engines/pi/auth.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
+import { fastagentVersion } from "./engines/pi/version.ts";
 import { listModels, loadConfig } from "./engines/pi/config.ts";
 import {
   type LoadedDefinition,
@@ -47,6 +49,7 @@ function usage(code: number): never {
   fastagent chat   [dir] [--model provider/modelId] [--global-skills]
   fastagent build [dir] [--out dir] [--model provider/modelId] [--global-skills] [--force]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
+  fastagent --version
 
   dev    assemble the agent in dir (default .) and serve a local HTTP channel.
          model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
@@ -94,8 +97,13 @@ const { positionals, values } = parseArgs({
     "no-install": { type: "boolean" },
     "no-watch": { type: "boolean" },
     help: { type: "boolean", short: "h" },
+    version: { type: "boolean", short: "v" },
   },
 });
+if (values.version) {
+  console.log(await fastagentVersion());
+  process.exit(0);
+}
 if (values.help) usage(0);
 
 const [command, dirArg] = positionals;
@@ -196,7 +204,8 @@ async function runInit(): Promise<void> {
   // instruction a newcomer can't act on yet is noise.
   console.error(`  next steps:`);
   const rel = relative(process.cwd(), dir);
-  if (rel !== "") console.error(`    cd ${rel}`);
+  // A relative target that climbs out of cwd (e.g. ../../../tmp/x) is noise — show the absolute path.
+  if (rel !== "") console.error(`    cd ${rel.startsWith("..") ? dir : rel}`);
   if (complete && (values["no-install"] || installFailed)) console.error(`    npm install`);
   console.error(`    fastagent dev   # serve locally and iterate`);
 }
@@ -467,6 +476,14 @@ async function runBuild(): Promise<void> {
   console.error(
     `[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}${globalSkills ? " (incl. global)" : ""}`,
   );
+  // The build excludes a gitignored .env (secrets must not ship), so an agent that reads a secret
+  // from process.env needs it supplied by the DEPLOY environment, not the workspace .env. Remind the
+  // operator at the boundary where the .env is left behind.
+  if (existsSync(join(dir, ".env"))) {
+    console.error(
+      `[fastagent] note: .env is not in the artifact — provide its secrets via the deploy environment (e.g. GITHUB_WEBHOOK_SECRET)`,
+    );
+  }
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 }
 

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -476,13 +476,20 @@ async function runBuild(): Promise<void> {
   console.error(
     `[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}${globalSkills ? " (incl. global)" : ""}`,
   );
-  // The build excludes a gitignored .env (secrets must not ship), so an agent that reads a secret
-  // from process.env needs it supplied by the DEPLOY environment, not the workspace .env. Remind the
-  // operator at the boundary where the .env is left behind.
+  // The build copies a .env only if the root .gitignore/.fastagentignore do NOT exclude it (the build
+  // does not special-case secrets — definition.ts), so check the authoritative matcher, not mere
+  // existence: an ignored .env is left behind (remind: secrets come from the deploy env); an
+  // un-ignored .env was just SHIPPED into the artifact (a secret there is now in the deployable — warn).
   if (existsSync(join(dir, ".env"))) {
-    console.error(
-      `[fastagent] note: .env is not in the artifact — provide its secrets via the deploy environment (e.g. GITHUB_WEBHOOK_SECRET)`,
-    );
+    if ((await loadRootIgnore(dir))?.ignores(".env")) {
+      console.error(
+        `[fastagent] note: .env is gitignored, so it is not in the artifact — provide its secrets via the deploy environment (e.g. GITHUB_WEBHOOK_SECRET)`,
+      );
+    } else {
+      console.error(
+        `[fastagent] warn: .env is NOT gitignored — the build SHIPPED it into the artifact; gitignore .env (or move the secret out) and rebuild`,
+      );
+    }
   }
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 }

--- a/core/test/cli.test.ts
+++ b/core/test/cli.test.ts
@@ -35,12 +35,25 @@ describe("cli papercuts", () => {
     expect(stderr).not.toMatch(/cd \.\./); // never the ../../.. noise
   });
 
-  it("build warns that a .env is not bundled (its secrets must come from the deploy env)", async () => {
+  async function envWorkspace(): Promise<string> {
     const dir = await mkdtemp(join(tmpdir(), "fa-cli-env-"));
     await writeFile(join(dir, "AGENTS.md"), "# Bot\n");
     await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };`);
     await writeFile(join(dir, ".env"), "GITHUB_WEBHOOK_SECRET=x\n");
+    return dir;
+  }
+
+  it("build: a gitignored .env is left out of the artifact — note that secrets come from the deploy env", async () => {
+    const dir = await envWorkspace();
+    await writeFile(join(dir, ".gitignore"), ".env\n"); // .env IS excluded from the build
     const { stderr } = await run(["build", dir]);
-    expect(stderr).toMatch(/\.env is not in the artifact/);
+    expect(stderr).toMatch(/\.env is gitignored, so it is not in the artifact/);
+    expect(stderr).not.toMatch(/SHIPPED/);
+  });
+
+  it("build: a NON-gitignored .env is shipped into the artifact — warn about the leaked secret", async () => {
+    const dir = await envWorkspace(); // no .gitignore → the build copies .env (secret leak)
+    const { stderr } = await run(["build", dir]);
+    expect(stderr).toMatch(/\.env is NOT gitignored.*SHIPPED/s);
   });
 });

--- a/core/test/cli.test.ts
+++ b/core/test/cli.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+
+/** Run the CLI to completion; capture stdout, stderr, exit code. */
+function run(args: string[], cwd?: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, ...args], cwd ? { cwd } : {});
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+describe("cli papercuts", () => {
+  it("--version / -v prints the version to stdout and exits 0 (no parse crash)", async () => {
+    const v = await run(["--version"]);
+    expect(v.code).toBe(0);
+    expect(v.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    expect((await run(["-v"])).stdout.trim()).toBe(v.stdout.trim());
+  });
+
+  it("init shows an absolute `cd` for a target outside cwd (not a ../../.. climb)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-cli-cwd-"));
+    const target = await mkdtemp(join(tmpdir(), "fa-cli-tgt-")); // a sibling temp dir, outside cwd
+    const { stderr } = await run(["init", target, "--minimal"], cwd);
+    expect(stderr).toMatch(/cd \/.*fa-cli-tgt/); // absolute path
+    expect(stderr).not.toMatch(/cd \.\./); // never the ../../.. noise
+  });
+
+  it("build warns that a .env is not bundled (its secrets must come from the deploy env)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-cli-env-"));
+    await writeFile(join(dir, "AGENTS.md"), "# Bot\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };`);
+    await writeFile(join(dir, ".env"), "GITHUB_WEBHOOK_SECRET=x\n");
+    const { stderr } = await run(["build", dir]);
+    expect(stderr).toMatch(/\.env is not in the artifact/);
+  });
+});


### PR DESCRIPTION
Three papercuts surfaced by walking the live E2E as a new user.

| Papercut | Before | After |
|---|---|---|
| `fastagent --version` | **crashes** (`parseArgs` rejects the unknown flag — stack trace on the most basic command) | prints the version to stdout, exits 0 (`-v` too) |
| `fastagent init <target>` next-step | `cd ../../../tmp/x` when target is outside cwd | absolute `cd /tmp/x` when a relative would climb out |
| `fastagent build` | silent about secrets | notes `.env is not in the artifact — provide its secrets via the deploy environment` when a `.env` exists |

The build note closes the **dev-.env -> prod-env cliff**: the build correctly excludes a gitignored `.env` (secrets must not ship), but nothing told the operator their secret won't be there at deploy.

Tests: `test/cli.test.ts` covers all three (version stdout+exit0, absolute cd / no `../`, build .env note). 200 tests, build clean.