### PR TITLE
fix(telegram): precise group summoning + HTML-aware message split (#3/#4/#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ While the project is pre-1.0, minor versions may include breaking changes.
 ### Changed
 - Narrative reframed to "Vibe first. Then FastAgent." — take a local agent folder out of
   the terminal and serve it in an app, on GitHub, in Telegram, or behind a custom channel.
+- **Telegram group summoning is now precise (default route).** A group message summons the bot only
+  on a Telegram **entity** mention (`@botname` or `/cmd@botname`, in text or a media caption) or a
+  reply to **the** bot (matched by the bot's own id, not any bot in the group) — a **bare `/cmd` no
+  longer summons in groups** (it is ambiguous, often meant for
+  another bot), and a loose `@botname` substring no longer matches. Private chats are unchanged
+  (always answer). The bot's own `@botname` handle is now stripped from the prompt (text or caption)
+  before the model sees it. **Migration:** groups that relied on bare slash commands must use `@botname` / `/cmd@botname`, a
+  reply, or a custom `route`. New: the `MessageEntity` type is exported from
+  `@kid7st/fastagent/telegram` (the message entities a custom route can inspect).
 - **Auth is now project-level by default.** The credentials file defaults to
   `<dir>/.fastagent/auth.json` (was the global `~/.fastagent/auth.json`); `fastagent login`,
   `dev`, `start`, `invoke`, and `info` all resolve it as `--auth-path` > `FASTAGENT_AUTH_PATH` >
@@ -37,6 +46,9 @@ While the project is pre-1.0, minor versions may include breaking changes.
   dir-less `createPiAgent`/`createPiModels` still default to the global file).
 
 ### Fixed
+- Telegram: long replies (>4096 chars) are split without cutting through an HTML tag — the split
+  point backs up to before a `<` it would otherwise land inside, so a chunk no longer degrades to
+  plain text just because a tag straddled the boundary.
 - `fastagent login <provider>` now loads `.env` from the current directory. It previously
   resolved `.env` against `./<provider>` (the positional is the provider, not a dir), so a proxy
   (e.g. `HTTPS_PROXY`) set in the workspace `.env` was ignored during the OAuth token exchange.

--- a/core/src/channels/telegram/scaffold/channel.ts
+++ b/core/src/channels/telegram/scaffold/channel.ts
@@ -18,7 +18,8 @@ const channel: ChannelModule = (agent) => ({
     onError: (failed) => `⚠️ ${failed.details}`,
     // The channel owns transport + format (HTML) + attachments (photo→vision, file→disk) + streaming.
     // `route` (POLICY) is OPTIONAL — omitted, it uses defaultTelegramRoute: private chats always answer,
-    // groups only on a command / reply to the bot / @mention. Override to customise, reusing the export:
+    // groups only on an @botname / /cmd@botname entity mention or a reply to the bot. Override to
+    // customise, reusing the export:
     //   route: (u) => defaultTelegramRoute(u) && { session: `user:${u.message?.from?.id}` },
     //   route: (u) => defaultTelegramRoute(u) && { text: `${telegramEnvelope(u.message!)}\n[extra]` },
   }),

--- a/core/src/channels/telegram/telegram-api.ts
+++ b/core/src/channels/telegram/telegram-api.ts
@@ -68,14 +68,24 @@ async function callBotApi(
   }
 }
 
