### PR TITLE
fix(tunnel): surface (and retry) a cloudflared start that fails before a URL

### DIFF
--- a/core/src/tunnel.ts
+++ b/core/src/tunnel.ts
@@ -5,7 +5,7 @@
  *
  * Process orchestration, not assembly — lives outside the engine, beside dev-supervisor.ts.
  */
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -22,43 +22,92 @@ export function parseTunnelUrl(chunk: string): string | undefined {
   return chunk.match(TUNNEL_URL_RE)?.[0];
 }
 
+const TUNNEL_ATTEMPTS = 3;
+const TUNNEL_RETRY_MS = 2000;
+
+/** How cloudflared is launched; injectable so tests can drive the child without a real process. */
+type SpawnCloudflared = (port: number) => ChildProcess;
+const spawnCloudflared: SpawnCloudflared = (port) =>
+  spawn("cloudflared", ["tunnel", "--url", `http://localhost:${port}`], { stdio: ["ignore", "pipe", "pipe"] });
+
+type TunnelSpawn =
+  | { tunnel: Tunnel }
+  | { tunnel?: undefined; fatal: true; message: string }
+  | { tunnel?: undefined; fatal: false; detail?: string };
+
 /**
- * Start a Cloudflare quick tunnel to localhost:`port`, resolving once its public URL appears. Resolves
- * to undefined (with an actionable hint) if cloudflared is not installed — serving continues either way.
+ * Start a Cloudflare quick tunnel to localhost:`port`, resolving once its public URL appears.
+ * cloudflared sometimes exits before printing a URL (a transient trycloudflare API error), so retry a
+ * few times. ALWAYS resolves to undefined WITH an operator log saying why — missing binary, the exit
+ * reason, or "gave up after retries" — never silently; serving continues without a tunnel either way.
+ * (Edge warmup AFTER the URL appears is the caller's concern: announceWebhooks polls /health.)
  */
