### PR TITLE
chore(publish): publish @kid7st/fastagent to npm, not GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,19 @@
 name: Publish
 
-# Publish @kid7st/fastagent to GitHub Packages when a GitHub Release is published.
+# Publish @kid7st/fastagent to npm when a GitHub Release is published.
 # The release tag is the manual gate; the job re-verifies (typecheck + test) before
 # publishing so a non-green tag never ships. Version comes from core/package.json —
-# bump it before tagging (GitHub Packages rejects re-publishing an existing version).
+# bump it before tagging (npm rejects re-publishing an existing version).
 on:
   release:
     types: [published]
 
 permissions:
   contents: read
-  packages: write # required to publish to GitHub Packages
 
 jobs:
   publish:
-    name: Publish to GitHub Packages
+    name: Publish to npm
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -27,7 +26,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '26'
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: 'https://registry.npmjs.org'
           scope: '@kid7st'
           cache: npm
           cache-dependency-path: core/package-lock.json
@@ -44,4 +43,4 @@ jobs:
       - name: Publish
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,16 +6,7 @@ This repository is a from-scratch implementation of the locked [Agent Handler SP
 
 ## Install
 
-`@kid7st/fastagent` is published to **GitHub Packages** (private), so installs authenticate with a GitHub token that has `read:packages`. Put the scope registry and token in your **user** npm config (`~/.npmrc`) so it applies to both a global CLI install and a project dependency, from any directory:
-
-```
-@kid7st:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-```
-
-(A per-project `.npmrc` is only read when you run npm from within that project, and a global `npm i -g` is usually run from elsewhere — so the user config is the reliable place. If you commit a project `.npmrc`, keep only the registry line there and supply the token via env / `~/.npmrc`; never commit the token.)
-
-Then install (requires Node ≥ 22.19):
+`@kid7st/fastagent` is published to **npm** (public). Install it directly (requires Node ≥ 22.19):
 
 ```bash
 npm i -g @kid7st/fastagent   # the `fastagent` CLI on PATH

--- a/core/package.json
+++ b/core/package.json
@@ -46,7 +46,8 @@
     "README.md"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   },
   "scripts": {
     "prebuild": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -64,7 +64,7 @@ function usage(code: number): never {
          as dev; pi handles login, sessions, and /resume natively.
   init   scaffold a runnable agent in dir (default .) and run npm install. Default is a
          complete agent: AGENTS.md, a skill, tools/word-count.ts (a code tool), config,
-         package.json, .npmrc, .gitignore. Refuses to overwrite an existing workspace.
+         package.json, .gitignore. Refuses to overwrite an existing workspace.
          --minimal      markdown-only (no package.json/tool/install) — a prompt+skills agent
          --no-install   scaffold but skip npm install
   models list the available "provider/modelId" specs (use one with --model or in the config).

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -3,7 +3,7 @@
  *
  * Default = a COMPLETE agent (instructions + a skill + a code tool): AGENTS.md, a house-style
  * skill, tools/word-count.ts (defineTool), fastagent.config.mjs, package.json (ESM + the
- * @kid7st/fastagent + zod deps), .npmrc (scope registry), .gitignore. A complete agent is
+ * @kid7st/fastagent + zod deps), .gitignore. A complete agent is
  * instructions + tools, so that is what `init` produces; the CLI then runs `npm install`.
  *
  * `--minimal` = the markdown-only unit (AGENTS.md + skill + config + .gitignore): zero npm
@@ -77,12 +77,6 @@ export default {
   model: "openai-codex/gpt-5.5",
   http: { port: 8787 },
 };
-`;
-
-const NPMRC = `; @kid7st/fastagent is published to GitHub Packages.
-; This maps the @kid7st scope to that registry; authenticate with a GitHub token
-; (read:packages) in your user ~/.npmrc — never commit the token.
-@kid7st:registry=https://npm.pkg.github.com
 `;
 
 const GITIGNORE = `# secrets — never commit, never ship in the build artifact
@@ -243,8 +237,8 @@ export async function scaffoldChannel(dir: string, kind: "github"): Promise<stri
 /**
  * Verify the workspace is ready to host a channel: a package.json that is ESM (`type: "module"`) and
  * declares `@kid7st/fastagent` (the channel file imports it, resolved from the workspace). `add` does
- * NOT bootstrap this — creating package.json, choosing a module type, writing .npmrc, or ignoring
- * .env is `fastagent init`'s job. Here we only CHECK and guide, never mutate; failures are actionable.
+ * NOT bootstrap this — creating package.json, choosing a module type, or ignoring .env is
+ * `fastagent init`'s job. Here we only CHECK and guide, never mutate; failures are actionable.
  */
 export async function assertChannelReady(dir: string): Promise<void> {
   const pkgPath = join(dir, "package.json");
@@ -292,7 +286,6 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
     files.push(
       { rel: join("tools", "word-count.ts"), content: TOOL_TS },
       { rel: "package.json", content: packageJson(toPackageName(dir), await fastagentVersion()) },
-      { rel: ".npmrc", content: NPMRC },
     );
   }
 

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -37,7 +37,6 @@ describe("init: scaffoldWorkspace", () => {
         join("tools", "word-count.ts"),
         "fastagent.config.mjs",
         "package.json",
-        ".npmrc",
         ".gitignore",
         ".env.example",
       ]),
@@ -67,7 +66,6 @@ describe("init: scaffoldWorkspace", () => {
     expect(pkg.dependencies["@kid7st/fastagent"]).toBe(`^${realVersion}`);
     expect(pkg.dependencies.zod).toBeDefined();
     expect(await readFile(join(dir, "tools", "word-count.ts"), "utf8")).toContain('from "@kid7st/fastagent"');
-    expect(await readFile(join(dir, ".npmrc"), "utf8")).toContain("npm.pkg.github.com");
 
     // AGENTS.md + skill load as a definition offline (loadAgentDefinition does not touch tools/).
     const def = await loadAgentDefinition(dir);

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,7 @@ From an installed CLI to a running, deployable agent in a few minutes. Everythin
 ## Prerequisites
 
 - **Node ≥ 22.19** (`node -v`). The package ships compiled JavaScript; consuming projects do not need a build step for FastAgent itself.
-- **The `fastagent` CLI** — see [Install](../README.md#install): `npm i -g @kid7st/fastagent`, with the `@kid7st` scope registry + a GitHub token in your `~/.npmrc`.
+- **The `fastagent` CLI** — see [Install](../README.md#install): `npm i -g @kid7st/fastagent` (published to npm, public).
 - **Model credentials** — either `fastagent login` (OAuth) or a provider API key in the workspace's `.env` (e.g. `OPENAI_API_KEY=…`). Run `fastagent models` to list the available `provider/modelId` specs.
 
 ## 1. Scaffold an agent

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,7 @@ my-agent/
 ├── fastagent.config.mjs         # deployment choices: model, http port
 ├── package.json                 # ESM + the @kid7st/fastagent + zod deps
 ├── .env.example                 # optional env knobs (model/keys/port) — copy to .env
-└── .gitignore / .npmrc
+└── .gitignore
 ```
 
 For a pure prompt+skills agent with no code and no dependencies, use `fastagent init my-agent --minimal`.


### PR DESCRIPTION
## Why

GitHub Packages gates every install behind a `read:packages` token + a per-user scope-registry `.npmrc` — friction the framework's core promise (existing definition → a service, fast) can't afford. The blocker to an open registry is gone: `@earendil-works/pi-*` already resolve from **public npm**, so a public `@kid7st/fastagent` installs with zero auth.

## Changes

| File | Change |
|---|---|
| `.github/workflows/publish.yml` | `registry-url` → `registry.npmjs.org`; `NODE_AUTH_TOKEN` → `secrets.NPM_TOKEN`; drop `packages:write`; rename job |
| `core/package.json` | `publishConfig` → `{ registry: registry.npmjs.org, access: public }` |
| `core/src/engines/pi/init.ts` | drop the scaffolded `.npmrc` (public npm needs none): removed the `NPMRC` template, scaffold entry, doc refs |
| `core/test/init.test.ts` | drop the `.npmrc` expectations |
| `README.md` / `docs/quickstart.md` | Install drops the GitHub Packages token dance; `npm i -g @kid7st/fastagent` directly |

## Prerequisites (maintainer, before the release)

1. The `@kid7st` **npm** scope owned by the publishing account.
2. An **`NPM_TOKEN`** (Automation) secret in the repo Actions secrets.
3. Drop `@kid7st:registry=https://npm.pkg.github.com` from your local `~/.npmrc`.

Then cut the `v0.5.0` release → publish.yml → first **npm** publish (0.5.0 is unpublished on any registry, so the first publish is clean).

## Verification

format / typecheck / lint clean; **214 tests**; build clean. Smoke: `fastagent init` no longer writes `.npmrc`. Only residual `npm.pkg.github` ref is a stale build artifact under `apps/github-reviewer/.fastagent/build/` (closed app, off the publish path) — flagged for separate cleanup.