### PR TITLE
fix(cli): build summary lists the bundled tools, matching dev/start

### DIFF
--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -40,7 +40,7 @@ import {
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
 import { resolveTools } from "./engines/pi/create.ts";
 import { assertChannelReady, channelExists, scaffoldChannel, scaffoldWorkspace } from "./engines/pi/init.ts";
-import { loadTools, mergeDiscoveredTools } from "./engines/pi/tool.ts";
+import { listToolFiles, loadTools, mergeDiscoveredTools } from "./engines/pi/tool.ts";
 import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
 
 function usage(code: number): never {
@@ -537,12 +537,14 @@ async function runBuild(): Promise<void> {
     force: values.force ?? false,
   }).catch(failStartup);
 
+  const toolFiles = await listToolFiles(outDir); // names from the bundled tools/, without importing them
   console.error(`[fastagent] built:  ${outDir}`);
   console.error(`[fastagent] model:  ${manifest.model}`);
   console.error(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);
   console.error(
     `[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}${globalSkills ? " (incl. global)" : ""}`,
   );
+  if (toolFiles.length > 0) console.error(`[fastagent] tools:  ${toolFiles.join(", ")}`);
   // The build copies a .env only if the root .gitignore/.fastagentignore do NOT exclude it (the build
   // does not special-case secrets — definition.ts), so check the authoritative matcher, not mere
   // existence: an ignored .env is left behind (remind: secrets come from the deploy env); an

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -537,7 +537,12 @@ async function runBuild(): Promise<void> {
     force: values.force ?? false,
   }).catch(failStartup);
 
-  const toolFiles = await listToolFiles(outDir); // names from the bundled tools/, without importing them
+  // Names from the bundled tools/, without importing them. The build already succeeded, so a failure
+  // reading the summary's tool list must not fail the build — warn (visibly) and omit the line.
+  const toolFiles = await listToolFiles(outDir).catch((error: Error) => {
+    console.error(`[fastagent] warn: ${error.message}`);
+    return [] as string[];
+  });
   console.error(`[fastagent] built:  ${outDir}`);
   console.error(`[fastagent] model:  ${manifest.model}`);
   console.error(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);