-export function startCloudflareTunnel(port: number): Promise<Tunnel | undefined> {
+export async function startCloudflareTunnel(
+  port: number,
+  spawnFn: SpawnCloudflared = spawnCloudflared,
+): Promise<Tunnel | undefined> {
+  for (let attempt = 1; attempt <= TUNNEL_ATTEMPTS; attempt++) {
+    const r = await spawnTunnelOnce(port, spawnFn);
+    if (r.tunnel) return r.tunnel;
+    if (r.fatal) {
+      console.error(r.message); // missing binary — retrying cannot help
+      return undefined;
+    }
+    const more = attempt < TUNNEL_ATTEMPTS;
+    console.error(
+      `[fastagent] --tunnel: cloudflared exited before a public URL appeared${r.detail ? ` (${r.detail})` : ""}` +
+        (more ? ` — retrying (${attempt}/${TUNNEL_ATTEMPTS - 1})…` : ". Serving without a tunnel."),
+    );
+    if (more) await sleep(TUNNEL_RETRY_MS);
+  }
+  return undefined;
+}
+
+/** One cloudflared launch: a Tunnel on the first URL, or a failure (missing binary / exit before a URL). */
+function spawnTunnelOnce(port: number, spawnFn: SpawnCloudflared): Promise<TunnelSpawn> {
   return new Promise((resolve) => {
-    const child = spawn("cloudflared", ["tunnel", "--url", `http://localhost:${port}`], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawnFn(port);
     let settled = false;
+    let tail = ""; // recent output, surfaced as the failure reason
     const onChunk = (buf: Buffer): void => {
+      tail = (tail + String(buf)).slice(-600);
       if (settled) return;
       const url = parseTunnelUrl(String(buf));
       if (url) {
         settled = true;
-        resolve({ url, close: () => child.kill("SIGTERM") });
+        resolve({ tunnel: { url, close: () => child.kill("SIGTERM") } });
       }
     };
-    child.stdout.on("data", onChunk);
-    child.stderr.on("data", onChunk); // cloudflared prints the URL on stderr
+    child.stdout?.on("data", onChunk);
+    child.stderr?.on("data", onChunk); // cloudflared prints the URL (and its errors) on stderr
     child.on("error", (e: NodeJS.ErrnoException) => {
       if (settled) return;
       settled = true;
-      console.error(
-        e.code === "ENOENT"
-          ? "[fastagent] --tunnel needs cloudflared — install it (e.g. `brew install cloudflared`), then re-run. Serving without a tunnel."
-          : `[fastagent] cloudflared failed: ${e.message}. Serving without a tunnel.`,
-      );
-      resolve(undefined);
-    });
-    child.on("exit", () => {
-      if (!settled) {
-        settled = true;
-        resolve(undefined); // exited before printing a URL
+      if (e.code === "ENOENT") {
+        resolve({
+          fatal: true,
+          message:
+            "[fastagent] --tunnel needs cloudflared — install it (e.g. `brew install cloudflared`), then re-run. Serving without a tunnel.",
+        });
+      } else {
+        resolve({ fatal: false, detail: e.message });
       }
     });
+    child.on("exit", () => {
+      if (settled) return;
+      settled = true;
+      resolve({ fatal: false, detail: lastErrorLine(tail) });
+    });
   });
+}
+
+/** The most informative line of cloudflared's output tail (prefer an error line) for a failure log. */
+function lastErrorLine(tail: string): string {
+  const lines = tail
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return ([...lines].reverse().find((l) => /err|error|failed/i.test(l)) ?? lines.at(-1) ?? "").slice(0, 200);
 }
 
 /** Channel basenames present in `<dir>/channels/`. */

--- a/core/test/tunnel.test.ts
+++ b/core/test/tunnel.test.ts
@@ -1,8 +1,32 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { announceWebhooks, parseTunnelUrl } from "../src/tunnel.ts";
+import { announceWebhooks, parseTunnelUrl, startCloudflareTunnel } from "../src/tunnel.ts";
+
+// Mirrors TUNNEL_RETRY_MS in tunnel.ts (the constant is not exported).
+const TUNNEL_RETRY_MS = 2000;
+
+/** A fake cloudflared child: EventEmitter with stdout/stderr emitters, drivable from a test. */
+function fakeCloudflared(): ChildProcess {
+  const child = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    kill: vi.fn(),
+  });
+  return child as unknown as ChildProcess;
+}
+
+/** Collect console.error lines for assertions. */
+function captureErrors(): string[] {
+  const errs: string[] = [];
+  vi.spyOn(console, "error").mockImplementation((m) => {
+    errs.push(String(m));
+  });
+  return errs;
+}
 
 afterEach(() => {
   vi.useRealTimers();
@@ -30,6 +54,49 @@ async function workspace(channels: string[]): Promise<string> {
   for (const c of channels) await writeFile(join(dir, "channels", `${c}.ts`), "export default () => ({});\n");
   return dir;
 }
+
+describe("tunnel: startCloudflareTunnel", () => {
+  it("resolves a tunnel on the first URL cloudflared prints", async () => {
+    const child = fakeCloudflared();
+    const p = startCloudflareTunnel(8800, () => child);
+    await Promise.resolve(); // let the listeners attach
+    child.stderr?.emit("data", Buffer.from("INF +-+ https://blue-cat-42.trycloudflare.com +-+\n"));
+    const t = await p;
+    expect(t?.url).toBe("https://blue-cat-42.trycloudflare.com");
+  });
+
+  it("does not retry a missing cloudflared (ENOENT); logs the install hint", async () => {
+    const errs = captureErrors();
+    let spawns = 0;
+    const child = fakeCloudflared();
+    const p = startCloudflareTunnel(8800, () => {
+      spawns++;
+      return child;
+    });
+    await Promise.resolve();
+    child.emit("error", Object.assign(new Error("spawn cloudflared"), { code: "ENOENT" }));
+    expect(await p).toBeUndefined();
+    expect(spawns).toBe(1); // fatal — no retry
+    expect(errs.some((e) => /needs cloudflared/.test(e))).toBe(true);
+  });
+
+  it("does not fail silently: an exit-before-URL is logged and retried, then it gives up", async () => {
+    vi.useFakeTimers();
+    const errs = captureErrors();
+    let spawns = 0;
+    const p = startCloudflareTunnel(8800, () => {
+      spawns++;
+      const child = fakeCloudflared();
+      queueMicrotask(() => child.emit("exit", 1, null)); // every attempt exits before a URL
+      return child;
+    });
+    await vi.advanceTimersByTimeAsync(TUNNEL_RETRY_MS * 3 + 100); // through both retry backoffs
+    expect(await p).toBeUndefined();
+    expect(spawns).toBe(3); // retried, not a single silent attempt
+    expect(errs.some((e) => /exited before a public URL/.test(e) && /retrying/.test(e))).toBe(true);
+    expect(errs.some((e) => /Serving without a tunnel/.test(e))).toBe(true);
+  });
+});
 
 describe("tunnel: parseTunnelUrl", () => {
   it("extracts a trycloudflare URL from cloudflared output", () => {


### PR DESCRIPTION
startCloudflareTunnel resolved undefined with NO log when cloudflared exited before
printing a URL (a transient trycloudflare API error, e.g. a 1101/500) — and both
callers (dev-supervisor, cli maybeTunnel) silently skip on undefined. Result: `--tunnel`
could leave you with a server, no public URL, and zero operator signal; only the
ENOENT (not-installed) case logged. This masked a transient, recoverable failure as a
total no-op.

Now: retry the spawn a few times (the failure is transient), and ALWAYS log why it
gave up — missing binary, the exit reason (a line from cloudflared's output), or
"gave up after retries". The cloudflared spawn is injectable so the retry/exit/ENOENT
paths are unit-tested (no real process). Edge warmup after the URL appears is unchanged
(announceWebhooks still polls /health).
