### PR TITLE
feat(telegram): per-session serial queue (model B: one shared turn at a time)

### DIFF
--- a/core/src/channels/telegram.ts
+++ b/core/src/channels/telegram.ts
@@ -441,6 +441,20 @@ export function telegramChannel(
     );
   }
   const decide = route ?? ((update: TelegramUpdate) => defaultTelegramRoute(update, { botUsername: mentionName }));
+  // Per-session serial queue: model B answers a shared chat[:thread] with ONE turn at a time, so a
+  // second update for the same session waits its turn (FIFO) instead of colliding on the engine lease
+  // and being dropped as "busy" — the wrong UX when several people talk in one group. Different sessions
+  // run concurrently (the engine's stateless multi-session invoke). In-process: a restart loses anything
+  // still queued (Telegram already got its 200). SPEC §8 leaves this concurrency policy to the channel.
+  const sessionChains = new Map<string, Promise<void>>();
+  const enqueueTurn = (session: string, task: () => Promise<void>): void => {
+    const prev = sessionChains.get(session) ?? Promise.resolve();
+    const next = prev.then(task, task); // run after this session's previous turn, in arrival order
+    sessionChains.set(session, next);
+    void next.finally(() => {
+      if (sessionChains.get(session) === next) sessionChains.delete(session); // drop the entry when drained
+    });
+  };
   let draftSeq = 0; // non-zero, per-turn draft ids (process-lived; the route handler is built once)
   return async (req) => {
     if (req.method !== "POST") return text("POST only\n", 405);
@@ -459,7 +473,8 @@ export function telegramChannel(
 
     // Decide whether/where to answer, then stream the reply. ACK 200 immediately (the turn may outlast
     // the webhook timeout); lifecycle goes to stderr — after the 200 there is no response body, so those
-    // lines are the operator's only signal. Concurrency safety = the engine's per-session lease.
+    // lines are the operator's only signal. Concurrency: a per-session serial queue (FIFO) here; the
+    // engine's per-session lease is the corruption floor beneath it.
     const m = pickMessage(update);
     const r = m ? decide(update) : null;
     if (m && r) {
@@ -481,26 +496,30 @@ export function telegramChannel(
       const imageFileIds = extractImages(m);
       const fileIds = extractFiles(m);
       if (baseText.trim() !== "" || imageFileIds.length > 0 || fileIds.length > 0) {
-        draftSeq = (draftSeq % 1_000_000_000) + 1;
-        const draftId = draftSeq;
         const turn = `${update.update_id}`;
         const where = `chat=${chatId}${target.threadId !== undefined ? ` thread=${target.threadId}` : ""}`;
-        console.error(`[telegram] turn start: turn=${turn} session=${session} ${where}`);
-        const startedAt = Date.now();
-        void streamReply(
-          invokeWithAttachments(agent, session, baseText, chatId, imageFileIds, fileIds, apiBaseUrl, botToken),
-          apiBaseUrl,
-          botToken,
-          target,
-          draftId,
-          formatError,
-        ).then(
-          () => console.error(`[telegram] turn done: turn=${turn} session=${session} (${Date.now() - startedAt}ms)`),
-          (error) =>
+        enqueueTurn(session, async () => {
+          // Run at DEQUEUE time (serialized), so the draft id, lifecycle log, and engine turn all reflect
+          // the actual execution order rather than arrival.
+          draftSeq = (draftSeq % 1_000_000_000) + 1;
+          const startedAt = Date.now();
+          console.error(`[telegram] turn start: turn=${turn} session=${session} ${where}`);
+          try {
+            await streamReply(
+              invokeWithAttachments(agent, session, baseText, chatId, imageFileIds, fileIds, apiBaseUrl, botToken),
+              apiBaseUrl,
+              botToken,
+              target,
+              draftSeq,
+              formatError,
+            );
+            console.error(`[telegram] turn done: turn=${turn} session=${session} (${Date.now() - startedAt}ms)`);
+          } catch (error) {
             console.error(
               `[telegram] turn failed: turn=${turn} session=${session} (${Date.now() - startedAt}ms): ${String(error)}`,
-            ),
-        );
+            );
+          }
+        });
       }
     }
     return new Response(null, { status: 200 });

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -323,6 +323,85 @@ describe("telegram channel", () => {
     expect(sent.reply_parameters).toBeUndefined(); // redirected → no quote (avoids a wrong-target reply)
   });
 
+  it("serializes same-session turns (FIFO) instead of dropping the second as 'busy'", async () => {
+    let started = 0;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const order: number[] = [];
+    let release1 = (): void => {};
+    const gate1 = new Promise<void>((r) => {
+      release1 = r;
+    });
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        const id = ++started;
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        if (id === 1) await gate1; // hold the first turn open while the second arrives
+        inFlight--;
+        order.push(id);
+        yield { type: "text", delta: `r${id}` };
+        yield { type: "completed" };
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response('{"ok":true}', { status: 200 })),
+    );
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
+    const upd = (n: number) => ({
+      update_id: n,
+      message: { message_id: n, text: "yo", chat: { id: 7, type: "private" } },
+    });
+    const settle = async (): Promise<void> => {
+      for (let k = 0; k < 6; k++) await new Promise((r) => setImmediate(r));
+    };
+
+    await ch(tgRequest(upd(1))); // session "7"
+    await ch(tgRequest(upd(2))); // session "7" — queued behind #1, not run concurrently, not dropped
+    await settle();
+    expect(started).toBe(1); // only turn 1 has invoked; turn 2 waits its turn
+    expect(maxInFlight).toBe(1);
+
+    release1();
+    await settle();
+    expect(order).toEqual([1, 2]); // FIFO
+    expect(maxInFlight).toBe(1); // never two at once for the same session
+  });
+
+  it("runs different sessions concurrently (no cross-session blocking)", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let release = (): void => {};
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await gate; // both turns park here at once iff they run concurrently
+        inFlight--;
+        yield { type: "completed" };
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response('{"ok":true}', { status: 200 })),
+    );
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
+    const settle = async (): Promise<void> => {
+      for (let k = 0; k < 6; k++) await new Promise((r) => setImmediate(r));
+    };
+
+    await ch(tgRequest({ update_id: 1, message: { message_id: 1, text: "a", chat: { id: 1, type: "private" } } }));
+    await ch(tgRequest({ update_id: 2, message: { message_id: 2, text: "b", chat: { id: 2, type: "private" } } }));
+    await settle();
+    expect(maxInFlight).toBe(2); // different sessions → both in flight at once
+    release();
+    await settle();
+  });
+
   it("serializes the live preview: never two draft sends in flight (the out-of-order flicker)", async () => {
     vi.useFakeTimers();
     let inFlight = 0;


### PR DESCRIPTION
In a shared group (model B: session = chat[:thread]), two people @-ing the bot at once
both resolved to the same session and the second collided on the engine's per-session
lease — dropped with a neutral "session busy, try again". Wrong UX for a collaborative
group.

The channel now serializes per session: a second update for the same session is queued
behind the first (FIFO) and runs when it finishes, rather than colliding. Different
sessions still run concurrently (the engine's stateless multi-session invoke), so the
queue never blocks unrelated chats. The engine lease stays as the corruption floor
beneath it. SPEC §8 explicitly leaves this concurrency policy to the channel.

In-process (a restart loses anything still queued — Telegram already got its 200); the
queue is a per-session promise chain whose map entry is dropped when it drains. The
draft id / lifecycle log / engine turn now run at DEQUEUE time, so they reflect the
actual execution order, not arrival.

Tests: same-session turns run one-at-a-time in FIFO order (maxInFlight === 1, the second
not dropped as busy); different sessions run concurrently (maxInFlight === 2).
