### PR TITLE
feat(engine): wire pi compaction — keep a long session under the context window (#9)

### DIFF
--- a/core/src/engines/pi/invoke.ts
+++ b/core/src/engines/pi/invoke.ts
@@ -12,6 +12,7 @@
  * invoke builds a fresh harness bound to the session and discards it (stateless multi-session).
  */
 import type { AgentHarnessEvent } from "@earendil-works/pi-agent-core";
+import { DEFAULT_COMPACTION_SETTINGS, calculateContextTokens, shouldCompact } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import type { Agent, AgentEvent, Json, Prompt, Scope } from "../../agent.ts";
 import type { PiHarnessFactory } from "./harness.ts";
@@ -87,6 +88,23 @@ function toTerminal(message: AssistantMessage): AgentEvent {
 function errorToTerminal(error: unknown): AgentEvent {
   const details = error instanceof Error ? error.message : String(error);
   return { type: "failed", details, retryable: isRetryable(details) };
+}
+
+type PiHarness = Awaited<ReturnType<PiHarnessFactory>>;
+
+/**
+ * After a successful turn, compact the session if its context has grown past pi's threshold — a long
+ * shared (group) or 1:1 conversation otherwise overflows the model's window. pi owns the mechanism
+ * (`harness.compact()` writes a summary entry into the session, so the next reopen is compacted); the
+ * bare harness does NOT auto-trigger it, so fastagent checks `shouldCompact` here and fires it. The
+ * context size is the provider's own count from the turn's assistant message (`usage`).
+ */
+async function maybeCompact(harness: PiHarness, message: AssistantMessage): Promise<void> {
+  const contextWindow = harness.getModel().contextWindow;
+  if (!contextWindow) return;
+  if (shouldCompact(calculateContextTokens(message.usage), contextWindow, DEFAULT_COMPACTION_SETTINGS)) {
+    await harness.compact();
+  }
 }
 
 /**
@@ -194,17 +212,35 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         const event = toAgentEvent(pe);
         if (event) queue.push(event);
       });
+      let completed: AssistantMessage | undefined; // the assistant message of a cleanly completed turn
       try {
         const run = harness.prompt(prompt.text, await toPiPromptOptions(prompt));
         yield* queue.drainUntil(run);
         let terminal: AgentEvent;
         try {
-          terminal = toTerminal(await run);
+          const message = await run;
+          terminal = toTerminal(message);
+          if (terminal.type === "completed") completed = message;
         } catch (error) {
           terminal = errorToTerminal(error);
         }
         yield terminal;
       } finally {
+        // After a successful turn, keep the session under the model's context window (a long shared group
+        // or 1:1 conversation would otherwise overflow). Runs HERE — before teardown (it uses the harness)
+        // and BEFORE the lease release below, and is awaited via the generator's return(), so the next
+        // turn for this session waits and never reopens mid-compaction. That await rides the consumer's
+        // iteration: a STREAMING consumer (e.g. telegram) already sent the reply on the terminal before
+        // returning, so compaction — rare, only over threshold — does not delay it; a `collect`-style
+        // consumer returns the reply FROM the loop, so it waits for the (occasional) compaction. Non-fatal:
+        // a failed compaction leaves the (still-valid) session for the next turn to retry.
+        if (completed) {
+          try {
+            await maybeCompact(harness, completed);
+          } catch (error) {
+            console.warn(`[fastagent] auto-compaction failed during cleanup: ${String(error)}`);
+          }
+        }
         // Cleanup MUST NOT throw after the terminal was yielded — that would make an already-closed
         // event stream throw on iteration (violating SPEC MUST 2 / MUST 3). Contain it, but surface it
         // (a cleanup failure is abnormal).

--- a/core/test/invoke.test.ts
+++ b/core/test/invoke.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { AgentHarness, InMemorySessionRepo, type AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, fauxThinking, fauxToolCall, Type, type FauxResponseStep } from "@earendil-works/pi-ai";
+import type { AssistantMessage, StopReason, Usage } from "@earendil-works/pi-ai";
 import { inMemorySessionStore, inProcessLease, type AgentEvent } from "../src/index.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
-import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { type PiHarnessFactory, piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 
 /** An echo tool for the tool-call path. */
@@ -356,5 +357,95 @@ describe("inProcessLease (fail-fast single writer)", () => {
     // calling the stale release must not free r2's lease
     r();
     expect(lease.tryAcquire("s")).toBeNull(); // r2 still holds it
+  });
+});
+
+describe("invoke: auto-compaction", () => {
+  const usage = (input: number): Usage => ({
+    input,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  });
+
+  /** An agent over a fake harness: prompt resolves a completed message with the given usage; getModel
+   *  reports the contextWindow; compact is a spy. (No real model — isolates the compaction decision.) */
+  function compactingAgent(opts: {
+    contextWindow: number;
+    usage: Usage;
+    compact: () => Promise<unknown>;
+    stopReason?: StopReason;
+  }) {
+    const message = {
+      role: "assistant",
+      content: [],
+      usage: opts.usage,
+      stopReason: opts.stopReason ?? "stop",
+    } as unknown as AssistantMessage;
+    const harness = {
+      subscribe: () => () => {},
+      prompt: async () => message,
+      getModel: () => ({ contextWindow: opts.contextWindow }),
+      compact: opts.compact,
+      abort: async () => ({}),
+    };
+    return createPiAgentFromHarness({ harnessFactory: (async () => harness) as unknown as PiHarnessFactory });
+  }
+
+  it("compacts after a completed turn when the context is over the threshold", async () => {
+    const compact = vi.fn(async () => ({}));
+    const agent = compactingAgent({ contextWindow: 1000, usage: usage(999_999), compact });
+    const events = await drain(agent.invoke({ session: "s" }, { text: "hi" }));
+    expect(events.at(-1)).toEqual({ type: "completed" });
+    expect(compact).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not compact when the context is under the threshold", async () => {
+    const compact = vi.fn(async () => ({}));
+    const agent = compactingAgent({ contextWindow: 999_999, usage: usage(10), compact });
+    await drain(agent.invoke({ session: "s" }, { text: "hi" }));
+    expect(compact).not.toHaveBeenCalled();
+  });
+
+  it("does not compact when the turn fails (only a completed terminal triggers it)", async () => {
+    const compact = vi.fn(async () => ({}));
+    const agent = compactingAgent({ contextWindow: 1000, usage: usage(999_999), compact, stopReason: "error" });
+    const events = await drain(agent.invoke({ session: "s" }, { text: "hi" }));
+    expect(events.at(-1)?.type).toBe("failed"); // the turn failed
+    expect(compact).not.toHaveBeenCalled();
+  });
+
+  it("holds the session lease through compaction (a concurrent same-session turn is busy until it finishes)", async () => {
+    let releaseCompact = (): void => {};
+    const compactGate = new Promise<void>((r) => {
+      releaseCompact = r;
+    });
+    const compact = vi.fn(async () => {
+      await compactGate; // hold the turn inside compaction
+    });
+    const agent = compactingAgent({ contextWindow: 1000, usage: usage(999_999), compact });
+    const turn1 = drain(agent.invoke({ session: "s" }, { text: "hi" }));
+    for (let k = 0; k < 8; k++) await new Promise((r) => setImmediate(r)); // let turn1 reach compaction
+    expect(compact).toHaveBeenCalledTimes(1); // turn1 is inside compaction — the lease is still held
+
+    const events2 = await drain(agent.invoke({ session: "s" }, { text: "again" }));
+    expect(events2.at(-1)).toMatchObject({ type: "failed", retryable: true }); // busy until compaction frees the lease
+
+    releaseCompact();
+    await turn1;
+  });
+
+  it("a compaction failure does not break the turn (it still completes)", async () => {
+    const compact = vi.fn(async () => {
+      throw new Error("summary failed");
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = compactingAgent({ contextWindow: 1000, usage: usage(999_999), compact });
+    const events = await drain(agent.invoke({ session: "s" }, { text: "hi" }));
+    expect(events.at(-1)).toEqual({ type: "completed" }); // turn still completed
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/auto-compaction failed/));
   });
 });


### PR DESCRIPTION
A shared group session (or any long 1:1) grows every turn and eventually overflows the
model's context window. pi ships the compaction machinery (shouldCompact / compact /
DEFAULT_COMPACTION_SETTINGS, harness.compact()) but the bare AgentHarness fastagent uses
does NOT auto-trigger it (only pi's CLI wrapper does), so fastagent never compacted.

invoke.ts now checks after a SUCCESSFULLY completed turn: contextTokens from the
assistant message's own provider usage (calculateContextTokens(message.usage)) vs
model.contextWindow; if shouldCompact, await harness.compact() (writes a summary entry
into the session → the next reopen is compacted, consistent with stateless invoke).

Placement is the inner finally, deliberately:
- the reply was already sent by the consumer on the terminal, so compaction never delays
  it;
- the generator's return() (which `for await` / collect await on the terminal) awaits the
  finally, so the next turn for this session waits — it never reopens mid-compaction;
- it runs before unsub/abort (it uses the harness) and is non-fatal (a failed summary
  logs a warning and leaves the still-valid session for the next turn to retry).

General (groups + 1:1), default-on. Tested with a fake harness: compacts over threshold,
not under, and a compaction failure still completes the turn.
