### PR TITLE
fix(telegram): live preview via sendMessage + editMessageText, not sendMessageDraft

### DIFF
--- a/core/src/channels/telegram/telegram-api.ts
+++ b/core/src/channels/telegram/telegram-api.ts
@@ -44,14 +44,17 @@ async function callBotApi(
   botToken: string,
   method: string,
   params: Record<string, unknown>,
-): Promise<{ ok: true } | { ok: false; status: number; description: string }> {
+): Promise<{ ok: true; result?: { message_id?: number } } | { ok: false; status: number; description: string }> {
   for (let attempt = 0; ; attempt++) {
     const res = await fetch(`${api}/bot${botToken}/${method}`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(params),
     });
-    if (res.ok) return { ok: true };
+    if (res.ok) {
+      const data = (await res.json().catch(() => ({}))) as { result?: { message_id?: number } };
+      return { ok: true, result: data.result };
+    }
     const data = (await res.json().catch(() => ({}))) as {
       description?: string;
       parameters?: { retry_after?: number };
@@ -66,7 +69,7 @@ async function callBotApi(
 }
 
 /** Split text into ≤4096-char chunks (Telegram's limit), preferring newline boundaries. */
-function chunkText(text: string): string[] {
+export function chunkText(text: string): string[] {
   if (text.length <= TELEGRAM_MAX_TEXT) return [text];
   const chunks: string[] = [];
   let rest = text;
@@ -81,12 +84,20 @@ function chunkText(text: string): string[] {
 }
 
 /**
- * Persist a final reply: split to Telegram's 4096-char limit, and send each chunk as HTML, falling back
- * to plain text only if Telegram rejects the markup — so a model formatting slip degrades instead of
- * losing the message. Format is the channel's job (Telegram's own parser); the developer never picks it.
- * `message_thread_id` is dropped from the JSON when undefined (linear chat).
+ * Send a message: split to Telegram's 4096-char limit, each chunk as HTML by default (`html:false` for
+ * a plain live-preview), falling back to plain only if Telegram rejects the markup — so a model
+ * formatting slip degrades instead of losing the message. Returns the FIRST chunk's message_id (so the
+ * caller can edit it as a live preview). `message_thread_id` is dropped from the JSON when undefined.
  */
-export async function sendMessage(api: string, botToken: string, t: Target, body: string): Promise<void> {
+export async function sendMessage(
+  api: string,
+  botToken: string,
+  t: Target,
+  body: string,
+  opts: { html?: boolean } = {},
+): Promise<number | undefined> {
+  const html = opts.html ?? true;
+  let firstId: number | undefined;
   let first = true;
   for (const chunk of chunkText(body)) {
     const base: Record<string, unknown> = { chat_id: t.chatId, message_thread_id: t.threadId, text: chunk };
@@ -96,31 +107,53 @@ export async function sendMessage(api: string, botToken: string, t: Target, body
     if (first && t.replyTo !== undefined) {
       base.reply_parameters = { message_id: t.replyTo, allow_sending_without_reply: true };
     }
-    first = false;
-    let result = await callBotApi(api, botToken, "sendMessage", { ...base, parse_mode: "HTML" });
-    if (!result.ok && PARSE_ERROR.test(result.description))
+    let result = html
+      ? await callBotApi(api, botToken, "sendMessage", { ...base, parse_mode: "HTML" })
+      : await callBotApi(api, botToken, "sendMessage", base);
+    if (html && !result.ok && PARSE_ERROR.test(result.description))
       result = await callBotApi(api, botToken, "sendMessage", base);
     if (!result.ok) throw new Error(`telegram sendMessage failed: ${result.status} ${result.description}`.trim());
+    if (first) firstId = result.result?.message_id;
+    first = false;
   }
+  return firstId;
 }
 
-/** Push an ephemeral draft (animated preview, capped at the text limit). Same draft_id animates updates. */
-export async function sendMessageDraft(
+/**
+ * Edit a message in place — the live-preview mechanism (one message, repeatedly updated). Plain by
+ * default (a partial preview may contain unbalanced HTML); `html:true` for the final answer, falling
+ * back to plain if Telegram rejects the markup. "message is not modified" is NOT an error: the pump may
+ * re-render an unchanged view. The message is identified by (chat_id, message_id) — no thread needed.
+ */
+export async function editMessageText(
   api: string,
   botToken: string,
   t: Target,
-  draftId: number,
+  messageId: number,
   body: string,
+  opts: { html?: boolean } = {},
 ): Promise<void> {
-  const result = await callBotApi(api, botToken, "sendMessageDraft", {
+  const base: Record<string, unknown> = {
     chat_id: t.chatId,
-    message_thread_id: t.threadId,
-    draft_id: draftId,
+    message_id: messageId,
     text: body.slice(0, TELEGRAM_MAX_TEXT),
-  });
-  if (!result.ok) throw new Error(`telegram sendMessageDraft failed: ${result.status} ${result.description}`.trim());
+  };
+  let result = opts.html
+    ? await callBotApi(api, botToken, "editMessageText", { ...base, parse_mode: "HTML" })
+    : await callBotApi(api, botToken, "editMessageText", base);
+  if (opts.html && !result.ok && PARSE_ERROR.test(result.description))
+    result = await callBotApi(api, botToken, "editMessageText", base);
+  if (!result.ok && /message is not modified/i.test(result.description)) return;
+  if (!result.ok) throw new Error(`telegram editMessageText failed: ${result.status} ${result.description}`.trim());
 }
 
+/** Delete a message — the wire primitive for removing a preview placeholder (the finalize POLICY lives
+ *  in telegram.ts). Throws on failure, like the other primitives; a caller that wants best-effort cleanup
+ *  catches explicitly rather than the primitive swallowing it. */
+export async function deleteMessage(api: string, botToken: string, t: Target, messageId: number): Promise<void> {
+  const result = await callBotApi(api, botToken, "deleteMessage", { chat_id: t.chatId, message_id: messageId });
+  if (!result.ok) throw new Error(`telegram deleteMessage failed: ${result.status} ${result.description}`.trim());
+}
 /** getMe: the bot's own @username (so default routing recognises group @mentions) and whether group
  *  privacy mode is OFF (`can_read_all_group_messages`) — needed to receive the un-summoned group
  *  messages that feed the context buffer. */

--- a/core/src/channels/telegram/telegram.ts
+++ b/core/src/channels/telegram/telegram.ts
@@ -5,8 +5,10 @@
  * is a JSON POST, outbound is a `fetch` to the Bot API. The developer writes only `route` (policy); the
  * channel owns transport + format + attachments.
  *
- * Live streaming: tool calls + partial text stream into an ephemeral draft (sendMessageDraft, a 30s
- * animated preview); the final text is persisted with sendMessage. Threaded Mode (topics in private
+ * Live streaming: a single "💭 Thinking…" message is sent once, then editMessageText'd in place with the
+ * latest tool calls + partial text (PLAIN — a partial answer may carry unbalanced HTML); on completion
+ * the same message is edited into the final answer as HTML. One message, works in groups and private
+ * (unlike sendMessageDraft, which is private/forum-topic only). Threaded Mode (topics in private
  * chats, a @BotFather toggle) is auto-adapted: an update carrying message_thread_id replies into that
  * thread; without one the chat is linear. Same code, both modes.
  *
@@ -14,7 +16,6 @@
  * kit: readBodyCapped / text), so it is exactly what a third-party `fastagent-channel-*` package would write.
  */
 import { timingSafeEqual } from "node:crypto";
-import { setTimeout as sleep } from "node:timers/promises";
 import type { Agent, AgentEvent, ImageRef, Json } from "../../agent.ts";
 import { log } from "../../log.ts";
 import { readBodyCapped } from "../body.ts";
@@ -24,8 +25,10 @@ import {
   resolveBotInfo,
   resolveFiles,
   resolveImages,
+  chunkText,
+  deleteMessage,
+  editMessageText,
   sendMessage,
-  sendMessageDraft,
 } from "./telegram-api.ts";
 import { text } from "../respond.ts";
 
@@ -43,11 +46,9 @@ interface BufferEntry {
   body: string;
 }
 
-/** How often (ms) to push a streamed draft update; tool events flush immediately for snappy feedback. */
-const DRAFT_THROTTLE_MS = 800;
-
-/** Re-push the draft at least this often, under Telegram's ~30s draft expiry, so a long step keeps the preview alive. */
-const DRAFT_KEEPALIVE_MS = 20_000;
+/** How often (ms) to edit the live-preview message; tool events still flush on the next loop. Edits to
+ *  one message are rate-limited tighter than sends, so pace them ~1.5s (vs every token). */
+const EDIT_THROTTLE_MS = 1500;
 
 /** Max length of a tool's arg preview in the live view. */
 const TOOL_ARG_MAX = 48;
@@ -200,18 +201,55 @@ function defaultErrorMessage(failed: TelegramFailure): string {
 }
 
 /**
- * Consume one turn's event stream into a Telegram chat, live. Tool calls + partial text stream into an
- * ephemeral draft; the final text is persisted with sendMessage (the draft is a ~30s preview, so the
- * real message MUST be sent to keep it, and a keepalive re-pushes it so a long step does not blank it).
- * Draft updates are best-effort: they are only a preview, and the authoritative sendMessage surfaces
- * any real failure (bad token, etc.) — a client that does not support drafts degrades to "final only".
+ * The terminal-write POLICY: resolve the single preview message into `text`. streamReply owns the
+ * preview lifecycle, so this composition of transport primitives lives here, not in telegram-api. One
+ * message → edit the preview in place; if the edit fails (preview gone, or a persistent 429/5xx) fall
+ * back to deleting the placeholder and sending fresh, so no "Thinking…" is left pinned above the answer.
+ * Many messages → delete the preview and send the whole answer as consecutive fresh messages (editing
+ * would pin the first chunk where an active group has scrolled past). No preview → fresh send. EMPTY text
+ * = "say nothing" → just delete the preview.
+ */
+async function finalize(
+  api: string,
+  botToken: string,
+  target: Target,
+  messageId: number | undefined,
+  text: string,
+  opts: { html?: boolean } = {},
+): Promise<void> {
+  const html = opts.html ?? true;
+  if (text.trim() === "") {
+    if (messageId !== undefined) await deleteMessage(api, botToken, target, messageId);
+    return;
+  }
+  if (messageId !== undefined) {
+    if (chunkText(text).length === 1) {
+      try {
+        await editMessageText(api, botToken, target, messageId, text, { html });
+        return;
+      } catch {
+        // Edit failed — the preview may be gone, or still there (429 retries exhausted / 5xx). Fall through
+        // to delete + fresh send below so a still-present "Thinking…" is not left pinned above the answer.
+      }
+    }
+    // Many chunks, OR a failed single-chunk edit: remove the placeholder best-effort (a lingering one above
+    // the answer is worse than the extra call), then send the whole reply as fresh, consecutive messages.
+    await deleteMessage(api, botToken, target, messageId).catch(() => {});
+  }
+  await sendMessage(api, botToken, target, text, { html });
+}
+
+/**
+ * Consume one turn's event stream into a Telegram chat, live. A single preview message is sent once and
+ * editMessageText'd in place with the latest tool calls + partial text (PLAIN); on completion it is
+ * edited into the final answer (HTML). Preview edits are best-effort (logged once if they fail); the
+ * final write is authoritative and surfaces a real failure (bad token, etc.).
  */
 async function streamReply(
   events: AsyncIterable<AgentEvent>,
   api: string,
   botToken: string,
   target: Target,
-  draftId: number,
   formatError: (failed: TelegramFailure) => string | undefined,
 ): Promise<void> {
   const tools: { label: string; status: "running" | "ok" | "error" }[] = [];
@@ -233,22 +271,46 @@ async function streamReply(
       .filter((s) => s.trim() !== "")
       .join("\n\n")
       .trim();
-    // Before the first reasoning/tool/text arrives the draft is empty — Telegram renders an empty draft
-    // as a bare "…", so show an explicit placeholder instead (this is also what the keepalive re-pushes).
+    // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
     return v === "" ? "💭 Thinking…" : v;
   };
+
+  // The live preview is ONE real message: sent once (capturing its id + threading under the asker),
+  // then edited in place. messageId/lastSent are shared with the final write on completion.
+  let messageId: number | undefined;
+  let previewSent = false; // a placeholder send was attempted — guards against re-sending when no id came back
+  let finalized = false; // a terminal write (completed/failed) ran — the finally skips its orphan cleanup
+  let lastSent = "";
+  const flushPreview = async (): Promise<void> => {
+    const text = view();
+    if (text === lastSent) return; // skip an unchanged edit (Telegram rejects "message is not modified")
+    lastSent = text;
+    if (messageId !== undefined) {
+      await editMessageText(api, botToken, target, messageId, text); // plain — a partial answer may carry unbalanced HTML
+      return;
+    }
+    // No preview message yet. Send the placeholder ONCE; never re-send (that would spam a new message per
+    // frame). If Telegram returns ok WITHOUT a message_id (proxy / odd API base / unparseable body) we
+    // cannot edit — fail visibly and stop previewing (the final write still lands via finalize).
+    if (previewSent) return;
+    previewSent = true;
+    messageId = await sendMessage(api, botToken, target, text, { html: false });
+    if (messageId === undefined)
+      throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
+  };
+
   // ── Live-preview pump: a SINGLE serialized writer. ──────────────────────────────────────────
-  // Events mutate state (thinking / tools / answer) and mark the preview dirty; the pump sends the
-  // LATEST view() with at most ONE sendMessageDraft in flight, paced by a throttle between sends, plus a
-  // trailing send after the final change. One-in-flight is the whole point: concurrent draft sends (an
-  // event update racing the keepalive, or a slow send overtaken by the next) can reach Telegram out of
-  // order — an older frame landing over a newer one is the "shows 3-4 steps, blanks, re-fills" flicker.
-  // Serializing through one writer keeps frames strictly monotonic; the keepalive marks dirty through
-  // the same writer, so it cannot race.
+  // Events mutate state (thinking / tools / answer) and mark the preview dirty; the pump edits the
+  // message to the LATEST view() with at most ONE edit in flight, paced by a throttle. One-in-flight is
+  // the whole point: concurrent edits can reach Telegram out of order — an older frame landing over a
+  // newer one is the "shows 3-4 steps, blanks, re-fills" flicker. Serializing keeps frames monotonic.
+  // (No keepalive: a real message does not expire, unlike the old 30s draft.)
   let dirty = false;
   let pumping = false;
   let stopped = false;
-  let draftErrLogged = false;
+  let previewErrLogged = false;
+  let pumpDone: Promise<void> | undefined;
+  let wakeThrottle: (() => void) | undefined; // set while the pump is mid-throttle; finish() cuts it short
 
   const runPump = async (): Promise<void> => {
     pumping = true;
@@ -256,38 +318,47 @@ async function streamReply(
       while (dirty && !stopped) {
         dirty = false;
         try {
-          await sendMessageDraft(api, botToken, target, draftId, view());
+          await flushPreview();
         } catch (e) {
-          // Best-effort preview (the final sendMessage is authoritative), but a failing draft must be
-          // visible — log once per turn so a never-rendering draft is diagnosable, not silent.
-          if (!draftErrLogged) {
-            draftErrLogged = true;
-            log.warn(`[telegram] live draft failed (preview may not render; final reply still sends): ${String(e)}`);
+          // Best-effort preview (the final write is authoritative), but a failing edit must be visible —
+          // log once per turn so a never-rendering preview is diagnosable, not silent.
+          if (!previewErrLogged) {
+            previewErrLogged = true;
+            log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`);
           }
         }
-        if (dirty && !stopped) await sleep(DRAFT_THROTTLE_MS); // pace + coalesce a burst into one send
+        if (dirty && !stopped) {
+          // Pace + coalesce a burst into one edit. Interruptible: finish() cuts this short so the final
+          // write is not delayed by up to EDIT_THROTTLE_MS after the turn completes.
+          await new Promise<void>((resolve) => {
+            const t = setTimeout(resolve, EDIT_THROTTLE_MS);
+            wakeThrottle = () => {
+              clearTimeout(t);
+              resolve();
+            };
+          });
+          wakeThrottle = undefined;
+        }
       }
     } finally {
       pumping = false;
     }
   };
-  // Mark the preview dirty and ensure the single writer is running (a send already in flight picks up
+  // Mark the preview dirty and ensure the single writer is running (an edit already in flight picks up
   // the new state on its next loop). Synchronous — callers never await a network write.
   const touch = (): void => {
     dirty = true;
-    if (!pumping) void runPump();
+    if (!pumping) pumpDone = runPump();
   };
 
-  touch(); // show the "💭 Thinking…" placeholder immediately
+  touch(); // send the "💭 Thinking…" placeholder immediately
 
-  // A draft is a ~30s ephemeral preview; a long event-less step would let it lapse, so re-mark dirty on
-  // a heartbeat to re-push the current view — through the same single writer, so no race.
-  const keepalive = setInterval(touch, DRAFT_KEEPALIVE_MS);
-  // Stop the writer (no draft frame after the authoritative final message); an in-flight send may land,
-  // but the pump starts no new one once stopped.
-  const finish = (): void => {
+  // Stop the pump and await any in-flight edit, so the final write below is strictly the LAST one to the
+  // preview message (no stale frame landing after the answer).
+  const finish = async (): Promise<void> => {
     stopped = true;
-    clearInterval(keepalive);
+    wakeThrottle?.(); // cut an in-flight throttle so the final write is not delayed up to EDIT_THROTTLE_MS
+    await pumpDone?.catch(() => {});
   };
 
   try {
@@ -309,21 +380,45 @@ async function streamReply(
         if (t) t.status = e.isError ? "error" : "ok";
         touch();
       } else if (e.type === "completed") {
-        finish();
-        if (answer.trim() !== "") await sendMessage(api, botToken, target, answer);
+        await finish();
+        // Edit the preview into the final answer (HTML, plain fallback); the persisted message is the
+        // answer alone — the process (thinking/tools) was preview-only. Mark finalized BEFORE delivering:
+        // the terminal was reached, so a delivery failure here is a plain failure, not an "abnormal exit"
+        // (which would wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
+        finalized = true;
+        await finalize(api, botToken, target, messageId, answer.trim() !== "" ? answer : "(no reply)");
         return;
       } else if (e.type === "failed") {
-        finish();
+        await finish();
         // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
-        // log (dev-facing — the full details, via the throw below + the handler's catch).
-        const msg = formatError({ details: e.details, retryable: e.retryable });
-        if (msg && msg.trim() !== "") await sendMessage(api, botToken, target, msg).catch(() => {});
+        // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
+        // write as completed: edit → fresh-send if the preview is gone; an empty notice deletes the
+        // placeholder (suppress = no residue). HTML like the answer — symmetric, and finalize already
+        // falls back to plain if a custom onError returns markup Telegram rejects. Best-effort — we throw
+        // below regardless.
+        finalized = true;
+        {
+          const msg = formatError({ details: e.details, retryable: e.retryable }) ?? "";
+          await finalize(api, botToken, target, messageId, msg).catch(() => {});
+        }
         throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
       }
     }
     throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
   } finally {
-    finish();
+    await finish();
+    // Abnormal exit (stream ended without a terminal, the generator threw, or the consumer abandoned): no
+    // terminal write ran. Show the SAME neutral notice a `failed` event would — the preview may show real
+    // partial work, so don't delete it silently, and don't leave the user in silence. A suppressing
+    // onError still collapses to a delete (finalize on empty text).
+    if (!finalized) {
+      // retryable:false — an abnormal end (no terminal / a throw) is of UNKNOWN retryability, so use the
+      // neutral "something went wrong" default rather than promising "try again" that may not help.
+      const notice = formatError({ details: "the turn ended without completing", retryable: false }) ?? "";
+      // finalize handles messageId===undefined (no preview reached) with a fresh send — so the user is
+      // told even when the turn died before any message.
+      await finalize(api, botToken, target, messageId, notice).catch(() => {});
+    }
   }
 }
 
@@ -517,7 +612,7 @@ export function telegramChannel(
     if (remaining.length === 0) buffers.delete(placeKey);
     else buffers.set(placeKey, remaining);
   };
-  let draftSeq = 0; // non-zero, per-turn draft ids (process-lived; the route handler is built once)
+
   return async (req) => {
     if (req.method !== "POST") return text("POST only\n", 405);
     // Fail closed: a missing/wrong secret token is 401, never routed.
@@ -571,10 +666,9 @@ export function telegramChannel(
         const turn = `${update.update_id}`;
         const where = `chat=${chatId}${target.threadId !== undefined ? ` thread=${target.threadId}` : ""}`;
         enqueueTurn(session, async () => {
-          // Run at DEQUEUE time (serialized), so the draft id, lifecycle log, and engine turn all reflect
-          // the actual execution order rather than arrival. Fold the un-summoned discussion since the last
+          // Run at DEQUEUE time (serialized), so the lifecycle log and engine turn all reflect the actual
+          // execution order rather than arrival. Fold the un-summoned discussion since the last
           // answered turn into the prompt, then clear it — it now lives in this turn's durable session.
-          draftSeq = (draftSeq % 1_000_000_000) + 1;
           const startedAt = Date.now();
           log.info(`[telegram] turn start: turn=${turn} session=${session} ${where}`);
           const { text: recent, consumed } = bufferPeek(placeKey);
@@ -587,7 +681,6 @@ export function telegramChannel(
               apiBaseUrl,
               botToken,
               target,
-              draftSeq,
               formatError,
             );
             log.info(`[telegram] turn done: turn=${turn} session=${session} (${Date.now() - startedAt}ms)`);

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -18,8 +18,18 @@ function replyingAgent(reply = "") {
   return { agent, calls };
 }
 
-/** Let fire-and-forget turns (started after the 200) run before asserting. */
-const flush = () => new Promise((r) => setImmediate(r));
+/** Let fire-and-forget turns (started after the 200) run before asserting. The streaming flow has
+ *  several hops, so rather than couple to a fixed tick count, settle until the Bot API mock goes quiet
+ *  (no new fetch for a full tick) — robust to adding/removing an await. (Real-timer tests only; the
+ *  fake-timer tests drive their own clock with advanceTimersByTimeAsync.) */
+const flush = async () => {
+  const f = globalThis.fetch as unknown as { mock?: { calls: unknown[] } };
+  let prev = -1;
+  for (let i = 0; i < 100 && (f.mock?.calls.length ?? 0) !== prev; i++) {
+    prev = f.mock?.calls.length ?? 0;
+    await new Promise((r) => setImmediate(r));
+  }
+};
 
 const SECRET = "tg-secret";
 const API = "http://tg.test";
@@ -41,6 +51,19 @@ const bodyOf = (call: [string, RequestInit] | undefined) => {
   if (!call) throw new Error("expected a matching fetch call");
   return JSON.parse(String(call[1].body));
 };
+
+/** Bot API fetch mock: sendMessage returns a message_id (so the channel edits its ONE preview message),
+ *  getMe returns a username, everything else is ok. */
+function okFetch() {
+  let id = 100;
+  return vi.fn(async (url: string) => {
+    const method = String(url).split("/").pop();
+    if (method === "getMe")
+      return new Response(JSON.stringify({ ok: true, result: { username: "mybot" } }), { status: 200 });
+    const result = method === "sendMessage" ? { message_id: id++ } : {};
+    return new Response(JSON.stringify({ ok: true, result }), { status: 200 });
+  });
+}
 
 afterEach(() => {
   vi.useRealTimers();
@@ -159,7 +182,7 @@ describe("telegram channel", () => {
   });
 
   it("answers a routed update: composes the prompt (envelope) and sends the reply (model A)", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent, calls } = replyingAgent("hello back");
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
@@ -171,16 +194,18 @@ describe("telegram channel", () => {
     expect(calls[0]?.text).toMatch(/\[telegram: chat 42/); // channel composed the envelope
     expect(calls[0]?.text).toMatch(/\bhi\b/); // …around the user's text
     const sent = callsTo(fetchMock, "sendMessage");
-    expect(sent).toHaveLength(1);
-    expect(bodyOf(sent[0])).toMatchObject({ chat_id: 42, text: "hello back", parse_mode: "HTML" });
-    expect(callsTo(fetchMock, "sendMessageDraft").length).toBeGreaterThan(0); // streamed live
+    expect(sent).toHaveLength(1); // ONE preview message, edited in place (no per-step spam)
+    expect(bodyOf(sent[0])).toMatchObject({ chat_id: 42, text: "💭 Thinking…" }); // a plain placeholder
+    const edits = callsTo(fetchMock, "editMessageText");
+    expect(edits.length).toBeGreaterThan(0); // streamed live by editing the message
+    expect(bodyOf(edits.at(-1))).toMatchObject({ text: "hello back", parse_mode: "HTML" }); // final = the HTML answer
   });
 
   it("uses the default route + getMe when route is omitted (no crash, answers a private chat)", async () => {
     const fetchMock = vi.fn(async (url: string) =>
       String(url).endsWith("/getMe")
         ? new Response(JSON.stringify({ ok: true, result: { username: "mybot" } }), { status: 200 })
-        : new Response('{"ok":true}', { status: 200 }),
+        : new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 }),
     );
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("ok");
@@ -191,7 +216,7 @@ describe("telegram channel", () => {
   });
 
   it("auto-adapts to Threaded Mode: per-thread session + reply into the same thread", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("yo");
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
@@ -204,12 +229,13 @@ describe("telegram channel", () => {
     expect(bodyOf(callsTo(fetchMock, "sendMessage")[0])).toMatchObject({
       chat_id: 42,
       message_thread_id: 99,
-      text: "yo",
+      text: "💭 Thinking…", // the placeholder threads into the topic; the answer follows by edit
     });
+    expect(bodyOf(callsTo(fetchMock, "editMessageText").at(-1)).text).toBe("yo");
   });
 
   it("a custom route can override just the session (reuse the default for the rest)", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent, calls } = replyingAgent("ok");
     const ch = telegramChannel(agent, {
@@ -228,32 +254,37 @@ describe("telegram channel", () => {
     expect(calls).toHaveLength(1);
   });
 
-  it("streams reasoning (💭) and tool activity into the draft; persists only the clean final text", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+  it("streams reasoning (💭) and tool activity into the preview; persists only the clean final text", async () => {
+    vi.useFakeTimers();
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const agent: Agent = {
       async *invoke(): AsyncIterable<AgentEvent> {
         yield { type: "thinking", delta: "weighing options" };
         yield { type: "tool_started", id: "t1", name: "word-count", args: { text: "the quick brown fox" } };
         yield { type: "tool_ended", id: "t1", isError: false, content: { words: 4 } };
+        await new Promise((r) => setTimeout(r, 2000)); // a gap: the pump renders the accumulated view here
         yield { type: "text", delta: "4 words" };
         yield { type: "completed" };
       },
     };
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
-    expect((await ch(tgRequest(MSG))).status).toBe(200);
-    await flush();
-    const drafts = callsTo(fetchMock, "sendMessageDraft").map((c) => bodyOf(c).text as string);
-    expect(drafts[0]).toBe("💭 Thinking…"); // initial draft is an explicit placeholder, never an empty "…"
-    expect(drafts.some((t) => /💭/.test(t) && /weighing options/.test(t))).toBe(true);
-    expect(drafts.some((t) => /word-count the quick brown fox/.test(t))).toBe(true);
-    const sent = callsTo(fetchMock, "sendMessage");
-    expect(sent).toHaveLength(1);
-    expect(bodyOf(sent[0]).text).toBe("4 words"); // clean final, no thinking/tool noise
+    const done = ch(tgRequest(MSG));
+    await vi.advanceTimersByTimeAsync(4000); // through the gap + the edit throttle
+    expect((await done).status).toBe(200);
+    const placeholder = bodyOf(callsTo(fetchMock, "sendMessage")[0]).text;
+    expect(placeholder).toBe("💭 Thinking…"); // the preview opens with an explicit placeholder, never an empty "…"
+    const edits = callsTo(fetchMock, "editMessageText").map((c) => bodyOf(c).text as string);
+    // a mid-turn frame shows the reasoning + tool activity (process), edited into the one preview message
+    expect(
+      edits.some((t) => /💭/.test(t) && /weighing options/.test(t) && /word-count the quick brown fox/.test(t)),
+    ).toBe(true);
+    expect(edits.at(-1)).toBe("4 words"); // …but the final message is the answer alone, no thinking/tool noise
+    expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1); // one preview message, not per-step spam
   });
 
   it("replies to the summoning message in a group (threads under the asker), but not in a DM", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("hi");
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
@@ -275,7 +306,7 @@ describe("telegram channel", () => {
   });
 
   it("still quotes when a custom route returns the same chat explicitly (compares value, not field-presence)", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("hi");
     const ch = telegramChannel(agent, {
@@ -292,7 +323,7 @@ describe("telegram channel", () => {
   });
 
   it("on a split group reply, only the first chunk quotes the summoning message", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("x".repeat(9000)); // > 4096 → multiple chunks
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
@@ -300,14 +331,19 @@ describe("telegram channel", () => {
       tgRequest({ update_id: 1, message: { message_id: 88, text: "yo", chat: { id: -100, type: "supergroup" } } }),
     );
     await flush();
-    const sends = callsTo(fetchMock, "sendMessage");
-    expect(sends.length).toBeGreaterThanOrEqual(2);
-    expect(bodyOf(sends[0]).reply_parameters).toMatchObject({ message_id: 88, allow_sending_without_reply: true }); // first quotes
-    for (const s of sends.slice(1)) expect(bodyOf(s).reply_parameters).toBeUndefined(); // rest don't
+    // Long reply: placeholder deleted, answer sent as consecutive fresh messages — only the FIRST answer
+    // message quotes the asker (N reply-quotes would be noise).
+    const answerSends = callsTo(fetchMock, "sendMessage").filter((c) => bodyOf(c).text !== "💭 Thinking…");
+    expect(answerSends.length).toBeGreaterThanOrEqual(2);
+    expect(bodyOf(answerSends[0]).reply_parameters).toMatchObject({
+      message_id: 88,
+      allow_sending_without_reply: true,
+    });
+    for (const s of answerSends.slice(1)) expect(bodyOf(s).reply_parameters).toBeUndefined();
   });
 
   it("does not quote when the route redirects the reply to another chat/thread", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("hi");
     const ch = telegramChannel(agent, {
@@ -348,7 +384,7 @@ describe("telegram channel", () => {
     };
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response('{"ok":true}', { status: 200 })),
+      vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 })),
     );
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
     const upd = (n: number) => ({
@@ -389,7 +425,7 @@ describe("telegram channel", () => {
     };
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response('{"ok":true}', { status: 200 })),
+      vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 })),
     );
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
     const settle = async (): Promise<void> => {
@@ -418,7 +454,7 @@ describe("telegram channel", () => {
     const { agent, calls } = replyingAgent("ok");
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response('{"ok":true}', { status: 200 })),
+      vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 })),
     );
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", apiBaseUrl: API, route: onlyCommands });
 
@@ -440,7 +476,7 @@ describe("telegram channel", () => {
     const { agent, calls } = replyingAgent("ok");
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response('{"ok":true}', { status: 200 })),
+      vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 })),
     );
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", apiBaseUrl: API, route: onlyCommands });
     for (let i = 0; i < 30; i++) await ch(tgRequest(groupMsg(i, "alice", `M${i}-${"x".repeat(290)}`))); // ~9000 chars
@@ -460,7 +496,7 @@ describe("telegram channel", () => {
         if (String(url).includes("/getFile"))
           return new Response(JSON.stringify({ ok: true, result: { file_path: "photo.jpg" } }), { status: 200 });
         if (String(url).includes("/file/bot")) return new Response("nope", { status: 500 }); // download fails
-        return new Response('{"ok":true}', { status: 200 });
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
       }),
     );
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", apiBaseUrl: API, route: onlyCommands });
@@ -510,7 +546,7 @@ describe("telegram channel", () => {
           await downloadGate; // hold the download open
           return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
         }
-        return new Response('{"ok":true}', { status: 200 });
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
       }),
     );
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", apiBaseUrl: API, route: onlyCommands });
@@ -556,7 +592,7 @@ describe("telegram channel", () => {
                 status: 200,
               },
             )
-          : new Response('{"ok":true}', { status: 200 }),
+          : new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 }),
       ),
     );
     const { agent } = replyingAgent();
@@ -572,18 +608,19 @@ describe("telegram channel", () => {
     expect(privacyWarnings()).toBe(1);
   });
 
-  it("serializes the live preview: never two draft sends in flight (the out-of-order flicker)", async () => {
+  it("serializes the live preview: never two writes in flight (the out-of-order flicker)", async () => {
     vi.useFakeTimers();
     let inFlight = 0;
     let maxInFlight = 0;
     const fetchMock = vi.fn(async (url: string) => {
-      if (String(url).endsWith("/sendMessageDraft")) {
+      const method = String(url).split("/").pop();
+      if (method === "sendMessage" || method === "editMessageText") {
         inFlight++;
         maxInFlight = Math.max(maxInFlight, inFlight);
-        await new Promise((r) => setTimeout(r, 30)); // a real send takes time — events arrive during it
+        await new Promise((r) => setTimeout(r, 30)); // a real write takes time — events arrive during it
         inFlight--;
       }
-      return new Response('{"ok":true}', { status: 200 });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
     });
     vi.stubGlobal("fetch", fetchMock);
     const agent: Agent = {
@@ -596,68 +633,45 @@ describe("telegram channel", () => {
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
     await ch(tgRequest(MSG));
     await vi.advanceTimersByTimeAsync(5000);
-    expect(maxInFlight).toBe(1); // single writer: concurrent draft sends are what reorder frames
-    expect(callsTo(fetchMock, "sendMessageDraft").length).toBeLessThan(9); // a burst coalesced, not 1/delta
-    expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1); // the authoritative final still sends
+    expect(maxInFlight).toBe(1); // single writer: concurrent edits are what reorder frames
+    expect(callsTo(fetchMock, "editMessageText").length).toBeLessThan(9); // a burst coalesced, not 1/delta
+    expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1); // one preview message (the placeholder)
   });
 
-  it("keeps the draft alive during a long event-less gap (heartbeat re-pushes it)", async () => {
-    vi.useFakeTimers();
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
-    let release = (): void => {};
-    const gate = new Promise<void>((r) => {
-      release = r;
-    });
-    const agent: Agent = {
-      async *invoke(): AsyncIterable<AgentEvent> {
-        yield { type: "tool_started", id: "t1", name: "write", args: {} };
-        await gate;
-        yield { type: "completed" };
-      },
-    };
-    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
-    await ch(tgRequest(MSG));
-    await vi.advanceTimersByTimeAsync(0);
-    const before = callsTo(fetchMock, "sendMessageDraft").length;
-    await vi.advanceTimersByTimeAsync(21_000);
-    expect(callsTo(fetchMock, "sendMessageDraft").length).toBeGreaterThan(before);
-    release();
-    await vi.advanceTimersByTimeAsync(0);
-  });
-
-  it("sends HTML, falling back to plain text when Telegram rejects the markup", async () => {
+  it("edits the final answer as HTML, falling back to plain text when Telegram rejects the markup", async () => {
     const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
-      if (String(url).endsWith("/sendMessage")) {
+      if (String(url).endsWith("/editMessageText")) {
         return JSON.parse(String(init.body)).parse_mode === "HTML"
           ? new Response(JSON.stringify({ ok: false, description: "Bad Request: can't parse entities: bad" }), {
               status: 400,
             })
-          : new Response('{"ok":true}', { status: 200 });
+          : new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
       }
-      return new Response('{"ok":true}', { status: 200 });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
     });
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("<b>oops");
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
     expect((await ch(tgRequest(MSG))).status).toBe(200);
     await flush();
-    const sends = callsTo(fetchMock, "sendMessage");
-    expect(sends).toHaveLength(2); // HTML rejected → plain retry
-    expect(bodyOf(sends[0]).parse_mode).toBe("HTML");
-    expect(bodyOf(sends[1]).parse_mode).toBeUndefined();
+    const finalEdits = callsTo(fetchMock, "editMessageText").filter((c) => bodyOf(c).text === "<b>oops");
+    expect(finalEdits.some((c) => bodyOf(c).parse_mode === "HTML")).toBe(true); // tried HTML
+    expect(finalEdits.some((c) => bodyOf(c).parse_mode === undefined)).toBe(true); // …fell back to plain
   });
 
   it("splits a reply longer than 4096 chars into multiple messages", async () => {
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("x".repeat(9000));
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
     expect((await ch(tgRequest(MSG))).status).toBe(200);
     await flush();
-    const sends = callsTo(fetchMock, "sendMessage");
-    expect(sends.length).toBeGreaterThanOrEqual(3);
-    for (const s of sends) expect((bodyOf(s).text as string).length).toBeLessThanOrEqual(4096);
+    // A long reply gives up in-place editing: the preview placeholder is DELETED and the whole answer is
+    // sent as consecutive fresh messages (so it stays together in an active group), each ≤4096.
+    expect(callsTo(fetchMock, "deleteMessage")).toHaveLength(1);
+    const answerSends = callsTo(fetchMock, "sendMessage").filter((c) => bodyOf(c).text !== "💭 Thinking…");
+    expect(answerSends.length).toBeGreaterThanOrEqual(3); // 9000 chars → ≥3 chunks
+    for (const s of answerSends) expect((bodyOf(s).text as string).length).toBeLessThanOrEqual(4096);
   });
 
   it("auto-extracts a photo from the message and passes it to the agent as a (vision) image", async () => {
@@ -667,7 +681,7 @@ describe("telegram channel", () => {
           status: 200,
         });
       if (String(url).includes("/file/bot")) return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
-      return new Response('{"ok":true}', { status: 200 });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
     });
     vi.stubGlobal("fetch", fetchMock);
     const { agent, calls } = replyingAgent("ok");
@@ -704,7 +718,7 @@ describe("telegram channel", () => {
             { status: 200 },
           );
         if (String(url).includes("/file/bot")) return new Response(new Uint8Array([1, 2, 3, 4, 5]), { status: 200 });
-        return new Response('{"ok":true}', { status: 200 });
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
       });
       vi.stubGlobal("fetch", fetchMock);
       const { agent, calls } = replyingAgent("ok");
@@ -738,7 +752,7 @@ describe("telegram channel", () => {
     const fetchMock = vi.fn(async (url: string) =>
       String(url).endsWith("/getFile")
         ? new Response(JSON.stringify({ ok: false }), { status: 200 })
-        : new Response('{"ok":true}', { status: 200 }),
+        : new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 }),
     );
     vi.stubGlobal("fetch", fetchMock);
     let invoked = false;
@@ -768,29 +782,71 @@ describe("telegram channel", () => {
     await flush();
     await flush();
     expect(invoked).toBe(false);
-    expect(bodyOf(callsTo(fetchMock, "sendMessage")[0]).text).toMatch(/could not load attachment/);
+    const writes = [...callsTo(fetchMock, "sendMessage"), ...callsTo(fetchMock, "editMessageText")].map(
+      (c) => bodyOf(c).text as string,
+    );
+    expect(writes.some((t) => /could not load attachment/.test(t))).toBe(true);
     expect(errors.some((e) => /turn failed/.test(e))).toBe(true);
   });
 
-  it("a failing live draft is logged once (not swallowed) and the final reply still sends", async () => {
+  it("a failing live preview edit is logged once (not swallowed) and the final reply still lands", async () => {
+    vi.useFakeTimers();
     const errors: string[] = [];
     vi.spyOn(console, "error").mockImplementation((m) => {
       errors.push(String(m));
     });
     const fetchMock = vi.fn(async (url: string) =>
-      String(url).endsWith("/sendMessageDraft")
+      String(url).endsWith("/editMessageText")
         ? new Response(JSON.stringify({ ok: false, description: "nope" }), { status: 400 })
-        : new Response('{"ok":true}', { status: 200 }),
+        : new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 }),
     );
     vi.stubGlobal("fetch", fetchMock);
-    const { agent } = replyingAgent("final answer");
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        yield { type: "text", delta: "final answer" };
+        await new Promise((r) => setTimeout(r, 2000)); // a gap so the pump attempts (and fails) a preview edit
+        yield { type: "completed" };
+      },
+    };
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
-    expect((await ch(tgRequest(MSG))).status).toBe(200);
-    await flush();
-    const draftErrs = errors.filter((e) => /live draft failed/.test(e));
-    expect(draftErrs).toHaveLength(1);
-    expect(draftErrs[0]).toMatch(/nope/);
-    expect(bodyOf(callsTo(fetchMock, "sendMessage")[0]).text).toBe("final answer");
+    const done = ch(tgRequest(MSG));
+    await vi.advanceTimersByTimeAsync(4000);
+    expect((await done).status).toBe(200);
+    const previewErrs = errors.filter((e) => /live preview failed/.test(e));
+    expect(previewErrs).toHaveLength(1); // logged ONCE, not per failed edit
+    expect(previewErrs[0]).toMatch(/nope/);
+    // the edit keeps failing, so the final answer lands via a fresh send instead
+    expect(callsTo(fetchMock, "sendMessage").map((c) => bodyOf(c).text)).toContain("final answer");
+  });
+
+  it("does not spam new messages when Telegram returns ok WITHOUT a message_id (preview disabled, not per-frame)", async () => {
+    vi.useFakeTimers();
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((m) => {
+      errors.push(String(m));
+    });
+    // ok but no result.message_id (proxy / odd API base / unparseable body) — the channel cannot edit
+    const fetchMock = vi.fn(async (url: string) =>
+      String(url).endsWith("/getMe")
+        ? new Response(JSON.stringify({ ok: true, result: { username: "mybot" } }), { status: 200 })
+        : new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        yield { type: "thinking", delta: "a" };
+        await new Promise((r) => setTimeout(r, 2000)); // a gap so the pump would retry preview writes
+        yield { type: "text", delta: "done" };
+        yield { type: "completed" };
+      },
+    };
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
+    const done = ch(tgRequest(MSG));
+    await vi.advanceTimersByTimeAsync(4000);
+    expect((await done).status).toBe(200);
+    expect(errors.filter((e) => /live preview failed/.test(e))).toHaveLength(1); // surfaced once, not silent
+    // placeholder sent once + the final fresh send — NOT one send per changed view
+    expect(callsTo(fetchMock, "sendMessage").length).toBeLessThanOrEqual(2);
   });
 
   it("a failed event tells the user (neutral by default) and logs the turn as failed", async () => {
@@ -798,7 +854,7 @@ describe("telegram channel", () => {
     const spy = vi.spyOn(console, "error").mockImplementation((m) => {
       errors.push(String(m));
     });
-    const fetchMock = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const agent: Agent = {
       async *invoke(): AsyncIterable<AgentEvent> {
@@ -809,9 +865,114 @@ describe("telegram channel", () => {
     expect((await ch(tgRequest(MSG))).status).toBe(200);
     await flush();
     expect(errors.some((e) => /turn failed/.test(e) && /boom/.test(e))).toBe(true); // dev log
-    const userText = bodyOf(callsTo(fetchMock, "sendMessage")[0]).text as string;
+    // the failed event is reported by editing the preview message (or a fresh send if none yet)
+    const errWrite = callsTo(fetchMock, "editMessageText").at(-1) ?? callsTo(fetchMock, "sendMessage").at(-1);
+    const userText = bodyOf(errWrite).text as string;
     expect(userText).not.toMatch(/boom/); // customer-facing: neutral, no leaked details
     expect(userText).toMatch(/something went wrong/i);
     spy.mockRestore();
+  });
+
+  it("a failed event still notifies the user when the preview can no longer be edited (fresh-send fallback)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // editMessageText always fails (preview deleted); sendMessage works
+    const fetchMock = vi.fn(async (url: string) =>
+      String(url).endsWith("/editMessageText")
+        ? new Response(JSON.stringify({ ok: false, description: "Bad Request: message to edit not found" }), {
+            status: 400,
+          })
+        : new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        yield { type: "failed", details: "boom", retryable: false };
+      },
+    };
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
+    await ch(tgRequest(MSG));
+    await flush();
+    // the neutral error lands via a fresh send (the edit failed), not silently lost — same fallback as completed
+    const sends = callsTo(fetchMock, "sendMessage").map((c) => bodyOf(c).text as string);
+    expect(sends.some((t) => /something went wrong/i.test(t))).toBe(true);
+  });
+
+  it("a failed turn with a suppressing formatError deletes the placeholder (no dead 'Thinking…')", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        yield { type: "failed", details: "boom", retryable: false };
+      },
+    };
+    const ch = telegramChannel(agent, {
+      secretToken: SECRET,
+      botToken: "BOT",
+      route: act,
+      apiBaseUrl: API,
+      onError: () => "", // developer suppresses the user-facing notice
+    });
+    await ch(tgRequest(MSG));
+    await flush();
+    expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1); // just the placeholder
+    expect(callsTo(fetchMock, "deleteMessage")).toHaveLength(1); // …which is then removed, not left as dead "Thinking…"
+  });
+
+  it("deletes the placeholder before a fresh send when a single-chunk edit fails but the preview still exists", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // editMessageText fails with a NON-"gone" error (5xx) — the placeholder is still there, so a bare fresh
+    // send would leave a "💭 Thinking…" residue above the answer
+    const fetchMock = vi.fn(async (url: string) =>
+      String(url).endsWith("/editMessageText")
+        ? new Response(JSON.stringify({ ok: false, description: "Bad Gateway" }), { status: 502 })
+        : new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { agent } = replyingAgent("the answer");
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
+    await ch(tgRequest(MSG));
+    await flush();
+    expect(callsTo(fetchMock, "deleteMessage")).toHaveLength(1); // placeholder removed — no residue
+    expect(callsTo(fetchMock, "sendMessage").map((c) => bodyOf(c).text)).toContain("the answer"); // answer lands fresh
+  });
+
+  it("shows (no reply) when a completed turn produced no text", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        yield { type: "tool_started", id: "t1", name: "noop", args: {} };
+        yield { type: "tool_ended", id: "t1", isError: false, content: {} };
+        yield { type: "completed" }; // completed, but no text was ever produced
+      },
+    };
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
+    await ch(tgRequest(MSG));
+    await flush();
+    // the preview is edited to an explicit "(no reply)" (a persisted message can't vanish like the old draft)
+    expect(callsTo(fetchMock, "editMessageText").map((c) => bodyOf(c).text)).toContain("(no reply)");
+  });
+
+  it("shows a neutral notice when the stream ends without a terminal event (not silence, not a dead 'Thinking…')", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    // an agent that ends WITHOUT completed/failed (a SPEC violation) — the user must still be told, and the
+    // preview (which may show real partial work) must not silently vanish
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        yield { type: "thinking", delta: "…" };
+      },
+    };
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", route: act, apiBaseUrl: API });
+    await ch(tgRequest(MSG));
+    await flush();
+    // the preview is edited into the neutral failure notice (unknown retryability → "something went wrong"),
+    // not deleted, not left stuck
+    const edits = callsTo(fetchMock, "editMessageText").map((c) => bodyOf(c).text as string);
+    expect(edits.some((t) => /something went wrong/i.test(t))).toBe(true);
+    expect(callsTo(fetchMock, "deleteMessage")).toHaveLength(0);
   });
 });

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -7,7 +7,7 @@ status: current
 
 The Telegram channel turns a Telegram Bot API webhook update into an agent turn and sends the agent's reply back to the chat.
 
-Unlike the GitHub channel, Telegram is request/reply: the channel holds the bot token, streams a live draft while the turn runs, and persists the final answer with `sendMessage`.
+Unlike the GitHub channel, Telegram is request/reply: the channel holds the bot token, streams a live preview message while the turn runs, and edits it into the final answer.
 
 ## Add the channel
 
@@ -146,14 +146,13 @@ Same-session concurrency is still controlled by the engine lease. If two updates
 
 ## Streaming behavior
 
-The channel streams progress into an ephemeral Telegram draft:
+The channel sends ONE preview message and edits it in place (`sendMessage` once → `editMessageText`), so it works in groups and private chats alike:
 
-- immediate "Thinking…" style draft,
-- tool-call previews,
-- partial answer text,
-- periodic keepalive while long steps run.
+- an immediate "💭 Thinking…" placeholder,
+- tool-call previews + partial answer text, edited in (plain text — a partial answer may carry unbalanced HTML),
+- on completion, the same message is edited into the final answer as HTML (falling back to plain if Telegram rejects the markup).
 
-The final answer is sent with `sendMessage`. The draft is only a live preview; the final message is authoritative.
+The preview is best-effort; the final write is authoritative. A short answer edits the preview in place (falling back to a fresh send if the message can no longer be edited). A long answer that overflows one message is sent as consecutive fresh messages — the preview placeholder is removed first, so the parts stay together instead of the first chunk being pinned where an active group has scrolled past. An empty answer leaves a `(no reply)` message rather than vanishing; a suppressed error notice deletes the placeholder, leaving no residue.
 
 ## Failures
 


### PR DESCRIPTION
sendMessageDraft (Bot API 9.3) streams a partial message TO A USER and is tied to forum-topic
mode — it is not a general group mechanism, so a normal group fails with TEXTDRAFT_PEER_INVALID.
The live preview was built entirely on it, so groups (the whole point of recent work) got NO
live preview, only the final reply. Switch to the standard, everywhere-working pattern.

- One preview message: sendMessage("💭 Thinking…") once (capturing its message_id, threaded under
  the asker), then editMessageText in place with the latest tool calls + partial text. The preview
  is PLAIN — a partial answer often carries unbalanced HTML that Telegram would reject.
- The final answer edits that message as HTML (plain fallback inside editMessageText); if it
  overflows one message the first chunk edits the preview and the rest are sent after it; if the
  edit fails (message gone) it falls back to a fresh send, so the answer always lands.
- The single-writer pump carries over (one write in flight keeps frames monotonic). No keepalive:
  a real message does not expire (unlike the 30s draft). The throttle is now interruptible —
  finish() cuts it so the final write is not delayed up to EDIT_THROTTLE_MS after completion.
- callBotApi now returns the result payload so sendMessage can hand back the message_id.

Drops sendMessageDraft + DRAFT_KEEPALIVE_MS; EDIT_THROTTLE_MS = 1500 (edits to one message are
rate-limited tighter than sends). Tests rewritten to the edit mechanism (placeholder → edits →
clean HTML final; not-modified skip; HTML→plain fallback; never-two-writes-in-flight; edit-fail
falls back to a send). 248 tests green.

This is the streaming half of the Telegram review (#1/#2/#5). Route fixes (#3 drop the group
slash-command summon, #4 entity-based @mention + strip) follow in a separate PR.
