### PR TITLE
refactor(channels): one folder per channel (telegram/, github/)

### DIFF
--- a/core/src/channels/github/github.ts
+++ b/core/src/channels/github/github.ts
@@ -5,11 +5,11 @@
  */
 import { verify } from "@octokit/webhooks-methods";
 import type { Schema } from "@octokit/webhooks-types";
-import type { Agent } from "../agent.ts";
-import { collect } from "../collect.ts";
-import { log } from "../log.ts";
-import { readBodyCapped } from "./body.ts";
-import { text } from "./respond.ts";
+import type { Agent } from "../../agent.ts";
+import { collect } from "../../collect.ts";
+import { log } from "../../log.ts";
+import { readBodyCapped } from "../body.ts";
+import { text } from "../respond.ts";
 
 /** Raw body cap before verification — GitHub caps webhook payloads at 25 MB; reject larger early. */
 const MAX_WEBHOOK_BYTES = 25 << 20;

--- a/core/src/channels/telegram/telegram-api.ts
+++ b/core/src/channels/telegram/telegram-api.ts
@@ -7,7 +7,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
-import type { ImageRef } from "../agent.ts";
+import type { ImageRef } from "../../agent.ts";
 
 /** Telegram's hard text limit per message. */
 const TELEGRAM_MAX_TEXT = 4096;

--- a/core/src/channels/telegram/telegram.ts
+++ b/core/src/channels/telegram/telegram.ts
@@ -15,9 +15,9 @@
  */
 import { timingSafeEqual } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
-import type { Agent, AgentEvent, ImageRef, Json } from "../agent.ts";
-import { log } from "../log.ts";
-import { readBodyCapped } from "./body.ts";
+import type { Agent, AgentEvent, ImageRef, Json } from "../../agent.ts";
+import { log } from "../../log.ts";
+import { readBodyCapped } from "../body.ts";
 import {
   type DownloadedFile,
   type Target,
@@ -27,7 +27,7 @@ import {
   sendMessage,
   sendMessageDraft,
 } from "./telegram-api.ts";
-import { text } from "./respond.ts";
+import { text } from "../respond.ts";
 
 /** Update body cap — Telegram updates are small JSON; 1 MiB is generous and guards a public endpoint. */
 const MAX_UPDATE_BYTES = 1 << 20;

--- a/core/src/github.ts
+++ b/core/src/github.ts
@@ -4,7 +4,7 @@ export {
   type GithubChannelOptions,
   type GithubEvent,
   type Intent,
-} from "./channels/github.ts";
+} from "./channels/github/github.ts";
 // `GithubEvent.payload` is typed as Schema (the official octokit union); re-exported so `on()`
 // authors can name it without importing @octokit/webhooks-types.
 export type { Schema } from "@octokit/webhooks-types";

--- a/core/src/telegram.ts
+++ b/core/src/telegram.ts
@@ -8,4 +8,4 @@ export {
   type TelegramMessage,
   type TelegramRoute,
   type TelegramFailure,
-} from "./channels/telegram.ts";
+} from "./channels/telegram/telegram.ts";


### PR DESCRIPTION
Move each channel's runtime into its own folder so a channel is a self-contained unit —
the cohesion boundary and the future package boundary (telegram is slated to become a
sibling @kid7st/fastagent-telegram; extracting it should be moving one folder). This also
makes room for each channel's scaffold kit to live beside its runtime in a follow-up.

- src/channels/telegram.ts + telegram-api.ts → src/channels/telegram/
- src/channels/github.ts → src/channels/github/
- http.ts / body.ts / respond.ts stay flat: the invoke handler and shared helpers are not
  channel units.

Pure move. The public export subpaths (./telegram, ./github) are unaffected — they resolve
through the src/telegram.ts / src/github.ts facades, whose one import line now points into
the folder. Internal relative imports shift a level; tests import via the facades, so they
are untouched. typecheck/lint/248 tests green; both subpaths still export as before.
