### PR TITLE
feat(telegram): precise @mention routing; drop the group slash-command summon

### DIFF
--- a/core/src/channels/telegram/scaffold/channel.ts
+++ b/core/src/channels/telegram/scaffold/channel.ts
@@ -18,7 +18,7 @@ const channel: ChannelModule = (agent) => ({
     onError: (failed) => `⚠️ ${failed.details}`,
     // The channel owns transport + format (HTML) + attachments (photo→vision, file→disk) + streaming.
     // `route` (POLICY) is OPTIONAL — omitted, it uses defaultTelegramRoute: private chats always answer,
-    // groups only on a command / reply to the bot / @mention. Override to customise, reusing the export:
+    // groups only on a reply to the bot or an @mention. Override to customise, reusing the export:
     //   route: (u) => defaultTelegramRoute(u) && { session: `user:${u.message?.from?.id}` },
     //   route: (u) => defaultTelegramRoute(u) && { text: `${telegramEnvelope(u.message!)}\n[extra]` },
   }),

--- a/core/src/channels/telegram/telegram.ts
+++ b/core/src/channels/telegram/telegram.ts
@@ -508,21 +508,37 @@ export function telegramEnvelope(m: TelegramMessage): string {
   return `[telegram: ${meta}]${scope}${replyTo}\n${parts.filter(Boolean).join("\n")}`;
 }
 
