### PR TITLE
refactor(telegram): single-pipeline transport — invariants by construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ While the project is pre-1.0, minor versions may include breaking changes.
   (`github`, `telegram`, `channel-development`), and maintainer notes under `docs/design/`.
 
 ### Changed
+- Telegram transport rewritten around a single pipeline (`callApi`): per-method wire code no longer exists, so the transport invariants — a per-attempt timeout on every call (30s API / 120s file bytes), bounded 429 retry honouring `retry_after` up to a 30s flood-wait cap, success gated on the body's own `ok:true` (a proxy's 200 + error page is a named failure, not a sent message), and self-describing `TelegramApiError`s — hold for every call by construction, including `--tunnel` webhook registration. The scaffold send-tool carries a documented standalone copy (fail-fast, no 429 retry: the agent sees the error and decides).
 - Telegram: a long reply (>4096 chars) is split as valid HTML — a tag that spans a boundary is closed at the chunk's end and reopened (attributes and all) at the next chunk's start, so a long `<pre>` code block stays formatted instead of degrading to plain text. The split also never cuts through a tag token.
 - Narrative reframed to "Vibe first. Then FastAgent." — take a local agent folder out of
   the terminal and serve it in an app, on GitHub, in Telegram, or behind a custom channel.

--- a/core/src/channels/telegram/scaffold/telegram-send.ts
+++ b/core/src/channels/telegram/scaffold/telegram-send.ts
@@ -23,9 +23,33 @@ export default defineTool({
     if (messageThreadId !== undefined) form.set("message_thread_id", String(messageThreadId));
     if (caption) form.set("caption", caption);
     form.set(asPhoto ? "photo" : "document", new Blob([await readFile(path)]), basename(path));
-    const res = await fetch(`https://api.telegram.org/bot${token}/${method}`, { method: "POST", body: form });
-    const data = (await res.json().catch(() => ({}))) as { ok?: boolean; description?: string };
-    if (!res.ok || !data.ok) throw new Error(`telegram ${method} failed: ${res.status} ${data.description ?? ""}`);
+    // Standalone copy of the channel transport's discipline (this template cannot import core
+    // internals): an upload timeout so a wedged connection can't hang the tool call (and the turn),
+    // named errors, and success gated on the body's own ok. Deliberately NO 429 retry — a tool error
+    // goes back to the agent, which can decide to retry; fail-fast beats a silently sleeping tool.
+    let res: Response;
+    let raw: string;
+    try {
+      res = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+        method: "POST",
+        body: form,
+        signal: AbortSignal.timeout(120_000),
+      });
+      raw = await res.text();
+    } catch (e) {
+      throw new Error(`telegram ${method}: ${String(e)}`, { cause: e });
+    }
+    let data: { ok?: boolean; description?: string };
+    try {
+      data = JSON.parse(raw) as { ok?: boolean; description?: string };
+    } catch {
+      data = {};
+    }
+    if (!res.ok || !data.ok) {
+      throw new Error(
+        `telegram ${method} failed: ${res.status} ${data.description ?? "Bot API response was not the expected JSON"}`,
+      );
+    }
     return `sent ${basename(path)} to chat ${chatId}`;
   },
 });

