### PR TITLE
fix(telegram): show an explicit "💭 Thinking…" placeholder, not an empty draft

### DIFF
--- a/core/src/channels/telegram.ts
+++ b/core/src/channels/telegram.ts
@@ -213,11 +213,15 @@ async function streamReply(
     if (t === "") return "";
     return `💭 ${t.length > THINKING_PREVIEW ? `…${t.slice(t.length - THINKING_PREVIEW + 1)}` : t}`;
   };
-  const view = (): string =>
-    [thinkingView(), toolView(), answer]
+  const view = (): string => {
+    const v = [thinkingView(), toolView(), answer]
       .filter((s) => s.trim() !== "")
       .join("\n\n")
       .trim();
+    // Before the first reasoning/tool/text arrives the draft is empty — Telegram renders an empty draft
+    // as a bare "…", so show an explicit placeholder instead (this is also what the keepalive re-pushes).
+    return v === "" ? "💭 Thinking…" : v;
+  };
   const draft = async (force: boolean): Promise<void> => {
     if (!force && Date.now() - lastDraftAt < DRAFT_THROTTLE_MS) return;
     lastDraftAt = Date.now();
@@ -233,7 +237,7 @@ async function streamReply(
     }
   };
 
-  await draft(true); // empty view → Telegram shows a "Thinking…" placeholder immediately
+  await draft(true); // show the "💭 Thinking…" placeholder immediately (view() fills the empty state)
 
   // A draft is a ~30s ephemeral preview; a long tool / arg-generation step emits no events, so without
   // a heartbeat the preview lapses and the chat looks dead. Re-push the current view to keep it alive.

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -216,6 +216,7 @@ describe("telegram channel", () => {
     expect((await ch(tgRequest(MSG))).status).toBe(200);
     await flush();
     const drafts = callsTo(fetchMock, "sendMessageDraft").map((c) => bodyOf(c).text as string);
+    expect(drafts[0]).toBe("💭 Thinking…"); // initial draft is an explicit placeholder, never an empty "…"
     expect(drafts.some((t) => /💭/.test(t) && /weighing options/.test(t))).toBe(true);
     expect(drafts.some((t) => /word-count the quick brown fox/.test(t))).toBe(true);
     const sent = callsTo(fetchMock, "sendMessage");


### PR DESCRIPTION
The live view's first draft (before any reasoning/tool/text streams) pushed an empty
string, on the assumption — stated in the comment — that Telegram renders an empty
draft as a "Thinking…" placeholder. It does not: an empty draft shows a bare "…", so
the thinking indicator never appeared until real content arrived (and for a fast turn,
never visibly at all). view() now returns "💭 Thinking…" for the empty state, which the
initial draft and the keepalive both push. Regression: assert the first draft is the
placeholder.
