### PR TITLE
refactor: one resolveWorkspaceTools shared by the dev/start/tool openers

### DIFF
--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -38,9 +38,9 @@ import {
   loadRootIgnore,
 } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
-import { resolveTools } from "./engines/pi/create.ts";
+import { resolveWorkspaceTools } from "./engines/pi/create.ts";
 import { assertChannelReady, channelExists, scaffoldChannel, scaffoldWorkspace } from "./engines/pi/init.ts";
-import { listToolFiles, loadTools, mergeDiscoveredTools } from "./engines/pi/tool.ts";
+import { listToolFiles } from "./engines/pi/tool.ts";
 import { createPiAgentFromArtifact } from "./engines/pi/start.ts";
 
 function usage(code: number): never {
@@ -145,12 +145,11 @@ async function runTool(): Promise<void> {
   }
   loadDotEnv(toolDir); // a tool may read a key from .env
   const { config } = await loadConfig(toolDir).catch(failStartup);
-  const discovered = await loadTools(toolDir).catch(failStartup);
   // Same tool set dev/start mount (pi defaults + config.tools + discovered, deduped) so the
   // runner exercises exactly what gets served — a tool shadowed by a default/config tool is not
   // run here either; surface that collision instead of silently testing the wrong implementation.
-  const { tools, collisions } = mergeDiscoveredTools(resolveTools(config, toolDir), discovered.tools);
-  for (const c of [...discovered.collisions, ...collisions]) {
+  const { tools, toolCollisions } = await resolveWorkspaceTools(config, toolDir).catch(failStartup);
+  for (const c of toolCollisions) {
     console.error(
       `[fastagent] warn: tool "${c.name}" (${c.source}) is shadowed by a default/config tool — not mounted`,
     );

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -74,6 +74,7 @@ import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, piHarnessFactory } from "./harness.ts";
 import { createPiModels } from "./models.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
+import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 
 // ── §1 tools: pi's real built-in core coding tools (engine assets) ───────────
@@ -103,6 +104,24 @@ export function piDefaultTools(cwd: string): AgentTool[] {
 export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] {
   const defaults = piDefaultTools(cwd);
   return config.tools ? [...defaults, ...config.tools] : defaults;
+}
+
+/**
+ * Resolve the full tool set a workspace/artifact mounts: pi defaults + `config.tools` + discovered
+ * `tools/` (deduped, existing win), plus the non-default tool names and the collisions to report.
+ * The single source of this resolution for the dev/start openers AND `fastagent tool` — they must
+ * mount exactly the same set, so it lives here once instead of being copied per opener.
+ */
+export async function resolveWorkspaceTools(
+  config: FastagentConfig,
+  dir: string,
+): Promise<{ tools: AgentTool[]; toolNames: string[]; toolCollisions: ToolCollision[] }> {
+  const discovered = await loadTools(dir);
+  const { tools, collisions } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
+  const toolCollisions = [...discovered.collisions, ...collisions];
+  const defaultNames = new Set(piDefaultTools(dir).map((t) => t.name));
+  const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
+  return { tools, toolNames, toolCollisions };
 }
 
 // ── §2 prompt: four-segment systemPrompt assembly (core-design §2) ───────────

--- a/core/src/engines/pi/dev.ts
+++ b/core/src/engines/pi/dev.ts
@@ -25,11 +25,11 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { Agent } from "../../agent.ts";
 import { type FastagentConfig, type LoadedConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { createPiAgentFromDefinition, piDefaultTools, resolveTools } from "./create.ts";
+import { createPiAgentFromDefinition, resolveWorkspaceTools } from "./create.ts";
 import { type LoadedDefinition, defaultGlobalSkillPaths, ensureStateDirSelfIgnored } from "./definition.ts";
 import { createPiModels } from "./models.ts";
 import { jsonlSessionStore } from "./sessions.ts";
-import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import type { ToolCollision } from "./tool.ts";
 
 export interface CreatePiAgentFromWorkspaceOptions {
   /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -76,12 +76,9 @@ export async function createPiAgentFromWorkspace(
       `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
     );
   }
-  // Discover tools/ and merge with pi defaults + config.tools (existing win name clashes).
-  const discovered = await loadTools(dir);
-  const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
-  const toolCollisions = [...discovered.collisions, ...crossCollisions];
-  const defaultNames = new Set(piDefaultTools(dir).map((t) => t.name));
-  const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
+  // Discover tools/ and merge with pi defaults + config.tools (existing win) — the same resolution
+  // start and `fastagent tool` use, so the dev server mounts exactly what gets served.
+  const { tools, toolNames, toolCollisions } = await resolveWorkspaceTools(config, dir);
   // The dev opener owns workspace state: .fastagent/ (machine state — gitignored, deletable,
   // rebuildable) is created HERE, not in the CLI, so library callers get the same
   // self-gitignored dir (vite/next-style).

--- a/core/src/engines/pi/start.ts
+++ b/core/src/engines/pi/start.ts
@@ -27,11 +27,11 @@ import { join } from "node:path";
 import type { Agent } from "../../agent.ts";
 import { type ArtifactManifest, MANIFEST_FILE } from "./build.ts";
 import { type FastagentConfig, loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
-import { createPiAgentFromDefinition, piDefaultTools, resolveTools } from "./create.ts";
+import { createPiAgentFromDefinition, resolveWorkspaceTools } from "./create.ts";
 import { type LoadedDefinition, ensureStateDirSelfIgnored } from "./definition.ts";
 import { createPiModels } from "./models.ts";
 import { jsonlSessionStore } from "./sessions.ts";
-import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import type { ToolCollision } from "./tool.ts";
 
 /**
  * Read + validate `<artifactDir>/fastagent.json`. The manifest is machine-generated, so this
@@ -128,15 +128,9 @@ export async function createPiAgentFromArtifact(
   // start run inside a git repo does not show conversations as untracked).
   await mkdir(sessionsDir, { recursive: true });
   await ensureStateDirSelfIgnored(sessionsDir);
-  // Discover tools/ (ships in the artifact as authored context) and merge with config.tools + defaults.
-  const discovered = await loadTools(artifactDir);
-  const { tools, collisions: crossCollisions } = mergeDiscoveredTools(
-    resolveTools(config, artifactDir),
-    discovered.tools,
-  );
-  const toolCollisions = [...discovered.collisions, ...crossCollisions];
-  const defaultNames = new Set(piDefaultTools(artifactDir).map((t) => t.name));
-  const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
+  // The same tool resolution dev and `fastagent tool` use (pi defaults + config.tools + discovered
+  // tools/, existing win) — tools/ ships in the artifact as authored context.
+  const { tools, toolNames, toolCollisions } = await resolveWorkspaceTools(config, artifactDir);
   const models = createPiModels();
   const { agent, definition } = await createPiAgentFromDefinition(artifactDir, {
     models,


### PR DESCRIPTION
## Why

A post-iteration scan found the `dev` and `start` openers carried a **verbatim** five-line tool-resolution block (discover `tools/` → merge with pi defaults + `config.tools` → name-filter), and `fastagent tool` carried the discover+merge half — three parallel copies of *'the tool set this workspace mounts'*. Identical today, but a drift risk: a fix in one opener silently missed by the others.

## Change

Extracted **`resolveWorkspaceTools(config, dir)`** in `create.ts` (the assembly module, next to `resolveTools`), returning `{ tools, toolNames, toolCollisions }`. `dev.ts`, `start.ts`, and `cli.ts`'s `runTool` now call it; the now-unused `loadTools`/`mergeDiscoveredTools`/`resolveTools`/`piDefaultTools` imports are dropped from the call sites. **No behavior change** — the three sites computed the same set; this makes it a single source.

## Verify

typecheck / lint clean; **218 tests** (tool/cli/start/dev paths exercise it); build clean.