--- a/core/src/channels/telegram/telegram-api.ts
+++ b/core/src/channels/telegram/telegram-api.ts
@@ -1,17 +1,41 @@
 /**
- * Telegram Bot API transport: the wire calls the channel orchestrates (telegram.ts). No agent, no
- * rendering — just `fetch` to the Bot API, with the protocol's hard edges handled here (429 backoff,
- * the 4096-char split, the HTML→plain parse fallback, the getFile→download dance). Split from the
- * channel so policy/streaming stays separate from the wire protocol.
+ * Telegram Bot API transport. ONE pipeline (`callApi`) carries every JSON call — per-method code does
+ * not exist, so a transport rule can never be missing from one call site. The transport invariants
+ * live here and nowhere else:
+ *
+ *  1. Every call has a per-attempt timeout (API_TIMEOUT_MS; file bytes DOWNLOAD_TIMEOUT_MS) — a wedged
+ *     connection cannot hang a turn, its session queue, or webhook registration.
+ *  2. Only a 429 is retried (bounded attempts, honouring `retry_after` up to FLOOD_WAIT_MAX_S per
+ *     wait); a longer flood ban or exhausted retries fail visibly. No other failure class is retried:
+ *     the request may have been processed, and a retried sendMessage would double-deliver.
+ *  3. Success requires the body's own `ok:true` — an intermediary's HTTP 200 is not a sent message.
+ *  4. Every failure is a {@link TelegramApiError} naming the method: self-description is a property of
+ *     the error type, not per-call-site string assembly.
+ *
+ * On top of the pipeline sits the channel's POLICY: the 4096-char HTML-aware split, the HTML→plain
+ * parse fallback, and the getFile→download dance. (telegram.ts orchestrates; no agent, no rendering.)
  */
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { setTimeout as sleep } from "node:timers/promises";
 import type { ImageRef } from "../../agent.ts";
 
 /** Telegram's hard text limit per message. */
 export const TELEGRAM_MAX_TEXT = 4096;
 const PARSE_ERROR = /can't parse|entit|unsupported|unclosed|tag/i;
+
+/** Per-attempt timeout for a JSON Bot API call — small JSON round-trips, so 30s is generous. */
+const API_TIMEOUT_MS = 30_000;
+
+/** Timeout for downloading file bytes (up to the 20 MB cap) — sized for a slow link, not a JSON call. */
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+
+/** Longest flood wait (seconds) honoured PER ATTEMPT before failing visibly instead. Telegram's
+ *  `retry_after` can reach minutes–hours on a flood ban; sleeping that long would silently park the
+ *  turn and every queued turn behind it. Aggregate is bounded by RETRIES: ~3× this cap worst-case. */
+const FLOOD_WAIT_MAX_S = 30;
+
+/** How many 429s one call absorbs before giving up. */
+const RETRIES = 3;
 
 /** Download sanity cap (Telegram's own getFile limit); a larger file/image is rejected visibly. The
  *  engine resizes images to the model's needs, so this is a transport guard, not the model size limit. */
@@ -38,33 +62,93 @@ export interface DownloadedFile {
   size: number;
 }
 