--- a/core/src/engines/pi/tool.ts
+++ b/core/src/engines/pi/tool.ts
@@ -146,16 +146,23 @@ export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; coll
  * deps may not be installed at build time). Missing `tools/` returns none.
  */
 export async function listToolFiles(dir: string): Promise<string[]> {
+  const toolsDir = join(dir, "tools");
   let entries: Dirent[];
   try {
-    entries = await readdir(join(dir, "tools"), { withFileTypes: true });
-  } catch {
-    return [];
+    entries = await readdir(toolsDir, { withFileTypes: true });
+  } catch (error) {
+    // Mirror loadTools: a missing tools/ is normal (none); any other failure is real — surface it
+    // rather than swallowing an unreadable dir into a false "no tools".
+    if ((error as NodeJS.ErrnoException).code === "not_found" || (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw new Error(`cannot read ${toolsDir}: ${(error as Error).message}`);
   }
-  return entries
+  // Dedup by basename, mirroring loadTools' "names that actually load" (foo.ts + foo.js → one foo).
+  const names = entries
     .filter((e) => e.isFile() && TOOL_EXTS.has(extname(e.name)) && !e.name.endsWith(".d.ts"))
-    .map((e) => basename(e.name, extname(e.name)))
-    .sort((a, b) => a.localeCompare(b));
+    .map((e) => basename(e.name, extname(e.name)));
+  return [...new Set(names)].sort((a, b) => a.localeCompare(b));
 }
 
 /**

--- a/core/src/engines/pi/tool.ts
+++ b/core/src/engines/pi/tool.ts
@@ -141,6 +141,24 @@ export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; coll
 }
 
 /**
+ * List the code-tool names in `<dir>/tools/` WITHOUT importing them — the tool name is the filename
+ * (authoritative), so the build summary can report what it bundled without executing tool code (whose
+ * deps may not be installed at build time). Missing `tools/` returns none.
+ */
+export async function listToolFiles(dir: string): Promise<string[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(join(dir, "tools"), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isFile() && TOOL_EXTS.has(extname(e.name)) && !e.name.endsWith(".d.ts"))
+    .map((e) => basename(e.name, extname(e.name)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
  * Merge already-resolved tools (pi defaults + `config.tools`) with discovered `tools/` tools,
  * deduping by name. Existing tools win a name clash (a discovered tool may not shadow a default or
  * a configured one); the dropped discovered tools are surfaced as collisions, never silent.

--- a/core/test/tool.test.ts
+++ b/core/test/tool.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defineTool, loadTools, z } from "../src/index.ts";
+import { listToolFiles } from "../src/engines/pi/tool.ts";
 
 describe("defineTool", () => {
   it("builds a pi AgentTool: JSON-schema parameters, validated + auto-wrapped execute", async () => {
@@ -59,6 +60,18 @@ describe("loadTools (filesystem discovery)", () => {
     expect(tools.map((t) => t.name)).toEqual(["ping"]); // filename = name
     expect(collisions).toEqual([]);
     expect((await tools[0]!.execute("c", {})).details).toBe("pong");
+  });
+
+  it("listToolFiles lists tool names from filenames WITHOUT importing them (build summary, no execution)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-tools-"));
+    expect(await listToolFiles(dir)).toEqual([]); // no tools/ dir yet
+    await mkdir(join(dir, "tools"));
+    await writeFile(join(dir, "tools", "lookup-order.ts"), "throw new Error('would crash if imported')");
+    await writeFile(join(dir, "tools", "alpha.mjs"), "export default {}");
+    await writeFile(join(dir, "tools", "types.d.ts"), "export {}"); // excluded
+    await writeFile(join(dir, "tools", "notes.md"), "x"); // excluded (not a tool ext)
+    // Sorted basenames; the crashing .ts is listed (proving names come from the filesystem, not import).
+    expect(await listToolFiles(dir)).toEqual(["alpha", "lookup-order"]);
   });
 
   it("fails visibly when a tool file does not default-export a tool", async () => {

--- a/core/test/tool.test.ts
+++ b/core/test/tool.test.ts
@@ -70,8 +70,16 @@ describe("loadTools (filesystem discovery)", () => {
     await writeFile(join(dir, "tools", "alpha.mjs"), "export default {}");
     await writeFile(join(dir, "tools", "types.d.ts"), "export {}"); // excluded
     await writeFile(join(dir, "tools", "notes.md"), "x"); // excluded (not a tool ext)
-    // Sorted basenames; the crashing .ts is listed (proving names come from the filesystem, not import).
+    await writeFile(join(dir, "tools", "lookup-order.js"), "export default {}"); // same basename → deduped
+    // Sorted, basename-deduped (lookup-order.ts + .js → one); the crashing .ts is listed, proving names
+    // come from the filesystem, not from importing the module.
     expect(await listToolFiles(dir)).toEqual(["alpha", "lookup-order"]);
+  });
+
+  it("listToolFiles surfaces a non-ENOENT readdir failure (no silent fallback to empty)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-tools-"));
+    await writeFile(join(dir, "tools"), "x"); // tools/ is a FILE → readdir fails ENOTDIR (not ENOENT)
+    await expect(listToolFiles(dir)).rejects.toThrow(/cannot read .*tools/);
   });
 
   it("fails visibly when a tool file does not default-export a tool", async () => {


### PR DESCRIPTION
## Why

A full clean-room E2E (install `@kid7st/fastagent@0.5.0` from npm → `init` → add a custom tool → `dev` → `build` → copy artifact → `npm ci` → `start`, driving a real Anthropic model that called the tool) validated the whole flow. One DX nit surfaced: `fastagent build` printed `model/agents/skills` but **not** `tools:`, while `dev` and `start` both do — so after `build` an author couldn't confirm at a glance that their code tools shipped.

## Change

`build` deliberately does **not** import tools (their deps may not be installed at build time), so it can't reuse `loadTools`' executed names. Added `listToolFiles(dir)` — a pure filesystem listing of `tools/` (names from filenames, the authoritative source) with **no import**. `runBuild` scans the bundled artifact and prints `tools:` when present.

`listToolFiles` is an internal build-summary helper, not public API, so it is imported from its module (not re-exported from `index.ts`).

## Test

Locks that a tool file which would **throw on import** is still listed (proving the listing does not execute tool code), `.d.ts`/non-tool extensions are excluded, and missing `tools/` returns none. Full suite green; smoke: `fastagent build` now prints `tools:  word-count`.

> The other E2E observation (port override) was **not** a bug — `--port` / `PORT` and the precedence are already documented in `fastagent --help`.