### PR TITLE
feat(telegram): enrich inbound context — stable attribution + fuller reply

### DIFF
--- a/core/src/channels/telegram.ts
+++ b/core/src/channels/telegram.ts
@@ -325,31 +325,63 @@ function extractImages(m: TelegramMessage): string[] {
   );
 }
 
-/** file_ids to download to disk for the agent's tools (document/voice/video/audio). */
+/** file_ids to download to disk for the agent's tools: this message's files + a replied-to message's
+ *  (so "summarize this file" works when the user replies to a document with the mention). */
 function extractFiles(m: TelegramMessage): string[] {
-  return [m.document?.file_id, m.voice?.file_id, m.video?.file_id, m.audio?.file_id].filter((id): id is string =>
-    Boolean(id),
-  );
+  const r = m.reply_to_message;
+  return [
+    m.document?.file_id,
+    m.voice?.file_id,
+    m.video?.file_id,
+    m.audio?.file_id,
+    r?.document?.file_id,
+    r?.voice?.file_id,
+    r?.video?.file_id,
+    r?.audio?.file_id,
+  ].filter((id): id is string => Boolean(id));
+}
+
+/** A stable sender label for attribution. In a shared (multi-user) session the model must tell who is
+ *  who across turns; a username-less user still gets a name + id rather than vanishing. */
+function fromLabel(from: TelegramMessage["from"]): string | undefined {
+  if (!from) return undefined;
+  return from.username ? `@${from.username}` : `${from.first_name ?? "user"} (id ${from.id})`;
+}
+
+/** A one-line description of a message's attachment, so the envelope names what was sent even before
+ *  the agent opens it (and so a media-only message isn't blank). */
+function attachmentSummary(m: TelegramMessage): string | undefined {
+  if (m.photo?.length) return "[photo]";
+  if (m.document) {
+    return `[document: ${m.document.file_name ?? "file"}${m.document.mime_type ? ` (${m.document.mime_type})` : ""}]`;
+  }
+  if (m.voice) return "[voice message]";
+  if (m.video) return "[video]";
+  if (m.audio) return "[audio]";
+  return undefined;
 }
 
 /**
- * The default base prompt: a context envelope (chat/thread/from + reply) then the user's text/caption
- * and a compact rendering of structured payloads (location/contact/poll). Exported so a custom `route`
- * can reuse it, e.g. `text: `${telegramEnvelope(m)}\n\n[extra]``. The channel still appends attachments.
+ * The default base prompt: a context envelope (chat/thread/sender + reply) then the user's text/caption
+ * and a compact rendering of structured payloads (location/contact/poll). The sender is named on every
+ * message — in a shared multi-user session that is how the model tells participants apart. The reply
+ * block carries the replied-to sender, message id, and text/caption or an attachment summary (and the
+ * channel downloads a replied-to file/photo too). Exported so a custom `route` can reuse it, e.g.
+ * `text: `${telegramEnvelope(m)}\n\n[extra]``. The channel still appends downloaded attachments.
  */
 export function telegramEnvelope(m: TelegramMessage): string {
   const r = m.reply_to_message;
   const meta = [
     `chat ${m.chat.id} (${m.chat.type})`,
     m.message_thread_id ? `thread ${m.message_thread_id}` : undefined,
-    m.from?.username ? `from @${m.from.username}` : undefined,
+    fromLabel(m.from) ? `from ${fromLabel(m.from)}` : undefined,
   ]
     .filter(Boolean)
     .join(", ");
   const replyTo = r
-    ? `\n[reply to ${r.from?.username ? `@${r.from.username}` : `msg ${r.message_id}`}: ${(r.text ?? r.caption ?? "(media)").slice(0, 200)}]`
+    ? `\n[in reply to ${fromLabel(r.from) ?? `msg ${r.message_id}`} (msg ${r.message_id}): ${(r.text ?? r.caption ?? attachmentSummary(r) ?? "(empty)").slice(0, 280)}]`
     : "";
-  const parts = [m.text ?? m.caption ?? ""];
+  const parts = [m.text ?? m.caption ?? attachmentSummary(m) ?? ""];
   if (m.location) parts.push(`[location: ${m.location.latitude},${m.location.longitude}]`);
   if (m.contact) parts.push(`[contact: ${m.contact.first_name} ${m.contact.phone_number ?? ""}]`);
   if (m.poll) parts.push(`[poll: ${m.poll.question} — ${(m.poll.options ?? []).map((o) => o.text).join(" / ")}]`);

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -59,7 +59,7 @@ describe("defaultTelegramRoute + telegramEnvelope", () => {
     expect(defaultTelegramRoute(mention, { botUsername: "mybot" })).toEqual({});
   });
 
-  it("composes a context envelope: chat/thread/from + reply + the user's text", () => {
+  it("composes a context envelope: chat/thread/sender + reply (with msg id) + the user's text", () => {
     const env = telegramEnvelope({
       message_id: 2,
       text: "what is this",
@@ -74,8 +74,34 @@ describe("defaultTelegramRoute + telegramEnvelope", () => {
       },
     });
     expect(env).toMatch(/\[telegram: chat 42 \(private\), thread 9, from @alice\]/);
-    expect(env).toMatch(/\[reply to @bob: the log\]/);
+    expect(env).toMatch(/\[in reply to @bob \(msg 1\): the log\]/);
     expect(env).toMatch(/what is this$/);
+  });
+
+  it("attributes a username-less sender by name + id (a shared session must still tell who is who)", () => {
+    const env = telegramEnvelope({
+      message_id: 3,
+      text: "hi",
+      chat: { id: -100, type: "supergroup" },
+      from: { id: 99, first_name: "Carol" },
+    });
+    expect(env).toMatch(/from Carol \(id 99\)/);
+  });
+
+  it("summarizes a replied-to attachment when it has no text ('summarize this file')", () => {
+    const env = telegramEnvelope({
+      message_id: 4,
+      text: "summarize this",
+      chat: { id: 42, type: "private" },
+      from: { id: 7, username: "alice" },
+      reply_to_message: {
+        message_id: 1,
+        chat: { id: 42, type: "private" },
+        from: { id: 8, username: "bob" },
+        document: { file_id: "doc1", file_name: "report.pdf", mime_type: "application/pdf" },
+      },
+    });
+    expect(env).toMatch(/\[in reply to @bob \(msg 1\): \[document: report\.pdf \(application\/pdf\)\]\]/);
   });
 });
 


### PR DESCRIPTION
Groundwork for collaborative groups (model B: one shared per-chat session).

- Sender attribution that survives a missing username: `@username`, else
  `<first_name> (id <n>)`. In a shared multi-user session, naming the sender on every
  message is how the model tells participants apart across turns.
- Reply context: the replied-to sender + message id + text/caption, or an attachment
  summary ([document: report.pdf (application/pdf)] / [photo] / [voice message] / …)
  when it has no text — so "explain this" / "summarize this file" have a referent.
- extractFiles now also pulls a replied-to message's document/voice/video/audio, so a
  reply-to-a-file mention downloads that file for the agent (photo was already folded
  into vision). A media-only message no longer renders blank in the envelope.

telegramEnvelope's signature is unchanged (richer output only).