-/** One Bot API call, retrying on a 429 with the server's `retry_after` (a few attempts). */
-async function callBotApi(
+/** The methods this channel speaks and their result shapes — a hand-written slice of the Bot API
+ *  schema. Adding a method = adding a row here, not writing a function. (If this table ever needs to
+ *  grow past roughly ten rows, or entity-based formatting, adopt gramIO instead of growing it.) */
+interface Api {
+  sendMessage: { message_id?: number };
+  editMessageText: unknown;
+  deleteMessage: unknown;
+  getMe: { username?: string; can_read_all_group_messages?: boolean };
+  getFile: { file_path?: string; file_size?: number };
+  setWebhook: unknown;
+}
+
+/** A named Bot API failure. `status` 0 = the transport itself failed (network error / timeout) before
+ *  any HTTP status existed; otherwise the HTTP status with Telegram's own description (or a note that
+ *  the body carried no usable answer). */
+export class TelegramApiError extends Error {
+  readonly method: string;
+  readonly status: number;
+  readonly description: string;
+  // No constructor parameter properties: the CLI runs source under Node's strip-only TS mode, which
+  // rejects them (ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX).
+  constructor(method: string, status: number, description: string, options?: { cause?: unknown }) {
+    super(
+      status === 0
+        ? `telegram ${method}: ${description}`
+        : `telegram ${method} failed: ${status} ${description}`.trim(),
+      options,
+    );
+    this.name = "TelegramApiError";
+    this.method = method;
+    this.status = status;
+    this.description = description;
+  }
+}
+
+/** Sleep on the GLOBAL timer (not `node:timers/promises`) so tests can drive it with fake timers. */
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * The pipeline: one Bot API call, carrying every transport invariant (see the module header). Returns
+ * the method's `result` payload; throws {@link TelegramApiError} on any failure.
+ */
+export async function callApi<M extends keyof Api>(
   api: string,
   botToken: string,
-  method: string,
+  method: M,
   params: Record<string, unknown>,
-): Promise<{ ok: true; result?: { message_id?: number } } | { ok: false; status: number; description: string }> {
+): Promise<Api[M]> {
   for (let attempt = 0; ; attempt++) {
-    const res = await fetch(`${api}/bot${botToken}/${method}`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(params),
-    });
-    if (res.ok) {
-      const data = (await res.json().catch(() => ({}))) as { result?: { message_id?: number } };
-      return { ok: true, result: data.result };
+    let res: Response;
+    let raw: string;
+    try {
+      res = await fetch(`${api}/bot${botToken}/${method}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(params),
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      });
+      raw = await res.text(); // the body read shares the timeout — a mid-body stall is a transport failure too
+    } catch (e) {
+      throw new TelegramApiError(method, 0, String(e), { cause: e });
     }
-    const data = (await res.json().catch(() => ({}))) as {
-      description?: string;
-      parameters?: { retry_after?: number };
-    };
-    const retryAfter = data.parameters?.retry_after;
-    if (res.status === 429 && retryAfter !== undefined && attempt < 3) {
-      await sleep((retryAfter + 1) * 1000);
-      continue;
+    let data: { ok?: boolean; result?: unknown; description?: string; parameters?: { retry_after?: number } };
+    try {
+      data = JSON.parse(raw) as typeof data;
+    } catch {
+      data = {}; // only the parse is forgiven — the ok-gate below turns it into a named failure
     }
-    return { ok: false, status: res.status, description: data.description ?? "" };
+    if (res.ok && data.ok === true) return data.result as Api[M];
+    if (res.status === 429 && attempt < RETRIES) {
+      const floodWait = data.parameters?.retry_after ?? attempt + 1; // no retry_after → short linear backoff
+      if (floodWait <= FLOOD_WAIT_MAX_S) {
+        await wait((floodWait + 1) * 1000);
+        continue;
+      }
+      throw new TelegramApiError(
+        method,
+        429,
+        `${data.description ?? ""} (retry_after ${floodWait}s exceeds the ${FLOOD_WAIT_MAX_S}s flood-wait cap)`.trim(),
+      );
+    }
+    const exhausted = res.status === 429 ? ` (gave up after ${attempt} retries)` : "";
+    throw new TelegramApiError(
+      method,
+      res.status,
+      `${data.description ?? "Bot API response was not the expected JSON"}${exhausted}`.trim(),
+    );
   }
 }
 
@@ -187,10 +271,11 @@ export async function sendMessage(
     if (first && t.replyTo !== undefined) {
       base.reply_parameters = { message_id: t.replyTo, allow_sending_without_reply: true };
     }
-    let result = mode
-      ? await callBotApi(api, botToken, "sendMessage", { ...base, parse_mode: "HTML" })
-      : await callBotApi(api, botToken, "sendMessage", base);
-    if (mode && !result.ok && PARSE_ERROR.test(result.description)) {
+    let result: Api["sendMessage"];
+    try {
+      result = await callApi(api, botToken, "sendMessage", mode ? { ...base, parse_mode: "HTML" } : base);
+    } catch (e) {
+      if (!(mode && e instanceof TelegramApiError && PARSE_ERROR.test(e.description))) throw e;
       if (first) {
         // Nothing sent yet — re-chunk the whole body as plain (no injected boundary tags leak) and restart.
         mode = false;
@@ -199,10 +284,9 @@ export async function sendMessage(
         continue;
       }
       // A later chunk failed after the first parsed cleanly (rare) — best-effort plain resend of this chunk.
-      result = await callBotApi(api, botToken, "sendMessage", base);
+      result = await callApi(api, botToken, "sendMessage", base);
     }
-    if (!result.ok) throw new Error(`telegram sendMessage failed: ${result.status} ${result.description}`.trim());
-    if (first) firstId = result.result?.message_id;
+    if (first) firstId = result.message_id;
     first = false;
   }
   return firstId;
@@ -227,36 +311,19 @@ export async function editMessageText(
     message_id: messageId,
     text: body.slice(0, TELEGRAM_MAX_TEXT),
   };
-  let result = opts.html
-    ? await callBotApi(api, botToken, "editMessageText", { ...base, parse_mode: "HTML" })
-    : await callBotApi(api, botToken, "editMessageText", base);
-  if (opts.html && !result.ok && PARSE_ERROR.test(result.description))
-    result = await callBotApi(api, botToken, "editMessageText", base);
-  if (!result.ok && /message is not modified/i.test(result.description)) return;
-  if (!result.ok) throw new Error(`telegram editMessageText failed: ${result.status} ${result.description}`.trim());
-}
-
-/** Delete a message — the wire primitive for removing a preview placeholder (the finalize POLICY lives
- *  in telegram.ts). Throws on failure, like the other primitives; a caller that wants best-effort cleanup
- *  catches explicitly rather than the primitive swallowing it. */
-export async function deleteMessage(api: string, botToken: string, t: Target, messageId: number): Promise<void> {
-  const result = await callBotApi(api, botToken, "deleteMessage", { chat_id: t.chatId, message_id: messageId });
-  if (!result.ok) throw new Error(`telegram deleteMessage failed: ${result.status} ${result.description}`.trim());
-}
-/** getMe: the bot's own @username (so default routing recognises group @mentions) and whether group
- *  privacy mode is OFF (`can_read_all_group_messages`) — needed to receive the un-summoned group
- *  messages that feed the context buffer. */
-export async function resolveBotInfo(
-  api: string,
-  botToken: string,
-): Promise<{ username?: string; canReadAllGroupMessages?: boolean }> {
-  const res = await fetch(`${api}/bot${botToken}/getMe`);
-  const data = (await res.json().catch(() => ({}))) as {
-    ok?: boolean;
-    result?: { username?: string; can_read_all_group_messages?: boolean };
-  };
-  if (!res.ok || !data.ok) throw new Error(`getMe failed: ${res.status}`);
-  return { username: data.result?.username, canReadAllGroupMessages: data.result?.can_read_all_group_messages };
+  const notModified = (e: unknown): boolean =>
+    e instanceof TelegramApiError && /message is not modified/i.test(e.description);
+  try {
+    await callApi(api, botToken, "editMessageText", opts.html ? { ...base, parse_mode: "HTML" } : base);
+  } catch (e) {
+    if (notModified(e)) return;
+    if (!(opts.html && e instanceof TelegramApiError && PARSE_ERROR.test(e.description))) throw e;
+    try {
+      await callApi(api, botToken, "editMessageText", base); // plain fallback for rejected markup
+    } catch (e2) {
+      if (!notModified(e2)) throw e2;
+    }
+  }
 }
 
 function mimeFromPath(path: string): string {
@@ -271,17 +338,38 @@ async function getFileBytes(
   botToken: string,
   fileId: string,
 ): Promise<{ bytes: Buffer; remotePath: string }> {
-  const meta = (await fetch(`${api}/bot${botToken}/getFile`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ file_id: fileId }),
-  }).then((r) => r.json())) as { ok?: boolean; result?: { file_path?: string; file_size?: number } };
-  const remotePath = meta.result?.file_path;
-  if (!meta.ok || !remotePath) throw new Error(`getFile failed for ${fileId}`);
-  if ((meta.result?.file_size ?? 0) > MAX_DOWNLOAD_BYTES) throw new Error("file is too large (max 20 MB)");
-  const res = await fetch(`${api}/file/bot${botToken}/${remotePath}`);
-  if (!res.ok) throw new Error(`download failed: ${res.status}`);
-  const bytes = Buffer.from(await res.arrayBuffer());
+  const meta = await callApi(api, botToken, "getFile", { file_id: fileId });
+  const remotePath = meta.file_path;
+  if (!remotePath) throw new Error(`telegram getFile: no file_path in response for ${fileId}`);
+  if ((meta.file_size ?? 0) > MAX_DOWNLOAD_BYTES) throw new Error("file is too large (max 20 MB)");
+  // The byte download is the one non-JSON call (a GET of the file endpoint), so it cannot ride the
+  // pipeline — same timeout + naming discipline, applied here once.
+  let res: Response;
+  let buf: ArrayBuffer | undefined;
+  let errBody: string | undefined;
+  try {
+    res = await fetch(`${api}/file/bot${botToken}/${remotePath}`, {
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    });
+    buf = res.ok ? await res.arrayBuffer() : undefined;
+    errBody = res.ok ? undefined : await res.text(); // the error body self-describes (expired path etc.)
+  } catch (e) {
+    throw new TelegramApiError("file download", 0, String(e), { cause: e });
+  }
+  if (!res.ok || buf === undefined) {
+    let description: string | undefined;
+    try {
+      description = (JSON.parse(errBody ?? "") as { description?: string }).description;
+    } catch {
+      /* non-JSON error body — fall through to the generic description */
+    }
+    throw new TelegramApiError(
+      "file download",
+      res.status,
+      description ?? "Bot API response was not the expected JSON",
+    );
+  }
+  const bytes = Buffer.from(buf);
   if (bytes.byteLength > MAX_DOWNLOAD_BYTES) throw new Error("file is too large (max 20 MB)");
   return { bytes, remotePath };
 }

--- a/core/src/channels/telegram/telegram.ts
+++ b/core/src/channels/telegram/telegram.ts
@@ -23,10 +23,9 @@ import {
   type DownloadedFile,
   type Target,
   TELEGRAM_MAX_TEXT,
-  resolveBotInfo,
+  callApi,
   resolveFiles,
   resolveImages,
-  deleteMessage,
   editMessageText,
   sendMessage,
 } from "./telegram-api.ts";
@@ -219,7 +218,8 @@ async function finalize(
 ): Promise<void> {
   const html = opts.html ?? true;
   if (text.trim() === "") {
-    if (messageId !== undefined) await deleteMessage(api, botToken, target, messageId);
+    if (messageId !== undefined)
+      await callApi(api, botToken, "deleteMessage", { chat_id: target.chatId, message_id: messageId });
     return;
   }
   if (messageId !== undefined) {
@@ -236,7 +236,7 @@ async function finalize(
     }
     // Too long for one message, OR a failed single-message edit: remove the placeholder best-effort (a lingering one above
     // the answer is worse than the extra call), then send the whole reply as fresh, consecutive messages.
-    await deleteMessage(api, botToken, target, messageId).catch(() => {});
+    await callApi(api, botToken, "deleteMessage", { chat_id: target.chatId, message_id: messageId }).catch(() => {});
   }
   await sendMessage(api, botToken, target, text, { html });
 }
@@ -571,10 +571,10 @@ export function telegramChannel(
   // not supplied) and the group-privacy flag — privacy mode off is required to receive the un-summoned
   // group messages that feed the context buffer, so warn if it is on.
   let mentionName = botUsername;
-  void resolveBotInfo(apiBaseUrl, botToken).then(
-    (info) => {
-      if (mentionName === undefined) mentionName = info.username;
-      if (info.canReadAllGroupMessages === false) {
+  void callApi(apiBaseUrl, botToken, "getMe", {}).then(
+    (me) => {
+      if (mentionName === undefined) mentionName = me.username;
+      if (me.can_read_all_group_messages === false) {
         log.warn(
           "[telegram] privacy mode is on: the bot only sees @mentions / replies / commands, so group " +
             "context (un-summoned messages) won't be captured. Disable it via @BotFather → /setprivacy.",

--- a/core/src/tunnel.ts
+++ b/core/src/tunnel.ts
@@ -9,6 +9,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { callApi } from "./channels/telegram/telegram-api.ts";
 import { log } from "./log.ts";
 
 export interface Tunnel {
@@ -174,47 +175,31 @@ async function registerTelegram(baseUrl: string): Promise<void> {
     );
     return;
   }
-  // Backstop after waitForTunnel: Telegram's resolver may lag our health poll by a moment.
+  // Backstop after waitForTunnel: Telegram's resolver may lag our health poll by a moment. The call
+  // itself rides the channel's hardened pipeline (timeout, ok-validation, named failures) — a thrown
+  // timeout stringifies with "timeout" in it, so the transient regex below catches it.
   const ATTEMPTS = 3;
   for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
     if (attempt > 0) await sleep(5000);
-    const result = await trySetWebhook(botToken, webhookUrl, secret);
-    if (result.ok) {
+    try {
+      await callApi("https://api.telegram.org", botToken, "setWebhook", { url: webhookUrl, secret_token: secret });
       log.info(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
       return;
+    } catch (e) {
+      // Only network-transient errors are worth retrying. A fresh tunnel's "bad webhook: Failed to
+      // resolve host" is caught by `resolve host`; a permanent "Bad webhook: HTTPS url must be provided"
+      // is a config error, not transient, so `bad webhook` is deliberately NOT a trigger.
+      const error = String(e);
+      const transient = /resolve host|getaddrinfo|ENOTFOUND|fetch failed|ECONNRESET|timeout/i.test(error);
+      if (!transient) {
+        log.error(`[fastagent] telegram: setWebhook failed (${error}). Register manually with url=${webhookUrl}`);
+        return;
+      }
+      if (attempt < ATTEMPTS - 1)
+        log.warn(`[fastagent] telegram: tunnel not resolvable yet, retrying… (${attempt + 1}/${ATTEMPTS - 1})`);
     }
-    // Only network-transient errors are worth retrying. A fresh tunnel's "bad webhook: Failed to
-    // resolve host" is caught by `resolve host`; a permanent "Bad webhook: HTTPS url must be provided"
-    // is a config error, not transient, so `bad webhook` is deliberately NOT a trigger.
-    const transient = /resolve host|getaddrinfo|ENOTFOUND|fetch failed|ECONNRESET|timeout/i.test(result.error);
-    if (!transient) {
-      log.error(`[fastagent] telegram: setWebhook failed (${result.error}). Register manually with url=${webhookUrl}`);
-      return;
-    }
-    if (attempt < ATTEMPTS - 1)
-      log.warn(`[fastagent] telegram: tunnel not resolvable yet, retrying… (${attempt + 1}/${ATTEMPTS - 1})`);
   }
   log.warn(
     `[fastagent] telegram: webhook still failing after retries (the tunnel may need another moment). Register manually with url=${webhookUrl}`,
   );
-}
-
-/** One setWebhook attempt. Resolves { ok } or { ok: false, error } (HTTP status + description, or a thrown message). */
-async function trySetWebhook(
-  botToken: string,
-  url: string,
-  secret: string,
-): Promise<{ ok: true } | { ok: false; error: string }> {
-  try {
-    const res = await fetch(`https://api.telegram.org/bot${botToken}/setWebhook`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url, secret_token: secret }),
-    });
-    const data = (await res.json().catch(() => ({}))) as { ok?: boolean; description?: string };
-    if (res.ok && data.ok) return { ok: true };
-    return { ok: false, error: `${res.status}${data.description ? `: ${data.description}` : ""}` };
-  } catch (e) {
-    return { ok: false, error: String(e) };
-  }
 }

--- a/core/test/telegram.test.ts
+++ b/core/test/telegram.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defaultTelegramRoute, type TelegramUpdate, telegramChannel, telegramEnvelope } from "../src/telegram.ts";
-import { chunkText, sendMessage } from "../src/channels/telegram/telegram-api.ts";
+import { callApi, chunkText, resolveImages, sendMessage } from "../src/channels/telegram/telegram-api.ts";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
 
 /** A faux Agent that records each invocation's prompt and replies with `reply`. */