+/** Normalize a configured bot username: drop a leading `@`, trim (regexes match case-insensitively).
+ *  Undefined when unknown. Telegram usernames are [A-Za-z0-9_], so the result needs no regex escaping. */
+function botName(botUsername: string | undefined): string | undefined {
+  const s = botUsername?.replace(/^@/, "").trim();
+  return s || undefined;
+}
+
+/**
+ * Whether `text` @mentions the bot: a boundary-anchored @name anywhere (case-insensitive). Boundary-
+ * anchored so `@fast` does not match `@fastagent` (a substring `includes` would), and a glued `/cmd@bot`
+ * — a command, not a mention — does not count (its `@` follows a word char).
+ */
+function mentionsBot(text: string, botUsername: string | undefined): boolean {
+  const name = botName(botUsername);
+  return name ? new RegExp(`(?<!\\w)@${name}(?!\\w)`, "i").test(text) : false;
+}
+
 /**
  * The default routing policy (used when `route` is omitted; exported so a custom route can reuse it):
- * answer private chats always, groups only on a command, a reply to the bot, or an @mention (when
- * `botUsername` is supplied — telegramChannel resolves it via getMe). Returns `{}` (act; the channel
- * fills session/target/prompt from the message) or `null` (ignore).
+ * answer private chats always; a group only on a reply to the bot or a boundary-anchored @mention of it (when
+ * `botUsername` is supplied — telegramChannel resolves it via getMe). A bare or directed slash command
+ * does NOT summon in a group (that was noisy; a bot author who wants commands adds a custom route).
+ * Returns `{}` (act; the channel fills session/target/prompt from the message) or `null` (ignore).
  */
 export function defaultTelegramRoute(update: TelegramUpdate, options?: { botUsername?: string }): TelegramRoute | null {
   const m = pickMessage(update);
   if (!m) return null;
-  const t = m.text ?? "";
   const summoned =
     m.chat.type === "private" ||
-    t.startsWith("/") ||
     m.reply_to_message?.from?.is_bot === true ||
-    (options?.botUsername ? t.includes(`@${options.botUsername}`) : false);
+    mentionsBot(m.text ?? m.caption ?? "", options?.botUsername);
   return summoned ? {} : null;
 }
 

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -72,14 +72,47 @@ afterEach(() => {
 });
 
 describe("defaultTelegramRoute + telegramEnvelope", () => {
-  it("answers a private message; stays silent in a group unless summoned", () => {
+  it("answers a private message; a group only on a boundary-@mention or reply-to-bot, not a slash command", () => {
     expect(defaultTelegramRoute(MSG)).toEqual({}); // private → act
     const group = { id: -100, type: "supergroup" };
-    expect(defaultTelegramRoute({ update_id: 1, message: { message_id: 2, text: "chatter", chat: group } })).toBeNull();
-    expect(defaultTelegramRoute({ update_id: 1, message: { message_id: 2, text: "/ask", chat: group } })).toEqual({});
-    const mention: TelegramUpdate = { update_id: 1, message: { message_id: 2, text: "hey @mybot", chat: group } };
+    const g = (text: string) => ({ update_id: 1, message: { message_id: 2, text, chat: group } });
+    expect(defaultTelegramRoute(g("chatter"))).toBeNull();
+    // a group slash command no longer summons — bare OR directed at the bot (only @mention / reply do)
+    expect(defaultTelegramRoute(g("/ask"))).toBeNull();
+    expect(defaultTelegramRoute(g("/ask@mybot"), { botUsername: "mybot" })).toBeNull();
+    const mention = g("hey @mybot");
     expect(defaultTelegramRoute(mention)).toBeNull(); // no username → no @mention summon
     expect(defaultTelegramRoute(mention, { botUsername: "mybot" })).toEqual({});
+    expect(defaultTelegramRoute(mention, { botUsername: "@mybot" })).toEqual({}); // a leading @ in the option is tolerated
+    expect(defaultTelegramRoute(g("yo @MyBot"), { botUsername: "mybot" })).toEqual({}); // case-insensitive
+    // boundary-anchored at BOTH ends: a suffix (@mybottington) and a prefix (glued after a word char)
+    expect(defaultTelegramRoute(g("@mybottington rocks"), { botUsername: "mybot" })).toBeNull(); // suffix boundary (?!\w)
+    expect(defaultTelegramRoute(g("mail x@mybot"), { botUsername: "mybot" })).toBeNull(); // prefix boundary, lookbehind (?<!\w)
+    // a reply to a bot summons (no @mention needed)
+    const replyToBot = {
+      update_id: 1,
+      message: {
+        message_id: 2,
+        text: "thanks",
+        chat: group,
+        reply_to_message: { message_id: 1, chat: group, from: { id: 9, is_bot: true } },
+      },
+    };
+    expect(defaultTelegramRoute(replyToBot)).toEqual({});
+  });
+
+  it("summons on a media caption @mention too, not just text", () => {
+    const group = { id: -100, type: "supergroup" };
+    const photo = {
+      message_id: 7,
+      caption: "@mybot look",
+      photo: [{ file_id: "f", file_unique_id: "u", width: 1, height: 1 }],
+      chat: group,
+    };
+    expect(defaultTelegramRoute({ update_id: 1, message: photo }, { botUsername: "mybot" })).toEqual({});
+    // a caption with no mention stays silent in a group
+    const plain = { ...photo, caption: "nice sunset" };
+    expect(defaultTelegramRoute({ update_id: 1, message: plain }, { botUsername: "mybot" })).toBeNull();
   });
 
   it("composes a context envelope: chat/thread/sender + reply (with msg id) + the user's text", () => {

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -76,11 +76,10 @@ Both `secretToken` and `botToken` are required. Construction fails if either is 
 By default, `telegramChannel` uses `defaultTelegramRoute`:
 
 - private chats always answer,
-- groups answer on a slash command,
 - groups answer when the message replies to a bot,
-- groups answer on `@botname` mention when the bot username is known.
+- groups answer on a boundary-anchored `@botname` mention when the bot username is known (case-insensitive; `@fast` does not match `@fastagent`).
 
-Override `route` to decide whether and where to answer. A custom route owns its own group-summon policy; if you rely on `@botname` mentions, pass a known `botUsername` to `defaultTelegramRoute`.
+A slash command does **not** summon in a group (bare or directed like `/cmd@botname`) — it was noise; a bot that wants commands adds a custom `route`. Override `route` to decide whether and where to answer; a custom route owns its own group-summon policy, and if you rely on `@botname` mentions, pass a known `botUsername` to `defaultTelegramRoute`.
 
 ## Group chats
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -148,7 +148,7 @@ Check:
 
 - `TELEGRAM_BOT_TOKEN` is set,
 - the bot is allowed to message the chat,
-- group messages match the route policy (private chat, slash command, reply to bot, or `@botname` mention by default),
+- group messages match the route policy (private chat, reply to bot, or `@botname` mention by default),
 - model credentials are configured,
 - the operator log for a `failed` event or Bot API error.
 


### PR DESCRIPTION
The default route summoned a group on ANY slash command and matched @mentions by substring.
Both were wrong:

- A group slash command (bare `/help` or directed `/help@botname`) no longer summons — it was
  noise, and a bot that wants commands can add a custom route. Groups now summon only on a
  reply to the bot or a real @mention; private chats still always answer.
- @mention detection is boundary-anchored (case-insensitive): `@fast` no longer matches
  `@fastagent`, and a glued `/cmd@bot` (a command, not a mention) does not count. Telegram
  usernames are [A-Za-z0-9_], so no regex escaping is needed.
- The mention check also reads a media message's caption (was text only), so a captioned
  photo/file that @mentions the bot summons it too — a deliberate, small expansion.

Stripping the summoning @mention from the prompt was explored and DROPPED: telling an addressing
mention from a content one ("is @bot down?") is a semantic call no regex makes cleanly, so any
strip either loses content or leaves noise. The agent sees the mention verbatim and handles it.

Tests cover the slash-drop, boundary/prefix/suffix/case cases, reply-to-bot, and the caption
path; docs/telegram.md + troubleshooting.md + the scaffold template updated. 266 tests green.
