### PR TITLE
fix(telegram): transport timeouts + honest flood-wait handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ While the project is pre-1.0, minor versions may include breaking changes.
   (`github`, `telegram`, `channel-development`), and maintainer notes under `docs/design/`.
 
 ### Changed
+- Telegram transport hardening: every Bot API call, file download, and the `--tunnel` webhook registration now carry a timeout (30s API / 120s download) so a wedged connection cannot hang a turn, its session queue, or dev startup; a 429 without `retry_after` gets a short backoff (the scaffold send-tool is the one exception — it stays fail-fast so the agent sees the error and decides); a flood ban demanding a wait beyond 30s fails visibly instead of silently parking the turn. Failures self-describe (`telegram <method>: …`, "gave up after N retries", the flood-wait cap), a success requires the body's own `ok:true` — a proxy's 200 + error page can no longer read as a sent message.
 - Telegram: a long reply (>4096 chars) is split as valid HTML — a tag that spans a boundary is closed at the chunk's end and reopened (attributes and all) at the next chunk's start, so a long `<pre>` code block stays formatted instead of degrading to plain text. The split also never cuts through a tag token.
 - Narrative reframed to "Vibe first. Then FastAgent." — take a local agent folder out of
   the terminal and serve it in an app, on GitHub, in Telegram, or behind a custom channel.

--- a/core/src/channels/telegram/scaffold/telegram-send.ts
+++ b/core/src/channels/telegram/scaffold/telegram-send.ts
@@ -23,9 +23,34 @@ export default defineTool({
     if (messageThreadId !== undefined) form.set("message_thread_id", String(messageThreadId));
     if (caption) form.set("caption", caption);
     form.set(asPhoto ? "photo" : "document", new Blob([await readFile(path)]), basename(path));
-    const res = await fetch(`https://api.telegram.org/bot${token}/${method}`, { method: "POST", body: form });
-    const data = (await res.json().catch(() => ({}))) as { ok?: boolean; description?: string };
-    if (!res.ok || !data.ok) throw new Error(`telegram ${method} failed: ${res.status} ${data.description ?? ""}`);
+    let res: Response;
+    let raw: string;
+    try {
+      // Upload timeout: a wedged connection would otherwise hang this tool call — and the whole turn.
+      // Deliberately NO 429 retry here (unlike the channel transport): a tool error goes back to the
+      // agent, which can decide to retry — fail-fast beats a tool call that silently sleeps.
+      res = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+        method: "POST",
+        body: form,
+        signal: AbortSignal.timeout(120_000),
+      });
+      raw = await res.text();
+    } catch (e) {
+      // Name the call — a bare TimeoutError says nothing in the agent's tool-error output.
+      throw new Error(`telegram ${method}: ${String(e)}`, { cause: e });
+    }
+    let data: { ok?: boolean; description?: string };
+    try {
+      data = JSON.parse(raw) as { ok?: boolean; description?: string };
+    } catch {
+      data = {};
+    }
+    if (!res.ok || !data.ok) {
+      // Self-describing even for a proxy's 200 + error page (no description to quote).
+      throw new Error(
+        `telegram ${method} failed: ${res.status} ${data.description ?? "Bot API response was not the expected JSON"}`,
+      );
+    }
     return `sent ${basename(path)} to chat ${chatId}`;
   },
 });

--- a/core/src/channels/telegram/telegram-api.ts
+++ b/core/src/channels/telegram/telegram-api.ts
@@ -1,17 +1,49 @@
 /**
  * Telegram Bot API transport: the wire calls the channel orchestrates (telegram.ts). No agent, no
- * rendering — just `fetch` to the Bot API, with the protocol's hard edges handled here (429 backoff,
- * the 4096-char split, the HTML→plain parse fallback, the getFile→download dance). Split from the
+ * rendering — just `fetch` to the Bot API, with the protocol's hard edges handled here (timeouts, 429
+ * backoff, the 4096-char split, the HTML→plain parse fallback, the getFile→download dance). Split from the
  * channel so policy/streaming stays separate from the wire protocol.
  */
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { setTimeout as sleep } from "node:timers/promises";
 import type { ImageRef } from "../../agent.ts";