@@ -199,6 +199,161 @@ describe("sendMessage HTML fallback", () => {
     expect(plain.length).toBe(1); // ONLY the failing chunk is resent — no whole-body restart
     expect(plain[0]?.text).toBe(secondHtml?.text); // byte-for-byte, injected boundary <pre> included
     expect(plain[0]?.text.startsWith("<pre>")).toBe(true); // the frozen trade-off: the tag leaks as literal text
+  });
+});
+
+// The transport invariants are tested ONCE, against the single pipeline (callApi) they live in — not
+// per method: per-method transport behavior does not exist by construction.
+describe("callApi transport pipeline", () => {
+  const ok = (result: unknown = {}) => new Response(JSON.stringify({ ok: true, result }), { status: 200 });
+
+  it("carries a 30s timeout signal on every call (a wedged connection can't hang the turn)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => ok());
+    vi.stubGlobal("fetch", fetchMock);
+    await callApi(API, "BOT", "getMe", {});
+    // Pin the MECHANISM, not just "some signal": the signal fetch received is the one
+    // AbortSignal.timeout produced — a never-firing plain signal would pass an instanceof check.
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(timeoutSpy.mock.results[0]?.value);
+  });
+
+  it("retries a 429 after the server's retry_after — and actually WAITS, not hammers", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        calls++;
+        if (calls === 1)
+          return new Response(JSON.stringify({ ok: false, parameters: { retry_after: 2 } }), { status: 429 });
+        return ok({ username: "bot" });
+      }),
+    );
+    const p = callApi(API, "BOT", "getMe", {});
+    await vi.advanceTimersByTimeAsync(1000); // before (retry_after 2 + 1) s elapses…
+    expect(calls).toBe(1); // …it is waiting, not retrying immediately
+    await vi.advanceTimersByTimeAsync(2100); // past the wait
+    expect((await p).username).toBe("bot");
+    expect(calls).toBe(2);
+  });
+
+  it("retries a 429 WITHOUT retry_after with a short backoff", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        calls++;
+        if (calls === 1) return new Response(JSON.stringify({ ok: false }), { status: 429 }); // no parameters
+        return ok();
+      }),
+    );
+    const p = callApi(API, "BOT", "getMe", {});
+    await vi.advanceTimersByTimeAsync(1000); // before the (attempt 0 → 1 + 1) s backoff elapses…
+    expect(calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(1100);
+    await p;
+    expect(calls).toBe(2);
+  });
+
+  it("fails fast on a flood ban whose retry_after exceeds the wait cap (no silent hour-long park)", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ ok: false, description: "Too Many Requests", parameters: { retry_after: 3600 } }),
+          { status: 429 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const t0 = Date.now();
+    // The error self-describes the transport's own decision (not just the server's text).
+    await expect(callApi(API, "BOT", "getMe", {})).rejects.toThrow(/exceeds the \d+s flood-wait cap/);
+    expect(Date.now() - t0).toBeLessThan(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // and did not burn retries on it either
+  });
+
+  it("gives up after exhausting 429 retries — bounded, and the error says it retried", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: false, description: "Too Many Requests", parameters: { retry_after: 0 } }), {
+          status: 429,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const p = callApi(API, "BOT", "getMe", {});
+    const rejection = expect(p).rejects.toThrow(/Too Many Requests \(gave up after 3 retries\)/);
+    await vi.advanceTimersByTimeAsync(3500); // three (0+1)s waits, then the 4th attempt fails for good
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledTimes(4); // bounded — not an infinite hammer
+  });
+
+  it("names the failing method when the transport throws (timeout/network)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+      }),
+    );
+    await expect(callApi(API, "BOT", "sendMessage", {})).rejects.toThrow(/telegram sendMessage: .*TimeoutError/);
+  });
+
+  it("a mid-body timeout throws named — never a silent fake success", async () => {
+    // 200 arrives, but reading the body times out. A `.json().catch(() => ({}))` would turn this into a
+    // fake success with no message_id; it must surface as a named transport failure.
+    const res = {
+      ok: true,
+      status: 200,
+      text: async () => {
+        throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+      },
+    } as unknown as Response;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => res),
+    );
+    await expect(callApi(API, "BOT", "sendMessage", {})).rejects.toThrow(/telegram sendMessage: .*TimeoutError/);
+  });
+
+  it("a 200 with a non-JSON body (a proxy's error page) is a named failure, not a fake success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("<html>gateway error</html>", { status: 200 })),
+    );
+    await expect(callApi(API, "BOT", "sendMessage", {})).rejects.toThrow(
+      /telegram sendMessage failed: 200 Bot API response was not the expected JSON/,
+    );
+  });
+});
+
+describe("file download (the one non-JSON call)", () => {
+  it("carries the 120s download timeout (same mechanism pin as the pipeline)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (String(url).endsWith("/getFile"))
+        return new Response(JSON.stringify({ ok: true, result: { file_path: "photos/x.jpg", file_size: 3 } }), {
+          status: 200,
+        });
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const images = await resolveImages(API, "BOT", ["f1"]);
+    expect(images?.length).toBe(1);
+    expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+    const download = fetchMock.mock.calls.find((c) => String(c[0]).includes("/file/"));
+    const produced = timeoutSpy.mock.results[timeoutSpy.mock.calls.findIndex((c) => c[0] === 120_000)];
+    expect(download?.[1]?.signal).toBe(produced?.value);
+  });
+
+  it("names a failing download", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).endsWith("/getFile"))
+        return new Response(JSON.stringify({ ok: true, result: { file_path: "photos/x.jpg" } }), { status: 200 });
+      throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(resolveImages(API, "BOT", ["f1"])).rejects.toThrow(/telegram file download: .*TimeoutError/);
   });
 });
 


