### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Flask/WSGI for agents: serve or embed an existing agent folder (AGENTS.md + skills/) as a production capability. Engine-, model-, and host-neutral.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## 0.7.0

Minor bump (new user-facing UX + a new dependency since 0.6.0).

- **#68 `feat(login)`**: `fastagent login` rewritten onto pi-ai's unified `ProviderAuth` API + `@clack/prompts` — method → provider (with configured status, searchable) → flow. De-deprecates the pi-ai call; adds `@clack/prompts`.
- **#66 `fix(channels)`**: narrow the `channels/` symlink guard to ESCAPING-only, applied in both load and scaffold.

Published to npmjs via OIDC Trusted Publishing (tokenless, no provenance — private repo).
