### PR TITLE
feat(embed): lock dep boundary + re-export every surface type

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -21,6 +21,7 @@
     "directory": "core"
   },
   "type": "module",
+  "sideEffects": false,
   "engines": {
     "node": ">=22.19.0"
   },

--- a/core/src/github.ts
+++ b/core/src/github.ts
@@ -5,3 +5,6 @@ export {
   type GithubEvent,
   type Intent,
 } from "./channels/github.ts";
+// `GithubEvent.payload` is typed as Schema (the official octokit union); re-exported so `on()`
+// authors can name it without importing @octokit/webhooks-types.
+export type { Schema } from "@octokit/webhooks-types";

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -38,7 +38,7 @@ export {
   type ToolCollision,
 } from "./engines/pi/tool.ts";
 export { z } from "zod";
-export type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
+export type { AgentTool } from "@earendil-works/pi-agent-core";
 
 // Channel discovery: a channels/<name>.ts default-exports a ChannelModule ((agent) => Routes).
 export { loadChannels, type ChannelModule, type ChannelCollision } from "./engines/pi/channel.ts";

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -26,6 +26,10 @@ export {
 export { scaffoldWorkspace, type ScaffoldResult } from "./engines/pi/init.ts";
 
 // Tool authoring: defineTool (+ re-exported z) and tools/ discovery.
+// Re-export rule: the engine-neutral contract (agent.ts) owns its types; the pi reference-impl
+// surface is openly engine-coupled, so every pi type that appears in its signatures is re-exported
+// (named, never `export *`) so embedders never reach into `@earendil-works/*`. Author tool schemas
+// with the `z` re-exported here (one zod copy — see DefineToolOptions).
 export {
   defineTool,
   loadTools,
@@ -34,6 +38,7 @@ export {
   type ToolCollision,
 } from "./engines/pi/tool.ts";
 export { z } from "zod";
+export type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 
 // Channel discovery: a channels/<name>.ts default-exports a ChannelModule ((agent) => Routes).
 export { loadChannels, type ChannelModule, type ChannelCollision } from "./engines/pi/channel.ts";
@@ -51,6 +56,7 @@ export {
   type LoadAgentDefinitionOptions,
   type SkillCollision,
 } from "./engines/pi/definition.ts";
+export type { Skill, SkillDiagnostic } from "@earendil-works/pi-agent-core";
 
 // Engine assets (prompt base + toolset). Internal assembly helpers (assembleSystemPrompt,
 // resolveTools) are NOT public: the ladder rungs own assembly.
@@ -81,6 +87,8 @@ export {
   inMemorySessionStore,
   jsonlSessionStore,
 } from "./engines/pi/sessions.ts";
+// Session is pi's session object that PiSessionStore.openOrCreate returns (custom stores produce it).
+export type { Session } from "@earendil-works/pi-agent-core";
 // Auth + the Models collection. createPiModels builds the default collection (built-in providers;
 // ~/.fastagent/auth.json → env vars); fastagentCredentialStore is the read-write store fastagent owns.
 export { FASTAGENT_AUTH_PATH, type FastagentAuthOptions, fastagentCredentialStore } from "./engines/pi/auth.ts";
@@ -90,3 +98,5 @@ export type { Models } from "@earendil-works/pi-ai";
 // option. createProvider builds one from parts; its wire-protocol `api` comes from
 // `@earendil-works/pi-ai/api/*`. Most agents never touch this — a `model` spec selects a built-in.
 export { createProvider, type Provider, type ProviderAuth } from "@earendil-works/pi-ai";
+// Model is the model descriptor a createProvider({ models }) author supplies.
+export type { Model } from "@earendil-works/pi-ai";

--- a/core/test/package-boundary.test.ts
+++ b/core/test/package-boundary.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Guards the embed/CLI dependency boundary so a future package split stays a packaging change, not a
+ * refactor: the public embed entry (index.ts) must never statically pull a CLI-only dependency.
+ *
+ * "Statically" = what gets eval-loaded when you `import "@kid7st/fastagent"`. We walk the relative
+ * import graph from an entry and collect the bare package specifiers reachable through STATIC
+ * `import`/`export … from`. Lazy `await import("pkg")` is intentionally excluded (e.g. giget stays
+ * lazy in init.ts) — that is the whole point of keeping it lazy.
+ */
+const srcDir = resolve(dirname(fileURLToPath(import.meta.url)), "../src");
+
+function staticPackageGraph(entryRel: string): Set<string> {
+  const visited = new Set<string>();
+  const packages = new Set<string>();
+  const fromRe = /^\s*(?:import|export)\b[^;]*?\bfrom\s*["']([^"']+)["']/gm;
+  const bareRe = /^\s*import\s+["']([^"']+)["']/gm;
+
+  const visit = (fileAbs: string): void => {
+    if (visited.has(fileAbs)) return;
+    visited.add(fileAbs);
+    const src = readFileSync(fileAbs, "utf8");
+    for (const re of [fromRe, bareRe]) {
+      for (const m of src.matchAll(re)) {
+        const spec = m[1];
+        if (!spec) continue;
+        if (spec.startsWith("./") || spec.startsWith("../")) visit(resolve(dirname(fileAbs), spec));
+        else if (!spec.startsWith("node:")) packages.add(spec);
+      }
+    }
+  };
+  visit(resolve(srcDir, entryRel));
+  return packages;
+}
+
+const CLI_ONLY = ["@clack/prompts", "undici", "chokidar", "giget"];
+
+describe("package boundary: embed entry stays free of CLI-only dependencies", () => {
+  it("index.ts does not statically load any CLI-only dep", () => {
+    const pkgs = staticPackageGraph("index.ts");
+    for (const dep of CLI_ONLY) expect(pkgs).not.toContain(dep);
+  });
+
+  it("octokit lives only behind the ./github subpath, not the root entry", () => {
+    expect(staticPackageGraph("index.ts")).not.toContain("@octokit/webhooks-methods");
+    expect(staticPackageGraph("github.ts")).toContain("@octokit/webhooks-methods");
+  });
+
+  it("the CLI entry is where the CLI-only deps actually live (the guard has teeth)", () => {
+    const pkgs = staticPackageGraph("cli.ts");
+    expect(pkgs).toContain("@clack/prompts");
+    expect(pkgs).toContain("undici");
+    expect(pkgs).toContain("chokidar"); // via dev-supervisor.ts
+  });
+});
+
+describe("engine neutrality: the contract + channel/host spine imports no engine package", () => {
+  // The neutral layer (the contract and the N-side that consumes only the contract) must never pull
+  // `@earendil-works/*` — that coupling belongs only under engines/pi. Locks the invariant so a
+  // stray pi import in agent.ts / a channel / the host is caught here, not in review.
+  const neutral = [
+    "agent.ts",
+    "collect.ts",
+    "invoke-stream.ts",
+    "channels/http.ts",
+    "channels/body.ts",
+    "channels/respond.ts",
+    "host/node.ts",
+  ];
+  for (const entry of neutral) {
+    it(`${entry} pulls no @earendil-works/* package`, () => {
+      const engine = [...staticPackageGraph(entry)].filter((p) => p.startsWith("@earendil-works/"));
+      expect(engine).toEqual([]);
+    });
+  }
+});

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -63,6 +63,8 @@ const agent = createPiAgent({
 });
 ```
 
+Author tool schemas with the `z` re-exported from `@kid7st/fastagent` (as above), not a separately installed `zod` — `defineTool` converts the schema with its own zod, so a single shared copy avoids version-skew surprises. Every type on this surface (`AgentTool`, `Skill`, `Session`, `Model`, …) is re-exported too, so you never import from `@earendil-works/*` (the one exception is a provider's wire-protocol `api`, see §5).
+
 `model` is always a spec string; `fastagent models` (or `listModels`) lists the available ones. `instructions` IS the system prompt — verbatim, no engine persona prepended. (The folder path assembles `AGENTS.md` differently: it adds the pi engine base + skills + env for fidelity with local pi. See [core-design §2](core-design.md).)
 
 ## 2. Consume the stream (three ways)


### PR DESCRIPTION
## Why

A full scan against the library-API domain consensus (Effective TypeScript **Item 67** "export all types in your public API" / **Item 70** "mirror to sever nonessential deps", semver-ts, the better-auth `export *` `.d.ts`-emit footgun) found the codebase mostly compliant — no `export *`, the engine-neutral contract is already pi-free, package.json publishing hygiene is in place, and exported functions have explicit return types (so no `TS2742`). The gaps were: **types on the pi-impl surface that weren't re-exported**, plus two small risks.

## What

**Re-export every pi type on the public surface (named, never `export *`).** The rule: the engine-neutral contract (`agent.ts`) owns its types and stays pi-free; the pi reference-impl surface is openly engine-coupled, so every pi type in its signatures is re-exported from `@kid7st/fastagent`, so embedders never import `@earendil-works/*`.

- root: `AgentTool`, `Skill`, `SkillDiagnostic`, `Session`, `Model`
- `./github`: `Schema`
- (already re-exported: `ExecutionEnv`, `Models`, `Provider`, `ProviderAuth`, `AnyModel`, `z`)

The one accepted exception: a provider's wire-protocol `api`, which comes from `@earendil-works/pi-ai/api/*` (inherently engine territory).

**Boundary guard test** (`test/package-boundary.test.ts`) — locks the seams so a future package split is packaging, not refactor:
- the embed entry never statically loads a CLI-only dep (`@clack/prompts` / `undici` / `chokidar` / `giget`; lazy `await import` excluded by design);
- octokit lives only behind `./github`;
- the neutral spine (`agent` / `collect` / `invoke-stream` / `channels/*` / `host/node`) pulls no `@earendil-works/*` package.

**`"sideEffects": false`** — the lib is side-effect-free (the `bin` is a separate entry, not in the lib import graph), improving embed tree-shaking.

**zod stays a `dependency`, not a peer** — re-exporting `z` plus a one-zod convention (author tool schemas with the re-exported `z`) avoids the dual-zod risk in `defineTool`'s `z.toJSONSchema` without forcing an install on embedders who author no tools. Documented in `embedding.md`.

## Verify

typecheck + lint clean; build (declaration emit) clean with the new named re-exports; **188 tests** (+10: the package-boundary suite).

## Review tier

Public API surface (additive re-exports) + package.json + a guard test. No behavior change.