### PR DESCRIPTION
## Why

Two PRs of transport hardening (#101, closed unmerged) kept producing the same review finding class: a rule established at one call site (timeout / named failure / guarded body read / ok:true validation) was missing at another. Six hand-rolled fetch sites → every cross-cutting invariant synced by hand → 9 review rounds, and every hand-owned edge needed its own pinning test. The churn was structural.

First-principles rethink + a study of gramIO's source (`bot.ts`) identified its architecture essence — not its feature list:
1. **The Bot API surface is one generic function** (`bot.api` is a Proxy over `_callApi`); per-method code does not exist.
2. **Cross-cutting policy is middleware on that one function** — applied to every method by construction.
3. **Errors are typed objects carrying (method, payload)** — self-description is a property of the type.

## What

`telegram-api.ts` rewritten around that lesson, without the dependency (we speak 6 methods; the hard parts — HTML-string chunking, the send ladder — are ours under any client):

- `callApi<M>` — ONE pipeline for every JSON call; a hand-written `Api` result-type table (adding a method = adding a row). The four transport invariants live in the pipeline and are documented as the module-header spec.
- `TelegramApiError{method,status,description}` — named failures by construction.
- Deleted: the `deleteMessage`/`resolveBotInfo` wrappers (call sites speak the pipeline, bot.api-style), the `{ok:false}` union threading, tunnel's parallel setWebhook fetch (registration now inherits the invariants for free).
- Kept verbatim: `chunkText` + the tag balancer, the chunk+HTML→plain send ladder, edit's not-modified swallow, getFile→download. Scaffold send-tool: documented standalone copy (fail-fast by choice — the agent sees the error and decides).

## Evidence

- Transport invariants tested **once** against the pipeline (~10 tests incl. two-phase clock advances proving the 429 retries actually wait, bounded exhaustion, timeout-signal identity, and the fake-success holes: mid-body stall, 200 + non-JSON body).
- All 60 pre-existing telegram tests pass unchanged — behavior preserved, carrier changed. 287 total.
- Isolated review (`rv.sh local`): **No findings on round 1** — vs 9 rounds for the per-site approach carrying the same semantics.

Tripwire (documented on the `Api` table): if the table needs ~10+ rows or entity-based formatting, adopt gramIO instead of growing it — `callApi<M>` is shape-compatible with `bot.api.*`, so the policy layer survives that swap.
