### PR TITLE
fix(config): a config syntax error names the file, not a raw SyntaxError

### DIFF
--- a/core/src/engines/pi/config.ts
+++ b/core/src/engines/pi/config.ts
@@ -69,7 +69,14 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   // Exactly one config file at this point (0 and >1 handled above).
   // biome-ignore lint/style/noNonNullAssertion: length checked above — exactly one element here
   const path = found[0]!;
-  const mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
+  let mod: { default?: unknown };
+  try {
+    mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
+  } catch (error) {
+    // A syntax/load error in the config would otherwise surface as a raw SyntaxError with a Node ESM
+    // internal stack; name the file and keep the message, matching the shape errors below.
+    throw new Error(`${path}: ${(error as Error).message}`);
+  }
   const config = mod.default;
   if (!config || typeof config !== "object") {
     throw new Error(`${path}: must default-export defineConfig({...})`);

--- a/core/src/engines/pi/config.ts
+++ b/core/src/engines/pi/config.ts
@@ -31,6 +31,7 @@ import { pathToFileURL } from "node:url";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { Models } from "@earendil-works/pi-ai";
 import type { AnyModel } from "./harness.ts";
+import { moduleLoadHint } from "./loader.ts";
 
 export interface FastagentConfig {
   /** "provider/modelId", e.g. "openai-codex/gpt-5.5". Precedence: CLI --model > FASTAGENT_MODEL > config. */
@@ -74,8 +75,9 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
   } catch (error) {
     // A syntax/load error in the config would otherwise surface as a raw SyntaxError with a Node ESM
-    // internal stack; name the file and keep the message, matching the shape errors below.
-    throw new Error(`${path}: ${(error as Error).message}`);
+    // internal stack; name the file and append the same load hint as loadTools/loadChannels (config
+    // fails for the same reasons: non-ESM package.json, an uninstalled dep imported by the config).
+    throw new Error(`${path}: ${(error as Error).message}${moduleLoadHint(error as NodeJS.ErrnoException)}`);
   }
   const config = mod.default;
   if (!config || typeof config !== "object") {

--- a/core/test/config.test.ts
+++ b/core/test/config.test.ts
@@ -48,6 +48,12 @@ describe("config: loadConfig", () => {
     await expect(loadConfig(join(fixtures, "bad-config"))).rejects.toThrow(/must default-export/);
   });
 
+  it("a config SYNTAX error names the file (not a raw SyntaxError + ESM stack)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: `); // truncated = parse error
+    await expect(loadConfig(dir)).rejects.toThrow(/fastagent\.config\.mjs: /);
+  });
+
   it("validates http shape as well: non-numeric/out-of-range http.port throws", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
     await writeFile(join(dir, "fastagent.config.mjs"), `export default { http: { port: "oops" } };`);

--- a/core/test/config.test.ts
+++ b/core/test/config.test.ts
@@ -54,6 +54,12 @@ describe("config: loadConfig", () => {
     await expect(loadConfig(dir)).rejects.toThrow(/fastagent\.config\.mjs: /);
   });
 
+  it("a config that imports a missing dep gets the same npm-install hint as tools/channels", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
+    await writeFile(join(dir, "fastagent.config.mjs"), `import "totally-not-installed-pkg";\nexport default {};`);
+    await expect(loadConfig(dir)).rejects.toThrow(/fastagent\.config\.mjs: .*npm install/s);
+  });
+
   it("validates http shape as well: non-numeric/out-of-range http.port throws", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
     await writeFile(join(dir, "fastagent.config.mjs"), `export default { http: { port: "oops" } };`);


### PR DESCRIPTION
## Why

A manual DX validation pass (building several agents across different paths) found one rough edge in an otherwise excellent error surface: `loadConfig` wraps every config **shape** error with the file path —

```
/path/fastagent.config.mjs: must default-export defineConfig({...})
/path/fastagent.config.mjs: unknown key "htttp" (valid keys: model, tools, http)
```

— but the dynamic `import()` of the config file was unwrapped, so a **syntax** error surfaced as:

```
SyntaxError: Unexpected end of input
    at compileSourceTextModule (node:internal/modules/esm/utils:354:16)
    ...node ESM internal stack...
```

No filename, no `[fastagent]` framing — a stack-trace outlier exactly where a vibe/AI-coding author most needs a located, actionable message.

## Change

Wrap the config `import()` in try/catch and rethrow as ```<path>: <message>```, matching the shape errors. A syntax error now reads ``/path/fastagent.config.mjs: Unexpected end of input``.

## Test

`config.test.ts`: a truncated config (parse error) → the thrown message names the file. Full suite green (217).

---

### Note on scope (honest retraction)
The validation pass *initially* flagged a more serious 'dev orphans its worker on exit → port stuck in use' bug. On clean re-investigation that was **my own test-harness pollution** (a wrong `pkill` pattern leaked workers across runs); `fastagent dev` cleanup (SIGINT/SIGTERM) and watch-reload are correct — no orphan, no port leak. So this PR fixes only the real, small issue.