### PR TITLE
chore(release): 0.5.1 + publish via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,18 @@
 name: Publish
 
-# Publish @kid7st/fastagent to npm when a GitHub Release is published.
-# The release tag is the manual gate; the job re-verifies (typecheck + test) before
-# publishing so a non-green tag never ships. Version comes from core/package.json —
-# bump it before tagging (npm rejects re-publishing an existing version).
+# Publish @kid7st/fastagent to npm when a GitHub Release is published, via npm Trusted Publishing
+# (OIDC) — no NPM_TOKEN secret, and provenance is attached automatically. Requires a trusted publisher
+# configured on npmjs (org/user kid7st, repo fastagent, workflow publish.yml) and npm >= 11.5.1 (Node 26
+# ships 11.12.1). The release tag is the manual gate; the job re-verifies (typecheck + test) before
+# publishing so a non-green tag never ships. Version comes from core/package.json — bump it before
+# tagging (npm rejects re-publishing an existing version).
 on:
   release:
     types: [published]
 
 permissions:
   contents: read
+  id-token: write # OIDC token for Trusted Publishing
 
 jobs:
   publish:
@@ -41,6 +44,4 @@ jobs:
         run: npm test
 
       - name: Publish
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish # Trusted Publishing (OIDC) authenticates from the id-token; access/registry come from publishConfig

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.80.2",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Flask/WSGI for agents: serve or embed an existing agent folder (AGENTS.md + skills/) as a production capability. Engine-, model-, and host-neutral.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Two release-enabling changes that ship together:

**1. Bump `core/package.json` to 0.5.1** — rolls up the DX fixes since 0.5.0 (all author-facing, no runtime/API change):
- #53 build summary lists the bundled `tools:`; `listToolFiles` mirrors `loadTools`'s edges.
- #54 vitest: longer timeout + explicit `pool: "forks"` (deflake CLI e2e under load).
- #55 config syntax/load errors name the file + carry the `npm install` / `type: module` hint.

**2. Switch `publish.yml` to npm Trusted Publishing (OIDC)** — no `NPM_TOKEN` secret, provenance attached automatically. Adds `id-token: write`, drops `NODE_AUTH_TOKEN`. Node 26 ships npm 11.12.1 (≥ 11.5.1), so no upgrade step.

## Before cutting the release (maintainer, one-time)
On npmjs.com → `@kid7st/fastagent` → Settings → **Trusted Publisher** → GitHub Actions:
- Organization or user: `kid7st` · Repository: `fastagent` · Workflow filename: `publish.yml`

Then `gh release create v0.5.1` triggers `publish.yml` → tokenless OIDC publish with provenance.