### PR TITLE
ci: add --provenance to npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish
 
 # Publish @kid7st/fastagent to npm when a GitHub Release is published, via npm Trusted Publishing
-# (OIDC) — no NPM_TOKEN secret, and provenance is attached automatically. Requires a trusted publisher
+# (OIDC) — no NPM_TOKEN secret; provenance comes from the explicit --provenance flag below (npm did NOT
+# auto-attach it under OIDC), which needs the id-token: write permission. Requires a trusted publisher
 # configured on npmjs (org/user kid7st, repo fastagent, workflow publish.yml) and npm >= 11.5.1 (Node 26
 # ships 11.12.1). The release tag is the manual gate; the job re-verifies (typecheck + test) before
 # publishing so a non-green tag never ships. Version comes from core/package.json — bump it before

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,4 +44,7 @@ jobs:
         run: npm test
 
       - name: Publish
-        run: npm publish # Trusted Publishing (OIDC) authenticates from the id-token; access/registry come from publishConfig
+        # Trusted Publishing (OIDC) authenticates from the id-token; access/registry come from publishConfig.
+        # --provenance is explicit: npm 11.12.1 did NOT auto-attach it under OIDC (despite the docs), so the
+        # flag is what actually generates the supply-chain provenance attestation (needs id-token: write).
+        run: npm publish --provenance


### PR DESCRIPTION
## Why

0.5.1 published cleanly via Trusted Publishing (tokenless OIDC) but shipped **without a provenance attestation**. npm's docs say provenance is automatic under trusted publishing, but npm 11.12.1 did **not** auto-attach it: the publish log had no provenance step and `dist.attestations` is empty on the registry (matches widely-reported behavior — the `--provenance` flag is what actually triggers it).

## Change

Add `--provenance` to the publish command. Everything the flag needs is already in place: `id-token: write`, a GitHub-hosted runner, and a public package (`publishConfig.access: public`). Future releases (0.5.2+) will carry the supply-chain provenance attestation — completing the OIDC trusted-publishing story.

No effect on 0.5.1 (already published); takes effect on the next release.