### PR TITLE
refactor(core): dedup + comment-slop cleanup, with phase-closeout residue

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -33,7 +33,9 @@ export const POST = createInvokeHandler(agent);
 
 ```bash
 fastagent init my-agent && cd my-agent
+fastagent info                # inspect what the folder assembles into — model/skills/tools/channels (no server)
 fastagent dev                 # local HTTP/SSE on :8787 (watch + reload)
+fastagent invoke "hello"       # run one turn and exit — no server, no TUI (CI smoke / scripting)
 fastagent start               # run the same directory in production posture (no build step)
 ```
 

--- a/core/src/agent.ts
+++ b/core/src/agent.ts
@@ -1,8 +1,7 @@
 /**
- * Agent Handler protocol v0.1 — the contract layer. Pure types, zero dependencies (sansio).
- * This is the engine-neutral abstraction (see docs/SPEC.md): both callers and engines
- * depend on it. Importing any engine implementation here is forbidden
- * (`@earendil-works/pi-*` may only appear under engines/).
+ * Agent Handler protocol v0.1 — the engine-neutral contract (docs/SPEC.md). Pure types, zero
+ * dependencies. Importing any engine implementation here is forbidden (`@earendil-works/pi-*` may
+ * only appear under engines/).
  */
 
 export type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
