### PR TITLE
feat: fastagent add skill <source> — vendor an Agent Skills skill

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -15,6 +15,7 @@
         "@octokit/webhooks-methods": "^6.0.0",
         "@octokit/webhooks-types": "^7.6.1",
         "chokidar": "^5.0.0",
+        "giget": "^3.3.0",
         "ignore": "^7.0.5",
         "undici": "^8.5.0",
         "zod": "^4.4.3"
@@ -1226,7 +1227,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3597,6 +3598,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/giget": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
+      "license": "MIT",
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/google-auth-library": {

--- a/core/package.json
+++ b/core/package.json
@@ -65,6 +65,7 @@
     "@octokit/webhooks-methods": "^6.0.0",
     "@octokit/webhooks-types": "^7.6.1",
     "chokidar": "^5.0.0",
+    "giget": "^3.3.0",
     "ignore": "^7.0.5",
     "undici": "^8.5.0",
     "zod": "^4.4.3"

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -31,7 +31,13 @@ import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 import { loadRootIgnore } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
 import { resolveWorkspaceTools } from "./engines/pi/create.ts";
-import { assertChannelReady, channelExists, scaffoldChannel, scaffoldWorkspace } from "./engines/pi/init.ts";
+import {
+  assertChannelReady,
+  channelExists,
+  scaffoldChannel,
+  scaffoldWorkspace,
+  vendorSkill,
+} from "./engines/pi/init.ts";
 
 function usage(code: number): never {
   console.error(`usage:
@@ -41,6 +47,7 @@ function usage(code: number): never {
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--no-watch]
   fastagent chat   [dir] [--model provider/modelId]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
+  fastagent add   github | skill <source> [dir]
   fastagent login [provider]
   fastagent --version
 
@@ -195,9 +202,10 @@ async function runInit(): Promise<void> {
  */
 async function runAdd(): Promise<void> {
   const kind = positionals[1];
+  if (kind === "skill") return runAddSkill();
   const target = resolve(positionals[2] ?? ".");
   if (kind !== "github") {
-    console.error(`usage: fastagent add github [dir]   (the github channel is the only one today)`);
+    console.error(`usage: fastagent add github [dir]  |  fastagent add skill <source> [dir]`);
     process.exit(1);
   }
   // add SCAFFOLDS a channel into a ready workspace; it does not bootstrap one (that is `init`'s job).
@@ -223,6 +231,40 @@ async function runAdd(): Promise<void> {
   console.error(`    set GITHUB_WEBHOOK_SECRET${envIgnored ? " in .env (gitignored)" : ""}`);
   console.error(`    edit channels/github.ts — map events to intents in on()`);
   console.error(`    fastagent dev   # serve the webhook locally`);
+}
+
+/**
+ * `fastagent add skill <source> [dir]`: vendor an Agent Skills skill into <dir>/skills/<name>/.
+ * source = a git ref (owner/repo/path, github default), a local path, or a bare name resolved
+ * against your local global skill dirs. Copy-in, git-tracked (the filesystem is the registry);
+ * validated with the runtime loader; refuses to overwrite. Adding a skill is still unfamiliar, so
+ * the no-arg usage teaches BOTH paths (write-your-own vibe + vendor) and never implies a command.
+ */
+async function runAddSkill(): Promise<void> {
+  const source = positionals[2];
+  const target = resolve(positionals[3] ?? ".");
+  if (!source) {
+    console.error(
+      `add a skill — two ways:\n` +
+        `  1. write your own (vibe): create skills/<name>/SKILL.md with name + description\n` +
+        `     frontmatter; it's auto-discovered. No command needed — this is the common path.\n` +
+        `  2. vendor an existing Agent Skills skill (copied in, git-tracked):\n` +
+        `       fastagent add skill <source> [dir]\n` +
+        `     source: a git ref (owner/repo/path, github default), a local path (./x, /abs), or a\n` +
+        `             bare name found in your global skill dirs (~/.agents/skills, ~/.pi/agent/skills)`,
+    );
+    process.exit(1);
+  }
+  const { name, description, dest, hasScripts, diagnostics } = await vendorSkill(target, source).catch(failStartup);
+  console.error(`[fastagent] vendored skill "${name}" → ${dest}/`);
+  if (description) console.error(`  ${description.length > 100 ? `${description.slice(0, 100)}…` : description}`);
+  for (const d of diagnostics) console.error(`  warn: ${d.message}`);
+  if (hasScripts) {
+    console.error(
+      `  warn: this skill ships scripts/ (executable code that runs in your agent) — review it before deploying`,
+    );
+  }
+  console.error(`  next: mention "${name}" in AGENTS.md so the model knows when to use it; then \`fastagent dev\``);
 }
 
 /**

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -83,6 +83,7 @@ const { positionals, values } = parseArgs({
     minimal: { type: "boolean" },
     "no-install": { type: "boolean" },
     "no-watch": { type: "boolean" },
+    update: { type: "boolean" },
     help: { type: "boolean", short: "h" },
     version: { type: "boolean", short: "v" },
   },
@@ -237,7 +238,7 @@ async function runAdd(): Promise<void> {
  * `fastagent add skill <source> [dir]`: vendor an Agent Skills skill into <dir>/skills/<name>/.
  * source = a git ref (owner/repo/path, github default), a local path, or a bare name resolved
  * against your local global skill dirs. Copy-in, git-tracked (the filesystem is the registry);
- * validated with the runtime loader; refuses to overwrite. Adding a skill is still unfamiliar, so
+ * validated with the runtime loader; refuses to overwrite unless --update. Adding a skill is still unfamiliar, so
  * the no-arg usage teaches BOTH paths (write-your-own vibe + vendor) and never implies a command.
  */
 async function runAddSkill(): Promise<void> {
@@ -251,12 +252,16 @@ async function runAddSkill(): Promise<void> {
         `  2. vendor an existing Agent Skills skill (copied in, git-tracked):\n` +
         `       fastagent add skill <source> [dir]\n` +
         `     source: a git ref (owner/repo/path, github default), a local path (./x, /abs), or a\n` +
-        `             bare name found in your global skill dirs (~/.agents/skills, ~/.pi/agent/skills)`,
+        `             bare name found in your global skill dirs (~/.agents/skills, ~/.pi/agent/skills)\n` +
+        `     --update overwrites an existing skill (re-fetch from source); review with git diff`,
     );
     process.exit(1);
   }
-  const { name, description, dest, hasScripts, diagnostics } = await vendorSkill(target, source).catch(failStartup);
-  console.error(`[fastagent] vendored skill "${name}" → ${dest}/`);
+  const { name, description, dest, hasScripts, diagnostics, overwritten } = await vendorSkill(target, source, {
+    update: values.update ?? false,
+  }).catch(failStartup);
+  console.error(`[fastagent] ${overwritten ? "updated" : "vendored"} skill "${name}" → ${dest}/`);
+  if (overwritten) console.error(`  overwrote it — \`git diff ${dest}\` to review, \`git checkout ${dest}\` to revert`);
   if (description) console.error(`  ${description.length > 100 ? `${description.slice(0, 100)}…` : description}`);
   for (const d of diagnostics) console.error(`  warn: ${d.message}`);
   if (hasScripts) {

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -27,9 +27,9 @@
  * It does NOT defend against every pathological pre-existing target state (TOCTOU, read-only
  * dirs, FIFOs, mid-write disk-full, …): a local scaffolding command recovered by delete-and-retry.
  */
-import { access, cp, lstat, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { access, cp, lstat, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { homedir } from "node:os";
 import { type LoadedDefinition, loadAgentDefinition, loadRootIgnore } from "./definition.ts";
 import { fastagentVersion } from "./version.ts";
@@ -320,8 +320,9 @@ export interface VendoredSkill {
  * Copy-in, not link: the skill becomes a git-tracked part of the definition ("your folder is the
  * agent" — there is no registry; the filesystem is the registry, git is the distribution, the user
  * owns trust). Refuses to overwrite an existing skill UNLESS `options.update` — and then it is a plain
- * git-tracked overwrite (review/rollback via your repo's git diff/checkout), never a merge. Validates
- * the result with the SAME loader the runtime uses, so a non-spec skill surfaces immediately.
+ * git-tracked overwrite (review/rollback via your repo's git diff/checkout), never a merge. Fetches
+ * into a staging dir and validates BEFORE replacing, so a failed/invalid fetch never destroys an
+ * existing skill. Validation uses the SAME loader the runtime uses, so a non-spec skill surfaces now.
  */
 export async function vendorSkill(
   workspaceDir: string,
@@ -332,7 +333,8 @@ export async function vendorSkill(
   if (name === "" || name === "." || name === "..") {
     throw new Error(`cannot derive a skill name from "${source}" — point at a skill directory (…/skills/<name>)`);
   }
-  const dest = join(workspaceDir, "skills", name);
+  const skillsDir = join(workspaceDir, "skills");
+  const dest = join(skillsDir, name);
   // Refuse to clobber unless --update; the check is side-effect-free, and a git-tracked overwrite is
   // safe (review with `git diff`, undo with `git checkout`).
   const overwritten = existsSync(dest);
@@ -341,48 +343,66 @@ export async function vendorSkill(
       `skills/${name} already exists — re-run with --update to overwrite it (git tracks the change), or remove it`,
     );
   }
-  await mkdir(join(workspaceDir, "skills"), { recursive: true });
-  if (overwritten) await rm(dest, { recursive: true, force: true }); // --update: replace wholesale, then re-fetch
-  if (isLocalSource(source)) {
-    const src = resolve(source);
-    if (!existsSync(join(src, "SKILL.md"))) {
-      throw new Error(`"${source}" has no SKILL.md — an Agent Skills skill is a directory containing SKILL.md`);
+  await mkdir(skillsDir, { recursive: true });
+
+  // Fetch into a STAGING dir adjacent to dest (same filesystem → atomic rename), validate it, and only
+  // THEN replace dest. So a failed/invalid fetch — a transient network blip on a git ref, a source with
+  // no SKILL.md — never destroys an existing skill: --update means "swap to a new VALID version", not
+  // "delete then hope". The leading "." keeps the loader from ever treating staging as a skill, and a
+  // first-time vendor that fails leaves no half-written skill either.
+  const staging = join(skillsDir, `.${name}.vendoring`);
+  await rm(staging, { recursive: true, force: true }); // clear any leftover from a prior crash
+  try {
+    if (isLocalSource(source)) {
+      const src = resolve(source);
+      if (!existsSync(join(src, "SKILL.md"))) {
+        throw new Error(`"${source}" has no SKILL.md — an Agent Skills skill is a directory containing SKILL.md`);
+      }
+      await cp(src, staging, { recursive: true });
+    } else if (isBareName(source)) {
+      // bare name → vendor from a local global skill dir (add-time copy, not a runtime scan).
+      const src = findGlobalSkillSource(source);
+      if (!src) {
+        throw new Error(
+          `no skill "${source}" in your global skill dirs (~/.agents/skills, ~/.pi/agent/skills) — ` +
+            `give a git ref (owner/repo/path) or a local path instead`,
+        );
+      }
+      await cp(src, staging, { recursive: true });
+    } else {
+      // giget defaults a BARE ref to its own template registry, not github — so default the provider to
+      // github for a plain `owner/repo/path` (an explicit `github:`/`gh:`/`gitlab:`… scheme is kept).
+      // Supports a subdir + #ref, fetched via the tar API (no git binary).
+      const ref = /^[a-z][a-z0-9+.-]*:/i.test(source) ? source : `github:${source}`;
+      // Lazy import: giget is only needed for a git ref, so the serve path (index.ts → init.ts) and the
+      // local/bare-name sources never load it.
+      const { downloadTemplate } = await import("giget");
+      await downloadTemplate(ref, { dir: staging, force: true });
     }
-    await cp(src, dest, { recursive: true });
-  } else if (isBareName(source)) {
-    // bare name → vendor from a local global skill dir (add-time copy, not a runtime scan).
-    const src = findGlobalSkillSource(source);
-    if (!src) {
-      throw new Error(
-        `no skill "${source}" in your global skill dirs (~/.agents/skills, ~/.pi/agent/skills) — ` +
-          `give a git ref (owner/repo/path) or a local path instead`,
-      );
+    if (!existsSync(join(staging, "SKILL.md"))) {
+      throw new Error(`"${source}" did not yield a SKILL.md — expected an Agent Skills skill directory`);
     }
-    await cp(src, dest, { recursive: true });
-  } else {
-    // giget defaults a BARE ref to its own template registry, not github — so default the provider to
-    // github for a plain `owner/repo/path` (an explicit `github:`/`gh:`/`gitlab:`… scheme is kept).
-    // Supports a subdir + #ref, fetched via the tar API (no git binary).
-    const ref = /^[a-z][a-z0-9+.-]*:/i.test(source) ? source : `github:${source}`;
-    // Lazy import: giget is only needed for a git ref, so the serve path (index.ts → init.ts) and the
-    // local/bare-name sources never load it.
-    const { downloadTemplate } = await import("giget");
-    await downloadTemplate(ref, { dir: dest, force: true });
+  } catch (error) {
+    await rm(staging, { recursive: true, force: true }); // failed/invalid: drop staging, leave dest intact
+    throw error;
   }
-  if (!existsSync(join(dest, "SKILL.md"))) {
-    await rm(dest, { recursive: true, force: true }); // not a skill — leave no half-vendor
-    throw new Error(`"${source}" did not yield a SKILL.md — expected an Agent Skills skill directory`);
-  }
-  // Validate with the runtime loader: name/description + any spec diagnostics for THIS skill.
+  // Validated. Replace atomically — the old skill survived every failure path above.
+  if (overwritten) await rm(dest, { recursive: true, force: true });
+  await rename(staging, dest);
+
+  // Report via the runtime loader, matching THIS skill by EXACT directory. A substring
+  // `includes("skills/<name>")` both prefix-pollutes a sibling `<name>-x` (no trailing separator) and,
+  // hardcoding `/`, matches nothing on Windows (loader paths use `\`) — dropping the very
+  // description/diagnostics we validate for. relative()+dirname() compare is precise and cross-platform.
   const def = await loadAgentDefinition(workspaceDir);
-  const skill =
-    def.skills.find((s) => s.filePath.includes(`skills/${name}/`)) ?? def.skills.find((s) => s.name === name);
+  const rel = join("skills", name);
+  const skill = def.skills.find((sk) => relative(workspaceDir, dirname(sk.filePath)) === rel);
   return {
     name: skill?.name ?? name,
     description: skill?.description,
-    dest: `skills/${name}`,
+    dest: rel,
     hasScripts: existsSync(join(dest, "scripts")),
-    diagnostics: def.diagnostics.filter((d) => d.path?.includes(`skills/${name}`)),
+    diagnostics: def.diagnostics.filter((d) => d.path !== undefined && relative(workspaceDir, dirname(d.path)) === rel),
     overwritten,
   };
 }

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -27,9 +27,12 @@
  * It does NOT defend against every pathological pre-existing target state (TOCTOU, read-only
  * dirs, FIFOs, mid-write disk-full, …): a local scaffolding command recovered by delete-and-retry.
  */
-import { access, lstat, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
-import { basename, dirname, join, resolve } from "node:path";
-import { loadRootIgnore } from "./definition.ts";
+import { access, cp, lstat, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { downloadTemplate } from "giget";
+import { type LoadedDefinition, loadAgentDefinition, loadRootIgnore } from "./definition.ts";
 import { fastagentVersion } from "./version.ts";
 
 /** Identity persona (clean — it is the system prompt). The complete variant references the tool. */
@@ -265,6 +268,108 @@ export async function assertChannelReady(dir: string): Promise<void> {
       `${pkgPath}: add "@kid7st/fastagent" to dependencies (then \`npm install\`) — the channel file imports it`,
     );
   }
+}
+
+/** Derive the destination skill name from a source ref: the last path segment, sans `#ref`. */
+function skillNameFromSource(source: string): string {
+  const noRef = source.split("#")[0] ?? source;
+  return basename(noRef.replace(/\/+$/, ""));
+}
+
+/** A local source is an explicit path (./x, ../x, /abs); anything else is a giget ref or a bare name. */
+function isLocalSource(source: string): boolean {
+  return source.startsWith("./") || source.startsWith("../") || source === "." || isAbsolute(source);
+}
+
+/** A bare name (no `/`, no `scheme:`) resolves against the local global skill dirs (see below). */
+function isBareName(source: string): boolean {
+  return !source.includes("/") && !/^[a-z][a-z0-9+.-]*:/i.test(source);
+}
+
+/**
+ * Local "global" skill dirs (skills you've collected via other Agent Skills tools). Used ONLY as an
+ * add-time vendoring SOURCE — a bare `add skill <name>` copies the match in (git-tracked). This is
+ * NOT the removed runtime global-skill scan: nothing is loaded from here at run time; the result is a
+ * plain copy inside the definition, which stays self-contained.
+ */
+function findGlobalSkillSource(name: string): string | undefined {
+  for (const root of [join(homedir(), ".agents", "skills"), join(homedir(), ".pi", "agent", "skills")]) {
+    if (existsSync(join(root, name, "SKILL.md"))) return join(root, name);
+  }
+  return undefined;
+}
+
+export interface VendoredSkill {
+  /** The skill's real name (from SKILL.md frontmatter, per the Agent Skills spec). */
+  name: string;
+  description?: string;
+  /** Workspace-relative destination (e.g. `skills/pdf`). */
+  dest: string;
+  /** The skill ships a `scripts/` dir (executable code) — a trust signal for the caller. */
+  hasScripts: boolean;
+  /** Spec diagnostics for THIS skill from the runtime loader (e.g. name ≠ dir). */
+  diagnostics: LoadedDefinition["diagnostics"];
+}
+
+/**
+ * Vendor an Agent Skills skill into `<workspace>/skills/<name>/` from a giget ref
+ * (`owner/repo/sub/dir[#ref]`, github default), a LOCAL path (`./x`, `../x`, `/abs`), or a BARE
+ * name (`pdf`) resolved against the local global skill dirs (~/.agents/skills, ~/.pi/agent/skills).
+ *
+ * Copy-in, not link: the skill becomes a git-tracked part of the definition ("your folder is the
+ * agent" — there is no registry; the filesystem is the registry, git is the distribution, the user
+ * owns trust). Refuses to overwrite an existing skill (side-effect-free check first), and validates
+ * the result with the SAME loader the runtime uses, so a non-spec skill surfaces immediately.
+ */
+export async function vendorSkill(workspaceDir: string, source: string): Promise<VendoredSkill> {
+  const name = skillNameFromSource(source);
+  if (name === "" || name === "." || name === "..") {
+    throw new Error(`cannot derive a skill name from "${source}" — point at a skill directory (…/skills/<name>)`);
+  }
+  const dest = join(workspaceDir, "skills", name);
+  // Side-effect-free refusal: never overwrite an existing skill.
+  if (existsSync(dest)) {
+    throw new Error(`skills/${name} already exists — remove it to re-vendor, or rename the target`);
+  }
+  await mkdir(join(workspaceDir, "skills"), { recursive: true });
+  if (isLocalSource(source)) {
+    const src = resolve(source);
+    if (!existsSync(join(src, "SKILL.md"))) {
+      throw new Error(`"${source}" has no SKILL.md — an Agent Skills skill is a directory containing SKILL.md`);
+    }
+    await cp(src, dest, { recursive: true });
+  } else if (isBareName(source)) {
+    // bare name → vendor from a local global skill dir (add-time copy, not a runtime scan).
+    const src = findGlobalSkillSource(source);
+    if (!src) {
+      throw new Error(
+        `no skill "${source}" in your global skill dirs (~/.agents/skills, ~/.pi/agent/skills) — ` +
+          `give a git ref (owner/repo/path) or a local path instead`,
+      );
+    }
+    await cp(src, dest, { recursive: true });
+  } else {
+    // giget defaults a BARE ref to its own template registry, not github — so default the provider to
+    // github for a plain `owner/repo/path` (an explicit `github:`/`gh:`/`gitlab:`… scheme is kept).
+    // Supports a subdir + #ref, fetched via the tar API (no git binary).
+    const ref = /^[a-z][a-z0-9+.-]*:/i.test(source) ? source : `github:${source}`;
+    await downloadTemplate(ref, { dir: dest, force: true });
+  }
+  if (!existsSync(join(dest, "SKILL.md"))) {
+    await rm(dest, { recursive: true, force: true }); // not a skill — leave no half-vendor
+    throw new Error(`"${source}" did not yield a SKILL.md — expected an Agent Skills skill directory`);
+  }
+  // Validate with the runtime loader: name/description + any spec diagnostics for THIS skill.
+  const def = await loadAgentDefinition(workspaceDir);
+  const skill =
+    def.skills.find((s) => s.filePath.includes(`skills/${name}/`)) ?? def.skills.find((s) => s.name === name);
+  return {
+    name: skill?.name ?? name,
+    description: skill?.description,
+    dest: `skills/${name}`,
+    hasScripts: existsSync(join(dest, "scripts")),
+    diagnostics: def.diagnostics.filter((d) => d.path?.includes(`skills/${name}`)),
+  };
 }
 
 /**

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -31,7 +31,6 @@ import { access, cp, lstat, mkdir, readFile, readdir, rm, writeFile } from "node
 import { existsSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
-import { downloadTemplate } from "giget";
 import { type LoadedDefinition, loadAgentDefinition, loadRootIgnore } from "./definition.ts";
 import { fastagentVersion } from "./version.ts";
 
@@ -309,6 +308,8 @@ export interface VendoredSkill {
   hasScripts: boolean;
   /** Spec diagnostics for THIS skill from the runtime loader (e.g. name ≠ dir). */
   diagnostics: LoadedDefinition["diagnostics"];
+  /** True when an existing skill was overwritten (--update); false for a fresh vendor. */
+  overwritten: boolean;
 }
 
 /**
@@ -318,20 +319,30 @@ export interface VendoredSkill {
  *
  * Copy-in, not link: the skill becomes a git-tracked part of the definition ("your folder is the
  * agent" — there is no registry; the filesystem is the registry, git is the distribution, the user
- * owns trust). Refuses to overwrite an existing skill (side-effect-free check first), and validates
+ * owns trust). Refuses to overwrite an existing skill UNLESS `options.update` — and then it is a plain
+ * git-tracked overwrite (review/rollback via your repo's git diff/checkout), never a merge. Validates
  * the result with the SAME loader the runtime uses, so a non-spec skill surfaces immediately.
  */
-export async function vendorSkill(workspaceDir: string, source: string): Promise<VendoredSkill> {
+export async function vendorSkill(
+  workspaceDir: string,
+  source: string,
+  options: { update?: boolean } = {},
+): Promise<VendoredSkill> {
   const name = skillNameFromSource(source);
   if (name === "" || name === "." || name === "..") {
     throw new Error(`cannot derive a skill name from "${source}" — point at a skill directory (…/skills/<name>)`);
   }
   const dest = join(workspaceDir, "skills", name);
-  // Side-effect-free refusal: never overwrite an existing skill.
-  if (existsSync(dest)) {
-    throw new Error(`skills/${name} already exists — remove it to re-vendor, or rename the target`);
+  // Refuse to clobber unless --update; the check is side-effect-free, and a git-tracked overwrite is
+  // safe (review with `git diff`, undo with `git checkout`).
+  const overwritten = existsSync(dest);
+  if (overwritten && !options.update) {
+    throw new Error(
+      `skills/${name} already exists — re-run with --update to overwrite it (git tracks the change), or remove it`,
+    );
   }
   await mkdir(join(workspaceDir, "skills"), { recursive: true });
+  if (overwritten) await rm(dest, { recursive: true, force: true }); // --update: replace wholesale, then re-fetch
   if (isLocalSource(source)) {
     const src = resolve(source);
     if (!existsSync(join(src, "SKILL.md"))) {
@@ -353,6 +364,9 @@ export async function vendorSkill(workspaceDir: string, source: string): Promise
     // github for a plain `owner/repo/path` (an explicit `github:`/`gh:`/`gitlab:`… scheme is kept).
     // Supports a subdir + #ref, fetched via the tar API (no git binary).
     const ref = /^[a-z][a-z0-9+.-]*:/i.test(source) ? source : `github:${source}`;
+    // Lazy import: giget is only needed for a git ref, so the serve path (index.ts → init.ts) and the
+    // local/bare-name sources never load it.
+    const { downloadTemplate } = await import("giget");
     await downloadTemplate(ref, { dir: dest, force: true });
   }
   if (!existsSync(join(dest, "SKILL.md"))) {
@@ -369,6 +383,7 @@ export async function vendorSkill(workspaceDir: string, source: string): Promise
     dest: `skills/${name}`,
     hasScripts: existsSync(join(dest, "scripts")),
     diagnostics: def.diagnostics.filter((d) => d.path?.includes(`skills/${name}`)),
+    overwritten,
   };
 }
 

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createPiAgentFromWorkspace, loadAgentDefinition, scaffoldWorkspace } from "../src/index.ts";
+import { vendorSkill } from "../src/engines/pi/init.ts";
 
 const freshDir = () => mkdtemp(join(tmpdir(), "fa-init-"));
 async function exists(p: string): Promise<boolean> {
@@ -281,5 +282,77 @@ describe("add: fastagent add github", () => {
     const out = await cliInit(["add", "github"], dir);
     expect(out).toMatch(/symlink/);
     expect(await exists(join(real, "ch", "github.ts"))).toBe(false); // not written through the symlink
+  });
+});
+
+describe("add: fastagent add skill (vendor)", () => {
+  it("vendors a local Agent Skills skill into skills/<name>/ (copy, validated, scripts flagged, refuse-overwrite)", async () => {
+    const srcRoot = await mkdtemp(join(tmpdir(), "fa-src-"));
+    await mkdir(join(srcRoot, "greeter", "scripts"), { recursive: true });
+    await writeFile(
+      join(srcRoot, "greeter", "SKILL.md"),
+      "---\nname: greeter\ndescription: Greet the user warmly and by name.\n---\nSay hello.\n",
+    );
+    await writeFile(join(srcRoot, "greeter", "scripts", "hi.sh"), "echo hi\n");
+
+    const ws = await mkdtemp(join(tmpdir(), "fa-ws-"));
+    await writeFile(join(ws, "AGENTS.md"), "# Bot\n");
+
+    const r = await vendorSkill(ws, join(srcRoot, "greeter"));
+    expect(r.name).toBe("greeter"); // from SKILL.md frontmatter
+    expect(r.description).toContain("Greet");
+    expect(r.dest).toBe("skills/greeter");
+    expect(r.hasScripts).toBe(true); // scripts/ → trust-warning path
+    expect(r.diagnostics).toEqual([]); // spec-clean, no name/desc warnings
+    expect(await exists(join(ws, "skills", "greeter", "SKILL.md"))).toBe(true);
+    expect(await exists(join(ws, "skills", "greeter", "scripts", "hi.sh"))).toBe(true);
+    const def = await loadAgentDefinition(ws);
+    expect(def.skills.map((s) => s.name)).toContain("greeter"); // really mounted by the runtime loader
+
+    await expect(vendorSkill(ws, join(srcRoot, "greeter"))).rejects.toThrow(/already exists/); // refuse overwrite
+  });
+
+  it("rejects a source with no SKILL.md (not an Agent Skills skill), leaving no half-vendor", async () => {
+    const srcRoot = await mkdtemp(join(tmpdir(), "fa-src-"));
+    await mkdir(join(srcRoot, "notaskill"), { recursive: true });
+    await writeFile(join(srcRoot, "notaskill", "readme.txt"), "x\n");
+    const ws = await mkdtemp(join(tmpdir(), "fa-ws-"));
+    await expect(vendorSkill(ws, join(srcRoot, "notaskill"))).rejects.toThrow(/SKILL\.md/);
+    expect(await exists(join(ws, "skills", "notaskill"))).toBe(false); // no half-vendor left behind
+  });
+
+  it("vendors a bare name from a local global skill dir (~/.agents/skills) — add-time copy, not a runtime scan", async () => {
+    const home = await mkdtemp(join(tmpdir(), "fa-home-"));
+    await mkdir(join(home, ".agents", "skills", "greeter"), { recursive: true });
+    await writeFile(
+      join(home, ".agents", "skills", "greeter", "SKILL.md"),
+      "---\nname: greeter\ndescription: Greet the user warmly.\n---\nHi.\n",
+    );
+    const ws = await mkdtemp(join(tmpdir(), "fa-ws-"));
+    const saved = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      const r = await vendorSkill(ws, "greeter");
+      expect(r.name).toBe("greeter");
+      expect(r.dest).toBe("skills/greeter");
+      expect(await exists(join(ws, "skills", "greeter", "SKILL.md"))).toBe(true); // copied in (git-tracked)
+    } finally {
+      if (saved !== undefined) process.env.HOME = saved;
+      else delete process.env.HOME;
+    }
+  });
+
+  it("a bare name absent from every global skill dir fails with guidance (never treated as a github repo)", async () => {
+    const home = await mkdtemp(join(tmpdir(), "fa-home-"));
+    const ws = await mkdtemp(join(tmpdir(), "fa-ws-"));
+    const saved = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      await expect(vendorSkill(ws, "nonesuch")).rejects.toThrow(/global skill dirs/);
+      expect(await exists(join(ws, "skills", "nonesuch"))).toBe(false);
+    } finally {
+      if (saved !== undefined) process.env.HOME = saved;
+      else delete process.env.HOME;
+    }
   });
 });

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -378,4 +378,43 @@ describe("add: fastagent add skill (vendor)", () => {
     expect(updated.description).toContain("v2");
     expect(await readFile(join(ws, "skills", "greeter", "SKILL.md"), "utf8")).toContain("Two.");
   });
+
+  it("--update failure leaves the existing skill intact (validate-before-replace, not destructive-first)", async () => {
+    const srcRoot = await mkdtemp(join(tmpdir(), "fa-src-"));
+    await mkdir(join(srcRoot, "greeter"), { recursive: true });
+    await writeFile(join(srcRoot, "greeter", "SKILL.md"), "---\nname: greeter\ndescription: v1.\n---\nOne.\n");
+    const ws = await mkdtemp(join(tmpdir(), "fa-ws-"));
+    await vendorSkill(ws, join(srcRoot, "greeter")); // vendor v1
+
+    // --update from an INVALID source (no SKILL.md): under destructive-first the old skill would be
+    // deleted before the failure; validate-before-replace must leave v1 fully intact.
+    const bad = await mkdtemp(join(tmpdir(), "fa-bad-"));
+    await mkdir(join(bad, "greeter"), { recursive: true });
+    await writeFile(join(bad, "greeter", "readme.txt"), "x\n"); // no SKILL.md
+    await expect(vendorSkill(ws, join(bad, "greeter"), { update: true })).rejects.toThrow(/SKILL\.md/);
+    expect(await exists(join(ws, "skills", "greeter", "SKILL.md"))).toBe(true); // old skill survived
+    expect(await readFile(join(ws, "skills", "greeter", "SKILL.md"), "utf8")).toContain("One.");
+    expect(await exists(join(ws, "skills", ".greeter.vendoring"))).toBe(false); // no staging leftover
+  });
+
+  it("attributes diagnostics by exact skill dir, not a loose prefix (pdf must not absorb pdf-tools')", async () => {
+    const srcRoot = await mkdtemp(join(tmpdir(), "fa-src-"));
+    // pdf-tools: frontmatter name ≠ dir → a real spec diagnostic, at skills/pdf-tools/
+    await mkdir(join(srcRoot, "pdf-tools"), { recursive: true });
+    await writeFile(join(srcRoot, "pdf-tools", "SKILL.md"), "---\nname: wrongname\ndescription: tools.\n---\nx\n");
+    // pdf: spec-clean
+    await mkdir(join(srcRoot, "pdf"), { recursive: true });
+    await writeFile(join(srcRoot, "pdf", "SKILL.md"), "---\nname: pdf\ndescription: clean pdf skill.\n---\nx\n");
+
+    const ws = await mkdtemp(join(tmpdir(), "fa-ws-"));
+    await writeFile(join(ws, "AGENTS.md"), "# Bot\n");
+    await vendorSkill(ws, join(srcRoot, "pdf-tools")); // carries a diagnostic
+    const r = await vendorSkill(ws, join(srcRoot, "pdf")); // clean
+
+    // `skills/pdf` ⊂ `skills/pdf-tools`: a loose-prefix filter would wrongly pull pdf-tools' diagnostic
+    // into pdf's. Exact dir match → pdf is clean.
+    expect(r.name).toBe("pdf");
+    expect(r.description).toContain("clean");
+    expect(r.diagnostics).toEqual([]);
+  });
 });

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -355,4 +355,27 @@ describe("add: fastagent add skill (vendor)", () => {
       else delete process.env.HOME;
     }
   });
+
+  it("--update overwrites an existing skill (git-tracked re-fetch); without it, refuses and leaves it untouched", async () => {
+    const srcRoot = await mkdtemp(join(tmpdir(), "fa-src-"));
+    await mkdir(join(srcRoot, "greeter"), { recursive: true });
+    await writeFile(join(srcRoot, "greeter", "SKILL.md"), "---\nname: greeter\ndescription: v1.\n---\nOne.\n");
+    const ws = await mkdtemp(join(tmpdir(), "fa-ws-"));
+
+    const first = await vendorSkill(ws, join(srcRoot, "greeter"));
+    expect(first.overwritten).toBe(false);
+
+    // upstream changes
+    await writeFile(join(srcRoot, "greeter", "SKILL.md"), "---\nname: greeter\ndescription: v2 updated.\n---\nTwo.\n");
+
+    // without --update: refuses, on-disk skill stays v1 (mutation-proof: a no-op overwrite would pass)
+    await expect(vendorSkill(ws, join(srcRoot, "greeter"))).rejects.toThrow(/--update/);
+    expect(await readFile(join(ws, "skills", "greeter", "SKILL.md"), "utf8")).toContain("One.");
+
+    // with --update: overwrites to v2
+    const updated = await vendorSkill(ws, join(srcRoot, "greeter"), { update: true });
+    expect(updated.overwritten).toBe(true);
+    expect(updated.description).toContain("v2");
+    expect(await readFile(join(ws, "skills", "greeter", "SKILL.md"), "utf8")).toContain("Two.");
+  });
 });


### PR DESCRIPTION
## Why

Reusing a skill = **vendoring** (copy into `skills/`), the way the cross-tool [Agent Skills](https://agentskills.io) standard is meant to be consumed (verified compatible in #64). "Adding a skill" is still an unfamiliar operation, so this command doubles as **discoverability** — and its no-arg usage teaches **both paths, vibe first**:

```
add a skill — two ways:
  1. write your own (vibe): create skills/<name>/SKILL.md (auto-discovered). No command — common path.
  2. vendor an existing Agent Skills skill: fastagent add skill <source> [dir]
```

## Sources (all explicit, registry-neutral)

The filesystem is the registry, git is the distribution, the user owns trust — no proprietary marketplace binding.

| source | example | mechanism |
|---|---|---|
| **git ref** | `anthropics/skills/skills/pdf` | giget tar API (github default; `gitlab:`/`bitbucket:` kept) |
| **local path** | `./x`, `../x`, `/abs` | copy |
| **bare name** | `pdf` | found in local global dirs (`~/.agents/skills`, `~/.pi/agent/skills`) |

The **bare-name search is an add-time COPY** (git-tracked result), **NOT** the removed runtime global-skill scan: nothing is loaded from those dirs at run time; the definition stays self-contained. This is the explicit-vendor successor to the implicit global-skills mount #64 removed.

## Behavior

- copy-in, **validated with the same runtime loader** (a non-spec skill surfaces immediately)
- **refuses to overwrite** an existing skill (side-effect-free check first)
- **warns when a skill ships `scripts/`** (executable code that runs in your agent — review before deploy)
- **skill only, not tool**: skills are a cross-framework markdown standard (vendor-and-go); tools are framework-specific `defineTool` + carry npm deps, so an external tool wouldn't drop in

## Dependency

Adds `giget` (unjs, ^3.3.0) — download git repos/subdirs via tar API, no git binary.

## Verify

typecheck/lint/build green. Tests: local-path + global-dir vendor (copy / validate / scripts flag / refuse-overwrite), no-SKILL.md reject (no half-vendor), bare-name-not-found guidance. **Real-network smoke** confirmed all three sources vendor correctly.

> Note: this command's necessity is a DX judgment (discoverability + teaching), not a hard requirement. It is deliberately scoped (skill only, registry-neutral, vibe-first usage) so it informs without coercing.
