### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.80.2",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Flask/WSGI for agents: serve or embed an existing agent folder (AGENTS.md + skills/) as a production capability. Engine-, model-, and host-neutral.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Version bump 0.5.2 → 0.6.0. After merge, cutting the `v0.6.0` GitHub Release triggers `publish.yml` → tokenless OIDC publish to npmjs.

## Breaking (pre-1.0 minor bump)

- **Removed `fastagent build` + the artifact/manifest concept.** An agent has no compile output — `build` was packaging, and it forced the ephemeral artifact dir to double as the agent's cwd. `start` now runs the definition directory directly (model/http from `fastagent.config.ts`, frozen by git, not a manifest). Deploy = copy the dir + `npm ci` + `start`. (#64)
- **Removed global skills** (`--global-skills`, `defaultGlobalSkillPaths`, `skillPaths`). Skills come ONLY from the definition's own `skills/` — your folder is the agent, no machine-state leak. (#64)
- **Public surface** dropped `buildPiArtifact` / `ArtifactManifest` / `BuildPiArtifactOptions` / `createPiAgentFromArtifact` / `loadManifest` / `CreatePiAgentFromArtifactOptions` / `defaultGlobalSkillPaths`.

## New

- **`fastagent add skill <source>`** — vendor an [Agent Skills](https://agentskills.io) skill into `skills/<name>/`. Sources: a git ref (`owner/repo/path`, github default, via giget), a local path, or a bare name resolved against your local global skill dirs. `--update` re-fetches with an atomic staging swap; refuses to overwrite without it; warns on `scripts/`. Registry-neutral (the filesystem is the registry, git the distribution). (#65, #66)

## Fixes / refactors

- add-skill: atomic staging swap (a failed `--update` no longer destroys the existing skill), exact-dir report (no prefix pollution, cross-platform).
- channels: an escaping-`channels/` symlink is rejected in both load and scaffold (self-containment); an in-workspace symlink is followed.
- scrubbed stale build/artifact/manifest references left by #64, incl. the scaffolded `.gitignore` template.

## Verify

typecheck/lint green; 161 tests; version + lock synced via `npm version`.
