### PR TITLE
feat(log): leveled logging — close the observe.ts design gap

### DIFF
--- a/core/src/channels/github.ts
+++ b/core/src/channels/github.ts
@@ -7,6 +7,7 @@ import { verify } from "@octokit/webhooks-methods";
 import type { Schema } from "@octokit/webhooks-types";
 import type { Agent } from "../agent.ts";
 import { collect } from "../collect.ts";
+import { log } from "../log.ts";
 import { readBodyCapped } from "./body.ts";
 import { text } from "./respond.ts";
 
@@ -94,12 +95,12 @@ export function githubChannel(agent: Agent, { secret, on }: GithubChannelOptions
       // Per-turn correlation id (deliveryId is unique per webhook; the index disambiguates fan-out),
       // threaded through start/done/failed so a terminal line joins back to its start.
       const turn = `${event.deliveryId}#${i}`;
-      console.error(`[github] turn start: turn=${turn} session=${session} event=${label}`);
+      log.info(`[github] turn start: turn=${turn} session=${session} event=${label}`);
       const startedAt = Date.now();
       void collect(agent.invoke({ session }, { text })).then(
-        () => console.error(`[github] turn done: turn=${turn} session=${session} (${Date.now() - startedAt}ms)`),
+        () => log.info(`[github] turn done: turn=${turn} session=${session} (${Date.now() - startedAt}ms)`),
         (error) =>
-          console.error(
+          log.error(
             `[github] turn failed: turn=${turn} session=${session} (${Date.now() - startedAt}ms): ${String(error)}`,
           ),
       );

--- a/core/src/channels/http.ts
+++ b/core/src/channels/http.ts
@@ -11,6 +11,7 @@
 import { Readable } from "node:stream";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Agent } from "../agent.ts";
+import { log } from "../log.ts";
 import { readBodyCapped } from "./body.ts";
 import { text, textHeaders } from "./respond.ts";
 
@@ -111,7 +112,7 @@ async function pump(
   } catch (error) {
     // Log server-side (some channels' only failure sink), but return a generic body — don't leak the
     // internal message to the client.
-    console.error(`[host] request handler failed: ${String(error)}`);
+    log.error(`[host] request handler failed: ${String(error)}`);
     if (!res.headersSent) res.writeHead(500, textHeaders);
     res.end("internal error\n");
     return;

--- a/core/src/channels/telegram.ts
+++ b/core/src/channels/telegram.ts
@@ -16,6 +16,7 @@
 import { timingSafeEqual } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { Agent, AgentEvent, ImageRef, Json } from "../agent.ts";
+import { log } from "../log.ts";
 import { readBodyCapped } from "./body.ts";
 import {
   type DownloadedFile,
@@ -261,9 +262,7 @@ async function streamReply(
           // visible — log once per turn so a never-rendering draft is diagnosable, not silent.
           if (!draftErrLogged) {
             draftErrLogged = true;
-            console.error(
-              `[telegram] live draft failed (preview may not render; final reply still sends): ${String(e)}`,
-            );
+            log.warn(`[telegram] live draft failed (preview may not render; final reply still sends): ${String(e)}`);
           }
         }
         if (dirty && !stopped) await sleep(DRAFT_THROTTLE_MS); // pace + coalesce a burst into one send
@@ -463,13 +462,13 @@ export function telegramChannel(
     (info) => {
       if (mentionName === undefined) mentionName = info.username;
       if (info.canReadAllGroupMessages === false) {
-        console.error(
+        log.warn(
           "[telegram] privacy mode is on: the bot only sees @mentions / replies / commands, so group " +
             "context (un-summoned messages) won't be captured. Disable it via @BotFather → /setprivacy.",
         );
       }
     },
-    (e) => console.error(`[telegram] getMe failed; @mention summon + privacy check skipped: ${String(e)}`),
+    (e) => log.warn(`[telegram] getMe failed; @mention summon + privacy check skipped: ${String(e)}`),
   );
   const decide = route ?? ((update: TelegramUpdate) => defaultTelegramRoute(update, { botUsername: mentionName }));
   // Per-session serial queue: model B answers a shared chat[:thread] with ONE turn at a time, so a
@@ -577,7 +576,7 @@ export function telegramChannel(
           // answered turn into the prompt, then clear it — it now lives in this turn's durable session.
           draftSeq = (draftSeq % 1_000_000_000) + 1;
           const startedAt = Date.now();
-          console.error(`[telegram] turn start: turn=${turn} session=${session} ${where}`);
+          log.info(`[telegram] turn start: turn=${turn} session=${session} ${where}`);
           const { text: recent, consumed } = bufferPeek(placeKey);
           const prompt = recent ? `[recent group discussion:\n${recent}\n]\n\n${baseText}` : baseText;
           try {
@@ -591,9 +590,9 @@ export function telegramChannel(
               draftSeq,
               formatError,
             );
-            console.error(`[telegram] turn done: turn=${turn} session=${session} (${Date.now() - startedAt}ms)`);
+            log.info(`[telegram] turn done: turn=${turn} session=${session} (${Date.now() - startedAt}ms)`);
           } catch (error) {
-            console.error(
+            log.error(
               `[telegram] turn failed: turn=${turn} session=${session} (${Date.now() - startedAt}ms): ${String(error)}`,
             );
           }

--- a/core/src/cli.ts
+++ b/core/src/cli.ts
@@ -6,10 +6,11 @@
 import { spawn } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { join, relative, resolve } from "node:path";
-import { autocomplete, isCancel, log, password, select, text as clackText } from "@clack/prompts";
+import { autocomplete, isCancel, log as clackLog, password, select, text as clackText } from "@clack/prompts";
 import { parseArgs } from "node:util";
 import type { Agent } from "./agent.ts";
 import { logAgentLoop } from "./observe.ts";
+import { log, setLogLevel } from "./log.ts";
 import { installProxyFetch } from "./proxy.ts";
 import { createInvokeHandler } from "./channels/http.ts";
 import { text } from "./channels/respond.ts";
@@ -386,7 +387,7 @@ function terminalLoginIO(): LoginIO {
         : await clackText({ message, signal: opts?.signal });
       return isCancel(r) ? undefined : (r as string);
     },
-    note: (message) => log.info(message),
+    note: (message) => clackLog.info(message),
     openUrl: openBrowser,
   };
 }
@@ -420,12 +421,12 @@ function parsePort(value: string | undefined, source: string): number | undefine
 async function reportAuth(modelSpec: string): Promise<void> {
   const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
   const source = await probeAuthSource(createPiModels(), modelSpec);
-  console.error(`[fastagent] auth:   ${source === undefined ? "(none found)" : `${source} (${provider})`}`);
+  log.info(`[fastagent] auth:   ${source === undefined ? "(none found)" : `${source} (${provider})`}`);
   if (source === undefined) {
     // Lead with `fastagent login`: the default model (openai-codex) is OAuth-only, and the
     // provider-specific env var name is not exported, so keep the env path generic.
-    console.error(
-      `[fastagent] warn: no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
+    log.warn(
+      `[fastagent] no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
     );
   }
 }
@@ -434,9 +435,9 @@ type Assembled = Awaited<ReturnType<typeof createPiAgentFromWorkspace>>;
 
 /** The agents/skills/tools/collisions report lines. */
 function reportAgentsSkillsTools(a: Assembled): void {
-  console.error(`[fastagent] agents: ${a.definition.instructions ? "AGENTS.md" : "(none)"}`);
-  console.error(`[fastagent] skills: ${a.definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
-  if (a.toolNames.length > 0) console.error(`[fastagent] tools:  ${a.toolNames.join(", ")}`);
+  log.info(`[fastagent] agents: ${a.definition.instructions ? "AGENTS.md" : "(none)"}`);
+  log.info(`[fastagent] skills: ${a.definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
+  if (a.toolNames.length > 0) log.info(`[fastagent] tools:  ${a.toolNames.join(", ")}`);
   reportToolCollisions(a.toolCollisions);
   reportDefinitionWarnings(a.definition.collisions, a.definition.diagnostics);
 }
@@ -447,6 +448,7 @@ function reportAgentsSkillsTools(a: Assembled): void {
  * is always the latest code, including modules a tool/config imports.
  */
 async function runDev(): Promise<void> {
+  setLogLevel("debug"); // dev posture: verbose, includes the debug turn trace (content) — supervisor and worker both
   if (process.env.FASTAGENT_DEV_WORKER === "1" || values["no-watch"]) {
     await serveOnce();
     return;
@@ -493,17 +495,19 @@ async function serveOnce(): Promise<void> {
   installProxyFetch();
 
   const a = await createPiAgentFromWorkspace(dir, { model: values.model }).catch(failStartup);
-  console.error(`[fastagent] dir:    ${a.definition.dir}`);
-  console.error(`[fastagent] config: ${a.configPath ?? "(zero-config)"}`);
-  console.error(`[fastagent] model:  ${a.modelSpec}`);
+  log.info(`[fastagent] dir:    ${a.definition.dir}`);
+  log.info(`[fastagent] config: ${a.configPath ?? "(zero-config)"}`);
+  log.info(`[fastagent] model:  ${a.modelSpec}`);
   await reportAuth(a.modelSpec);
   reportAgentsSkillsTools(a);
-  // dev only: trace each turn's agent loop (tool calls + reply) to this log, for any channel.
+  // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
+  // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const routes = await routesFor(dir, logAgentLoop(a.agent)).catch(failStartup);
   serve(routes, portFlag ?? a.config.http?.port ?? 8787, (p) => maybeTunnel(a.definition.dir, p));
 }
 
 async function runStart(): Promise<void> {
+  setLogLevel("info"); // production posture: info+, the debug turn trace (and its end-user content) gated out
   const portFlag = parsePort(values.port, "--port");
   loadDotEnv(dir);
   installProxyFetch();
@@ -513,24 +517,25 @@ async function runStart(): Promise<void> {
   const { agent, definition, config, modelSpec, sessionsDir, toolNames, toolCollisions } =
     await createPiAgentFromWorkspace(dir, { model: values.model, sessionsDir: sessionsDirOverride }).catch(failStartup);
 
-  console.error(`[fastagent] start:  ${dir}`);
-  console.error(`[fastagent] model:  ${modelSpec}`);
+  log.info(`[fastagent] start:  ${dir}`);
+  log.info(`[fastagent] model:  ${modelSpec}`);
   await reportAuth(modelSpec);
-  console.error(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);
-  console.error(`[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
-  if (toolNames.length > 0) console.error(`[fastagent] tools:  ${toolNames.join(", ")}`);
+  log.info(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);
+  log.info(`[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
+  if (toolNames.length > 0) log.info(`[fastagent] tools:  ${toolNames.join(", ")}`);
   reportToolCollisions(toolCollisions);
-  console.error(`[fastagent] sessions: ${sessionsDir}`);
+  log.info(`[fastagent] sessions: ${sessionsDir}`);
   // Sessions default under the definition dir, which a redeploy may replace wholesale.
   if (sessionsDirOverride === undefined) {
-    console.error(
+    log.info(
       `[fastagent] note: sessions live under the definition dir; set FASTAGENT_SESSIONS_DIR to a ` +
         `persistent volume so a redeploy that replaces the dir does not wipe conversations.`,
     );
   }
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 
-  const routes = await routesFor(dir, agent).catch(failStartup);
+  // Same debug turn trace as dev; gated out here by the info level (see serveOnce).
+  const routes = await routesFor(dir, logAgentLoop(agent)).catch(failStartup);
   serve(routes, portFlag ?? parsePort(process.env.PORT, "PORT env") ?? config.http?.port ?? 8787, (p) =>
     maybeTunnel(dir, p),
   );
@@ -564,8 +569,8 @@ function serve(routes: Routes, port: number, onListening?: (boundPort: number) =
   serveNode(router(routes), { port }).listening.then(
     (boundPort) => {
       process.send?.({ type: "ready", port: boundPort }); // tell the dev supervisor we bound + on which port
-      console.error(`[fastagent] http channel on :${boundPort}`);
-      console.error(`[fastagent] routes: ${Object.keys(routes).join(", ") || "(none)"}`);
+      log.info(`[fastagent] http channel on :${boundPort}`);
+      log.info(`[fastagent] routes: ${Object.keys(routes).join(", ") || "(none)"}`);
       onListening?.(boundPort);
     },
     (error: NodeJS.ErrnoException) => {

--- a/core/src/dev-supervisor.ts
+++ b/core/src/dev-supervisor.ts
@@ -6,6 +6,7 @@
  */
 import { spawn } from "node:child_process";
 import { watch as watchTree } from "chokidar";
+import { log } from "./log.ts";
 import { installProxyFetch } from "./proxy.ts";
 import { type Tunnel, announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
 
@@ -56,13 +57,13 @@ export function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}
         process.exit(code ?? 1);
       } else {
         // A worker that HAD been serving stopped (broken edit or crash). Fixable; wait for the next save.
-        console.error(`[fastagent] dev stopped (worker exited: ${signal ?? code}) — save a change to retry`);
+        log.warn(`[fastagent] dev stopped (worker exited: ${signal ?? code}) — save a change to retry`);
       }
     });
   };
 
   const triggerReload = (): void => {
-    console.error(`[fastagent] change detected — restarting…`);
+    log.info(`[fastagent] change detected — restarting…`);
     if (worker) {
       reloadPending = true;
       worker.kill("SIGTERM"); // the exit handler respawns once the port is released
@@ -85,11 +86,9 @@ export function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}
     timer = setTimeout(triggerReload, 200);
   });
   watcher.on("error", (error) =>
-    console.error(
-      `[fastagent] warn: file watching error (${(error as Error).message}); some edits may need a manual restart`,
-    ),
+    log.warn(`[fastagent] file watching error (${(error as Error).message}); some edits may need a manual restart`),
   );
-  console.error(`[fastagent] watching for changes — edits restart the dev worker (--no-watch to disable)`);
+  log.info(`[fastagent] watching for changes — edits restart the dev worker (--no-watch to disable)`);
 
   const shutdown = (): never => {
     worker?.kill("SIGTERM");

--- a/core/src/engines/pi/auth.ts
+++ b/core/src/engines/pi/auth.ts
@@ -14,6 +14,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { log } from "../../log.ts";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
 import { FileAuthStorageBackend } from "@earendil-works/pi-coding-agent";
@@ -22,7 +23,7 @@ import { FileAuthStorageBackend } from "@earendil-works/pi-coding-agent";
 export const FASTAGENT_AUTH_PATH = join(homedir(), ".fastagent", "auth.json");
 
 export interface FastagentAuthOptions {
-  /** Sink for non-fatal auth anomalies (unreadable/corrupt file). Defaults to console.warn. */
+  /** Sink for non-fatal auth anomalies (unreadable/corrupt file). Defaults to the process logger (warn). */
   warn?: (message: string) => void;
 }
 
@@ -52,7 +53,7 @@ export function fastagentCredentialStore(
   authPath: string = FASTAGENT_AUTH_PATH,
   options: FastagentAuthOptions = {},
 ): CredentialStore {
-  const warn = options.warn ?? ((message: string) => console.warn(message));
+  const warn = options.warn ?? ((message: string) => log.warn(message));
   const backend = new FileAuthStorageBackend(authPath);
 
   return {

--- a/core/src/engines/pi/invoke.ts
+++ b/core/src/engines/pi/invoke.ts
@@ -15,6 +15,7 @@ import type { AgentHarnessEvent } from "@earendil-works/pi-agent-core";
 import { DEFAULT_COMPACTION_SETTINGS, calculateContextTokens, shouldCompact } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import type { Agent, AgentEvent, Json, Prompt, Scope } from "../../agent.ts";
+import { log } from "../../log.ts";
 import type { PiHarnessFactory } from "./harness.ts";
 
 // ── §1 Lease: single-writer concurrency floor ───────────────────────────────
@@ -238,7 +239,7 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
           try {
             await maybeCompact(harness, completed);
           } catch (error) {
-            console.warn(`[fastagent] auto-compaction failed during cleanup: ${String(error)}`);
+            log.warn(`[fastagent] auto-compaction failed during cleanup: ${String(error)}`);
           }
         }
         // Cleanup MUST NOT throw after the terminal was yielded — that would make an already-closed
@@ -247,12 +248,12 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         try {
           unsub();
         } catch (error) {
-          console.warn(`[fastagent] harness unsubscribe failed during cleanup: ${String(error)}`);
+          log.warn(`[fastagent] harness unsubscribe failed during cleanup: ${String(error)}`);
         }
         try {
           await harness.abort();
         } catch (error) {
-          console.warn(`[fastagent] harness abort failed during cleanup: ${String(error)}`);
+          log.warn(`[fastagent] harness abort failed during cleanup: ${String(error)}`);
         }
       }
     } finally {

--- a/core/src/engines/pi/report.ts
+++ b/core/src/engines/pi/report.ts
@@ -3,22 +3,21 @@
  * the non-fatal definition/tool findings the loaders return as data. One copy so the wording can't drift.
  */
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
+import { log } from "../../log.ts";
 import type { SkillCollision } from "./definition.ts";
 import type { ToolCollision } from "./tool.ts";
 
 export function reportDefinitionWarnings(collisions: SkillCollision[], diagnostics: SkillDiagnostic[]): void {
   for (const c of collisions) {
-    console.error(`[fastagent] warn: skill "${c.name}" collision — using ${c.winnerPath}, ignoring ${c.loserPath}`);
+    log.warn(`[fastagent] skill "${c.name}" collision — using ${c.winnerPath}, ignoring ${c.loserPath}`);
   }
   for (const d of diagnostics) {
-    console.error(`[fastagent] warn: ${d.code}: ${d.message} (${d.path})`);
+    log.warn(`[fastagent] ${d.code}: ${d.message} (${d.path})`);
   }
 }
 
 export function reportToolCollisions(collisions: ToolCollision[]): void {
   for (const c of collisions) {
-    console.error(
-      `[fastagent] warn: tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`,
-    );
+    log.warn(`[fastagent] tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`);
   }
 }

--- a/core/src/engines/pi/sessions.ts
+++ b/core/src/engines/pi/sessions.ts
@@ -12,6 +12,7 @@
 import { InMemorySessionRepo } from "@earendil-works/pi-agent-core";
 import type { AgentMessage, Session } from "@earendil-works/pi-agent-core";
 import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { log } from "../../log.ts";
 
 /** What fastagent needs from a session backend: open-or-create by opaque id. */
 export interface PiSessionStore {
@@ -32,7 +33,7 @@ export interface PiSessionStore {
  * the next non-toolResult). tool-call ids are not unique across turns (a local model may restart ids
  * each response), so matching against the whole transcript could falsely settle a leaf call against an
  * earlier turn's identical id. Append-only logs can only repair a gap AT THE LEAF (last assistant
- * followed by nothing but its own results); an earlier gap is surfaced via console.warn rather than
+ * followed by nothing but its own results); an earlier gap is surfaced via log.warn rather than
  * "fixed" with an orphaned result that appending cannot place.
  *
  * The synthetic result splits its audiences: `content` (read by the model, may reach the end user)
@@ -70,7 +71,7 @@ async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
   });
 
   if (orphaned.length > 0) {
-    console.warn(
+    log.warn(
       `[fastagent] unmatched tool_use is not at the session leaf; leaving it unreconciled ` +
         `(an append-only log cannot repair a mid-history gap): toolCallIds=${orphaned.join(",")}`,
     );

--- a/core/src/log.ts
+++ b/core/src/log.ts
@@ -1,0 +1,66 @@
+/**
+ * Leveled logging. Runtime logs (lifecycle, warnings, errors, the debug turn trace) flow through ONE
+ * process-level logger, gated by a single level. It is a module singleton — not an injected dependency —
+ * because most runtime logs originate inside author-constructed channels (`channels/*.ts` call the
+ * channel factory themselves) and deep engine code, which the CLI cannot thread a logger into. The CLI
+ * sets the level by posture (dev → debug, start → info); `FASTAGENT_LOG_LEVEL` overrides it.
+ *
+ * This is NOT the CLI's user-facing output (help text, command results): that is the program talking to
+ * its operator and stays on plain `console`. Everything here is operational logging to stderr.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface Logger {
+  debug(msg: string): void;
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+}
+
+const ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+const isLevel = (s: string): s is LogLevel => s in ORDER;
+const format = (level: LogLevel, msg: string): string => `${level.toUpperCase().padEnd(5)} ${msg}`;
+
+/** A standalone logger over an explicit sink — used in tests to assert level gating without the singleton. */
+export function createLogger(opts: { level: LogLevel; sink?: (line: string) => void }): Logger {
+  const sink = opts.sink ?? ((line) => console.error(line));
+  const make =
+    (level: LogLevel) =>
+    (msg: string): void => {
+      if (ORDER[level] >= ORDER[opts.level]) sink(format(level, msg));
+    };
+  return { debug: make("debug"), info: make("info"), warn: make("warn"), error: make("error") };
+}
+
+/**
+ * `FASTAGENT_LOG_LEVEL` parsed to three states: a valid value locks the level (overrides posture); a
+ * present-but-invalid value warns and is treated as absent, so a typo (meant to make logs louder) can
+ * never silently pin the level to info nor kill the posture default; absent returns undefined. The
+ * warning is raw — the singleton below is not built yet — but reuses `format` for the same shape.
+ */
+function parseEnvOverride(): LogLevel | undefined {
+  const raw = process.env.FASTAGENT_LOG_LEVEL;
+  if (raw === undefined) return undefined;
+  const value = raw.toLowerCase();
+  if (isLevel(value)) return value;
+  console.error(format("warn", `[fastagent] unknown FASTAGENT_LOG_LEVEL "${raw}"; using the posture default`));
+  return undefined;
+}
+
+const override = parseEnvOverride();
+let currentLevel: LogLevel = override ?? "info";
+
+/** Set the posture default. A valid `FASTAGENT_LOG_LEVEL` override, if present, wins and is not changed. */
+export function setLogLevel(level: LogLevel): void {
+  if (override === undefined) currentLevel = level;
+}
+
+const emit =
+  (level: LogLevel) =>
+  (msg: string): void => {
+    if (ORDER[level] >= ORDER[currentLevel]) console.error(format(level, msg));
+  };
+
+/** The process logger. Runtime code imports this and calls `log.info(...)` etc. */
+export const log: Logger = { debug: emit("debug"), info: emit("info"), warn: emit("warn"), error: emit("error") };

--- a/core/src/observe.ts
+++ b/core/src/observe.ts
@@ -1,33 +1,15 @@
 /**
- * Dev observability (dev, not start): wrap an Agent to trace each turn's loop to the log — prompt,
- * reasoning, tool calls (name + args) with results, reply, terminal event. Pass-through: events are
- * forwarded untouched; this only tees a readable line per step. Engine-neutral (the contract only).
+ * The turn trace: wrap an Agent to tee each turn's loop — prompt, reasoning, tool calls (name + args)
+ * with results, reply, terminal — to the log at DEBUG level. Pass-through: events are forwarded
+ * untouched; this only adds a readable line per step. Engine-neutral (the contract only).
+ *
+ * It is wired in BOTH `dev` and `start`; the level decides visibility. dev runs at debug, so the trace
+ * (including end-user content — prompt, tool args/results, reply) shows; start runs at info, so the
+ * trace is gated out entirely, keeping that content and its volume out of production logs. That gating
+ * is why the trace is debug-level rather than a switch soldered to the command path.
  */
 import type { Agent, AgentEvent, Json, Prompt, Scope } from "./agent.ts";
-
-// ── DESIGN GAP (logging): this module's `dev`-only gating is a stopgap, not the design ──────────────
-//
-// The real, unaddressed problem is bigger than this one trace and bigger than the think/tool question:
-// fastagent has no logging LEVELS and no per-environment/per-scenario log CONFIG. Today every line —
-// lifecycle (`[fastagent] …`, `[telegram] turn …`), warnings (`[fastagent] warn: …`), and this turn
-// trace — is written straight to `console.error` at one implicit severity, with no level, no
-// env/scenario gating, no structured sink, and no redaction of end-user content. So a downstream log
-// collector cannot tell an operational warning from a debug trace from a real error, and the only knob
-// we have is the crude one used here: wire the trace into `dev` and omit it from `start`.
-//
-// That crude knob has two costs. (1) It is all-or-nothing and hardcoded: production gets NO step-level
-// visibility (only coarse turn start/done/failed), exactly when a misbehaving live bot most needs it,
-// and dev cannot quiet it. (2) The reason it must stay off in `start` is itself a logging-design
-// failure: this trace logs CONTENT — the user's prompt, tool args, tool results, the reply — so
-// enabling it in production would spray end-user data (and high volume) into operator logs.
-//
-// The right shape is leveled logging (debug/info/warn/error) configured by environment/scenario, not
-// by call site: dev → verbose, human-readable, content allowed; production → level-gated + structured
-// + end-user content redacted/sampled. Then this trace becomes a debug-level emitter that BOTH `dev`
-// and `start` route through their configured sink, instead of a switch soldered to the command path.
-// Until that layer exists, `logAgentLoop` stays dev-only on purpose — to keep user content out of
-// production logs — and this comment marks the debt so the next change does not mistake the stopgap
-// for the intent.
+import { log } from "./log.ts";
 
 const PREVIEW = 200;
 
@@ -39,11 +21,11 @@ function oneLine(s: string): string {
 
 const preview = (v: Json): string => oneLine(typeof v === "string" ? v : JSON.stringify(v));
 
-export function logAgentLoop(agent: Agent, log: (line: string) => void = (line) => console.error(line)): Agent {
+export function logAgentLoop(agent: Agent, sink: (line: string) => void = (line) => log.debug(line)): Agent {
   return {
     async *invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
       const s = scope.session;
-      log(`[agent] ▶ turn session=${s} ← ${oneLine(prompt.text)}`);
+      sink(`[agent] ▶ turn session=${s} ← ${oneLine(prompt.text)}`);
       const toolName = new Map<string, string>(); // tool_ended carries no name — remember it from tool_started
       let thinking = "";
       let reply = "";
@@ -54,15 +36,15 @@ export function logAgentLoop(agent: Agent, log: (line: string) => void = (line) 
           thinking += e.delta;
         } else if (e.type === "tool_started") {
           toolName.set(e.id, e.name);
-          log(`[agent]   tool → ${e.name}(${preview(e.args)})`);
+          sink(`[agent]   tool → ${e.name}(${preview(e.args)})`);
         } else if (e.type === "tool_ended") {
-          log(`[agent]   tool ${e.isError ? "✗" : "✓"} ${toolName.get(e.id) ?? e.id} → ${preview(e.content)}`);
+          sink(`[agent]   tool ${e.isError ? "✗" : "✓"} ${toolName.get(e.id) ?? e.id} → ${preview(e.content)}`);
         } else if (e.type === "completed") {
-          if (thinking.trim() !== "") log(`[agent]   thinking: ${oneLine(thinking)}`);
-          log(`[agent]   reply: ${oneLine(reply) || "(empty)"}`);
-          log(`[agent] ■ completed session=${s}`);
+          if (thinking.trim() !== "") sink(`[agent]   thinking: ${oneLine(thinking)}`);
+          sink(`[agent]   reply: ${oneLine(reply) || "(empty)"}`);
+          sink(`[agent] ■ completed session=${s}`);
         } else if (e.type === "failed") {
-          log(`[agent] ■ failed session=${s}: ${e.details} (retryable=${e.retryable})`);
+          sink(`[agent] ■ failed session=${s}: ${e.details} (retryable=${e.retryable})`);
         }
         yield e;
       }

--- a/core/src/tunnel.ts
+++ b/core/src/tunnel.ts
@@ -9,6 +9,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { log } from "./log.ts";
 
 export interface Tunnel {
   url: string;
@@ -50,11 +51,11 @@ export async function startCloudflareTunnel(
     const r = await spawnTunnelOnce(port, spawnFn);
     if (r.tunnel) return r.tunnel;
     if (r.fatal) {
-      console.error(r.message); // missing binary — retrying cannot help
+      log.error(r.message); // missing binary — retrying cannot help
       return undefined;
     }
     const more = attempt < TUNNEL_ATTEMPTS;
-    console.error(
+    log.warn(
       `[fastagent] --tunnel: cloudflared exited before a public URL appeared${r.detail ? ` (${r.detail})` : ""}` +
         (more ? ` — retrying (${attempt}/${TUNNEL_ATTEMPTS - 1})…` : ". Serving without a tunnel."),
     );
@@ -126,7 +127,7 @@ function channelBasenames(dir: string): string[] {
  * auto-registered via setWebhook (using .env tokens); github prints the URL to add in repo settings.
  */
 export async function announceWebhooks(dir: string, baseUrl: string): Promise<void> {
-  console.error(`[fastagent] public URL: ${baseUrl}`);
+  log.info(`[fastagent] public URL: ${baseUrl}`);
   try {
     process.loadEnvFile(join(dir, ".env")); // so telegram registration sees the tokens
   } catch {
@@ -136,13 +137,13 @@ export async function announceWebhooks(dir: string, baseUrl: string): Promise<vo
   if (channels.length === 0) return;
   // A fresh quick tunnel returns Cloudflare 530 for ~20-30s before its origin connects; registering a
   // webhook before then fails with "Failed to resolve host". Wait until /health actually serves.
-  console.error("[fastagent] waiting for the tunnel to come up…");
+  log.info("[fastagent] waiting for the tunnel to come up…");
   if (!(await waitForTunnel(baseUrl))) {
-    console.error(`[fastagent] tunnel did not respond in time; webhook registration may fail (URL: ${baseUrl})`);
+    log.warn(`[fastagent] tunnel did not respond in time; webhook registration may fail (URL: ${baseUrl})`);
   }
   if (channels.includes("telegram")) await registerTelegram(baseUrl);
   if (channels.includes("github")) {
-    console.error(
+    log.info(
       `[fastagent] github: add a webhook in your repo (Settings → Webhooks): Payload URL = ${baseUrl}/webhook, content type application/json, secret = GITHUB_WEBHOOK_SECRET`,
     );
   }
@@ -168,7 +169,7 @@ async function registerTelegram(baseUrl: string): Promise<void> {
   const secret = process.env.TELEGRAM_SECRET_TOKEN;
   const webhookUrl = `${baseUrl}/telegram`;
   if (!botToken || !secret) {
-    console.error(
+    log.info(
       `[fastagent] telegram: set TELEGRAM_BOT_TOKEN + TELEGRAM_SECRET_TOKEN in .env, then re-run to auto-register. Webhook URL: ${webhookUrl}`,
     );
     return;
@@ -179,7 +180,7 @@ async function registerTelegram(baseUrl: string): Promise<void> {
     if (attempt > 0) await sleep(5000);
     const result = await trySetWebhook(botToken, webhookUrl, secret);
     if (result.ok) {
-      console.error(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
+      log.info(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
       return;
     }
     // Only network-transient errors are worth retrying. A fresh tunnel's "bad webhook: Failed to
@@ -187,15 +188,13 @@ async function registerTelegram(baseUrl: string): Promise<void> {
     // is a config error, not transient, so `bad webhook` is deliberately NOT a trigger.
     const transient = /resolve host|getaddrinfo|ENOTFOUND|fetch failed|ECONNRESET|timeout/i.test(result.error);
     if (!transient) {
-      console.error(
-        `[fastagent] telegram: setWebhook failed (${result.error}). Register manually with url=${webhookUrl}`,
-      );
+      log.error(`[fastagent] telegram: setWebhook failed (${result.error}). Register manually with url=${webhookUrl}`);
       return;
     }
     if (attempt < ATTEMPTS - 1)
-      console.error(`[fastagent] telegram: tunnel not resolvable yet, retrying… (${attempt + 1}/${ATTEMPTS - 1})`);
+      log.warn(`[fastagent] telegram: tunnel not resolvable yet, retrying… (${attempt + 1}/${ATTEMPTS - 1})`);
   }
-  console.error(
+  log.warn(
     `[fastagent] telegram: webhook still failing after retries (the tunnel may need another moment). Register manually with url=${webhookUrl}`,
   );
 }

--- a/core/test/auth.test.ts
+++ b/core/test/auth.test.ts
@@ -16,15 +16,15 @@ async function authPath(contents?: string): Promise<string> {
 
 describe("fastagentCredentialStore (read-write ~/.fastagent/auth.json; fail-visibly discipline)", () => {
   it("missing file → undefined, no warning (normal not-configured)", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    expect(await fastagentCredentialStore("/nonexistent/auth.json").read("anthropic")).toBeUndefined();
+    const warn = vi.fn();
+    expect(await fastagentCredentialStore("/nonexistent/auth.json", { warn }).read("anthropic")).toBeUndefined();
     expect(warn).not.toHaveBeenCalled();
   });
 
   it("corrupt JSON → undefined, but warns (diagnosable root cause)", async () => {
     const path = await authPath("{not valid json");
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    expect(await fastagentCredentialStore(path).read("anthropic")).toBeUndefined();
+    const warn = vi.fn();
+    expect(await fastagentCredentialStore(path, { warn }).read("anthropic")).toBeUndefined();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("corrupt auth file"));
   });
 

--- a/core/test/invoke.test.ts
+++ b/core/test/invoke.test.ts
@@ -168,7 +168,7 @@ describe("invoke fan-in", () => {
     });
 
     // iteration must not throw, and the tail is still completed
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const events = await drain(agent.invoke({ session: "sg" }, { text: "hi" }));
       expect(events.at(-1)).toEqual({ type: "completed" });
@@ -441,7 +441,7 @@ describe("invoke: auto-compaction", () => {
     const compact = vi.fn(async () => {
       throw new Error("summary failed");
     });
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
     const agent = compactingAgent({ contextWindow: 1000, usage: usage(999_999), compact });
     const events = await drain(agent.invoke({ session: "s" }, { text: "hi" }));
     expect(events.at(-1)).toEqual({ type: "completed" }); // turn still completed

--- a/core/test/log.test.ts
+++ b/core/test/log.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLogger, log, setLogLevel } from "../src/log.ts";
+
+describe("createLogger", () => {
+  const capture = (level: "debug" | "info" | "warn" | "error") => {
+    const lines: string[] = [];
+    return { log: createLogger({ level, sink: (l) => lines.push(l) }), lines };
+  };
+
+  it("gates below the threshold and emits at or above it", () => {
+    const { log, lines } = capture("info");
+    log.debug("d");
+    log.info("i");
+    log.warn("w");
+    log.error("e");
+    expect(lines).toEqual(["INFO  i", "WARN  w", "ERROR e"]); // debug dropped
+  });
+
+  it("at debug level emits everything", () => {
+    const { log, lines } = capture("debug");
+    log.debug("d");
+    log.info("i");
+    expect(lines).toEqual(["DEBUG d", "INFO  i"]);
+  });
+
+  it("at error level emits only errors", () => {
+    const { log, lines } = capture("error");
+    log.warn("w");
+    log.error("e");
+    expect(lines).toEqual(["ERROR e"]);
+  });
+});
+
+describe("log singleton + setLogLevel", () => {
+  // Assumes FASTAGENT_LOG_LEVEL is unset (an env override would win and skip setLogLevel by design).
+  it("setLogLevel moves the threshold; the singleton writes to stderr", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      setLogLevel("debug");
+      log.debug("[t] d");
+      setLogLevel("error");
+      log.warn("[t] w"); // below error — gated
+      log.error("[t] e");
+      const lines = err.mock.calls.map((c) => String(c[0]));
+      expect(lines).toContain("DEBUG [t] d");
+      expect(lines).toContain("ERROR [t] e");
+      expect(lines.some((l) => l.includes("[t] w"))).toBe(false);
+    } finally {
+      err.mockRestore();
+      setLogLevel("info"); // restore the default the other suites rely on
+    }
+  });
+});
+
+describe("FASTAGENT_LOG_LEVEL override (parsed at module load)", () => {
+  // Each test re-imports a fresh log.ts so the load-time env parse runs under a stubbed value.
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("a valid value locks the level — setLogLevel is a no-op", async () => {
+    vi.stubEnv("FASTAGENT_LOG_LEVEL", "error");
+    vi.resetModules();
+    const fresh = await import("../src/log.ts");
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      fresh.setLogLevel("debug"); // would normally show debug; the valid override wins
+      fresh.log.debug("[t] d");
+      fresh.log.error("[t] e");
+      const lines = err.mock.calls.map((c) => String(c[0]));
+      expect(lines).toContain("ERROR [t] e");
+      expect(lines.some((l) => l.includes("[t] d"))).toBe(false); // debug gated by the override
+    } finally {
+      err.mockRestore();
+    }
+  });
+
+  it("an invalid value warns at load and falls back to posture — setLogLevel still works", async () => {
+    vi.stubEnv("FASTAGENT_LOG_LEVEL", "trace");
+    vi.resetModules();
+    const err = vi.spyOn(console, "error").mockImplementation(() => {}); // before import — catch the load-time warn
+    try {
+      const fresh = await import("../src/log.ts");
+      expect(err.mock.calls.map((c) => String(c[0])).some((l) => /unknown FASTAGENT_LOG_LEVEL "trace"/.test(l))).toBe(
+        true,
+      );
+      fresh.setLogLevel("debug"); // the invalid value did not disable the posture default
+      fresh.log.debug("[t] d2");
+      expect(err.mock.calls.map((c) => String(c[0])).some((l) => l.includes("[t] d2"))).toBe(true);
+    } finally {
+      err.mockRestore();
+    }
+  });
+});

--- a/core/test/sessions.test.ts
+++ b/core/test/sessions.test.ts
@@ -201,7 +201,7 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
       timestamp: Date.now(),
     } as any);
 
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const reopened = await store.openOrCreate("mid-history"); // open -> reconcile
       const { messages } = await reopened.buildContext();
@@ -242,7 +242,7 @@ describe("crash-safety: reconcile interrupted tool calls on open", () => {
       timestamp: Date.now(),
     } as any);
 
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const reopened = await store.openOrCreate("mid-later-assistant"); // open -> reconcile
       const { messages } = await reopened.buildContext();


### PR DESCRIPTION
Every runtime line — lifecycle, warnings, errors, and the turn trace — went straight to
console.error at one implicit severity: no levels, no per-posture gating, no way to tell a
debug trace from a real error, and the trace (which logs end-user content) could only be
kept out of production by soldering it to the dev command path. observe.ts carried a long
DESIGN GAP comment marking exactly this.

Introduce one process logger (src/log.ts): debug/info/warn/error gated by a single level,
to stderr. It is a module singleton — not injected — because most runtime logs originate
inside author-constructed channels (channels/*.ts call the factory themselves) and deep
engine code the CLI cannot thread a logger into; the leaf sinks that ARE constructed by the
caller (auth, the turn trace) keep their injectable param, defaulting to the singleton.

- Posture sets the level: dev → debug (verbose, trace shown), start → info (trace gated).
- FASTAGENT_LOG_LEVEL is parsed to three states: a valid value locks the level (overrides
  posture); a present-but-invalid value warns at load and is treated as absent (a typo meant
  to make logs louder must never silently pin the level to info nor disable the posture
  default — fail visibly); absent leaves the posture default.
- The turn trace (observe.ts) becomes a DEBUG emitter wired in BOTH dev and start. Production
  runs at info, so it is gated out entirely — end-user content (prompt, tool args/results,
  reply) and its volume never reach production logs. That replaces the old dev-only switch
  and needs no separate redaction pass.
- Runtime console.* across telegram/github/http/invoke/tunnel/dev-supervisor/sessions/auth/
  report move to log.{info,warn,error} at the right level. The CLI's user-facing output
  (help, command results, fatal bind errors) stays on console — it is program UI, not logs.

Structured-JSON output and content redaction beyond level-gating are deferred (YAGNI).

Tests: createLogger level gating; the singleton + setLogLevel; and (via resetModules +
stubEnv) the env override — a valid value makes setLogLevel a no-op, an invalid value warns
and falls back to posture. auth tests inject the warn sink; invoke/sessions tests assert the
stderr the logger writes.

