### PR TITLE
feat(login): provider picker via @clack/prompts on pi-ai's unified ProviderAuth API

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
+        "@clack/prompts": "^1.6.0",
         "@earendil-works/pi-agent-core": "^0.80.2",
         "@earendil-works/pi-ai": "^0.80.2",
         "@earendil-works/pi-coding-agent": "^0.80.2",
@@ -682,6 +683,34 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
+      "integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.2",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
@@ -3504,6 +3533,30 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4280,6 +4333,12 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/core/package.json
+++ b/core/package.json
@@ -59,6 +59,7 @@
     "format": "biome check --write src test examples"
   },
   "dependencies": {
+    "@clack/prompts": "^1.6.0",
     "@earendil-works/pi-agent-core": "^0.80.2",
     "@earendil-works/pi-ai": "^0.80.2",
     "@earendil-works/pi-coding-agent": "^0.80.2",

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -14,7 +14,7 @@
  */
 import { spawn } from "node:child_process";
 import { join, relative, resolve } from "node:path";
-import { createInterface } from "node:readline/promises";
+import { autocomplete, isCancel, log, password, select, text as clackText } from "@clack/prompts";
 import { parseArgs } from "node:util";
 import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
 import type { Agent } from "./agent.ts";
@@ -275,7 +275,7 @@ async function runAddSkill(): Promise<void> {
 /**
  * `fastagent login [provider]`: authenticate a model provider into `~/.fastagent/auth.json`. An
  * OAuth-capable provider runs the device/browser flow; any other provider id stores an API key. The
- * flow logic lives in engines/pi/login.ts; here we supply the terminal IO (readline + browser open).
+ * flow logic lives in engines/pi/login.ts; here we supply the terminal IO (@clack/prompts + browser open).
  */
 async function runLogin(): Promise<void> {
   const io = terminalLoginIO();
@@ -289,47 +289,21 @@ function openBrowser(url: string): void {
   spawn(cmd, [url], { stdio: "ignore", detached: true, shell: process.platform === "win32" }).on("error", () => {});
 }
 
-/** Read one line of input with NO echo (for API keys), via raw-mode stdin. */
-function readHidden(message: string): Promise<string> {
-  return new Promise((resolveLine, reject) => {
-    const stdin = process.stdin;
-    process.stderr.write(message);
-    const wasRaw = stdin.isRaw ?? false;
-    stdin.setRawMode?.(true);
-    stdin.resume();
-    let buf = "";
-    const done = (fn: () => void) => {
-      stdin.off("data", onData);
-      stdin.setRawMode?.(wasRaw);
-      stdin.pause();
-      process.stderr.write("\n");
-      fn();
-    };
-    const onData = (d: Buffer) => {
-      for (const ch of d.toString("utf8")) {
-        if (ch === "\r" || ch === "\n") return done(() => resolveLine(buf));
-        if (ch === "\u0003") return done(() => reject(new Error("cancelled"))); // Ctrl-C
-        if (ch === "\u007f" || ch === "\b") buf = buf.slice(0, -1);
-        else if (ch >= " ") buf += ch;
-      }
-    };
-    stdin.on("data", onData);
-  });
-}
-
-/** Terminal IO for the login flow: a fresh readline per visible prompt, raw-mode for hidden input. */
+/** Login terminal IO via @clack/prompts: a searchable list once long, a hidden prompt for keys. */
 function terminalLoginIO(): LoginIO {
   return {
-    print: (line) => console.error(line),
-    prompt: async (message, signal) => {
-      const rl = createInterface({ input: process.stdin, output: process.stderr });
-      try {
-        return await (signal ? rl.question(message, { signal }) : rl.question(message));
-      } finally {
-        rl.close();
-      }
+    async select(message, options) {
+      // autocomplete (searchable) once the list is long (the API-key providers); plain select otherwise.
+      const r = await (options.length > 7 ? autocomplete : select)({ message, options });
+      return isCancel(r) ? undefined : (r as string);
     },
-    promptHidden: (message) => readHidden(message),
+    async prompt(message, opts) {
+      const r = opts?.hidden
+        ? await password({ message, signal: opts.signal })
+        : await clackText({ message, signal: opts?.signal });
+      return isCancel(r) ? undefined : (r as string);
+    },
+    note: (message) => log.info(message),
     openUrl: openBrowser,
   };
 }

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -273,9 +273,11 @@ async function runAddSkill(): Promise<void> {
 }
 
 /**
- * `fastagent login [provider]`: authenticate a model provider into `~/.fastagent/auth.json`. An
- * OAuth-capable provider runs the device/browser flow; any other provider id stores an API key. The
- * flow logic lives in engines/pi/login.ts; here we supply the terminal IO (@clack/prompts + browser open).
+ * `fastagent login [provider]`: authenticate a model provider into `~/.fastagent/auth.json`. Pick an
+ * authentication method (subscription/OAuth or API key), then a provider that offers it (with its
+ * configured status). A `[provider]` argument skips the provider picker and takes the method from what
+ * that provider supports — asked only when it offers both. The flow logic lives in engines/pi/login.ts;
+ * here we supply the terminal IO (@clack/prompts + browser open).
  */
 async function runLogin(): Promise<void> {
   const io = terminalLoginIO();

--- a/core/src/engines/pi/login.ts
+++ b/core/src/engines/pi/login.ts
@@ -1,144 +1,198 @@
 /**
- * `fastagent login`: authenticate a model provider into fastagent's OWN `~/.fastagent/auth.json` via
+ * `fastagent login`: authenticate a MODEL PROVIDER into fastagent's OWN `~/.fastagent/auth.json` via
  * the SAME {@link fastagentCredentialStore} the runtime uses — ONE writer over the file, ONE
- * corruption/lock semantics. The OAuth device/browser flow comes from pi-ai/oauth
- * (`getOAuthProvider().login`); the result is persisted with `store.modify`, which refuses to clobber a
- * corrupt file — so a failed save fails visibly without any extra reconciliation machinery. An
- * OAuth-capable provider (Anthropic Claude Pro/Max, ChatGPT Codex, GitHub Copilot) runs the flow; any
- * other provider id stores an API key.
+ * corruption/lock semantics.
  *
- * Why not pi's `AuthStorage`: the runtime resolves auth through pi-ai's `CredentialStore` port (Models
- * consumes it), and pi ships no file-backed `CredentialStore` — so `fastagentCredentialStore` is
- * mandatory and already owns the file. `AuthStorage` is pi-coding-agent's CLI-world manager (a
- * different port, record-don't-throw persistence); routing login through it put two stores over one
- * file. Login joins the engine-world store instead.
+ * Scope: this is **model provider** auth (the runtime credential to call an LLM), NOT deploy/platform
+ * auth. Deploy-target auth (a future `fastagent deploy login`) is a separate K-axis concern with its
+ * own store; login never touches it (see core-design: auth is separated by what it serves).
  *
- * The terminal IO and the OAuth flow are INJECTED ({@link LoginIO}, {@link OAuthFlow}) so the routing
- * is testable against a real store without real stdin or a real OAuth round-trip.
+ * Flow (pi-ai's UNIFIED `ProviderAuth` API, not the deprecated oauth-only one): pick an authentication
+ * method (subscription/OAuth or API key), then a provider that offers it (with its configured status),
+ * then run `provider.auth.{oauth|apiKey}.login(callbacks)` — one path for both, driven by pi-ai's
+ * `AuthLoginCallbacks` — and persist the returned credential with `store.modify`, which refuses to
+ * clobber a corrupt file (a failed save fails visibly without extra reconciliation).
+ *
+ * The terminal IO is INJECTED ({@link LoginIO}) and providers are injectable, so the routing is
+ * testable against a real store without real stdin or a real auth round-trip. The CLI wires `LoginIO`
+ * to `@clack/prompts` (searchable select + hidden password), never a full-screen TUI.
  */
-import type { Credential, CredentialStore, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import { getOAuthProvider, getOAuthProviderInfoList } from "@earendil-works/pi-ai/oauth";
+import type {
+  AuthEvent,
+  AuthLoginCallbacks,
+  AuthPrompt,
+  Credential,
+  CredentialStore,
+  Provider,
+} from "@earendil-works/pi-ai";
+import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
 import { FASTAGENT_AUTH_PATH, fastagentCredentialStore } from "./auth.ts";
 
-/** Terminal interaction, injectable for tests (no real stdin/stdout or browser in unit tests). */
+/** One picker option: a stable `value`, a human `label`, and an optional `hint` (e.g. configured status). */
+export interface IoOption {
+  value: string;
+  label: string;
+  hint?: string;
+}
+
+/**
+ * Terminal interaction, injectable for tests (no real stdin/stdout or browser). The CLI implements it
+ * with `@clack/prompts` (a searchable list for many options, a hidden prompt for keys).
+ */
 export interface LoginIO {
-  print(line: string): void;
-  /** Read a line of visible input (codes, selections); rejects if `signal` aborts (cancellable paste). */
-  prompt(message: string, signal?: AbortSignal): Promise<string>;
-  /** Read a line with no echo (API keys). */
-  promptHidden(message: string): Promise<string>;
+  /** Single-choice picker. Returns the chosen `value`, or undefined on cancel. */
+  select(message: string, options: IoOption[]): Promise<string | undefined>;
+  /** Free-text or hidden input. Returns the entered string, or undefined on cancel/abort. */
+  prompt(message: string, opts?: { hidden?: boolean; signal?: AbortSignal }): Promise<string | undefined>;
+  /** Print an informational line (auth URL, device code, progress). */
+  note(message: string): void;
   /** Best-effort open a URL in the browser (printed regardless). */
   openUrl(url: string): void;
 }
 
-/** The OAuth device/browser flow for a provider — injected so the routing is testable without a round-trip. */
-export type OAuthFlow = (providerId: string, callbacks: OAuthLoginCallbacks) => Promise<OAuthCredentials>;
-
-const defaultOAuthFlow: OAuthFlow = (providerId, callbacks) => {
-  const provider = getOAuthProvider(providerId);
-  if (!provider) throw new Error(`unknown OAuth provider "${providerId}"`);
-  return provider.login(callbacks);
-};
-
+export type LoginMethod = "oauth" | "api_key";
 export interface LoginResult {
   provider: string;
-  method: "oauth" | "api_key";
+  method: LoginMethod;
 }
 
-/** Present a numbered list; accept a number or a literal id; undefined on an empty answer (cancel). */
-async function chooseFromList(
-  io: LoginIO,
-  message: string,
-  options: Array<{ id: string; label: string }>,
-): Promise<string | undefined> {
-  io.print(message);
-  options.forEach((o, i) => {
-    io.print(`  ${i + 1}. ${o.label}`);
-  });
-  const answer = (await io.prompt("> ")).trim();
-  if (answer === "") return undefined;
-  const n = Number(answer);
-  if (Number.isInteger(n) && n >= 1 && n <= options.length) return options[n - 1]?.id;
-  return options.find((o) => o.id === answer)?.id;
+/** Combine present abort signals into one (no-op when none/one). */
+function anySignal(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const present = signals.filter((s): s is AbortSignal => s !== undefined);
+  return present.length === 0 ? undefined : present.length === 1 ? present[0] : AbortSignal.any(present);
 }
 
 /**
- * pi's anthropic/codex `onAuth` tells the user they may paste the redirect URL from another machine,
- * but that paste is only offered CONCURRENTLY with the local callback server when `onManualCodeInput`
- * is wired — otherwise the flow blocks on the server and the instruction is an empty promise. We wire
- * it to a cancellable prompt (`manualPromptSignal`): a browser/server win leaves that prompt pending,
- * so the caller aborts the signal to cancel it instead of hanging the one-shot CLI on stdin.
+ * Map pi-ai's unified `AuthLoginCallbacks` onto the injected {@link LoginIO}. `userSignal` is the
+ * overall login abort (e.g. CLI Ctrl-C); `doneSignal` fires when the flow resolves, so a prompt the
+ * provider left pending (a manual-code paste racing a callback server it just won) is cancelled and
+ * the one-shot CLI can exit instead of hanging on stdin.
  */
-function oauthCallbacks(io: LoginIO, manualPromptSignal: AbortSignal, signal?: AbortSignal): OAuthLoginCallbacks {
+function authCallbacks(io: LoginIO, userSignal: AbortSignal | undefined, doneSignal: AbortSignal): AuthLoginCallbacks {
   return {
-    onAuth: ({ url, instructions }) => {
-      io.print(`Open this URL to authorize:\n  ${url}`);
-      if (instructions) io.print(instructions);
-      io.openUrl(url);
+    signal: userSignal,
+    prompt: async (p: AuthPrompt): Promise<string> => {
+      if (p.type === "select") {
+        const v = await io.select(
+          p.message,
+          p.options.map((o) => ({ value: o.id, label: o.label, hint: o.description })),
+        );
+        if (v === undefined) throw new Error("cancelled");
+        return v;
+      }
+      const signal = anySignal(p.signal, userSignal, doneSignal);
+      const v = await io.prompt(p.message, { hidden: p.type === "secret", signal });
+      if (v === undefined) throw new Error("cancelled");
+      return v;
     },
-    onDeviceCode: ({ userCode, verificationUri }) => {
-      io.print(`Go to ${verificationUri} and enter the code:  ${userCode}`);
-      io.openUrl(verificationUri);
+    notify: (e: AuthEvent): void => {
+      if (e.type === "auth_url") {
+        io.note(`Open this URL to authorize:\n  ${e.url}`);
+        if (e.instructions) io.note(e.instructions);
+        io.openUrl(e.url);
+      } else if (e.type === "device_code") {
+        io.note(`Go to ${e.verificationUri} and enter the code:  ${e.userCode}`);
+        io.openUrl(e.verificationUri);
+      } else {
+        io.note(e.message);
+      }
     },
-    onPrompt: ({ message }) => io.prompt(message),
-    onManualCodeInput: () =>
-      io.prompt("…or paste the final redirect URL here if your browser is on another machine: ", manualPromptSignal),
-    onSelect: ({ message, options }) => chooseFromList(io, message, options),
-    onProgress: (message) => io.print(`  ${message}`),
-    signal,
   };
 }
 
+/** Providers offering the given method as an INTERACTIVE login (so `login` can actually run it). */
+function candidatesFor(providers: Provider[], method: LoginMethod): Provider[] {
+  return providers.filter((p) => (method === "oauth" ? p.auth.oauth : p.auth.apiKey?.login));
+}
+
+async function selectMethod(io: LoginIO): Promise<LoginMethod> {
+  const v = await io.select("Authentication method", [
+    { value: "oauth", label: "Use a subscription (OAuth)" },
+    { value: "api_key", label: "Use an API key" },
+  ]);
+  if (v !== "oauth" && v !== "api_key") throw new Error("no authentication method selected");
+  return v;
+}
+
+/** Given a provider arg, pick the method it supports (asking only when it offers both). */
+async function methodForProvider(io: LoginIO, p: Provider): Promise<LoginMethod> {
+  const hasOauth = !!p.auth.oauth;
+  const hasKeyLogin = !!p.auth.apiKey?.login;
+  if (hasOauth && hasKeyLogin) return selectMethod(io);
+  if (hasOauth) return "oauth";
+  if (hasKeyLogin) return "api_key";
+  throw new Error(`provider "${p.id}" has no interactive login — set its API key via the provider's env var`);
+}
+
+/** List providers for the method with their configured status, and let the user pick one. */
+async function selectProvider(
+  io: LoginIO,
+  providers: Provider[],
+  method: LoginMethod,
+  store: CredentialStore,
+): Promise<string> {
+  const candidates = candidatesFor(providers, method);
+  if (candidates.length === 0) throw new Error(`no provider supports ${method} login`);
+  const options = await Promise.all(
+    candidates.map(async (p): Promise<IoOption> => {
+      const cred = await store.read(p.id);
+      const auth = method === "oauth" ? p.auth.oauth : p.auth.apiKey;
+      return { value: p.id, label: auth?.name ?? p.name, hint: cred ? `configured (${cred.type})` : undefined };
+    }),
+  );
+  const id = await io.select("Select a provider", options);
+  if (!id) throw new Error("no provider selected");
+  return id;
+}
+
 /**
- * Resolve the provider (argument or interactive select among the OAuth providers), then either run the
- * OAuth flow or prompt for an API key, and persist via `store.modify`. The persist refuses to overwrite
- * a corrupt file, so it fails visibly on its own; a no-op `modify` up front runs that same check BEFORE
- * the OAuth round-trip / key prompt, so a known-bad file fails fast instead of after the user's work.
+ * Resolve method + provider (asking only what is not already given), run the provider's login flow,
+ * and persist. The persist refuses a corrupt file, so it fails visibly on its own; a no-op `modify` up
+ * front runs that same check BEFORE the flow, so a known-bad file fails fast instead of after the work.
  */
 export async function loginFlow(
   io: LoginIO,
   options: {
     provider?: string;
+    method?: LoginMethod;
     authPath?: string;
     store?: CredentialStore;
-    oauthFlow?: OAuthFlow;
+    providers?: Provider[];
     signal?: AbortSignal;
   } = {},
 ): Promise<LoginResult> {
   const store = options.store ?? fastagentCredentialStore(options.authPath ?? FASTAGENT_AUTH_PATH);
-  const oauthFlow = options.oauthFlow ?? defaultOAuthFlow;
-  const oauthProviders = getOAuthProviderInfoList();
+  const providers = options.providers ?? builtinProviders();
 
-  let provider = options.provider;
-  if (!provider) {
-    provider = await chooseFromList(
-      io,
-      "Which provider? (or `fastagent login <provider>` to set an API key)",
-      oauthProviders.map((p) => ({ id: p.id, label: `${p.name} (${p.id})` })),
-    );
-    if (!provider) throw new Error("no provider selected");
+  let method: LoginMethod;
+  let providerId: string;
+  if (options.provider) {
+    providerId = options.provider;
+    const p = providers.find((x) => x.id === providerId);
+    if (!p) throw new Error(`unknown provider "${providerId}"`);
+    method = options.method ?? (await methodForProvider(io, p));
+  } else {
+    method = options.method ?? (await selectMethod(io));
+    providerId = await selectProvider(io, providers, method, store);
   }
 
-  // Preflight: a no-op modify runs the store's refuse-corrupt check (and surfaces an unwritable file)
-  // before any OAuth round-trip or key prompt — so the user is not made to do the work only to fail.
-  await store.modify(provider, async () => undefined);
+  // Preflight: a no-op modify runs the store's refuse-corrupt / writability check BEFORE the flow.
+  await store.modify(providerId, async () => undefined);
 
-  if (oauthProviders.some((p) => p.id === provider)) {
-    const promptAbort = new AbortController();
-    let credentials: OAuthCredentials;
-    try {
-      credentials = await oauthFlow(provider, oauthCallbacks(io, promptAbort.signal, options.signal));
-    } finally {
-      // A server/browser win leaves the concurrent manual-paste prompt pending on stdin; abort it so
-      // the one-shot CLI can exit (pi does not await that prompt once the server returns a code).
-      promptAbort.abort();
-    }
-    await store.modify(provider, async (): Promise<Credential> => ({ type: "oauth", ...credentials }));
-    return { provider, method: "oauth" };
+  const provider = providers.find((p) => p.id === providerId);
+  if (!provider) throw new Error(`unknown provider "${providerId}"`);
+  const auth = method === "oauth" ? provider.auth.oauth : provider.auth.apiKey;
+  if (!auth?.login) throw new Error(`provider "${providerId}" has no ${method} login`);
+
+  // `done` fires when login resolves, cancelling any prompt the provider left pending (manual-code
+  // race backstop) so the one-shot CLI exits instead of hanging on stdin.
+  const done = new AbortController();
+  let credential: Credential;
+  try {
+    credential = await auth.login(authCallbacks(io, options.signal, done.signal));
+  } finally {
+    done.abort();
   }
-
-  const key = (await io.promptHidden(`API key for "${provider}": `)).trim();
-  if (!key) throw new Error(`no API key entered for "${provider}"`);
-  await store.modify(provider, async (): Promise<Credential> => ({ type: "api_key", key }));
-  return { provider, method: "api_key" };
+  await store.modify(providerId, async () => credential);
+  return { provider: providerId, method };
 }

--- a/core/test/login.test.ts
+++ b/core/test/login.test.ts
@@ -1,16 +1,15 @@
 import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getOAuthProviderInfoList } from "@earendil-works/pi-ai/oauth";
-import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import type { AuthLoginCallbacks, Credential, Provider } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { fastagentCredentialStore } from "../src/engines/pi/auth.ts";
-import type { LoginIO, OAuthFlow } from "../src/engines/pi/login.ts";
+import type { IoOption, LoginIO } from "../src/engines/pi/login.ts";
 import { loginFlow } from "../src/engines/pi/login.ts";
 
 // The store is the REAL fastagentCredentialStore over a temp file — the same writer the runtime uses,
-// so these tests exercise the actual persist/corruption semantics, not a mock of them. Only the OAuth
-// device/browser flow (external) is injected.
+// so these tests exercise the actual persist/corruption semantics. Only the providers' login flow
+// (external) is injected via fake providers; pi's unified ProviderAuth shape is what loginFlow drives.
 async function tmpAuth(content?: string): Promise<string> {
   const path = join(await mkdtemp(join(tmpdir(), "fa-login-")), "auth.json");
   if (content !== undefined) await writeFile(path, content);
@@ -18,129 +17,198 @@ async function tmpAuth(content?: string): Promise<string> {
 }
 const readAuth = async (path: string) => JSON.parse(await readFile(path, "utf8"));
 
-/** A fake terminal: scripted prompt/hidden answers, no real stdin/browser. */
-function fakeIO(answers: { prompt?: string[]; hidden?: string[] } = {}): LoginIO {
-  const prompts = [...(answers.prompt ?? [])];
-  const hiddens = [...(answers.hidden ?? [])];
+const OAUTH_CRED: Credential = { type: "oauth", access: "tok", refresh: "rt", expires: Date.now() + 3_600_000 };
+
+/** A fake provider: an oauth login returning a fixed credential, and/or an api-key login that prompts. */
+function fakeProvider(
+  id: string,
+  opts: { oauth?: boolean; apiKeyLogin?: boolean; onOauthLogin?: (cb: AuthLoginCallbacks) => Promise<Credential> } = {},
+): Provider {
   return {
-    print: () => {},
-    prompt: async () => prompts.shift() ?? "",
-    promptHidden: async () => hiddens.shift() ?? "",
-    openUrl: () => {},
-  };
+    id,
+    name: id,
+    auth: {
+      oauth: opts.oauth ? { name: `${id} (OAuth)`, login: opts.onOauthLogin ?? (async () => OAUTH_CRED) } : undefined,
+      apiKey: opts.apiKeyLogin
+        ? {
+            name: `${id} API key`,
+            login: async (cb: AuthLoginCallbacks): Promise<Credential> => ({
+              type: "api_key",
+              key: await cb.prompt({ type: "secret", message: "API key" }),
+            }),
+          }
+        : undefined,
+    },
+  } as unknown as Provider;
 }
 
-const fakeCreds = { access: "tok", refresh: "rt", expires: Date.now() + 3_600_000 } as unknown as OAuthCredentials;
-const oauthOk: OAuthFlow = async () => fakeCreds;
+const PROVIDERS = [
+  fakeProvider("anthropic", { oauth: true, apiKeyLogin: true }), // both methods
+  fakeProvider("openai", { apiKeyLogin: true }), // key only
+  fakeProvider("codex", { oauth: true }), // oauth only
+];
+
+/** Scripted terminal: `select`/`prompt` answers in order; records the options shown to each `select`. */
+function fakeIO(script: { select?: Array<string | undefined>; prompt?: Array<string | undefined> } = {}) {
+  const selects = [...(script.select ?? [])];
+  const prompts = [...(script.prompt ?? [])];
+  const shown: IoOption[][] = [];
+  const io: LoginIO = {
+    select: async (_message, options) => {
+      shown.push(options);
+      return selects.shift();
+    },
+    prompt: async () => prompts.shift(),
+    note: () => {},
+    openUrl: () => {},
+  };
+  return { io, shown };
+}
 
 describe("loginFlow", () => {
-  it("an OAuth-capable provider runs the flow and persists {type:oauth} via the store", async () => {
+  it("a single-method provider auto-runs that method (oauth) and persists {type:oauth}", async () => {
     const path = await tmpAuth();
-    const store = fastagentCredentialStore(path);
-    const res = await loginFlow(fakeIO(), { provider: "anthropic", store, oauthFlow: oauthOk });
-    expect(res).toEqual({ provider: "anthropic", method: "oauth" });
-    expect((await readAuth(path)).anthropic).toMatchObject({ type: "oauth", access: "tok" });
+    const res = await loginFlow(fakeIO().io, {
+      provider: "codex",
+      providers: PROVIDERS,
+      store: fastagentCredentialStore(path),
+    });
+    expect(res).toEqual({ provider: "codex", method: "oauth" });
+    expect((await readAuth(path)).codex).toMatchObject({ type: "oauth", access: "tok" });
   });
 
-  it("any non-OAuth provider prompts (hidden) for and persists {type:api_key}", async () => {
+  it("an api-key provider prompts (hidden) and persists {type:api_key}", async () => {
     const path = await tmpAuth();
-    const store = fastagentCredentialStore(path);
-    const res = await loginFlow(fakeIO({ hidden: ["sk-123"] }), { provider: "openai", store, oauthFlow: oauthOk });
+    const res = await loginFlow(fakeIO({ prompt: ["sk-123"] }).io, {
+      provider: "openai",
+      providers: PROVIDERS,
+      store: fastagentCredentialStore(path),
+    });
     expect(res).toEqual({ provider: "openai", method: "api_key" });
     expect((await readAuth(path)).openai).toEqual({ type: "api_key", key: "sk-123" });
   });
 
-  it("no provider → interactive select among the real OAuth providers (by number or id)", async () => {
-    const first = getOAuthProviderInfoList()[0]?.id; // the list is pi's; assert against it, not a hardcode
-    const byNumber = await loginFlow(fakeIO({ prompt: ["1"] }), {
-      store: fastagentCredentialStore(await tmpAuth()),
-      oauthFlow: oauthOk,
+  it("a dual-method provider asks which method, then runs it", async () => {
+    const path = await tmpAuth();
+    const res = await loginFlow(fakeIO({ select: ["api_key"], prompt: ["sk-a"] }).io, {
+      provider: "anthropic",
+      providers: PROVIDERS,
+      store: fastagentCredentialStore(path),
     });
-    expect(byNumber.provider).toBe(first);
-    const byId = await loginFlow(fakeIO({ prompt: ["anthropic"] }), {
-      store: fastagentCredentialStore(await tmpAuth()),
-      oauthFlow: oauthOk,
-    });
-    expect(byId.provider).toBe("anthropic");
+    expect(res).toEqual({ provider: "anthropic", method: "api_key" });
+    expect((await readAuth(path)).anthropic).toEqual({ type: "api_key", key: "sk-a" });
   });
 
-  it("an empty selection fails visibly", async () => {
+  it("no args → method select then provider select (filtered to that method)", async () => {
+    const path = await tmpAuth();
+    const { io, shown } = fakeIO({ select: ["oauth", "anthropic"] });
+    const res = await loginFlow(io, { providers: PROVIDERS, store: fastagentCredentialStore(path) });
+    expect(res).toEqual({ provider: "anthropic", method: "oauth" });
+    // the provider picker listed only oauth-capable providers (anthropic, codex), NOT the key-only openai
+    expect(shown[1]?.map((o) => o.value).sort()).toEqual(["anthropic", "codex"]);
+  });
+
+  it("the provider picker shows configured status from the store", async () => {
+    const path = await tmpAuth();
+    const store = fastagentCredentialStore(path);
+    await store.modify("anthropic", async () => OAUTH_CRED); // pre-configure
+    const { io, shown } = fakeIO({ select: ["oauth", "codex"] });
+    await loginFlow(io, { providers: PROVIDERS, store });
+    expect(shown[1]?.find((o) => o.value === "anthropic")?.hint).toMatch(/configured \(oauth\)/);
+    expect(shown[1]?.find((o) => o.value === "codex")?.hint).toBeUndefined(); // unconfigured
+  });
+
+  it("an empty provider selection fails visibly", async () => {
     await expect(
-      loginFlow(fakeIO({ prompt: [""] }), { store: fastagentCredentialStore(await tmpAuth()), oauthFlow: oauthOk }),
+      loginFlow(fakeIO({ select: ["oauth", undefined] }).io, {
+        providers: PROVIDERS,
+        store: fastagentCredentialStore(await tmpAuth()),
+      }),
     ).rejects.toThrow(/no provider selected/);
   });
 
   it("an empty API key fails visibly and persists no credential", async () => {
     const path = await tmpAuth();
     await expect(
-      loginFlow(fakeIO({ hidden: [""] }), {
+      loginFlow(fakeIO({ prompt: [undefined] }).io, {
         provider: "openai",
+        providers: PROVIDERS,
         store: fastagentCredentialStore(path),
-        oauthFlow: oauthOk,
       }),
-    ).rejects.toThrow(/no API key/);
-    // The preflight modify may touch the file ("{}"), but no openai credential was written.
+    ).rejects.toThrow(/cancelled/);
     expect((await readAuth(path).catch(() => ({}))).openai).toBeUndefined();
   });
 
-  it("a corrupt auth file fails up front (preflight), before the OAuth round-trip", async () => {
+  it("a corrupt auth file fails up front (preflight), before the provider flow runs", async () => {
     const path = await tmpAuth("{ not valid json");
-    let flowRan = false;
-    const oauthFlow: OAuthFlow = async () => {
-      flowRan = true;
-      return fakeCreds;
-    };
+    let ran = false;
+    const providers = [
+      fakeProvider("codex", {
+        oauth: true,
+        onOauthLogin: async () => {
+          ran = true;
+          return OAUTH_CRED;
+        },
+      }),
+    ];
     await expect(
-      loginFlow(fakeIO(), { provider: "anthropic", store: fastagentCredentialStore(path), oauthFlow }),
+      loginFlow(fakeIO().io, { provider: "codex", providers, store: fastagentCredentialStore(path) }),
     ).rejects.toThrow(/corrupt auth file/);
-    expect(flowRan).toBe(false); // preflight threw before the flow — no wasted round-trip
+    expect(ran).toBe(false); // preflight threw before the flow — no wasted round-trip
   });
 
-  // The #51 invariant: the SECOND modify (the real in-place write, AFTER a successful flow) must fail
-  // visibly — never a false success. The corrupt-preflight test above only exercises the parse throw on
-  // the FIRST (no-op) modify; this one drives the write-IO path the preflight never reaches. A read-only
-  // (0444) file lets the preflight pass (read + lock, no write) and the flow run, then the persist write
-  // hits EACCES. (Skipped under root, which bypasses the permission check.)
+  // #58 invariant: the persist write AFTER a successful flow must fail visibly, never a false success.
+  // A read-only (0444) file lets the preflight pass (read + lock, no write) and the flow run, then the
+  // persist write hits EACCES. (Skipped under root, which bypasses the permission check.)
   it.skipIf(process.getuid?.() === 0)(
-    "a persist write failure after a successful OAuth flow rejects, persisting nothing",
+    "a persist write failure after a successful flow rejects, persisting nothing",
     async () => {
-      const path = await tmpAuth(JSON.stringify({ existing: { type: "api_key", key: "x" } })); // valid JSON
-      await chmod(path, 0o444); // read-only file; parent dir stays writable so the lock can still be taken
-      let flowRan = false;
-      const oauthFlow: OAuthFlow = async () => {
-        flowRan = true;
-        return fakeCreds;
-      };
+      const path = await tmpAuth(JSON.stringify({ existing: { type: "api_key", key: "x" } }));
+      await chmod(path, 0o444);
+      let ran = false;
+      const providers = [
+        fakeProvider("codex", {
+          oauth: true,
+          onOauthLogin: async () => {
+            ran = true;
+            return OAUTH_CRED;
+          },
+        }),
+      ];
       await expect(
-        loginFlow(fakeIO(), { provider: "anthropic", store: fastagentCredentialStore(path), oauthFlow }),
+        loginFlow(fakeIO().io, { provider: "codex", providers, store: fastagentCredentialStore(path) }),
       ).rejects.toThrow(/EACCES|permission/i);
-      expect(flowRan).toBe(true); // got past preflight + flow; only the persist write failed
-      expect((await readAuth(path)).anthropic).toBeUndefined(); // no false success — nothing landed
+      expect(ran).toBe(true); // got past preflight + flow; only the persist write failed
+      expect((await readAuth(path)).codex).toBeUndefined(); // no false success
     },
   );
 
-  it("c1: a server win that leaves the manual-paste prompt pending is aborted, so the CLI does not hang", async () => {
-    let manualAborted = false;
+  it("a prompt the provider leaves pending is aborted when the flow resolves, so the CLI does not hang", async () => {
+    let aborted = false;
     const io: LoginIO = {
-      print: () => {},
-      prompt: (_message, signal) =>
-        new Promise<string>((_resolve, reject) => {
-          signal?.addEventListener("abort", () => {
-            manualAborted = true;
-            reject(new Error("aborted"));
+      select: async () => undefined,
+      prompt: (_m, opts) =>
+        new Promise<string>((_res, rej) => {
+          opts?.signal?.addEventListener("abort", () => {
+            aborted = true;
+            rej(new Error("aborted"));
           });
         }),
-      promptHidden: async () => "",
+      note: () => {},
       openUrl: () => {},
     };
-    // The flow starts the concurrent manual prompt, then the server wins: resolve without awaiting it.
-    const oauthFlow: OAuthFlow = async (_id, callbacks) => {
-      void callbacks.onManualCodeInput?.().catch(() => {});
-      return fakeCreds;
-    };
+    const providers = [
+      fakeProvider("codex", {
+        oauth: true,
+        onOauthLogin: async (cb) => {
+          void cb.prompt({ type: "manual_code", message: "paste" }).catch(() => {}); // pending, never awaited
+          return OAUTH_CRED;
+        },
+      }),
+    ];
     await expect(
-      loginFlow(io, { provider: "anthropic", store: fastagentCredentialStore(await tmpAuth()), oauthFlow }),
-    ).resolves.toEqual({ provider: "anthropic", method: "oauth" });
-    expect(manualAborted).toBe(true);
+      loginFlow(io, { provider: "codex", providers, store: fastagentCredentialStore(await tmpAuth()) }),
+    ).resolves.toEqual({ provider: "codex", method: "oauth" });
+    expect(aborted).toBe(true); // `done` backstop cancelled the pending prompt
   });
 });


### PR DESCRIPTION
## Why

`fastagent login` was a residual flow on pi-ai's **deprecated** oauth-only API (`getOAuthProviderInfoList` is `@deprecated`): it listed only the 3 OAuth providers, **locked them into OAuth** (no API-key choice), showed **no status**, and made you **know provider ids** for anything else.

I researched how modern CLIs do this first (per the design discussion):
- gh / stripe / aws logins are **line-based prompts + browser/device flow**, not full-screen TUIs. pi is the exception because it's a resident TUI agent.
- **`@clack/prompts`** is the 2026 standard for interactive Node CLIs (used by Astro CLI, SvelteKit) — `select` / `autocomplete` (searchable) / `password`, all line-based.

## What

Rewrote on pi-ai's **unified `ProviderAuth` API** + `@clack/prompts`:

```
$ fastagent login
◆ Authentication method:  subscription (OAuth)  |  API key
◆ Select a provider:      Anthropic (Claude Pro/Max)  ✓ configured   ← searchable once long
◇ Opening browser…
✓ Logged in to anthropic (oauth)
```

- three steps: method → provider (from `builtinProviders()`, with configured status, `autocomplete` when long) → `provider.auth.{oauth|apiKey}.login(callbacks)` (one path, pi-ai's `AuthLoginCallbacks`) → persist.
- `@clack/prompts` is line-based, **not a full TUI**; replaces the hand-rolled raw-mode `readHidden`. Terminal IO stays injected (`LoginIO`) so `loginFlow` is tested against the **real `fastagentCredentialStore`** with fake providers — no stdin/TUI.
- persists to fastagent's own store (unchanged from #58); **de-deprecates** the pi-ai call.
- scope is **model-provider auth only** — deploy/platform auth is a future `fastagent deploy login` (K axis), kept out of `login` by design (auth separated by what it serves).

## Why not reuse pi's login TUI components

`LoginDialogComponent`/`OAuthSelectorComponent` **bind pi's `AuthStorage`** (writes `~/.pi`, breaks the #58 store split) and need a **pi-tui runtime that isn't in our dependency tree** (pi-coding-agent bundles it; `import("@earendil-works/pi-tui")` → `ERR_MODULE_NOT_FOUND`). Deep-importing pi's unexported internals for a one-shot command is the wrong dependency. `@clack` is carefully-chosen, swappable, engine-neutral.

## Verify

typecheck/lint green; **163 tests** (login: method/provider resolution, status hint, dual-method ask, method-filtered list, empty-selection + corrupt-file preflight + post-flow write failure #58 + pending-prompt abort backstop). Smoke: `login <unknown>` errors cleanly (wiring + @clack bundled). Adds `@clack/prompts`.

> The live TTY interaction (arrow keys / search) is inherent to interactive prompts and not covered by CI; the injected `LoginIO` covers the flow logic.
