### PR TITLE
feat(cli): fastagent login — authenticate a provider into ~/.fastagent/auth.json

### DIFF
--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -17,6 +17,7 @@ import { spawn } from "node:child_process";
 import { watch as watchTree } from "chokidar";
 import { existsSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { parseArgs } from "node:util";
 import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
 import type { Agent } from "./agent.ts";
@@ -27,6 +28,8 @@ import { loadChannels } from "./engines/pi/channel.ts";
 import { buildPiArtifact } from "./engines/pi/build.ts";
 import { fastagentVersion } from "./engines/pi/version.ts";
 import { listModels, loadConfig } from "./engines/pi/config.ts";
+import { FASTAGENT_AUTH_PATH } from "./engines/pi/auth.ts";
+import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
 import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 import {
   type LoadedDefinition,
@@ -49,6 +52,7 @@ function usage(code: number): never {
   fastagent chat   [dir] [--model provider/modelId] [--global-skills]
   fastagent build [dir] [--out dir] [--model provider/modelId] [--global-skills] [--force]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
+  fastagent login [provider]
   fastagent --version
 
   dev    assemble the agent in dir (default .) and serve a local HTTP channel.
@@ -118,6 +122,7 @@ else if (command === "chat") await runChat();
 else if (command === "build") await runBuild();
 else if (command === "start") await runStart();
 else if (command === "add") await runAdd();
+else if (command === "login") await runLogin();
 else usage(1);
 
 /** `fastagent models`: print every registered "provider/modelId" to stdout (pipe-friendly). */
@@ -247,6 +252,68 @@ async function runAdd(): Promise<void> {
   console.error(`    fastagent dev   # serve the webhook locally`);
 }
 
+/**
+ * `fastagent login [provider]`: authenticate a model provider into `~/.fastagent/auth.json`. An
+ * OAuth-capable provider runs the device/browser flow; any other provider id stores an API key. The
+ * flow logic lives in engines/pi/login.ts; here we supply the terminal IO (readline + browser open).
+ */
+async function runLogin(): Promise<void> {
+  const io = terminalLoginIO();
+  const result = await loginFlow(io, { provider: positionals[1] }).catch(failStartup);
+  console.error(`[fastagent] logged in to ${result.provider} (${result.method}) — saved to ${FASTAGENT_AUTH_PATH}`);
+}
+
+/** Best-effort open a URL in the default browser; failure is fine (the URL is always printed too). */
+function openBrowser(url: string): void {
+  const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  spawn(cmd, [url], { stdio: "ignore", detached: true, shell: process.platform === "win32" }).on("error", () => {});
+}
+
+/** Read one line of input with NO echo (for API keys), via raw-mode stdin. */
+function readHidden(message: string): Promise<string> {
+  return new Promise((resolveLine, reject) => {
+    const stdin = process.stdin;
+    process.stderr.write(message);
+    const wasRaw = stdin.isRaw ?? false;
+    stdin.setRawMode?.(true);
+    stdin.resume();
+    let buf = "";
+    const done = (fn: () => void) => {
+      stdin.off("data", onData);
+      stdin.setRawMode?.(wasRaw);
+      stdin.pause();
+      process.stderr.write("\n");
+      fn();
+    };
+    const onData = (d: Buffer) => {
+      for (const ch of d.toString("utf8")) {
+        if (ch === "\r" || ch === "\n") return done(() => resolveLine(buf));
+        if (ch === "\u0003") return done(() => reject(new Error("cancelled"))); // Ctrl-C
+        if (ch === "\u007f" || ch === "\b") buf = buf.slice(0, -1);
+        else if (ch >= " ") buf += ch;
+      }
+    };
+    stdin.on("data", onData);
+  });
+}
+
+/** Terminal IO for the login flow: a fresh readline per visible prompt, raw-mode for hidden input. */
+function terminalLoginIO(): LoginIO {
+  return {
+    print: (line) => console.error(line),
+    prompt: async (message) => {
+      const rl = createInterface({ input: process.stdin, output: process.stderr });
+      try {
+        return await rl.question(message);
+      } finally {
+        rl.close();
+      }
+    },
+    promptHidden: (message) => readHidden(message),
+    openUrl: openBrowser,
+  };
+}
+
 /** Run `npm install` in `cwd` (inherit stdio so the user sees progress). Returns the exit code. */
 function npmInstall(cwd: string): Promise<number> {
   return new Promise((resolveCode) => {
@@ -288,7 +355,7 @@ async function reportAuth(modelSpec: string): Promise<void> {
     // the right env var (it is provider-specific and pi-ai's mapping is not exported). Keep the
     // env path generic so we never advertise a key that can't satisfy the probed provider.
     console.error(
-      `[fastagent] warn: no credentials for "${provider}" — set the provider's API key in .env (or place ~/.fastagent/auth.json); invokes will fail until then`,
+      `[fastagent] warn: no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
     );
   }
 }

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -301,10 +301,10 @@ function readHidden(message: string): Promise<string> {
 function terminalLoginIO(): LoginIO {
   return {
     print: (line) => console.error(line),
-    prompt: async (message) => {
+    prompt: async (message, signal) => {
       const rl = createInterface({ input: process.stdin, output: process.stderr });
       try {
-        return await rl.question(message);
+        return await (signal ? rl.question(message, { signal }) : rl.question(message));
       } finally {
         rl.close();
       }
@@ -351,7 +351,7 @@ async function reportAuth(modelSpec: string): Promise<void> {
   const source = await probeAuthSource(createPiModels(), modelSpec);
   console.error(`[fastagent] auth:   ${source === undefined ? "(none found)" : `${source} (${provider})`}`);
   if (source === undefined) {
-    // Lead with `pi login`: the default model (openai-codex) is OAuth-only, and we cannot name
+    // Lead with `fastagent login`: the default model (openai-codex) is OAuth-only, and we cannot name
     // the right env var (it is provider-specific and pi-ai's mapping is not exported). Keep the
     // env path generic so we never advertise a key that can't satisfy the probed provider.
     console.error(

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -16,7 +16,7 @@
  *   - .gitignore lists `.env` so the "secrets are the user's responsibility" model
  *     (core-design §10.1) is wired up from the first commit (build honors .gitignore).
  *   - .env.example documents the (optional) env knobs and is committable (only `.env` is ignored);
- *     it is all-commented and states the default model uses OAuth (`pi login`), not an API key, so
+ *     it is all-commented and states the default model uses OAuth (`fastagent login`), not an API key, so
  *     it never implies a key is required.
  *
  * Node composition-root module: writes template files (the CLI handles `npm install`).
@@ -96,12 +96,12 @@ node_modules/
 `;
 
 // All-commented: copying to .env sets nothing by accident, and every knob is optional. Auth leads
-// with `pi login` because the default model (openai-codex) is OAuth-only — never imply an API key.
+// with `fastagent login` because the default model (openai-codex) is OAuth-only — never imply an API key.
 const ENV_EXAMPLE = `# Environment for this agent. Copy to .env (gitignored) and uncomment what you need.
 # Everything here is OPTIONAL — the defaults work without a .env.
 
 # --- Model auth ---
-# The default model (openai-codex) signs in with OAuth, not an API key: run \`pi login\` once.
+# The default model (openai-codex) signs in with OAuth, not an API key: run \`fastagent login\` once.
 # Switch to an API-key provider? Set its key here — the variable name is provider-specific
 # (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY). Run \`fastagent models\` to see available specs.
 # OPENAI_API_KEY=

--- a/core/src/engines/pi/login.ts
+++ b/core/src/engines/pi/login.ts
@@ -12,8 +12,8 @@ import { FASTAGENT_AUTH_PATH } from "./auth.ts";
 /** Terminal interaction, injectable for tests (no real stdin/stdout or browser in unit tests). */
 export interface LoginIO {
   print(line: string): void;
-  /** Read a line of visible input (codes, selections). */
-  prompt(message: string): Promise<string>;
+  /** Read a line of visible input (codes, selections); rejects if `signal` aborts (cancellable paste). */
+  prompt(message: string, signal?: AbortSignal): Promise<string>;
   /** Read a line with no echo (API keys). */
   promptHidden(message: string): Promise<string>;
   /** Best-effort open a URL in the browser (printed regardless). */
@@ -55,7 +55,14 @@ async function chooseFromList(
   return options.find((o) => o.id === answer)?.id;
 }
 
-function oauthCallbacks(io: LoginIO, signal?: AbortSignal): OAuthLoginCallbacks {
+/**
+ * pi's anthropic/codex `onAuth` tells the user they may paste the redirect URL from another machine,
+ * but that paste is only offered CONCURRENTLY with the local callback server when `onManualCodeInput`
+ * is wired — otherwise the flow blocks on the server and the instruction is an empty promise. We wire
+ * it to a cancellable prompt (`manualPromptSignal`): a browser/server win leaves that prompt pending,
+ * so the caller aborts the signal to cancel it instead of hanging the one-shot CLI on stdin.
+ */
+function oauthCallbacks(io: LoginIO, manualPromptSignal: AbortSignal, signal?: AbortSignal): OAuthLoginCallbacks {
   return {
     onAuth: ({ url, instructions }) => {
       io.print(`Open this URL to authorize:\n  ${url}`);
@@ -67,6 +74,8 @@ function oauthCallbacks(io: LoginIO, signal?: AbortSignal): OAuthLoginCallbacks 
       io.openUrl(verificationUri);
     },
     onPrompt: ({ message }) => io.prompt(message),
+    onManualCodeInput: () =>
+      io.prompt("…or paste the final redirect URL here if your browser is on another machine: ", manualPromptSignal),
     onSelect: ({ message, options }) => chooseFromList(io, message, options),
     onProgress: (message) => io.print(`  ${message}`),
     signal,
@@ -83,6 +92,9 @@ export async function loginFlow(
   options: { provider?: string; authPath?: string; store?: AuthStore; signal?: AbortSignal } = {},
 ): Promise<LoginResult> {
   const store: AuthStore = options.store ?? AuthStorage.create(options.authPath ?? FASTAGENT_AUTH_PATH);
+  // A corrupt/unwritable file is recorded at construction and makes every later write a silent no-op;
+  // surface it before any prompt or the OAuth round-trip, not after the user has done the work.
+  preflightAuthFile(store);
   const oauthProviders = store.getOAuthProviders();
 
   let provider = options.provider;
@@ -96,7 +108,14 @@ export async function loginFlow(
   }
 
   if (oauthProviders.some((p) => p.id === provider)) {
-    await store.login(provider, oauthCallbacks(io, options.signal));
+    const promptAbort = new AbortController();
+    try {
+      await store.login(provider, oauthCallbacks(io, promptAbort.signal, options.signal));
+    } finally {
+      // A server/browser win leaves the concurrent manual-paste prompt pending on stdin; abort it so
+      // the one-shot CLI can exit (pi does not await that prompt once the server returns a code).
+      promptAbort.abort();
+    }
     assertPersisted(store, provider);
     return { provider, method: "oauth" };
   }
@@ -117,5 +136,17 @@ function assertPersisted(store: AuthStore, provider: string): void {
   const errors = store.drainErrors();
   if (errors.length > 0) {
     throw new Error(`failed to save credentials for "${provider}": ${errors.map((e) => e.message).join("; ")}`);
+  }
+}
+
+/**
+ * Drain errors recorded at AuthStorage construction (reload()'s corrupt/unwritable load) so a known-bad
+ * auth file fails up front — mirrors fastagentCredentialStore.read's "corrupt auth file" warning, and
+ * stops the user from completing an OAuth flow that persistProviderChange would silently refuse to save.
+ */
+function preflightAuthFile(store: AuthStore): void {
+  const errors = store.drainErrors();
+  if (errors.length > 0) {
+    throw new Error(`auth file unusable: ${errors.map((e) => e.message).join("; ")} — fix or remove it`);
   }
 }

--- a/core/src/engines/pi/login.ts
+++ b/core/src/engines/pi/login.ts
@@ -25,6 +25,12 @@ export interface AuthStore {
   getOAuthProviders(): Array<{ id: string; name: string }>;
   login(providerId: string, callbacks: OAuthLoginCallbacks): Promise<void>;
   set(provider: string, credential: { type: "api_key"; key: string }): void;
+  /**
+   * pi's `AuthStorage` RECORDS persistence failures (corrupt file → `persistProviderChange`
+   * early-returns; write IO failure → caught) instead of throwing, so a failed save looks like a
+   * success at the call site. We must drain after a write to surface them (see {@link assertPersisted}).
+   */
+  drainErrors(): Error[];
 }
 
 export interface LoginResult {
@@ -39,7 +45,9 @@ async function chooseFromList(
   options: Array<{ id: string; label: string }>,
 ): Promise<string | undefined> {
   io.print(message);
-  options.forEach((o, i) => io.print(`  ${i + 1}. ${o.label}`));
+  options.forEach((o, i) => {
+    io.print(`  ${i + 1}. ${o.label}`);
+  });
   const answer = (await io.prompt("> ")).trim();
   if (answer === "") return undefined;
   const n = Number(answer);
@@ -89,11 +97,25 @@ export async function loginFlow(
 
   if (oauthProviders.some((p) => p.id === provider)) {
     await store.login(provider, oauthCallbacks(io, options.signal));
+    assertPersisted(store, provider);
     return { provider, method: "oauth" };
   }
 
   const key = (await io.promptHidden(`API key for "${provider}": `)).trim();
   if (!key) throw new Error(`no API key entered for "${provider}"`);
   store.set(provider, { type: "api_key", key });
+  assertPersisted(store, provider);
   return { provider, method: "api_key" };
+}
+
+/**
+ * Turn pi's RECORDED persistence failures into a visible throw, so `fastagent login` never reports
+ * success on a save that silently no-op'd (corrupt/unwritable ~/.fastagent/auth.json) — the
+ * fail-visibly boundary that AuthStorage's record-don't-throw contract would otherwise swallow.
+ */
+function assertPersisted(store: AuthStore, provider: string): void {
+  const errors = store.drainErrors();
+  if (errors.length > 0) {
+    throw new Error(`failed to save credentials for "${provider}": ${errors.map((e) => e.message).join("; ")}`);
+  }
 }

--- a/core/src/engines/pi/login.ts
+++ b/core/src/engines/pi/login.ts
@@ -1,0 +1,99 @@
+/**
+ * `fastagent login`: authenticate a model provider into fastagent's OWN `~/.fastagent/auth.json`
+ * (read by {@link fastagentCredentialStore}), using pi's `AuthStorage`. An OAuth-capable provider
+ * (Anthropic Claude Pro/Max, ChatGPT Codex, GitHub Copilot) runs the device/browser flow; any other
+ * provider id stores an API key. The terminal IO is INJECTED ({@link LoginIO}) so the flow is testable
+ * without a real OAuth round-trip or stdin.
+ */
+import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { FASTAGENT_AUTH_PATH } from "./auth.ts";
+
+/** Terminal interaction, injectable for tests (no real stdin/stdout or browser in unit tests). */
+export interface LoginIO {
+  print(line: string): void;
+  /** Read a line of visible input (codes, selections). */
+  prompt(message: string): Promise<string>;
+  /** Read a line with no echo (API keys). */
+  promptHidden(message: string): Promise<string>;
+  /** Best-effort open a URL in the browser (printed regardless). */
+  openUrl(url: string): void;
+}
+
+/** The slice of pi's `AuthStorage` the flow uses (so a test can pass a fake). `AuthStorage` satisfies it. */
+export interface AuthStore {
+  getOAuthProviders(): Array<{ id: string; name: string }>;
+  login(providerId: string, callbacks: OAuthLoginCallbacks): Promise<void>;
+  set(provider: string, credential: { type: "api_key"; key: string }): void;
+}
+
+export interface LoginResult {
+  provider: string;
+  method: "oauth" | "api_key";
+}
+
+/** Present a numbered list; accept a number or a literal id; undefined on an empty answer (cancel). */
+async function chooseFromList(
+  io: LoginIO,
+  message: string,
+  options: Array<{ id: string; label: string }>,
+): Promise<string | undefined> {
+  io.print(message);
+  options.forEach((o, i) => io.print(`  ${i + 1}. ${o.label}`));
+  const answer = (await io.prompt("> ")).trim();
+  if (answer === "") return undefined;
+  const n = Number(answer);
+  if (Number.isInteger(n) && n >= 1 && n <= options.length) return options[n - 1]?.id;
+  return options.find((o) => o.id === answer)?.id;
+}
+
+function oauthCallbacks(io: LoginIO, signal?: AbortSignal): OAuthLoginCallbacks {
+  return {
+    onAuth: ({ url, instructions }) => {
+      io.print(`Open this URL to authorize:\n  ${url}`);
+      if (instructions) io.print(instructions);
+      io.openUrl(url);
+    },
+    onDeviceCode: ({ userCode, verificationUri }) => {
+      io.print(`Go to ${verificationUri} and enter the code:  ${userCode}`);
+      io.openUrl(verificationUri);
+    },
+    onPrompt: ({ message }) => io.prompt(message),
+    onSelect: ({ message, options }) => chooseFromList(io, message, options),
+    onProgress: (message) => io.print(`  ${message}`),
+    signal,
+  };
+}
+
+/**
+ * Resolve the provider (argument or interactive select among the OAuth providers), then either run
+ * the OAuth flow (OAuth-capable provider) or prompt for and store an API key (any other id). Both
+ * persist to `~/.fastagent/auth.json` via `AuthStorage`.
+ */
+export async function loginFlow(
+  io: LoginIO,
+  options: { provider?: string; authPath?: string; store?: AuthStore; signal?: AbortSignal } = {},
+): Promise<LoginResult> {
+  const store: AuthStore = options.store ?? AuthStorage.create(options.authPath ?? FASTAGENT_AUTH_PATH);
+  const oauthProviders = store.getOAuthProviders();
+
+  let provider = options.provider;
+  if (!provider) {
+    provider = await chooseFromList(
+      io,
+      "Which provider? (or `fastagent login <provider>` to set an API key)",
+      oauthProviders.map((p) => ({ id: p.id, label: `${p.name} (${p.id})` })),
+    );
+    if (!provider) throw new Error("no provider selected");
+  }
+
+  if (oauthProviders.some((p) => p.id === provider)) {
+    await store.login(provider, oauthCallbacks(io, options.signal));
+    return { provider, method: "oauth" };
+  }
+
+  const key = (await io.promptHidden(`API key for "${provider}": `)).trim();
+  if (!key) throw new Error(`no API key entered for "${provider}"`);
+  store.set(provider, { type: "api_key", key });
+  return { provider, method: "api_key" };
+}

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -45,9 +45,9 @@ describe("init: scaffoldWorkspace", () => {
     expect(warnings).toEqual([]);
 
     // .env.example documents env knobs without misleading: all-commented (sets nothing), and it
-    // states the default model uses OAuth (`pi login`), never implying an API key is required.
+    // states the default model uses OAuth (`fastagent login`), never implying an API key is required.
     const envExample = await readFile(join(dir, ".env.example"), "utf8");
-    expect(envExample).toMatch(/pi login/);
+    expect(envExample).toMatch(/fastagent login/);
     expect(envExample).toMatch(/OAuth, not an API key/);
     for (const line of envExample.split("\n")) {
       if (line.trim() !== "") expect(line.startsWith("#")).toBe(true); // every non-blank line is a comment

--- a/core/test/login.test.ts
+++ b/core/test/login.test.ts
@@ -1,13 +1,12 @@
+import { AuthStorage, InMemoryAuthStorageBackend } from "@earendil-works/pi-coding-agent";
+import type { AuthStorageBackend } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import type { AuthStore, LoginIO } from "../src/engines/pi/login.ts";
 import { loginFlow } from "../src/engines/pi/login.ts";
 
-/** A fake AuthStore recording the calls the flow makes (anthropic/openai-codex are OAuth-capable). */
-function fakeStore(opts: { persistError?: Error } = {}) {
+/** A fake AuthStore for the ROUTING tests (anthropic/openai-codex are OAuth-capable); persistence ok. */
+function fakeStore() {
   const calls: { login?: string; set?: [string, { type: string; key: string }] } = {};
-  // Model pi's record-don't-throw persistence: set/login "succeed" at the call site but a recorded
-  // error remains, drained afterwards — exactly the silent-failure window assertPersisted must catch.
-  const errors = opts.persistError ? [opts.persistError] : [];
   const store: AuthStore = {
     getOAuthProviders: () => [
       { id: "anthropic", name: "Anthropic (Claude Pro/Max)" },
@@ -19,7 +18,7 @@ function fakeStore(opts: { persistError?: Error } = {}) {
     set: (provider, credential) => {
       calls.set = [provider, credential];
     },
-    drainErrors: () => errors.splice(0),
+    drainErrors: () => [],
   };
   return { store, calls };
 }
@@ -74,13 +73,67 @@ describe("loginFlow", () => {
     expect(calls.set).toBeUndefined();
   });
 
-  it("a silent persistence failure (recorded, not thrown) becomes a visible error — never a false success", async () => {
-    // Both routes: a corrupt/unwritable ~/.fastagent/auth.json makes AuthStorage record (not throw),
-    // so the flow must drain and surface it rather than reporting "saved".
-    for (const provider of ["anthropic", "openai"]) {
-      const { store } = fakeStore({ persistError: new Error("EACCES: permission denied") });
-      const io = fakeIO({ hidden: ["sk-123"] }).io;
-      await expect(loginFlow(io, { provider, store })).rejects.toThrow(/failed to save credentials.*EACCES/);
-    }
+  // The persistence-failure paths are tested against the REAL AuthStorage (not a mock of the binding the
+  // fix depends on): pi RECORDS failures into drainErrors() rather than throwing, and the flow must drain.
+  it("real AuthStorage: a corrupt auth file fails up front (preflight), before any prompt or OAuth round-trip", async () => {
+    const backend = new InMemoryAuthStorageBackend();
+    backend.withLock(() => ({ result: undefined, next: "{ not valid json" })); // corrupt content at construction
+    const store = AuthStorage.fromStorage(backend);
+    await expect(loginFlow(fakeIO({ hidden: ["sk"] }).io, { provider: "openai", store })).rejects.toThrow(
+      /auth file unusable/,
+    );
+  });
+
+  it("real AuthStorage: a write failure recorded by persistProviderChange surfaces as a thrown error", async () => {
+    // Reads clean at construction, throws on write — exercises the REAL persistProviderChange
+    // catch → recordError → drainErrors binding (the one new risk point, not a fake of it).
+    const backend: AuthStorageBackend = {
+      withLock: (fn) => {
+        const { result, next } = fn(undefined);
+        if (next !== undefined) throw new Error("EROFS: read-only file system");
+        return result;
+      },
+      withLockAsync: async (fn) => {
+        const { result, next } = await fn(undefined);
+        if (next !== undefined) throw new Error("EROFS: read-only file system");
+        return result;
+      },
+    };
+    const store = AuthStorage.fromStorage(backend);
+    await expect(loginFlow(fakeIO({ hidden: ["sk-x"] }).io, { provider: "openai", store })).rejects.toThrow(
+      /failed to save credentials.*EROFS/,
+    );
+  });
+
+  it("c1: a server win that leaves the manual-paste prompt pending is aborted, so the CLI does not hang", async () => {
+    let manualAborted = false;
+    const io: LoginIO = {
+      print: () => {},
+      // The manual-paste prompt never receives an answer (the browser won); it must be aborted, not hang.
+      prompt: (_message, signal) =>
+        new Promise<string>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            manualAborted = true;
+            reject(new Error("aborted"));
+          });
+        }),
+      promptHidden: async () => "",
+      openUrl: () => {},
+    };
+    const store: AuthStore = {
+      getOAuthProviders: () => [{ id: "anthropic", name: "Anthropic" }],
+      // pi starts the concurrent manual prompt, then the local server wins: resolve without awaiting it
+      // (and .catch it, as pi does, so the later abort-rejection stays handled).
+      login: async (_id, callbacks) => {
+        void callbacks.onManualCodeInput?.().catch(() => {});
+      },
+      set: () => {},
+      drainErrors: () => [],
+    };
+    await expect(loginFlow(io, { provider: "anthropic", store })).resolves.toEqual({
+      provider: "anthropic",
+      method: "oauth",
+    });
+    expect(manualAborted).toBe(true);
   });
 });

--- a/core/test/login.test.ts
+++ b/core/test/login.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { AuthStore, LoginIO } from "../src/engines/pi/login.ts";
+import { loginFlow } from "../src/engines/pi/login.ts";
+
+/** A fake AuthStore recording the calls the flow makes (anthropic/openai-codex are OAuth-capable). */
+function fakeStore() {
+  const calls: { login?: string; set?: [string, { type: string; key: string }] } = {};
+  const store: AuthStore = {
+    getOAuthProviders: () => [
+      { id: "anthropic", name: "Anthropic (Claude Pro/Max)" },
+      { id: "openai-codex", name: "ChatGPT Codex" },
+    ],
+    login: async (providerId) => {
+      calls.login = providerId;
+    },
+    set: (provider, credential) => {
+      calls.set = [provider, credential];
+    },
+  };
+  return { store, calls };
+}
+
+/** A fake terminal: scripted prompt/hidden answers, captured prints, no real stdin/browser. */
+function fakeIO(answers: { prompt?: string[]; hidden?: string[] } = {}) {
+  const printed: string[] = [];
+  const prompts = [...(answers.prompt ?? [])];
+  const hiddens = [...(answers.hidden ?? [])];
+  const io: LoginIO = {
+    print: (l) => printed.push(l),
+    prompt: async () => prompts.shift() ?? "",
+    promptHidden: async () => hiddens.shift() ?? "",
+    openUrl: () => {},
+  };
+  return { io, printed };
+}
+
+describe("loginFlow", () => {
+  it("an OAuth-capable provider runs the login flow (no api_key write)", async () => {
+    const { store, calls } = fakeStore();
+    const res = await loginFlow(fakeIO().io, { provider: "anthropic", store });
+    expect(res).toEqual({ provider: "anthropic", method: "oauth" });
+    expect(calls.login).toBe("anthropic");
+    expect(calls.set).toBeUndefined();
+  });
+
+  it("any other provider prompts (hidden) for and stores an API key (no OAuth)", async () => {
+    const { store, calls } = fakeStore();
+    const res = await loginFlow(fakeIO({ hidden: ["sk-123"] }).io, { provider: "openai", store });
+    expect(res).toEqual({ provider: "openai", method: "api_key" });
+    expect(calls.set).toEqual(["openai", { type: "api_key", key: "sk-123" }]);
+    expect(calls.login).toBeUndefined();
+  });
+
+  it("no provider → interactive select among the OAuth providers (by number or id)", async () => {
+    const byNumber = await loginFlow(fakeIO({ prompt: ["2"] }).io, { store: fakeStore().store });
+    expect(byNumber.provider).toBe("openai-codex");
+    const byId = await loginFlow(fakeIO({ prompt: ["anthropic"] }).io, { store: fakeStore().store });
+    expect(byId.provider).toBe("anthropic");
+  });
+
+  it("an empty selection fails visibly", async () => {
+    await expect(loginFlow(fakeIO({ prompt: [""] }).io, { store: fakeStore().store })).rejects.toThrow(
+      /no provider selected/,
+    );
+  });
+
+  it("an empty API key fails visibly and writes nothing", async () => {
+    const { store, calls } = fakeStore();
+    await expect(loginFlow(fakeIO({ hidden: [""] }).io, { provider: "openai", store })).rejects.toThrow(/no API key/);
+    expect(calls.set).toBeUndefined();
+  });
+});

--- a/core/test/login.test.ts
+++ b/core/test/login.test.ts
@@ -3,8 +3,11 @@ import type { AuthStore, LoginIO } from "../src/engines/pi/login.ts";
 import { loginFlow } from "../src/engines/pi/login.ts";
 
 /** A fake AuthStore recording the calls the flow makes (anthropic/openai-codex are OAuth-capable). */
-function fakeStore() {
+function fakeStore(opts: { persistError?: Error } = {}) {
   const calls: { login?: string; set?: [string, { type: string; key: string }] } = {};
+  // Model pi's record-don't-throw persistence: set/login "succeed" at the call site but a recorded
+  // error remains, drained afterwards — exactly the silent-failure window assertPersisted must catch.
+  const errors = opts.persistError ? [opts.persistError] : [];
   const store: AuthStore = {
     getOAuthProviders: () => [
       { id: "anthropic", name: "Anthropic (Claude Pro/Max)" },
@@ -16,6 +19,7 @@ function fakeStore() {
     set: (provider, credential) => {
       calls.set = [provider, credential];
     },
+    drainErrors: () => errors.splice(0),
   };
   return { store, calls };
 }
@@ -68,5 +72,15 @@ describe("loginFlow", () => {
     const { store, calls } = fakeStore();
     await expect(loginFlow(fakeIO({ hidden: [""] }).io, { provider: "openai", store })).rejects.toThrow(/no API key/);
     expect(calls.set).toBeUndefined();
+  });
+
+  it("a silent persistence failure (recorded, not thrown) becomes a visible error — never a false success", async () => {
+    // Both routes: a corrupt/unwritable ~/.fastagent/auth.json makes AuthStorage record (not throw),
+    // so the flow must drain and surface it rather than reporting "saved".
+    for (const provider of ["anthropic", "openai"]) {
+      const { store } = fakeStore({ persistError: new Error("EACCES: permission denied") });
+      const io = fakeIO({ hidden: ["sk-123"] }).io;
+      await expect(loginFlow(io, { provider, store })).rejects.toThrow(/failed to save credentials.*EACCES/);
+    }
   });
 });

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ From an installed CLI to a running, deployable agent in a few minutes. Everythin
 
 - **Node ≥ 22.19** (`node -v`). The package ships compiled JavaScript; consuming projects do not need a build step for FastAgent itself.
 - **The `fastagent` CLI** — see [Install](../README.md#install): `npm i -g @kid7st/fastagent`, with the `@kid7st` scope registry + a GitHub token in your `~/.npmrc`.
-- **Model credentials** — either `pi login` (OAuth) or a provider API key in the workspace's `.env` (e.g. `OPENAI_API_KEY=…`). Run `fastagent models` to list the available `provider/modelId` specs.
+- **Model credentials** — either `fastagent login` (OAuth) or a provider API key in the workspace's `.env` (e.g. `OPENAI_API_KEY=…`). Run `fastagent models` to list the available `provider/modelId` specs.
 
 ## 1. Scaffold an agent
 


### PR DESCRIPTION
## What

Makes the owned-store auth (#49) usable. `fastagent login [provider]` writes credentials to fastagent's own `~/.fastagent/auth.json` (read by `fastagentCredentialStore`), via pi's `AuthStorage`.

- **OAuth-capable provider** (Anthropic Claude Pro/Max, ChatGPT Codex, GitHub Copilot) → device/browser flow (`AuthStorage.login` + terminal callbacks: print the auth URL / device code, best-effort open the browser, readline for prompts/selects).
- **Any other provider id** → prompt (no echo) for an API key, store `{type:"api_key",key}`.
- **No provider** → interactive select among the OAuth providers.

Both persist to `~/.fastagent/auth.json`. (pi has no plain-CLI login to reuse — its login UI is a TUI dialog — so this is a clean terminal flow over pi's public `AuthStorage` API, not a copy of pi's component.)

## Structure / testability

`engines/pi/login.ts` holds the flow with the terminal IO **injected** (`LoginIO`), so the routing is unit-tested with a fake store + fake io — OAuth vs api_key, select by number/id, empty-selection and empty-key fail visibly — without a real OAuth round-trip or stdin. `cli.ts` supplies the real terminal IO (a fresh readline per visible prompt; raw-mode no-echo for the API key; `open`/`xdg-open`/`start` best-effort, URL printed regardless). The no-credentials hint references `fastagent login` again now that it exists.

## Verification

format / typecheck / lint clean; **211 tests** (login.test: 5, covering both routes + the failure cases); build clean. Smoke: `fastagent login` lists the real OAuth providers and selects/cancels correctly.