### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Flask/WSGI for agents: serve or embed an existing agent folder (AGENTS.md + skills/) as a production capability. Engine-, model-, and host-neutral.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Patch release: the #71 cleanup landed on main past v0.7.0 (internal refactor + docs, no public-surface or behavior change). Bump core to 0.7.1 to publish the cleaned-up internals/docs.

Contents since v0.7.0:
- refactor(core): dedup discovery + port validation, drop retryClassifier seam; comment-slop sweep
- refactor(report): dedupe assembly-warning reporters
- docs: document invoke + info; align config name to .mjs; restore SPEC MUST/§ contract anchors

Version-only commit; no code change in this PR.