### PR TITLE
feat(telegram): HTML-aware message split — balance tags across chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ While the project is pre-1.0, minor versions may include breaking changes.
   (`github`, `telegram`, `channel-development`), and maintainer notes under `docs/design/`.
 
 ### Changed
+- Telegram: a long reply (>4096 chars) is split as valid HTML — a tag that spans a boundary is closed at the chunk's end and reopened (attributes and all) at the next chunk's start, so a long `<pre>` code block stays formatted instead of degrading to plain text. The split also never cuts through a tag token.
 - Narrative reframed to "Vibe first. Then FastAgent." — take a local agent folder out of
   the terminal and serve it in an app, on GitHub, in Telegram, or behind a custom channel.
 - **Auth is now project-level by default.** The credentials file defaults to

--- a/core/src/channels/telegram/telegram-api.ts
+++ b/core/src/channels/telegram/telegram-api.ts
@@ -10,7 +10,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import type { ImageRef } from "../../agent.ts";
 
 /** Telegram's hard text limit per message. */
-const TELEGRAM_MAX_TEXT = 4096;
+export const TELEGRAM_MAX_TEXT = 4096;
 const PARSE_ERROR = /can't parse|entit|unsupported|unclosed|tag/i;
 
 /** Download sanity cap (Telegram's own getFile limit); a larger file/image is rejected visibly. The
@@ -68,25 +68,102 @@ async function callBotApi(
   }
 }
 
-/** Split text into ≤4096-char chunks (Telegram's limit), preferring newline boundaries. */
-export function chunkText(text: string): string[] {
+/** Tags left open at the end of `html`, innermost last, each as its full opening string (attributes and
+ *  all) so a reopen reproduces `<a href=…>` / `<code class=…>` exactly. A close pops the nearest matching
+ *  open. Telegram's HTML is a shallow flat subset, so this simple stack is enough. */
+function unclosedTags(html: string): { name: string; open: string }[] {
+  const stack: { name: string; open: string }[] = [];
+  for (const m of html.matchAll(/<(\/?)([a-z][a-z0-9-]*)(?:\s[^>]*)?>/gi)) {
+    const name = m[2]?.toLowerCase();
+    if (name === undefined) continue;
+    if (m[1] === "/") {
+      const i = stack.map((t) => t.name).lastIndexOf(name);
+      if (i !== -1) stack.splice(i, 1);
+    } else {
+      stack.push({ name, open: m[0] });
+    }
+  }
+  return stack;
+}
+
+/** Reserve for the `</…>` closers appended at a chunk boundary — Telegram nesting is shallow, so this
+ *  covers the worst realistic stack. A pathological deeper nest would push the chunk past 4096 and fail
+ *  visibly on send (Telegram's "message is too long", not a silent truncation); real agent output does
+ *  not reach it. */
+const TAG_CLOSE_BUDGET = 64;
+
+/**
+ * Split text into ≤4096-char chunks (Telegram's limit), preferring a newline boundary. When `html`, it is
+ * tag-aware: a tag that would SPAN a boundary is CLOSED at the chunk's end and REOPENED (attributes and
+ * all) at the next chunk's start, so every chunk is self-contained valid HTML — a long `<pre>` code block
+ * stays formatted instead of the first chunk degrading to plain text. It also never cuts THROUGH a tag
+ * token (backs the cut up before a `<` it would land inside). For plain text a `<` is literal content, so
+ * both behaviours are skipped.
+ */
+export function chunkText(text: string, opts: { html?: boolean } = {}): string[] {
   if (text.length <= TELEGRAM_MAX_TEXT) return [text];
   const chunks: string[] = [];
+  let open: { name: string; open: string }[] = []; // tags carried across the current boundary (html only)
   let rest = text;
-  while (rest.length > TELEGRAM_MAX_TEXT) {
-    const nl = rest.lastIndexOf("\n", TELEGRAM_MAX_TEXT);
-    const cut = nl > 0 ? nl : TELEGRAM_MAX_TEXT;
-    chunks.push(rest.slice(0, cut));
-    rest = rest.slice(cut).replace(/^\n/, "");
+  while (rest.length > 0) {
+    const prefix = open.map((t) => t.open).join(""); // reopen carried tags at the chunk head
+    if (prefix.length + rest.length <= TELEGRAM_MAX_TEXT) {
+      chunks.push(prefix + rest); // the tail closes the carried tags itself
+      break;
+    }
+    // Room for content, reserving the reopen prefix + (html) the closers appended below. ≥1 guarantees
+    // progress even in a pathological deep nest.
+    const room = Math.max(1, TELEGRAM_MAX_TEXT - prefix.length - (opts.html ? TAG_CLOSE_BUDGET : 0));
+    let cut = rest.lastIndexOf("\n", room);
+    if (cut <= 0) cut = room; // no newline in range → hard cut at the limit
+    if (opts.html) {
+      // Don't cut through a tag token: if the last `<` before the cut has no `>` after it, back up to it
+      // (lt > 0 keeps at least one content char, so the loop still progresses).
+      const lt = rest.lastIndexOf("<", cut - 1);
+      if (lt > 0 && lt > rest.lastIndexOf(">", cut - 1)) cut = lt;
+      // Likewise don't split an entity token (`&amp;`): entities are short, so a `&` within ~12 chars of
+      // the cut with no `;` yet means the cut is inside one — back up to that `&`. Only when the `&` is
+      // CONTENT, not inside a tag token (a raw `&` in an attribute is legal and common — any href with
+      // query params); backing up to one of those would cut through the tag this very rule's sibling
+      // protects.
+      const amp = rest.lastIndexOf("&", cut - 1);
+      if (
+        amp > 0 &&
+        cut - amp < 12 &&
+        amp > rest.lastIndexOf(";", cut - 1) &&
+        rest.lastIndexOf("<", amp) <= rest.lastIndexOf(">", amp)
+      )
+        cut = amp;
+    }
+    let chunk = rest.slice(0, cut);
+    let advance = cut;
+    if (opts.html) {
+      // A boundary newline is CONTENT in html (it may sit inside a <pre>) — keep it at this chunk's end
+      // (before the closers) rather than dropping it, so rejoined <pre> code is lossless.
+      if (rest[cut] === "\n") {
+        chunk += "\n";
+        advance = cut + 1;
+      }
+      open = unclosedTags(prefix + chunk);
+      chunk += open
+        .map((t) => `</${t.name}>`)
+        .reverse()
+        .join("");
+    }
+    chunks.push(prefix + chunk);
+    // Plain text: drop the boundary newline (the message split itself separates the parts). Html: keep
+    // everything (the newline was already folded into the chunk above).
+    rest = opts.html ? rest.slice(advance) : rest.slice(cut).replace(/^\n/, "");
   }
-  if (rest !== "") chunks.push(rest);
   return chunks;
 }
 
 /**
- * Send a message: split to Telegram's 4096-char limit, each chunk as HTML by default (`html:false` for
- * a plain live-preview), falling back to plain only if Telegram rejects the markup — so a model
- * formatting slip degrades instead of losing the message. Returns the FIRST chunk's message_id (so the
+ * Send a message: split to Telegram's 4096-char limit, each chunk as HTML by default (`html:false` for a
+ * plain live-preview). If Telegram rejects the markup on the FIRST chunk (a model formatting slip), the
+ * whole body is re-chunked and resent as PLAIN — re-chunked, not the same bytes, so the tag-balancer's
+ * injected boundary tags don't leak as literal text. (A later chunk failing after the first parsed
+ * cleanly is rare; it falls back per-chunk, best-effort.) Returns the FIRST chunk's message_id (so the
  * caller can edit it as a live preview). `message_thread_id` is dropped from the JSON when undefined.
  */
 export async function sendMessage(
@@ -96,10 +173,13 @@ export async function sendMessage(
   body: string,
   opts: { html?: boolean } = {},
 ): Promise<number | undefined> {
-  const html = opts.html ?? true;
+  let mode = opts.html ?? true;
+  let chunks = chunkText(body, { html: mode });
   let firstId: number | undefined;
   let first = true;
-  for (const chunk of chunkText(body)) {
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    if (chunk === undefined) continue;
     const base: Record<string, unknown> = { chat_id: t.chatId, message_thread_id: t.threadId, text: chunk };
     // Reply to the summoning message on the FIRST chunk only — threads the answer under the asker in a
     // group; allow_sending_without_reply so a since-deleted original still delivers. Continuation
@@ -107,11 +187,20 @@ export async function sendMessage(
     if (first && t.replyTo !== undefined) {
       base.reply_parameters = { message_id: t.replyTo, allow_sending_without_reply: true };
     }
-    let result = html
+    let result = mode
       ? await callBotApi(api, botToken, "sendMessage", { ...base, parse_mode: "HTML" })
       : await callBotApi(api, botToken, "sendMessage", base);
-    if (html && !result.ok && PARSE_ERROR.test(result.description))
+    if (mode && !result.ok && PARSE_ERROR.test(result.description)) {
+      if (first) {
+        // Nothing sent yet — re-chunk the whole body as plain (no injected boundary tags leak) and restart.
+        mode = false;
+        chunks = chunkText(body, { html: false });
+        i = -1;
+        continue;
+      }
+      // A later chunk failed after the first parsed cleanly (rare) — best-effort plain resend of this chunk.
       result = await callBotApi(api, botToken, "sendMessage", base);
+    }
     if (!result.ok) throw new Error(`telegram sendMessage failed: ${result.status} ${result.description}`.trim());
     if (first) firstId = result.result?.message_id;
     first = false;

--- a/core/src/channels/telegram/telegram.ts
+++ b/core/src/channels/telegram/telegram.ts
@@ -22,10 +22,10 @@ import { readBodyCapped } from "../body.ts";
 import {
   type DownloadedFile,
   type Target,
+  TELEGRAM_MAX_TEXT,
   resolveBotInfo,
   resolveFiles,
   resolveImages,
-  chunkText,
   deleteMessage,
   editMessageText,
   sendMessage,
@@ -223,7 +223,9 @@ async function finalize(
     return;
   }
   if (messageId !== undefined) {
-    if (chunkText(text).length === 1) {
+    // "Fits in one message" is a plain length check against Telegram's limit — not chunkText, whose html
+    // mode exists for SPLIT chunks and is irrelevant to an un-split text.
+    if (text.length <= TELEGRAM_MAX_TEXT) {
       try {
         await editMessageText(api, botToken, target, messageId, text, { html });
         return;
@@ -232,7 +234,7 @@ async function finalize(
         // to delete + fresh send below so a still-present "Thinking…" is not left pinned above the answer.
       }
     }
-    // Many chunks, OR a failed single-chunk edit: remove the placeholder best-effort (a lingering one above
+    // Too long for one message, OR a failed single-message edit: remove the placeholder best-effort (a lingering one above
     // the answer is worse than the extra call), then send the whole reply as fresh, consecutive messages.
     await deleteMessage(api, botToken, target, messageId).catch(() => {});
   }

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defaultTelegramRoute, type TelegramUpdate, telegramChannel, telegramEnvelope } from "../src/telegram.ts";
+import { chunkText, sendMessage } from "../src/channels/telegram/telegram-api.ts";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
 
 /** A faux Agent that records each invocation's prompt and replies with `reply`. */
@@ -69,6 +70,136 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe("chunkText (HTML-aware split)", () => {
+  it("returns one chunk under the limit, and prefers a newline boundary over it", () => {
+    expect(chunkText("short")).toEqual(["short"]);
+    const long = `${"a".repeat(4000)}\n${"b".repeat(200)}`; // > 4096 with a newline before the limit
+    expect(chunkText(long)).toEqual(["a".repeat(4000), "b".repeat(200)]);
+  });
+
+  it("(html) closes a tag that spans a boundary and reopens it, so every chunk is valid, size-capped HTML", () => {
+    const code = "line\n".repeat(1300); // ~6500 chars → forced split, inside one <pre>
+    const chunks = chunkText(`<pre>${code}</pre>`, { html: true });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(4096);
+      expect(c.startsWith("<pre>")).toBe(true); // reopened at the head
+      expect(c.endsWith("</pre>")).toBe(true); // closed at the tail
+    }
+    // the code survives LOSSLESSLY — strip each chunk's <pre>…</pre> wrapper and rejoin; boundary newlines
+    // (content inside <pre>) are preserved, so this reconstructs the original exactly
+    const rejoined = chunks.map((c) => c.slice(5, -6)).join("");
+    expect(rejoined).toBe(code);
+  });
+
+  it("(html) balances NESTED tags across a boundary in the correct order (close innermost, reopen outermost)", () => {
+    const code = "print(x)\n".repeat(700); // > 4096 inside <pre><code> — the real fenced-code-with-language shape
+    const wrapped = `<pre><code class="language-python">${code}</code></pre>`;
+    const chunks = chunkText(wrapped, { html: true });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(4096);
+      expect(c.startsWith('<pre><code class="language-python">')).toBe(true); // reopen outermost-first, attrs kept
+      expect(c.endsWith("</code></pre>")).toBe(true); // close innermost-first
+    }
+    const openLen = '<pre><code class="language-python">'.length;
+    const rejoined = chunks.map((c) => c.slice(openLen, -"</code></pre>".length)).join("");
+    expect(rejoined).toBe(code); // lossless
+  });
+
+  it("(html) reopens a spanning tag WITH its attributes", () => {
+    const long = `<a href="https://example.com/x">${"word ".repeat(1200)}</a>`; // link text > 4096
+    const chunks = chunkText(long, { html: true });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c).toContain('href="https://example.com/x"'); // attr preserved on each chunk
+  });
+
+  it("(html) backs the cut up before a tag token that straddles the boundary", () => {
+    const long = `${"a".repeat(4030)}<b>${"c".repeat(300)}</b>`; // the `<b>` straddles the ~4032 cut
+    const chunks = chunkText(long, { html: true });
+    expect(chunks[0]).toBe("a".repeat(4030)); // cut BEFORE the `<b`, not mid-token
+    expect(chunks[1]?.startsWith("<b>")).toBe(true); // the whole tag moved to the next chunk
+    for (const c of chunks) expect(/<[a-z]*$/i.test(c)).toBe(false); // no chunk ends with a partial tag
+  });
+
+  it("(html) does not cut through an HTML entity that straddles the boundary", () => {
+    const long = `<pre>${"a".repeat(4025)}&amp;${"b".repeat(300)}</pre>`; // `&amp;` straddles the ~4032 cut
+    const chunks = chunkText(long, { html: true });
+    expect(chunks.some((c) => c.includes("&amp;"))).toBe(true); // intact somewhere, never `&am` | `p;`
+    // no chunk ends with a dangling `&…` (ignoring the appended `</…>` closer)
+    expect(chunks.some((c) => /&[a-z#0-9]*$/i.test(c.replace(/<\/[a-z]+>$/i, "")))).toBe(false);
+  });
+
+  it("(html) does not back up to a raw `&` inside a tag token (an href with query params)", () => {
+    // The tag ends just before the ~4032 cut; the href's `&` (no `;`) sits within 12 chars of the cut —
+    // an unguarded entity back-up would move the cut INTO the tag (`…?a` | `&b">…` debris).
+    const tag = '<a href="https://x.com/?a&b">';
+    const long = `${"a".repeat(4000)}${tag}link</a>${"c".repeat(300)}`;
+    const chunks = chunkText(long, { html: true });
+    expect(chunks[0]).toContain(tag); // the tag survives intact, `&` and all
+    expect(chunks.every((c) => !/<[^>]*$/.test(c))).toBe(true); // no chunk ends inside a tag token
+  });
+
+  it("(html) progresses — no empty chunk / infinite loop — on an unclosed `<` at the head", () => {
+    const long = `<${"a".repeat(6000)}`; // a lone `<` then a huge run, never closed
+    const chunks = chunkText(long, { html: true });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.length > 0)).toBe(true); // terminates, no empty chunk
+  });
+
+  it("(plain) ignores tags — a `<` is literal content, split at the limit", () => {
+    const chunks = chunkText("a".repeat(4200)); // no html, no newline
+    expect(chunks.length).toBe(2);
+    expect(chunks[0]?.length).toBe(4096);
+  });
+});
+
+describe("sendMessage HTML fallback", () => {
+  it("re-chunks the whole body as plain when the first HTML chunk is rejected (no leaked boundary tags)", async () => {
+    const sent: { text: string; parse_mode?: string }[] = [];
+    const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+      const b = JSON.parse(String(init.body));
+      if (String(url).endsWith("/sendMessage")) {
+        sent.push({ text: b.text, parse_mode: b.parse_mode });
+        if (b.parse_mode === "HTML")
+          return new Response(JSON.stringify({ ok: false, description: "can't parse entities" }), { status: 400 });
+      }
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const long = `<pre>${"a".repeat(5000)}</pre>`; // > 4096, spans → balancer injects boundary <pre>/</pre>
+    await sendMessage(API, "BOT", { chatId: 42 }, long, { html: true });
+    // after the HTML rejection everything is resent as PLAIN, re-chunked from the ORIGINAL — the injected
+    // boundary tags are gone, so the plain parts reconstruct the original exactly (no leaked <pre></pre>)
+    const plain = sent.filter((s) => s.parse_mode === undefined).map((s) => s.text);
+    expect(plain.length).toBeGreaterThan(0);
+    expect(plain.join("")).toBe(long);
+  });
+
+  it("resends only the failing LATER chunk as plain, same bytes (boundary tags leak — the named trade-off)", async () => {
+    const sent: { text: string; parse_mode?: string }[] = [];
+    let htmlSends = 0;
+    const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+      const b = JSON.parse(String(init.body));
+      if (String(url).endsWith("/sendMessage")) {
+        sent.push({ text: b.text, parse_mode: b.parse_mode });
+        // Only the SECOND HTML chunk fails to parse (first parsed cleanly — no whole-body restart).
+        if (b.parse_mode === "HTML" && ++htmlSends === 2)
+          return new Response(JSON.stringify({ ok: false, description: "can't parse entities" }), { status: 400 });
+      }
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const long = `<pre>${"a".repeat(5000)}</pre>`; // spans → balancer injects boundary </pre> / <pre>
+    await sendMessage(API, "BOT", { chatId: 42 }, long, { html: true });
+    const plain = sent.filter((s) => s.parse_mode === undefined);
+    const secondHtml = sent.filter((s) => s.parse_mode === "HTML")[1];
+    expect(plain.length).toBe(1); // ONLY the failing chunk is resent — no whole-body restart
+    expect(plain[0]?.text).toBe(secondHtml?.text); // byte-for-byte, injected boundary <pre> included
+    expect(plain[0]?.text.startsWith("<pre>")).toBe(true); // the frozen trade-off: the tag leaks as literal text
+  });
 });
 
 describe("defaultTelegramRoute + telegramEnvelope", () => {

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -178,7 +178,7 @@ Downloaded files persist until the operator cleans them up. Treat `.fastagent/te
 
 ## Limits
 
-- Telegram messages are split to the 4096-character limit.
+- Telegram messages are split to the 4096-character limit as valid HTML: a tag spanning a boundary is closed at the chunk end and reopened (with its attributes) at the next chunk start, and the split never cuts through a tag token — so a long `<pre>` code block stays formatted instead of degrading to a plain-text fallback.
 - HTML parse failures fall back to plain text so a model formatting mistake does not lose the reply.
 - Bot API 429 responses are retried with Telegram's `retry_after` hint.
 - Audio/video transcription is not built in; the agent must use its own tools if it needs media content.


### PR DESCRIPTION
A long reply (>4096 chars) was split at a newline or the hard limit, which could split an HTML
tag or, more commonly, cut a `<pre>` code block so the first chunk's tag was left open —
Telegram then rejects the chunk's markup and the whole chunk degrades to a plain-text fallback,
losing formatting for content that was otherwise fine.

chunkText is now a tag-balancer for HTML: a tag that SPANS a boundary is closed at the chunk's
end and reopened at the next chunk's start, with its attributes preserved (so a spanning
`<a href=…>` / `<code class=…>` keeps them), so every chunk is self-contained valid HTML. It also
never cuts THROUGH a tag token (backs the cut up before a `<` it would land inside). Plain text
(html:false) is unaffected — a `<` there is literal content — and the html flag now gates the
tag logic just as it gates parse_mode in sendMessage.

The stack (`unclosedTags`) is a flat name-matched stack, which fits Telegram's shallow HTML
subset; a boundary reserves TAG_CLOSE_BUDGET for the closers, and the loop always advances ≥1
char (no empty chunk / infinite loop even on a pathological head-`<`).

(Extracted from the closed #98, then reworked into a real balancer after research showed the
reliable approaches are entity-based splitting — which would mean changing the send model — or
exactly this close/reopen-across-chunks pattern. chunkText was already exported by #96.)
Tests: spanning-`<pre>` close/reopen with size caps, attribute preservation, no mid-token cut +
head-`<` progress, and the plain path. CHANGELOG + docs/telegram.md updated. 271 tests green.
