### PR TITLE
feat(cli): authoring loop — invoke, info, models [search] (0.7.0)

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Flask/WSGI for agents: serve or embed an existing agent folder (AGENTS.md + skills/) as a production capability. Engine-, model-, and host-neutral.",
   "keywords": [
     "agent",

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -14,6 +14,7 @@
  */
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { readdir } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import { autocomplete, isCancel, log, password, select, text as clackText } from "@clack/prompts";
 import { parseArgs } from "node:util";
@@ -25,11 +26,11 @@ import { type Routes, parseRouteKey, router, serveNode } from "./host/node.ts";
 import { runDevSupervisor } from "./dev-supervisor.ts";
 import { loadChannels } from "./engines/pi/channel.ts";
 import { fastagentVersion } from "./engines/pi/version.ts";
-import { listModels, loadConfig, resolveSessionsDirOverride } from "./engines/pi/config.ts";
+import { listModels, loadConfig, resolveModelSpec, resolveSessionsDirOverride } from "./engines/pi/config.ts";
 import { FASTAGENT_AUTH_PATH } from "./engines/pi/auth.ts";
 import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
 import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
-import { loadRootIgnore } from "./engines/pi/definition.ts";
+import { loadAgentDefinition, loadRootIgnore } from "./engines/pi/definition.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
 import { resolveWorkspaceTools } from "./engines/pi/create.ts";
 import {
@@ -44,6 +45,7 @@ function usage(code: number): never {
   console.error(`usage:
   fastagent init   [dir] [--minimal] [--no-install]
   fastagent models [search]
+  fastagent info   [dir] [--json]
   fastagent tool   <name> '<json-args>' [dir]
   fastagent invoke <message> [dir] [--model provider/modelId]
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--no-watch]
@@ -65,6 +67,10 @@ function usage(code: number): never {
          --no-install   scaffold but skip npm install
   models list the available "provider/modelId" specs ([search] filters by substring; use one with
          --model or in the config).
+  info   print what dir (default .) ASSEMBLES into — model, AGENTS.md, skills, tools (+ collisions),
+         channels, sessions, load diagnostics — WITHOUT serving. Read-only (never creates sessions /
+         writes .gitignore); an unset model is reported, not fatal. --json for CI. Run it first when
+         something looks off.
   tool   run one tool (from tools/ or config.tools) directly with JSON args — no model, no
          server, no tokens. Fast feedback while authoring: fastagent tool add '{"a":2,"b":3}'
   invoke run ONE turn against the assembled agent and exit — no server, no TUI. The reply streams
@@ -96,6 +102,7 @@ const { positionals, values } = parseArgs({
     "no-install": { type: "boolean" },
     "no-watch": { type: "boolean" },
     update: { type: "boolean" },
+    json: { type: "boolean" },
     help: { type: "boolean", short: "h" },
     version: { type: "boolean", short: "v" },
   },
@@ -113,6 +120,7 @@ if (command === "init") await runInit();
 else if (command === "models") runModels();
 else if (command === "tool") await runTool();
 else if (command === "invoke") await runInvoke();
+else if (command === "info") await runInfo();
 else if (command === "dev") await runDev();
 else if (command === "chat") await runChat();
 else if (command === "start") await runStart();
@@ -207,6 +215,72 @@ async function runInvoke(): Promise<void> {
   }
   process.stdout.write("\n");
   if (failed) process.exit(1); // a failed turn is a non-zero exit so CI can gate on it
+}
+
+/** List channel file basenames in <dir>/channels/ — the authoring view (no import, unlike loadChannels). */
+async function discoverChannelFiles(workspaceDir: string): Promise<string[]> {
+  let names: string[];
+  try {
+    names = await readdir(join(workspaceDir, "channels"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; // no channels/ is normal
+    throw error;
+  }
+  return names
+    .filter((n) => /\.(ts|js|mjs)$/.test(n) && !n.endsWith(".d.ts"))
+    .map((n) => n.replace(/\.(ts|js|mjs)$/, ""))
+    .sort();
+}
+
+/**
+ * `fastagent info [dir] [--json]`: print what the directory ASSEMBLES into — model, AGENTS.md, skills,
+ * tools (with collisions), channels, sessions dir, and load diagnostics — WITHOUT booting a server.
+ * Read-only inspection: it never creates the sessions dir or writes .gitignore (unlike dev/start), and
+ * an unset model is reported, not fatal. The discovery counterpart of `tool`/`invoke` (which RUN
+ * things): run it first when something looks off (faster than dev), or `--json` it in CI.
+ */
+async function runInfo(): Promise<void> {
+  loadDotEnv(dir); // skills/tools may read env at load time
+  const { config, path: configPath } = await loadConfig(dir).catch(failStartup);
+  const modelSpec = resolveModelSpec(values.model, config);
+  const definition = await loadAgentDefinition(dir).catch(failStartup);
+  const { toolNames, toolCollisions } = await resolveWorkspaceTools(config, dir).catch(failStartup);
+  const channels = await discoverChannelFiles(dir).catch(failStartup);
+  // The default sessions path WITHOUT creating it (info is read-only; dev/start mkdir it, info must not).
+  const sessionsDir = resolveSessionsDirOverride(values["sessions-dir"]) ?? join(dir, ".fastagent", "sessions");
+
+  if (values.json) {
+    console.log(
+      JSON.stringify(
+        {
+          dir,
+          configPath: configPath ?? null,
+          model: modelSpec ?? null,
+          instructions: definition.instructions !== undefined,
+          skills: definition.skills.map((skill) => ({ name: skill.name, description: skill.description })),
+          tools: toolNames,
+          channels,
+          sessionsDir,
+          diagnostics: definition.diagnostics,
+          skillCollisions: definition.collisions,
+          toolCollisions,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  console.log(`dir:      ${dir}`);
+  console.log(`config:   ${configPath ?? "(none)"}`);
+  console.log(`model:    ${modelSpec ?? "(not set — pass --model, set FASTAGENT_MODEL, or config.model)"}`);
+  console.log(`agents:   ${definition.instructions ? "AGENTS.md" : "(none)"}`);
+  console.log(`skills:   ${definition.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
+  console.log(`tools:    ${toolNames.join(", ") || "(none)"}`);
+  console.log(`channels: ${channels.join(", ") || "(none)"}`);
+  console.log(`sessions: ${sessionsDir}`);
+  reportToolCollisions(toolCollisions);
+  reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 }
 
 async function runInit(): Promise<void> {

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -13,6 +13,7 @@
  * is the application entry point.
  */
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { join, relative, resolve } from "node:path";
 import { autocomplete, isCancel, log, password, select, text as clackText } from "@clack/prompts";
 import { parseArgs } from "node:util";
@@ -42,8 +43,9 @@ import {
 function usage(code: number): never {
   console.error(`usage:
   fastagent init   [dir] [--minimal] [--no-install]
-  fastagent models
+  fastagent models [search]
   fastagent tool   <name> '<json-args>' [dir]
+  fastagent invoke <message> [dir] [--model provider/modelId]
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--no-watch]
   fastagent chat   [dir] [--model provider/modelId]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir]
@@ -61,16 +63,26 @@ function usage(code: number): never {
          package.json, .gitignore. Refuses to overwrite an existing workspace.
          --minimal      markdown-only (no package.json/tool/install) — a prompt+skills agent
          --no-install   scaffold but skip npm install
-  models list the available "provider/modelId" specs (use one with --model or in the config).
+  models list the available "provider/modelId" specs ([search] filters by substring; use one with
+         --model or in the config).
   tool   run one tool (from tools/ or config.tools) directly with JSON args — no model, no
          server, no tokens. Fast feedback while authoring: fastagent tool add '{"a":2,"b":3}'
+  invoke run ONE turn against the assembled agent and exit — no server, no TUI. The reply streams
+         to stdout, tool/diagnostics to stderr, a failed turn exits non-zero. The all-agent
+         counterpart of tool, for CI smoke and quick checks. Same model resolution as dev.
   start  run the agent in dir (default .) in production posture — the SAME assembly as dev
          (your folder is the agent), just no file-watching. No build step: start reads the
          definition directly; model/http come from fastagent.config.ts (frozen by git, not a manifest).
          model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
          port precedence:  --port > PORT env > fastagent.config.ts http.port > 8787
          sessions: --sessions-dir > FASTAGENT_SESSIONS_DIR > <dir>/.fastagent/sessions
-                   (point FASTAGENT_SESSIONS_DIR at a volume so a redeploy never wipes conversations)`);
+                   (point FASTAGENT_SESSIONS_DIR at a volume so a redeploy never wipes conversations)
+  add    github: scaffold channels/<kind>.ts (third-party adapter glue, an on() to edit). skill
+         <source>: vendor an Agent Skills skill into skills/<name>/ (git ref owner/repo/path, a local
+         path, or a bare name from ~/.agents/skills; --update re-fetches, review with git diff).
+  login  authenticate a model provider into ~/.fastagent/auth.json: pick a method (subscription/OAuth
+         or API key), then a provider that offers it (configured status shown). [provider] takes the
+         method from what that provider supports, asked only when it offers both.`);
   process.exit(code);
 }
 
@@ -100,6 +112,7 @@ const dir = resolve(dirArg ?? ".");
 if (command === "init") await runInit();
 else if (command === "models") runModels();
 else if (command === "tool") await runTool();
+else if (command === "invoke") await runInvoke();
 else if (command === "dev") await runDev();
 else if (command === "chat") await runChat();
 else if (command === "start") await runStart();
@@ -107,9 +120,16 @@ else if (command === "add") await runAdd();
 else if (command === "login") await runLogin();
 else usage(1);
 
-/** `fastagent models`: print every registered "provider/modelId" to stdout (pipe-friendly). */
+/**
+ * `fastagent models [search]`: print every registered "provider/modelId" to stdout (pipe-friendly).
+ * `[search]` filters by case-insensitive substring (the full list is long — 35 providers).
+ */
 function runModels(): void {
-  for (const spec of listModels(createPiModels())) console.log(spec);
+  const search = positionals[1]?.toLowerCase();
+  const specs = listModels(createPiModels());
+  const shown = search ? specs.filter((spec) => spec.toLowerCase().includes(search)) : specs;
+  for (const spec of shown) console.log(spec);
+  if (search && shown.length === 0) console.error(`no model matches "${positionals[1]}"`);
 }
 
 /**
@@ -154,6 +174,39 @@ async function runTool(): Promise<void> {
       ? result.details
       : (result?.content ?? []).map((c) => ("text" in c ? c.text : "")).join("");
   console.log(typeof out === "string" ? out : JSON.stringify(out, null, 2));
+}
+
+/**
+ * `fastagent invoke <message> [dir]`: run ONE turn against the assembled agent, then exit — no server,
+ * no TUI. The SAME assembly as dev/start (the folder is the agent), so it answers exactly as the
+ * served agent would. The reply text streams to stdout; tool and diagnostic lines go to stderr; a
+ * `failed` event exits non-zero. The all-agent counterpart of `tool` (one tool, no model): for CI
+ * smoke and quick "what does it answer to X" checks while authoring.
+ */
+async function runInvoke(): Promise<void> {
+  const message = positionals[1];
+  if (!message) {
+    console.error(`usage: fastagent invoke <message> [dir]`);
+    process.exit(2);
+  }
+  const invokeDir = resolve(positionals[2] ?? ".");
+  loadDotEnv(invokeDir); // model API key from .env, like start
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+  installUndiciFetch();
+  const { agent, modelSpec } = await createPiAgentFromWorkspace(invokeDir, { model: values.model }).catch(failStartup);
+  console.error(`[fastagent] invoke: ${invokeDir} (${modelSpec})`);
+  // A fresh session per invoke (one-shot — no resume); the reply streams to stdout as it arrives.
+  let failed = false;
+  for await (const event of agent.invoke({ session: randomUUID() }, { text: message })) {
+    if (event.type === "text") process.stdout.write(event.delta);
+    else if (event.type === "tool_started") console.error(`\n[tool] ${event.name}`);
+    else if (event.type === "failed") {
+      failed = true;
+      console.error(`\n[fastagent] failed: ${event.details}${event.retryable ? " (retryable)" : ""}`);
+    }
+  }
+  process.stdout.write("\n");
+  if (failed) process.exit(1); // a failed turn is a non-zero exit so CI can gate on it
 }
 
 async function runInit(): Promise<void> {

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -30,7 +30,8 @@ import { listModels, loadConfig, resolveModelSpec, resolveSessionsDirOverride } 
 import { FASTAGENT_AUTH_PATH } from "./engines/pi/auth.ts";
 import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
 import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
-import { loadAgentDefinition, loadRootIgnore } from "./engines/pi/definition.ts";
+import { assertInsideWorkspace, loadAgentDefinition, loadRootIgnore } from "./engines/pi/definition.ts";
+import { runInvokeStream } from "./invoke-stream.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
 import { resolveWorkspaceTools } from "./engines/pi/create.ts";
 import {
@@ -203,22 +204,24 @@ async function runInvoke(): Promise<void> {
   installUndiciFetch();
   const { agent, modelSpec } = await createPiAgentFromWorkspace(invokeDir, { model: values.model }).catch(failStartup);
   console.error(`[fastagent] invoke: ${invokeDir} (${modelSpec})`);
-  // A fresh session per invoke (one-shot — no resume); the reply streams to stdout as it arrives.
-  let failed = false;
-  for await (const event of agent.invoke({ session: randomUUID() }, { text: message })) {
-    if (event.type === "text") process.stdout.write(event.delta);
-    else if (event.type === "tool_started") console.error(`\n[tool] ${event.name}`);
-    else if (event.type === "failed") {
-      failed = true;
-      console.error(`\n[fastagent] failed: ${event.details}${event.retryable ? " (retryable)" : ""}`);
-    }
-  }
-  process.stdout.write("\n");
-  if (failed) process.exit(1); // a failed turn is a non-zero exit so CI can gate on it
+  // A fresh session per invoke (one-shot — no resume). The event→IO mapping is a pure, tested function
+  // (runInvokeStream): reply text→stdout, tool start/error + the failure reason→stderr, exit code 1 iff
+  // the turn failed so CI can gate on it.
+  const exitCode = await runInvokeStream(
+    agent.invoke({ session: randomUUID() }, { text: message }),
+    (text) => process.stdout.write(text),
+    (line) => console.error(line),
+  );
+  process.stdout.write("\n"); // end the streamed reply line
+  if (exitCode !== 0) process.exit(exitCode);
 }
 
 /** List channel file basenames in <dir>/channels/ — the authoring view (no import, unlike loadChannels). */
 async function discoverChannelFiles(workspaceDir: string): Promise<string[]> {
+  // The same containment guard loadChannels uses (#66): reject a channels/ symlink that escapes the
+  // workspace, so info reports the SAME surface dev/start would accept — never a channels/ they'd
+  // refuse. Pure realpath, no channel import, so info keeps its no-import-channels choice.
+  await assertInsideWorkspace(workspaceDir, "channels");
   let names: string[];
   try {
     names = await readdir(join(workspaceDir, "channels"));

--- a/core/src/invoke-stream.ts
+++ b/core/src/invoke-stream.ts
@@ -1,0 +1,45 @@
+/**
+ * Render an Agent event stream to two output sinks plus an exit code — the `fastagent invoke` contract,
+ * pulled out of cli.ts as a PURE function (IO injected, no process/stream access) so the contract is
+ * unit-testable rather than resting on a live-model smoke run:
+ *
+ *   - `text` deltas → `out` (the reply, streamed; stdout at the CLI),
+ *   - `tool_started` and a `tool_ended` that ERRORED → `err` (diagnostics; stderr at the CLI),
+ *   - `failed` → `err` (the reason) and a non-zero exit code (the CI-gating guarantee).
+ *
+ * A `tool_ended` with `isError: true` inside an otherwise-`completed` turn must still surface — a
+ * failed tool that does not fail the turn is exactly the diagnostic the operator needs. Its event
+ * carries no name, so the name is remembered from the matching `tool_started`. The trailing newline
+ * that ends the streamed reply is the caller's concern (only it knows the output device).
+ */
+import type { AgentEvent } from "./agent.ts";
+
+export async function runInvokeStream(
+  events: AsyncIterable<AgentEvent>,
+  out: (text: string) => void,
+  err: (line: string) => void,
+): Promise<number> {
+  const toolName = new Map<string, string>(); // tool_ended carries no name — remember it from tool_started
+  let exitCode = 0;
+  for await (const event of events) {
+    switch (event.type) {
+      case "text":
+        out(event.delta);
+        break;
+      case "tool_started":
+        toolName.set(event.id, event.name);
+        err(`[tool] ${event.name}`);
+        break;
+      case "tool_ended":
+        if (event.isError) err(`[tool] ${toolName.get(event.id) ?? event.id} failed`);
+        break;
+      case "failed":
+        err(`[fastagent] failed: ${event.details}${event.retryable ? " (retryable)" : ""}`);
+        exitCode = 1;
+        break;
+      case "completed":
+        break; // terminal success — nothing to render (structured data, if any, is not a CLI concern)
+    }
+  }
+  return exitCode;
+}

--- a/core/test/cli.test.ts
+++ b/core/test/cli.test.ts
@@ -8,9 +8,13 @@ import { fileURLToPath } from "node:url";
 const CLI = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
 
 /** Run the CLI to completion; capture stdout, stderr, exit code. */
-function run(args: string[], cwd?: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
+function run(
+  args: string[],
+  cwd?: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [CLI, ...args], cwd ? { cwd } : {});
+    const child = spawn(process.execPath, [CLI, ...args], { ...(cwd ? { cwd } : {}), env: env ?? process.env });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (d) => (stdout += d));
@@ -33,5 +37,32 @@ describe("cli papercuts", () => {
     const { stderr } = await run(["init", target, "--minimal"], cwd);
     expect(stderr).toMatch(/cd \/.*fa-cli-tgt/); // absolute path
     expect(stderr).not.toMatch(/cd \.\./); // never the ../../.. noise
+  });
+
+  it("models [search] filters by substring; a no-match prints nothing to stdout", async () => {
+    const hit = await run(["models", "openai"]);
+    expect(hit.code).toBe(0);
+    expect(hit.stdout.trim().length).toBeGreaterThan(0);
+    for (const line of hit.stdout.trim().split("\n")) expect(line.toLowerCase()).toContain("openai");
+    const miss = await run(["models", "zzznope"]);
+    expect(miss.stdout).toBe(""); // a no-match leaves stdout empty (pipe-friendly)
+    expect(miss.stderr).toMatch(/no model matches/);
+  });
+
+  it("invoke without a message prints usage to stderr and exits 2 (stdout clean)", async () => {
+    const { code, stdout, stderr } = await run(["invoke"]);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/usage: fastagent invoke/);
+    expect(stdout).toBe("");
+  });
+
+  it("invoke surfaces a startup error to stderr, keeps stdout empty, exits non-zero", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-cli-inv-"));
+    const env = { ...process.env };
+    delete env.FASTAGENT_MODEL; // no model source → assembly fails before any model call (no auth needed)
+    const { code, stdout, stderr } = await run(["invoke", "hi", cwd], undefined, env);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/missing model/);
+    expect(stdout).toBe(""); // a failure never pollutes stdout
   });
 });

--- a/core/test/cli.test.ts
+++ b/core/test/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -64,5 +64,41 @@ describe("cli papercuts", () => {
     expect(code).toBe(1);
     expect(stderr).toMatch(/missing model/);
     expect(stdout).toBe(""); // a failure never pollutes stdout
+  });
+
+  it("info reports the assembled surface as JSON, read-only (no sessions dir created)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-info-"));
+    await mkdir(join(dir, "skills", "greet"), { recursive: true });
+    await mkdir(join(dir, "channels"), { recursive: true });
+    await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
+    await writeFile(
+      join(dir, "skills", "greet", "SKILL.md"),
+      "---\nname: greet\ndescription: Greet warmly.\n---\nHi.\n",
+    );
+    await writeFile(
+      join(dir, "channels", "github.ts"),
+      'export default () => ({ "POST /x": () => new Response("ok") });\n',
+    );
+    const env = { ...process.env };
+    delete env.FASTAGENT_MODEL;
+    const { code, stdout } = await run(["info", dir, "--json"], undefined, env);
+    expect(code).toBe(0); // an unset model is reported, not fatal
+    const info = JSON.parse(stdout);
+    expect(info.model).toBeNull();
+    expect(info.instructions).toBe(true);
+    expect(info.skills.map((s: { name: string }) => s.name)).toEqual(["greet"]);
+    expect(info.channels).toEqual(["github"]);
+    await expect(stat(join(dir, ".fastagent"))).rejects.toThrow(); // read-only: never creates sessions dir
+  });
+
+  it("info surfaces a malformed skill as a diagnostic instead of crashing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-info-"));
+    await mkdir(join(dir, "skills", "bad"), { recursive: true });
+    await writeFile(join(dir, "skills", "bad", "SKILL.md"), "---\nname: bad\n---\nno description.\n"); // no description
+    const { code, stdout } = await run(["info", dir, "--json", "--model", "x/y"]);
+    expect(code).toBe(0);
+    const info = JSON.parse(stdout);
+    expect(info.skills).toEqual([]); // the malformed skill is skipped, not loaded
+    expect(JSON.stringify(info.diagnostics)).toMatch(/description/); // and surfaced as a diagnostic
   });
 });

--- a/core/test/cli.test.ts
+++ b/core/test/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -100,5 +100,15 @@ describe("cli papercuts", () => {
     const info = JSON.parse(stdout);
     expect(info.skills).toEqual([]); // the malformed skill is skipped, not loaded
     expect(JSON.stringify(info.diagnostics)).toMatch(/description/); // and surfaced as a diagnostic
+  });
+
+  it("info refuses a channels/ symlink that escapes the workspace (matches loadChannels #66)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-info-"));
+    const outside = await mkdtemp(join(tmpdir(), "fa-outside-"));
+    await writeFile(join(outside, "github.ts"), "export default () => ({});\n");
+    await symlink(outside, join(dir, "channels")); // channels/ -> outside the workspace
+    const { code, stderr } = await run(["info", dir, "--model", "x/y"]);
+    expect(code).not.toBe(0); // dev/start would refuse it (#66); info must not report it as a clean surface
+    expect(stderr).toMatch(/outside the workspace/);
   });
 });

--- a/core/test/invoke-stream.test.ts
+++ b/core/test/invoke-stream.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../src/agent.ts";
+import { runInvokeStream } from "../src/invoke-stream.ts";
+
+async function* stream(...events: AgentEvent[]): AsyncIterable<AgentEvent> {
+  for (const e of events) yield e;
+}
+/** Capture the two sinks runInvokeStream writes to (out = reply text, err = diagnostics). */
+function sinks() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, outFn: (s: string) => out.push(s), errFn: (s: string) => err.push(s) };
+}
+
+describe("runInvokeStream", () => {
+  it("streams text to out and exits 0 on completed (err stays empty)", async () => {
+    const s = sinks();
+    const code = await runInvokeStream(
+      stream({ type: "text", delta: "Red, " }, { type: "text", delta: "blue" }, { type: "completed" }),
+      s.outFn,
+      s.errFn,
+    );
+    expect(code).toBe(0);
+    expect(s.out.join("")).toBe("Red, blue");
+    expect(s.err).toEqual([]);
+  });
+
+  it("a failed turn exits 1 with the reason on err — the CI-gating guarantee", async () => {
+    const s = sinks();
+    const code = await runInvokeStream(
+      stream({ type: "text", delta: "hmm" }, { type: "failed", details: "boom", retryable: true }),
+      s.outFn,
+      s.errFn,
+    );
+    expect(code).toBe(1);
+    expect(s.err.join("\n")).toMatch(/failed: boom \(retryable\)/);
+    expect(s.out.join("")).toBe("hmm"); // text still went to out, never err
+  });
+
+  it("a tool that errors inside a completed turn surfaces on err, by name", async () => {
+    const s = sinks();
+    const code = await runInvokeStream(
+      stream(
+        { type: "tool_started", id: "t1", name: "lookup", args: {} },
+        { type: "tool_ended", id: "t1", isError: true, content: "404" },
+        { type: "completed" },
+      ),
+      s.outFn,
+      s.errFn,
+    );
+    expect(code).toBe(0); // the TURN completed — only the tool errored
+    expect(s.err.join("\n")).toMatch(/\[tool\] lookup/); // started
+    expect(s.err.join("\n")).toMatch(/lookup failed/); // and its error, named from the matching tool_started
+  });
+
+  it("a successful tool is not reported as a failure", async () => {
+    const s = sinks();
+    await runInvokeStream(
+      stream(
+        { type: "tool_started", id: "t1", name: "lookup", args: {} },
+        { type: "tool_ended", id: "t1", isError: false, content: "ok" },
+        { type: "completed" },
+      ),
+      s.outFn,
+      s.errFn,
+    );
+    expect(s.err.join("\n")).not.toMatch(/failed/);
+  });
+});


### PR DESCRIPTION
## Why

Reviewed pi's `--help`, then eve's and flue's CLIs, deciding each idea against **our** product (serving layer, "the directory is the agent"), not theirs. Most of pi's flags are runtime **injection** (`--system-prompt` / `--tools` / `--thinking` / session management) — they contradict "the folder is the behavior" and were **not** ported. eve/flue's `build`→artifact→`deploy` is framework-shaped; we deleted `build` in #64 on purpose. What fits is the **authoring loop**: inspect → run → iterate.

## What (0.7.0)

**1. `fastagent invoke <message> [dir]`** — run ONE turn against the assembled agent and exit; no server, no TUI. The all-agent counterpart of `tool` (one tool, no model), filling the gap between `tool` and the interactive `chat`. Named for **our contract** (`invoke` is the Agent Handler verb — SPEC/agent.ts/invoke.ts), not pi's `-p`; a subcommand, since we default to non-interactive. Same assembly as dev/start. Reply → stdout, tool/diagnostics → stderr, `failed` → non-zero exit (pipe-clean, CI-gatable). *(flue's `run --input`, eve's `dev --no-ui` are the same idea.)*

**2. `fastagent info [dir] [--json]`** — print what the directory **assembles into** (model, AGENTS.md, skills, tools + collisions, channels, sessions, load diagnostics) **without serving**. Borrowed from **eve's `info`**, which both eve and flue treat as the first thing to run when something looks off (discovery + diagnostics, faster than the dev server). **Read-only by construction**: composes the no-side-effect parts (not `createPiAgentFromWorkspace`), so it never creates the sessions dir or writes `.gitignore`, and an unset model is reported, not fatal.

**3. `fastagent models [search]`** — substring filter (the list is 35 providers); pi's `--list-models [search]` as a positional.

**4. usage** — add the missing `add` / `login` paragraphs (companion text), document `invoke` + `info`.

## Decisions confirmed by the survey (no change)

- **deploy auth belongs under deploy**: eve puts AI Gateway creds in `link` (deploy context), not top-level auth — matches our K-axis split (`deploy login`, not `login`).
- **no `build`**: eve/flue compile to an artifact; #64's "the directory is the agent" is a deliberate posture difference, not a gap.

## Backlog (out of scope now)

- **eval** (eve): batch assertions + exit 0/1/2 + junit — the "batch + assert" superset of `invoke`; for when fastagent extends from serving to agent-dev lifecycle.
- **`invoke --url <remote>`** (flue `run --server`, eve `dev <url>`): smoke-test a deployed agent — natural once `deploy` lands.

## Verify

End-to-end on **real anthropic** (invoke success → stdout + exit 0; failed → stderr + exit 1; info read-only proven — no `.fastagent` created). **168 tests**, the new ones **mutation-proven**: models filter, invoke missing-message → exit 2 / startup error → stderr + empty stdout + exit 1, info assembled-surface JSON + read-only + malformed-skill diagnostic.
