### PR TITLE
redesign(login): persist via fastagent's own CredentialStore, not pi's AuthStorage

### DIFF
--- a/core/src/engines/pi/auth.ts
+++ b/core/src/engines/pi/auth.ts
@@ -62,8 +62,9 @@ function parseForWrite(raw: string | undefined, where: string): Creds {
  * A read-write `CredentialStore` backed by `~/.fastagent/auth.json`.
  *
  * - `read` returns the provider's stored credential (missing file/entry = not configured → the
- *   collection falls back to ambient env). Read under the lock, so a concurrent in-place write is
- *   never seen torn; a genuinely corrupt file reads lenient (warn + not-configured, no throw).
+ *   collection falls back to ambient env). UNLOCKED (pi-ai's per-request hot path): a concurrent
+ *   in-place write's sub-ms torn read is absorbed by re-reading; a genuinely corrupt file reads
+ *   lenient (warn + not-configured, no throw).
  * - `modify` is the serialized read-modify-write `Models.getAuth()` runs OAuth refresh inside: it
  *   locks the file, applies `fn`, and PERSISTS the result — a rotated refresh token is saved, not lost.
  * - `delete` removes the entry (logout); a no-op when nothing is stored, never creating the file.

--- a/core/src/engines/pi/login.ts
+++ b/core/src/engines/pi/login.ts
@@ -1,13 +1,24 @@
 /**
- * `fastagent login`: authenticate a model provider into fastagent's OWN `~/.fastagent/auth.json`
- * (read by {@link fastagentCredentialStore}), using pi's `AuthStorage`. An OAuth-capable provider
- * (Anthropic Claude Pro/Max, ChatGPT Codex, GitHub Copilot) runs the device/browser flow; any other
- * provider id stores an API key. The terminal IO is INJECTED ({@link LoginIO}) so the flow is testable
- * without a real OAuth round-trip or stdin.
+ * `fastagent login`: authenticate a model provider into fastagent's OWN `~/.fastagent/auth.json` via
+ * the SAME {@link fastagentCredentialStore} the runtime uses — ONE writer over the file, ONE
+ * corruption/lock semantics. The OAuth device/browser flow comes from pi-ai/oauth
+ * (`getOAuthProvider().login`); the result is persisted with `store.modify`, which refuses to clobber a
+ * corrupt file — so a failed save fails visibly without any extra reconciliation machinery. An
+ * OAuth-capable provider (Anthropic Claude Pro/Max, ChatGPT Codex, GitHub Copilot) runs the flow; any
+ * other provider id stores an API key.
+ *
+ * Why not pi's `AuthStorage`: the runtime resolves auth through pi-ai's `CredentialStore` port (Models
+ * consumes it), and pi ships no file-backed `CredentialStore` — so `fastagentCredentialStore` is
+ * mandatory and already owns the file. `AuthStorage` is pi-coding-agent's CLI-world manager (a
+ * different port, record-don't-throw persistence); routing login through it put two stores over one
+ * file. Login joins the engine-world store instead.
+ *
+ * The terminal IO and the OAuth flow are INJECTED ({@link LoginIO}, {@link OAuthFlow}) so the routing
+ * is testable against a real store without real stdin or a real OAuth round-trip.
  */
-import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import { AuthStorage } from "@earendil-works/pi-coding-agent";
-import { FASTAGENT_AUTH_PATH } from "./auth.ts";
+import type { Credential, CredentialStore, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import { getOAuthProvider, getOAuthProviderInfoList } from "@earendil-works/pi-ai/oauth";
+import { FASTAGENT_AUTH_PATH, fastagentCredentialStore } from "./auth.ts";
 
 /** Terminal interaction, injectable for tests (no real stdin/stdout or browser in unit tests). */
 export interface LoginIO {
@@ -20,18 +31,14 @@ export interface LoginIO {
   openUrl(url: string): void;
 }
 
-/** The slice of pi's `AuthStorage` the flow uses (so a test can pass a fake). `AuthStorage` satisfies it. */
-export interface AuthStore {
-  getOAuthProviders(): Array<{ id: string; name: string }>;
-  login(providerId: string, callbacks: OAuthLoginCallbacks): Promise<void>;
-  set(provider: string, credential: { type: "api_key"; key: string }): void;
-  /**
-   * pi's `AuthStorage` RECORDS persistence failures (corrupt file → `persistProviderChange`
-   * early-returns; write IO failure → caught) instead of throwing, so a failed save looks like a
-   * success at the call site. We must drain after a write to surface them (see {@link assertPersisted}).
-   */
-  drainErrors(): Error[];
-}
+/** The OAuth device/browser flow for a provider — injected so the routing is testable without a round-trip. */
+export type OAuthFlow = (providerId: string, callbacks: OAuthLoginCallbacks) => Promise<OAuthCredentials>;
+
+const defaultOAuthFlow: OAuthFlow = (providerId, callbacks) => {
+  const provider = getOAuthProvider(providerId);
+  if (!provider) throw new Error(`unknown OAuth provider "${providerId}"`);
+  return provider.login(callbacks);
+};
 
 export interface LoginResult {
   provider: string;
@@ -83,19 +90,24 @@ function oauthCallbacks(io: LoginIO, manualPromptSignal: AbortSignal, signal?: A
 }
 
 /**
- * Resolve the provider (argument or interactive select among the OAuth providers), then either run
- * the OAuth flow (OAuth-capable provider) or prompt for and store an API key (any other id). Both
- * persist to `~/.fastagent/auth.json` via `AuthStorage`.
+ * Resolve the provider (argument or interactive select among the OAuth providers), then either run the
+ * OAuth flow or prompt for an API key, and persist via `store.modify`. The persist refuses to overwrite
+ * a corrupt file, so it fails visibly on its own; a no-op `modify` up front runs that same check BEFORE
+ * the OAuth round-trip / key prompt, so a known-bad file fails fast instead of after the user's work.
  */
 export async function loginFlow(
   io: LoginIO,
-  options: { provider?: string; authPath?: string; store?: AuthStore; signal?: AbortSignal } = {},
+  options: {
+    provider?: string;
+    authPath?: string;
+    store?: CredentialStore;
+    oauthFlow?: OAuthFlow;
+    signal?: AbortSignal;
+  } = {},
 ): Promise<LoginResult> {
-  const store: AuthStore = options.store ?? AuthStorage.create(options.authPath ?? FASTAGENT_AUTH_PATH);
-  // A corrupt/unwritable file is recorded at construction and makes every later write a silent no-op;
-  // surface it before any prompt or the OAuth round-trip, not after the user has done the work.
-  preflightAuthFile(store);
-  const oauthProviders = store.getOAuthProviders();
+  const store = options.store ?? fastagentCredentialStore(options.authPath ?? FASTAGENT_AUTH_PATH);
+  const oauthFlow = options.oauthFlow ?? defaultOAuthFlow;
+  const oauthProviders = getOAuthProviderInfoList();
 
   let provider = options.provider;
   if (!provider) {
@@ -107,46 +119,26 @@ export async function loginFlow(
     if (!provider) throw new Error("no provider selected");
   }
 
+  // Preflight: a no-op modify runs the store's refuse-corrupt check (and surfaces an unwritable file)
+  // before any OAuth round-trip or key prompt — so the user is not made to do the work only to fail.
+  await store.modify(provider, async () => undefined);
+
   if (oauthProviders.some((p) => p.id === provider)) {
     const promptAbort = new AbortController();
+    let credentials: OAuthCredentials;
     try {
-      await store.login(provider, oauthCallbacks(io, promptAbort.signal, options.signal));
+      credentials = await oauthFlow(provider, oauthCallbacks(io, promptAbort.signal, options.signal));
     } finally {
       // A server/browser win leaves the concurrent manual-paste prompt pending on stdin; abort it so
       // the one-shot CLI can exit (pi does not await that prompt once the server returns a code).
       promptAbort.abort();
     }
-    assertPersisted(store, provider);
+    await store.modify(provider, async (): Promise<Credential> => ({ type: "oauth", ...credentials }));
     return { provider, method: "oauth" };
   }
 
   const key = (await io.promptHidden(`API key for "${provider}": `)).trim();
   if (!key) throw new Error(`no API key entered for "${provider}"`);
-  store.set(provider, { type: "api_key", key });
-  assertPersisted(store, provider);
+  await store.modify(provider, async (): Promise<Credential> => ({ type: "api_key", key }));
   return { provider, method: "api_key" };
-}
-
-/**
- * Turn pi's RECORDED persistence failures into a visible throw, so `fastagent login` never reports
- * success on a save that silently no-op'd (corrupt/unwritable ~/.fastagent/auth.json) — the
- * fail-visibly boundary that AuthStorage's record-don't-throw contract would otherwise swallow.
- */
-function assertPersisted(store: AuthStore, provider: string): void {
-  const errors = store.drainErrors();
-  if (errors.length > 0) {
-    throw new Error(`failed to save credentials for "${provider}": ${errors.map((e) => e.message).join("; ")}`);
-  }
-}
-
-/**
- * Drain errors recorded at AuthStorage construction (reload()'s corrupt/unwritable load) so a known-bad
- * auth file fails up front — mirrors fastagentCredentialStore.read's "corrupt auth file" warning, and
- * stops the user from completing an OAuth flow that persistProviderChange would silently refuse to save.
- */
-function preflightAuthFile(store: AuthStore): void {
-  const errors = store.drainErrors();
-  if (errors.length > 0) {
-    throw new Error(`auth file unusable: ${errors.map((e) => e.message).join("; ")} — fix or remove it`);
-  }
 }

--- a/core/test/login.test.ts
+++ b/core/test/login.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getOAuthProviderInfoList } from "@earendil-works/pi-ai/oauth";
@@ -95,6 +95,29 @@ describe("loginFlow", () => {
     ).rejects.toThrow(/corrupt auth file/);
     expect(flowRan).toBe(false); // preflight threw before the flow — no wasted round-trip
   });
+
+  // The #51 invariant: the SECOND modify (the real in-place write, AFTER a successful flow) must fail
+  // visibly — never a false success. The corrupt-preflight test above only exercises the parse throw on
+  // the FIRST (no-op) modify; this one drives the write-IO path the preflight never reaches. A read-only
+  // (0444) file lets the preflight pass (read + lock, no write) and the flow run, then the persist write
+  // hits EACCES. (Skipped under root, which bypasses the permission check.)
+  it.skipIf(process.getuid?.() === 0)(
+    "a persist write failure after a successful OAuth flow rejects, persisting nothing",
+    async () => {
+      const path = await tmpAuth(JSON.stringify({ existing: { type: "api_key", key: "x" } })); // valid JSON
+      await chmod(path, 0o444); // read-only file; parent dir stays writable so the lock can still be taken
+      let flowRan = false;
+      const oauthFlow: OAuthFlow = async () => {
+        flowRan = true;
+        return fakeCreds;
+      };
+      await expect(
+        loginFlow(fakeIO(), { provider: "anthropic", store: fastagentCredentialStore(path), oauthFlow }),
+      ).rejects.toThrow(/EACCES|permission/i);
+      expect(flowRan).toBe(true); // got past preflight + flow; only the persist write failed
+      expect((await readAuth(path)).anthropic).toBeUndefined(); // no false success — nothing landed
+    },
+  );
 
   it("c1: a server win that leaves the manual-paste prompt pending is aborted, so the CLI does not hang", async () => {
     let manualAborted = false;

--- a/core/test/login.test.ts
+++ b/core/test/login.test.ts
@@ -1,115 +1,105 @@
-import { AuthStorage, InMemoryAuthStorageBackend } from "@earendil-works/pi-coding-agent";
-import type { AuthStorageBackend } from "@earendil-works/pi-coding-agent";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getOAuthProviderInfoList } from "@earendil-works/pi-ai/oauth";
+import type { OAuthCredentials } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import type { AuthStore, LoginIO } from "../src/engines/pi/login.ts";
+import { fastagentCredentialStore } from "../src/engines/pi/auth.ts";
+import type { LoginIO, OAuthFlow } from "../src/engines/pi/login.ts";
 import { loginFlow } from "../src/engines/pi/login.ts";
 
-/** A fake AuthStore for the ROUTING tests (anthropic/openai-codex are OAuth-capable); persistence ok. */
-function fakeStore() {
-  const calls: { login?: string; set?: [string, { type: string; key: string }] } = {};
-  const store: AuthStore = {
-    getOAuthProviders: () => [
-      { id: "anthropic", name: "Anthropic (Claude Pro/Max)" },
-      { id: "openai-codex", name: "ChatGPT Codex" },
-    ],
-    login: async (providerId) => {
-      calls.login = providerId;
-    },
-    set: (provider, credential) => {
-      calls.set = [provider, credential];
-    },
-    drainErrors: () => [],
-  };
-  return { store, calls };
+// The store is the REAL fastagentCredentialStore over a temp file — the same writer the runtime uses,
+// so these tests exercise the actual persist/corruption semantics, not a mock of them. Only the OAuth
+// device/browser flow (external) is injected.
+async function tmpAuth(content?: string): Promise<string> {
+  const path = join(await mkdtemp(join(tmpdir(), "fa-login-")), "auth.json");
+  if (content !== undefined) await writeFile(path, content);
+  return path;
 }
+const readAuth = async (path: string) => JSON.parse(await readFile(path, "utf8"));
 
-/** A fake terminal: scripted prompt/hidden answers, captured prints, no real stdin/browser. */
-function fakeIO(answers: { prompt?: string[]; hidden?: string[] } = {}) {
-  const printed: string[] = [];
+/** A fake terminal: scripted prompt/hidden answers, no real stdin/browser. */
+function fakeIO(answers: { prompt?: string[]; hidden?: string[] } = {}): LoginIO {
   const prompts = [...(answers.prompt ?? [])];
   const hiddens = [...(answers.hidden ?? [])];
-  const io: LoginIO = {
-    print: (l) => printed.push(l),
+  return {
+    print: () => {},
     prompt: async () => prompts.shift() ?? "",
     promptHidden: async () => hiddens.shift() ?? "",
     openUrl: () => {},
   };
-  return { io, printed };
 }
 
+const fakeCreds = { access: "tok", refresh: "rt", expires: Date.now() + 3_600_000 } as unknown as OAuthCredentials;
+const oauthOk: OAuthFlow = async () => fakeCreds;
+
 describe("loginFlow", () => {
-  it("an OAuth-capable provider runs the login flow (no api_key write)", async () => {
-    const { store, calls } = fakeStore();
-    const res = await loginFlow(fakeIO().io, { provider: "anthropic", store });
+  it("an OAuth-capable provider runs the flow and persists {type:oauth} via the store", async () => {
+    const path = await tmpAuth();
+    const store = fastagentCredentialStore(path);
+    const res = await loginFlow(fakeIO(), { provider: "anthropic", store, oauthFlow: oauthOk });
     expect(res).toEqual({ provider: "anthropic", method: "oauth" });
-    expect(calls.login).toBe("anthropic");
-    expect(calls.set).toBeUndefined();
+    expect((await readAuth(path)).anthropic).toMatchObject({ type: "oauth", access: "tok" });
   });
 
-  it("any other provider prompts (hidden) for and stores an API key (no OAuth)", async () => {
-    const { store, calls } = fakeStore();
-    const res = await loginFlow(fakeIO({ hidden: ["sk-123"] }).io, { provider: "openai", store });
+  it("any non-OAuth provider prompts (hidden) for and persists {type:api_key}", async () => {
+    const path = await tmpAuth();
+    const store = fastagentCredentialStore(path);
+    const res = await loginFlow(fakeIO({ hidden: ["sk-123"] }), { provider: "openai", store, oauthFlow: oauthOk });
     expect(res).toEqual({ provider: "openai", method: "api_key" });
-    expect(calls.set).toEqual(["openai", { type: "api_key", key: "sk-123" }]);
-    expect(calls.login).toBeUndefined();
+    expect((await readAuth(path)).openai).toEqual({ type: "api_key", key: "sk-123" });
   });
 
-  it("no provider → interactive select among the OAuth providers (by number or id)", async () => {
-    const byNumber = await loginFlow(fakeIO({ prompt: ["2"] }).io, { store: fakeStore().store });
-    expect(byNumber.provider).toBe("openai-codex");
-    const byId = await loginFlow(fakeIO({ prompt: ["anthropic"] }).io, { store: fakeStore().store });
+  it("no provider → interactive select among the real OAuth providers (by number or id)", async () => {
+    const first = getOAuthProviderInfoList()[0]?.id; // the list is pi's; assert against it, not a hardcode
+    const byNumber = await loginFlow(fakeIO({ prompt: ["1"] }), {
+      store: fastagentCredentialStore(await tmpAuth()),
+      oauthFlow: oauthOk,
+    });
+    expect(byNumber.provider).toBe(first);
+    const byId = await loginFlow(fakeIO({ prompt: ["anthropic"] }), {
+      store: fastagentCredentialStore(await tmpAuth()),
+      oauthFlow: oauthOk,
+    });
     expect(byId.provider).toBe("anthropic");
   });
 
   it("an empty selection fails visibly", async () => {
-    await expect(loginFlow(fakeIO({ prompt: [""] }).io, { store: fakeStore().store })).rejects.toThrow(
-      /no provider selected/,
-    );
+    await expect(
+      loginFlow(fakeIO({ prompt: [""] }), { store: fastagentCredentialStore(await tmpAuth()), oauthFlow: oauthOk }),
+    ).rejects.toThrow(/no provider selected/);
   });
 
-  it("an empty API key fails visibly and writes nothing", async () => {
-    const { store, calls } = fakeStore();
-    await expect(loginFlow(fakeIO({ hidden: [""] }).io, { provider: "openai", store })).rejects.toThrow(/no API key/);
-    expect(calls.set).toBeUndefined();
+  it("an empty API key fails visibly and persists no credential", async () => {
+    const path = await tmpAuth();
+    await expect(
+      loginFlow(fakeIO({ hidden: [""] }), {
+        provider: "openai",
+        store: fastagentCredentialStore(path),
+        oauthFlow: oauthOk,
+      }),
+    ).rejects.toThrow(/no API key/);
+    // The preflight modify may touch the file ("{}"), but no openai credential was written.
+    expect((await readAuth(path).catch(() => ({}))).openai).toBeUndefined();
   });
 
-  // The persistence-failure paths are tested against the REAL AuthStorage (not a mock of the binding the
-  // fix depends on): pi RECORDS failures into drainErrors() rather than throwing, and the flow must drain.
-  it("real AuthStorage: a corrupt auth file fails up front (preflight), before any prompt or OAuth round-trip", async () => {
-    const backend = new InMemoryAuthStorageBackend();
-    backend.withLock(() => ({ result: undefined, next: "{ not valid json" })); // corrupt content at construction
-    const store = AuthStorage.fromStorage(backend);
-    await expect(loginFlow(fakeIO({ hidden: ["sk"] }).io, { provider: "openai", store })).rejects.toThrow(
-      /auth file unusable/,
-    );
-  });
-
-  it("real AuthStorage: a write failure recorded by persistProviderChange surfaces as a thrown error", async () => {
-    // Reads clean at construction, throws on write — exercises the REAL persistProviderChange
-    // catch → recordError → drainErrors binding (the one new risk point, not a fake of it).
-    const backend: AuthStorageBackend = {
-      withLock: (fn) => {
-        const { result, next } = fn(undefined);
-        if (next !== undefined) throw new Error("EROFS: read-only file system");
-        return result;
-      },
-      withLockAsync: async (fn) => {
-        const { result, next } = await fn(undefined);
-        if (next !== undefined) throw new Error("EROFS: read-only file system");
-        return result;
-      },
+  it("a corrupt auth file fails up front (preflight), before the OAuth round-trip", async () => {
+    const path = await tmpAuth("{ not valid json");
+    let flowRan = false;
+    const oauthFlow: OAuthFlow = async () => {
+      flowRan = true;
+      return fakeCreds;
     };
-    const store = AuthStorage.fromStorage(backend);
-    await expect(loginFlow(fakeIO({ hidden: ["sk-x"] }).io, { provider: "openai", store })).rejects.toThrow(
-      /failed to save credentials.*EROFS/,
-    );
+    await expect(
+      loginFlow(fakeIO(), { provider: "anthropic", store: fastagentCredentialStore(path), oauthFlow }),
+    ).rejects.toThrow(/corrupt auth file/);
+    expect(flowRan).toBe(false); // preflight threw before the flow — no wasted round-trip
   });
 
   it("c1: a server win that leaves the manual-paste prompt pending is aborted, so the CLI does not hang", async () => {
     let manualAborted = false;
     const io: LoginIO = {
       print: () => {},
-      // The manual-paste prompt never receives an answer (the browser won); it must be aborted, not hang.
       prompt: (_message, signal) =>
         new Promise<string>((_resolve, reject) => {
           signal?.addEventListener("abort", () => {
@@ -120,20 +110,14 @@ describe("loginFlow", () => {
       promptHidden: async () => "",
       openUrl: () => {},
     };
-    const store: AuthStore = {
-      getOAuthProviders: () => [{ id: "anthropic", name: "Anthropic" }],
-      // pi starts the concurrent manual prompt, then the local server wins: resolve without awaiting it
-      // (and .catch it, as pi does, so the later abort-rejection stays handled).
-      login: async (_id, callbacks) => {
-        void callbacks.onManualCodeInput?.().catch(() => {});
-      },
-      set: () => {},
-      drainErrors: () => [],
+    // The flow starts the concurrent manual prompt, then the server wins: resolve without awaiting it.
+    const oauthFlow: OAuthFlow = async (_id, callbacks) => {
+      void callbacks.onManualCodeInput?.().catch(() => {});
+      return fakeCreds;
     };
-    await expect(loginFlow(io, { provider: "anthropic", store })).resolves.toEqual({
-      provider: "anthropic",
-      method: "oauth",
-    });
+    await expect(
+      loginFlow(io, { provider: "anthropic", store: fastagentCredentialStore(await tmpAuth()), oauthFlow }),
+    ).resolves.toEqual({ provider: "anthropic", method: "oauth" });
     expect(manualAborted).toBe(true);
   });
 });


### PR DESCRIPTION
## The structural finding (from a post-iteration refactor scan)

`fastagent login` wrote credentials through pi-coding-agent's **`AuthStorage`**, while the runtime read/refreshed the **same** `~/.fastagent/auth.json` through fastagent's own **`fastagentCredentialStore`** (auth.ts). Two writer abstractions over one file, with **divergent semantics**: AuthStorage records-don't-throw; the store refuses-corrupt-**throws**. The entire #51 saga's residue — `drainErrors` plumbing, `assertPersisted`, `preflightAuthFile` — existed only to bolt fail-visibly onto AuthStorage's record-don't-throw persistence. The repeated #51 review bleeding was the symptom of this split.

## Why this direction (not preference — port shapes force it)

- The runtime resolves auth through **pi-ai's `CredentialStore` port** (`Models` consumes it), and pi ships **no file-backed `CredentialStore`** (only `InMemoryCredentialStore`). So `fastagentCredentialStore` is **mandatory** and already owns the file.
- `AuthStorage` is pi-coding-agent's **CLI-world** manager — a different port (no `modify(id, fn)` for OAuth-refresh-in-lock) the runtime cannot consume.
- ∴ "all pi's AuthStorage" is **impossible**; the only coherent unification is **login joining the engine-world store**.

## Change

- `login.ts`: OAuth flow via `pi-ai/oauth` `getOAuthProvider().login` (injectable `OAuthFlow` seam) + provider list via `getOAuthProviderInfoList()`; persist via `store.modify` (refuses to clobber a corrupt file → fails visibly on its own). A no-op `modify` up front is the preflight. **Deleted** the `AuthStore` interface, `drainErrors` plumbing, `assertPersisted`, `preflightAuthFile`, and the `AuthStorage` import — one writer, one semantics.
- `login.test.ts`: runs against the **real** `fastagentCredentialStore` over a temp file (not a mock of the binding); only the external OAuth flow is injected. Both routes, select, empty-selection/empty-key, corrupt-file preflight (asserts the flow did **not** run), manual-prompt abort.
- `auth.ts`: fix the `read` docstring that claimed "Read under the lock" — it is the deliberately **unlocked** hot path with resilient re-read (the L1 nit).

## Verify

typecheck / lint clean; **217 tests**; build clean; `fastagent login` lists the real providers. Net: deletes the #51 reconciliation machinery and ends the two-stores-one-file split.