### PR TITLE
feat(telegram): flag a group chat in the envelope (multi-person context)

### DIFF
--- a/core/src/channels/telegram.ts
+++ b/core/src/channels/telegram.ts
@@ -362,9 +362,10 @@ function attachmentSummary(m: TelegramMessage): string | undefined {
 }
 
 /**
- * The default base prompt: a context envelope (chat/thread/sender + reply) then the user's text/caption
- * and a compact rendering of structured payloads (location/contact/poll). The sender is named on every
- * message — in a shared multi-user session that is how the model tells participants apart. The reply
+ * The default base prompt: a context envelope (chat/thread/sender + a group note + reply) then the
+ * user's text/caption and a compact rendering of structured payloads (location/contact/poll). The
+ * sender is named on every message and a group chat is flagged — in a shared multi-user session that is
+ * how the model tells participants apart and knows it is not a 1:1. The reply
  * block carries the replied-to sender, message id, and text/caption or an attachment summary (and the
  * channel downloads a replied-to file/photo too). Exported so a custom `route` can reuse it, e.g.
  * `text: `${telegramEnvelope(m)}\n\n[extra]``. The channel still appends downloaded attachments.
@@ -378,6 +379,11 @@ export function telegramEnvelope(m: TelegramMessage): string {
   ]
     .filter(Boolean)
     .join(", ");
+  // In a shared group session the model sees turns from different people (each `from`-tagged); tell it
+  // so it addresses participants by name and does not assume one continuous interlocutor. A 1:1 DM is
+  // self-evident, so no note there.
+  const isGroup = m.chat.type === "group" || m.chat.type === "supergroup";
+  const scope = isGroup ? "\n[group chat — multiple people; each message is prefixed with its sender]" : "";
   const replyTo = r
     ? `\n[in reply to ${fromLabel(r.from) ?? `msg ${r.message_id}`} (msg ${r.message_id}): ${(r.text ?? r.caption ?? attachmentSummary(r) ?? "(empty)").slice(0, 280)}]`
     : "";
@@ -385,7 +391,7 @@ export function telegramEnvelope(m: TelegramMessage): string {
   if (m.location) parts.push(`[location: ${m.location.latitude},${m.location.longitude}]`);
   if (m.contact) parts.push(`[contact: ${m.contact.first_name} ${m.contact.phone_number ?? ""}]`);
   if (m.poll) parts.push(`[poll: ${m.poll.question} — ${(m.poll.options ?? []).map((o) => o.text).join(" / ")}]`);
-  return `[telegram: ${meta}]${replyTo}\n${parts.filter(Boolean).join("\n")}`;
+  return `[telegram: ${meta}]${scope}${replyTo}\n${parts.filter(Boolean).join("\n")}`;
 }
 
 /**

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -76,6 +76,7 @@ describe("defaultTelegramRoute + telegramEnvelope", () => {
     expect(env).toMatch(/\[telegram: chat 42 \(private\), thread 9, from @alice\]/);
     expect(env).toMatch(/\[in reply to @bob \(msg 1\): the log\]/);
     expect(env).toMatch(/what is this$/);
+    expect(env).not.toMatch(/group chat/); // a 1:1 DM gets no group note
   });
 
   it("attributes a username-less sender by name + id (a shared session must still tell who is who)", () => {
@@ -86,6 +87,7 @@ describe("defaultTelegramRoute + telegramEnvelope", () => {
       from: { id: 99, first_name: "Carol" },
     });
     expect(env).toMatch(/from Carol \(id 99\)/);
+    expect(env).toMatch(/\[group chat — multiple people; each message is prefixed with its sender\]/);
   });
 
   it("summarizes a replied-to attachment when it has no text ('summarize this file')", () => {


### PR DESCRIPTION
In a shared group session (model B) the agent sees turns from several people, each
`from`-tagged. A 1:1 DM is self-evident, but a group is not — without a cue the model
may read consecutive turns as one continuous interlocutor. The envelope now adds, for a
group/supergroup, "[group chat — multiple people; each message is prefixed with its
sender]" so the agent addresses participants by name and knows it is not a 1:1. A
private chat gets no note.