@@ -34,10 +33,9 @@ export type AgentEvent =
   | { type: "failed"; details: string; retryable: boolean };
 
 /**
- * One turn = one invoke. Returns a single async event stream.
- * The stream MUST terminate with exactly one of completed / failed, or be cancelled
- * by the caller (no terminal event). Agent is a contract (interface), not a base class:
- * any AsyncIterable producer that implements it conforms.
+ * One turn = one invoke, returning a single async event stream. The stream MUST terminate with
+ * exactly one of completed / failed, or be cancelled by the caller (no terminal event). Any
+ * AsyncIterable producer that implements this conforms (interface, not base class).
  */
 export interface Agent {
   invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent>;

--- a/core/src/channels/body.ts
+++ b/core/src/channels/body.ts
@@ -1,7 +1,6 @@
 /**
- * Read a request body with a hard byte cap (real bytes, not JS chars). A streaming cap is the only
- * robust guard against an unauthenticated client buffering an unbounded body (Content-Length is
- * bypassable with chunked encoding); web-streams only, so it works on any runtime.
+ * Read a request body with a hard byte cap (real bytes). A streaming cap is the only robust guard
+ * against an unbounded body (Content-Length is bypassable with chunked encoding). Web-streams only.
  */
 export async function readBodyCapped(req: Request, max: number): Promise<{ text: string } | { tooLarge: true }> {
   if (!req.body) return { text: "" };

--- a/core/src/channels/github.ts
+++ b/core/src/channels/github.ts
@@ -1,8 +1,7 @@
 /**
  * GitHub webhook channel: verify → route via `on(event)` → fire-and-forget agent turns, ACK 202.
  * The developer writes only `on`. Concurrency safety is the engine's per-session lease. A turn that
- * fails after the 202, or any in-flight turn on shutdown, is lost (server log only). The agent acts
- * back via `gh`, so the channel holds no outbound credentials beyond `secret` (inbound verification).
+ * fails after the 202, or an in-flight turn on shutdown, is lost (server log only).
  */
 import { verify } from "@octokit/webhooks-methods";
 import type { Schema } from "@octokit/webhooks-types";
@@ -22,10 +21,7 @@ export interface GithubEvent {
   action?: string;
   /** `X-GitHub-Delivery` — unique per delivery. */
   deliveryId: string;
-  /**
-   * The native payload, typed via `@octokit/webhooks-types` (the official source). It's the union of
-   * all events; narrow it for event-specific fields, e.g. `if ("pull_request" in event.payload)`.
-   */
+  /** The native payload (union of all events); narrow it, e.g. `if ("pull_request" in event.payload)`. */
   payload: Schema;
 }
 
@@ -47,7 +43,7 @@ export interface GithubChannelOptions {
  */
 export function githubChannel(agent: Agent, { secret, on }: GithubChannelOptions): (req: Request) => Promise<Response> {
   // A non-empty secret is mandatory: verify() against an empty key accepts a signature anyone can
-  // compute, so an unset secret must fail at construction (startup), never silently run forgeable.
+  // compute, so an unset secret must fail at construction, never silently run forgeable.
   if (!secret) {
     throw new Error(
       "githubChannel requires a non-empty secret (the GitHub webhook secret, e.g. GITHUB_WEBHOOK_SECRET)",
@@ -59,8 +55,7 @@ export function githubChannel(agent: Agent, { secret, on }: GithubChannelOptions
     const body = await readBodyCapped(req, MAX_WEBHOOK_BYTES);
     if ("tooLarge" in body) return text("payload too large\n", 413);
     const raw = body.text;
-    // Fail closed: @octokit/webhooks-methods verify throws on an empty/missing arg, so treat any verify
-    // error (e.g. an empty body) as a clean 401, not a 500. Signature is over the raw body.
+    // Fail closed: verify() throws on an empty/missing arg, so treat any verify error as a clean 401.
     const signature = req.headers.get("x-hub-signature-256");
     if (!signature || !(await verify(secret, raw, signature).catch(() => false))) {
       return text("invalid signature\n", 401);
@@ -89,17 +84,15 @@ export function githubChannel(agent: Agent, { secret, on }: GithubChannelOptions
       payload: payload as unknown as Schema, // trust boundary: the verified body is a GitHub event
     };
 
-    // Fire each turn, return 202; the long-running process runs them to completion. The turn lifecycle
-    // is logged to stderr — after the 202 there is no response body, so these lines are the operator's
-    // only signal that a turn ran (and the failure sink that keeps a post-ACK error from going
-    // unhandled). Concurrency safety = the engine's per-session lease.
+    // Fire each turn, return 202; the process runs them to completion. The lifecycle is logged to
+    // stderr — after the 202 there is no response body, so these lines are the operator's only signal
+    // (and the sink that keeps a post-ACK error from going unhandled).
     const intents = on(event);
     const label = event.action ? `${event.event}.${event.action}` : event.event;
     for (let i = 0; i < intents.length; i++) {
       const { session, text } = intents[i] as Intent;
-      // A per-turn correlation id: deliveryId is unique per webhook, the index disambiguates the
-      // multiple turns one delivery can fan out to (session, by contract, recurs across deliveries).
-      // It threads through start/done/failed so a terminal line joins back to its start.
+      // Per-turn correlation id (deliveryId is unique per webhook; the index disambiguates fan-out),
+      // threaded through start/done/failed so a terminal line joins back to its start.
       const turn = `${event.deliveryId}#${i}`;
       console.error(`[github] turn start: turn=${turn} session=${session} event=${label}`);
       const startedAt = Date.now();

--- a/core/src/channels/http.ts
+++ b/core/src/channels/http.ts
@@ -1,19 +1,12 @@
 /**
  * HTTP/SSE channel: fan one invoke stream out to Server-Sent Events.
  *
- * The handler is **Fetch-shaped** (`(Request) => Promise<Response>`) on purpose: that is the
- * cross-runtime form every embedding host speaks (Next/Astro/Hono/Bun/Deno/Cloudflare), so the
- * same handler mounts inside an existing app's own route. It is path-agnostic — the host owns the
- * route; this handler only turns a POST body `{session,text}` into an SSE stream. Cancellation,
- * backpressure, and the body cap are all native to the web stream primitives:
- *   - consumer cancels the response body (client disconnect) → ReadableStream.cancel() →
- *     iterator.return() → invoke cancellation (SPEC MUST 3);
- *   - pull-based ReadableStream applies backpressure (next event is pulled when wanted);
- *   - concurrent same-session requests → the agent's fail-fast lease (invoke.ts) makes the second
- *     receive `failed{session busy}`.
+ * The handler is Fetch-shaped (`(Request) => Promise<Response>`) — the cross-runtime form every
+ * embedding host speaks, so it mounts inside an existing app's own route. It is path-agnostic. The
+ * web stream primitives give cancellation (consumer disconnect → cancel() → iterator.return() →
+ * invoke cancellation), backpressure (pull-based), and the body cap natively.
  *
- * `nodeListener` is the thin node:http adapter (used by the standalone `fastagent dev/start`
- * server). The SSE logic lives once in the Fetch handler; node:http is just transport.
+ * `nodeListener` is the thin node:http adapter for the standalone `fastagent dev/start` server.
  */
 import { Readable } from "node:stream";
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -21,7 +14,7 @@ import type { Agent } from "../agent.ts";
 import { readBodyCapped } from "./body.ts";
 import { text, textHeaders } from "./respond.ts";
 
-/** Request body cap — prompts are text (+ base64 images later); 1 MiB is generous for v1. */
+/** Request body cap (1 MiB). */
 const MAX_BODY_BYTES = 1 << 20;
 
 const encoder = new TextEncoder();
@@ -48,9 +41,8 @@ export function createInvokeHandler(agent: Agent): (req: Request) => Promise<Res
       return text('need { "session": string, "text": string }\n', 400);
     }
 
-    // Take the iterator explicitly so the stream's cancel() (consumer disconnect) can return() it
-    // and run invoke's cancellation cleanup (SPEC MUST 3). pull = backpressure: the next event is
-    // produced only when the consumer wants it.
+    // Take the iterator explicitly so the stream's cancel() (consumer disconnect) can return() it and
+    // run invoke's cancellation cleanup. pull = backpressure: the next event is produced on demand.
     const iterator = agent.invoke({ session }, { text: promptText })[Symbol.asyncIterator]();
     const stream = new ReadableStream<Uint8Array>({
       async pull(controller) {
@@ -117,8 +109,8 @@ async function pump(
     } as RequestInit & { duplex: "half" });
     response = await handler(request);
   } catch (error) {
-    // A handler exception is operator-relevant: log it server-side (some channels' only failure sink),
-    // and return a GENERIC body — don't leak the internal message to the client.
+    // Log server-side (some channels' only failure sink), but return a generic body — don't leak the
+    // internal message to the client.
     console.error(`[host] request handler failed: ${String(error)}`);
     if (!res.headersSent) res.writeHead(500, textHeaders);
     res.end("internal error\n");
@@ -141,10 +133,9 @@ async function pump(
     for (;;) {
       const { done, value } = await reader.read();
       if (done || res.destroyed) break;
-      // Backpressure: wait for drain, but ALSO resolve on close. If the client disconnects after
-      // write() returned false, Node never emits 'drain' on the closed socket, so waiting on 'drain'
-      // alone would suspend pump() forever (leaking the request/stream) even though the close handler
-      // cancelled the reader.
+      // Backpressure: wait for drain, but ALSO resolve on close. A client disconnect after write()
+      // returned false never emits 'drain' on the closed socket, so waiting on 'drain' alone would
+      // suspend pump() forever (leaking the request/stream).
       if (!res.write(value)) {
         await new Promise<void>((resolve) => {
           const done = () => {

--- a/core/src/channels/http.ts
+++ b/core/src/channels/http.ts
@@ -4,7 +4,7 @@
  * The handler is Fetch-shaped (`(Request) => Promise<Response>`) — the cross-runtime form every
  * embedding host speaks, so it mounts inside an existing app's own route. It is path-agnostic. The
  * web stream primitives give cancellation (consumer disconnect → cancel() → iterator.return() →
- * invoke cancellation), backpressure (pull-based), and the body cap natively.
+ * invoke cancellation, SPEC MUST 3), backpressure (pull-based), and the body cap natively.
  *
  * `nodeListener` is the thin node:http adapter for the standalone `fastagent dev/start` server.
  */
@@ -42,7 +42,7 @@ export function createInvokeHandler(agent: Agent): (req: Request) => Promise<Res
     }
 
     // Take the iterator explicitly so the stream's cancel() (consumer disconnect) can return() it and
-    // run invoke's cancellation cleanup. pull = backpressure: the next event is produced on demand.
+    // run invoke's cancellation cleanup (SPEC MUST 3). pull = backpressure: the next event is produced on demand.
     const iterator = agent.invoke({ session }, { text: promptText })[Symbol.asyncIterator]();
     const stream = new ReadableStream<Uint8Array>({
       async pull(controller) {

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -1,16 +1,7 @@
 #!/usr/bin/env node
 /**
- * fastagent CLI — the consumer of fastagent.config.ts (product entry point,
- * replacing hand-written entry scripts).
- *
- *   fastagent init  [dir] — scaffold a minimal runnable workspace
- *   fastagent models      — list available "provider/modelId" specs
- *   fastagent tool  <name> '<json>' [dir] — run one tool directly (no model)
- *   fastagent dev   [dir] — assemble + serve a local HTTP channel, watch + reload (iteration)
- *   fastagent start [dir] — run the same directory in production posture, no watch (core-design §10.3)
- *
- * Process-level side effects (proxy dispatcher, .env loading) belong here — the CLI
- * is the application entry point.
+ * fastagent CLI — the product entry point and consumer of fastagent.config.ts. Process-level side
+ * effects (proxy dispatcher, .env loading) belong here.
  */
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
@@ -25,8 +16,15 @@ import { text } from "./channels/respond.ts";
 import { type Routes, parseRouteKey, router, serveNode } from "./host/node.ts";
 import { runDevSupervisor } from "./dev-supervisor.ts";
 import { loadChannels } from "./engines/pi/channel.ts";
+import { isModuleFile } from "./engines/pi/loader.ts";
 import { fastagentVersion } from "./engines/pi/version.ts";
-import { listModels, loadConfig, resolveModelSpec, resolveSessionsDirOverride } from "./engines/pi/config.ts";
+import {
+  isValidPort,
+  listModels,
+  loadConfig,
+  resolveModelSpec,
+  resolveSessionsDirOverride,
+} from "./engines/pi/config.ts";
 import { FASTAGENT_AUTH_PATH } from "./engines/pi/auth.ts";
 import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
 import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
@@ -87,7 +85,7 @@ function usage(code: number): never {
                    (point FASTAGENT_SESSIONS_DIR at a volume so a redeploy never wipes conversations)
   add    github: scaffold channels/<kind>.ts (third-party adapter glue, an on() to edit). skill
          <source>: vendor an Agent Skills skill into skills/<name>/ (git ref owner/repo/path, a local
-         path, or a bare name from ~/.agents/skills; --update re-fetches, review with git diff).
+         path, or a bare name from ~/.agents/skills; --update re-fetches, review with git diff)
   login  authenticate a model provider into ~/.fastagent/auth.json: pick a method (subscription/OAuth
          or API key), then a provider that offers it (configured status shown). [provider] takes the
          method from what that provider supports, asked only when it offers both.`);
@@ -130,10 +128,7 @@ else if (command === "add") await runAdd();
 else if (command === "login") await runLogin();
 else usage(1);
 
-/**
- * `fastagent models [search]`: print every registered "provider/modelId" to stdout (pipe-friendly).
- * `[search]` filters by case-insensitive substring (the full list is long — 35 providers).
- */
+/** `fastagent models [search]`: print every registered "provider/modelId"; `[search]` filters by substring. */
 function runModels(): void {
   const search = positionals[1]?.toLowerCase();
   const specs = listModels(createPiModels());
@@ -142,11 +137,7 @@ function runModels(): void {
   if (search && shown.length === 0) console.error(`no model matches "${positionals[1]}"`);
 }
 
-/**
- * `fastagent tool <name> '<json>' [dir]`: run one tool's body directly with JSON args — no model,
- * no server, no tokens. The tightest authoring feedback loop. Args are validated by the tool's
- * own schema (a defineTool tool returns an "Invalid arguments" result the same way the model sees).
- */
+/** `fastagent tool <name> '<json>' [dir]`: run one tool's body directly with JSON args — no model. */
 async function runTool(): Promise<void> {
   const name = positionals[1];
   const argsJson = positionals[2] ?? "{}";
@@ -157,9 +148,8 @@ async function runTool(): Promise<void> {
   }
   loadDotEnv(toolDir); // a tool may read a key from .env
   const { config } = await loadConfig(toolDir).catch(failStartup);
-  // Same tool set dev/start mount (pi defaults + config.tools + discovered, deduped) so the
-  // runner exercises exactly what gets served — a tool shadowed by a default/config tool is not
-  // run here either; surface that collision instead of silently testing the wrong implementation.
+  // The same tool set dev/start mount (defaults + config.tools + discovered, deduped), so the runner
+  // exercises exactly what gets served — a shadowed tool is surfaced, not silently run.
   const { tools, toolCollisions } = await resolveWorkspaceTools(config, toolDir).catch(failStartup);
   for (const c of toolCollisions) {
     console.error(
@@ -186,13 +176,7 @@ async function runTool(): Promise<void> {
   console.log(typeof out === "string" ? out : JSON.stringify(out, null, 2));
 }
 
-/**
- * `fastagent invoke <message> [dir]`: run ONE turn against the assembled agent, then exit — no server,
- * no TUI. The SAME assembly as dev/start (the folder is the agent), so it answers exactly as the
- * served agent would. The reply text streams to stdout; tool and diagnostic lines go to stderr; a
- * `failed` event exits non-zero. The all-agent counterpart of `tool` (one tool, no model): for CI
- * smoke and quick "what does it answer to X" checks while authoring.
- */
+/** `fastagent invoke <message> [dir]`: run ONE turn against the assembled agent, then exit. */
 async function runInvoke(): Promise<void> {
   const message = positionals[1];
   if (!message) {
@@ -200,49 +184,40 @@ async function runInvoke(): Promise<void> {
     process.exit(2);
   }
   const invokeDir = resolve(positionals[2] ?? ".");
-  loadDotEnv(invokeDir); // model API key from .env, like start
+  loadDotEnv(invokeDir);
   setGlobalDispatcher(new EnvHttpProxyAgent());
   installUndiciFetch();
   const { agent, modelSpec } = await createPiAgentFromWorkspace(invokeDir, { model: values.model }).catch(failStartup);
   console.error(`[fastagent] invoke: ${invokeDir} (${modelSpec})`);
-  // A fresh session per invoke (one-shot — no resume). The event→IO mapping is a pure, tested function
-  // (runInvokeStream): reply text→stdout, tool start/error + the failure reason→stderr, exit code 1 iff
-  // the turn failed so CI can gate on it.
+  // Fresh session per invoke (one-shot, no resume). runInvokeStream maps events→IO: reply→stdout,
+  // tool/failure→stderr, exit 1 iff the turn failed (so CI can gate on it).
   const exitCode = await runInvokeStream(
     agent.invoke({ session: randomUUID() }, { text: message }),
     (text) => process.stdout.write(text),
     (line) => console.error(line),
   );
-  process.stdout.write("\n"); // end the streamed reply line
+  process.stdout.write("\n");
   if (exitCode !== 0) process.exit(exitCode);
 }
 
 /** List channel file basenames in <dir>/channels/ — the authoring view (no import, unlike loadChannels). */
 async function discoverChannelFiles(workspaceDir: string): Promise<string[]> {
-  // The same containment guard loadChannels uses (#66): reject a channels/ symlink that escapes the
-  // workspace, so info reports the SAME surface dev/start would accept — never a channels/ they'd
-  // refuse. Pure realpath, no channel import, so info keeps its no-import-channels choice.
+  // The same containment guard loadChannels uses, so info reports the surface dev/start would accept.
   await assertInsideWorkspace(workspaceDir, "channels");
   let names: string[];
   try {
     names = await readdir(join(workspaceDir, "channels"));
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; // no channels/ is normal
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
     throw error;
   }
   return names
-    .filter((n) => /\.(ts|js|mjs)$/.test(n) && !n.endsWith(".d.ts"))
+    .filter(isModuleFile)
     .map((n) => n.replace(/\.(ts|js|mjs)$/, ""))
     .sort();
 }
 
-/**
- * `fastagent info [dir] [--json]`: print what the directory ASSEMBLES into — model, AGENTS.md, skills,
- * tools (with collisions), channels, sessions dir, and load diagnostics — WITHOUT booting a server.
- * Read-only inspection: it never creates the sessions dir or writes .gitignore (unlike dev/start), and
- * an unset model is reported, not fatal. The discovery counterpart of `tool`/`invoke` (which RUN
- * things): run it first when something looks off (faster than dev), or `--json` it in CI.
- */
+/** `fastagent info [dir] [--json]`: print what the directory ASSEMBLES into, WITHOUT booting a server. Read-only. */
 async function runInfo(): Promise<void> {
   loadDotEnv(dir); // skills/tools may read env at load time
   const { config, path: configPath } = await loadConfig(dir).catch(failStartup);
@@ -302,10 +277,7 @@ async function runInit(): Promise<void> {
   }
   for (const w of warnings) console.error(`[fastagent] warn: ${w}`);
 
-  // A complete agent has a tool that imports @kid7st/fastagent, so its deps must be installed.
-  // Run `npm install` for the developer (the package is public; users handling a private package
-  // will have run `npm login`). --no-install skips it; --minimal has no deps at all. A kept
-  // (pre-existing) package.json is not ours, so we do not install over it.
+  // Install deps only for a complete agent whose package.json we just wrote (a kept one is not ours).
   const willInstall = complete && !values["no-install"] && created.includes("package.json");
   let installFailed = false;
   if (willInstall) {
@@ -315,23 +287,15 @@ async function runInit(): Promise<void> {
       console.error(`[fastagent] warn: npm install failed — run it manually in ${dir} before \`fastagent dev\``);
   }
 
-  // Next steps act on the scaffolded dir. For a named target (`fastagent init my-agent`) lead with
-  // a `cd` so bare `fastagent dev` (which defaults to .) is correct. Credentials are NOT mentioned
-  // here — `dev`/`start` prompt for them in context when missing (reportAuth); front-loading an
-  // instruction a newcomer can't act on yet is noise.
   console.error(`  next steps:`);
   const rel = relative(process.cwd(), dir);
-  // A relative target that climbs out of cwd (e.g. ../../../tmp/x) is noise — show the absolute path.
+  // A relative target that climbs out of cwd (../../../tmp/x) is noise — show the absolute path.
   if (rel !== "") console.error(`    cd ${rel.startsWith("..") ? dir : rel}`);
   if (complete && (values["no-install"] || installFailed)) console.error(`    npm install`);
   console.error(`    fastagent dev   # serve locally and iterate`);
 }
 
-/**
- * `fastagent add github [dir]`: scaffold `channels/<kind>.ts` — the third-party adapter import plus a
- * starter `on()` to edit. A channel always needs glue, so it is a file (not a config entry). Only
- * `github` today. Never clobbers an existing file (authored glue is not overwritten).
- */
+/** `fastagent add github [dir]`: scaffold `channels/<kind>.ts` — the adapter import plus a starter `on()`. */
 async function runAdd(): Promise<void> {
   const kind = positionals[1];
   if (kind === "skill") return runAddSkill();
@@ -340,18 +304,15 @@ async function runAdd(): Promise<void> {
     console.error(`usage: fastagent add github [dir]  |  fastagent add skill <source> [dir]`);
     process.exit(1);
   }
-  // add SCAFFOLDS a channel into a ready workspace; it does not bootstrap one (that is `init`'s job).
-  // Preconditions before the write, so a refusal is side-effect-free: the channel must not already
-  // exist, and the workspace must be a fastagent-ready ESM package that declares the dependency.
+  // Preconditions before the write, so a refusal is side-effect-free.
   if (await channelExists(target, kind).catch(failStartup)) {
     failStartup(new Error(`channels/${kind}.ts already exists — edit it, or remove it to re-scaffold`));
   }
   await assertChannelReady(target).catch(failStartup);
   const file = await scaffoldChannel(target, kind).catch(failStartup);
   console.error(`[fastagent] created ${relative(target, file)}`);
-  // Read-only secret-hygiene check (no mutation): a deploy that copies the directory ships whatever
-  // the root .gitignore/.fastagentignore don't exclude, so warn (don't refuse — on() may read a real
-  // env var) when .env is not ignored, rather than blindly recommending the user put a secret there.
+  // Secret-hygiene check (read-only): warn when .env is not ignored, since a deploy that copies the
+  // directory would ship a secret placed there. Warn, not refuse — on() may read a real env var.
   const envIgnored = (await loadRootIgnore(target).catch(failStartup))?.ignores(".env") ?? false;
   if (!envIgnored) {
     console.error(
@@ -365,13 +326,7 @@ async function runAdd(): Promise<void> {
   console.error(`    fastagent dev   # serve the webhook locally`);
 }
 
-/**
- * `fastagent add skill <source> [dir]`: vendor an Agent Skills skill into <dir>/skills/<name>/.
- * source = a git ref (owner/repo/path, github default), a local path, or a bare name resolved
- * against your local global skill dirs. Copy-in, git-tracked (the filesystem is the registry);
- * validated with the runtime loader; refuses to overwrite unless --update. Adding a skill is still unfamiliar, so
- * the no-arg usage teaches BOTH paths (write-your-own vibe + vendor) and never implies a command.
- */
+/** `fastagent add skill <source> [dir]`: vendor an Agent Skills skill into <dir>/skills/<name>/. */
 async function runAddSkill(): Promise<void> {
   const source = positionals[2];
   const target = resolve(positionals[3] ?? ".");
@@ -403,13 +358,7 @@ async function runAddSkill(): Promise<void> {
   console.error(`  next: mention "${name}" in AGENTS.md so the model knows when to use it; then \`fastagent dev\``);
 }
 
-/**
- * `fastagent login [provider]`: authenticate a model provider into `~/.fastagent/auth.json`. Pick an
- * authentication method (subscription/OAuth or API key), then a provider that offers it (with its
- * configured status). A `[provider]` argument skips the provider picker and takes the method from what
- * that provider supports — asked only when it offers both. The flow logic lives in engines/pi/login.ts;
- * here we supply the terminal IO (@clack/prompts + browser open).
- */
+/** `fastagent login [provider]`: authenticate a model provider into `~/.fastagent/auth.json`. */
 async function runLogin(): Promise<void> {
   const io = terminalLoginIO();
   const result = await loginFlow(io, { provider: positionals[1] }).catch(failStartup);
@@ -426,7 +375,6 @@ function openBrowser(url: string): void {
 function terminalLoginIO(): LoginIO {
   return {
     async select(message, options) {
-      // autocomplete (searchable) once the list is long (the API-key providers); plain select otherwise.
       const r = await (options.length > 7 ? autocomplete : select)({ message, options });
       return isCancel(r) ? undefined : (r as string);
     },
@@ -441,46 +389,39 @@ function terminalLoginIO(): LoginIO {
   };
 }
 
-/** Run `npm install` in `cwd` (inherit stdio so the user sees progress). Returns the exit code. */
+/** Run `npm install` in `cwd` (inherit stdio). Returns the exit code. */
 function npmInstall(cwd: string): Promise<number> {
   return new Promise((resolveCode) => {
     const child = spawn("npm", ["install"], { cwd, stdio: "inherit" });
     child.on("close", (code) => resolveCode(code ?? 1));
-    child.on("error", () => resolveCode(1)); // npm not on PATH, etc.
+    child.on("error", () => resolveCode(1));
   });
 }
 
 /**
- * Parse + range-check a port string (CLI flag or env). Empty/whitespace (e.g. `PORT=` in an
- * env file) is treated as "not set" → undefined, so the `??` precedence chain falls through to
- * the next source instead of binding port 0 (an ephemeral port) — `Number("")` is 0. A
- * non-empty but non-decimal/out-of-range value is an argument error → exit 1. Strict `^\d+$`
- * (not `Number`) rejects hex/exponent/negative/whitespace coercion quirks.
+ * Parse + range-check a port string (CLI flag or env). Empty/whitespace is "not set" → undefined, so
+ * the `??` chain falls through instead of binding port 0 (`Number("")` is 0). A non-decimal or
+ * out-of-range value is an argument error → exit 1.
  */
 function parsePort(value: string | undefined, source: string): number | undefined {
   if (value === undefined) return undefined;
   const trimmed = value.trim();
   if (trimmed === "") return undefined;
-  if (!/^\d+$/.test(trimmed) || Number(trimmed) > 65535) {
+  if (!/^\d+$/.test(trimmed) || !isValidPort(Number(trimmed))) {
     console.error(`invalid ${source} "${value}": must be an integer 0-65535`);
     process.exit(1);
   }
   return Number(trimmed);
 }
 
-/**
- * Report which source provides the model's credentials — and, when none is found, surface a
- * remediation hint at STARTUP (dev and start alike) rather than letting the agent fail silently
- * at first invoke. Non-blocking: you may be iterating on prompts, or set credentials afterward.
- */
+/** Report which source provides the model's credentials, surfacing a remediation hint at startup. Non-blocking. */
 async function reportAuth(modelSpec: string): Promise<void> {
   const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
   const source = await probeAuthSource(createPiModels(), modelSpec);
   console.error(`[fastagent] auth:   ${source === undefined ? "(none found)" : `${source} (${provider})`}`);
   if (source === undefined) {
-    // Lead with `fastagent login`: the default model (openai-codex) is OAuth-only, and we cannot name
-    // the right env var (it is provider-specific and pi-ai's mapping is not exported). Keep the
-    // env path generic so we never advertise a key that can't satisfy the probed provider.
+    // Lead with `fastagent login`: the default model (openai-codex) is OAuth-only, and the
+    // provider-specific env var name is not exported, so keep the env path generic.
     console.error(
       `[fastagent] warn: no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
     );
@@ -499,34 +440,25 @@ function reportAgentsSkillsTools(a: Assembled): void {
 }
 
 /**
- * `fastagent dev` hot-reload is process-restart, not in-process swap: the dev command is a
- * SUPERVISOR that spawns a worker (this same command with FASTAGENT_DEV_WORKER set) to assemble +
- * serve, and restarts that worker on any workspace edit. A fresh process per reload means what is
- * served is ALWAYS your latest code — no in-process module-cache staleness, including modules a
- * tool/config imports (the reason in-process busting was dropped). The supervisor never crashes;
- * a broken edit stops the worker with a loud error and waits for the next save to retry.
+ * `fastagent dev`: a SUPERVISOR that spawns a worker (this command with FASTAGENT_DEV_WORKER set) to
+ * assemble + serve, restarting it on workspace edits. A fresh process per reload means what is served
+ * is always the latest code, including modules a tool/config imports.
  */
 async function runDev(): Promise<void> {
-  // Worker (spawned by the supervisor) or `--no-watch`: assemble + serve once, no watching.
   if (process.env.FASTAGENT_DEV_WORKER === "1" || values["no-watch"]) {
     await serveOnce();
     return;
   }
-  parsePort(values.port, "--port"); // flag-shape check (a non-integer port fails before spawning)
+  parsePort(values.port, "--port"); // flag-shape check before spawning
   runDevSupervisor(dir);
 }
 
-/** Open the workspace agent in pi's interactive TUI (the pi-specific `chat` command). */
 async function runChat(): Promise<void> {
-  loadDotEnv(dir); // model spec + provider API keys may come from .env
-  // Run the chat process IN the workspace. chat is workspace-scoped, and pi resolves a session's
-  // cwd as `header.cwd ?? process.cwd()`; aligning process.cwd() with the workspace makes that
-  // fallback land on the workspace for every session-replacement path (resume/import/fork/new),
-  // so a cwd-less legacy/imported session never drifts to the launch directory. `dir` is absolute.
+  loadDotEnv(dir);
+  // Run the chat process IN the workspace: pi resolves a session's cwd as `header.cwd ?? process.cwd()`,
+  // so aligning process.cwd() with the workspace keeps a cwd-less session on the workspace. `dir` is absolute.
   process.chdir(dir);
-  // Lazy-import: chat pulls pi's interactive TUI module graph (InteractiveMode, pi-tui). A static
-  // import would load it on EVERY command; headless `start`/`dev` never need it. Runtime hygiene
-  // only — the dependency (and install size) is unchanged.
+  // Lazy-import: chat pulls pi's interactive TUI module graph; headless start/dev never need it.
   const { runPiChat } = await import("./engines/pi/chat.ts");
   await runPiChat(dir, { model: values.model }).catch(failStartup);
 }
@@ -535,9 +467,8 @@ async function runChat(): Promise<void> {
 async function serveOnce(): Promise<void> {
   const portFlag = parsePort(values.port, "--port");
   loadDotEnv(dir);
-  // Node's fetch does not honor HTTPS_PROXY by itself; route through the local proxy, and keep
-  // fetch + dispatcher on the SAME undici implementation (pi's core/http-dispatcher; otherwise
-  // Node 26's bundled fetch skips gzip decompression — empty stopReason:"stop" messages).
+  // Route fetch through the local proxy and keep fetch + dispatcher on the same undici implementation
+  // (otherwise Node's bundled fetch skips gzip decompression — empty stopReason:"stop" messages).
   setGlobalDispatcher(new EnvHttpProxyAgent());
   installUndiciFetch();
 
@@ -547,24 +478,17 @@ async function serveOnce(): Promise<void> {
   console.error(`[fastagent] model:  ${a.modelSpec}`);
   await reportAuth(a.modelSpec);
   reportAgentsSkillsTools(a);
-  // dev == deployed: serve the same channels/ a deploy would (default invoke when none declared).
-  // routesFor constructs each discovered channel, which may throw on a misconfig (e.g. an unset
-  // secret) — surface it as a clean startup error, not an unhandled stack.
   const routes = await routesFor(dir, a.agent).catch(failStartup);
   serve(routes, portFlag ?? a.config.http?.port ?? 8787);
 }
 
 async function runStart(): Promise<void> {
   const portFlag = parsePort(values.port, "--port");
-  loadDotEnv(dir); // env API keys + an optional PORT/FASTAGENT_MODEL override
-  // Same proxy/undici setup as dev (see runDev): route fetch through the local proxy and
-  // keep fetch + dispatcher on the same undici implementation.
+  loadDotEnv(dir);
   setGlobalDispatcher(new EnvHttpProxyAgent());
   installUndiciFetch();
 
-  // start runs the definition directory in production posture — the SAME opener dev uses (single
-  // assembly source), just no watch. Sessions precedence (--sessions-dir > FASTAGENT_SESSIONS_DIR >
-  // the opener's <dir>/.fastagent/sessions default) lives in resolveSessionsDirOverride (unit-tested).
+  // The same opener dev uses (single assembly source), just no watch.
   const sessionsDirOverride = resolveSessionsDirOverride(values["sessions-dir"]);
   const { agent, definition, config, modelSpec, sessionsDir, toolNames, toolCollisions } =
     await createPiAgentFromWorkspace(dir, { model: values.model, sessionsDir: sessionsDirOverride }).catch(failStartup);
@@ -577,8 +501,7 @@ async function runStart(): Promise<void> {
   if (toolNames.length > 0) console.error(`[fastagent] tools:  ${toolNames.join(", ")}`);
   reportToolCollisions(toolCollisions);
   console.error(`[fastagent] sessions: ${sessionsDir}`);
-  // Sessions default under the definition dir, which a redeploy may replace wholesale. Remind the
-  // operator (only when using the default) to point them at a volume so conversations survive.
+  // Sessions default under the definition dir, which a redeploy may replace wholesale.
   if (sessionsDirOverride === undefined) {
     console.error(
       `[fastagent] note: sessions live under the definition dir; set FASTAGENT_SESSIONS_DIR to a ` +
@@ -589,15 +512,13 @@ async function runStart(): Promise<void> {
 
   const routes = await routesFor(dir, agent).catch(failStartup);
   serve(routes, portFlag ?? parsePort(process.env.PORT, "PORT env") ?? config.http?.port ?? 8787);
-  // No graceful drain: webhook turns run fire-and-forget and outlive a short shutdown grace anyway
-  // (the engine's lease is the only concurrency guard); SIGTERM just exits. In-flight turns are lost
-  // on redeploy — durable execution is the real fix (deferred).
+  // No graceful drain: webhook turns run fire-and-forget; SIGTERM just exits, losing in-flight turns
+  // (durable execution is the real fix, deferred).
 }
 
 /**
- * The routes this deployment serves: a default `GET /health` (deployment infra; a channel may
- * override it) plus the workspace's discovered `channels/` — or the default invoke channel at
- * POST /invoke when none are declared (zero-config still runs). Route collisions are surfaced.
+ * The routes this deployment serves: a default `GET /health` plus the workspace's discovered
+ * `channels/` — or the default invoke channel at POST /invoke when none are declared.
  */
 async function routesFor(workspaceDir: string, agent: Agent): Promise<Routes> {
   const { routes, collisions } = await loadChannels(workspaceDir, agent);
@@ -607,9 +528,8 @@ async function routesFor(workspaceDir: string, agent: Agent): Promise<Routes> {
     );
   }
   const channels = Object.keys(routes).length > 0 ? routes : { "POST /invoke": createInvokeHandler(agent) };
-  // Add a default GET /health unless a channel already covers it. Overlap, not exact-key: an
-  // any-method `/health` also handles GET, so the built-in must step aside (an exact `GET /health`
-  // would too). `POST /health` does NOT cover GET, so the default stays alongside it.
+  // Add a default GET /health unless a channel already covers it (overlap, not exact-key: an
+  // any-method `/health` also handles GET, so the built-in steps aside).
   const healthCovered = Object.keys(channels).some((k) => {
     const e = parseRouteKey(k);
     return e.path === "/health" && (e.method === undefined || e.method === "GET");
@@ -617,11 +537,7 @@ async function routesFor(workspaceDir: string, agent: Agent): Promise<Routes> {
   return healthCovered ? channels : { "GET /health": () => text("ok\n", 200), ...channels };
 }
 
-/**
- * Serve `routes` via the Node host. serveNode owns binding; the CLI owns policy: a clean message +
- * exit(1) on a bind failure (EADDRINUSE is a startup problem, not a bug), the dev-supervisor ready
- * signal, and the startup log.
- */
+/** Serve `routes` via the Node host. serveNode owns binding; the CLI owns policy (errors, ready signal, log). */
 function serve(routes: Routes, port: number): void {
   serveNode(router(routes), { port }).listening.then(
     (boundPort) => {
@@ -646,9 +562,10 @@ function loadDotEnv(d: string): void {
   }
 }
 
-/** User-fixable startup problems (missing model / bad config / broken definition) are
- *  thrown as plain `Error` with actionable messages — print just the message. Anything
- *  else (TypeError, non-Error, …) is a bug: keep the full stack visible. */
+/**
+ * User-fixable startup problems (missing model / bad config / broken definition) are thrown as plain
+ * `Error` — print just the message. Anything else (TypeError, non-Error) is a bug: keep the stack.
+ */
 function failStartup(error: unknown): never {
   if (error instanceof Error && error.constructor === Error) console.error(error.message);
   else console.error(error);

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -32,6 +32,7 @@ import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
 import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 import { assertInsideWorkspace, loadAgentDefinition, loadRootIgnore } from "./engines/pi/definition.ts";
 import { runInvokeStream } from "./invoke-stream.ts";
+import { reportDefinitionWarnings, reportToolCollisions } from "./engines/pi/report.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/dev.ts";
 import { resolveWorkspaceTools } from "./engines/pi/create.ts";
 import {
@@ -79,7 +80,7 @@ function usage(code: number): never {
          counterpart of tool, for CI smoke and quick checks. Same model resolution as dev.
   start  run the agent in dir (default .) in production posture — the SAME assembly as dev
          (your folder is the agent), just no file-watching. No build step: start reads the
-         definition directly; model/http come from fastagent.config.ts (frozen by git, not a manifest).
+         definition directly; model/http come from fastagent.config.ts (frozen by git).
          model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
          port precedence:  --port > PORT env > fastagent.config.ts http.port > 8787
          sessions: --sessions-dir > FASTAGENT_SESSIONS_DIR > <dir>/.fastagent/sessions
@@ -652,24 +653,4 @@ function failStartup(error: unknown): never {
   if (error instanceof Error && error.constructor === Error) console.error(error.message);
   else console.error(error);
   process.exit(1);
-}
-
-function reportDefinitionWarnings(
-  collisions: { name: string; winnerPath: string; loserPath: string }[],
-  diagnostics: { code: string; message: string; path: string }[],
-): void {
-  for (const c of collisions) {
-    console.error(`[fastagent] warn: skill "${c.name}" collision — using ${c.winnerPath}, ignoring ${c.loserPath}`);
-  }
-  for (const d of diagnostics) {
-    console.error(`[fastagent] warn: ${d.code}: ${d.message} (${d.path})`);
-  }
-}
-
-function reportToolCollisions(collisions: { name: string; source: string }[]): void {
-  for (const c of collisions) {
-    console.error(
-      `[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`,
-    );
-  }
 }

--- a/core/src/collect.ts
+++ b/core/src/collect.ts
@@ -1,8 +1,6 @@
 /**
- * Buffered consumption helper (caller-side, SPEC §7).
- * Reduces an AgentEvent stream to a final value and encodes the terminal discipline:
- * failed → throw, missing terminal → error. Streaming consumers (render-as-you-go /
- * SSE fan-out) still for-await the stream themselves — that is per-caller UI/wire.
+ * Buffered consumption helper: reduce an AgentEvent stream to a final value, encoding the terminal
+ * discipline (failed → throw, missing terminal → error). Streaming consumers for-await themselves.
  */
 import type { AgentEvent, Json } from "./agent.ts";
 
@@ -30,5 +28,5 @@ export async function collect(events: AsyncIterable<AgentEvent>): Promise<Collec
     else if (e.type === "completed") return { text, data: e.data };
     else if (e.type === "failed") throw new AgentFailure(e.details, e.retryable);
   }
-  throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
+  throw new Error("stream ended without a terminal event");
 }

--- a/core/src/collect.ts
+++ b/core/src/collect.ts
@@ -1,6 +1,7 @@
 /**
- * Buffered consumption helper: reduce an AgentEvent stream to a final value, encoding the terminal
- * discipline (failed → throw, missing terminal → error). Streaming consumers for-await themselves.
+ * Buffered consumption helper (caller-side, SPEC §7): reduce an AgentEvent stream to a final value,
+ * encoding the terminal discipline (failed → throw, missing terminal → error). Streaming consumers
+ * for-await themselves.
  */
 import type { AgentEvent, Json } from "./agent.ts";
 
@@ -28,5 +29,5 @@ export async function collect(events: AsyncIterable<AgentEvent>): Promise<Collec
     else if (e.type === "completed") return { text, data: e.data };
     else if (e.type === "failed") throw new AgentFailure(e.details, e.retryable);
   }
-  throw new Error("stream ended without a terminal event");
+  throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
 }

--- a/core/src/dev-supervisor.ts
+++ b/core/src/dev-supervisor.ts
@@ -1,11 +1,8 @@
 /**
- * The `fastagent dev` process supervisor — the watch-and-restart mechanism behind the dev command.
- *
- * It re-spawns the CLI itself as a worker (`FASTAGENT_DEV_WORKER=1`) and restarts that worker on
- * debounced workspace edits. Each restart is a FRESH process (always-latest, no stale module cache).
- * The supervisor never exits on a bad edit — the worker fails loudly (its own startup error) and the
- * supervisor waits for the next save. This is process orchestration, not assembly: it lives outside
- * cli.ts's command dispatch (and outside the engine), holding only the dev process lifecycle.
+ * The `fastagent dev` process supervisor: re-spawn the CLI as a worker (`FASTAGENT_DEV_WORKER=1`) and
+ * restart it on debounced workspace edits. Each restart is a fresh process (always-latest, no stale
+ * module cache). The supervisor never exits on a bad edit — the worker fails loudly and it waits for
+ * the next save.
  */
 import { spawn } from "node:child_process";
 import { watch as watchTree } from "chokidar";
@@ -33,16 +30,14 @@ export function runDevSupervisor(dir: string): void {
       worker = undefined;
       if (reloadPending) {
         reloadPending = false;
-        spawnWorker(); // restart requested: the old worker has now exited, so the port is free
+        spawnWorker(); // restart requested: the old worker has exited, so the port is free
       } else if (!everServed) {
-        // The worker failed BEFORE ever serving — a non-editable startup failure (bad flag,
-        // EADDRINUSE, broken initial workspace) that saving cannot fix. Propagate the exit code so
-        // `fastagent dev` fails like the old CLI did (and smoke tests don't hang). The worker
-        // already printed the specific error (inherited stdio).
+        // Failed BEFORE ever serving — a non-editable startup failure (bad flag, EADDRINUSE, broken
+        // initial workspace) that saving cannot fix. Propagate the exit code (the worker already
+        // printed the error via inherited stdio).
         process.exit(code ?? 1);
       } else {
-        // A worker that HAD been serving stopped (a broken edit, or a crash). The edit is fixable;
-        // the error is already printed. Wait for the next save to retry, do not loop or exit.
+        // A worker that HAD been serving stopped (broken edit or crash). Fixable; wait for the next save.
         console.error(`[fastagent] dev stopped (worker exited: ${signal ?? code}) — save a change to retry`);
       }
     });
@@ -58,12 +53,11 @@ export function runDevSupervisor(dir: string): void {
     }
   };
 
-  // Recursively watch the workspace, structurally ignoring machine-state dirs. The worker writes
-  // jsonl sessions DEEP under .fastagent on every invoke, so watching it would restart dev on its
-  // own writes; node_modules/.git are noise. Everything else is watched — tools, skills, AND helper
-  // dirs a tool/config imports (e.g. lib/) — so a saved transitive import triggers the fresh-process
-  // reload too. chokidar gives reliable cross-platform recursion + structural ignore that native
-  // fs.watch cannot (its `filename` is not guaranteed, defeating a path-based filter).
+  // Recursively watch the workspace, structurally ignoring machine-state dirs: the worker writes
+  // jsonl sessions under .fastagent on every invoke (watching it would restart dev on its own
+  // writes); node_modules/.git are noise. Everything else — tools, skills, helper dirs a tool/config
+  // imports — is watched. chokidar gives reliable cross-platform recursion + structural ignore that
+  // native fs.watch cannot.
   const watcher = watchTree(dir, {
     ignoreInitial: true, // the startup scan is not a change
     ignored: /(?:^|[\\/])(?:\.fastagent|node_modules|\.git)(?:[\\/]|$)/,

--- a/core/src/engines/pi/auth.ts
+++ b/core/src/engines/pi/auth.ts
@@ -1,22 +1,15 @@
 /**
  * Auth for the pi engine: a read-WRITE {@link CredentialStore} over fastagent's OWN credentials file
- * (`~/.fastagent/auth.json`), consumed by the `Models` collection (models.ts). pi 0.80 made auth
- * first-class: providers carry `ProviderAuth`, and the collection resolves per request through a
- * `CredentialStore` (stored credentials) plus an `AuthContext` (ambient env vars).
+ * (`~/.fastagent/auth.json`), consumed by the `Models` collection (models.ts).
  *
- * fastagent owns this file, SEPARATE from the pi CLI's `~/.pi/agent/auth.json`:
- *   - two stores cannot share one OAuth refresh lifecycle (a rotated refresh token consumed by one
- *     would break the other), so fastagent never reads/copies pi's credential — `fastagent login`
- *     does a fresh login into this file;
- *   - the engine binding must not write the user's global pi state, nor be coupled to pi's private
- *     file location/format (engine-neutrality: a future engine binding owns its own auth).
+ * fastagent owns this file, SEPARATE from the pi CLI's `~/.pi/agent/auth.json`: two stores cannot
+ * share one OAuth refresh lifecycle (a rotated refresh token consumed by one would break the other),
+ * and the engine binding must not write the user's global pi state.
  *
  * Persistence + locking reuse pi's `FileAuthStorageBackend` (a cross-process file lock) on the WRITE
- * path only. `read` is pi-ai's per-request hot path (`resolveProviderAuth` reads on every request,
- * "valid tokens cost zero locks"), so it stays UNLOCKED; the backend's in-place write opens only a
- * sub-millisecond torn-read window (during a rare OAuth rotation), which `read` absorbs by re-reading
- * rather than dragging a lock onto the hot path. The write path refuses to overwrite a corrupt file
- * (never clobbering other providers' credentials), and `delete` is a no-op that does not create it.
+ * path only. `read` is pi-ai's per-request hot path, so it stays UNLOCKED; the backend's in-place
+ * write opens only a sub-millisecond torn-read window, which `read` absorbs by re-reading. The write
+ * path refuses to overwrite a corrupt file (never clobbering other providers' credentials).
  */
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -29,10 +22,7 @@ import { FileAuthStorageBackend } from "@earendil-works/pi-coding-agent";
 export const FASTAGENT_AUTH_PATH = join(homedir(), ".fastagent", "auth.json");
 
 export interface FastagentAuthOptions {
-  /**
-   * Sink for non-fatal auth anomalies (unreadable/corrupt credentials file). Defaults to
-   * console.warn (fail visibly out of the box); embedders inject their own logger.
-   */
+  /** Sink for non-fatal auth anomalies (unreadable/corrupt file). Defaults to console.warn. */
   warn?: (message: string) => void;
 }
 
@@ -46,8 +36,7 @@ function pick(creds: Creds, providerId: string): Credential | undefined {
 
 /**
  * Parse the credentials JSON for a WRITE: a corrupt file must THROW — serializing `{}` over it would
- * wipe every other provider's credentials. The throw aborts the locked write (the backend only writes
- * a returned `next`), so the corrupt file is left intact for the user to fix.
+ * wipe every other provider's credentials. The throw aborts the locked write, leaving the file intact.
  */
 function parseForWrite(raw: string | undefined, where: string): Creds {
   if (!raw) return {};
@@ -58,17 +47,7 @@ function parseForWrite(raw: string | undefined, where: string): Creds {
   }
 }
 
-/**
- * A read-write `CredentialStore` backed by `~/.fastagent/auth.json`.
- *
- * - `read` returns the provider's stored credential (missing file/entry = not configured → the
- *   collection falls back to ambient env). UNLOCKED (pi-ai's per-request hot path): a concurrent
- *   in-place write's sub-ms torn read is absorbed by re-reading; a genuinely corrupt file reads
- *   lenient (warn + not-configured, no throw).
- * - `modify` is the serialized read-modify-write `Models.getAuth()` runs OAuth refresh inside: it
- *   locks the file, applies `fn`, and PERSISTS the result — a rotated refresh token is saved, not lost.
- * - `delete` removes the entry (logout); a no-op when nothing is stored, never creating the file.
- */
+/** A read-write `CredentialStore` backed by `~/.fastagent/auth.json`. */
 export function fastagentCredentialStore(
   authPath: string = FASTAGENT_AUTH_PATH,
   options: FastagentAuthOptions = {},
@@ -78,10 +57,9 @@ export function fastagentCredentialStore(
 
   return {
     async read(providerId) {
-      // Missing file = not configured (normal). UNLOCKED — this is pi-ai's per-request hot path; the
-      // only race is a sub-millisecond in-place write during an OAuth rotation, which can yield an
-      // empty/partial file. Re-read a few times before concluding the file is genuinely corrupt; a
-      // valid `{}` (provider simply absent) returns immediately, so a not-configured read costs nothing.
+      // UNLOCKED hot path: the only race is a sub-millisecond in-place write during an OAuth rotation,
+      // which can yield an empty/partial file. Re-read a few times before concluding it is corrupt;
+      // a valid `{}` (provider absent) returns immediately, so a not-configured read costs nothing.
       for (let attempt = 0; attempt < 3; attempt++) {
         let raw: string;
         try {
@@ -98,14 +76,14 @@ export function fastagentCredentialStore(
             // A partial read mid-write parses as garbage — fall through and retry.
           }
         }
-        if (attempt < 2) await sleep(2); // the write window is tiny; let it finish, then re-read
+        if (attempt < 2) await sleep(2);
       }
-      warn(`[fastagent] corrupt auth file ${authPath} — fix or remove it`); // still bad after retries
+      warn(`[fastagent] corrupt auth file ${authPath} — fix or remove it`);
       return undefined;
     },
     modify(providerId, fn) {
       return backend.withLockAsync(async (current) => {
-        const creds = parseForWrite(current, authPath); // corrupt → throw → no write (no clobber)
+        const creds = parseForWrite(current, authPath); // corrupt → throw → no clobber
         const next = await fn(pick(creds, providerId));
         if (next === undefined) return { result: pick(creds, providerId) }; // unchanged: no write
         creds[providerId] = next;
@@ -113,11 +91,11 @@ export function fastagentCredentialStore(
       });
     },
     async delete(providerId) {
-      // No-op when there is nothing to remove: do NOT take the lock (which would create the file via
-      // the backend's ensureFileExists) on a machine that never stored this provider.
+      // No-op when nothing is stored: do NOT take the lock (which would create the file via the
+      // backend's ensureFileExists) on a machine that never stored this provider.
       if (!existsSync(authPath)) return;
       await backend.withLockAsync(async (current) => {
-        const creds = parseForWrite(current, authPath); // corrupt → throw → no clobber
+        const creds = parseForWrite(current, authPath);
         if (!(providerId in creds)) return { result: undefined }; // absent: no write
         delete creds[providerId];
         return { result: undefined, next: `${JSON.stringify(creds, null, 2)}\n` };

--- a/core/src/engines/pi/channel.ts
+++ b/core/src/engines/pi/channel.ts
@@ -1,19 +1,14 @@
 /**
  * Channel discovery (the N axis, filesystem form): a workspace declares its inbound surface by
- * dropping files in `channels/`, mirroring how `tools/` declares capabilities. Each file wires a
- * third-party ADAPTER (e.g. githubChannel — verify + parse + ACK) to the app's mandatory `on()`
- * glue and returns the routes it mounts. There is no config-level channel list: a channel always
- * needs glue, so it is always a file (unlike a glue-free third-party tool, which `config.tools`
- * may list inline).
+ * dropping files in `channels/`, mirroring `tools/`. Each file wires a third-party adapter to the
+ * app's `on()` glue and returns the routes it mounts. There is no config-level channel list — a
+ * channel always needs glue, so it is always a file.
  */
-import type { Dirent } from "node:fs";
-import { readdir } from "node:fs/promises";
-import { extname, join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { join } from "node:path";
 import type { Agent } from "../../agent.ts";
 import { parseRouteKey, type Routes } from "../../host/node.ts";
 import { assertInsideWorkspace } from "./definition.ts";
-import { moduleLoadHint } from "./loader.ts";
+import { loadModuleDir } from "./loader.ts";
 
 /** A `channels/<name>.ts` default export: receives the assembled agent, returns the routes it mounts. */
 export type ChannelModule = (agent: Agent) => Routes;
@@ -24,104 +19,62 @@ export interface ChannelCollision {
   source: string;
 }
 
-const CHANNEL_EXTS = new Set([".ts", ".js", ".mjs"]);
-
 /**
- * Discover channels in `<dir>/channels/`: each top-level `*.ts|.js|.mjs` default-exports a
- * `(agent) => Routes` factory, called here with the assembled agent; the returned route maps are
- * merged (first file wins a route-key clash, the dropped route surfaced). Missing `channels/` is
- * normal (no routes). A file that does not default-export a function fails visibly.
+ * Discover channels in `<dir>/channels/`: each `*.ts|.js|.mjs` default-exports a `(agent) => Routes`
+ * factory, called here with the assembled agent; the returned route maps are merged (first file
+ * wins a route-key clash, the dropped route surfaced). A file that does not contribute a valid,
+ * non-empty Routes object fails visibly.
  */
 export async function loadChannels(
   dir: string,
   agent: Agent,
 ): Promise<{ routes: Routes; collisions: ChannelCollision[] }> {
-  const channelsDir = join(dir, "channels");
-  // A symlinked channels/ is followed only if it stays INSIDE the workspace: an escaping symlink would
-  // put the agent's channels outside its own directory, and a deploy that copies the dir would not
-  // include them — dev/deployed diverge, exactly what "the directory is the agent" forbids. (Top-level
-  // non-file entries — including symlinks-to-files — are skipped by the isFile() filter below.)
+  // A symlinked channels/ is followed only if it stays inside the workspace, so a deploy that copies
+  // the dir includes it (the directory is the agent).
   await assertInsideWorkspace(dir, "channels");
-  let entries: Dirent[];
-  try {
-    entries = await readdir(channelsDir, { withFileTypes: true });
-  } catch (error) {
-    const e = error as NodeJS.ErrnoException;
-    if (e.code === "ENOENT" || e.code === "not_found") return { routes: {}, collisions: [] }; // no channels/ is normal
-    throw new Error(`cannot read ${channelsDir}: ${(error as Error).message}`);
-  }
+  const modules = await loadModuleDir(join(dir, "channels"));
   const routes: Routes = {};
   const collisions: ChannelCollision[] = [];
-  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!entry.isFile()) continue;
-    const ext = extname(entry.name);
-    if (!CHANNEL_EXTS.has(ext) || entry.name.endsWith(".d.ts")) continue;
-    const file = join(channelsDir, entry.name);
-    let mod: { default?: unknown };
-    try {
-      mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
-    } catch (error) {
-      throw new Error(
-        `cannot load channels/${entry.name}: ${(error as Error).message}${moduleLoadHint(error as NodeJS.ErrnoException)}`,
-      );
-    }
+  for (const { label, mod } of modules) {
     const factory = mod.default;
     if (typeof factory !== "function") {
-      throw new Error(`channels/${entry.name} must default-export (agent) => Routes`);
+      throw new Error(`${label} must default-export (agent) => Routes`);
     }
     let declared: Routes;
     try {
       declared = (factory as ChannelModule)(agent);
     } catch (error) {
-      // A channel constructed at startup may reject a misconfig (e.g. an unset secret) — name the file.
-      throw new Error(`channels/${entry.name}: ${(error as Error).message}`);
+      throw new Error(`${label}: ${(error as Error).message}`);
     }
-    // A Promise (async factory) needs its own branch BEFORE the object check (a Promise is an object):
-    // it must be marked handled so a rejected setup is not an unhandled rejection, and it earns a
-    // precise message rather than the generic zero-routes one below.
+    // A Promise needs its own branch before the object check: mark it handled (a rejected async setup
+    // must not go unhandled) and reject it with a precise message rather than the zero-routes one.
     if (
       declared !== null &&
       typeof declared === "object" &&
       typeof (declared as { then?: unknown }).then === "function"
     ) {
-      (declared as unknown as Promise<unknown>).catch(() => {}); // a rejected async factory must not go unhandled
-      throw new Error(
-        `channels/${entry.name} must return Routes synchronously, not a Promise (an async factory is not supported)`,
-      );
+      (declared as unknown as Promise<unknown>).catch(() => {});
+      throw new Error(`${label} must return Routes synchronously, not a Promise (an async factory is not supported)`);
     }
-    // The real invariant for everything else: an authored channels/ file must contribute at least one
-    // route. Assert that directly rather than enumerating bad shapes — a Map/Set, an array, a primitive,
-    // or an empty object all yield zero Object.entries and would otherwise silently fall back to
-    // /invoke; null/undefined would throw unwrapped.
     if (declared === null || typeof declared !== "object") {
-      throw new Error(
-        `channels/${entry.name} must return a Routes object, got ${declared === null ? "null" : typeof declared}`,
-      );
+      throw new Error(`${label} must return a Routes object, got ${declared === null ? "null" : typeof declared}`);
     }
     const declaredRoutes = Object.entries(declared);
     if (declaredRoutes.length === 0) {
       throw new Error(
-        `channels/${entry.name} declared no routes — return a non-empty { "METHOD /path": handler } object (a Promise, Map, array, or {} yields none)`,
+        `${label} declared no routes — return a non-empty { "METHOD /path": handler } object (a Promise, Map, array, or {} yields none)`,
       );
     }
     for (const [route, handler] of declaredRoutes) {
       if (typeof handler !== "function") {
-        throw new Error(
-          `channels/${entry.name}: route "${route}" must map to a handler function, got ${typeof handler}`,
-        );
+        throw new Error(`${label}: route "${route}" must map to a handler function, got ${typeof handler}`);
       }
-      // The KEY must be a well-formed route spec (the router matches on a path that starts with "/").
-      // Without this, a non-empty array of handlers (numeric keys like "0") or a missing-slash key
-      // would pass the value check yet mount at an unreachable path — silently serving nothing.
-      if (!parseRouteKey(route).path.startsWith("/")) {
-        throw new Error(
-          `channels/${entry.name}: route "${route}" is not a valid route key (expected "METHOD /path" or "/path")`,
-        );
+      const parsed = parseRouteKey(route);
+      if (!parsed.path.startsWith("/")) {
+        throw new Error(`${label}: route "${route}" is not a valid route key (expected "METHOD /path" or "/path")`);
       }
       // Overlap, not literal-key, equality: the router treats a bare `/path` as any-method, so
-      // `/webhook` and `POST /webhook` would both mount yet shadow each other. Two routes clash when
-      // they share a path and either is any-method (or the methods match); `GET /x` vs `POST /x` is fine.
-      const parsed = parseRouteKey(route);
+      // `/webhook` and `POST /webhook` clash. `GET /x` vs `POST /x` is fine.
       const clash = Object.keys(routes).some((k) => {
         const e = parseRouteKey(k);
         return (
@@ -130,7 +83,7 @@ export async function loadChannels(
         );
       });
       if (clash) {
-        collisions.push({ route, source: `channels/${entry.name}` });
+        collisions.push({ route, source: label });
         continue;
       }
       routes[route] = handler;

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -48,7 +48,8 @@ import { loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
 import { createPiModels } from "./models.ts";
 import { loadAgentDefinition } from "./definition.ts";
-import { loadTools, mergeDiscoveredTools, type ToolCollision } from "./tool.ts";
+import { loadTools, mergeDiscoveredTools } from "./tool.ts";
+import { reportDefinitionWarnings, reportToolCollisions } from "./report.ts";
 
 export interface RunPiChatOptions {
   /** Model spec override (the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -188,26 +189,6 @@ export async function buildChatRuntime(
   });
   enforceWorkspaceScopedSessionSwitches(runtime, rootCwd);
   return runtime;
-}
-
-function reportDefinitionWarnings(
-  collisions: { name: string; winnerPath: string; loserPath: string }[],
-  diagnostics: { code: string; message: string; path: string }[],
-): void {
-  for (const c of collisions) {
-    console.error(`[fastagent] warn: skill "${c.name}" collision — using ${c.winnerPath}, ignoring ${c.loserPath}`);
-  }
-  for (const d of diagnostics) {
-    console.error(`[fastagent] warn: ${d.code}: ${d.message} (${d.path})`);
-  }
-}
-
-function reportToolCollisions(collisions: ToolCollision[]): void {
-  for (const c of collisions) {
-    console.error(
-      `[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`,
-    );
-  }
 }
 
 function workspaceScopeError(targetCwd: string): Error {

--- a/core/src/engines/pi/chat.ts
+++ b/core/src/engines/pi/chat.ts
@@ -1,34 +1,19 @@
 /**
- * Chat: open a workspace into pi's interactive TUI (`fastagent chat`).
+ * Chat: open a workspace into pi's interactive TUI (`fastagent chat`). A pi-specific COMMAND, not an
+ * engine-neutral channel: it drives pi's full session API (InteractiveMode) for fidelity, so it lives
+ * under engines/pi/ and is not re-exported.
  *
- * `chat` is a pi-specific COMMAND, beside dev.ts/start.ts — NOT an engine-neutral channel. The HTTP
- * channel (channels/http.ts) consumes only the Agent contract (agent.ts), so it works with any
- * engine; `chat` instead drives pi's full session API (`InteractiveMode` — editor, streaming
- * render, tool-call display, slash commands, model cycling, session tree/fork, compaction) and
- * never touches the contract. It HAS to be engine-coupled: the contract is a minimal turn-based
- * `invoke`, while a real TUI needs the engine's whole session lifecycle — forcing it through the
- * contract would collapse it to the crude REPL this command exists to avoid. chat trades
- * neutrality for fidelity, so it lives under engines/pi/ (and is not re-exported from index.ts).
+ * FIDELITY: chat must run the SAME agent dev/start serve, not pi's vanilla discovery (which would walk
+ * AGENTS.md up to the repo root and discover skills from pi's own global dirs). So fastagent's
+ * assembly is INJECTED into pi's session:
+ *   - prompt  → systemPromptOverride = base + instructions ONLY; pi appends the skill section and env
+ *               (date/cwd) itself (including them here would duplicate both).
+ *   - skills  → skillsOverride (fastagent's skills, for the section + invocation).
+ *   - tools   → default coding tools by NAME (pi rebuilds them cwd-bound for rich rendering) +
+ *               fastagent's custom tools via pi's customTools path (so they survive /new, /resume, fork).
  *
- * FIDELITY CONTRACT — chat must run the SAME agent dev/start serve, not pi's vanilla discovery.
- * pi's DefaultResourceLoader would walk AGENTS.md up to the repo root and discover skills under its
- * own `.pi/skills`/`.agents/skills` convention — neither matches fastagent's "the agent is its
- * folder" (dir-only AGENTS.md + `skills/` + `tools/`). So we INJECT fastagent's assembly into pi's
- * session:
- *   - model      → fromServices({ model })            (fastagent's flag>env>config resolution)
- *   - prompt     → resourceLoaderOptions.systemPromptOverride = fastagent's base + instructions
- *                  ONLY; pi appends the skill section and env (date/cwd) itself, so including them
- *                  here would duplicate both. The result equals what dev/start serve (pi's skill/env
- *                  renderers are the ones assembleSystemPrompt mirrors).
- *   - skills     → resourceLoaderOptions.skillsOverride  (fastagent's skills, for the section + invocation)
- *   - tools      → default coding tools by NAME (pi rebuilds them cwd-bound, keeping its rich TUI
- *                  rendering) + fastagent's custom tools registered via pi's customTools path, so
- *                  they survive the TUI rebuilding the session on /new, /resume, and fork
- *
- * Auth/login, model HTTP, and same-workspace sessions ride pi's native machinery on purpose (the
- * login dialog, OAuth, and /resume are part of the "real harness" experience this command exists to
- * show). Cross-workspace session switches are rejected: `.env` is process-global, so one chat TUI is
- * one workspace; run `fastagent chat <other-dir>` for another workspace.
+ * Cross-workspace session switches are rejected: `.env` is process-global, so one chat TUI is one
+ * workspace.
  */
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -81,16 +66,14 @@ export async function buildChatRuntime(
     const definition = await loadAgentDefinition(cwd, { env });
     reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 
-    // Same tool resolution as the dev opener (defaults + config.tools + discovered tools/, deduped),
-    // then split: defaults go to pi by NAME (so pi rebuilds them cwd-bound, keeping rich TUI
-    // rendering); customs go through pi's `customTools` path so they survive /new, /resume, fork.
+    // Same tool resolution as the dev opener, then split: defaults go to pi by NAME (rebuilt cwd-bound
+    // for rich rendering); customs go through pi's `customTools` path so they survive /new, /resume, fork.
     const discovered = await loadTools(cwd);
     const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
     reportToolCollisions([...discovered.collisions, ...crossCollisions]);
     const defaultNames = piDefaultTools(cwd).map((t) => t.name);
     const customTools = tools.filter((t) => !defaultNames.includes(t.name));
-    // Adapt fastagent's AgentTool to pi's ToolDefinition. (`parameters` is plain JSON-Schema; pi
-    // accepts it. The extra execute args onUpdate/ctx are unused by fastagent tools.)
+    // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts it).
     const customToolDefs = customTools.map((t) => ({
       name: t.name,
       label: t.name,
@@ -99,9 +82,8 @@ export async function buildChatRuntime(
       execute: (id: string, params: unknown, signal: AbortSignal | undefined) => t.execute(id, params, signal),
     })) as unknown as ToolDefinition[];
 
-    // base + instructions ONLY. pi appends the skill section (from skillsOverride) and the env
-    // (date/cwd) itself; including them here would duplicate both — chat must match what dev/start
-    // serve, and pi's renderers are the ones fastagent's assembleSystemPrompt mirrors.
+    // base + instructions ONLY — pi appends the skill section and env (date/cwd) itself (including
+    // them here would duplicate both).
     const systemPrompt = assembleSystemPrompt({
       base: piBasePrompt({ tools }),
       instructions: definition.instructions,
@@ -111,20 +93,16 @@ export async function buildChatRuntime(
     return { model, definition, defaultNames, customTools, customToolDefs, systemPrompt };
   }
 
-  // pi calls the factory again on /new, /resume, switch, and fork. Dynamic imports for config/tools
-  // are cached by Node, so trying to treat same-cwd rebuilds as hot reload would silently produce a
-  // half-fresh agent (new AGENTS.md/skills from fs, stale config/tools from ESM cache). Keep chat a
-  // coherent startup snapshot instead: restart `fastagent chat` to load edits.
-  //
-  // Also keep chat workspace-scoped. `.env` is process-global and is loaded by the CLI for the
-  // startup workspace; switching the same TUI process to another cwd would either inherit those env
-  // values or require mutating global env at runtime (secrets/leakage footgun). Fail visibly and ask
-  // the user to run a separate `fastagent chat <dir>` for that workspace.
+  // pi calls the factory again on /new, /resume, switch, and fork. Config/tools dynamic imports are
+  // ESM-cached, so treating same-cwd rebuilds as hot reload would yield a half-fresh agent (fresh
+  // AGENTS.md/skills, stale config/tools). Keep chat a coherent startup snapshot: restart to load
+  // edits. And keep it workspace-scoped — `.env` is process-global, so a switch to another cwd would
+  // leak env or require mutating global env at runtime.
   const rootCwd = canonicalCwd(dir);
   let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
   const assemblyFor = (cwd: string) => {
-    // Compare canonical paths: process.cwd() (pi's fallback) returns the realpath, so a workspace
-    // reached through a symlink would otherwise mismatch a non-realpath rootCwd.
+    // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
+    // otherwise mismatch a non-realpath rootCwd.
     const activeCwd = canonicalCwd(cwd);
     if (activeCwd !== rootCwd) {
       throw workspaceScopeError(activeCwd);
@@ -139,19 +117,16 @@ export async function buildChatRuntime(
     const services = await createAgentSessionServices({
       cwd,
       resourceLoaderOptions: {
-        // Definition-only, like dev/start: suppress pi's machine-global discovery (the developer's
-        // own ~/.pi extensions, slash commands, global AGENTS.md, and APPEND_SYSTEM.md append
-        // prompts) so chat runs the SAME agent that gets served, not the authoring machine's pi
-        // setup layered on top. (noContextFiles covers AGENTS.md context only; the append prompt is
-        // discovered separately and needs its own override.)
+        // Definition-only, like dev/start: suppress pi's machine-global discovery (the developer's own
+        // ~/.pi extensions, slash commands, global AGENTS.md, APPEND_SYSTEM.md) so chat runs the same
+        // agent that gets served, not the authoring machine's pi setup on top.
         noExtensions: true,
         noPromptTemplates: true,
         noContextFiles: true,
         systemPromptOverride: () => systemPrompt,
         appendSystemPromptOverride: () => [],
-        // Replace pi's discovered skills with fastagent's resolved skills (so the agent's skills are
-        // invocable and match the prompt's listing). fastagent's Skill (pi-agent-core: content
-        // inline) is reshaped to pi-coding-agent's (read from filePath/baseDir at invocation time).
+        // Replace pi's discovered skills with fastagent's. fastagent's Skill (content inline) is
+        // reshaped to pi-coding-agent's (read from filePath/baseDir at invocation time).
         skillsOverride: (base) => ({
           skills: definition.skills.map((s) => ({
             name: s.name,
@@ -223,15 +198,10 @@ function readSessionHeaderCwd(sessionPath: string): string | undefined {
 }
 
 /**
- * Keep resume/import inside the chat's single workspace, deciding BEFORE delegating to pi.
- *
- * The chat process is chdir'd into rootCwd at startup (see runChat), so pi's `?? process.cwd()`
- * fallback for a session with no cwd header already resolves to rootCwd on EVERY replacement path
- * (resume, import, fork, new). The one remaining gap is a session that EXPLICITLY records a
- * different workspace cwd: pi would bind that foreign cwd and the runtime factory would reject it —
- * but only AFTER tearing the live session down, leaving the TUI on an invalidated session. Reject
- * such a switch up front. (fork/new carry no foreign target: fork reopens the current, already
- * vetted session; new reuses the current cwd.)
+ * Keep resume/import inside the chat's single workspace, deciding BEFORE delegating to pi. The chat
+ * process is chdir'd into rootCwd, so a session with no cwd header already lands on rootCwd. The gap
+ * is a session that EXPLICITLY records a different cwd: pi would bind it and the factory would reject
+ * it — but only AFTER tearing the live session down. Reject such a switch up front.
  */
 function enforceWorkspaceScopedSessionSwitches(runtime: AgentSessionRuntime, rootCwd: string): void {
   const rejectForeignTarget = (sessionPath: string, cwdOverride: string | undefined): void => {

--- a/core/src/engines/pi/config.ts
+++ b/core/src/engines/pi/config.ts
@@ -1,29 +1,10 @@
 /**
- * The config subsystem: schema (defineConfig), loading (loadConfig), and
- * interpretation of config values (resolveModelSpec for source precedence,
- * resolveModel for the `model` string). One concern: everything about
- * fastagent.config.ts, nothing else.
+ * The config subsystem: schema (defineConfig), loading (loadConfig), and value interpretation
+ * (resolveModel, resolveModelSpec). One concern: everything about fastagent.config.ts.
  *
- * fastagent.config.ts — layer 2 of the three-layer workspace (production source):
- * deployment/assembly choices. Checked into git; secrets go in .env.
- *
- * v1 keys (each passes the "explainable in one sentence + has a near-term story" bar):
- *   - model:    which LLM ("provider/modelId" string — serializable; a repo default overridden by env/CLI);
- *   - tools:    extra custom tools, appended after pi's default tools;
- *   - http:     serving options for the built-in HTTP channel (bind port).
- *
- * The deployment's inbound surface (webhook channels) is NOT a config key: a channel always needs
- * app glue (its `on()` handler), so it is authored as a file under `channels/` (discovered like
- * `tools/`), never listed inline. Absent any channel = the default invoke channel at POST /invoke.
- *
- * Deliberately NOT in v1 (kept as library-API escape hatches):
- *   - sessions/env backend selection — K axis; the hosting knife shapes it from real backends;
- *   - base/auth overrides — the defaults are almost always right; putting them
- *     in config invites misuse.
- *
- * Red line: config describes "choices for this deployment", never the agent's identity
- * or behavior (that lives in AGENTS.md + skills). Deleting the config must still leave
- * a runnable zero-config agent (model via --model / FASTAGENT_MODEL).
+ * Red line: config describes "choices for this deployment" (model / extra tools / http port), never
+ * the agent's identity or behavior (that lives in AGENTS.md + skills). Deleting the config must
+ * still leave a runnable zero-config agent (model via --model / FASTAGENT_MODEL).
  */
 import { existsSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
@@ -34,11 +15,10 @@ import type { AnyModel } from "./harness.ts";
 import { moduleLoadHint } from "./loader.ts";
 
 export interface FastagentConfig {
-  /** "provider/modelId", e.g. "openai-codex/gpt-5.5". Precedence: CLI --model > FASTAGENT_MODEL > config. */
+  /** "provider/modelId". Precedence: CLI --model > FASTAGENT_MODEL > config. */
   model?: string;
-  /** Extra custom tools, appended after pi defaults — never replaces them (materialized by resolveTools in create.ts). */
+  /** Extra custom tools, appended after pi defaults — never replaces them. */
   tools?: AgentTool[];
-  /** Built-in HTTP channel options. */
   http?: { port?: number };
 }
 
@@ -53,10 +33,12 @@ export interface LoadedConfig {
   path?: string;
 }
 
-/**
- * Load `<dir>/fastagent.config.ts|.js|.mjs`. No file = zero-config ({});
- * a file with the wrong shape throws (fail visibly).
- */
+/** A valid bindable port. */
+export function isValidPort(n: number): boolean {
+  return Number.isInteger(n) && n >= 0 && n <= 65535;
+}
+
+/** Load `<dir>/fastagent.config.ts|.js|.mjs`. No file = zero-config; a wrong-shape file throws. */
 export async function loadConfig(dir: string): Promise<LoadedConfig> {
   const names = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"];
   const found = names.map((name) => join(dir, name)).filter((path) => existsSync(path));
@@ -67,16 +49,12 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     );
   }
 
-  // Exactly one config file at this point (0 and >1 handled above).
   // biome-ignore lint/style/noNonNullAssertion: length checked above — exactly one element here
   const path = found[0]!;
   let mod: { default?: unknown };
   try {
     mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
   } catch (error) {
-    // A syntax/load error in the config would otherwise surface as a raw SyntaxError with a Node ESM
-    // internal stack; name the file and append the same load hint as loadTools/loadChannels (config
-    // fails for the same reasons: non-ESM package.json, an uninstalled dep imported by the config).
     throw new Error(`${path}: ${(error as Error).message}${moduleLoadHint(error as NodeJS.ErrnoException)}`);
   }
   const config = mod.default;
@@ -84,8 +62,8 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     throw new Error(`${path}: must default-export defineConfig({...})`);
   }
   const c = config as FastagentConfig;
-  // Unknown keys throw: defineConfig only type-protects .ts authors; a typo in a
-  // .js/.mjs config (`modle:`) must not silently degrade to zero-config.
+  // Unknown keys throw: defineConfig only type-protects .ts authors; a typo in a .js/.mjs config
+  // (`modle:`) must not silently degrade to zero-config.
   for (const key of Object.keys(c)) {
     if (key !== "model" && key !== "tools" && key !== "http") {
       throw new Error(`${path}: unknown key "${key}" (valid keys: model, tools, http)`);
@@ -111,27 +89,18 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   if (c.http !== undefined && (typeof c.http !== "object" || c.http === null)) {
     throw new Error(`${path}: "http" must be an object`);
   }
-  // Same typo discipline one level down: { http: { porrt } } must not silently
-  // fall back to the default port.
   for (const key of Object.keys(c.http ?? {})) {
     if (key !== "port") {
       throw new Error(`${path}: unknown key "http.${key}" (valid keys: port)`);
     }
   }
-  if (
-    c.http?.port !== undefined &&
-    (typeof c.http.port !== "number" || !Number.isInteger(c.http.port) || c.http.port < 0 || c.http.port > 65535)
-  ) {
+  if (c.http?.port !== undefined && (typeof c.http.port !== "number" || !isValidPort(c.http.port))) {
     throw new Error(`${path}: "http.port" must be an integer 0-65535`);
   }
   return { config: c, path };
 }
 
-/**
- * Resolve "provider/modelId" → a pi Model from the given collection. Unknown
- * specs throw a clear error. The model is looked up in `models` so the harness
- * resolves its auth from the same collection.
- */
+/** Resolve "provider/modelId" → a pi Model from `models`, so the harness resolves auth from the same collection. */
 export function resolveModel(models: Models, spec: string): AnyModel {
   const slash = spec.indexOf("/");
   if (slash < 1 || slash === spec.length - 1) {
@@ -148,11 +117,7 @@ export function resolveModel(models: Models, spec: string): AnyModel {
   return model;
 }
 
-/**
- * All registered "provider/modelId" specs in `models`, sorted — the discovery
- * list behind `fastagent models`. Sourced from the same collection {@link resolveModel}
- * accepts, so they stay in sync. Pure (no IO); the CLI prints it to stdout.
- */
+/** All registered "provider/modelId" specs in `models`, sorted — the list behind `fastagent models`. */
 export function listModels(models: Models): string[] {
   const specs: string[] = [];
   for (const provider of models.getProviders()) {
@@ -161,7 +126,7 @@ export function listModels(models: Models): string[] {
   return specs.sort();
 }
 
-/** Model selection precedence: CLI flag > FASTAGENT_MODEL env var > config default. All absent = undefined (caller errors). */
+/** Model selection precedence: CLI flag > FASTAGENT_MODEL env > config default. */
 export function resolveModelSpec(
   flag: string | undefined,
   config: FastagentConfig,
@@ -172,8 +137,8 @@ export function resolveModelSpec(
 
 /**
  * `start`'s sessions-dir override: `--sessions-dir` flag > `FASTAGENT_SESSIONS_DIR` env > undefined
- * (undefined = let the opener fall back to the in-tree `<dir>/.fastagent/sessions` default). A given
- * value is resolved to an absolute path so the store and the startup report agree regardless of cwd.
+ * (the opener then falls back to `<dir>/.fastagent/sessions`). Resolved to absolute so the store and
+ * the startup report agree regardless of cwd.
  */
 export function resolveSessionsDirOverride(
   flag: string | undefined,

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -1,63 +1,14 @@
 /**
- * Agent assembly — everything CONFIGURATION-TIME lives in this module.
- * (Division of labor: invoke.ts decides HOW a turn runs, request time; this
- * module decides WHAT parts an agent is assembled from, configuration time.)
+ * Agent assembly (configuration-time): the engine assets (tools, prompt) plus the reusable ladder
+ * that puts a pi agent together.
  *
- * Organized as the engine-asset parts plus the reusable assembly ladder that consumes them:
+ *   L2  createPiAgentFromDefinition(dir, options)   — load a definition folder, assemble, then L1.
+ *   L1  createPiAgent(options)                       — assemble from typed parts (the canonical ctor).
+ *   L0  createPiAgentFromHarness({ harnessFactory }) — in invoke.ts (its body is the turn mechanism).
  *
- *   §1 tools   — pi default toolset (engine asset)
- *   §2 prompt  — four-segment systemPrompt assembly (pure functions)
- *   §3 ladder  — the reusable rungs that put a pi agent together (L0–L2).
- *
- * Ladder naming rule: `From<source>` marks INDIRECTION — that rung derives its
- * inputs from the named source (a definition folder, engine wiring). L1 carries no
- * suffix: its inputs are given directly as typed options — it is the canonical
- * constructor every other rung ultimately calls. Each rung also has a semantic verb —
- * what its fold actually does — used as its label below:
- *
- *   L2  createPiAgentFromDefinition(dir, options)       (this file)     [LOAD]
- *       "Load the portable agent definition": definition.ts loads, §2 assembles,
- *       then L1. For folder-based embedding.
- *   L1  createPiAgent(options)                          (this file)     [ASSEMBLE]
- *       "Assemble from typed parts": every M/K/auth input explicit, every default
- *       overridable. For embedding with hand-picked parts.
- *   L0  createPiAgentFromHarness({ harnessFactory })    (invoke.ts)     [ADAPT]
- *       "Adapt engine wiring to the Agent contract": adds only the concurrency/
- *       stream shell. For tests and fully custom wiring.
- *
- * Above L2 sits the COMMAND OPENER — not a ladder rung, but a command-posture
- * composition that opens a directory, resolves model/tools, picks session storage, then
- * calls L2: createPiAgentFromWorkspace (dev.ts), which BOTH `dev` and `start` drive (the
- * directory IS the agent). It owns command policy (config
- * precedence, the .fastagent session dir, the sessionsDir override); the ladder owns
- * engine assembly.
- *
- * Each rung only calls the one below; options narrow as you go up (L2 owns
- * systemPrompt/skills itself — they come from the definition; the openers own model/tools —
- * they come from the config resolution, so L2's options deliberately do not
- * accept them as the openers' job).
- *
- * Two ladder-wide rules, written down so the per-rung choices stay explainable:
- *
- * 1. L0 is the odd rung out: L1–L2 fold *configuration
- *    inputs* (files → values → closures); L0 adapts *behavior* (pi's two ports →
- *    SPEC stream + concurrency discipline) — strictly an Adapter. It joins the
- *    create… family by NAME because it is a legitimate entry point (discoverability),
- *    but lives in invoke.ts because its body IS the turn mechanism (cohesion).
- *
- * 2. An injection point climbs only as high as the last persona who owns the
- *    decision, then stops:
- *      - sessions / lease (deployment backends)  → reach L2 (embedding developer);
- *        the openers pick their own default (jsonl under <dir>/.fastagent/, which start can
- *        override to a mounted volume) without exposing a choice;
- *      - base (definition-assembly)               → stop at L2 (L2 owns prompt/skill mounting);
- *      - retryClassifier (engine adaptation)     → stays at L0 (custom-wiring persona);
- *      - an opener exposes only what an operator may say: the model flag. Skills are
- *        always definition-only (your folder is the agent — no scope toggle, no mount path).
- *    KNOWN DEBT: "the openers accept no K" is a v1 line, not an invariant — sessions/env
- *    ARE deployment choices semantically. When backend #2 lands (DDB / sandbox env),
- *    this boundary must be re-cut: either config grows K keys (the openers inherit them)
- *    or opener options grow K overrides. Decide from real backends; do not pre-wire.
+ * Above L2 sits the command opener createPiAgentFromWorkspace (dev.ts), which both `dev` and `start`
+ * drive. Each rung calls the one below; options narrow as you go up (L2 owns systemPrompt/skills —
+ * they come from the definition; the openers own model/tools — from config resolution).
  */
 import { join } from "node:path";
 import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
@@ -74,40 +25,27 @@ import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 
-// ── §1 tools: pi's real built-in core coding tools (engine assets) ───────────
+// ── §1 tools ─────────────────────────────────────────────────────────────────
 //
-// Stance:
-//   - **Full default toolset = fidelity**: definition authors vibe in local pi with the
-//     full toolset; serving with fewer tools = behavior drift (same logic as the base
-//     prompt). We use pi-coding-agent's factories so tool names/descriptions/behavior
-//     match local pi verbatim.
-//   - **The tool layer is not the security boundary**: isolation is the K-side
-//     ExecutionEnv/sandbox's job (local = the user's own machine; AgentCore = microVM).
-//     Locking down for public exposure = explicitly passing a restricted `tools`
-//     list — a deployment posture, not the default.
-//   - pi tools take injectable operations (BashOperations etc.); a future sandbox
-//     adapter swaps operations rather than being locked to local fs.
+// The full pi toolset is the default for fidelity: authors vibe in local pi with it, so serving with
+// fewer tools is behavior drift. Isolation is the K-side ExecutionEnv/sandbox's job, not the tool
+// layer's; locking down for public exposure = passing a restricted `tools` list (a deployment posture).
 
-/** pi's core default toolset (read/bash/edit/write, matching pi defaults), rooted at cwd. */
+/** pi's core default toolset (read/bash/edit/write), rooted at cwd. */
 export function piDefaultTools(cwd: string): AgentTool[] {
   return createCodingTools(cwd) as AgentTool[];
 }
 
-/**
- * Materialize the documented `config.tools` semantics: extra tools are APPENDED
- * after pi's defaults, never replacing them. Used by the dev/start openers; exported
- * for callers assembling manually from a loaded config.
- */
+/** `config.tools` semantics: extra tools APPENDED after pi's defaults, never replacing them. */
 export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] {
   const defaults = piDefaultTools(cwd);
   return config.tools ? [...defaults, ...config.tools] : defaults;
 }
 
 /**
- * Resolve the full tool set a workspace mounts: pi defaults + `config.tools` + discovered
- * `tools/` (deduped, existing win), plus the non-default tool names and the collisions to report.
- * The single source of this resolution for the dev/start openers AND `fastagent tool` — they must
- * mount exactly the same set, so it lives here once instead of being copied per opener.
+ * The full tool set a workspace mounts: pi defaults + `config.tools` + discovered `tools/` (deduped,
+ * existing win), plus the non-default tool names and collisions to report. One source for the
+ * dev/start openers AND `fastagent tool`, so they all mount exactly the same set.
  */
 export async function resolveWorkspaceTools(
   config: FastagentConfig,
@@ -121,25 +59,18 @@ export async function resolveWorkspaceTools(
   return { tools, toolNames, toolCollisions };
 }
 
-// ── §2 prompt: four-segment systemPrompt assembly (core-design §2) ───────────
+// ── §2 prompt: four-segment systemPrompt assembly ───────────────────────────
 //
 //   systemPrompt = ① base (engine asset) + ② instructions (<project_instructions>-wrapped)
 //                + ③ skills listing + ④ env context (date/cwd)
 //
-// AGENTS.md ≠ system prompt. Pure functions: no IO, no clock — segment ④ inputs
-// (date/cwd) are provided by the caller, so the same inputs always produce the
-// same prompt (testable, reproducible).
+// AGENTS.md ≠ system prompt. Pure functions: segment ④ inputs (date/cwd) are caller-provided, so the
+// same inputs always produce the same prompt (testable, reproducible).
 
 /**
- * The pi engine's base prompt (segment ①, inherited from the engine — not invented
- * by fastagent).
- *
- * Mirrors pi-coding-agent's buildSystemPrompt default path (identity + tool list +
- * guidelines), with two deliberate deviations: the pi-TUI docs section is dropped
- * (those local paths do not exist in deployments), and the tool list is generated
- * from the **actually mounted tools** (base and toolset must agree — pi's own
- * parameterization). Future claude/codex engine bindings will not need this: their
- * SDKs assemble their own prompts internally.
+ * The pi engine's base prompt (segment ①), mirroring pi-coding-agent's default path with two
+ * deviations: the pi-TUI docs section is dropped (those paths don't exist in deployments), and the
+ * tool list is generated from the actually-mounted tools (base and toolset must agree).
  */
 export function piBasePrompt(options: { tools?: AgentTool[] } = {}): string {
   const tools = options.tools ?? [];
@@ -159,14 +90,13 @@ Guidelines:
 
 export interface AssembleSystemPromptOptions {
   /**
-   * Base prompt (①), REQUIRED — deliberately no default: a defaulted
-   * piBasePrompt() would render "Available tools: (none)" even when tools are
-   * mounted (base and toolset must agree). Pass piBasePrompt({ tools }) for pi.
+   * Base prompt (①), REQUIRED — no default: a defaulted piBasePrompt() would render
+   * "Available tools: (none)" even when tools are mounted. Pass piBasePrompt({ tools }) for pi.
    */
   base: string;
   /** ② AGENTS.md content (verbatim), injected wrapped — never pasted bare. */
   instructions?: string;
-  /** Path rendered into the <project_instructions path=…> attribute (lets the model re-read the file). */
+  /** Path rendered into the <project_instructions path=…> attribute. */
   instructionsPath?: string;
   /** ③ Skills for the <available_skills> listing. */
   skills?: Skill[];
@@ -175,7 +105,6 @@ export interface AssembleSystemPromptOptions {
   cwd?: string;
 }
 
-/** Assemble the final system prompt (four segments, with the pi-isomorphic <project_instructions> wrapper). */
 export function assembleSystemPrompt(options: AssembleSystemPromptOptions): string {
   let prompt = options.base;
   if (options.instructions) {
@@ -192,33 +121,25 @@ export function assembleSystemPrompt(options: AssembleSystemPromptOptions): stri
   return prompt;
 }
 
-// ── §3 the reusable assembly ladder: L1 / L2 (L0 lives in invoke.ts) ─────────
-//
-// The command opener (createPiAgentFromWorkspace in dev.ts) composes OVER L2 and lives in its
-// own command module — see the header. Both `dev` and `start` drive it.
+// ── §3 the reusable assembly ladder: L1 / L2 ────────────────────────────────
 
-/** L1 options, grouped by the two-axis model (core-design §6.1). */
+/** L1 options, grouped by the two-axis model: M (what the agent is) + K (where/how it runs). */
 export interface CreatePiAgentOptions {
-  // ── M: what the agent is ───────────────────────────────────────────────
+  // ── M ───────────────────────────────────────────────────────────────────
   /**
-   * Provider collection for model requests + auth. Defaults to {@link createPiModels}
-   * (built-in providers; pi OAuth file then env vars). Inject a custom collection
-   * to change providers or auth. {@link model} must belong to it (same provider id).
+   * Provider collection for model requests + auth. Defaults to {@link createPiModels}. {@link model}
+   * must belong to it (same provider id).
    */
   models?: Models;
   model: AnyModel;
-  /**
-   * The FINAL assembled prompt (see §2 for assembly from parts), or a
-   * factory re-evaluated per invoke (keeps time-sensitive segments fresh).
-   */
+  /** The FINAL assembled prompt, or a factory re-evaluated per invoke (keeps time-sensitive segments fresh). */
   systemPrompt?: string | (() => string);
   tools?: AgentTool[];
-  /** Skills visible to the model / explicitly invokable (injected as harness resources). */
   skills?: Skill[];
-  // ── K: where/how it runs ───────────────────────────────────────────────
-  /** Session persistence. Defaults to in-memory (embedding/tests); inject jsonlSessionStore for restart-surviving continuity. */
+  // ── K ───────────────────────────────────────────────────────────────────
+  /** Session persistence. Defaults to in-memory; inject jsonlSessionStore for restart-surviving continuity. */
   sessions?: PiSessionStore;
-  /** Tool execution environment. Defaults to local NodeExecutionEnv (cwd); production injects sandbox/e2b. */
+  /** Tool execution environment. Defaults to local NodeExecutionEnv (cwd); production injects a sandbox. */
   env?: ExecutionEnv;
   /** Single-writer lease. Defaults to in-process fail-fast inProcessLease(). */
   lease?: Lease;
@@ -241,29 +162,24 @@ export function createPiAgent(options: CreatePiAgentOptions): Agent {
 }
 
 /**
- * L2 options — written out explicitly (no Omit<> surgery) so the type can only
- * promise what the implementation honors. Notably absent by design:
- * `systemPrompt` (assembled from the definition) and `skills` (they come from
- * the definition folder — that is the whole point of L2).
+ * L2 options. `systemPrompt` and `skills` are absent by design: they are assembled from the
+ * definition folder — the whole point of L2.
  */
 export interface CreatePiAgentFromDefinitionOptions {
-  // ── M ──────────────────────────────────────────────────────────────────
-  /** Provider collection for model requests + auth. Defaults to {@link createPiModels}. */
   models?: Models;
   model: AnyModel;
-  /** Override the base prompt (segment ①). Defaults to piBasePrompt({tools}) (engine-inherited). */
+  /** Override the base prompt (segment ①). Defaults to piBasePrompt({tools}). */
   base?: string;
-  /** Override tools. Defaults to piDefaultTools (full pi toolset, fidelity; lock down with a custom list). */
+  /** Override tools. Defaults to piDefaultTools (lock down with a custom list). */
   tools?: AgentTool[];
-  // ── K ──────────────────────────────────────────────────────────────────
   sessions?: PiSessionStore;
   env?: ExecutionEnv;
   lease?: Lease;
 }
 
 /**
- * L2: "point at a folder → agent": load + assemble + L1 in one call.
- * Returns the definition so callers can surface diagnostics/collisions.
+ * L2: "point at a folder → agent": load + assemble + L1 in one call. Returns the definition so
+ * callers can surface diagnostics/collisions.
  */
 export async function createPiAgentFromDefinition(
   dir: string,
@@ -274,12 +190,10 @@ export async function createPiAgentFromDefinition(
   const tools = options.tools ?? piDefaultTools(env.cwd);
   const base = options.base ?? piBasePrompt({ tools });
   const agent = createPiAgent({
-    // M — assembled here from the definition (no spread: every field deliberate)
     models: options.models,
     model: options.model,
-    // Factory, not a string: re-assembled per invoke so `date` is the date of the
-    // turn, not of agent creation (long-running deployments would otherwise serve
-    // the boot date forever). Static segments are captured once above.
+    // Factory, not a string: re-assembled per invoke so `date` is the date of the turn, not of agent
+    // creation (a long-running deployment would otherwise serve the boot date forever).
     systemPrompt: () =>
       assembleSystemPrompt({
         base,
@@ -291,14 +205,9 @@ export async function createPiAgentFromDefinition(
       }),
     tools,
     skills: definition.skills,
-    // K + auth — pass-through
     sessions: options.sessions,
     env,
     lease: options.lease,
   });
   return { agent, definition };
 }
-
-// The command OPENER that composes over L2 lives in its own command module:
-//   dev / start → createPiAgentFromWorkspace  (dev.ts)
-// keeping create.ts the pure reusable ladder (L0–L2 + engine assets). See the header.

--- a/core/src/engines/pi/create.ts
+++ b/core/src/engines/pi/create.ts
@@ -28,7 +28,7 @@
  * Above L2 sits the COMMAND OPENER — not a ladder rung, but a command-posture
  * composition that opens a directory, resolves model/tools, picks session storage, then
  * calls L2: createPiAgentFromWorkspace (dev.ts), which BOTH `dev` and `start` drive (the
- * directory IS the agent — no build, no artifact). It owns command policy (config
+ * directory IS the agent). It owns command policy (config
  * precedence, the .fastagent session dir, the sessionsDir override); the ladder owns
  * engine assembly.
  *

--- a/core/src/engines/pi/definition.ts
+++ b/core/src/engines/pi/definition.ts
@@ -1,26 +1,14 @@
 /**
- * Definition domain: read an agent definition folder (AGENTS.md + skills/) into
- * memory. No dependency on agent creation — this module produces data; create.ts
- * consumes it.
+ * Definition domain: read an agent definition folder (AGENTS.md + skills/) into memory. Produces
+ * data; create.ts consumes it.
  *
- * Domain note: the definition CONCEPT is engine-neutral (AGENTS.md / agentskills
- * are cross-product standards — the definition is input to a harness, never part
- * of it). This IMPLEMENTATION is pi-folded (pi's loadSkills / Skill types) per the
- * folded-M decision; lift it out of engines/pi when engine #2 lands.
+ * IO policy: the runtime load path (loadAgentDefinition) does IO only through ExecutionEnv (portable
+ * across local/sandbox/remote envs); the invoke path never touches disk. config/auth/sessions and
+ * this module's Node helpers are composition-root code and may use node fs.
  *
- * IO policy (the precise form of the "core does not read disk" invariant):
- *   - the runtime load path (loadAgentDefinition) does IO **only through ExecutionEnv**
- *     (portable: local / sandbox / remote envs);
- *   - the invoke path (invoke.ts/harness.ts) never touches the disk itself;
- *   - config.ts / auth.ts / sessions.ts (and create.ts's L3 workspace-state setup)
- *     are Node composition-root code and may use node fs.
- *
- * Error conventions on this path:
- *   - ExecutionEnv layer returns Result (pi's contract);
- *   - this module converts Results to **throws** (a broken definition should fail
- *     loudly at startup, not at first invoke);
- *   - non-fatal load findings (bad skill files, name collisions) are returned as
- *     data (diagnostics/collisions) for the caller to surface — visible, not fatal.
+ * Errors: ExecutionEnv returns Result; this module converts a broken definition to a throw (fail
+ * loudly at startup), while non-fatal findings (bad skill files, name collisions) are returned as
+ * data for the caller to surface.
  */
 import { readFile, realpath, writeFile } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve } from "node:path";
@@ -30,16 +18,15 @@ import { loadSkills } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 /**
- * Refuse a workspace subdir (`channels/`, …) that resolves OUTSIDE the workspace via a symlink. Part
- * of "the directory is the agent": an escaping subdir puts part of the agent outside its own directory
- * — a deploy that copies the dir would not include it (dev/deployed diverge), and a write through it
- * lands outside the workspace. An IN-workspace symlink is self-contained and allowed; a missing subdir
- * is fine. Both ends are realpath'd so a symlinked workspace root (/tmp → /private/tmp) is not a false escape.
+ * Refuse a workspace subdir (`channels/`, …) that resolves OUTSIDE the workspace via a symlink: an
+ * escaping subdir puts part of the agent outside its own directory (a deploy that copies the dir
+ * would miss it, and a write through it lands outside). An in-workspace symlink is fine; a missing
+ * subdir is fine. Both ends are realpath'd so a symlinked root (/tmp → /private/tmp) is not a false escape.
  */
 export async function assertInsideWorkspace(workspaceDir: string, name: string): Promise<void> {
   const target = join(workspaceDir, name);
   const real = await realpath(target).catch((e: NodeJS.ErrnoException) => {
-    if (e.code === "ENOENT" || e.code === "not_found") return undefined; // not there yet — nothing to check
+    if (e.code === "ENOENT" || e.code === "not_found") return undefined;
     throw e;
   });
   if (real === undefined) return;
@@ -53,24 +40,21 @@ export async function assertInsideWorkspace(workspaceDir: string, name: string):
   }
 }
 
-/** A same-name skill collision (the discarded side). Must surface, never swallowed (fail visibly). */
+/** A same-name skill collision (the discarded side). Surfaced, never swallowed. */
 export interface SkillCollision {
   name: string;
   winnerPath: string;
   loserPath: string;
 }
 
-/**
- * Result of loading a definition folder. Produced by {@link loadAgentDefinition};
- * never hand-authored — the authored definition is the folder itself.
- */
+/** Result of loading a definition folder. Produced by {@link loadAgentDefinition}. */
 export interface LoadedDefinition {
   /** Verbatim AGENTS.md content (feeds prompt segment ②); undefined when the file does not exist. */
   instructions?: string;
   skills: Skill[];
-  /** Non-fatal per-file skill problems reported by pi's loader (skill skipped, reason recorded). */
+  /** Non-fatal per-file skill problems reported by pi's loader. */
   diagnostics: SkillDiagnostic[];
-  /** Same-name conflicts across mounts (first-wins; definition-local wins). */
+  /** Same-name conflicts across mounts (first-wins). */
   collisions: SkillCollision[];
   /** Absolute definition folder path. AGENTS.md, when present, is at join(dir, "AGENTS.md"). */
   dir: string;
@@ -88,22 +72,21 @@ export async function loadAgentDefinition(
   const e = options.env ?? new NodeExecutionEnv({ cwd: dir });
   const rootResult = await e.absolutePath(dir);
   if (!rootResult.ok) {
-    // No silent fallback: a failing absolutePath means the env itself is broken.
     throw new Error(`cannot resolve definition dir "${dir}": ${rootResult.error.message}`);
   }
   const root = rootResult.value;
 
   const agentsPath = join(root, "AGENTS.md");
   const read = await e.readTextFile(agentsPath);
-  // Only not_found means "no AGENTS.md". Anything else (permission, io) must surface,
-  // otherwise the agent silently runs without instructions (AGENTS.md rule 8).
+  // Only not_found means "no AGENTS.md". Anything else (permission, io) must surface, or the agent
+  // silently runs without instructions.
   if (!read.ok && read.error.code !== "not_found") {
     throw new Error(`cannot read ${agentsPath}: ${read.error.message}`);
   }
   const instructions = read.ok ? read.value : undefined;
 
-  // Skills come ONLY from the definition's own skills/ — your folder is the agent, with
-  // no external/global mount, so the same definition loads the same skills on every machine.
+  // Skills come ONLY from the definition's own skills/ (no external/global mount), so the same
+  // definition loads the same skills on every machine.
   const { skills: raw, diagnostics } = await loadSkills(e, [join(root, "skills")]);
   const byName = new Map<string, Skill>();
   const collisions: SkillCollision[] = [];
@@ -116,20 +99,12 @@ export async function loadAgentDefinition(
     }
   }
 
-  return {
-    instructions,
-    skills: [...byName.values()],
-    diagnostics,
-    collisions,
-    dir: root,
-  };
+  return { instructions, skills: [...byName.values()], diagnostics, collisions, dir: root };
 }
 
 /**
- * Self-ignore a `.fastagent` state dir: write `<stateDir>/.gitignore` = "*" (idempotent —
- * an existing one is kept). Machine state (runtime sessions) is gitignored, deletable, and
- * rebuildable, so a workspace that runs dev/start never shows it as untracked. The caller
- * creates the dir; this only drops the marker.
+ * Self-ignore a `.fastagent` state dir: write `<stateDir>/.gitignore` = "*" (idempotent — an
+ * existing one is kept), so a workspace that runs dev/start never shows machine state as untracked.
  */
 export async function ensureStateDirSelfIgnored(stateDir: string): Promise<void> {
   await writeFile(join(stateDir, ".gitignore"), "*\n", { flag: "wx" }).catch((e: NodeJS.ErrnoException) => {
@@ -138,22 +113,13 @@ export async function ensureStateDirSelfIgnored(stateDir: string): Promise<void>
 }
 
 /**
- * Load the root's exclude rules into ONE flat matcher: `.gitignore` then
- * `.fastagentignore` (fa last → authoritative on conflicts), applied relative to the tree
- * root. Deliberately FLAT — we read only the ROOT files, not nested .gitignore
- * down the tree and not ancestor .gitignore up a monorepo. Reproducing git's full nested +
- * ancestor + repo-boundary ignore engine by hand is an open-ended edge factory (it was);
- * the contract is simply "hard excludes + your root .gitignore/.fastagentignore". For
- * finer or monorepo-package control, put rules in the root `.fastagentignore`. The single
- * `ignore` library matcher handles git's PER-FILE pattern syntax (negation, anchoring,
- * `**`, dir-slash) faithfully — that part is not hand-rolled.
+ * Load the root's exclude rules into ONE flat matcher: `.gitignore` then `.fastagentignore` (fa last
+ * → authoritative on conflicts). Deliberately FLAT — only the ROOT files, not nested or ancestor
+ * .gitignore; for finer control put rules in the root `.fastagentignore`. The `ignore` library
+ * handles git's per-file pattern syntax. An unreadable file fails visibly.
  *
- * An existing-but-unreadable file fails visibly — silently building with no rules could
- * ship files the author meant to exclude.
- *
- * Exported (module-internal, not on the public surface) so commands can ask whether a path is
- * ignored — e.g. `init` and `add github` check whether `.env` is gitignored before advising
- * where to keep a secret.
+ * Exported (module-internal) so commands can ask whether a path is ignored — e.g. whether `.env`
+ * would ship before advising where to keep a secret.
  */
 export async function loadRootIgnore(dir: string): Promise<Ignore | undefined> {
   let rules = "";
@@ -166,8 +132,7 @@ export async function loadRootIgnore(dir: string): Promise<Ignore | undefined> {
       }
     }
   }
-  // ignorecase:false — the `ignore` library defaults to case-INSENSITIVE, which would make a
-  // rule `README.md` also drop an authored `readme.md`. Match git on a case-sensitive
-  // filesystem (our main deploy target) and stay reproducible (a fixed mode, not FS-derived).
+  // ignorecase:false — the library defaults to case-INSENSITIVE, which would make a rule `README.md`
+  // also drop an authored `readme.md`. Match git on a case-sensitive filesystem, reproducibly.
   return rules.trim() === "" ? undefined : ignore({ ignorecase: false }).add(rules);
 }

--- a/core/src/engines/pi/dev.ts
+++ b/core/src/engines/pi/dev.ts
@@ -1,26 +1,12 @@
 /**
  * Open a definition directory into an agent — the single opener BOTH `fastagent dev` and
- * `fastagent start` drive (despite the file name, this is not dev-only).
+ * `fastagent start` drive (despite the file name, not dev-only).
  *
  * A thin command-posture composition over L2 `createPiAgentFromDefinition`: open the directory →
  * resolve model (flag > env > config) and tools (append-after-defaults) → pick session storage →
- * call L2. NOT a ladder rung (the reusable ladder is L0–L2 in create.ts/invoke.ts). dev and start
- * share the SAME assembly here — single source of truth, so what you iterate is what you serve;
- * they differ only at the CLI:
- *
- *   | concern  | dev (fastagent dev)                  | start (fastagent start)                |
- *   |----------|--------------------------------------|----------------------------------------|
- *   | watch    | yes (restart the worker on edits)    | no (stable process)                    |
- *   | sessions | <dir>/.fastagent/sessions (default)  | same default, overridable to a volume  |
- *   | posture  | authoring                            | production                             |
- *
- * There is no build/artifact: the directory IS the agent, run directly (model/http from
- * fastagent.config.ts, frozen by git). Sessions default under the definition's own `.fastagent/`
- * (restart-surviving local continuity, faithful to local pi); start can point them at a mounted
- * volume (sessionsDir) so a redeploy that replaces the directory does not wipe conversations.
- *
- * Node composition-root module (IO policy, see definition.ts): loads config + sets up the
- * session state dir on disk; the invoke path itself stays disk-free.
+ * call L2. dev and start share the SAME assembly here (what you iterate is what you serve); they
+ * differ only at the CLI — dev watches and uses the in-tree sessions default, start runs without
+ * watch and can point sessions at a mounted volume.
  */
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
@@ -36,22 +22,17 @@ export interface CreatePiAgentFromWorkspaceOptions {
   /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
   model?: string;
   /**
-   * Session store directory. Default `<dir>/.fastagent/sessions` (machine state, gitignored).
-   * `start` overrides it (--sessions-dir / FASTAGENT_SESSIONS_DIR / a mounted volume) so production
-   * continuity survives redeploys; dev keeps the local default (restart-surviving, like local pi).
+   * Session store directory. Default `<dir>/.fastagent/sessions` (gitignored machine state). `start`
+   * overrides it (--sessions-dir / FASTAGENT_SESSIONS_DIR / a mounted volume) so production continuity
+   * survives redeploys.
    */
   sessionsDir?: string;
 }
 
 /**
- * "Point at a workspace → agent": the workspace = definition folder + fastagent.config.ts (+ .env
- * handled by the process entry). Loads the config, resolves model (flag > env > config) and tools
- * (append-after-defaults), then L2. Throws a clear error when no model source is set (fail visibly
- * at startup). Returns everything an entry point needs to report what it assembled.
- *
- * Notably absent from the options by design: `model`/`tools` as objects (they come from the config
- * resolution — the whole point of this opener) and K/auth overrides (deployment backends are a
- * library-API concern; use L2/L1 — see create.ts ladder rule 2, KNOWN DEBT: re-cut when hosting lands).
+ * "Point at a workspace → agent": load the config, resolve model and tools, then L2. Throws a clear
+ * error when no model source is set (fail visibly at startup). Returns everything an entry point needs
+ * to report what it assembled.
  */
 export async function createPiAgentFromWorkspace(
   dir: string,
@@ -60,7 +41,6 @@ export async function createPiAgentFromWorkspace(
   agent: Agent;
   definition: LoadedDefinition;
   config: FastagentConfig;
-  /** Config file path; undefined when running zero-config. */
   configPath?: string;
   /** The resolved "provider/modelId" spec actually in use. */
   modelSpec: string;
@@ -68,7 +48,6 @@ export async function createPiAgentFromWorkspace(
   sessionsDir: string;
   /** Non-default tool names in effect: config.tools + discovered tools/. */
   toolNames: string[];
-  /** Discovered tools dropped on a name clash with a default/config tool (surfaced, not silent). */
   toolCollisions: ToolCollision[];
 }> {
   const { config, path: configPath }: LoadedConfig = await loadConfig(dir);
@@ -78,23 +57,18 @@ export async function createPiAgentFromWorkspace(
       `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
     );
   }
-  // Discover tools/ and merge with pi defaults + config.tools (existing win) — the same resolution
-  // start and `fastagent tool` use, so the dev server mounts exactly what gets served.
   const { tools, toolNames, toolCollisions } = await resolveWorkspaceTools(config, dir);
-  // Sessions: default under the definition's own .fastagent/ (machine state — gitignored, deletable).
   const sessionsDir = options.sessionsDir ?? join(dir, ".fastagent", "sessions");
   await mkdir(sessionsDir, { recursive: true });
-  // Self-ignore ONLY the default in-tree state dir, so dev/start don't show <dir>/.fastagent as
-  // untracked. An explicit sessionsDir is the operator's path (e.g. a mounted volume) — never write
-  // our `.gitignore` into it; that path's git-hygiene is theirs, and the volume isn't in the git tree.
+  // Self-ignore only the default in-tree state dir. An explicit sessionsDir is the operator's path
+  // (e.g. a mounted volume) — never write our `.gitignore` into it.
   if (!options.sessionsDir) await ensureStateDirSelfIgnored(join(dir, ".fastagent"));
   const models = createPiModels();
   const { agent, definition } = await createPiAgentFromDefinition(dir, {
     models,
     model: resolveModel(models, modelSpec),
     tools,
-    // Skills are definition-only (the agent is its folder) — no global/external mount, so dev
-    // mirrors deployment exactly (see create.ts ladder rule 2 + core-design §6).
+    // Skills are definition-only (the agent is its folder), so dev mirrors deployment exactly.
     sessions: jsonlSessionStore({ dir: sessionsDir, cwd: dir }),
   });
   return { agent, definition, config, configPath, modelSpec, sessionsDir, toolNames, toolCollisions };

--- a/core/src/engines/pi/harness.ts
+++ b/core/src/engines/pi/harness.ts
@@ -1,16 +1,10 @@
 /**
- * pi harness **wiring** — note: the harness itself (turn loop, tool execution,
- * context management) is pi's `AgentHarness`; this module only constructs one per
- * session. The agent definition (AGENTS.md + skills) is NOT part of the harness —
- * it is content fed INTO it (see definition.ts), the boundary the product rests on.
+ * pi harness wiring: construct one pi `AgentHarness` per session. The agent definition (AGENTS.md +
+ * skills) is content fed INTO the harness (see definition.ts), not part of it.
  *
- * pi continuity wiring: open-or-create delivers "same session, multi-turn memory".
- *
- * Under the stateless design the harness is discarded after each use; continuity
- * comes from **persisting the session (PiSessionStore) and re-opening it per invoke** — pi's
- * prompt() runs buildContext() (getPathToRoot + buildSessionContext), folding the
- * historical entries back into context. This is SPEC portable conformance
- * (no location dependence) made concrete.
+ * Under the stateless design the harness is discarded after each use; continuity comes from
+ * persisting the session (PiSessionStore) and re-opening it per invoke — pi's prompt() folds the
+ * historical entries back into context via buildContext().
  */
 import { AgentHarness } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
@@ -18,45 +12,30 @@ import type { Model, Models } from "@earendil-works/pi-ai";
 import type { PiSessionStore } from "./sessions.ts";
 
 /**
- * pi's Model with the API-shape generic erased — fastagent only passes models
- * through to the harness, so the generic carries no information. One alias keeps
- * the `any` auditable (tighten here if pi exports a variance-friendly type).
+ * pi's Model with the API-shape generic erased — fastagent only passes models through to the
+ * harness, so the generic carries no information. One alias keeps the `any` auditable.
  */
-// biome-ignore lint/suspicious/noExplicitAny: intentional variance-friendly model type, audited at this single point (see above)
+// biome-ignore lint/suspicious/noExplicitAny: intentional variance-friendly model type, audited at this single point
 export type AnyModel = Model<any>;
 
-/**
- * Builds a pi harness bound to the given session — called once per invoke.
- * env/model/tools are injected inside the factory (the closure is the wiring).
- * Constructed by {@link piHarnessFactory}; hand-rolled in tests/custom wiring.
- */
+/** Builds a pi harness bound to the given session — called once per invoke. */
 export type PiHarnessFactory = (session: string) => AgentHarness | Promise<AgentHarness>;
 
 export interface PiHarnessFactoryOptions {
-  /** Session persistence (see sessions.ts). Continuity = same backing store + same session id. */
+  /** Session persistence. Continuity = same backing store + same session id. */
   sessions: PiSessionStore;
   env: ExecutionEnv;
-  /**
-   * Provider collection used for all model requests; resolves auth through the
-   * providers' own `ProviderAuth`. {@link model} must belong to this collection
-   * (same provider id) for its auth to be in scope.
-   */
+  /** Provider collection for all model requests; {@link model} must belong to it (same provider id). */
   models: Models;
   model: AnyModel;
   tools?: AgentTool[];
-  /**
-   * Final assembled prompt, or a factory **re-evaluated per invoke** (a fresh harness
-   * is built per turn) so time-sensitive segments (e.g. current date) stay current.
-   */
+  /** Final assembled prompt, or a factory re-evaluated per invoke so time-sensitive segments stay current. */
   systemPrompt?: string | (() => string);
   /** Skills visible to the model / explicitly invokable (injected as harness resources). */
   skills?: Skill[];
 }
 
-/**
- * The continuity-capable PiHarnessFactory: open-or-create the session per invoke.
- * Existing → open (the harness sees history via buildContext); missing → create.
- */
+/** Open-or-create the session per invoke: existing → open (history via buildContext); missing → create. */
 export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFactory {
   return async (sessionId) => {
     const session = await options.sessions.openOrCreate(sessionId);

--- a/core/src/engines/pi/init.ts
+++ b/core/src/engines/pi/init.ts
@@ -1,31 +1,12 @@
 /**
- * Init: scaffold a runnable fastagent workspace.
+ * Init: scaffold a runnable fastagent workspace. Default = a COMPLETE agent (AGENTS.md, a house-style
+ * skill, tools/word-count.ts, fastagent.config.mjs, package.json, .gitignore); `--minimal` is the
+ * markdown-only unit (no package.json/tool/install). AGENTS.md is a clean persona because it IS the
+ * system prompt; tools/ is auto-discovered; .gitignore lists `.env`.
  *
- * Default = a COMPLETE agent (instructions + a skill + a code tool): AGENTS.md, a house-style
- * skill, tools/word-count.ts (defineTool), fastagent.config.mjs, package.json (ESM + the
- * @kid7st/fastagent + zod deps), .gitignore. A complete agent is
- * instructions + tools, so that is what `init` produces; the CLI then runs `npm install`.
- *
- * `--minimal` = the markdown-only unit (AGENTS.md + skill + config + .gitignore): zero npm
- * dependencies, no package.json, no install — for a pure prompt+skills agent.
- *
- * Scaffold conventions:
- *   - AGENTS.md is a CLEAN persona (no meta "edit me" text) because it IS the system prompt;
- *     "what to do next" is printed to the console by the CLI, not baked into a file.
- *   - tools/ is auto-discovered (filename = tool name), so the config needs no `tools: []`.
- *   - .gitignore lists `.env` so the "secrets are the user's responsibility" model
- *     (core-design §10.1) is wired up from the first commit.
- *   - .env.example documents the (optional) env knobs and is committable (only `.env` is ignored);
- *     it is all-commented and states the default model uses OAuth (`fastagent login`), not an API key, so
- *     it never implies a key is required.
- *
- * Node composition-root module: writes template files (the CLI handles `npm install`).
- *
- * Scope boundary (deliberate — do not keep hardening past it): init is best-effort atomic for
- * ORDINARY inputs. It guards the common, recoverable cases — never overwrites an existing
- * workspace, preflights non-directory/symlink scaffold parents, and rolls back a partial write.
- * It does NOT defend against every pathological pre-existing target state (TOCTOU, read-only
- * dirs, FIFOs, mid-write disk-full, …): a local scaffolding command recovered by delete-and-retry.
+ * Scope: init is best-effort atomic for ORDINARY inputs — it never overwrites an existing workspace,
+ * preflights non-directory scaffold parents, and rolls back a partial write. It does not defend
+ * against every pathological target state (TOCTOU, FIFOs, disk-full): recover by delete-and-retry.
  */
 import { access, cp, lstat, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -114,9 +95,8 @@ const ENV_EXAMPLE = `# Environment for this agent. Copy to .env (gitignored) and
 # FASTAGENT_SESSIONS_DIR=./fastagent-sessions
 `;
 
-/** package.json for the complete (code-tool) agent: ESM + the deps a defineTool tool imports.
- *  The @kid7st/fastagent range tracks THIS build's version (0.x caret locks the minor), so a fresh
- *  workspace installs a version that actually has the API/exports it was scaffolded against. */
+/** package.json for the complete agent: ESM + the deps a defineTool tool imports. The
+ *  @kid7st/fastagent range tracks THIS build's version, so a fresh workspace installs an API-matching version. */
 function packageJson(name: string, version: string): string {
   return `${JSON.stringify(
     {
@@ -208,21 +188,18 @@ function channelPath(dir: string, kind: "github"): string {
   return join(dir, "channels", `${kind}.ts`);
 }
 
-/** Whether a channel file already exists — checked BEFORE any package mutation, so a no-clobber
- *  re-add is a zero-side-effect failure (it must not leave dependency/registry writes behind). */
+/** Whether a channel file already exists — checked before any mutation, so a no-clobber re-add is side-effect-free. */
 export async function channelExists(dir: string, kind: "github"): Promise<boolean> {
   return exists(channelPath(dir, kind));
 }
 
 /**
- * Scaffold `channels/<kind>.ts` into {@link dir}. Only `github` today. Never clobbers an existing
- * file — the `on()` glue is authored content. Returns the written path. (Callers check
- * {@link channelExists} first; the wx write here is the TOCTOU safety net.)
+ * Scaffold `channels/<kind>.ts` into {@link dir}. Never clobbers an existing file (the `on()` glue is
+ * authored content). The wx write is the TOCTOU safety net behind {@link channelExists}.
  */
 export async function scaffoldChannel(dir: string, kind: "github"): Promise<string> {
   const channelsDir = join(dir, "channels");
-  // Don't write through a channels/ symlink that escapes the workspace (github.ts would land outside
-  // the definition); an in-workspace symlink is fine. Mirrors loadChannels + scaffoldWorkspace's guard.
+  // Don't write through a channels/ symlink that escapes the workspace; an in-workspace one is fine.
   await assertInsideWorkspace(dir, "channels");
   const file = channelPath(dir, kind);
   if (await exists(file)) {
@@ -234,10 +211,9 @@ export async function scaffoldChannel(dir: string, kind: "github"): Promise<stri
 }
 
 /**
- * Verify the workspace is ready to host a channel: a package.json that is ESM (`type: "module"`) and
- * declares `@kid7st/fastagent` (the channel file imports it, resolved from the workspace). `add` does
- * NOT bootstrap this — creating package.json, choosing a module type, or ignoring .env is
- * `fastagent init`'s job. Here we only CHECK and guide, never mutate; failures are actionable.
+ * Verify the workspace is ready to host a channel: an ESM package.json that declares
+ * `@kid7st/fastagent` (the channel file imports it). `add` checks and guides, never bootstraps — that
+ * is `init`'s job.
  */
 export async function assertChannelReady(dir: string): Promise<void> {
   const pkgPath = join(dir, "package.json");
@@ -282,12 +258,8 @@ function isBareName(source: string): boolean {
   return !source.includes("/") && !/^[a-z][a-z0-9+.-]*:/i.test(source);
 }
 
-/**
- * Local "global" skill dirs (skills you've collected via other Agent Skills tools). Used ONLY as an
- * add-time vendoring SOURCE — a bare `add skill <name>` copies the match in (git-tracked). This is
- * NOT the removed runtime global-skill scan: nothing is loaded from here at run time; the result is a
- * plain copy inside the definition, which stays self-contained.
- */
+/** Local "global" skill dirs, used ONLY as an add-time vendoring source (a bare `add skill <name>`
+ *  copies the match in, git-tracked) — nothing is loaded from here at run time. */
 function findGlobalSkillSource(name: string): string | undefined {
   for (const root of [join(homedir(), ".agents", "skills"), join(homedir(), ".pi", "agent", "skills")]) {
     if (existsSync(join(root, name, "SKILL.md"))) return join(root, name);
@@ -310,16 +282,11 @@ export interface VendoredSkill {
 }
 
 /**
- * Vendor an Agent Skills skill into `<workspace>/skills/<name>/` from a giget ref
- * (`owner/repo/sub/dir[#ref]`, github default), a LOCAL path (`./x`, `../x`, `/abs`), or a BARE
- * name (`pdf`) resolved against the local global skill dirs (~/.agents/skills, ~/.pi/agent/skills).
- *
- * Copy-in, not link: the skill becomes a git-tracked part of the definition ("your folder is the
- * agent" — there is no registry; the filesystem is the registry, git is the distribution, the user
- * owns trust). Refuses to overwrite an existing skill UNLESS `options.update` — and then it is a plain
- * git-tracked overwrite (review/rollback via your repo's git diff/checkout), never a merge. Fetches
- * into a staging dir and validates BEFORE replacing, so a failed/invalid fetch never destroys an
- * existing skill. Validation uses the SAME loader the runtime uses, so a non-spec skill surfaces now.
+ * Vendor an Agent Skills skill into `<workspace>/skills/<name>/` from a giget ref (github default), a
+ * local path, or a bare name (resolved against the local global skill dirs). Copy-in, git-tracked.
+ * Refuses to overwrite unless `options.update` (then a plain git-tracked overwrite, never a merge).
+ * Validates a staging copy with the runtime loader BEFORE replacing, so a bad fetch never destroys an
+ * existing skill.
  */
 export async function vendorSkill(
   workspaceDir: string,
@@ -342,11 +309,9 @@ export async function vendorSkill(
   }
   await mkdir(skillsDir, { recursive: true });
 
-  // Fetch into a STAGING dir adjacent to dest (same filesystem → atomic rename), validate it, and only
-  // THEN replace dest. So a failed/invalid fetch — a transient network blip on a git ref, a source with
-  // no SKILL.md — never destroys an existing skill: --update means "swap to a new VALID version", not
-  // "delete then hope". The leading "." keeps the loader from ever treating staging as a skill, and a
-  // first-time vendor that fails leaves no half-written skill either.
+  // Fetch into a STAGING dir (same filesystem → atomic rename), validate, and only THEN replace dest,
+  // so a failed/invalid fetch never destroys an existing skill. The leading "." keeps the loader from
+  // treating staging as a skill.
   const staging = join(skillsDir, `.${name}.vendoring`);
   await rm(staging, { recursive: true, force: true }); // clear any leftover from a prior crash
   try {
@@ -387,10 +352,8 @@ export async function vendorSkill(
   if (overwritten) await rm(dest, { recursive: true, force: true });
   await rename(staging, dest);
 
-  // Report via the runtime loader, matching THIS skill by EXACT directory. A substring
-  // `includes("skills/<name>")` both prefix-pollutes a sibling `<name>-x` (no trailing separator) and,
-  // hardcoding `/`, matches nothing on Windows (loader paths use `\`) — dropping the very
-  // description/diagnostics we validate for. relative()+dirname() compare is precise and cross-platform.
+  // Report via the runtime loader, matching THIS skill by EXACT directory (a substring match would
+  // prefix-pollute a sibling `<name>-x` and break on Windows path separators).
   const def = await loadAgentDefinition(workspaceDir);
   const rel = join("skills", name);
   const skill = def.skills.find((sk) => relative(workspaceDir, dirname(sk.filePath)) === rel);
@@ -439,10 +402,9 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
   // Was the target non-empty BEFORE we wrote anything? (missing dir = empty).
   const intoNonEmpty = (await readdir(dir).catch(() => [] as string[])).length > 0;
 
-  // Preflight scaffold parent dirs (e.g. `skills`, `tools`): a pre-existing NON-directory there
-  // would make mkdir fail mid-loop (ENOTDIR) AFTER the first write, leaving a half-scaffold the
-  // identity guard then blocks on retry. Detect it BEFORE any write (lstat, not stat: a symlinked
-  // parent must be rejected, not followed: a symlink here would write outside the workspace).
+  // Preflight scaffold parent dirs: a pre-existing non-directory there would make mkdir fail mid-loop
+  // AFTER the first write, leaving a half-scaffold. Detect it before any write (lstat, not stat: a
+  // symlinked parent must be rejected, not followed — it would write outside the workspace).
   const parents = new Set<string>();
   for (const file of files) {
     let p = dirname(file.rel);
@@ -464,8 +426,8 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
   const created: string[] = [];
   const skipped: string[] = [];
   const warnings: string[] = [];
-  // ONE rollback scope over all post-write work: any failure removes files written THIS run
-  // (guard + wx guarantee they are ours), so scaffoldWorkspace is atomic (retryable on failure).
+  // ONE rollback scope: any failure removes files written THIS run (guard + wx guarantee they are
+  // ours), so scaffoldWorkspace is atomic.
   try {
     for (const file of files) {
       const abs = join(dir, file.rel);
@@ -479,11 +441,9 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
       }
     }
 
-    // Security wiring: a deploy that copies the directory ships secrets unless .gitignore/
-    // .fastagentignore exclude them. If a kept .gitignore does not ignore .env, the scaffold's
-    // secret line silently did not take effect. Use loadRootIgnore (the same matcher) so the
-    // advisory matches what would ship; it can throw on an unreadable ignore file (kept in the
-    // rollback scope so such a throw leaves no half-scaffold).
+    // A deploy that copies the dir ships secrets unless .gitignore/.fastagentignore exclude them. Use
+    // loadRootIgnore (the same matcher) so the advisory matches what would ship; a kept .gitignore
+    // that doesn't ignore .env means the scaffold's secret line silently didn't take effect.
     const rootIgnore = await loadRootIgnore(dir);
     if (!rootIgnore?.ignores(".env")) {
       warnings.push(

--- a/core/src/engines/pi/invoke.ts
+++ b/core/src/engines/pi/invoke.ts
@@ -73,7 +73,7 @@ function toAgentEvent(pe: AgentHarnessEvent): AgentEvent | null {
 /**
  * Terminal mapping, decided by the resolved message's stopReason: pi's prompt() resolves a message
  * with stopReason "error"/"aborted" rather than throwing, so relying on catch alone would miss this
- * entire failure class (violating "the stream must terminate").
+ * entire failure class (violating SPEC MUST 1).
  */
 function toTerminal(message: AssistantMessage): AgentEvent {
   if (message.stopReason === "error" || message.stopReason === "aborted") {
@@ -186,7 +186,8 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         yield terminal;
       } finally {
         // Cleanup MUST NOT throw after the terminal was yielded — that would make an already-closed
-        // event stream throw on iteration. Contain it, but surface it (a cleanup failure is abnormal).
+        // event stream throw on iteration (violating SPEC MUST 2 / MUST 3). Contain it, but surface it
+        // (a cleanup failure is abnormal).
         try {
           unsub();
         } catch (error) {

--- a/core/src/engines/pi/invoke.ts
+++ b/core/src/engines/pi/invoke.ts
@@ -1,32 +1,15 @@
 /**
- * The turn mechanism — everything REQUEST-TIME lives in this module.
- * (Division of labor: create.ts decides WHAT parts an agent is assembled from,
- * configuration time; this module decides HOW a turn runs, request time.)
- *
- * pi reference implementation: fans pi AgentHarness's two ports (subscribe event
- * side-channel + prompt final value) into SPEC's single event stream. The module
- * is organized as the L0 entry plus the three mechanism parts it owns — they are
- * consumer-owned: each exists only because this orchestration needs it:
+ * The turn mechanism (request-time): fan pi AgentHarness's two ports (subscribe event side-channel
+ * + prompt final value) into SPEC's single event stream, under a single-writer-per-session lease.
  *
  *   §1 Lease       — single-writer concurrency floor (injectable port + in-process default)
  *   §2 translate   — the single pi↔SPEC translation point (both directions)
  *   §3 EventQueue  — push→pull plumbing for pi's two-port shape
- *   §4 createPiAgentFromHarness — the L0 rung: composes §1–§3 into Agent.invoke
+ *   §4 createPiAgentFromHarness — composes §1–§3 into Agent.invoke
  *
- * createPiAgentFromHarness returns an object that **implements the Agent contract**
- * (composition, not inheritance).
- *
- * Concurrency: at most one in-flight turn per session. Contention = fail-fast: the
- * second invoke immediately yields `failed{retryable}` ("session busy"), leaving
- * dedupe/queueing/steering UX decisions to the channel.
- * Each invoke spins up a fresh harness bound to the session, discarded after use
- * (stateless multi-session). Session construction and env/model/tools injection all
- * live in the caller-provided harness factory.
- *
- * KNOWN DEBT: the orchestration skeleton here (lease + queue + single-stream terminal
- * discipline) is engine-generic, but the module is pi-coupled via PiHarnessFactory's
- * two-port shape (subscribe + prompt). When engine #2 lands, lift the skeleton out of
- * engines/pi instead of copying it — do not generalize before then.
+ * Concurrency: at most one in-flight turn per session; a second invoke fails fast with
+ * `failed{retryable}` ("session busy"), leaving dedupe/queueing/steering to the channel. Each
+ * invoke builds a fresh harness bound to the session and discards it (stateless multi-session).
  */
 import type { AgentHarnessEvent } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
@@ -35,21 +18,10 @@ import type { PiHarnessFactory } from "./harness.ts";
 
 // ── §1 Lease: single-writer concurrency floor ───────────────────────────────
 //
-// **Contention policy = fail-fast, no queueing**: when already held, `tryAcquire`
-// returns null and the caller emits `failed{retryable:true}` ("session busy").
-// This is a corruption-prevention floor only — it does not pick a UX for any
-// scenario: dedupe / queueing / steering are channel/upper-layer decisions
-// (they know the trigger semantics).
-//
-// Why not queue: real same-session concurrency is mostly "duplicate intent"
-// (dedupe) or "single user firing follow-ups" (steering), not "two real turns";
-// FIFO serialization fits only the multi-participant case, and introduces an
-// unbounded queue plus a slot-leak deadlock when a queued waiter is cancelled.
-//
-// Synchronous, no awaits: nothing interleaves between acquire and entering try,
-// so cancellation at any point still releases in finally — no deadlock class.
-// Cross-process/multi-instance distributed locking (TTL + fencing) is a separate
-// future interface, not this one.
+// Corruption-prevention floor only: it does not pick a UX. Fail-fast over queueing because real
+// same-session concurrency is mostly duplicate intent or a user firing follow-ups, not two real
+// turns; a queue would also leak a slot when a waiter is cancelled. Synchronous (no awaits) so
+// nothing interleaves between acquire and entering try — cancellation always releases in finally.
 
 export type Release = () => void;
 
@@ -58,7 +30,6 @@ export interface Lease {
   tryAcquire(session: string): Release | null;
 }
 
-/** In-process single-writer: a per-session occupancy set. */
 export function inProcessLease(): Lease {
   const busy = new Set<string>();
   return {
@@ -67,7 +38,7 @@ export function inProcessLease(): Lease {
       busy.add(session);
       let released = false;
       return () => {
-        if (released) return; // idempotent
+        if (released) return;
         released = true;
         busy.delete(session);
       };
@@ -75,31 +46,12 @@ export function inProcessLease(): Lease {
   };
 }
 
-// ── §2 translate: the single pi↔SPEC translation point (both directions) ────
-//
-//   pi → SPEC:
-//   - toAgentEvent: in-stream events (text / tool_*); all other pi events return null (dropped).
-//   - toTerminal:   the AssistantMessage resolved by pi `prompt()` → completed / failed.
-//   - errorToTerminal: catch-all for genuine throws → failed.
-//   SPEC → pi:
-//   - toPiPromptOptions: SPEC Prompt images → pi prompt options.
+// ── §2 translate: the single pi↔SPEC translation point ───────────────────────
 
-/**
- * Classifies a failure's `details` as worth re-sending with the same session.
- * The SPEC `retryable` field is contract semantics; making the classifier an
- * injectable strategy keeps the contract from being hard-wired to one heuristic.
- */
-export type RetryClassifier = (details: string) => boolean;
-
-/**
- * Default: minimal string heuristic (pi's _isRetryableError is not exported —
- * KNOWN DEBT: replace with structured error classification if pi exports one).
- * Matching a transient-looking error pattern means "worth re-sending".
- */
+/** Whether a failure's `details` is worth re-sending with the same session (transient-looking). */
 const RETRYABLE =
   /\b(429|5\d\d|timeout|timed out|rate.?limit|overloaded|ECONNRESET|ETIMEDOUT|ENETUNREACH|EAI_AGAIN|socket hang up)\b/i;
-
-export const defaultRetryClassifier: RetryClassifier = (details) => RETRYABLE.test(details);
+const isRetryable = (details: string): boolean => RETRYABLE.test(details);
 
 /** In-stream event mapping. Non text/tool_* pi events (turn_start, message_start, …) are dropped. */
 function toAgentEvent(pe: AgentHarnessEvent): AgentEvent | null {
@@ -110,31 +62,20 @@ function toAgentEvent(pe: AgentHarnessEvent): AgentEvent | null {
       }
       return null;
     case "tool_execution_start":
-      return {
-        type: "tool_started",
-        id: pe.toolCallId,
-        name: pe.toolName,
-        args: pe.args as Json,
-      };
+      return { type: "tool_started", id: pe.toolCallId, name: pe.toolName, args: pe.args as Json };
     case "tool_execution_end":
-      return {
-        type: "tool_ended",
-        id: pe.toolCallId,
-        isError: pe.isError,
-        content: pe.result as Json,
-      };
+      return { type: "tool_ended", id: pe.toolCallId, isError: pe.isError, content: pe.result as Json };
     default:
       return null;
   }
 }
 
 /**
- * Terminal mapping. **Decided by the resolved message's stopReason** (core-design §8):
- * pi's prompt() does not necessarily throw on model error/abort — the normal path is
- * resolving a message with stopReason "error" | "aborted". Relying on catch alone would
- * miss this entire failure class (violating MUST 1).
+ * Terminal mapping, decided by the resolved message's stopReason: pi's prompt() resolves a message
+ * with stopReason "error"/"aborted" rather than throwing, so relying on catch alone would miss this
+ * entire failure class (violating "the stream must terminate").
  */
-function toTerminal(message: AssistantMessage, isRetryable: RetryClassifier): AgentEvent {
+function toTerminal(message: AssistantMessage): AgentEvent {
   if (message.stopReason === "error" || message.stopReason === "aborted") {
     const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
     return { type: "failed", details, retryable: isRetryable(details) };
@@ -142,29 +83,20 @@ function toTerminal(message: AssistantMessage, isRetryable: RetryClassifier): Ag
   return { type: "completed" };
 }
 
-/** Catch-all: genuinely thrown exceptions → failed. */
-function errorToTerminal(error: unknown, isRetryable: RetryClassifier): AgentEvent {
+function errorToTerminal(error: unknown): AgentEvent {
   const details = error instanceof Error ? error.message : String(error);
   return { type: "failed", details, retryable: isRetryable(details) };
 }
 
-/** SPEC Prompt → pi prompt options (the reverse direction: images attachment). */
 function toPiPromptOptions(prompt: Prompt): { images?: ImageContent[] } | undefined {
   if (!prompt.images || prompt.images.length === 0) return undefined;
-  return {
-    images: prompt.images.map((img) => ({
-      type: "image",
-      data: img.data,
-      mimeType: img.mimeType,
-    })),
-  };
+  return { images: prompt.images.map((img) => ({ type: "image", data: img.data, mimeType: img.mimeType })) };
 }
 
 // ── §3 EventQueue: push→pull plumbing for pi's two-port shape ────────────────
 //
-// Single-consumer async queue. It exists because of that shape: engines that are
-// natively async-iterable (e.g. the claude SDK) would not need it.
-// Single-threaded JS: no await interleaves between push and drain, so no locking.
+// Single-consumer async queue; single-threaded JS means no await interleaves between push and
+// drain, so no locking. Engines that are natively async-iterable would not need it.
 
 class EventQueue<T> {
   private buffer: T[] = [];
@@ -178,9 +110,8 @@ class EventQueue<T> {
   }
 
   /**
-   * Yield pushed events in order until `done` settles AND the buffer is drained.
-   * Does not yield the result of `done` — the terminal is produced separately by the
-   * caller (toTerminal). Rejections of `done` are swallowed here (the caller awaits
+   * Yield pushed events in order until `done` settles AND the buffer is drained. The terminal is
+   * produced separately (toTerminal); rejections of `done` are swallowed here (the caller awaits
    * `run` itself) to avoid unhandled rejections.
    */
   async *drainUntil(done: Promise<unknown>): AsyncGenerator<T> {
@@ -206,26 +137,19 @@ class EventQueue<T> {
   }
 }
 
-// ── §4 L0: createPiAgentFromHarness ─────────────────────────────────────────
-//
-// Lives here, not in create.ts: its body IS the turn mechanism (ladder rule 1).
+// ── §4 createPiAgentFromHarness ──────────────────────────────────────────────
 
 export interface CreatePiAgentFromHarnessOptions {
   harnessFactory: PiHarnessFactory;
   /** Single-writer lease. Defaults to the in-process per-session fail-fast lease. */
   lease?: Lease;
-  /** Strategy for the `failed.retryable` field. Defaults to defaultRetryClassifier (string heuristic). */
-  retryClassifier?: RetryClassifier;
 }
 
-/** L0 of the assembly ladder: "from a harness factory" — engine wired by the caller, adds only the concurrency/stream shell. */
+/** "From a harness factory": engine wired by the caller; adds only the concurrency/stream shell. */
 export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOptions): Agent {
-  const { harnessFactory, lease = inProcessLease(), retryClassifier = defaultRetryClassifier } = options;
+  const { harnessFactory, lease = inProcessLease() } = options;
 
   async function* invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
-    // Fail-fast single writer: if the session already has an in-flight turn, report
-    // busy immediately — no queueing. tryAcquire is synchronous, so no await sits
-    // between acquiring and entering try: cancellation anywhere still releases.
     const release = lease.tryAcquire(scope.session);
     if (!release) {
       yield {
@@ -240,9 +164,8 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       try {
         harness = await harnessFactory(scope.session);
       } catch (error) {
-        // Setup failures (session open / auth / …) MUST also surface as a failed
-        // event, never as a throw.
-        yield errorToTerminal(error, retryClassifier);
+        // Setup failures (session open / auth / …) MUST surface as a failed event, never a throw.
+        yield errorToTerminal(error);
         return;
       }
 
@@ -253,25 +176,17 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       });
       try {
         const run = harness.prompt(prompt.text, toPiPromptOptions(prompt));
-        // Yield text / tool_* as they happen, until run settles and the buffer drains.
         yield* queue.drainUntil(run);
-        // Terminal is decided by the resolved message's stopReason; catch only
-        // covers genuine throws.
         let terminal: AgentEvent;
         try {
-          terminal = toTerminal(await run, retryClassifier);
+          terminal = toTerminal(await run);
         } catch (error) {
-          terminal = errorToTerminal(error, retryClassifier);
+          terminal = errorToTerminal(error);
         }
         yield terminal;
       } finally {
-        // Both cancel (generator return → finally) and normal completion pass here.
-        // Cleanup MUST NOT throw: an abort()/unsub() exception after the terminal
-        // was yielded would make iteration throw, polluting an already-closed
-        // event stream (violating SPEC MUST 2 / MUST 3). So we contain the throw
-        // here — but a cleanup failure is abnormal (resource/abort regression), so
-        // surface it visibly instead of swallowing it (fail visibly). A pluggable
-        // sink can replace console.warn once the production logging seam exists.
+        // Cleanup MUST NOT throw after the terminal was yielded — that would make an already-closed
+        // event stream throw on iteration. Contain it, but surface it (a cleanup failure is abnormal).
         try {
           unsub();
         } catch (error) {
@@ -284,7 +199,7 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         }
       }
     } finally {
-      release(); // release after cleanup so the next invoke for this session can enter
+      release(); // after cleanup, so the next invoke for this session can enter
     }
   }
 

--- a/core/src/engines/pi/loader.ts
+++ b/core/src/engines/pi/loader.ts
@@ -1,8 +1,59 @@
+import type { Dirent } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MODULE_EXTS = new Set([".ts", ".js", ".mjs"]);
+
+/** Whether `name` is an importable workspace module (a discovery candidate, not a type declaration). */
+export function isModuleFile(name: string): boolean {
+  return MODULE_EXTS.has(extname(name)) && !name.endsWith(".d.ts");
+}
+
+export interface DiscoveredModule {
+  /** Basename without extension — the authoritative name for tools/channels. */
+  name: string;
+  /** "tools/foo.ts"-style label for errors and collisions. */
+  label: string;
+  file: string;
+  mod: { default?: unknown };
+}
+
 /**
- * A short hint for a dynamic-import failure, covering the two common workspace causes — an
- * uninstalled dependency, or a non-ESM package — and EMPTY otherwise, so an unrelated error (a
- * syntax error, a top-level throw) is reported on its own rather than mis-attributed to module type.
- * Shared by tools/ and channels/ discovery (loadTools, loadChannels).
+ * Import every module file in `subDir`, sorted by name. Missing dir returns none.
+ * A failed import names the file and appends {@link moduleLoadHint}.
+ */
+export async function loadModuleDir(subDir: string): Promise<DiscoveredModule[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(subDir, { withFileTypes: true });
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException;
+    if (e.code === "ENOENT" || e.code === "not_found") return [];
+    throw new Error(`cannot read ${subDir}: ${(error as Error).message}`);
+  }
+  const sub = basename(subDir);
+  const out: DiscoveredModule[] = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile() || !isModuleFile(entry.name)) continue;
+    const file = join(subDir, entry.name);
+    const label = `${sub}/${entry.name}`;
+    let mod: { default?: unknown };
+    try {
+      mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
+    } catch (error) {
+      throw new Error(
+        `cannot load ${label}: ${(error as Error).message}${moduleLoadHint(error as NodeJS.ErrnoException)}`,
+      );
+    }
+    out.push({ name: basename(entry.name, extname(entry.name)), label, file, mod });
+  }
+  return out;
+}
+
+/**
+ * A hint for the two common dynamic-import failures — an uninstalled dependency or a non-ESM
+ * package — and empty otherwise, so an unrelated error is reported on its own.
  */
 export function moduleLoadHint(error: NodeJS.ErrnoException): string {
   if (error.code === "ERR_MODULE_NOT_FOUND" || /Cannot find (package|module)/.test(error.message)) {

--- a/core/src/engines/pi/login.ts
+++ b/core/src/engines/pi/login.ts
@@ -1,21 +1,11 @@
 /**
- * `fastagent login`: authenticate a MODEL PROVIDER into fastagent's OWN `~/.fastagent/auth.json` via
- * the SAME {@link fastagentCredentialStore} the runtime uses — ONE writer over the file, ONE
- * corruption/lock semantics.
+ * `fastagent login`: authenticate a MODEL PROVIDER into `~/.fastagent/auth.json` via the same
+ * {@link fastagentCredentialStore} the runtime uses (one writer, one lock/corruption semantics).
  *
- * Scope: this is **model provider** auth (the runtime credential to call an LLM), NOT deploy/platform
- * auth. Deploy-target auth (a future `fastagent deploy login`) is a separate K-axis concern with its
- * own store; login never touches it (see core-design: auth is separated by what it serves).
- *
- * Flow (pi-ai's UNIFIED `ProviderAuth` API, not the deprecated oauth-only one): pick an authentication
- * method (subscription/OAuth or API key), then a provider that offers it (with its configured status),
- * then run `provider.auth.{oauth|apiKey}.login(callbacks)` — one path for both, driven by pi-ai's
- * `AuthLoginCallbacks` — and persist the returned credential with `store.modify`, which refuses to
- * clobber a corrupt file (a failed save fails visibly without extra reconciliation).
- *
- * The terminal IO is INJECTED ({@link LoginIO}) and providers are injectable, so the routing is
- * testable against a real store without real stdin or a real auth round-trip. The CLI wires `LoginIO`
- * to `@clack/prompts` (searchable select + hidden password), never a full-screen TUI.
+ * Flow (pi-ai's unified `ProviderAuth` API): pick a method (OAuth or API key), then a provider that
+ * offers it, then run `provider.auth.{oauth|apiKey}.login(callbacks)` and persist with `store.modify`
+ * (which refuses to clobber a corrupt file). The terminal IO and providers are injected, so the
+ * routing is testable without real stdin or a real auth round-trip.
  */
 import type {
   AuthEvent,
@@ -63,10 +53,9 @@ function anySignal(...signals: Array<AbortSignal | undefined>): AbortSignal | un
 }
 
 /**
- * Map pi-ai's unified `AuthLoginCallbacks` onto the injected {@link LoginIO}. `userSignal` is the
- * overall login abort (e.g. CLI Ctrl-C); `doneSignal` fires when the flow resolves, so a prompt the
- * provider left pending (a manual-code paste racing a callback server it just won) is cancelled and
- * the one-shot CLI can exit instead of hanging on stdin.
+ * Map pi-ai's `AuthLoginCallbacks` onto the injected {@link LoginIO}. `doneSignal` fires when the flow
+ * resolves, cancelling a prompt the provider left pending (a manual-code paste racing a callback
+ * server it just won) so the one-shot CLI exits instead of hanging on stdin.
  */
 function authCallbacks(io: LoginIO, userSignal: AbortSignal | undefined, doneSignal: AbortSignal): AuthLoginCallbacks {
   return {
@@ -146,9 +135,8 @@ async function selectProvider(
 }
 
 /**
- * Resolve method + provider (asking only what is not already given), run the provider's login flow,
- * and persist. The persist refuses a corrupt file, so it fails visibly on its own; a no-op `modify` up
- * front runs that same check BEFORE the flow, so a known-bad file fails fast instead of after the work.
+ * Resolve method + provider (asking only what is not given), run the login flow, and persist. A no-op
+ * `modify` up front runs the refuse-corrupt check BEFORE the flow, so a known-bad file fails fast.
  */
 export async function loginFlow(
   io: LoginIO,
@@ -176,7 +164,7 @@ export async function loginFlow(
     providerId = await selectProvider(io, providers, method, store);
   }
 
-  // Preflight: a no-op modify runs the store's refuse-corrupt / writability check BEFORE the flow.
+  // Preflight: a no-op modify runs the refuse-corrupt / writability check BEFORE the flow.
   await store.modify(providerId, async () => undefined);
 
   const provider = providers.find((p) => p.id === providerId);
@@ -184,8 +172,7 @@ export async function loginFlow(
   const auth = method === "oauth" ? provider.auth.oauth : provider.auth.apiKey;
   if (!auth?.login) throw new Error(`provider "${providerId}" has no ${method} login`);
 
-  // `done` fires when login resolves, cancelling any prompt the provider left pending (manual-code
-  // race backstop) so the one-shot CLI exits instead of hanging on stdin.
+  // `done` cancels any prompt left pending when login resolves (manual-code race backstop).
   const done = new AbortController();
   let credential: Credential;
   try {

--- a/core/src/engines/pi/models.ts
+++ b/core/src/engines/pi/models.ts
@@ -1,15 +1,8 @@
 /**
- * The pi `Models` collection — the single hub that owns BOTH model resolution
- * (provider/modelId lookup) AND auth (per-request credential resolution).
- *
- * pi 0.80 folded the old split — a global model registry (`getModel`/`getModels`)
- * plus a harness-injected `getApiKeyAndHeaders` callback — into one `Models`
- * object built from provider factories. Providers carry their own `ProviderAuth`,
- * so auth resolves through the collection (`Models.getAuth`), not a side channel.
- *
- * fastagent builds one `Models` per opener (dev/start) and threads it into the
- * harness alongside the selected `model`; the two must come from the same
- * collection so the selected model's provider auth is in scope.
+ * The pi `Models` collection — the single hub that owns BOTH model resolution (provider/modelId
+ * lookup) AND auth (per-request credential resolution). fastagent builds one per opener and threads
+ * it into the harness alongside the selected `model`; the two must come from the same collection so
+ * the model's provider auth is in scope.
  */
 import { type Models, defaultProviderAuthContext } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
@@ -21,15 +14,9 @@ export interface CreatePiModelsOptions extends FastagentAuthOptions {
 }
 
 /**
- * A `Models` with every built-in pi provider registered, wired to fastagent's
- * default auth:
- * - **stored credentials** from fastagent's own `~/.fastagent/auth.json` (OAuth
- *   tokens or `api_key` entries, written by `fastagent login`) via
- *   {@link fastagentCredentialStore}, refreshed and persisted in place, and
- * - **ambient env vars** (e.g. `ANTHROPIC_API_KEY`) via pi's default auth context.
- *
- * Resolution order is upstream-owned: a stored credential owns the provider;
- * env is consulted only when nothing is stored.
+ * A `Models` with every built-in pi provider, wired to fastagent's auth: stored credentials from
+ * `~/.fastagent/auth.json` (via {@link fastagentCredentialStore}), then ambient env vars. A stored
+ * credential owns the provider; env is consulted only when nothing is stored (resolution order is upstream-owned).
  */
 export function createPiModels(options: CreatePiModelsOptions = {}): Models {
   return builtinModels({
@@ -39,10 +26,9 @@ export function createPiModels(options: CreatePiModelsOptions = {}): Models {
 }
 
 /**
- * Which source currently satisfies auth for `spec` — a startup diagnostic
- * (dev/start print it). Returns the upstream `AuthResult.source` label
- * (e.g. "OAuth", "ANTHROPIC_API_KEY") or undefined when unconfigured.
- * Reporting-only; never throws (a failed OAuth refresh reports unconfigured).
+ * Which source currently satisfies auth for `spec` — a startup diagnostic. Returns the upstream
+ * `AuthResult.source` label (e.g. "OAuth", "ANTHROPIC_API_KEY") or undefined when unconfigured.
+ * Reporting-only; never throws.
  */
 export async function probeAuthSource(models: Models, spec: string): Promise<string | undefined> {
   const slash = spec.indexOf("/");

--- a/core/src/engines/pi/report.ts
+++ b/core/src/engines/pi/report.ts
@@ -1,8 +1,6 @@
 /**
  * Render assembly warnings to stderr — the one place both the CLI runners and the `chat` runtime show
- * non-fatal definition/tool findings. The loaders return these as DATA (definition.ts: findings are
- * surfaced by the caller, not thrown), so the surfacing is the entry point's job; keeping a single copy
- * means the wording can't drift between the two callers.
+ * the non-fatal definition/tool findings the loaders return as data. One copy so the wording can't drift.
  */
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import type { SkillCollision } from "./definition.ts";

--- a/core/src/engines/pi/report.ts
+++ b/core/src/engines/pi/report.ts
@@ -1,0 +1,26 @@
+/**
+ * Render assembly warnings to stderr — the one place both the CLI runners and the `chat` runtime show
+ * non-fatal definition/tool findings. The loaders return these as DATA (definition.ts: findings are
+ * surfaced by the caller, not thrown), so the surfacing is the entry point's job; keeping a single copy
+ * means the wording can't drift between the two callers.
+ */
+import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
+import type { SkillCollision } from "./definition.ts";
+import type { ToolCollision } from "./tool.ts";
+
+export function reportDefinitionWarnings(collisions: SkillCollision[], diagnostics: SkillDiagnostic[]): void {
+  for (const c of collisions) {
+    console.error(`[fastagent] warn: skill "${c.name}" collision — using ${c.winnerPath}, ignoring ${c.loserPath}`);
+  }
+  for (const d of diagnostics) {
+    console.error(`[fastagent] warn: ${d.code}: ${d.message} (${d.path})`);
+  }
+}
+
+export function reportToolCollisions(collisions: ToolCollision[]): void {
+  for (const c of collisions) {
+    console.error(
+      `[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`,
+    );
+  }
+}

--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -25,6 +25,8 @@ export interface PiSessionStore {
  * persists the assistant message before the tool runs). The next turn would then hand the provider an
  * `assistant(tool_use) -> user` sequence that Anthropic/OpenAI reject — the session is poisoned. We
  * append an honest "interrupted" error result for each dangling call, restoring a valid transcript.
+ * Tool side-effect idempotency stays the tool's responsibility (SPEC §6); this only restores
+ * transcript validity, not exactly-once execution.
  *
  * Pairing is TURN-LOCAL: a tool_use is paired only by a toolResult that immediately follows it (up to
  * the next non-toolResult). tool-call ids are not unique across turns (a local model may restart ids

--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -1,24 +1,13 @@
 /**
  * Session persistence — the K-axis port and its first two backends.
  *
- * PiSessionStore is the consumer-owned port: exactly what the harness factory needs
- * (open-or-create by opaque session id) and nothing more. pi's full SessionRepo
- * surface (list/open/create/delete/fork, backend-specific create options) stays
- * behind the adapters — the invoke path never needs it, and backend-specific
- * requirements (jsonl's `cwd`) stay out of the port.
+ * PiSessionStore is the consumer-owned port: open-or-create by opaque session id, nothing more.
+ * pi's full SessionRepo surface (list/open/create/delete/fork) stays behind the adapters. The `Pi`
+ * prefix is honest — `openOrCreate` returns pi's `Session`, so this is pi-coupled, not a neutral
+ * persistence contract.
  *
- * The name carries the `Pi` prefix on purpose: `openOrCreate` returns pi's `Session`,
- * so this port is pi-coupled, not an engine-neutral persistence contract. A neutral
- * session-log port would be a separate abstraction, justified only once a second engine
- * provides the real requirement.
- *
- * Continuity contract: same backing store + same session id = same conversation.
- *   - in-memory: continuity bound to the store INSTANCE (gone on restart; tests/embedding);
- *   - jsonl: continuity survives process restarts (disk is the truth) — faithful to
- *     local pi, which persists sessions too.
- *
- * Node composition-root module (IO policy, see definition.ts): may touch the disk
- * via pi's repos; the invoke path itself stays disk-free.
+ * Continuity = same backing store + same session id: in-memory continuity dies with the instance;
+ * jsonl survives process restarts (disk is the truth).
  */
 import { InMemorySessionRepo } from "@earendil-works/pi-agent-core";
 import type { AgentMessage, Session } from "@earendil-works/pi-agent-core";
@@ -32,44 +21,25 @@ export interface PiSessionStore {
 /**
  * Crash-safety reconciliation, run on every OPEN of an existing session.
  *
- * A turn that dies mid tool-execution leaves the session with an assistant tool_use that
- * has no matching tool result: pi persists the assistant message at `message_end` — BEFORE
- * the tool runs — and `buildSessionContext` does not repair the gap. The next turn would
- * then hand the provider an `assistant(tool_use) -> user` sequence that Anthropic/OpenAI
- * reject, so a retry after a crash fails outright (the session is "poisoned"). We append an
- * honest "interrupted" error tool result for each dangling call, restoring a valid transcript
- * so the next turn proceeds and the model can re-decide.
+ * A turn that dies mid tool-execution leaves an assistant `tool_use` with no matching result (pi
+ * persists the assistant message before the tool runs). The next turn would then hand the provider an
+ * `assistant(tool_use) -> user` sequence that Anthropic/OpenAI reject — the session is poisoned. We
+ * append an honest "interrupted" error result for each dangling call, restoring a valid transcript.
  *
- * Tool side-effect idempotency stays the tool's responsibility (SPEC §6); this only restores
- * transcript validity, it does not promise the interrupted tool ran exactly once.
+ * Pairing is TURN-LOCAL: a tool_use is paired only by a toolResult that immediately follows it (up to
+ * the next non-toolResult). tool-call ids are not unique across turns (a local model may restart ids
+ * each response), so matching against the whole transcript could falsely settle a leaf call against an
+ * earlier turn's identical id. Append-only logs can only repair a gap AT THE LEAF (last assistant
+ * followed by nothing but its own results); an earlier gap is surfaced via console.warn rather than
+ * "fixed" with an orphaned result that appending cannot place.
  *
- * Pairing is TURN-LOCAL, never transcript-global: a tool_use is paired only by a toolResult
- * that FOLLOWS it (append-only — a result always lands after the assistant that requested it).
- * tool-call ids are not guaranteed unique across turns (model-neutral: a local/custom model may
- * restart ids at `call-1` each response), so matching against the whole transcript would falsely
- * "settle" the leaf's call against an earlier turn's identical id and skip the repair.
- *
- * Append-only logs can only repair a gap AT THE LEAF (the last assistant followed by nothing but
- * its own toolResults): appending the missing result there yields a valid `assistant -> toolResults`
- * run. We still scan EVERY assistant turn-locally so a gap that is NOT at the leaf — an earlier
- * assistant's call, or a leaf call already followed by later history — is surfaced via `console.warn`
- * rather than silently ignored or "fixed" with an orphaned result that appending cannot place
- * correctly. (Mid-history gaps are unreachable in the reconcile-on-open design — we reconcile before
- * any later turn is appended — so the guard exists for forks/navigation or pre-fix sessions.)
- *
- * The synthetic result has three audiences, so it splits them deliberately:
- *   - `content` is read by the MODEL next turn (and may be relayed to the end user). It stays
- *     neutral and decision-guiding. It must NOT say "aborted" — pi uses that for a user
- *     cancellation, and the model would read it as "the user dropped this" and abandon work
- *     the user actually wants. It must NOT leak infra detail ("process restarted"/"crash")
- *     — that text can surface to the end user and reads as an outage.
- *   - `details` carries the operational marker for developers (logs/session inspection); it is
- *     never sent to the provider (`transform-messages` forwards only `content`).
+ * The synthetic result splits its audiences: `content` (read by the model, may reach the end user)
+ * stays neutral — it must NOT say "aborted" (pi's word for a user cancellation) or leak infra detail;
+ * `details` carries the operational marker for developers and is never sent to the provider.
  */
 async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
   const { messages } = await session.buildContext();
 
-  // The leaf is the last assistant; only its gap can be repaired by appending (append-only log).
   let leafIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i]?.role === "assistant") {
@@ -80,10 +50,6 @@ async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
   if (leafIdx === -1) return; // no assistant turn yet
   const leafReparable = messages.slice(leafIdx + 1).every((m) => m.role === "toolResult");
 
-  // Scan EVERY assistant turn-locally: a tool_use is paired only by the toolResults that
-  // immediately follow it (up to the next non-toolResult). Turn-local windows are robust to
-  // ids reused across turns; scanning every turn (not only the leaf) lets a mid-history gap be
-  // surfaced rather than silently ignored.
   const toRepair: { id: string; name: string }[] = [];
   const orphaned: string[] = [];
   messages.forEach((m, idx) => {
@@ -96,16 +62,12 @@ async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
     }
     for (const block of m.content) {
       if (block.type !== "toolCall" || paired.has(block.id)) continue;
-      // The leaf's gap (last assistant, followed only by its own results) is repairable by
-      // appending. Any earlier gap is mid-history: an append-only log cannot fix it.
       if (idx === leafIdx && leafReparable) toRepair.push({ id: block.id, name: block.name });
       else orphaned.push(block.id);
     }
   });
 
   if (orphaned.length > 0) {
-    // Behind later history: a result appended at the end arrives too late. Surface, do not add an
-    // orphan. Unreachable in the reconcile-on-open design; the guard is for forks/pre-fix sessions.
     console.warn(
       `[fastagent] unmatched tool_use is not at the session leaf; leaving it unreconciled ` +
         `(an append-only log cannot repair a mid-history gap): toolCallIds=${orphaned.join(",")}`,
@@ -146,24 +108,18 @@ export function inMemorySessionStore(): PiSessionStore {
 }
 
 /**
- * Disk-backed store (pi JsonlSessionRepo under `dir`). The first persistent
- * backend: restart the process, conversations continue.
- * `cwd` is recorded in session metadata (pi associates sessions with a project
- * directory); defaults to process.cwd().
+ * Disk-backed store (pi JsonlSessionRepo under `dir`): restart the process, conversations continue.
+ * `cwd` is recorded in session metadata; defaults to process.cwd().
  */
 export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSessionStore {
   const cwd = options.cwd ?? process.cwd();
-  const repo = new JsonlSessionRepo({
-    fs: new NodeExecutionEnv({ cwd }),
-    sessionsRoot: options.dir,
-  });
+  const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
   return {
     async openOrCreate(sessionId) {
-      // Caller-provided session ids land verbatim in jsonl FILENAMES — encode
-      // anything unsafe (path separators, "..") before they reach the disk.
+      // Caller-provided ids land in jsonl FILENAMES — encode anything unsafe before it reaches disk.
       const id = encodeSessionId(sessionId);
-      // Scope the lookup to this store's cwd: pi groups sessions by project dir,
-      // and two stores sharing a sessionsRoot must not open each other's sessions.
+      // Scope the lookup to this store's cwd: two stores sharing a sessionsRoot must not open each
+      // other's sessions (pi groups sessions by project dir).
       const existing = (await repo.list({ cwd })).find((m) => m.id === id);
       if (!existing) return repo.create({ id, cwd });
       const session = await repo.open(existing);
@@ -173,7 +129,7 @@ export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSes
   };
 }
 
-/** Injective filename-safe encoding: [A-Za-z0-9._-] verbatim ("s1" stays "s1"), the rest %-escaped ("%" itself included). */
+/** Injective filename-safe encoding: [A-Za-z0-9._-] verbatim, the rest %-escaped. */
 function encodeSessionId(id: string): string {
   return id.replace(/[^A-Za-z0-9._-]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`);
 }

--- a/core/src/engines/pi/tool.ts
+++ b/core/src/engines/pi/tool.ts
@@ -1,56 +1,30 @@
 /**
- * Tool authoring: `defineTool` (the vibe surface) and `loadTools` (filesystem discovery).
- *
- * The two together let a developer add a code tool with no ceremony: drop a file in `tools/`,
- * default-export `defineTool({...})`, and it is discovered, named from the filename, validated,
- * and injected — no `name` field, no manual registration in the config.
+ * Tool authoring: `defineTool` (the authoring surface) and `loadTools` (filesystem discovery).
+ * Drop a file in `tools/`, default-export `defineTool({...})`, and it is discovered, named from
+ * the filename, validated, and injected.
  *
  *   // tools/lookup-order.ts            → tool "lookup-order"
- *   import { defineTool, z } from "@kid7st/fastagent";
  *   export default defineTool({
  *     description: "Look up an order by id.",
  *     input: z.object({ orderId: z.string() }),
- *     async execute({ orderId }) { return await db.find(orderId); },  // plain value, auto-wrapped
+ *     async execute({ orderId }) { return await db.find(orderId); },
  *   });
- *
- * defineTool produces a pi `AgentTool` (folded-M): it converts the Zod schema to JSON Schema for
- * the model, validates the model's arguments before calling `execute` (a validation failure is
- * returned to the model as an error result, not a crash), and wraps a plain return value into the
- * pi result shape. The `parameters` field is a plain JSON-Schema object — pi accepts it (the
- * `TSchema` bound is compile-time only; there is no TypeBox runtime dependency on this path).
- *
- * Node composition-root module: `loadTools` dynamically imports the workspace's tool modules
- * (local files, not node_modules — so Node strips their types); the invoke path stays disk-free.
  */
-import type { Dirent } from "node:fs";
-import { readdir } from "node:fs/promises";
-import { basename, extname, join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { join } from "node:path";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { z } from "zod";
-import { moduleLoadHint } from "./loader.ts";
+import { loadModuleDir } from "./loader.ts";
 
-/** Runtime context passed to a tool's `execute`. Minimal today; reserved for growth (session, …). */
 export interface ToolContext {
   /** Abort signal for the current turn — honor it to cancel in-flight work on cancellation. */
   signal?: AbortSignal;
 }
 
 export interface DefineToolOptions<I extends z.ZodType> {
-  /**
-   * Explicit tool name. Usually omitted: a tool in `tools/<name>.ts` is named from its filename
-   * (authoritative). Set this only when injecting programmatically via `config.tools`.
-   */
+  /** Explicit name. Usually omitted — a `tools/<name>.ts` tool is named from its filename. */
   name?: string;
-  /** What the tool does — the text the model reads to decide when to call it. */
   description: string;
-  /** Input parameters as a Zod schema; `execute` receives the parsed, typed value. */
   input: I;
-  /**
-   * The tool body. Receives the validated input and a {@link ToolContext}. Return a plain value
-   * (string/object/…) and it is wrapped for the model; return a full `{ content, details }` result
-   * for control over content blocks.
-   */
   execute: (input: z.infer<I>, ctx: ToolContext) => unknown | Promise<unknown>;
 }
 
@@ -63,12 +37,7 @@ function wrapResult(value: unknown): AgentToolResult<unknown> {
   return { content: [{ type: "text", text }], details: value };
 }
 
-/**
- * Define a tool from a Zod input schema and an `execute` body. Returns a pi `AgentTool` with a
- * JSON-Schema `parameters`, schema-validated arguments, and auto-wrapped results.
- */
 export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): AgentTool {
-  // Zod → JSON Schema for the model. Drop `$schema` (providers don't need the dialect marker).
   const { $schema: _drop, ...parameters } = z.toJSONSchema(options.input) as Record<string, unknown>;
   const tool = {
     name: options.name ?? "",
@@ -93,46 +62,18 @@ export interface ToolCollision {
   source: string;
 }
 
-const TOOL_EXTS = new Set([".ts", ".js", ".mjs"]);
-
-/**
- * Discover code tools in `<dir>/tools/`: each top-level `*.ts|*.js|*.mjs` is dynamically imported,
- * its default export taken as the tool, and named from the filename (authoritative). Missing
- * `tools/` is normal (returns none). A file that does not default-export a tool fails visibly.
- */
+/** Discover code tools in `<dir>/tools/`: each `*.ts|.js|.mjs` default-exports a tool, named from its filename. */
 export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; collisions: ToolCollision[] }> {
-  const toolsDir = join(dir, "tools");
-  let entries: Dirent[];
-  try {
-    entries = await readdir(toolsDir, { withFileTypes: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "not_found" || (error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { tools: [], collisions: [] };
-    }
-    throw new Error(`cannot read ${toolsDir}: ${(error as Error).message}`);
-  }
+  const modules = await loadModuleDir(join(dir, "tools"));
   const byName = new Map<string, AgentTool>();
   const collisions: ToolCollision[] = [];
-  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!entry.isFile()) continue;
-    const ext = extname(entry.name);
-    if (!TOOL_EXTS.has(ext) || entry.name.endsWith(".d.ts")) continue;
-    const file = join(toolsDir, entry.name);
-    let mod: { default?: unknown };
-    try {
-      mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
-    } catch (error) {
-      throw new Error(
-        `cannot load tools/${entry.name}: ${(error as Error).message}${moduleLoadHint(error as NodeJS.ErrnoException)}`,
-      );
-    }
+  for (const { name, label, mod } of modules) {
     const tool = mod.default as Partial<AgentTool> | undefined;
     if (!tool || typeof tool.execute !== "function") {
-      throw new Error(`tools/${entry.name} must default-export defineTool({...})`);
+      throw new Error(`${label} must default-export defineTool({...})`);
     }
-    const name = basename(entry.name, ext); // filename is the tool name (authoritative)
     if (byName.has(name)) {
-      collisions.push({ name, source: `tools/${entry.name}` });
+      collisions.push({ name, source: label });
       continue;
     }
     byName.set(name, { ...(tool as AgentTool), name });
@@ -141,9 +82,8 @@ export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; coll
 }
 
 /**
- * Merge already-resolved tools (pi defaults + `config.tools`) with discovered `tools/` tools,
- * deduping by name. Existing tools win a name clash (a discovered tool may not shadow a default or
- * a configured one); the dropped discovered tools are surfaced as collisions, never silent.
+ * Merge resolved tools (pi defaults + `config.tools`) with discovered `tools/`, deduped by name.
+ * Existing tools win; dropped discovered tools surface as collisions.
  */
 export function mergeDiscoveredTools(
   existing: AgentTool[],

--- a/core/src/engines/pi/version.ts
+++ b/core/src/engines/pi/version.ts
@@ -2,9 +2,8 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 /**
- * This build's own @kid7st/fastagent version (from the package's package.json). THROWS if it can't be
- * read — a real version is load-bearing for the scaffolded dependency range (`^${version}`), so init
- * must fail visibly rather than ever scaffold an uninstallable `^0.0.0`.
+ * This build's own @kid7st/fastagent version. THROWS if unreadable — the version is load-bearing for
+ * the scaffolded dependency range (`^${version}`), so init must never scaffold an uninstallable `^0.0.0`.
  */
 export async function fastagentVersion(): Promise<string> {
   const pkgPath = fileURLToPath(new URL("../../../package.json", import.meta.url));

--- a/core/src/github.ts
+++ b/core/src/github.ts
@@ -1,8 +1,4 @@
-/**
- * `@kid7st/fastagent/github` — the GitHub channel entry point (subpath export).
- * Platform-specific channel; kept off the root surface (the root stays the contract + pi + neutral
- * channels). See channels/github.ts.
- */
+/** `@kid7st/fastagent/github` — the GitHub channel subpath export, kept off the root surface. */
 export {
   githubChannel,
   type GithubChannelOptions,

--- a/core/src/host/node.ts
+++ b/core/src/host/node.ts
@@ -22,8 +22,7 @@ export function parseRouteKey(key: string): { method?: string; path: string } {
 
 /**
  * Compose a {@link Routes} table into one handler: exact pathname match (optionally method-qualified),
- * 405 when the path exists under another method, 404 otherwise. No params/wildcards — channels mount
- * at fixed paths.
+ * 405 when the path exists under another method, 404 otherwise. No params/wildcards.
  */
 export function router(routes: Routes): ChannelHandler {
   const entries = Object.entries(routes).map(([key, handler]) => ({ ...parseRouteKey(key), handler }));
@@ -38,9 +37,9 @@ export function router(routes: Routes): ChannelHandler {
 }
 
 /**
- * Serve `handler` on a Node HTTP server. Thin mechanism: bind, report the port, and let the caller
- * close it — no logging, signal handling, or process.exit (the CLI / app entry owns those).
- * `listening` resolves with the bound port (useful for port 0) or rejects on a bind error (EADDRINUSE).
+ * Serve `handler` on a Node HTTP server. Thin mechanism: bind, report the port, let the caller close
+ * it — no logging/signals/exit (the CLI owns those). `listening` resolves with the bound port (useful
+ * for port 0) or rejects on a bind error.
  */
 export function serveNode(
   handler: ChannelHandler,

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,24 +1,20 @@
-// Naming on this surface: `create…From<input>` = the assembly ladder (create.ts); `resolve*` =
-// multi-source precedence; `load*` = disk → memory (→ `Loaded*`); pi-coupled names carry `pi`/`Pi`;
-// `Config` = user-authored file shape, `Options` = function inputs.
+// Naming: `create…From<input>` = the assembly ladder; `resolve*` = multi-source precedence;
+// `load*` = disk → memory (→ `Loaded*`); pi-coupled names carry `pi`/`Pi`; `Config` = user file
+// shape, `Options` = function inputs.
 
 // Protocol contract (neutral, engine-free)
 export type { Agent, AgentEvent, ImageRef, Json, Prompt, Scope } from "./agent.ts";
 export { collect, AgentFailure, type CollectResult } from "./collect.ts";
 
-// Channels (N-side; consume only the Agent contract)
-// createInvokeHandler is Fetch-shaped ((Request) => Promise<Response>) so it mounts in any host
-// route; nodeListener bridges it onto node:http for the standalone server.
+// Channels (N-side; consume only the Agent contract). createInvokeHandler is Fetch-shaped so it
+// mounts in any host route; nodeListener bridges it onto node:http. The GitHub channel is a subpath
+// export: `@kid7st/fastagent/github`.
 export { createInvokeHandler, nodeListener } from "./channels/http.ts";
-// The GitHub channel is a platform-specific subpath export: `@kid7st/fastagent/github` (see
-// src/github.ts). It ACKs 202 and runs turns fire-and-forget on the long-running process.
 
-// Node host (K-side; a long-running-process target adapter). serveNode binds a route table on
-// node:http; router composes a Routes table. `fastagent start`/`dev` use these to serve the
-// workspace's discovered channels/.
+// Node host (K-side). serveNode binds a route table on node:http; router composes a Routes table.
 export { type ChannelHandler, type Routes, router, serveNode } from "./host/node.ts";
 
-// pi reference implementation — reusable assembly ladder (L1/L2; L0 below)
+// pi reference implementation — the reusable assembly ladder (L1/L2; L0 is internal to invoke.ts).
 export {
   createPiAgent,
   createPiAgentFromDefinition,
@@ -26,10 +22,10 @@ export {
   type CreatePiAgentFromDefinitionOptions,
 } from "./engines/pi/create.ts";
 
-// pi reference implementation — init (scaffold a minimal runnable workspace).
+// init: scaffold a runnable workspace.
 export { scaffoldWorkspace, type ScaffoldResult } from "./engines/pi/init.ts";
 
-// pi reference implementation — tool authoring: defineTool (+ re-exported z) and tools/ discovery.
+// Tool authoring: defineTool (+ re-exported z) and tools/ discovery.
 export {
   defineTool,
   loadTools,
@@ -39,18 +35,16 @@ export {
 } from "./engines/pi/tool.ts";
 export { z } from "zod";
 
-// pi reference implementation — channel discovery: a channels/<name>.ts default-exports a
-// ChannelModule ((agent) => Routes); loadChannels merges them, surfacing route collisions.
+// Channel discovery: a channels/<name>.ts default-exports a ChannelModule ((agent) => Routes).
 export { loadChannels, type ChannelModule, type ChannelCollision } from "./engines/pi/channel.ts";
 
-// pi reference implementation — the command opener: point at a definition directory → agent.
-// Composes over L2; `dev` and `start` both drive it (dev watches, start runs production posture).
+// The command opener `dev` and `start` both drive: point at a definition directory → agent.
 export {
   createPiAgentFromWorkspace,
   type CreatePiAgentFromWorkspaceOptions,
 } from "./engines/pi/dev.ts";
 
-// pi reference implementation — definition domain (load).
+// Definition domain (load).
 export {
   loadAgentDefinition,
   type LoadedDefinition,
@@ -58,13 +52,11 @@ export {
   type SkillCollision,
 } from "./engines/pi/definition.ts";
 
-// pi reference implementation — engine assets (prompt base + toolsets, in create.ts).
-// Internal assembly helpers (assembleSystemPrompt, resolveTools) are NOT public:
-// the ladder rungs own assembly; embedders compose via L1/L2/L3.
+// Engine assets (prompt base + toolset). Internal assembly helpers (assembleSystemPrompt,
+// resolveTools) are NOT public: the ladder rungs own assembly.
 export { piBasePrompt, piDefaultTools } from "./engines/pi/create.ts";
 
-// pi reference implementation — config subsystem.
-// loadConfig is internal (L3 owns config loading); resolveModel bridges a
+// Config subsystem. loadConfig is internal (L3 owns config loading); resolveModel bridges a
 // "provider/modelId" string to a model for L1/L2 embedders.
 export {
   defineConfig,
@@ -73,29 +65,24 @@ export {
   type FastagentConfig,
 } from "./engines/pi/config.ts";
 
-// pi reference implementation — injection ports referenced by the ladder options.
-// L0 (createPiAgentFromHarness) and the pi harness-factory wiring are deliberately
-// NOT exported: they expose pi's two-port shape and would pin the engine-coupled
-// surface as a public promise before engine #2 exists. Reach them via internal
-// modules for custom wiring/tests.
+// Injection ports referenced by the ladder options. L0 (createPiAgentFromHarness) and the pi
+// harness-factory wiring are deliberately NOT exported (they would pin pi's engine-coupled shape as
+// a public promise before engine #2 exists); reach them via internal modules for custom wiring/tests.
 export {
   type Lease,
   type Release,
   inProcessLease,
 } from "./engines/pi/invoke.ts";
 export type { AnyModel } from "./engines/pi/harness.ts";
-// ExecutionEnv is the K-axis env port referenced by the ladder's `env` option (L1/L2): export the
-// type so embedders can inject a sandbox env without reaching into pi-agent-core directly.
+// ExecutionEnv is the K-axis env port referenced by the ladder's `env` option.
 export type { ExecutionEnv } from "@earendil-works/pi-agent-core";
 export {
   type PiSessionStore,
   inMemorySessionStore,
   jsonlSessionStore,
 } from "./engines/pi/sessions.ts";
-// pi reference implementation — auth + the Models collection (model resolution +
-// per-request auth). createPiModels builds the default collection (built-in
-// providers; ~/.fastagent/auth.json → env vars); fastagentCredentialStore is the
-// read-write store fastagent owns (refresh persists in place).
+// Auth + the Models collection. createPiModels builds the default collection (built-in providers;
+// ~/.fastagent/auth.json → env vars); fastagentCredentialStore is the read-write store fastagent owns.
 export { FASTAGENT_AUTH_PATH, type FastagentAuthOptions, fastagentCredentialStore } from "./engines/pi/auth.ts";
 export { type CreatePiModelsOptions, createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 export type { Models } from "@earendil-works/pi-ai";

--- a/core/src/invoke-stream.ts
+++ b/core/src/invoke-stream.ts
@@ -1,16 +1,10 @@
 /**
- * Render an Agent event stream to two output sinks plus an exit code — the `fastagent invoke` contract,
- * pulled out of cli.ts as a PURE function (IO injected, no process/stream access) so the contract is
- * unit-testable rather than resting on a live-model smoke run:
+ * Render an Agent event stream to two sinks plus an exit code — the `fastagent invoke` contract, a
+ * PURE function (IO injected) so it is unit-testable: text deltas → `out`; tool start + an ERRORED
+ * tool_ended → `err`; `failed` → `err` + a non-zero exit code (the CI-gating guarantee).
  *
- *   - `text` deltas → `out` (the reply, streamed; stdout at the CLI),
- *   - `tool_started` and a `tool_ended` that ERRORED → `err` (diagnostics; stderr at the CLI),
- *   - `failed` → `err` (the reason) and a non-zero exit code (the CI-gating guarantee).
- *
- * A `tool_ended` with `isError: true` inside an otherwise-`completed` turn must still surface — a
- * failed tool that does not fail the turn is exactly the diagnostic the operator needs. Its event
- * carries no name, so the name is remembered from the matching `tool_started`. The trailing newline
- * that ends the streamed reply is the caller's concern (only it knows the output device).
+ * An errored tool inside an otherwise-completed turn still surfaces (the diagnostic the operator
+ * needs); tool_ended carries no name, so it is remembered from the matching tool_started.
  */
 import type { AgentEvent } from "./agent.ts";
 

--- a/core/test/invoke.test.ts
+++ b/core/test/invoke.test.ts
@@ -311,27 +311,6 @@ describe("systemPrompt factory (re-evaluated per invoke)", () => {
   });
 });
 
-describe("retryClassifier injection (failed.retryable policy is replaceable)", () => {
-  it("injected policy overrides the default string heuristic", async () => {
-    const { faux, models } = makeFaux();
-    // "weird custom failure" does not match the default regex, so the default would be retryable:false
-    faux.setResponses([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "weird custom failure" })]);
-    const agent = createPiAgentFromHarness({
-      retryClassifier: () => true,
-      harnessFactory: piHarnessFactory({
-        sessions: inMemorySessionStore(),
-        env: new NodeExecutionEnv({ cwd: process.cwd() }),
-        models,
-        model: faux.getModel(),
-        systemPrompt: "test",
-      }),
-    });
-
-    const events = await drain(agent.invoke({ session: "r" }, { text: "hi" }));
-    expect(events.at(-1)).toMatchObject({ type: "failed", retryable: true });
-  });
-});
-
 describe("inProcessLease (fail-fast single writer)", () => {
   it("occupied session makes the second tryAcquire return null (no queue)", () => {
     const lease = inProcessLease();

--- a/core/test/report.test.ts
+++ b/core/test/report.test.ts
@@ -1,0 +1,34 @@
+import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { reportDefinitionWarnings, reportToolCollisions } from "../src/engines/pi/report.ts";
+
+// Locks the warning WORDING shared by the CLI runners and `chat` (the reason A1 deduped these into one
+// module: two copies could drift). Spies on console.error rather than going through a runner.
+describe("report", () => {
+  afterEach(() => vi.restoreAllMocks());
+  const lines = (spy: { mock: { calls: unknown[][] } }) => spy.mock.calls.map((c) => String(c[0])).join("\n");
+
+  it("renders skill collisions and diagnostics to stderr", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    reportDefinitionWarnings([{ name: "greet", winnerPath: "/a/SKILL.md", loserPath: "/b/SKILL.md" }], [
+      { type: "warning", code: "invalid_metadata", message: "description is required", path: "/c/SKILL.md" },
+    ] as SkillDiagnostic[]);
+    expect(lines(err)).toMatch(/skill "greet" collision — using \/a\/SKILL.md, ignoring \/b\/SKILL.md/);
+    expect(lines(err)).toMatch(/invalid_metadata: description is required \(\/c\/SKILL.md\)/);
+  });
+
+  it("renders tool collisions to stderr", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    reportToolCollisions([{ name: "lookup", source: "tools/lookup.ts" }]);
+    expect(lines(err)).toMatch(
+      /tool "lookup" \(tools\/lookup.ts\) dropped — a default\/config tool already uses that name/,
+    );
+  });
+
+  it("prints nothing when there are no findings", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    reportDefinitionWarnings([], []);
+    reportToolCollisions([]);
+    expect(err).not.toHaveBeenCalled();
+  });
+});

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -233,6 +233,8 @@ One opener (§4), two postures — both reuse **L2** (`createPiAgentFromDefiniti
 
 **Startup report (minimal observable surface):** run dir, model, **auth source** (pi's resolved label + provider, e.g. `OAuth (anthropic)` or `ANTHROPIC_API_KEY (anthropic)`), `AGENTS.md` presence, the **loaded skills** (enumerable), the session dir, and the bound port. It does **not** enumerate authored context files: they are ambient (§10.1a), so the only meaningful, bounded list is skills.
 
+**Authoring commands (same assembly, no serving).** `fastagent info` is a read-only inspect of that same surface (model/skills/tools+collisions/channels/diagnostics) without booting a server — it composes the no-side-effect loaders, so it never creates the sessions dir and an unset model is reported, not fatal. `fastagent invoke <message>` runs ONE turn through the same opener and exits (reply text→stdout, tool/diagnostics→stderr, a `failed` event→non-zero exit, so CI can gate on it). Both reuse the dev/start assembly, so they report and answer exactly as the served agent would — the all-agent counterpart of `fastagent tool` (one tool, no model).
+
 ### 10.4 Auth at runtime (env key or OAuth)
 
 Auth rides the pi `Models` collection, not a side channel; `start` is **not** env-only. Since pi 0.80 a `Models` (built by `createPiModels` → `builtinModels`) owns both model resolution and per-request auth: each provider carries its own `ProviderAuth`, resolved against a `CredentialStore` (stored credentials) plus an `AuthContext` (ambient env vars). Two deploy-appropriate sources, both upstream-native:

--- a/docs/core-design.md
+++ b/docs/core-design.md
@@ -31,7 +31,7 @@ FastAgent consumes existing definition artifacts:
 workspace/
 ├── AGENTS.md
 ├── skills/
-├── fastagent.config.ts
+├── fastagent.config.mjs
 └── .fastagent/          # generated machine state, ignored by git
 ```
 
@@ -103,7 +103,7 @@ L0 lives in `invoke.ts` because its body is the request-time turn mechanism; L1�
 
 ## 5. Config v1
 
-`fastagent.config.ts` currently has three keys:
+`fastagent.config.mjs` currently has three keys:
 
 ```ts
 export default defineConfig({
@@ -181,7 +181,7 @@ An agent splits into two halves along the N×M×K seam:
 
 | Half | Contents | In the definition directory? |
 |---|---|---|
-| **M — what the agent is** | the definition tree: `AGENTS.md` + `skills/` + authored context files (reference docs, schemas, data the agent reads on demand) + code tools + `fastagent.config.ts` | **yes — it IS the directory** |
+| **M — what the agent is** | the definition tree: `AGENTS.md` + `skills/` + authored context files (reference docs, schemas, data the agent reads on demand) + code tools + `fastagent.config.mjs` | **yes — it IS the directory** |
 | **K — where/how it runs** | conversational context (sessions), execution env (fs/shell/sandbox), auth/secrets | **no** — host-provided at runtime; secrets stay outside the directory |
 
 Two distinct things are called "context"; they live on opposite sides:
@@ -222,12 +222,12 @@ One opener (§4), two postures — both reuse **L2** (`createPiAgentFromDefiniti
 | Aspect | dev | start |
 |---|---|---|
 | watch | restart the worker on edits | none (stable process) |
-| model/http | `fastagent.config.ts` (flag > env > config) | same — read directly, frozen by git, **no manifest** |
+| model/http | `fastagent.config.mjs` (flag > env > config) | same — read directly, frozen by git, **no manifest** |
 | skills | definition-only | definition-only (same) |
 | sessions | `<dir>/.fastagent/sessions` | same default; `--sessions-dir` / `FASTAGENT_SESSIONS_DIR` override to a volume |
 | posture | authoring (verbose) | production (stable, no watch) |
 
-`start` depends on zero builder-machine state: it reads the directory + `fastagent.config.ts`, resolves model/sessions, calls L2 — no manifest, no frozen copy.
+`start` depends on zero builder-machine state: it reads the directory + `fastagent.config.mjs`, resolves model/sessions, calls L2 — no manifest, no frozen copy.
 
 **Sessions** default under the definition's own `.fastagent/sessions` (restart-surviving local continuity, faithful to local pi). A container may replace the definition directory wholesale on redeploy, so point `FASTAGENT_SESSIONS_DIR` at a mounted volume to keep conversations — `start` reminds the operator when running on the default. Precedence `--sessions-dir > FASTAGENT_SESSIONS_DIR > <dir>/.fastagent/sessions`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -103,7 +103,7 @@ fastagent tool reverse '{"text":"hello"}'
 fastagent start                  # run the SAME directory in production posture (no watch, no build)
 ```
 
-There is **no build step** — the directory IS the agent. `start` runs it exactly as `dev` did, minus file-watching: model and http come from `fastagent.config.ts` (frozen by git, not a manifest), and sessions persist under `.fastagent/sessions` (override with `--sessions-dir` / `FASTAGENT_SESSIONS_DIR` to point at a deploy volume so a redeploy never wipes conversations). To deploy: copy the directory anywhere with Node ≥ 22.19, run `npm ci`, then `fastagent start`.
+There is **no build step** — the directory IS the agent. `start` runs it exactly as `dev` did, minus file-watching: model and http come from `fastagent.config.mjs` (frozen by git, not a manifest), and sessions persist under `.fastagent/sessions` (override with `--sessions-dir` / `FASTAGENT_SESSIONS_DIR` to point at a deploy volume so a redeploy never wipes conversations). To deploy: copy the directory anywhere with Node ≥ 22.19, run `npm ci`, then `fastagent start`.
 
 ## Where next
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,6 +38,8 @@ For a pure prompt+skills agent with no code and no dependencies, use `fastagent 
 
 ## 2. Run it
 
+First, `fastagent info` prints what the directory assembles into — model, `AGENTS.md`, skills, tools (with any collisions), channels, and load diagnostics — without starting anything (run it whenever something looks off; `--json` for scripts). Then serve it:
+
 ```bash
 fastagent dev
 ```
@@ -61,6 +63,14 @@ data: {"type":"completed"}
 Reuse the same `session` value to continue a conversation; conversations persist under `.fastagent/sessions`, so a `dev` restart keeps them.
 
 To try the agent interactively instead of over HTTP, run `fastagent chat`. It opens the **same** assembled agent (same model, tools, skills, instructions) in pi's full interactive TUI — streaming, tool rendering, `/` commands, model switching, session resume — so you can vibe-check what you'll serve without writing a client.
+
+For a quick non-interactive check — one turn in, one reply out, no server and no TUI — run `fastagent invoke`:
+
+```bash
+fastagent invoke "How many words are in: the quick brown fox jumps"
+```
+
+The reply streams to stdout, tool and diagnostic lines to stderr, and a failed turn exits non-zero — handy for CI smoke or scripting. It is the all-agent counterpart of `fastagent tool` (one tool, no model).
 
 ## 3. Add a tool
 


### PR DESCRIPTION
## Why

Started as a phase-closeout scan, then expanded into an actual cleanup pass over `core/src`. Two layers:

1. **Refactor** — remove real duplication and one speculative seam.
2. **Comment-slop sweep** — apply AGENTS.md rule 12 (a comment must carry what the code cannot; the rest is cognitive debt). Comment lines in `core/src` dropped from ~35% to ~21% (~490 lines), with no behavior change.

Plus the small phase-closeout residue that prompted the original scan, and the doc fix the prior review flagged.

## What

**Refactor (behavior-preserving, no public-surface change)**
- `loader.ts`: extract `loadModuleDir` + `isModuleFile`; `loadTools` / `loadChannels` / cli `discoverChannelFiles` now share one discovery skeleton instead of three copies of readdir + ENOENT + sort + ext-filter + dynamic-import + hint.
- `config.ts`: add `isValidPort`, shared by config `http.port` validation and cli `parsePort`.
- `invoke.ts`: collapse the unused injectable `RetryClassifier` (self-admitted debt, never injected in production) into a module-local `isRetryable`; drop its isolated test.
- `report.ts`: the byte-identical `reportDefinitionWarnings` / `reportToolCollisions` reporters deduped into one module both cli and chat import (locked by `report.test`).

**Comment sweep** — remove `KNOWN DEBT` markers, doc-section refs (`SPEC MUST`, `core-design §`, `#66`), historical narration, and multi-paragraph header essays across `core/src`; keep only bug-prevention *why*. Trim the two dead-concept code asides.

**Docs**
- Document `invoke` + `info` in quickstart / core-design §10.3 / core/README.
- Align the config-file name to `fastagent.config.mjs` across docs (match `init`'s actual output; the scaffold tree previously claimed `.ts`).

## Verify

typecheck + lint clean; **175 tests** (the removed retryClassifier test is the −1 vs the prior count; `report.test` still locks the deduped wording). No public-surface change, no version bump.

## Note

This supersedes the original "explicitly not a refactor / codebase already clean" framing — the scan's conclusion changed once rule 12 was applied. The earlier review approved the tight-residue version; this needs a fresh look at the expanded scope, in particular whether the comment sweep removed any *why* worth keeping.
