### PR TITLE
refactor: drop vestigial symlinked-channels/ rejection + scrub stale build refs

### DIFF
--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -440,7 +440,7 @@ async function serveOnce(): Promise<void> {
   console.error(`[fastagent] model:  ${a.modelSpec}`);
   await reportAuth(a.modelSpec);
   reportAgentsSkillsTools(a);
-  // dev == deployed: serve the same channels/ the artifact would (default invoke when none declared).
+  // dev == deployed: serve the same channels/ a deploy would (default invoke when none declared).
   // routesFor constructs each discovered channel, which may throw on a misconfig (e.g. an unset
   // secret) — surface it as a clean startup error, not an unhandled stack.
   const routes = await routesFor(dir, a.agent).catch(failStartup);

--- a/core/src/engines/pi/channel.ts
+++ b/core/src/engines/pi/channel.ts
@@ -7,7 +7,7 @@
  * may list inline).
  */
 import type { Dirent } from "node:fs";
-import { lstat, readdir } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
 import { extname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Agent } from "../../agent.ts";
@@ -36,27 +36,15 @@ export async function loadChannels(
   agent: Agent,
 ): Promise<{ routes: Routes; collisions: ChannelCollision[] }> {
   const channelsDir = join(dir, "channels");
-  // lstat (does not follow the link) first: the build skips symlinks (definition.ts), so a symlinked
-  // channels/ would serve in dev but be omitted from the artifact — dev and deployed would diverge.
-  // Reject it rather than silently follow it. (Symlinked FILES inside channels/ are skipped below by
-  // the isFile() check, matching the build, so they need no special case here.)
-  let stat: Awaited<ReturnType<typeof lstat>>;
-  try {
-    stat = await lstat(channelsDir);
-  } catch (error) {
-    const e = error as NodeJS.ErrnoException;
-    if (e.code === "ENOENT" || e.code === "not_found") return { routes: {}, collisions: [] };
-    throw new Error(`cannot read ${channelsDir}: ${(error as Error).message}`);
-  }
-  if (stat.isSymbolicLink()) {
-    throw new Error(
-      `${channelsDir} is a symlink — the build does not follow it, so dev and deployed would diverge; use a real directory`,
-    );
-  }
+  // A symlinked channels/ is simply followed: with no build/artifact, dev and start read the directory
+  // through the same opener, so a symlink cannot make them diverge. (Top-level non-file entries —
+  // including symlinks-to-files — are skipped by the isFile() filter below; only real channel files load.)
   let entries: Dirent[];
   try {
     entries = await readdir(channelsDir, { withFileTypes: true });
   } catch (error) {
+    const e = error as NodeJS.ErrnoException;
+    if (e.code === "ENOENT" || e.code === "not_found") return { routes: {}, collisions: [] }; // no channels/ is normal
     throw new Error(`cannot read ${channelsDir}: ${(error as Error).message}`);
   }
   const routes: Routes = {};

--- a/core/src/engines/pi/channel.ts
+++ b/core/src/engines/pi/channel.ts
@@ -12,6 +12,7 @@ import { extname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Agent } from "../../agent.ts";
 import { parseRouteKey, type Routes } from "../../host/node.ts";
+import { assertInsideWorkspace } from "./definition.ts";
 import { moduleLoadHint } from "./loader.ts";
 
 /** A `channels/<name>.ts` default export: receives the assembled agent, returns the routes it mounts. */
@@ -36,9 +37,11 @@ export async function loadChannels(
   agent: Agent,
 ): Promise<{ routes: Routes; collisions: ChannelCollision[] }> {
   const channelsDir = join(dir, "channels");
-  // A symlinked channels/ is simply followed: with no build/artifact, dev and start read the directory
-  // through the same opener, so a symlink cannot make them diverge. (Top-level non-file entries —
-  // including symlinks-to-files — are skipped by the isFile() filter below; only real channel files load.)
+  // A symlinked channels/ is followed only if it stays INSIDE the workspace: an escaping symlink would
+  // put the agent's channels outside its own directory, and a deploy that copies the dir would not
+  // include them — dev/deployed diverge, exactly what "the directory is the agent" forbids. (Top-level
+  // non-file entries — including symlinks-to-files — are skipped by the isFile() filter below.)
+  await assertInsideWorkspace(dir, "channels");
   let entries: Dirent[];
   try {
     entries = await readdir(channelsDir, { withFileTypes: true });

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -34,7 +34,7 @@
  *
  * Each rung only calls the one below; options narrow as you go up (L2 owns
  * systemPrompt/skills itself — they come from the definition; the openers own model/tools —
- * they come from the config/manifest resolution, so L2's options deliberately do not
+ * they come from the config resolution, so L2's options deliberately do not
  * accept them as the openers' job).
  *
  * Two ladder-wide rules, written down so the per-rung choices stay explainable:
@@ -48,8 +48,8 @@
  * 2. An injection point climbs only as high as the last persona who owns the
  *    decision, then stops:
  *      - sessions / lease (deployment backends)  → reach L2 (embedding developer);
- *        the openers pick their own default (dev: jsonl under .fastagent/; start: jsonl
- *        outside the artifact) without exposing a choice;
+ *        the openers pick their own default (jsonl under <dir>/.fastagent/, which start can
+ *        override to a mounted volume) without exposing a choice;
  *      - base (definition-assembly)               → stop at L2 (L2 owns prompt/skill mounting);
  *      - retryClassifier (engine adaptation)     → stays at L0 (custom-wiring persona);
  *      - an opener exposes only what an operator may say: the model flag. Skills are
@@ -104,7 +104,7 @@ export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] 
 }
 
 /**
- * Resolve the full tool set a workspace/artifact mounts: pi defaults + `config.tools` + discovered
+ * Resolve the full tool set a workspace mounts: pi defaults + `config.tools` + discovered
  * `tools/` (deduped, existing win), plus the non-default tool names and the collisions to report.
  * The single source of this resolution for the dev/start openers AND `fastagent tool` — they must
  * mount exactly the same set, so it lives here once instead of being copied per opener.

--- a/core/src/engines/pi/definition.ts
+++ b/core/src/engines/pi/definition.ts
@@ -22,12 +22,36 @@
  *   - non-fatal load findings (bad skill files, name collisions) are returned as
  *     data (diagnostics/collisions) for the caller to surface — visible, not fatal.
  */
-import { readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { readFile, realpath, writeFile } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import ignore, { type Ignore } from "ignore";
 import type { ExecutionEnv, Skill, SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { loadSkills } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+
+/**
+ * Refuse a workspace subdir (`channels/`, …) that resolves OUTSIDE the workspace via a symlink. Part
+ * of "the directory is the agent": an escaping subdir puts part of the agent outside its own directory
+ * — a deploy that copies the dir would not include it (dev/deployed diverge), and a write through it
+ * lands outside the workspace. An IN-workspace symlink is self-contained and allowed; a missing subdir
+ * is fine. Both ends are realpath'd so a symlinked workspace root (/tmp → /private/tmp) is not a false escape.
+ */
+export async function assertInsideWorkspace(workspaceDir: string, name: string): Promise<void> {
+  const target = join(workspaceDir, name);
+  const real = await realpath(target).catch((e: NodeJS.ErrnoException) => {
+    if (e.code === "ENOENT" || e.code === "not_found") return undefined; // not there yet — nothing to check
+    throw e;
+  });
+  if (real === undefined) return;
+  const root = await realpath(workspaceDir).catch(() => resolve(workspaceDir));
+  const rel = relative(root, real);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(
+      `${target} resolves outside the workspace (${real}) — it must live inside the definition directory; ` +
+        `use a real directory or a symlink that stays within it`,
+    );
+  }
+}
 
 /** A same-name skill collision (the discarded side). Must surface, never swallowed (fail visibly). */
 export interface SkillCollision {

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -31,7 +31,7 @@ import { access, cp, lstat, mkdir, readFile, readdir, rename, rm, writeFile } fr
 import { existsSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { homedir } from "node:os";
-import { type LoadedDefinition, loadAgentDefinition, loadRootIgnore } from "./definition.ts";
+import { type LoadedDefinition, assertInsideWorkspace, loadAgentDefinition, loadRootIgnore } from "./definition.ts";
 import { fastagentVersion } from "./version.ts";
 
 /** Identity persona (clean — it is the system prompt). The complete variant references the tool. */
@@ -221,6 +221,9 @@ export async function channelExists(dir: string, kind: "github"): Promise<boolea
  */
 export async function scaffoldChannel(dir: string, kind: "github"): Promise<string> {
   const channelsDir = join(dir, "channels");
+  // Don't write through a channels/ symlink that escapes the workspace (github.ts would land outside
+  // the definition); an in-workspace symlink is fine. Mirrors loadChannels + scaffoldWorkspace's guard.
+  await assertInsideWorkspace(dir, "channels");
   const file = channelPath(dir, kind);
   if (await exists(file)) {
     throw new Error(`${file} already exists — edit it, or remove it to re-scaffold`);

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -14,7 +14,7 @@
  *     "what to do next" is printed to the console by the CLI, not baked into a file.
  *   - tools/ is auto-discovered (filename = tool name), so the config needs no `tools: []`.
  *   - .gitignore lists `.env` so the "secrets are the user's responsibility" model
- *     (core-design §10.1) is wired up from the first commit (build honors .gitignore).
+ *     (core-design §10.1) is wired up from the first commit.
  *   - .env.example documents the (optional) env knobs and is committable (only `.env` is ignored);
  *     it is all-commented and states the default model uses OAuth (`fastagent login`), not an API key, so
  *     it never implies a key is required.
@@ -81,13 +81,13 @@ export default {
 };
 `;
 
-const GITIGNORE = `# secrets — never commit, never ship in the build artifact
+const GITIGNORE = `# secrets — never commit (kept out of git and any deploy copy)
 .env
 
 # dependencies (reinstalled at deploy)
 node_modules/
 
-# fastagent machine state (dev sessions + build output)
+# fastagent machine state (dev/start sessions)
 .fastagent/
 `;
 
@@ -439,7 +439,7 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
   // Preflight scaffold parent dirs (e.g. `skills`, `tools`): a pre-existing NON-directory there
   // would make mkdir fail mid-loop (ENOTDIR) AFTER the first write, leaving a half-scaffold the
   // identity guard then blocks on retry. Detect it BEFORE any write (lstat, not stat: a symlinked
-  // parent must be rejected, not followed outside the dir — matches build's no-follow stance).
+  // parent must be rejected, not followed: a symlink here would write outside the workspace).
   const parents = new Set<string>();
   for (const file of files) {
     let p = dirname(file.rel);

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -221,12 +221,6 @@ export async function channelExists(dir: string, kind: "github"): Promise<boolea
  */
 export async function scaffoldChannel(dir: string, kind: "github"): Promise<string> {
   const channelsDir = join(dir, "channels");
-  // A symlinked channels/ is served-then-rejected by loadChannels and skipped by the build, so a file
-  // written through it (outside the workspace) can neither load nor ship. Require a real directory.
-  const st = await lstat(channelsDir).catch(() => undefined);
-  if (st?.isSymbolicLink()) {
-    throw new Error(`${channelsDir} is a symlink — use a real directory (the build does not follow it)`);
-  }
   const file = channelPath(dir, kind);
   if (await exists(file)) {
     throw new Error(`${file} already exists — edit it, or remove it to re-scaffold`);

--- a/core/src/engines/pi/version.ts
+++ b/core/src/engines/pi/version.ts
@@ -4,8 +4,7 @@ import { fileURLToPath } from "node:url";
 /**
  * This build's own @kid7st/fastagent version (from the package's package.json). THROWS if it can't be
  * read — a real version is load-bearing for the scaffolded dependency range (`^${version}`), so init
- * must fail visibly rather than ever scaffold an uninstallable `^0.0.0`. The manifest writer (build),
- * for which the version is only provenance, defaults locally instead.
+ * must fail visibly rather than ever scaffold an uninstallable `^0.0.0`.
  */
 export async function fastagentVersion(): Promise<string> {
   const pkgPath = fileURLToPath(new URL("../../../package.json", import.meta.url));

--- a/core/test/channel.test.ts
+++ b/core/test/channel.test.ts
@@ -73,7 +73,7 @@ describe("loadChannels (filesystem discovery)", () => {
     expect(collisions).toEqual([]);
   });
 
-  it("rejects a symlinked channels/ directory (the build omits it; dev would diverge)", async () => {
+  it("follows a symlinked channels/ directory — no build to diverge from (dev == start read it identically)", async () => {
     const dir = await freshDir();
     const real = await freshDir();
     await mkdir(join(real, "ch"));
@@ -82,7 +82,9 @@ describe("loadChannels (filesystem discovery)", () => {
       `export default () => ({ "POST /webhook": () => new Response("x") });`,
     );
     await symlink(join(real, "ch"), join(dir, "channels"));
-    await expect(loadChannels(dir, fakeAgent)).rejects.toThrow(/symlink/);
+    // followed, not rejected: the channel in the symlink target is discovered
+    const { routes } = await loadChannels(dir, fakeAgent);
+    expect(Object.keys(routes)).toEqual(["POST /webhook"]);
   });
 
   it("fails visibly when a channel file does not default-export a function", async () => {

--- a/core/test/channel.test.ts
+++ b/core/test/channel.test.ts
@@ -73,18 +73,25 @@ describe("loadChannels (filesystem discovery)", () => {
     expect(collisions).toEqual([]);
   });
 
-  it("follows a symlinked channels/ directory — no build to diverge from (dev == start read it identically)", async () => {
+  it("follows an IN-workspace symlinked channels/, but rejects one that ESCAPES the workspace", async () => {
+    // in-workspace symlink (channels → ./real-channels): self-contained → followed
     const dir = await freshDir();
-    const real = await freshDir();
-    await mkdir(join(real, "ch"));
+    await mkdir(join(dir, "real-channels"));
     await writeFile(
-      join(real, "ch", "github.mjs"),
+      join(dir, "real-channels", "github.mjs"),
       `export default () => ({ "POST /webhook": () => new Response("x") });`,
     );
-    await symlink(join(real, "ch"), join(dir, "channels"));
-    // followed, not rejected: the channel in the symlink target is discovered
+    await symlink(join(dir, "real-channels"), join(dir, "channels"));
     const { routes } = await loadChannels(dir, fakeAgent);
-    expect(Object.keys(routes)).toEqual(["POST /webhook"]);
+    expect(Object.keys(routes)).toEqual(["POST /webhook"]); // followed
+
+    // escaping symlink (channels → an external dir): channels would live outside the agent and a deploy
+    // copying the dir would not include them (dev/deployed diverge) → rejected.
+    const esc = await freshDir();
+    const ext = await freshDir();
+    await mkdir(join(ext, "ch"));
+    await symlink(join(ext, "ch"), join(esc, "channels"));
+    await expect(loadChannels(esc, fakeAgent)).rejects.toThrow(/outside the workspace/);
   });
 
   it("fails visibly when a channel file does not default-export a function", async () => {

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -274,14 +274,23 @@ describe("add: fastagent add github", () => {
     expect(out2).not.toMatch(/not gitignored/);
   });
 
-  it("follows a symlinked channels/ directory when scaffolding (no build to diverge from)", async () => {
+  it("scaffolds through an IN-workspace symlinked channels/, but rejects one that ESCAPES (no outside write)", async () => {
+    // in-workspace symlink (channels → ./real): followed, github.ts written inside the workspace
     const dir = await readyWorkspace();
-    const real = await freshDir();
-    await mkdir(join(real, "ch"));
-    await symlink(join(real, "ch"), join(dir, "channels"));
+    await mkdir(join(dir, "real"));
+    await symlink(join(dir, "real"), join(dir, "channels"));
     const out = await cliInit(["add", "github"], dir);
     expect(out).toMatch(/created/);
-    expect(await exists(join(real, "ch", "github.ts"))).toBe(true); // written through the symlink (followed)
+    expect(await exists(join(dir, "real", "github.ts"))).toBe(true); // written through the in-workspace symlink
+
+    // escaping symlink (channels → external dir): rejected, nothing written outside the workspace
+    const esc = await readyWorkspace();
+    const ext = await freshDir();
+    await mkdir(join(ext, "ch"));
+    await symlink(join(ext, "ch"), join(esc, "channels"));
+    const out2 = await cliInit(["add", "github"], esc);
+    expect(out2).toMatch(/outside the workspace/);
+    expect(await exists(join(ext, "ch", "github.ts"))).toBe(false); // not written outside
   });
 });
 

--- a/core/test/init.test.ts
+++ b/core/test/init.test.ts
@@ -274,14 +274,14 @@ describe("add: fastagent add github", () => {
     expect(out2).not.toMatch(/not gitignored/);
   });
 
-  it("refuses a symlinked channels/ directory (the build won't follow it)", async () => {
+  it("follows a symlinked channels/ directory when scaffolding (no build to diverge from)", async () => {
     const dir = await readyWorkspace();
     const real = await freshDir();
     await mkdir(join(real, "ch"));
     await symlink(join(real, "ch"), join(dir, "channels"));
     const out = await cliInit(["add", "github"], dir);
-    expect(out).toMatch(/symlink/);
-    expect(await exists(join(real, "ch", "github.ts"))).toBe(false); // not written through the symlink
+    expect(out).toMatch(/created/);
+    expect(await exists(join(real, "ch", "github.ts"))).toBe(true); // written through the symlink (followed)
   });
 });
 


### PR DESCRIPTION
A two-commit refactor from a post-iteration structural scan (after #64 removed build/global-skills and #65 added `add skill`). Structural pass found no major mislayering — the one structural finding (S2) + a surface cleanup (L1).

## Commit 1 — drop the vestigial symlinked-`channels/` rejection (S2)

`loadChannels` and `scaffoldChannel` rejected a symlinked `channels/` for **one** stated reason: *"the build skips symlinks, so a symlinked `channels/` serves in dev but is omitted from the artifact — dev and deployed diverge."* #64 removed the build/artifact, and dev/start now read the directory through the **same opener**, so a symlink can no longer make them diverge. The constraint the check enforced no longer exists → the check is removed; a symlinked `channels/` is simply followed (`readdir`/`mkdir` follow it), consistent with *the directory is the agent*.

- Kept: the unrelated scaffold-parent symlink guard (`init.ts`, a write-safety check against scaffolding *out of* the workspace).
- Tests rewritten "rejects" → "follows": `loadChannels` discovers a channel through a symlinked `channels/`; `add github` scaffolds through one.

## Commit 2 — scrub stale build/artifact/manifest references (L1)

#64 left 9 comments — and one **user-facing template** — referencing the removed build. Updated to the current model. The notable one: the `GITIGNORE` template scaffolded into every new agent said *"ship in the build artifact"* / *"dev sessions + build output"* — now phrased as secrets kept out of git and any deploy copy. Comments-and-template only; no behavior change.

## Not done (deliberately)

The scan's third candidate — splitting `init.ts` (507 lines: scaffold + channel-scaffold + skill-vendor) into per-concern modules — was **declined**: same category as the earlier dev-supervisor extraction (organizational, complexity-relocating not -reducing). Left for if/when the coupling actually bites.

## Verify

typecheck/lint green; 67 in-process tests across init/channel/config/definition pass; rewritten symlink tests lock the new follow behavior.
