### PR TITLE
chore(release): 0.5.2

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.80.2",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Flask/WSGI for agents: serve or embed an existing agent folder (AGENTS.md + skills/) as a production capability. Engine-, model-, and host-neutral.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Patch release rolling up everything merged since 0.5.1 (all internal / CI / refactor — no runtime API change):

- **#57** ci: `--provenance` on publish (npm 11.12.1 did not auto-attach it under OIDC) + header consistency.
- **#58** redesign(login): persist via fastagent's own `CredentialStore`, not pi's `AuthStorage` — one writer over `~/.fastagent/auth.json`, deletes the #51 reconciliation machinery.
- **#59** refactor: one `resolveWorkspaceTools` shared by the dev/start/tool openers.
- **#61** refactor: extract the dev process supervisor to `src/dev-supervisor.ts` (cli.ts 690 → 606).

Bumps `core/package.json` to 0.5.2 (package.json + lock synced via `npm version`). After merge, cutting the `v0.5.2` GitHub Release triggers `publish.yml` → tokenless OIDC publish **with provenance** (the first release to carry it).