+
+/** Sleep on the GLOBAL timer (not `node:timers/promises`) so tests can drive it with fake timers. */
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Parse a Bot API response body; a non-JSON body (a proxy's error page) is treated as empty — the
+ *  caller then fails on the missing `ok` field rather than trusting an intermediary's HTTP 200. Only the
+ *  PARSE is forgiven here: a network/timeout error while READING the body happens at the `res.text()`
+ *  call sites, inside their context-adding try/catch. */
+function parseBotJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+/** The self-description when a body carries no usable Bot API answer — either not JSON at all (an
+ *  intermediary's error page) or JSON without the expected fields. Phrased to be true for both; callers
+ *  that can tell a more specific truth (e.g. "no file_path") say that instead. */
+const MALFORMED_BODY = "Bot API response was not the expected JSON";
 
 /** Telegram's hard text limit per message. */
 export const TELEGRAM_MAX_TEXT = 4096;
 const PARSE_ERROR = /can't parse|entit|unsupported|unclosed|tag/i;
+
+/** Per-attempt timeout for a JSON Bot API call — without one a wedged connection hangs the turn (and the
+ *  session's serial queue behind it) forever. Generous: these are small JSON round-trips. */
+const API_TIMEOUT_MS = 30_000;
+
+/** Timeout for downloading file bytes (up to the 20 MB cap) — sized for a slow link, not a JSON call. */
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+
+/** Longest flood wait (seconds) we honour PER ATTEMPT before failing visibly instead. Telegram's
+ *  `retry_after` can reach minutes–hours on a flood ban; sleeping that long would silently hold the turn
+ *  and every queued turn behind it — a fast, diagnosable failure is better. The aggregate is bounded by
+ *  the retry count: at most 3 waits, so ~3× this cap worst-case. */
+const FLOOD_WAIT_MAX_S = 30;
 
 /** Download sanity cap (Telegram's own getFile limit); a larger file/image is rejected visibly. The
  *  engine resizes images to the model's needs, so this is a transport guard, not the model size limit. */
@@ -38,33 +70,69 @@ export interface DownloadedFile {
   size: number;
 }
 
-/** One Bot API call, retrying on a 429 with the server's `retry_after` (a few attempts). */
-async function callBotApi(
+/** One Bot API call, retrying on a 429 (a few attempts): waits the server's `retry_after` when given
+ *  (exported for the tunnel's setWebhook registration — one hardened call, not parallel copies)
+ *  (a missing one gets a short linear backoff), but only up to {@link FLOOD_WAIT_MAX_S} — beyond that
+ *  the flood ban fails visibly rather than silently parking the turn. No retry on other statuses or on
+ *  network errors/timeouts: the request may have been processed, and a retried sendMessage would
+ *  double-deliver; those fail visibly (a thrown fetch error, or `ok:false`) for the caller to surface. */
+export async function callBotApi(
   api: string,
   botToken: string,
   method: string,
   params: Record<string, unknown>,
 ): Promise<{ ok: true; result?: { message_id?: number } } | { ok: false; status: number; description: string }> {
   for (let attempt = 0; ; attempt++) {
-    const res = await fetch(`${api}/bot${botToken}/${method}`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(params),
-    });
-    if (res.ok) {
-      const data = (await res.json().catch(() => ({}))) as { result?: { message_id?: number } };
-      return { ok: true, result: data.result };
+    let res: Response;
+    let raw: string;
+    try {
+      res = await fetch(`${api}/bot${botToken}/${method}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(params),
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      });
+      raw = await res.text(); // the body read is under the same timeout — keep it in the guarded region
+    } catch (e) {
+      // Name the call: a bare `TimeoutError` in the operator log names no method — the whole point of
+      // the timeout is a diagnosable failure.
+      throw new Error(`telegram ${method}: ${String(e)}`, { cause: e });
     }
-    const data = (await res.json().catch(() => ({}))) as {
+    const data = parseBotJson(raw) as {
+      ok?: boolean;
+      result?: { message_id?: number };
       description?: string;
       parameters?: { retry_after?: number };
     };
-    const retryAfter = data.parameters?.retry_after;
-    if (res.status === 429 && retryAfter !== undefined && attempt < 3) {
-      await sleep((retryAfter + 1) * 1000);
-      continue;
+    // Success requires the BODY's own `ok:true` (every Bot API response carries it), not just HTTP 200:
+    // a proxy's 200 + HTML error page must be a named failure, not a fake success with no message_id.
+    if (res.ok && data.ok === true) return { ok: true, result: data.result };
+    if (res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        description: data.description ?? MALFORMED_BODY,
+      };
     }
-    return { ok: false, status: res.status, description: data.description ?? "" };
+    if (res.status === 429 && attempt < 3) {
+      const floodWait = data.parameters?.retry_after ?? attempt + 1;
+      if (floodWait <= FLOOD_WAIT_MAX_S) {
+        await wait((floodWait + 1) * 1000);
+        continue;
+      }
+      // A longer flood ban fails visibly — and says WHY the transport refused to wait, rather than
+      // relying on the server's description to mention the retry_after.
+      return {
+        ok: false,
+        status: res.status,
+        description:
+          `${data.description ?? ""} (retry_after ${floodWait}s exceeds the ${FLOOD_WAIT_MAX_S}s flood-wait cap)`.trim(),
+      };
+    }
+    // Same self-describing rule for the other transport decision: a 429 that survived every retry says
+    // so, distinguishable in the log from one that was never retried.
+    const exhausted = res.status === 429 ? ` (gave up after ${attempt} retries)` : "";
+    return { ok: false, status: res.status, description: `${data.description ?? MALFORMED_BODY}${exhausted}`.trim() };
   }
 }
 
@@ -250,12 +318,22 @@ export async function resolveBotInfo(
   api: string,
   botToken: string,
 ): Promise<{ username?: string; canReadAllGroupMessages?: boolean }> {
-  const res = await fetch(`${api}/bot${botToken}/getMe`);
-  const data = (await res.json().catch(() => ({}))) as {
+  let res: Response;
+  let raw: string;
+  try {
+    res = await fetch(`${api}/bot${botToken}/getMe`, { signal: AbortSignal.timeout(API_TIMEOUT_MS) });
+    raw = await res.text();
+  } catch (e) {
+    throw new Error(`telegram getMe: ${String(e)}`, { cause: e });
+  }
+  const data = parseBotJson(raw) as {
     ok?: boolean;
+    description?: string;
     result?: { username?: string; can_read_all_group_messages?: boolean };
   };
-  if (!res.ok || !data.ok) throw new Error(`getMe failed: ${res.status}`);
+  if (!res.ok || !data.ok) {
+    throw new Error(`telegram getMe failed: ${res.status} ${data.description ?? MALFORMED_BODY}`);
+  }
   return { username: data.result?.username, canReadAllGroupMessages: data.result?.can_read_all_group_messages };
 }
 
@@ -271,17 +349,45 @@ async function getFileBytes(
   botToken: string,
   fileId: string,
 ): Promise<{ bytes: Buffer; remotePath: string }> {
-  const meta = (await fetch(`${api}/bot${botToken}/getFile`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ file_id: fileId }),
-  }).then((r) => r.json())) as { ok?: boolean; result?: { file_path?: string; file_size?: number } };
+  let meta: { ok?: boolean; description?: string; result?: { file_path?: string; file_size?: number } };
+  let metaStatus: number;
+  try {
+    const res = await fetch(`${api}/bot${botToken}/getFile`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file_id: fileId }),
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+    metaStatus = res.status;
+    meta = parseBotJson(await res.text()) as typeof meta;
+  } catch (e) {
+    throw new Error(`telegram getFile: ${String(e)}`, { cause: e });
+  }
   const remotePath = meta.result?.file_path;
-  if (!meta.ok || !remotePath) throw new Error(`getFile failed for ${fileId}`);
+  if (!meta.ok || !remotePath) {
+    // A valid `ok:true` body missing file_path gets the specific truth, not the generic one.
+    const why = meta.ok ? "no file_path in response" : (meta.description ?? MALFORMED_BODY);
+    throw new Error(`telegram getFile failed for ${fileId}: ${metaStatus} ${why}`);
+  }
   if ((meta.result?.file_size ?? 0) > MAX_DOWNLOAD_BYTES) throw new Error("file is too large (max 20 MB)");
-  const res = await fetch(`${api}/file/bot${botToken}/${remotePath}`);
-  if (!res.ok) throw new Error(`download failed: ${res.status}`);
-  const bytes = Buffer.from(await res.arrayBuffer());
+  let res: Response;
+  let buf: ArrayBuffer | undefined;
+  let errBody: string | undefined;
+  try {
+    res = await fetch(`${api}/file/bot${botToken}/${remotePath}`, {
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    });
+    // The error body self-describes too (an expired file_path's "Not Found") — read it in the guarded region.
+    buf = res.ok ? await res.arrayBuffer() : undefined;
+    errBody = res.ok ? undefined : await res.text();
+  } catch (e) {
+    throw new Error(`telegram file download: ${String(e)}`, { cause: e });
+  }
+  if (!res.ok || buf === undefined) {
+    const why = (parseBotJson(errBody ?? "") as { description?: string }).description ?? MALFORMED_BODY;
+    throw new Error(`telegram file download failed: ${res.status} ${why}`);
+  }
+  const bytes = Buffer.from(buf);
   if (bytes.byteLength > MAX_DOWNLOAD_BYTES) throw new Error("file is too large (max 20 MB)");
   return { bytes, remotePath };
 }

--- a/core/src/tunnel.ts
+++ b/core/src/tunnel.ts
@@ -9,6 +9,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { callBotApi } from "./channels/telegram/telegram-api.ts";
 import { log } from "./log.ts";
 
 export interface Tunnel {
@@ -199,21 +200,21 @@ async function registerTelegram(baseUrl: string): Promise<void> {
   );
 }
 
-/** One setWebhook attempt. Resolves { ok } or { ok: false, error } (HTTP status + description, or a thrown message). */
+/** One setWebhook attempt via the channel's hardened transport (timeout, body-ok validation, 429
+ *  retry, self-describing failures) — one implementation, not a parallel copy. A thrown timeout
+ *  stringifies to `telegram setWebhook: TimeoutError…`, which matches the caller's transient regex. */
 async function trySetWebhook(
   botToken: string,
   url: string,
   secret: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
-    const res = await fetch(`https://api.telegram.org/bot${botToken}/setWebhook`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url, secret_token: secret }),
+    const result = await callBotApi("https://api.telegram.org", botToken, "setWebhook", {
+      url,
+      secret_token: secret,
     });
-    const data = (await res.json().catch(() => ({}))) as { ok?: boolean; description?: string };
-    if (res.ok && data.ok) return { ok: true };
-    return { ok: false, error: `${res.status}${data.description ? `: ${data.description}` : ""}` };
+    if (result.ok) return { ok: true };
+    return { ok: false, error: `${result.status}: ${result.description}` };
   } catch (e) {
     return { ok: false, error: String(e) };
   }

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defaultTelegramRoute, type TelegramUpdate, telegramChannel, telegramEnvelope } from "../src/telegram.ts";
-import { chunkText, sendMessage } from "../src/channels/telegram/telegram-api.ts";
+import { chunkText, resolveImages, sendMessage } from "../src/channels/telegram/telegram-api.ts";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
 
 /** A faux Agent that records each invocation's prompt and replies with `reply`. */
@@ -176,6 +176,154 @@ describe("sendMessage HTML fallback", () => {
     const plain = sent.filter((s) => s.parse_mode === undefined).map((s) => s.text);
     expect(plain.length).toBeGreaterThan(0);
     expect(plain.join("")).toBe(long);
+  });
+
+  it("sendMessage carries a 30s timeout signal (a wedged connection can't hang the turn)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchMock = vi.fn(
+      async (_url: string, _init: RequestInit) =>
+        new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await sendMessage(API, "BOT", { chatId: 42 }, "hi");
+    // Pin the MECHANISM, not just "some signal": the signal fetch received is the one AbortSignal.timeout
+    // produced for the API timeout — a never-firing plain signal would pass an instanceof check.
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(timeoutSpy.mock.results[0]?.value);
+  });
+
+  it("the file download carries the 120s timeout (same mechanism pin as sendMessage)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (String(url).endsWith("/getFile"))
+        return new Response(JSON.stringify({ ok: true, result: { file_path: "photos/x.jpg", file_size: 3 } }), {
+          status: 200,
+        });
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const images = await resolveImages(API, "BOT", ["f1"]);
+    expect(images?.length).toBe(1);
+    expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+    const download = fetchMock.mock.calls.find((c) => String(c[0]).includes("/file/"));
+    const produced = timeoutSpy.mock.results[timeoutSpy.mock.calls.findIndex((c) => c[0] === 120_000)];
+    expect(download?.[1]?.signal).toBe(produced?.value);
+  });
+
+  it("names a failing file download", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).endsWith("/getFile"))
+        return new Response(JSON.stringify({ ok: true, result: { file_path: "photos/x.jpg" } }), { status: 200 });
+      throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(resolveImages(API, "BOT", ["f1"])).rejects.toThrow(/telegram file download: .*TimeoutError/);
+  });
+
+  it("names the failing call when the transport throws (timeout/network)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+      }),
+    );
+    await expect(sendMessage(API, "BOT", { chatId: 42 }, "hi")).rejects.toThrow(/telegram sendMessage: .*TimeoutError/);
+  });
+
+  it("a 200 with a non-JSON body (a proxy's error page) is a named failure, not a fake success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("<html>gateway error</html>", { status: 200 })),
+    );
+    await expect(sendMessage(API, "BOT", { chatId: 42 }, "hi")).rejects.toThrow(
+      /telegram sendMessage failed: 200 Bot API response was not the expected JSON/,
+    );
+  });
+
+  it("gives up after exhausting 429 retries — bounded, and the error says it retried", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: false, description: "Too Many Requests", parameters: { retry_after: 0 } }), {
+          status: 429,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const p = sendMessage(API, "BOT", { chatId: 42 }, "hi");
+    const rejection = expect(p).rejects.toThrow(/Too Many Requests \(gave up after 3 retries\)/);
+    await vi.advanceTimersByTimeAsync(3500); // three (0+1)s waits, then the 4th attempt fails for good
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledTimes(4); // the `attempt < 3` bound — not an infinite hammer
+  });
+
+  it("a mid-body timeout throws named — never a silent fake success (the old .json().catch swallow)", async () => {
+    // 200 arrives, but reading the body times out. The old `.json().catch(() => ({}))` turned this into
+    // `ok:true, result:undefined`; it must instead surface as a named transport failure.
+    const res = {
+      ok: true,
+      status: 200,
+      text: async () => {
+        throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+      },
+    } as unknown as Response;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => res),
+    );
+    await expect(sendMessage(API, "BOT", { chatId: 42 }, "hi")).rejects.toThrow(/telegram sendMessage: .*TimeoutError/);
+  });
+
+  it("retries a 429 after the server's retry_after, then succeeds", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls++;
+      if (calls === 1)
+        return new Response(JSON.stringify({ ok: false, parameters: { retry_after: 2 } }), { status: 429 });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 7 } }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = sendMessage(API, "BOT", { chatId: 42 }, "hi");
+    await vi.advanceTimersByTimeAsync(1000); // before (retry_after 2 + 1) s elapses…
+    expect(calls).toBe(1); // …it is actually WAITING, not hammering an immediate retry
+    await vi.advanceTimersByTimeAsync(2100); // past the wait
+    expect(await p).toBe(7);
+    expect(calls).toBe(2);
+  });
+
+  it("retries a 429 WITHOUT retry_after with a short backoff, then succeeds", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls++;
+      if (calls === 1) return new Response(JSON.stringify({ ok: false }), { status: 429 }); // no parameters
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 7 } }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = sendMessage(API, "BOT", { chatId: 42 }, "hi");
+    await vi.advanceTimersByTimeAsync(1000); // before the (attempt 0 → 1 + 1) s backoff elapses…
+    expect(calls).toBe(1); // …it waits here too
+    await vi.advanceTimersByTimeAsync(1100); // past the backoff
+    expect(await p).toBe(7);
+    expect(calls).toBe(2);
+  });
+
+  it("fails fast on a flood ban whose retry_after exceeds the wait cap (no silent hour-long park)", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ ok: false, description: "Too Many Requests", parameters: { retry_after: 3600 } }),
+          {
+            status: 429,
+          },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const t0 = Date.now();
+    // The error self-describes the transport's own decision (not just the server's text).
+    await expect(sendMessage(API, "BOT", { chatId: 42 }, "hi")).rejects.toThrow(/exceeds the \d+s flood-wait cap/);
+    expect(Date.now() - t0).toBeLessThan(1000); // failed visibly, did not honour the hour-long wait
+    expect(fetchMock).toHaveBeenCalledTimes(1); // and did not burn retries on it either
   });
 
   it("resends only the failing LATER chunk as plain, same bytes (boundary tags leak — the named trade-off)", async () => {


### PR DESCRIPTION
The Bot API transport had long-run reliability gaps (found comparing against what a bot
framework hardens for): no fetch timeout anywhere — a wedged connection hangs the turn, the
per-session serial queue behind it, or `--tunnel` webhook registration, forever — an unbounded
429 sleep (Telegram's retry_after reaches minutes–hours on a flood ban, silently parking a turn
and its queue), no retry at all on a 429 *without* retry_after, and two fake-success holes: a
timeout mid-body-read was swallowed by `.json().catch(() => ({}))` into `ok:true`, and a proxy's
HTTP 200 + error page read as a sent message.

Every fetch now carries AbortSignal.timeout — API_TIMEOUT_MS=30s for JSON calls (callBotApi,
getMe, getFile, setWebhook) and DOWNLOAD_TIMEOUT_MS=120s for file bytes and the scaffold
send-tool's uploads. Failures are named and self-describing: fetch/body-read errors rethrow as
`telegram <method>: …` (not a bare TimeoutError); the body is read via text() inside the guarded
region and only the JSON *parse* is forgiven; success requires the body's own `ok:true`, not
just HTTP 200; a flood ban beyond FLOOD_WAIT_MAX_S=30 refuses to wait and says so; an exhausted
429 says "gave up after N retries" — each transport decision is distinguishable in the log.

429 handling: retry_after is honoured up to the cap; a missing retry_after gets a short linear
backoff (bounded by the same attempt < 3). Deliberately NO new retry classes for 5xx/network/
timeout errors: the request may have been processed, and a retried sendMessage would
double-deliver — those keep failing visibly for the caller to surface.

The retry sleep moved off node:timers/promises onto the global timer so fake timers can drive
it. Tests pin the mechanisms, not just shapes: timeout signal identity (30s send / 120s
download), both 429 retries actually WAIT (two-phase clock advance), retry exhaustion is bounded
(4 calls) and labeled, the flood-cap fast-fail, named throws (fetch reject + mid-body reject),
and the 200-with-garbage named failure. 287 tests green.