-/** Split text into ≤4096-char chunks (Telegram's limit), preferring newline boundaries. */
+/**
+ * Split text into ≤4096-char chunks (Telegram's limit), preferring newline boundaries and never cutting
+ * through an HTML tag: if the chosen boundary lands after an unclosed `<` (a `<` with no `>` yet), back
+ * it up to that `<` so a `<b>`/`<a …>` is not split mid-token (which Telegram would reject, forcing the
+ * whole chunk to plain-text fallback). This does NOT balance tags that SPAN a boundary (open in one
+ * chunk, close in the next) — that rarer case still relies on the caller's per-chunk plain fallback.
+ * Exported for unit tests; not part of the public channel surface.
+ */
 export function chunkText(text: string): string[] {
   if (text.length <= TELEGRAM_MAX_TEXT) return [text];
   const chunks: string[] = [];
   let rest = text;
   while (rest.length > TELEGRAM_MAX_TEXT) {
     const nl = rest.lastIndexOf("\n", TELEGRAM_MAX_TEXT);
-    const cut = nl > 0 ? nl : TELEGRAM_MAX_TEXT;
+    let cut = nl > 0 ? nl : TELEGRAM_MAX_TEXT;
+    // Inside a tag? A `<` after the last `>` before the cut means the cut splits a tag — break before it.
+    const lt = rest.lastIndexOf("<", cut - 1);
+    if (lt > 0 && lt > rest.lastIndexOf(">", cut - 1)) cut = lt;
     chunks.push(rest.slice(0, cut));
     rest = rest.slice(cut).replace(/^\n/, "");
   }
@@ -154,20 +164,25 @@ export async function deleteMessage(api: string, botToken: string, t: Target, me
   const result = await callBotApi(api, botToken, "deleteMessage", { chat_id: t.chatId, message_id: messageId });
   if (!result.ok) throw new Error(`telegram deleteMessage failed: ${result.status} ${result.description}`.trim());
 }
-/** getMe: the bot's own @username (so default routing recognises group @mentions) and whether group
- *  privacy mode is OFF (`can_read_all_group_messages`) — needed to receive the un-summoned group
- *  messages that feed the context buffer. */
+/** getMe: the bot's own `id` (so default routing recognises a reply to THIS bot, not any bot) and
+ *  `@username` (for group @mention summon), plus whether group privacy mode is OFF
+ *  (`can_read_all_group_messages`) — needed to receive the un-summoned group messages that feed the
+ *  context buffer. */
 export async function resolveBotInfo(
   api: string,
   botToken: string,
-): Promise<{ username?: string; canReadAllGroupMessages?: boolean }> {
+): Promise<{ id?: number; username?: string; canReadAllGroupMessages?: boolean }> {
   const res = await fetch(`${api}/bot${botToken}/getMe`);
   const data = (await res.json().catch(() => ({}))) as {
     ok?: boolean;
-    result?: { username?: string; can_read_all_group_messages?: boolean };
+    result?: { id?: number; username?: string; can_read_all_group_messages?: boolean };
   };
   if (!res.ok || !data.ok) throw new Error(`getMe failed: ${res.status}`);
-  return { username: data.result?.username, canReadAllGroupMessages: data.result?.can_read_all_group_messages };
+  return {
+    id: data.result?.id,
+    username: data.result?.username,
+    canReadAllGroupMessages: data.result?.can_read_all_group_messages,
+  };
 }
 
 function mimeFromPath(path: string): string {

--- a/core/src/channels/telegram/telegram.ts
+++ b/core/src/channels/telegram/telegram.ts
@@ -75,12 +75,25 @@ function summarizeArgs(args: Json): string {
   return values.length > 0 ? clip(JSON.stringify(args)) : "";
 }
 
+/** A Telegram message entity (subset): `mention` (`@username`), `bot_command` (`/cmd` or `/cmd@bot`),
+ *  a link, etc. `offset`/`length` are UTF-16 code units into the text — matching JS string slicing. */
+export interface MessageEntity {
+  type: string;
+  offset: number;
+  length: number;
+  [k: string]: unknown;
+}
+
 /** A Telegram message (the common subset; `[k]` keeps the rest reachable without a types dependency). */
 export interface TelegramMessage {
   message_id: number;
   text?: string;
+  /** Entities over `text` (mentions, commands, links…) — used to detect a bot @mention precisely. */
+  entities?: MessageEntity[];
   /** Caption on a media message (photo/document/…) — often the user's instruction for the attachment. */
   caption?: string;
+  /** Entities over `caption` (same shape as {@link entities}). */
+  caption_entities?: MessageEntity[];
   /** Photo sizes, smallest → largest. The channel sends the largest to the model as a vision image. */
   photo?: { file_id: string; file_unique_id: string; width: number; height: number; file_size?: number }[];
   /** Structured payloads worth rendering into the prompt as text (no new modality needed). */
@@ -475,16 +488,77 @@ function messageText(m: TelegramMessage): string {
   return (m.text ?? m.caption ?? attachmentSummary(m) ?? "").replace(/\s+/g, " ").trim().slice(0, 280);
 }
 
+/** The message's text (else caption) with its matching entities — one accessor so mention detection
+ *  and stripping read the same source. `text` is undefined only when neither is present. */
+function textWithEntities(m: TelegramMessage): { text?: string; entities: MessageEntity[] } {
+  if (m.text !== undefined) return { text: m.text, entities: m.entities ?? [] };
+  if (m.caption !== undefined) return { text: m.caption, entities: m.caption_entities ?? [] };
+  return { entities: [] };
+}
+
+/**
+ * If entity `e` references our bot (`@botUsername` mention, or a `/cmd@botUsername` command targeting
+ * it), the character range `[start, end)` of the `@botUsername` handle token — else null. The ONE place
+ * that defines "what counts as the bot's own handle": {@link mentionsBotHandle} asks "does any exist"
+ * and {@link stripBotHandle} removes each, so a new case (e.g. `text_mention`) changes both at once. Entity
+ * offsets are exact (UTF-16, matching JS slicing), so `@botUsername_typo` can't false-match.
+ */
+function botHandleRange(text: string, e: MessageEntity, at: string): [number, number] | null {
+  const s = text.slice(e.offset, e.offset + e.length).toLowerCase();
+  if (e.type === "mention" && s === at) return [e.offset, e.offset + e.length];
+  if (e.type === "bot_command" && s.endsWith(at)) return [e.offset + e.length - at.length, e.offset + e.length];
+  return null;
+}
+
+/**
+ * Whether the message references `botUsername` via a Telegram ENTITY (not a loose substring): a
+ * `mention` entity that IS `@botUsername`, OR a `bot_command` entity targeting it (`/cmd@botUsername`).
+ * The entity-mention arm of the group summon decision — internal; a custom `route` reuses the whole
+ * decision via {@link defaultTelegramRoute}, not this sub-predicate. Case-insensitive.
+ */
+function mentionsBotHandle(m: TelegramMessage, botUsername: string): boolean {
+  const { text = "", entities } = textWithEntities(m);
+  const at = `@${botUsername}`.toLowerCase();
+  return entities.some((e) => botHandleRange(text, e, at) !== null);
+}
+
+/**
+ * Remove the bot's OWN handle from the text before it reaches the agent — the model should never see
+ * `@botUsername` (whether or not it routed the message): `@botUsername` mention tokens, and the
+ * `@botUsername` suffix of a `/cmd@botUsername` command (the bare `/cmd` stays). Uses entity offsets so
+ * ONLY the exact handle is cut (right-to-left, keeping earlier offsets valid), consuming one adjacent
+ * space per cut so no double-space / edge gap is left — the rest of the body (its indentation, alignment,
+ * and any pre-existing leading/trailing whitespace) is untouched. No handle → unchanged. Deliberately
+ * does NOT trim the whole body: a trim would fire only on this strip path (when `botUsername` is known),
+ * so an identical message would read differently before vs after getMe resolves.
+ */
+function stripBotHandle(text: string, entities: MessageEntity[], botUsername: string): string {
+  const at = `@${botUsername}`.toLowerCase();
+  const cuts = entities.map((e) => botHandleRange(text, e, at)).filter((r): r is [number, number] => r !== null);
+  let out = text;
+  for (let [start, end] of cuts.sort((a, b) => b[0] - a[0])) {
+    if (out[end] === " ")
+      end++; // consume the trailing space, else the leading one — never both
+    else if (out[start - 1] === " ") start--;
+    out = out.slice(0, start) + out.slice(end);
+  }
+  return out;
+}
+
 /**
  * The default base prompt: a context envelope (chat/thread/sender + a group note + reply) then the
  * user's text/caption and a compact rendering of structured payloads (location/contact/poll). The
  * sender is named on every message and a group chat is flagged — in a shared multi-user session that is
  * how the model tells participants apart and knows it is not a 1:1. The reply
  * block carries the replied-to sender, message id, and text/caption or an attachment summary (and the
- * channel downloads a replied-to file/photo too). Exported so a custom `route` can reuse it, e.g.
- * `text: `${telegramEnvelope(m)}\n\n[extra]``. The channel still appends downloaded attachments.
+ * channel downloads a replied-to file/photo too). With `botUsername`, the bot's OWN `@botUsername`
+ * mention (and the `@botUsername` suffix of a `/cmd@botUsername`) is stripped from the user's
+ * text/caption — the model should not see its own handle — whether or not that mention is what routed
+ * the message. Exported so
+ * a custom `route` can reuse it, e.g. `text: `${telegramEnvelope(m)}\n\n[extra]``. The channel still
+ * appends downloaded attachments.
  */
-export function telegramEnvelope(m: TelegramMessage): string {
+export function telegramEnvelope(m: TelegramMessage, options?: { botUsername?: string }): string {
   const r = m.reply_to_message;
   const meta = [
     `chat ${m.chat.id} (${m.chat.type})`,
@@ -501,7 +575,9 @@ export function telegramEnvelope(m: TelegramMessage): string {
   const replyTo = r
     ? `\n[in reply to ${fromLabel(r.from) ?? `msg ${r.message_id}`} (msg ${r.message_id}): ${(r.text ?? r.caption ?? attachmentSummary(r) ?? "(empty)").slice(0, 280)}]`
     : "";
-  const parts = [m.text ?? m.caption ?? attachmentSummary(m) ?? ""];
+  const { text: raw, entities } = textWithEntities(m);
+  const body = raw !== undefined && options?.botUsername ? stripBotHandle(raw, entities, options.botUsername) : raw;
+  const parts = [body ?? attachmentSummary(m) ?? ""];
   if (m.location) parts.push(`[location: ${m.location.latitude},${m.location.longitude}]`);
   if (m.contact) parts.push(`[contact: ${m.contact.first_name} ${m.contact.phone_number ?? ""}]`);
   if (m.poll) parts.push(`[poll: ${m.poll.question} — ${(m.poll.options ?? []).map((o) => o.text).join(" / ")}]`);
@@ -510,19 +586,28 @@ export function telegramEnvelope(m: TelegramMessage): string {
 
 /**
  * The default routing policy (used when `route` is omitted; exported so a custom route can reuse it):
- * answer private chats always, groups only on a command, a reply to the bot, or an @mention (when
- * `botUsername` is supplied — telegramChannel resolves it via getMe). Returns `{}` (act; the channel
- * fills session/target/prompt from the message) or `null` (ignore).
+ * answer private chats always, groups ONLY on a reply to THIS bot or an explicit @mention (via a
+ * Telegram entity in the text OR a media caption, when `botUsername` is supplied — telegramChannel
+ * resolves it via getMe). A bare slash command no longer summons in groups: `/cmd` there is ambiguous
+ * (often meant for another bot), and `/cmd@botUsername` is already caught as an entity mention. Private
+ * chats always answer, so their commands still work.
+ *
+ * The reply arm is exact when `botId` is known (a reply to THIS bot, not any bot in the group); before
+ * getMe resolves (or without an id) it falls back to "any bot". Returns `{}` (act; the channel fills
+ * session/target/prompt) or `null` (ignore).
  */
-export function defaultTelegramRoute(update: TelegramUpdate, options?: { botUsername?: string }): TelegramRoute | null {
+export function defaultTelegramRoute(
+  update: TelegramUpdate,
+  options?: { botUsername?: string; botId?: number },
+): TelegramRoute | null {
   const m = pickMessage(update);
   if (!m) return null;
-  const t = m.text ?? "";
+  const repliedTo = m.reply_to_message?.from;
+  const repliesToThisBot = options?.botId !== undefined ? repliedTo?.id === options.botId : repliedTo?.is_bot === true;
   const summoned =
     m.chat.type === "private" ||
-    t.startsWith("/") ||
-    m.reply_to_message?.from?.is_bot === true ||
-    (options?.botUsername ? t.includes(`@${options.botUsername}`) : false);
+    repliesToThisBot ||
+    (options?.botUsername ? mentionsBotHandle(m, options.botUsername) : false);
   return summoned ? {} : null;
 }
 
@@ -553,9 +638,11 @@ export function telegramChannel(
   // not supplied) and the group-privacy flag — privacy mode off is required to receive the un-summoned
   // group messages that feed the context buffer, so warn if it is on.
   let mentionName = botUsername;
+  let botId: number | undefined;
   void resolveBotInfo(apiBaseUrl, botToken).then(
     (info) => {
       if (mentionName === undefined) mentionName = info.username;
+      botId = info.id;
       if (info.canReadAllGroupMessages === false) {
         log.warn(
           "[telegram] privacy mode is on: the bot only sees @mentions / replies / commands, so group " +
@@ -563,9 +650,14 @@ export function telegramChannel(
         );
       }
     },
-    (e) => log.warn(`[telegram] getMe failed; @mention summon + privacy check skipped: ${String(e)}`),
+    (e) =>
+      log.warn(
+        `[telegram] getMe failed; group @mention + /cmd@bot summon and the privacy check are disabled ` +
+          `(set botUsername to keep group summoning; replies to a bot still work): ${String(e)}`,
+      ),
   );
-  const decide = route ?? ((update: TelegramUpdate) => defaultTelegramRoute(update, { botUsername: mentionName }));
+  const decide =
+    route ?? ((update: TelegramUpdate) => defaultTelegramRoute(update, { botUsername: mentionName, botId }));
   // Per-session serial queue: model B answers a shared chat[:thread] with ONE turn at a time, so a
   // second update for the same session waits its turn (FIFO) instead of colliding on the engine lease
   // and being dropped as "busy" — the wrong UX when several people talk in one group. Different sessions
@@ -659,7 +751,7 @@ export function telegramChannel(
         threadId,
         replyTo: m.chat.type !== "private" && sameTarget ? m.message_id : undefined,
       };
-      const baseText = r.text ?? telegramEnvelope(m);
+      const baseText = r.text ?? telegramEnvelope(m, { botUsername: mentionName });
       const imageFileIds = extractImages(m);
       const fileIds = extractFiles(m);
       if (baseText.trim() !== "" || imageFileIds.length > 0 || fileIds.length > 0) {

--- a/core/src/telegram.ts
+++ b/core/src/telegram.ts
@@ -6,6 +6,7 @@ export {
   type TelegramChannelOptions,
   type TelegramUpdate,
   type TelegramMessage,
+  type MessageEntity,
   type TelegramRoute,
   type TelegramFailure,
 } from "./channels/telegram/telegram.ts";

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defaultTelegramRoute, type TelegramUpdate, telegramChannel, telegramEnvelope } from "../src/telegram.ts";
+import { chunkText } from "../src/channels/telegram/telegram-api.ts";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
 
 /** A faux Agent that records each invocation's prompt and replies with `reply`. */
@@ -71,15 +72,145 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe("chunkText (HTML-aware split)", () => {
+  it("returns one chunk under the limit and prefers newline boundaries over it", () => {
+    expect(chunkText("short")).toEqual(["short"]);
+    const long = `${"a".repeat(4000)}\n${"b".repeat(200)}`; // > 4096, a newline before the limit
+    const chunks = chunkText(long);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toBe("a".repeat(4000)); // cut at the newline, not mid-line
+    expect(chunks[1]).toBe("b".repeat(200));
+  });
+
+  it("never ends a chunk inside an HTML tag (backs the cut up to the '<')", () => {
+    // A tag straddles the 4096 boundary: filler fills 0..4093, `<b>` opens at 4094 with no newline, so a
+    // naive cut at 4096 would land inside `<b>`. The split must back up to the '<' so no chunk is broken.
+    const body = `${"a".repeat(4094)}<b>bold</b> and a good deal more text to force a second chunk here.`;
+    const chunks = chunkText(body);
+    expect(chunks[0]).toBe("a".repeat(4094)); // stops before the tag, not mid-`<b>`
+    expect(chunks[0]).not.toContain("<"); // no dangling tag open
+    expect(chunks[1]).toMatch(/^<b>bold<\/b>/); // the tag stays intact in the next chunk
+  });
+
+  it("does NOT back up for a CLOSED tag before the cut (only an unclosed one)", () => {
+    // a complete `<b>x</b>` sits well before the boundary; the cut lands in plain text after it and must
+    // stay there — a naive `if (lt > 0)` (dropping the `>` comparison) would wrongly rewind to that `<`.
+    const body = `${"a".repeat(2000)}<b>x</b>${"c".repeat(2090)}dd${"e".repeat(200)}`; // closed tag ~2000, cut ~4096
+    const chunks = chunkText(body);
+    expect(chunks[0]).toContain("<b>x</b>"); // the closed tag stays in the first chunk (cut not rewound to it)
+    expect((chunks[0] ?? "").length).toBeGreaterThan(4000); // cut near the limit, not pulled back ~2000 chars
+  });
+});
+
 describe("defaultTelegramRoute + telegramEnvelope", () => {
-  it("answers a private message; stays silent in a group unless summoned", () => {
+  it("answers a private message; a group summons only on an @mention entity or reply-to-bot", () => {
     expect(defaultTelegramRoute(MSG)).toEqual({}); // private → act
     const group = { id: -100, type: "supergroup" };
-    expect(defaultTelegramRoute({ update_id: 1, message: { message_id: 2, text: "chatter", chat: group } })).toBeNull();
-    expect(defaultTelegramRoute({ update_id: 1, message: { message_id: 2, text: "/ask", chat: group } })).toEqual({});
-    const mention: TelegramUpdate = { update_id: 1, message: { message_id: 2, text: "hey @mybot", chat: group } };
-    expect(defaultTelegramRoute(mention)).toBeNull(); // no username → no @mention summon
-    expect(defaultTelegramRoute(mention, { botUsername: "mybot" })).toEqual({});
+    const g = (text: string, extra: Record<string, unknown> = {}): TelegramUpdate => ({
+      update_id: 1,
+      message: { message_id: 2, text, chat: group, ...extra },
+    });
+    expect(defaultTelegramRoute(g("chatter"))).toBeNull();
+    // #3: a bare slash command no longer summons in a group (ambiguous; often meant for another bot)
+    expect(defaultTelegramRoute(g("/ask"))).toBeNull();
+    // #4: a loose SUBSTRING is not a summon — only a Telegram `mention` entity is
+    expect(defaultTelegramRoute(g("hey @mybot"), { botUsername: "mybot" })).toBeNull();
+    const mention = g("hey @mybot", { entities: [{ type: "mention", offset: 4, length: 6 }] });
+    expect(defaultTelegramRoute(mention)).toBeNull(); // no username configured → no summon
+    expect(defaultTelegramRoute(mention, { botUsername: "mybot" })).toEqual({}); // entity @mybot → act
+    // a `mention` for a look-alike username must NOT match (exact entity text, not prefix)
+    const other = g("@mybotanic hi", { entities: [{ type: "mention", offset: 0, length: 9 }] });
+    expect(defaultTelegramRoute(other, { botUsername: "mybot" })).toBeNull();
+    // #4: `/cmd@mybot` (a bot_command entity targeting THIS bot) summons; `/cmd@othbot` does not
+    const cmd = g("/summarize@mybot", { entities: [{ type: "bot_command", offset: 0, length: 16 }] });
+    expect(defaultTelegramRoute(cmd, { botUsername: "mybot" })).toEqual({});
+    const otherCmd = g("/summarize@othbot", { entities: [{ type: "bot_command", offset: 0, length: 17 }] });
+    expect(defaultTelegramRoute(otherCmd, { botUsername: "mybot" })).toBeNull();
+    // #4: a media message whose CAPTION @mentions the bot summons too (caption_entities, not just text)
+    const cap: TelegramUpdate = {
+      update_id: 1,
+      message: {
+        message_id: 2,
+        caption: "look @mybot",
+        caption_entities: [{ type: "mention", offset: 5, length: 6 }],
+        photo: [{ file_id: "f", file_unique_id: "u", width: 1, height: 1 }],
+        chat: group,
+      },
+    };
+    expect(defaultTelegramRoute(cap, { botUsername: "mybot" })).toEqual({});
+    // reply arm: with a known botId, only a reply to THIS bot summons; without one, any bot (fallback)
+    const reply = g("thanks", { reply_to_message: { message_id: 1, chat: group, from: { id: 5, is_bot: true } } });
+    expect(defaultTelegramRoute(reply)).toEqual({}); // no botId → is_bot fallback summons
+    expect(defaultTelegramRoute(reply, { botId: 5 })).toEqual({}); // reply to THIS bot
+    expect(defaultTelegramRoute(reply, { botId: 99 })).toBeNull(); // reply to ANOTHER bot → not us
+  });
+
+  it("strips the summon @mention from the prompt text (the model shouldn't see the routing @bot)", () => {
+    const env = telegramEnvelope(
+      {
+        message_id: 2,
+        text: "hey @mybot summarize this",
+        entities: [{ type: "mention", offset: 4, length: 6 }],
+        chat: { id: -100, type: "supergroup" },
+        from: { id: 7, username: "alice" },
+      },
+      { botUsername: "mybot" },
+    );
+    expect(env).toMatch(/hey summarize this$/); // @mybot removed, surrounding space collapsed
+    expect(env).not.toMatch(/@mybot/);
+    // mention at the END: the leading space is consumed too, so no trailing gap is left
+    const tail = telegramEnvelope(
+      {
+        message_id: 5,
+        text: "summarize this @mybot",
+        entities: [{ type: "mention", offset: 15, length: 6 }],
+        chat: { id: -100, type: "supergroup" },
+      },
+      { botUsername: "mybot" },
+    );
+    expect(tail).toMatch(/summarize this$/);
+    expect(tail).not.toMatch(/@mybot|this $/);
+    // TWO mentions: cuts must apply right-to-left (else the first removal shifts the second's offset)
+    // and each consumes one space — no double-space, no leftover handle
+    const multi = telegramEnvelope(
+      {
+        message_id: 6,
+        text: "@mybot ping @mybot pong",
+        entities: [
+          { type: "mention", offset: 0, length: 6 },
+          { type: "mention", offset: 12, length: 6 },
+        ],
+        chat: { id: -100, type: "supergroup" },
+      },
+      { botUsername: "mybot" },
+    );
+    expect(multi).toMatch(/ping pong$/);
+    expect(multi).not.toMatch(/@mybot| {2}/);
+    // a `/cmd@bot` keeps the bare command, drops the @bot target
+    const cmd = telegramEnvelope(
+      {
+        message_id: 3,
+        text: "/summarize@mybot",
+        entities: [{ type: "bot_command", offset: 0, length: 16 }],
+        chat: { id: -100, type: "supergroup" },
+      },
+      { botUsername: "mybot" },
+    );
+    expect(cmd).toMatch(/\/summarize$/);
+    expect(cmd).not.toMatch(/@mybot/);
+    // caption strip: a photo captioned "@mybot ..." has the summon removed from the caption body
+    const capEnv = telegramEnvelope(
+      {
+        message_id: 4,
+        caption: "@mybot describe",
+        caption_entities: [{ type: "mention", offset: 0, length: 6 }],
+        photo: [{ file_id: "f", file_unique_id: "u", width: 1, height: 1 }],
+        chat: { id: -100, type: "supergroup" },
+      },
+      { botUsername: "mybot" },
+    );
+    expect(capEnv).toMatch(/describe$/);
+    expect(capEnv).not.toMatch(/@mybot/);
   });
 
   it("composes a context envelope: chat/thread/sender + reply (with msg id) + the user's text", () => {
@@ -211,6 +342,35 @@ describe("telegram channel", () => {
     const { agent } = replyingAgent("ok");
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", apiBaseUrl: API }); // no route → default
     expect((await ch(tgRequest(MSG))).status).toBe(200);
+    await flush();
+    expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1);
+  });
+
+  it("threads the bot's own id from getMe into the default route (reply to THIS bot vs another)", async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      String(url).endsWith("/getMe")
+        ? new Response(JSON.stringify({ ok: true, result: { id: 42, username: "mybot" } }), { status: 200 })
+        : // sendMessage must return a message_id so the live-preview edit flow doesn't fresh-send a fallback
+          new Response(JSON.stringify({ ok: true, result: { message_id: 100 } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { agent } = replyingAgent("ok");
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", apiBaseUrl: API }); // default route
+    await flush(); // let getMe resolve so botId is known before routing
+    const group = { id: -100, type: "supergroup" };
+    const replyToBot = (botId: number): TelegramUpdate => ({
+      update_id: 1,
+      message: {
+        message_id: 2,
+        text: "thanks",
+        chat: group,
+        reply_to_message: { message_id: 1, chat: group, from: { id: botId, is_bot: true } },
+      },
+    });
+    await ch(tgRequest(replyToBot(42))); // reply to THIS bot (id 42) → answered
+    await flush();
+    expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1);
+    await ch(tgRequest(replyToBot(7))); // reply to ANOTHER bot → ignored, no new reply
     await flush();
     expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1);
   });

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -76,11 +76,17 @@ Both `secretToken` and `botToken` are required. Construction fails if either is 
 By default, `telegramChannel` uses `defaultTelegramRoute`:
 
 - private chats always answer,
-- groups answer on a slash command,
-- groups answer when the message replies to a bot,
-- groups answer on `@botname` mention when the bot username is known.
+- groups answer when the message replies to the bot,
+- groups answer on an `@botname` mention or a `/cmd@botname` command targeting the bot (a Telegram
+  **entity**, in the text or a media caption, when the bot username is known) — a bare `/cmd` no
+  longer summons in a group (it is ambiguous, often meant for another bot; private chats keep it).
 
-Override `route` to decide whether and where to answer. A custom route owns its own group-summon policy; if you rely on `@botname` mentions, pass a known `botUsername` to `defaultTelegramRoute`.
+The summon `@botname` (and the `@botname` suffix of `/cmd@botname`) is stripped from the prompt before
+the model sees it — it only routed the message. Override `route` to decide whether and where to answer.
+A custom route owns its own group-summon policy; if you rely on `@botname` mentions, pass a known
+`botUsername` to `defaultTelegramRoute`. Note: only the built-in path resolves the bot's own id via
+getMe, so a custom route that reuses `defaultTelegramRoute` without a `botId` matches a reply to
+**any** bot in the group, not just this one — pass `botId` too if you need that precision.
 
 ## Group chats
 
@@ -108,7 +114,7 @@ telegramChannel(agent, {
     return {
       ...base,
       session: `telegram:${message.chat.id}`,
-      text: `${telegramEnvelope(message)}\n\nAnswer briefly.`,
+      text: `${telegramEnvelope(message, { botUsername })}\n\nAnswer briefly.`,
     };
   },
 });
@@ -129,7 +135,7 @@ Return `null` to ignore the update. Omitted fields default from the message.
 
 ## Prompt envelope
 
-The exported `telegramEnvelope(message)` builds a text envelope with chat/thread/from metadata, reply context, text/caption, and structured payloads such as location, contact, and poll. You can reuse it when customizing `route`.
+The exported `telegramEnvelope(message)` builds a text envelope with chat/thread/from metadata, reply context, text/caption, and structured payloads such as location, contact, and poll. You can reuse it when customizing `route`. Pass `{ botUsername }` (as the example above does) to strip the bot's own `@handle` from the user's text/caption before the model sees it.
 
 The channel appends a formatting instruction so replies use Telegram-supported HTML rather than Markdown.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -148,7 +148,7 @@ Check:
 
 - `TELEGRAM_BOT_TOKEN` is set,
 - the bot is allowed to message the chat,
-- group messages match the route policy (private chat, slash command, reply to bot, or `@botname` mention by default),
+- group messages match the route policy (by default: private chat, reply to the bot, or an `@botname` / `/cmd@botname` entity mention — a bare `/cmd` no longer summons in groups),
 - model credentials are configured,
 - the operator log for a `failed` event or Bot API error.
 


### PR DESCRIPTION
Implements the **route/summon** and **split** items from the Telegram review (#3, #4, #6). The streaming half (#1/#2/#5) is PR #96, separately owned — this PR does not touch it.

## #3/#4 — precise group summoning

`defaultTelegramRoute` (default group policy) changes:

- **Bare `/cmd` no longer summons in a group** — ambiguous, often meant for another bot. Private chats keep slash commands (they always answer).
- **@mention is entity-based, not a substring** — a Telegram `mention` entity that IS `@botname`, or a `bot_command` targeting it (`/cmd@botname`), in **text or a media caption**. `@botname_typo` / look-alikes can't false-match.
- **Reply arm matches THIS bot** — the bot's own id (from `getMe`) instead of "any bot in the group". Falls back to "any bot" only before `getMe` resolves / when the id is unknown.
- **The bot's own `@handle` is stripped from the prompt** (text/caption) before the model sees it — it only routed the message.

## #6 — HTML-aware split

`chunkText` no longer cuts through an HTML tag: the split point backs up before an unclosed `<`, so a chunk stops degrading to plain text just because a tag straddled the 4096 boundary. Tags that *span* a boundary still rely on the existing per-chunk plain fallback (documented).

## API

- `MessageEntity` type exported from `@kid7st/fastagent/telegram` (entities a custom route can inspect).
- `resolveBotInfo` now returns the bot's `id`.
- Public surface change → **review-tier** (waits for review per CONTRIBUTING).

## Coordination with PR #96

`chunkText` (in `telegram-api.ts`) is the one function both PRs touch — #96 only adds `export` to it, this PR makes its body tag-aware. A trivial rebase merge on that one function when the second of the two lands. Everything else is in functions #96 leaves untouched (`defaultTelegramRoute`, `telegramEnvelope`, `resolveBotInfo`).

## Test

`cd core && npm run lint && npm run typecheck && npm test` — 265 pass, lint + typecheck clean. New coverage: entity mention (incl. caption), `/cmd@bot` vs `/cmd@othbot`, look-alike username, bare `/cmd` no-summon, reply-to-this-bot vs another (unit + channel `getMe`→id→route chain), handle strip (mid/end/double-mention/caption), chunkText tag-safety incl. the closed-tag "don't rewind" case.
