### PR TITLE
refactor/telegram decompose

### DIFF
--- a/core/src/channels/telegram/context-buffer.ts
+++ b/core/src/channels/telegram/context-buffer.ts
@@ -1,0 +1,185 @@
+/**
+ * Group-context buffer: recent UN-summoned messages per Telegram "place" (chat[:thread]), kept under a
+ * char budget and folded into the next answered turn's prompt, so a summoned agent has the discussion
+ * it didn't see turn-by-turn. Bucketed by place (not session): an un-summoned message has no route
+ * session, and the flush feeds whatever turn answers that place.
+ *
+ * DURABLE: persisted synchronously before the webhook 200 (Telegram never redelivers an ACKed update,
+ * so ACK-then-persist would be a silent-loss window) and reloaded on start. The consume protocol is
+ * peek → (turn completes) → commit: peek renders WITHOUT clearing and snapshots exactly which entries
+ * it consumed; commit removes only those, by object identity — so a failure or crash before the turn's
+ * `completed` leaves them intact for the next summon, and a message that arrives while the turn runs
+ * survives for the next answered turn (a whole-bucket delete would lose it).
+ */
+import { log } from "../../log.ts";
+import { loadStateFile, saveStateFile } from "./state.ts";
+
+/** Char budget for the per-place buffer — bounds the cost of folding it into a prompt; when exceeded
+ *  the OLDEST un-summoned messages are dropped (not a time window: a quiet group keeps its
+ *  sparse-but-relevant lines, a busy burst is capped). */
+const BUFFER_MAX_CHARS = 4000;
+
+/** One buffered un-summoned message (object identity is the commit key). Besides the sender label and
+ *  one-line body, it carries what a LATER summon needs to resolve references into the discussion:
+ *  message ids ("reply to the one Alex answered"), and attachment file_ids so "summarize the file from
+ *  earlier" can actually open it — an un-summoned attachment otherwise surfaces only as its caption or
+ *  a `[document: …]` label, never the bytes. */
+export interface BufferEntry {
+  sender: string;
+  body: string;
+  /** The message's id — rendered into the fold so the model can correlate replies. */
+  messageId?: number;
+  /** The message_id this one replied to, when it was a reply. */
+  replyTo?: number;
+  /** file_ids of document/voice/video/audio attachments (downloadable on a later summon). */
+  fileIds?: string[];
+  /** file_ids of photos (usable as vision inputs on a later summon). */
+  imageIds?: string[];
+}
+
+/** A buffered attachment reference: its file_id plus WHO posted it in WHICH message, so the manifest
+ *  can attribute it ("the file Bob sent") the way the fold attributes text. */
+export interface BufferedRef {
+  id: string;
+  from: string;
+  msg?: number;
+}
+
+/** How many buffered files and images (each, most recent first) a summon pulls in with the folded
+ *  discussion — bounds the latency/token cost of "summarize the file from earlier" against a chatty
+ *  group posting many attachments between summons. Skipped ones are counted into the prompt note, so
+ *  the model never sees an attachment reference it silently cannot open. */
+const BUFFER_ATTACH_MAX = 3;
+
+/** One fold line. ALSO the eviction cost basis: the budget must price what the fold actually renders
+ *  (sender + body + the msg/reply meta), or the fold would systematically overrun BUFFER_MAX_CHARS. */
+function bufferLine(e: BufferEntry): string {
+  const meta = [
+    e.messageId !== undefined ? `msg ${e.messageId}` : undefined,
+    e.replyTo !== undefined ? `reply to msg ${e.replyTo}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  return `${e.sender}${meta ? ` (${meta})` : ""}: ${e.body}`;
+}
+
+/**
+ * The buffered attachment references a summoned turn pulls in with the fold — most recent
+ * BUFFER_ATTACH_MAX of each kind, MINUS the summoning message's own ids: replying to a still-buffered
+ * attachment puts its file_id in both sets, and without the filter the same file would download twice
+ * and appear in the manifest twice (primary wins — it is what the user pointed at this turn).
+ * Cap-skipped ones are COUNTED, not silently dropped: a fold line may show a [document: …] label, but
+ * a captioned attachment renders as its caption text alone — without a note, the model holds
+ * references it silently cannot open and may pretend it read them.
+ */
+export function collectAttachments(
+  consumed: BufferEntry[],
+  primary: { files: Set<string>; images: Set<string> },
+): { files: BufferedRef[]; images: BufferedRef[]; skipped: number } {
+  const refs = (pick: (e: BufferEntry) => string[] | undefined, exclude: Set<string>): BufferedRef[] => {
+    const seen = new Set<string>();
+    const out: BufferedRef[] = [];
+    for (const e of consumed) {
+      for (const id of pick(e) ?? []) {
+        if (exclude.has(id) || seen.has(id)) continue;
+        seen.add(id);
+        out.push({ id, from: e.sender, msg: e.messageId });
+      }
+    }
+    return out;
+  };
+  const files = refs((e) => e.fileIds, primary.files);
+  const images = refs((e) => e.imageIds, primary.images);
+  return {
+    files: files.slice(-BUFFER_ATTACH_MAX),
+    images: images.slice(-BUFFER_ATTACH_MAX),
+    skipped: Math.max(0, files.length - BUFFER_ATTACH_MAX) + Math.max(0, images.length - BUFFER_ATTACH_MAX),
+  };
+}
+
+export interface ContextBuffer {
+  /** Record an un-summoned message. Persists BEFORE returning (pre-ACK: a throw becomes the webhook's
+   *  500, and Telegram redelivers once the disk recovers) — staged on a copy and rolled back on a
+   *  failed write, so the redelivery does not double-append the entry already in memory. */
+  push(placeKey: string, entry: BufferEntry): void;
+  /** Render the fold text and snapshot the consumed entries (see the module header's consume protocol). */
+  peek(placeKey: string): { text: string; consumed: BufferEntry[] };
+  /** Remove exactly `consumed` (by identity) — call on the turn's `completed` event, when the folded
+   *  discussion provably lives in the durable session. Consumes entries WHOLE, including ones whose
+   *  attachments failed to load or were cap-skipped: their text is in the session (keeping them would
+   *  re-fold duplicate text), and the prompt note said what is missing; re-post an attachment to use
+   *  it. Post-ACK: a failed write is logged, never thrown (it must not abort the turn's delivery). */
+  commit(placeKey: string, consumed: BufferEntry[]): void;
+}
+
+/** State files are an IO boundary: valid JSON of the WRONG SHAPE (hand-edited, version drift) must
+ *  degrade exactly like a corrupt file — warn + empty — not flow in as trusted data. */
+function isBufferEntry(e: unknown): e is BufferEntry {
+  const t = e as BufferEntry;
+  const strings = (v: unknown): boolean =>
+    v === undefined || (Array.isArray(v) && v.every((x) => typeof x === "string"));
+  return (
+    typeof t?.sender === "string" &&
+    typeof t.body === "string" &&
+    (t.messageId === undefined || typeof t.messageId === "number") &&
+    (t.replyTo === undefined || typeof t.replyTo === "number") &&
+    strings(t.fileIds) &&
+    strings(t.imageIds)
+  );
+}
+
+export function createContextBuffer(path: string): ContextBuffer {
+  const load = (): Map<string, BufferEntry[]> => {
+    const raw = loadStateFile(path);
+    if (raw === undefined) return new Map();
+    if (
+      typeof raw === "object" &&
+      raw !== null &&
+      !Array.isArray(raw) &&
+      Object.values(raw).every((v) => Array.isArray(v) && v.every(isBufferEntry))
+    ) {
+      return new Map(Object.entries(raw as Record<string, BufferEntry[]>));
+    }
+    log.warn(`[telegram] unexpected shape in ${path} — starting with an empty buffer`);
+    return new Map();
+  };
+  const buffers = load();
+  const persist = (): void => saveStateFile(path, Object.fromEntries(buffers));
+
+  return {
+    push(placeKey, entry) {
+      const prev = buffers.get(placeKey);
+      const buf = prev ? [...prev] : [];
+      buf.push(entry);
+      let total = buf.reduce((n, e) => n + bufferLine(e).length + 1, 0);
+      while (buf.length > 1 && total > BUFFER_MAX_CHARS) {
+        const dropped = buf.shift();
+        if (dropped) total -= bufferLine(dropped).length + 1;
+      }
+      buffers.set(placeKey, buf);
+      try {
+        persist();
+      } catch (e) {
+        if (prev) buffers.set(placeKey, prev);
+        else buffers.delete(placeKey);
+        throw e;
+      }
+    },
+    peek(placeKey) {
+      const buf = buffers.get(placeKey) ?? [];
+      return { text: buf.map(bufferLine).join("\n"), consumed: [...buf] };
+    },
+    commit(placeKey, consumed) {
+      const buf = buffers.get(placeKey);
+      if (!buf) return;
+      const remaining = buf.filter((e) => !consumed.includes(e));
+      if (remaining.length === 0) buffers.delete(placeKey);
+      else buffers.set(placeKey, remaining);
+      try {
+        persist();
+      } catch (e) {
+        log.error(`[telegram] buffer write failed post-ACK (a restart may re-fold answered discussion): ${String(e)}`);
+      }
+    },
+  };
+}

--- a/core/src/channels/telegram/preview.ts
+++ b/core/src/channels/telegram/preview.ts
@@ -1,0 +1,277 @@
+/**
+ * Live-preview rendering: consume one turn's event stream into a Telegram chat. A single real message
+ * is sent once ("💭 Thinking…", or an already-sent "⏳ queued" notice is taken over), then
+ * editMessageText'd in place with the latest tool calls + partial text (PLAIN — a partial answer may
+ * carry unbalanced HTML); on completion the same message is edited into the final answer as HTML. One
+ * message, works in groups and private (unlike sendMessageDraft, which is private/forum-topic only).
+ */
+import type { AgentEvent, Json } from "../../agent.ts";
+import { log } from "../../log.ts";
+import { TELEGRAM_MAX_TEXT, type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
+
+/** A terminal failure, as the channel hands it to `onError`. */
+export interface TelegramFailure {
+  details: string;
+  retryable: boolean;
+}
+
+/** The customer-facing default: neutral, no leaked internals; differentiate only on whether to retry. */
+export function defaultErrorMessage(failed: TelegramFailure): string {
+  return failed.retryable ? "⚠️ Temporary problem — please try again." : "⚠️ Sorry, something went wrong.";
+}
+
+/** How often (ms) to edit the live-preview message; tool events still flush on the next loop. Edits to
+ *  one message are rate-limited tighter than sends, so pace them ~1.5s (vs every token). */
+const EDIT_THROTTLE_MS = 1500;
+
+/** Max length of a tool's arg preview in the live view. */
+const TOOL_ARG_MAX = 48;
+
+/** How much of the (growing) reasoning to peek at in the live view — the most recent tail. */
+const THINKING_PREVIEW = 280;
+
+/** One-line, truncated: collapse whitespace so a multi-line command/arg stays on one line. */
+function clip(s: string): string {
+  const one = s.replace(/\s+/g, " ").trim();
+  return one.length > TOOL_ARG_MAX ? `${one.slice(0, TOOL_ARG_MAX - 1)}…` : one;
+}
+
+/**
+ * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
+ * rather than just `🔧 read`. Generic (the channel knows no tool schemas): show the salient value — the
+ * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
+ */
+function summarizeArgs(args: Json): string {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));
+  const values = Object.values(args);
+  const primary = values.find((v) => typeof v === "string" || typeof v === "number");
+  if (primary !== undefined) return clip(String(primary));
+  return values.length > 0 ? clip(JSON.stringify(args)) : "";
+}
+
+/**
+ * The terminal-write POLICY: resolve the single preview message into `text`. streamReply owns the
+ * preview lifecycle, so this composition of transport primitives lives here, not in telegram-api. One
+ * message → edit the preview in place; if the edit fails (preview gone, or a persistent 429/5xx) fall
+ * back to deleting the placeholder and sending fresh, so no "Thinking…" is left pinned above the answer.
+ * Many messages → delete the preview and send the whole answer as consecutive fresh messages (editing
+ * would pin the first chunk where an active group has scrolled past). No preview → fresh send. EMPTY text
+ * = "say nothing" → just delete the preview.
+ */
+async function finalize(
+  api: string,
+  botToken: string,
+  target: Target,
+  messageId: number | undefined,
+  text: string,
+  opts: { html?: boolean } = {},
+): Promise<void> {
+  const html = opts.html ?? true;
+  if (text.trim() === "") {
+    if (messageId !== undefined)
+      await callApi(api, botToken, "deleteMessage", { chat_id: target.chatId, message_id: messageId });
+    return;
+  }
+  if (messageId !== undefined) {
+    // "Fits in one message" is a plain length check against Telegram's limit — not chunkText, whose html
+    // mode exists for SPLIT chunks and is irrelevant to an un-split text.
+    if (text.length <= TELEGRAM_MAX_TEXT) {
+      try {
+        await editMessageText(api, botToken, target, messageId, text, { html });
+        return;
+      } catch {
+        // Edit failed — the preview may be gone, or still there (429 retries exhausted / 5xx). Fall through
+        // to delete + fresh send below so a still-present "Thinking…" is not left pinned above the answer.
+      }
+    }
+    // Too long for one message, OR a failed single-message edit: remove the placeholder best-effort (a lingering one above
+    // the answer is worse than the extra call), then send the whole reply as fresh, consecutive messages.
+    await callApi(api, botToken, "deleteMessage", { chat_id: target.chatId, message_id: messageId }).catch(() => {});
+  }
+  await sendMessage(api, botToken, target, text, { html });
+}
+
+/**
+ * Consume one turn's event stream into a Telegram chat, live (see the module header for the preview
+ * model). Preview edits are best-effort (logged once if they fail); the final write is authoritative
+ * and surfaces a real failure (bad token, etc.).
+ */
+export async function streamReply(
+  events: AsyncIterable<AgentEvent>,
+  api: string,
+  botToken: string,
+  target: Target,
+  formatError: (failed: TelegramFailure) => string | undefined,
+  previewId?: number,
+): Promise<void> {
+  const tools: { label: string; status: "running" | "ok" | "error" }[] = [];
+  const toolIndexById = new Map<string, number>();
+  let thinking = "";
+  let answer = "";
+
+  const mark = { running: "…", ok: "✓", error: "✗" } as const;
+  const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
+  // Reasoning is process, not the answer: shown (capped to its tail) in the live preview only, never
+  // in the persisted final message (which is `answer` alone).
+  const thinkingView = (): string => {
+    const t = thinking.replace(/\s+/g, " ").trim();
+    if (t === "") return "";
+    return `💭 ${t.length > THINKING_PREVIEW ? `…${t.slice(t.length - THINKING_PREVIEW + 1)}` : t}`;
+  };
+  const view = (): string => {
+    const v = [thinkingView(), toolView(), answer]
+      .filter((s) => s.trim() !== "")
+      .join("\n\n")
+      .trim();
+    // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
+    return v === "" ? "💭 Thinking…" : v;
+  };
+
+  // The live preview is ONE real message: sent once (capturing its id + threading under the asker),
+  // then edited in place. messageId/lastSent are shared with the final write on completion.
+  // `previewId`: an already-sent message to take over as the preview (the "⏳ queued" notice) — the
+  // pump edits it in place, so the queue notice morphs into the live view instead of leaving an orphan.
+  let messageId: number | undefined = previewId;
+  let previewSent = messageId !== undefined; // a placeholder send was attempted — guards against re-sending when no id came back
+  let finalized = false; // a terminal write (completed/failed) ran — the finally skips its orphan cleanup
+  let lastSent = "";
+  const flushPreview = async (): Promise<void> => {
+    const text = view();
+    if (text === lastSent) return; // skip an unchanged edit (Telegram rejects "message is not modified")
+    lastSent = text;
+    if (messageId !== undefined) {
+      await editMessageText(api, botToken, target, messageId, text); // plain — a partial answer may carry unbalanced HTML
+      return;
+    }
+    // No preview message yet. Send the placeholder ONCE; never re-send (that would spam a new message per
+    // frame). If Telegram returns ok WITHOUT a message_id (proxy / odd API base / unparseable body) we
+    // cannot edit — fail visibly and stop previewing (the final write still lands via finalize).
+    if (previewSent) return;
+    previewSent = true;
+    messageId = await sendMessage(api, botToken, target, text, { html: false });
+    if (messageId === undefined)
+      throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
+  };
+
+  // ── Live-preview pump: a SINGLE serialized writer. ──────────────────────────────────────────
+  // Events mutate state (thinking / tools / answer) and mark the preview dirty; the pump edits the
+  // message to the LATEST view() with at most ONE edit in flight, paced by a throttle. One-in-flight is
+  // the whole point: concurrent edits can reach Telegram out of order — an older frame landing over a
+  // newer one is the "shows 3-4 steps, blanks, re-fills" flicker. Serializing keeps frames monotonic.
+  // (No keepalive: a real message does not expire, unlike the old 30s draft.)
+  let dirty = false;
+  let pumping = false;
+  let stopped = false;
+  let previewErrLogged = false;
+  let pumpDone: Promise<void> | undefined;
+  let wakeThrottle: (() => void) | undefined; // set while the pump is mid-throttle; finish() cuts it short
+
+  const runPump = async (): Promise<void> => {
+    pumping = true;
+    try {
+      while (dirty && !stopped) {
+        dirty = false;
+        try {
+          await flushPreview();
+        } catch (e) {
+          // Best-effort preview (the final write is authoritative), but a failing edit must be visible —
+          // log once per turn so a never-rendering preview is diagnosable, not silent.
+          if (!previewErrLogged) {
+            previewErrLogged = true;
+            log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`);
+          }
+        }
+        if (dirty && !stopped) {
+          // Pace + coalesce a burst into one edit. Interruptible: finish() cuts this short so the final
+          // write is not delayed by up to EDIT_THROTTLE_MS after the turn completes.
+          await new Promise<void>((resolve) => {
+            const t = setTimeout(resolve, EDIT_THROTTLE_MS);
+            wakeThrottle = () => {
+              clearTimeout(t);
+              resolve();
+            };
+          });
+          wakeThrottle = undefined;
+        }
+      }
+    } finally {
+      pumping = false;
+    }
+  };
+  // Mark the preview dirty and ensure the single writer is running (an edit already in flight picks up
+  // the new state on its next loop). Synchronous — callers never await a network write.
+  const touch = (): void => {
+    dirty = true;
+    if (!pumping) pumpDone = runPump();
+  };
+
+  touch(); // send the "💭 Thinking…" placeholder immediately
+
+  // Stop the pump and await any in-flight edit, so the final write below is strictly the LAST one to the
+  // preview message (no stale frame landing after the answer).
+  const finish = async (): Promise<void> => {
+    stopped = true;
+    wakeThrottle?.(); // cut an in-flight throttle so the final write is not delayed up to EDIT_THROTTLE_MS
+    await pumpDone?.catch(() => {});
+  };
+
+  try {
+    for await (const e of events) {
+      if (e.type === "text") {
+        answer += e.delta;
+        touch();
+      } else if (e.type === "thinking") {
+        thinking += e.delta;
+        touch();
+      } else if (e.type === "tool_started") {
+        const arg = summarizeArgs(e.args);
+        toolIndexById.set(e.id, tools.length);
+        tools.push({ label: arg ? `${e.name} ${arg}` : e.name, status: "running" });
+        touch();
+      } else if (e.type === "tool_ended") {
+        const i = toolIndexById.get(e.id);
+        const t = i === undefined ? undefined : tools[i];
+        if (t) t.status = e.isError ? "error" : "ok";
+        touch();
+      } else if (e.type === "completed") {
+        await finish();
+        // Edit the preview into the final answer (HTML, plain fallback); the persisted message is the
+        // answer alone — the process (thinking/tools) was preview-only. Mark finalized BEFORE delivering:
+        // the terminal was reached, so a delivery failure here is a plain failure, not an "abnormal exit"
+        // (which would wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
+        finalized = true;
+        await finalize(api, botToken, target, messageId, answer.trim() !== "" ? answer : "(no reply)");
+        return;
+      } else if (e.type === "failed") {
+        await finish();
+        // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
+        // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
+        // write as completed: edit → fresh-send if the preview is gone; an empty notice deletes the
+        // placeholder (suppress = no residue). HTML like the answer — symmetric, and finalize already
+        // falls back to plain if a custom onError returns markup Telegram rejects. Best-effort — we throw
+        // below regardless.
+        finalized = true;
+        {
+          const msg = formatError({ details: e.details, retryable: e.retryable }) ?? "";
+          await finalize(api, botToken, target, messageId, msg).catch(() => {});
+        }
+        throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
+      }
+    }
+    throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
+  } finally {
+    await finish();
+    // Abnormal exit (stream ended without a terminal, the generator threw, or the consumer abandoned): no
+    // terminal write ran. Show the SAME neutral notice a `failed` event would — the preview may show real
+    // partial work, so don't delete it silently, and don't leave the user in silence. A suppressing
+    // onError still collapses to a delete (finalize on empty text).
+    if (!finalized) {
+      // retryable:false — an abnormal end (no terminal / a throw) is of UNKNOWN retryability, so use the
+      // neutral "something went wrong" default rather than promising "try again" that may not help.
+      const notice = formatError({ details: "the turn ended without completing", retryable: false }) ?? "";
+      // finalize handles messageId===undefined (no preview reached) with a fresh send — so the user is
+      // told even when the turn died before any message.
+      await finalize(api, botToken, target, messageId, notice).catch(() => {});
+    }
+  }
+}

--- a/core/src/channels/telegram/register-webhook.ts
+++ b/core/src/channels/telegram/register-webhook.ts
@@ -1,0 +1,49 @@
+/**
+ * `--tunnel` webhook registration for the telegram channel — TELEGRAM-domain logic invoked by the
+ * tunnel's channel dispatch (tunnel.ts orchestrates cloudflared; what "registering telegram" means
+ * lives here, beside the channel it serves). Reads the same .env tokens the channel itself uses.
+ */
+import { setTimeout as sleep } from "node:timers/promises";
+import { log } from "../../log.ts";
+import { callApi } from "./telegram-api.ts";
+
+/** Register `<baseUrl>/telegram` as the bot's webhook (with the .env secret), retrying while a fresh
+ *  tunnel's DNS settles. Missing tokens print the manual instruction instead of failing the tunnel. */
+export async function registerTelegramWebhook(baseUrl: string): Promise<void> {
+  const botToken = process.env.TELEGRAM_BOT_TOKEN;
+  const secret = process.env.TELEGRAM_SECRET_TOKEN;
+  const webhookUrl = `${baseUrl}/telegram`;
+  if (!botToken || !secret) {
+    log.info(
+      `[fastagent] telegram: set TELEGRAM_BOT_TOKEN + TELEGRAM_SECRET_TOKEN in .env, then re-run to auto-register. Webhook URL: ${webhookUrl}`,
+    );
+    return;
+  }
+  // Backstop after the tunnel's health poll: Telegram's resolver may lag it by a moment. The call
+  // itself rides the channel's hardened pipeline (timeout, ok-validation, named failures) — a thrown
+  // timeout stringifies with "timeout" in it, so the transient regex below catches it.
+  const ATTEMPTS = 3;
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    if (attempt > 0) await sleep(5000);
+    try {
+      await callApi("https://api.telegram.org", botToken, "setWebhook", { url: webhookUrl, secret_token: secret });
+      log.info(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
+      return;
+    } catch (e) {
+      // Only network-transient errors are worth retrying. A fresh tunnel's "bad webhook: Failed to
+      // resolve host" is caught by `resolve host`; a permanent "Bad webhook: HTTPS url must be provided"
+      // is a config error, not transient, so `bad webhook` is deliberately NOT a trigger.
+      const error = String(e);
+      const transient = /resolve host|getaddrinfo|ENOTFOUND|fetch failed|ECONNRESET|timeout/i.test(error);
+      if (!transient) {
+        log.error(`[fastagent] telegram: setWebhook failed (${error}). Register manually with url=${webhookUrl}`);
+        return;
+      }
+      if (attempt < ATTEMPTS - 1)
+        log.warn(`[fastagent] telegram: tunnel not resolvable yet, retrying… (${attempt + 1}/${ATTEMPTS - 1})`);
+    }
+  }
+  log.warn(
+    `[fastagent] telegram: webhook still failing after retries (the tunnel may need another moment). Register manually with url=${webhookUrl}`,
+  );
+}

--- a/core/src/channels/telegram/telegram.ts
+++ b/core/src/channels/telegram/telegram.ts
@@ -5,98 +5,43 @@
  * is a JSON POST, outbound is a `fetch` to the Bot API. The developer writes only `route` (policy); the
  * channel owns transport + format + attachments.
  *
- * Live streaming: a single "💭 Thinking…" message is sent once, then editMessageText'd in place with the
- * latest tool calls + partial text (PLAIN — a partial answer may carry unbalanced HTML); on completion
- * the same message is edited into the final answer as HTML. One message, works in groups and private
- * (unlike sendMessageDraft, which is private/forum-topic only). Threaded Mode (topics in private
- * chats, a @BotFather toggle) is auto-adapted: an update carrying message_thread_id replies into that
- * thread; without one the chat is linear. Same code, both modes.
+ * This file is the Telegram DOMAIN: ingress + summon policy + prompt assembly. The subsystems it
+ * composes each own their invariants in their own module:
+ *   - turn-store.ts     durable per-session serial execution, crash recovery, redelivery dedup
+ *   - context-buffer.ts un-summoned group discussion, folded into the next answered turn
+ *   - preview.ts        the live-preview pump ("💭 Thinking…" → edits → final answer) + terminal writes
+ *   - telegram-api.ts   the single Bot API pipeline (timeouts, 429, ok-gating, HTML-aware split)
+ *   - state.ts          atomic state files under the channel-state home
+ *
+ * Threaded Mode (topics in private chats, a @BotFather toggle) is auto-adapted: an update carrying
+ * message_thread_id replies into that thread; without one the chat is linear. Same code, both modes.
  *
  * Authored against the public `@kid7st/fastagent` surface only (the contract + the channel-authoring
  * kit: readBodyCapped / text), so it is exactly what a third-party `fastagent-channel-*` package would write.
  */
 import { timingSafeEqual } from "node:crypto";
 import { join, resolve } from "node:path";
-import type { Agent, AgentEvent, ImageRef, Json } from "../../agent.ts";
+import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
 import { log } from "../../log.ts";
 import { readBodyCapped } from "../body.ts";
-import {
-  type DownloadedFile,
-  type Target,
-  TELEGRAM_MAX_TEXT,
-  callApi,
-  resolveFiles,
-  resolveImages,
-  editMessageText,
-  sendMessage,
-} from "./telegram-api.ts";
 import { text } from "../respond.ts";
-import { ensureStateHome, loadStateFile, saveStateFile } from "./state.ts";
+import { type BufferedRef, collectAttachments, createContextBuffer } from "./context-buffer.ts";
+import { type TelegramFailure, defaultErrorMessage, streamReply } from "./preview.ts";
+import { ensureStateHome } from "./state.ts";
+import { type DownloadedFile, type Target, callApi, resolveFiles, resolveImages, sendMessage } from "./telegram-api.ts";
+import { type TurnRecord, createTurnStore } from "./turn-store.ts";
+
+export type { TelegramFailure };
 
 /** Update body cap — Telegram updates are small JSON; 1 MiB is generous and guards a public endpoint. */
 const MAX_UPDATE_BYTES = 1 << 20;
 
-/** Char budget for the per-place group-context buffer — bounds the cost of folding it into a prompt;
- *  when exceeded the OLDEST un-summoned messages are dropped (not a time window: a quiet group keeps its
- *  sparse-but-relevant lines, a busy burst is capped). */
-const BUFFER_MAX_CHARS = 4000;
-
-/** One buffered un-summoned message (object identity is the commit key). Besides the sender label and
- *  one-line body, it carries what a LATER summon needs to resolve references into the discussion:
- *  message ids ("reply to the one Alex answered"), and attachment file_ids so "summarize the file from
- *  earlier" can actually open it — an un-summoned attachment otherwise surfaces only as its caption or
- *  a `[document: …]` label, never the bytes. */
-interface BufferEntry {
-  sender: string;
-  body: string;
-  /** The message's id — rendered into the fold so the model can correlate replies. */
-  messageId?: number;
-  /** The message_id this one replied to, when it was a reply. */
-  replyTo?: number;
-  /** file_ids of document/voice/video/audio attachments (downloadable on a later summon). */
-  fileIds?: string[];
-  /** file_ids of photos (usable as vision inputs on a later summon). */
-  imageIds?: string[];
-}
-
-/** A buffered attachment reference: its file_id plus WHO posted it in WHICH message, so the manifest
- *  can attribute it ("the file Bob sent") the way the fold attributes text. */
-interface BufferedRef {
-  id: string;
-  from: string;
-  msg?: number;
-}
-
-/** How many buffered files and images (each, most recent first) a summon pulls in with the folded
- *  discussion — bounds the latency/token cost of "summarize the file from earlier" against a chatty
- *  group posting many attachments between summons. Skipped ones are counted into the prompt note, so
- *  the model never sees an attachment reference it silently cannot open. */
-const BUFFER_ATTACH_MAX = 3;
-
-/** One fold line. ALSO the eviction cost basis: the budget must price what the fold actually renders
- *  (sender + body + the msg/reply meta), or the fold would systematically overrun BUFFER_MAX_CHARS. */
-function bufferLine(e: BufferEntry): string {
-  const meta = [
-    e.messageId !== undefined ? `msg ${e.messageId}` : undefined,
-    e.replyTo !== undefined ? `reply to msg ${e.replyTo}` : undefined,
-  ]
-    .filter(Boolean)
-    .join(", ");
-  return `${e.sender}${meta ? ` (${meta})` : ""}: ${e.body}`;
-}
-
-/** One accepted-but-unfinished turn, as persisted in the queue WAL: everything needed to run it again
- *  after a restart (Telegram never redelivers an ACKed update, so this record IS the turn). */
-interface PendingTurn {
-  /** The update_id — the turn's identity in logs and on disk. */
-  id: string;
+/** One accepted-but-unfinished turn, as persisted in the turn store's WAL: everything needed to run it
+ *  again after a restart (Telegram never redelivers an ACKed update, so this record IS the turn). */
+interface PendingTurn extends TurnRecord {
   /** The "⏳ queued" notice's message_id, when one was sent — the turn's preview takes it over (and a
    *  replay after a restart reuses it instead of orphaning it). */
   previewId?: number;
-  /** `queued` → never reached the agent, safe to replay; `started` → may have already sent output,
-   *  replaying risks a duplicate answer, so recovery drops it loudly instead. */
-  state: "queued" | "started";
-  session: string;
   placeKey: string;
   baseText: string;
   chatId: number | string;
@@ -106,33 +51,24 @@ interface PendingTurn {
   fileIds: string[];
 }
 
-/** How often (ms) to edit the live-preview message; tool events still flush on the next loop. Edits to
- *  one message are rate-limited tighter than sends, so pace them ~1.5s (vs every token). */
-const EDIT_THROTTLE_MS = 1500;
-
-/** Max length of a tool's arg preview in the live view. */
-const TOOL_ARG_MAX = 48;
-
-/** How much of the (growing) reasoning to peek at in the live view — the most recent tail. */
-const THINKING_PREVIEW = 280;
-
-/** One-line, truncated: collapse whitespace so a multi-line command/arg stays on one line. */
-function clip(s: string): string {
-  const one = s.replace(/\s+/g, " ").trim();
-  return one.length > TOOL_ARG_MAX ? `${one.slice(0, TOOL_ARG_MAX - 1)}…` : one;
-}
-
-/**
- * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
- * rather than just `🔧 read`. Generic (the channel knows no tool schemas): show the salient value — the
- * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
- */
-function summarizeArgs(args: Json): string {
-  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));
-  const values = Object.values(args);
-  const primary = values.find((v) => typeof v === "string" || typeof v === "number");
-  if (primary !== undefined) return clip(String(primary));
-  return values.length > 0 ? clip(JSON.stringify(args)) : "";
+/** Shape validation at the turn store's IO boundary (the record shape is this channel's, not the store's). */
+function isPendingTurn(r: unknown): r is PendingTurn {
+  const t = r as PendingTurn;
+  return (
+    typeof t?.id === "string" &&
+    (t.state === "queued" || t.state === "started") &&
+    typeof t.session === "string" &&
+    typeof t.placeKey === "string" &&
+    typeof t.baseText === "string" &&
+    (typeof t.chatId === "number" || typeof t.chatId === "string") &&
+    (t.threadId === undefined || typeof t.threadId === "number") &&
+    (t.replyTo === undefined || typeof t.replyTo === "number") &&
+    (t.previewId === undefined || typeof t.previewId === "number") &&
+    Array.isArray(t.imageFileIds) &&
+    t.imageFileIds.every((x) => typeof x === "string") &&
+    Array.isArray(t.fileIds) &&
+    t.fileIds.every((x) => typeof x === "string")
+  );
 }
 
 /** A Telegram message (the common subset; `[k]` keeps the rest reachable without a types dependency). */
@@ -175,12 +111,6 @@ export interface TelegramUpdate {
   message?: TelegramMessage;
   channel_post?: TelegramMessage;
   [k: string]: unknown;
-}
-
-/** A terminal failure, as the channel hands it to `onError`. */
-export interface TelegramFailure {
-  details: string;
-  retryable: boolean;
 }
 
 /** What `route` returns: act with these (every field optional — omitted ones default from the message), or null to ignore. */
@@ -303,7 +233,7 @@ async function* invokeWithAttachments(
   // PRIMARY first, background after — consistent with "primary wins": what the user pointed at this
   // turn leads. Buffered file entries are attributed like the fold's text lines ("the file Bob sent"
   // resolves); buffered PHOTOS cannot be (ImageRef carries no label), so their attribution stops at
-  // the fold's attachment markers (bufferPush appends `[photo]` even to captioned lines) — a
+  // the fold's attachment markers (the buffer appends `[photo]` even to captioned lines) — a
   // documented limit.
   const allFiles = [
     ...(files ?? []),
@@ -322,239 +252,6 @@ async function* invokeWithAttachments(
   )) {
     if (e.type === "completed") onCompleted?.(); // the turn is durably in the session — commit point
     yield e;
-  }
-}
-
-/** The customer-facing default: neutral, no leaked internals; differentiate only on whether to retry. */
-function defaultErrorMessage(failed: TelegramFailure): string {
-  return failed.retryable ? "⚠️ Temporary problem — please try again." : "⚠️ Sorry, something went wrong.";
-}
-
-/**
- * The terminal-write POLICY: resolve the single preview message into `text`. streamReply owns the
- * preview lifecycle, so this composition of transport primitives lives here, not in telegram-api. One
- * message → edit the preview in place; if the edit fails (preview gone, or a persistent 429/5xx) fall
- * back to deleting the placeholder and sending fresh, so no "Thinking…" is left pinned above the answer.
- * Many messages → delete the preview and send the whole answer as consecutive fresh messages (editing
- * would pin the first chunk where an active group has scrolled past). No preview → fresh send. EMPTY text
- * = "say nothing" → just delete the preview.
- */
-async function finalize(
-  api: string,
-  botToken: string,
-  target: Target,
-  messageId: number | undefined,
-  text: string,
-  opts: { html?: boolean } = {},
-): Promise<void> {
-  const html = opts.html ?? true;
-  if (text.trim() === "") {
-    if (messageId !== undefined)
-      await callApi(api, botToken, "deleteMessage", { chat_id: target.chatId, message_id: messageId });
-    return;
-  }
-  if (messageId !== undefined) {
-    // "Fits in one message" is a plain length check against Telegram's limit — not chunkText, whose html
-    // mode exists for SPLIT chunks and is irrelevant to an un-split text.
-    if (text.length <= TELEGRAM_MAX_TEXT) {
-      try {
-        await editMessageText(api, botToken, target, messageId, text, { html });
-        return;
-      } catch {
-        // Edit failed — the preview may be gone, or still there (429 retries exhausted / 5xx). Fall through
-        // to delete + fresh send below so a still-present "Thinking…" is not left pinned above the answer.
-      }
-    }
-    // Too long for one message, OR a failed single-message edit: remove the placeholder best-effort (a lingering one above
-    // the answer is worse than the extra call), then send the whole reply as fresh, consecutive messages.
-    await callApi(api, botToken, "deleteMessage", { chat_id: target.chatId, message_id: messageId }).catch(() => {});
-  }
-  await sendMessage(api, botToken, target, text, { html });
-}
-
-/**
- * Consume one turn's event stream into a Telegram chat, live. A single preview message is sent once and
- * editMessageText'd in place with the latest tool calls + partial text (PLAIN); on completion it is
- * edited into the final answer (HTML). Preview edits are best-effort (logged once if they fail); the
- * final write is authoritative and surfaces a real failure (bad token, etc.).
- */
-async function streamReply(
-  events: AsyncIterable<AgentEvent>,
-  api: string,
-  botToken: string,
-  target: Target,
-  formatError: (failed: TelegramFailure) => string | undefined,
-  previewId?: number,
-): Promise<void> {
-  const tools: { label: string; status: "running" | "ok" | "error" }[] = [];
-  const toolIndexById = new Map<string, number>();
-  let thinking = "";
-  let answer = "";
-
-  const mark = { running: "…", ok: "✓", error: "✗" } as const;
-  const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
-  // Reasoning is process, not the answer: shown (capped to its tail) in the live preview only, never
-  // in the persisted final message (which is `answer` alone).
-  const thinkingView = (): string => {
-    const t = thinking.replace(/\s+/g, " ").trim();
-    if (t === "") return "";
-    return `💭 ${t.length > THINKING_PREVIEW ? `…${t.slice(t.length - THINKING_PREVIEW + 1)}` : t}`;
-  };
-  const view = (): string => {
-    const v = [thinkingView(), toolView(), answer]
-      .filter((s) => s.trim() !== "")
-      .join("\n\n")
-      .trim();
-    // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
-    return v === "" ? "💭 Thinking…" : v;
-  };
-
-  // The live preview is ONE real message: sent once (capturing its id + threading under the asker),
-  // then edited in place. messageId/lastSent are shared with the final write on completion.
-  // `previewId`: an already-sent message to take over as the preview (the "⏳ queued" notice) — the
-  // pump edits it in place, so the queue notice morphs into the live view instead of leaving an orphan.
-  let messageId: number | undefined = previewId;
-  let previewSent = messageId !== undefined; // a placeholder send was attempted — guards against re-sending when no id came back
-  let finalized = false; // a terminal write (completed/failed) ran — the finally skips its orphan cleanup
-  let lastSent = "";
-  const flushPreview = async (): Promise<void> => {
-    const text = view();
-    if (text === lastSent) return; // skip an unchanged edit (Telegram rejects "message is not modified")
-    lastSent = text;
-    if (messageId !== undefined) {
-      await editMessageText(api, botToken, target, messageId, text); // plain — a partial answer may carry unbalanced HTML
-      return;
-    }
-    // No preview message yet. Send the placeholder ONCE; never re-send (that would spam a new message per
-    // frame). If Telegram returns ok WITHOUT a message_id (proxy / odd API base / unparseable body) we
-    // cannot edit — fail visibly and stop previewing (the final write still lands via finalize).
-    if (previewSent) return;
-    previewSent = true;
-    messageId = await sendMessage(api, botToken, target, text, { html: false });
-    if (messageId === undefined)
-      throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
-  };
-
-  // ── Live-preview pump: a SINGLE serialized writer. ──────────────────────────────────────────
-  // Events mutate state (thinking / tools / answer) and mark the preview dirty; the pump edits the
-  // message to the LATEST view() with at most ONE edit in flight, paced by a throttle. One-in-flight is
-  // the whole point: concurrent edits can reach Telegram out of order — an older frame landing over a
-  // newer one is the "shows 3-4 steps, blanks, re-fills" flicker. Serializing keeps frames monotonic.
-  // (No keepalive: a real message does not expire, unlike the old 30s draft.)
-  let dirty = false;
-  let pumping = false;
-  let stopped = false;
-  let previewErrLogged = false;
-  let pumpDone: Promise<void> | undefined;
-  let wakeThrottle: (() => void) | undefined; // set while the pump is mid-throttle; finish() cuts it short
-
-  const runPump = async (): Promise<void> => {
-    pumping = true;
-    try {
-      while (dirty && !stopped) {
-        dirty = false;
-        try {
-          await flushPreview();
-        } catch (e) {
-          // Best-effort preview (the final write is authoritative), but a failing edit must be visible —
-          // log once per turn so a never-rendering preview is diagnosable, not silent.
-          if (!previewErrLogged) {
-            previewErrLogged = true;
-            log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`);
-          }
-        }
-        if (dirty && !stopped) {
-          // Pace + coalesce a burst into one edit. Interruptible: finish() cuts this short so the final
-          // write is not delayed by up to EDIT_THROTTLE_MS after the turn completes.
-          await new Promise<void>((resolve) => {
-            const t = setTimeout(resolve, EDIT_THROTTLE_MS);
-            wakeThrottle = () => {
-              clearTimeout(t);
-              resolve();
-            };
-          });
-          wakeThrottle = undefined;
-        }
-      }
-    } finally {
-      pumping = false;
-    }
-  };
-  // Mark the preview dirty and ensure the single writer is running (an edit already in flight picks up
-  // the new state on its next loop). Synchronous — callers never await a network write.
-  const touch = (): void => {
-    dirty = true;
-    if (!pumping) pumpDone = runPump();
-  };
-
-  touch(); // send the "💭 Thinking…" placeholder immediately
-
-  // Stop the pump and await any in-flight edit, so the final write below is strictly the LAST one to the
-  // preview message (no stale frame landing after the answer).
-  const finish = async (): Promise<void> => {
-    stopped = true;
-    wakeThrottle?.(); // cut an in-flight throttle so the final write is not delayed up to EDIT_THROTTLE_MS
-    await pumpDone?.catch(() => {});
-  };
-
-  try {
-    for await (const e of events) {
-      if (e.type === "text") {
-        answer += e.delta;
-        touch();
-      } else if (e.type === "thinking") {
-        thinking += e.delta;
-        touch();
-      } else if (e.type === "tool_started") {
-        const arg = summarizeArgs(e.args);
-        toolIndexById.set(e.id, tools.length);
-        tools.push({ label: arg ? `${e.name} ${arg}` : e.name, status: "running" });
-        touch();
-      } else if (e.type === "tool_ended") {
-        const i = toolIndexById.get(e.id);
-        const t = i === undefined ? undefined : tools[i];
-        if (t) t.status = e.isError ? "error" : "ok";
-        touch();
-      } else if (e.type === "completed") {
-        await finish();
-        // Edit the preview into the final answer (HTML, plain fallback); the persisted message is the
-        // answer alone — the process (thinking/tools) was preview-only. Mark finalized BEFORE delivering:
-        // the terminal was reached, so a delivery failure here is a plain failure, not an "abnormal exit"
-        // (which would wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
-        finalized = true;
-        await finalize(api, botToken, target, messageId, answer.trim() !== "" ? answer : "(no reply)");
-        return;
-      } else if (e.type === "failed") {
-        await finish();
-        // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
-        // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
-        // write as completed: edit → fresh-send if the preview is gone; an empty notice deletes the
-        // placeholder (suppress = no residue). HTML like the answer — symmetric, and finalize already
-        // falls back to plain if a custom onError returns markup Telegram rejects. Best-effort — we throw
-        // below regardless.
-        finalized = true;
-        {
-          const msg = formatError({ details: e.details, retryable: e.retryable }) ?? "";
-          await finalize(api, botToken, target, messageId, msg).catch(() => {});
-        }
-        throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
-      }
-    }
-    throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
-  } finally {
-    await finish();
-    // Abnormal exit (stream ended without a terminal, the generator threw, or the consumer abandoned): no
-    // terminal write ran. Show the SAME neutral notice a `failed` event would — the preview may show real
-    // partial work, so don't delete it silently, and don't leave the user in silence. A suppressing
-    // onError still collapses to a delete (finalize on empty text).
-    if (!finalized) {
-      // retryable:false — an abnormal end (no terminal / a throw) is of UNKNOWN retryability, so use the
-      // neutral "something went wrong" default rather than promising "try again" that may not help.
-      const notice = formatError({ details: "the turn ended without completing", retryable: false }) ?? "";
-      // finalize handles messageId===undefined (no preview reached) with a fresh send — so the user is
-      // told even when the turn died before any message.
-      await finalize(api, botToken, target, messageId, notice).catch(() => {});
-    }
   }
 }
 
@@ -757,229 +454,63 @@ export function telegramChannel(
   }
   const decide =
     route ?? ((update: TelegramUpdate) => defaultTelegramRoute(update, { botUsername: mentionName, botId }));
-  // Per-session serial queue: model B answers a shared chat[:thread] with ONE turn at a time, so a
-  // second update for the same session waits its turn (FIFO) instead of colliding on the engine lease
-  // and being dropped as "busy" — the wrong UX when several people talk in one group. Different sessions
-  // run concurrently (the engine's stateless multi-session invoke). The chain itself is in-memory; the
-  // pending-turn WAL below is what survives a restart. SPEC §8 leaves this concurrency policy to the
-  // channel.
-  const sessionChains = new Map<string, Promise<void>>();
-  const enqueueTurn = (session: string, task: () => Promise<void>): void => {
-    const prev = sessionChains.get(session) ?? Promise.resolve();
-    const next = prev.then(task, task); // run after this session's previous turn, in arrival order
-    sessionChains.set(session, next);
-    void next.finally(() => {
-      if (sessionChains.get(session) === next) sessionChains.delete(session); // drop the entry when drained
-    });
-  };
-  // Group-context buffer: recent UN-summoned messages per Telegram "place" (chat[:thread]), kept under
-  // a char budget and folded into the next answered turn's prompt so a summoned agent has the discussion
-  // it didn't see turn-by-turn. Bucketed by place (not session): an un-summoned message has no route
-  // session, and the flush feeds whatever turn answers that place. DURABLE: persisted (synchronously,
-  // before the webhook 200 — Telegram never redelivers an ACKed update) and reloaded on start, so a
-  // restart keeps the discussion. Needs group privacy OFF to receive the messages at all.
+
   // Normalize once: a relative stateDir resolves against the process cwd HERE, so every derived path
   // (incl. the attachment paths handed to the agent) honours DownloadedFile's absolute-path contract.
   const stateHome = resolve(stateDir);
   ensureStateHome(stateHome); // create + self-ignore — buffers/WAL/files may carry chat content
-  const buffersPath = join(stateHome, "buffers.json");
-  const queuePath = join(stateHome, "queue.json");
-  // State files are an IO boundary: valid JSON of the WRONG SHAPE (hand-edited, version drift) must
-  // degrade exactly like a corrupt file — warn + empty — not flow into the channel as trusted data.
-  const isBufferEntry = (e: unknown): e is BufferEntry => {
-    const t = e as BufferEntry;
-    const strings = (v: unknown): boolean =>
-      v === undefined || (Array.isArray(v) && v.every((x) => typeof x === "string"));
-    return (
-      typeof t?.sender === "string" &&
-      typeof t.body === "string" &&
-      (t.messageId === undefined || typeof t.messageId === "number") &&
-      (t.replyTo === undefined || typeof t.replyTo === "number") &&
-      strings(t.fileIds) &&
-      strings(t.imageIds)
-    );
-  };
-  const loadBuffers = (): Map<string, BufferEntry[]> => {
-    const raw = loadStateFile(buffersPath);
-    if (raw === undefined) return new Map();
-    if (
-      typeof raw === "object" &&
-      raw !== null &&
-      !Array.isArray(raw) &&
-      Object.values(raw).every((v) => Array.isArray(v) && v.every(isBufferEntry))
-    ) {
-      return new Map(Object.entries(raw as Record<string, BufferEntry[]>));
-    }
-    log.warn(`[telegram] unexpected shape in ${buffersPath} — starting with an empty buffer`);
-    return new Map();
-  };
-  const buffers = loadBuffers();
-  const persistBuffers = (): void => saveStateFile(buffersPath, Object.fromEntries(buffers));
-  const bufferPush = (placeKey: string, entry: BufferEntry): void => {
-    // Stage on a copy and roll back if the pre-ACK persist throws: the throw becomes a 500 and Telegram
-    // REDELIVERS — with the entry already in memory, the redelivery would append it a second time.
-    const prev = buffers.get(placeKey);
-    const buf = prev ? [...prev] : [];
-    buf.push(entry);
-    let total = buf.reduce((n, e) => n + bufferLine(e).length + 1, 0);
-    while (buf.length > 1 && total > BUFFER_MAX_CHARS) {
-      const dropped = buf.shift();
-      if (dropped) total -= bufferLine(dropped).length + 1;
-    }
-    buffers.set(placeKey, buf);
-    try {
-      persistBuffers();
-    } catch (e) {
-      if (prev) buffers.set(placeKey, prev);
-      else buffers.delete(placeKey);
-      throw e;
-    }
-  };
-  // Peek renders the buffer WITHOUT clearing and snapshots exactly which entries it consumed; the commit
-  // (on the turn's COMPLETED event — only then is the folded discussion durably in the session) removes
-  // only those entries by identity. So a failure or crash anywhere earlier leaves them intact for the
-  // next summon, AND a message that arrives while the turn runs (pushed to the same bucket, not in this
-  // prompt) survives for the next answered turn — a whole-bucket delete would lose it.
-  // Message ids in the fold let the model resolve references ("the one Bob replied to") — rendered
-  // only when known (bufferLine), so a plain line stays plain.
-  const bufferPeek = (placeKey: string): { text: string; consumed: BufferEntry[] } => {
-    const buf = buffers.get(placeKey) ?? [];
-    return { text: buf.map(bufferLine).join("\n"), consumed: [...buf] };
-  };
-  // Commit consumes entries WHOLE — including ones whose attachments failed to load or were cap-
-  // skipped: their text is durably in the session (keeping them would re-fold duplicate text), and the
-  // prompt note told the model/user what is missing; re-post an attachment to use it. The alternative
-  // (retrying unloaded attachments on later summons) buys a rare recovery at the cost of duplicated
-  // context every time — rejected.
-  const bufferCommit = (placeKey: string, consumed: BufferEntry[]): void => {
-    const buf = buffers.get(placeKey);
-    if (!buf) return;
-    const remaining = buf.filter((e) => !consumed.includes(e));
-    if (remaining.length === 0) buffers.delete(placeKey);
-    else buffers.set(placeKey, remaining);
-    // Post-ACK write: a disk error here must not abort the turn's delivery — log it; whatever the last
-    // successful write left on disk still holds the committed entries, so a restart merely re-folds
-    // already-answered discussion. (bufferPush's write, by contrast, is PRE-ACK and deliberately
-    // throws: the 500 makes Telegram redeliver once the disk recovers.)
-    try {
-      persistBuffers();
-    } catch (e) {
-      log.error(`[telegram] buffer write failed post-ACK (a restart may re-fold answered discussion): ${String(e)}`);
-    }
-  };
+  const buffer = createContextBuffer(join(stateHome, "buffers.json"));
 
-  // Pending-turn queue WAL: an accepted turn is persisted from ACK to completion, so a crash between
-  // the two is not a silent loss. Recovery: `queued` records never reached the agent — replay them in
-  // arrival order; a `started` record may have already sent output, so it is dropped LOUDLY (replaying
-  // would risk a duplicate answer — a visible loss beats a confusing double reply).
-  const pending = new Map<string, PendingTurn>();
-  // Tombstones for every update_id the WAL RECOVERY took over — dropped (started) AND replayed (queued)
-  // alike: if the previous process died BEFORE its webhook 200 went out, Telegram redelivers the same
-  // update, and without a tombstone the redelivery would run the turn a second time (the dropped one may
-  // already have answered; the replayed one answers via the replay). Persisted alongside the queue so
-  // they survive a further restart. Bounded by turn count, not time: Telegram's redelivery retries span
-  // minutes–hours of backoff, far fewer than 50 turns in any deployment this channel targets — an
-  // evicted id being redelivered is an extreme edge where a rare duplicate beats unbounded growth.
-  const tombstones = new Set<string>();
-  const TOMBSTONES_MAX = 50;
-  const tombstone = (id: string): void => {
-    tombstones.add(id);
-    for (const old of tombstones) {
-      if (tombstones.size <= TOMBSTONES_MAX) break;
-      tombstones.delete(old);
-    }
-  };
-  const persistQueue = (): void =>
-    saveStateFile(queuePath, { pending: [...pending.values()], tombstones: [...tombstones] });
-  // For WAL writes AFTER the webhook 200: a disk error there has no request to fail into, and an
-  // uncaught throw inside a queued task would surface as an unhandled rejection — log instead. The
-  // stale-but-atomic WAL stays diagnosable: at worst a completed turn is still `started` on disk, and
-  // the next restart drops + tombstones it (no redelivery is coming — its 200 was long delivered).
-  const persistQueuePostAck = (): void => {
-    try {
-      persistQueue();
-    } catch (e) {
-      log.error(`[telegram] WAL write failed post-ACK (state stale until the next write): ${String(e)}`);
-    }
-  };
-  // Enqueue only — durability is the CALLER's line: the webhook path persists per turn (pre-ACK, a
-  // throw becomes a 500 and Telegram redelivers), while recovery replays MANY records already on disk
-  // and persists ONCE after the loop — a per-record persist there could fail mid-loop and leave the
-  // already-replayed prefix still `queued` in the WAL, to be replayed AGAIN on the next boot.
   // In-memory: the in-flight "⏳ queued" notice per turn, awaited at dequeue so the turn reliably takes
   // the notice message over (rec.previewId) instead of racing it and orphaning a late-arriving notice.
   const notices = new Map<string, Promise<void>>();
-  const runTurn = (rec: PendingTurn): void => {
-    pending.set(rec.id, rec);
-    const target: Target = { chatId: rec.chatId, threadId: rec.threadId, replyTo: rec.replyTo };
+  const store = createTurnStore<PendingTurn>({
+    path: join(stateHome, "queue.json"),
+    label: "[telegram]",
+    isRecord: isPendingTurn,
     // Queue feedback: when this session already has a turn running/queued, a silent wait reads as "the
     // bot ignored me" once the current turn runs long — tell the asker NOW (reply-quoted, so it is
     // clear whose ask is queued). Best-effort and post-ACK: a failed notice is a log line, never a
     // failed update. The turn's live preview then edits this same message in place.
-    if (rec.previewId === undefined && sessionChains.has(rec.session)) {
+    onQueuedBehind: (rec, s) => {
+      if (rec.previewId !== undefined) return; // a replayed record that already has its notice
+      const target: Target = { chatId: rec.chatId, threadId: rec.threadId, replyTo: rec.replyTo };
       notices.set(
         rec.id,
         sendMessage(apiBaseUrl, botToken, target, "⏳ Queued — I’ll start once the current task finishes.", {
           html: false,
         }).then(
           (id) => {
-            if (id !== undefined) {
-              rec.previewId = id;
-              persistQueuePostAck(); // a replay after a restart reuses the notice instead of orphaning it
-            }
+            // Through the store, which owns the record — a replay after a restart reuses the notice
+            // instead of orphaning it.
+            if (id !== undefined) s.update(rec.id, { previewId: id });
           },
           (e) => log.warn(`[telegram] queue notice failed (the turn still runs): ${String(e)}`),
         ),
       );
-    }
-    const where = `chat=${rec.chatId}${rec.threadId !== undefined ? ` thread=${rec.threadId}` : ""}`;
-    enqueueTurn(rec.session, async () => {
-      // Run at DEQUEUE time (serialized), so the lifecycle log and engine turn all reflect the actual
-      // execution order rather than arrival. Fold the un-summoned discussion since the last answered
-      // turn into the prompt; it is cleared only when the turn COMPLETES (then it lives in the session).
+    },
+    run: async (rec, s) => {
+      // Runs at DEQUEUE time (serialized), so the lifecycle log and engine turn reflect the actual
+      // execution order rather than arrival.
       // Settle the queue notice (if any) so rec.previewId is final. NOT free: a slow (not failed)
       // notice delays this turn's start by up to the API timeout — accepted, because racing it would
       // orphan the ⏳ message and double-post a placeholder; in the common path the notice resolved
       // while the previous turn was still running, so this await is instant.
       await notices.get(rec.id);
       notices.delete(rec.id);
-      rec.state = "started";
-      persistQueuePostAck();
+      s.started(rec.id); // output becomes possible from here — a crash past this point must not replay
       const startedAt = Date.now();
+      const where = `chat=${rec.chatId}${rec.threadId !== undefined ? ` thread=${rec.threadId}` : ""}`;
       log.info(`[telegram] turn start: turn=${rec.id} session=${rec.session} ${where}`);
-      const { text: recent, consumed } = bufferPeek(rec.placeKey);
+      // Fold the un-summoned discussion since the last answered turn into the prompt; it is cleared
+      // only when the turn COMPLETES (then it lives in the session).
+      const { text: recent, consumed } = buffer.peek(rec.placeKey);
       const prompt = recent ? `[recent group discussion:\n${recent}\n]\n\n${rec.baseText}` : rec.baseText;
-      // Attachments posted in the un-summoned discussion, so "summarize the file from earlier" can open
-      // them — most recent BUFFER_ATTACH_MAX of each kind (bounds cost against an attachment-heavy gap).
-      // Minus the summoning message's OWN ids: replying to a still-buffered attachment puts its file_id
-      // in both sets, and without this filter the same file would download twice and appear in the
-      // manifest twice (primary wins — it is what the user pointed at this turn).
-      const primaryFiles = new Set(rec.fileIds);
-      const primaryImages = new Set(rec.imageFileIds);
-      // Attribution rides along (sender + msg id) so the manifest can answer "the file BOB sent" — the
-      // fold's msg-id annotations resolve text references, this resolves the attachment side.
-      const refs = (pick: (e: BufferEntry) => string[] | undefined, primary: Set<string>): BufferedRef[] => {
-        const seen = new Set<string>();
-        const out: BufferedRef[] = [];
-        for (const e of consumed) {
-          for (const id of pick(e) ?? []) {
-            if (primary.has(id) || seen.has(id)) continue;
-            seen.add(id);
-            out.push({ id, from: e.sender, msg: e.messageId });
-          }
-        }
-        return out;
-      };
-      const bufFiles = refs((e) => e.fileIds, primaryFiles);
-      const bufImages = refs((e) => e.imageIds, primaryImages);
-      const buffered = {
-        files: bufFiles.slice(-BUFFER_ATTACH_MAX),
-        images: bufImages.slice(-BUFFER_ATTACH_MAX),
-        // Cap-skipped ones count into the prompt note. The note is the ONLY guarantee: a fold line may
-        // show a [document: …] label, but a captioned attachment renders as its caption text alone —
-        // without the note, the model holds references it silently cannot open and may pretend it read them.
-        skipped: Math.max(0, bufFiles.length - BUFFER_ATTACH_MAX) + Math.max(0, bufImages.length - BUFFER_ATTACH_MAX),
-      };
+      const buffered = collectAttachments(consumed, {
+        files: new Set(rec.fileIds),
+        images: new Set(rec.imageFileIds),
+      });
+      const target: Target = { chatId: rec.chatId, threadId: rec.threadId, replyTo: rec.replyTo };
       try {
         await streamReply(
           invokeWithAttachments(
@@ -993,7 +524,7 @@ export function telegramChannel(
             botToken,
             join(stateHome, "files"),
             buffered,
-            () => bufferCommit(rec.placeKey, consumed),
+            () => buffer.commit(rec.placeKey, consumed),
           ),
           apiBaseUrl,
           botToken,
@@ -1006,67 +537,9 @@ export function telegramChannel(
         log.error(
           `[telegram] turn failed: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms): ${String(error)}`,
         );
-      } finally {
-        pending.delete(rec.id);
-        persistQueuePostAck();
       }
-    });
-  };
-  const isPendingTurn = (r: unknown): r is PendingTurn => {
-    const t = r as PendingTurn;
-    return (
-      typeof t?.id === "string" &&
-      (t.state === "queued" || t.state === "started") &&
-      typeof t.session === "string" &&
-      typeof t.placeKey === "string" &&
-      typeof t.baseText === "string" &&
-      (typeof t.chatId === "number" || typeof t.chatId === "string") &&
-      (t.threadId === undefined || typeof t.threadId === "number") &&
-      (t.replyTo === undefined || typeof t.replyTo === "number") &&
-      (t.previewId === undefined || typeof t.previewId === "number") &&
-      Array.isArray(t.imageFileIds) &&
-      t.imageFileIds.every((x) => typeof x === "string") &&
-      Array.isArray(t.fileIds) &&
-      t.fileIds.every((x) => typeof x === "string")
-    );
-  };
-  const loadQueue = (): { pending: PendingTurn[]; tombstones: string[] } => {
-    const raw = loadStateFile(queuePath);
-    if (raw !== undefined) {
-      const q = raw as { pending?: unknown; tombstones?: unknown };
-      if (
-        typeof raw === "object" &&
-        raw !== null &&
-        Array.isArray(q.pending) &&
-        q.pending.every(isPendingTurn) &&
-        Array.isArray(q.tombstones) &&
-        q.tombstones.every((d) => typeof d === "string")
-      ) {
-        return q as { pending: PendingTurn[]; tombstones: string[] };
-      }
-      log.warn(`[telegram] unexpected shape in ${queuePath} — starting with an empty queue`);
-    }
-    return { pending: [], tombstones: [] };
-  };
-  // Recover the WAL a previous process left behind (constructor-time, before any new update arrives).
-  // EVERY recovered id is tombstoned first: if the crash predated the webhook 200, Telegram redelivers
-  // the update — and whether this recovery replays the turn or drops it, running the redelivery too
-  // would answer twice.
-  const recovered = loadQueue();
-  for (const id of recovered.tombstones) tombstones.add(id);
-  for (const rec of recovered.pending) {
-    tombstone(rec.id);
-    if (rec.state === "started") {
-      log.error(
-        `[telegram] dropping turn ${rec.id} (session=${rec.session}): it was mid-flight when the previous ` +
-          "process died and may have already answered — replaying would risk a duplicate reply. Ask again.",
-      );
-      continue;
-    }
-    log.info(`[telegram] recovering queued turn ${rec.id} (session=${rec.session}) from a previous process`);
-    runTurn(rec);
-  }
-  persistQueue(); // rewrite the WAL now: recovered records must not survive as pending
+    },
+  });
 
   return async (req) => {
     if (req.method !== "POST") return text("POST only\n", 405);
@@ -1083,16 +556,15 @@ export function telegramChannel(
       return text("invalid json\n", 400);
     }
 
-    // Decide whether/where to answer, then stream the reply. ACK 200 immediately (the turn may outlast
-    // the webhook timeout); lifecycle goes to stderr — after the 200 there is no response body, so those
-    // lines are the operator's only signal. Concurrency: a per-session serial queue (FIFO) here; the
-    // engine's per-session lease is the corruption floor beneath it.
+    // Decide whether/where to answer, then run the turn. ACK 200 immediately (the turn may outlast the
+    // webhook timeout); lifecycle goes to stderr — after the 200 there is no response body, so those
+    // lines are the operator's only signal.
     const m = pickMessage(update);
     if (!m) return new Response(null, { status: 200 });
-    // A redelivery of an update whose turn the WAL recovery already took over (replayed or dropped):
-    // ACK and skip — Telegram redelivers exactly when the 200 never made it out, which is the crash
-    // window recovery covers; running it again would answer twice.
-    if (tombstones.has(`${update.update_id}`)) {
+    // A redelivery of an update whose turn the store's recovery already took over (replayed or
+    // dropped): ACK and skip — Telegram redelivers exactly when the 200 never made it out, which is
+    // the crash window recovery covers; running it again would answer twice.
+    if (store.suppressed(`${update.update_id}`)) {
       log.info(`[telegram] suppressing redelivered update ${update.update_id} — recovery already handled it`);
       return new Response(null, { status: 200 });
     }
@@ -1106,16 +578,16 @@ export function telegramChannel(
       if (isGroup && content) {
         // OWN attachments only: each message is its own buffer entry, so a reply's referenced
         // attachment is already (or will be) the other entry's — recounting it here would duplicate
-        // downloads and squeeze the BUFFER_ATTACH_MAX cap.
+        // downloads and squeeze the attachment cap.
         const fileIds = ownFiles(m);
         const imageIds = ownImages(m);
         // A captioned attachment renders as its caption — append the attachment marker so the fold
         // ALWAYS labels attachments (that label + sender is all the attribution a photo gets).
         const summary = attachmentSummary(m);
-        const body = summary && content !== summary ? `${content} ${summary}` : content;
-        bufferPush(placeKey, {
+        const bodyLine = summary && content !== summary ? `${content} ${summary}` : content;
+        buffer.push(placeKey, {
           sender: fromLabel(m.from) ?? "someone",
-          body,
+          body: bodyLine,
           messageId: m.message_id,
           replyTo: m.reply_to_message?.message_id,
           fileIds: fileIds.length ? fileIds : undefined,
@@ -1138,9 +610,10 @@ export function telegramChannel(
       const imageFileIds = extractImages(m);
       const fileIds = extractFiles(m);
       if (baseText.trim() !== "" || imageFileIds.length > 0 || fileIds.length > 0) {
-        // Everything the turn needs, as a plain record — persisted in the WAL (before this handler's
-        // 200) so an accepted turn survives a crash; file_ids stay resolvable for a replay.
-        const rec: PendingTurn = {
+        // Everything the turn needs, as a plain record — the store persists it before this handler's
+        // 200 (durable-or-nothing), so an accepted turn survives a crash; file_ids stay resolvable for
+        // a replay.
+        store.accept({
           id: `${update.update_id}`,
           state: "queued",
           session,
@@ -1151,18 +624,7 @@ export function telegramChannel(
           replyTo: m.chat.type !== "private" && sameTarget ? m.message_id : undefined,
           imageFileIds,
           fileIds,
-        };
-        // Persist BEFORE scheduling, with rollback: if the pre-ACK write throws (→ 500 → redelivery),
-        // nothing may be enqueued yet — a scheduled task would run regardless, and the redelivery would
-        // then run the same turn a second time.
-        pending.set(rec.id, rec);
-        try {
-          persistQueue();
-        } catch (e) {
-          pending.delete(rec.id);
-          throw e;
-        }
-        runTurn(rec);
+        });
       }
     }
     return new Response(null, { status: 200 });

--- a/core/src/channels/telegram/turn-store.ts
+++ b/core/src/channels/telegram/turn-store.ts
@@ -1,0 +1,186 @@
+/**
+ * Durable, per-session-serialized turn execution with crash recovery and redelivery dedup — the
+ * reliability spine under a webhook channel. Nothing here is Telegram-specific (records are opaque
+ * beyond {@link TurnRecord}); it lives in the telegram folder because that is its only consumer today.
+ *
+ * The invariants (they live HERE, not in the caller):
+ *  1. ACCEPT is durable-or-nothing: a record is staged and persisted BEFORE anything is scheduled; a
+ *     failed pre-ACK write rolls the stage back and rethrows (the webhook 500s, the platform
+ *     redelivers) — nothing half-scheduled can run twice.
+ *  2. One turn at a time per session (FIFO chains); different sessions run concurrently.
+ *  3. Two-state WAL: `queued` → never reached execution, safe to replay after a crash; `started` → may
+ *     already have produced output, so recovery DROPS it loudly (a duplicate answer is worse than a
+ *     visible loss). The runner calls {@link TurnStore.started} at the point output becomes possible.
+ *  4. Every id recovery takes over — replayed AND dropped — is tombstoned (bounded, persisted): if the
+ *     crash predated the webhook 200, the platform redelivers the update, and running it again would
+ *     answer twice. Callers gate inbound updates on {@link TurnStore.suppressed}.
+ *  5. Post-ACK writes never throw (no request to fail into; an uncaught throw in a chained task would
+ *     be an unhandled rejection) — they log. The stale-but-atomic WAL stays diagnosable: at worst a
+ *     completed turn is still `started` on disk, and the next restart drops + tombstones it (no
+ *     redelivery is coming — its 200 was long delivered).
+ */
+import { log } from "../../log.ts";
+import { loadStateFile, saveStateFile } from "./state.ts";
+
+/** What the store needs of a record; the caller's type carries everything else the turn needs. */
+export interface TurnRecord {
+  /** The update's id — the turn's identity in logs, on disk, and for redelivery dedup. */
+  id: string;
+  /** Serialization key: one turn at a time per session. */
+  session: string;
+  state: "queued" | "started";
+}
+
+export interface TurnStore<T extends TurnRecord> {
+  /** Stage + persist (durable-or-nothing, see invariant 1) + schedule onto the session's chain. */
+  accept(rec: T): void;
+  /** Whether recovery already took this id over — ACK and skip the redelivery instead of re-running. */
+  suppressed(id: string): boolean;
+  /** The runner MUST call this when the turn irreversibly reaches execution (output becomes possible):
+   *  it flips the WAL record to `started`, which is what tells a future recovery not to replay it. */
+  started(id: string): void;
+  /** Merge caller-domain fields into the held record and persist (post-ACK, logged-not-thrown) — e.g.
+   *  a preview message id attached after acceptance, so a replay can reuse it. The STORE owns the
+   *  record: mutations go through here, never by writing the caller's reference and hoping the store
+   *  shares it. */
+  update(id: string, patch: Partial<Omit<T, keyof TurnRecord>>): void;
+}
+
+/** Bounded by turn count, not time: the platform's redelivery retries span minutes–hours of backoff,
+ *  far fewer than 50 turns in any deployment this store targets — an evicted id being redelivered is
+ *  an extreme edge where a rare duplicate beats unbounded growth. */
+const TOMBSTONES_MAX = 50;
+
+export function createTurnStore<T extends TurnRecord>(opts: {
+  /** The WAL file (`{ pending, tombstones }`), atomic via state.ts. */
+  path: string;
+  /** Log prefix naming the consumer (e.g. "[telegram]") — the store itself is channel-neutral. */
+  label: string;
+  /** Shape validation at the IO boundary — wrong-shaped JSON degrades to empty, never flows in. */
+  isRecord: (r: unknown) => r is T;
+  /** Executes ONE turn. The store wraps it: dequeue in FIFO order, remove + persist when it settles.
+   *  The runner owns the `started` transition (see {@link TurnStore.started}, via the passed handle)
+   *  and its own error surface; a rejection that escapes anyway is caught and logged by the store
+   *  (never a silent unhandled rejection), but the runner's own catch is where diagnosis belongs. */
+  run: (rec: T, store: TurnStore<T>) => Promise<void>;
+  /** Fired synchronously when a record is scheduled BEHIND an active turn (accept and recovery alike)
+   *  — the caller's hook for queue feedback to the user. */
+  onQueuedBehind?: (rec: T, store: TurnStore<T>) => void;
+}): TurnStore<T> {
+  const { path, label, isRecord, run, onQueuedBehind } = opts;
+
+  const pending = new Map<string, T>();
+  const tombstones = new Set<string>();
+  const addTombstone = (id: string): void => {
+    tombstones.add(id);
+    for (const old of tombstones) {
+      if (tombstones.size <= TOMBSTONES_MAX) break;
+      tombstones.delete(old);
+    }
+  };
+  const persist = (): void => saveStateFile(path, { pending: [...pending.values()], tombstones: [...tombstones] });
+  const persistPostAck = (): void => {
+    try {
+      persist();
+    } catch (e) {
+      log.error(`${label} WAL write failed post-ACK (state stale until the next write): ${String(e)}`);
+    }
+  };
+
+  // Per-session serial chains: a second turn for the same session waits its turn (FIFO) instead of
+  // colliding on the engine lease and being dropped as "busy". The chain itself is in-memory; the WAL
+  // is what survives a restart.
+  const chains = new Map<string, Promise<void>>();
+  const schedule = (rec: T): void => {
+    if (chains.has(rec.session)) onQueuedBehind?.(rec, self);
+    const prev = chains.get(rec.session) ?? Promise.resolve();
+    const task = async (): Promise<void> => {
+      try {
+        await run(rec, self);
+      } catch (e) {
+        // The runner is expected to own its error surface, but a rejection that escapes it must not
+        // become a silent unhandled rejection off the `void next.finally` branch — log it here.
+        log.error(`${label} turn ${rec.id} runner rejected (own your error surface in run()): ${String(e)}`);
+      } finally {
+        pending.delete(rec.id);
+        persistPostAck();
+      }
+    };
+    const next = prev.then(task, task); // run after this session's previous turn, in arrival order
+    chains.set(rec.session, next);
+    void next.finally(() => {
+      if (chains.get(rec.session) === next) chains.delete(rec.session); // drop the entry when drained
+    });
+  };
+
+  const loadWal = (): { pending: T[]; tombstones: string[] } => {
+    const raw = loadStateFile(path);
+    if (raw !== undefined) {
+      const q = raw as { pending?: unknown; tombstones?: unknown };
+      if (
+        typeof raw === "object" &&
+        raw !== null &&
+        Array.isArray(q.pending) &&
+        q.pending.every(isRecord) &&
+        Array.isArray(q.tombstones) &&
+        q.tombstones.every((d) => typeof d === "string")
+      ) {
+        return q as { pending: T[]; tombstones: string[] };
+      }
+      log.warn(`${label} unexpected shape in ${path} — starting with an empty queue`);
+    }
+    return { pending: [], tombstones: [] };
+  };
+
+  const self: TurnStore<T> = {
+    accept(rec) {
+      pending.set(rec.id, rec);
+      try {
+        persist();
+      } catch (e) {
+        pending.delete(rec.id);
+        throw e;
+      }
+      schedule(rec);
+    },
+    suppressed: (id) => tombstones.has(id),
+    started(id) {
+      const rec = pending.get(id);
+      if (!rec) {
+        log.error(`${label} started() for unknown turn ${id} — a lifecycle bug, not a user error`);
+        return;
+      }
+      rec.state = "started";
+      persistPostAck();
+    },
+    update(id, patch) {
+      const rec = pending.get(id);
+      if (!rec) return; // the turn already completed — nothing to persist the patch onto
+      Object.assign(rec, patch);
+      persistPostAck();
+    },
+  };
+
+  // Recover the WAL a previous process left behind (construction-time, before any new update arrives).
+  // EVERY recovered id is tombstoned first (invariant 4). Recovery persists ONCE after the loop — a
+  // per-record persist could fail mid-loop and leave the already-replayed prefix still `queued` in the
+  // WAL, to be replayed AGAIN on the next boot.
+  const recovered = loadWal();
+  for (const id of recovered.tombstones) tombstones.add(id);
+  for (const rec of recovered.pending) {
+    addTombstone(rec.id);
+    if (rec.state === "started") {
+      log.error(
+        `${label} dropping turn ${rec.id} (session=${rec.session}): it was mid-flight when the previous ` +
+          "process died and may have already answered — replaying would risk a duplicate reply. Ask again.",
+      );
+      continue;
+    }
+    log.info(`${label} recovering queued turn ${rec.id} (session=${rec.session}) from a previous process`);
+    pending.set(rec.id, rec);
+    schedule(rec);
+  }
+  persist(); // rewrite the WAL now: recovered records must not survive as pending (throws = boot fails loudly)
+
+  return self;
+}

--- a/core/src/tunnel.ts
+++ b/core/src/tunnel.ts
@@ -9,7 +9,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
-import { callApi } from "./channels/telegram/telegram-api.ts";
+import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
 import { log } from "./log.ts";
 
 export interface Tunnel {
@@ -142,7 +142,7 @@ export async function announceWebhooks(dir: string, baseUrl: string): Promise<vo
   if (!(await waitForTunnel(baseUrl))) {
     log.warn(`[fastagent] tunnel did not respond in time; webhook registration may fail (URL: ${baseUrl})`);
   }
-  if (channels.includes("telegram")) await registerTelegram(baseUrl);
+  if (channels.includes("telegram")) await registerTelegramWebhook(baseUrl);
   if (channels.includes("github")) {
     log.info(
       `[fastagent] github: add a webhook in your repo (Settings → Webhooks): Payload URL = ${baseUrl}/webhook, content type application/json, secret = GITHUB_WEBHOOK_SECRET`,
@@ -163,43 +163,4 @@ async function waitForTunnel(baseUrl: string, timeoutMs = 60000): Promise<boolea
     await sleep(3000);
   }
   return false;
-}
-
-async function registerTelegram(baseUrl: string): Promise<void> {
-  const botToken = process.env.TELEGRAM_BOT_TOKEN;
-  const secret = process.env.TELEGRAM_SECRET_TOKEN;
-  const webhookUrl = `${baseUrl}/telegram`;
-  if (!botToken || !secret) {
-    log.info(
-      `[fastagent] telegram: set TELEGRAM_BOT_TOKEN + TELEGRAM_SECRET_TOKEN in .env, then re-run to auto-register. Webhook URL: ${webhookUrl}`,
-    );
-    return;
-  }
-  // Backstop after waitForTunnel: Telegram's resolver may lag our health poll by a moment. The call
-  // itself rides the channel's hardened pipeline (timeout, ok-validation, named failures) — a thrown
-  // timeout stringifies with "timeout" in it, so the transient regex below catches it.
-  const ATTEMPTS = 3;
-  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
-    if (attempt > 0) await sleep(5000);
-    try {
-      await callApi("https://api.telegram.org", botToken, "setWebhook", { url: webhookUrl, secret_token: secret });
-      log.info(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
-      return;
-    } catch (e) {
-      // Only network-transient errors are worth retrying. A fresh tunnel's "bad webhook: Failed to
-      // resolve host" is caught by `resolve host`; a permanent "Bad webhook: HTTPS url must be provided"
-      // is a config error, not transient, so `bad webhook` is deliberately NOT a trigger.
-      const error = String(e);
-      const transient = /resolve host|getaddrinfo|ENOTFOUND|fetch failed|ECONNRESET|timeout/i.test(error);
-      if (!transient) {
-        log.error(`[fastagent] telegram: setWebhook failed (${error}). Register manually with url=${webhookUrl}`);
-        return;
-      }
-      if (attempt < ATTEMPTS - 1)
-        log.warn(`[fastagent] telegram: tunnel not resolvable yet, retrying… (${attempt + 1}/${ATTEMPTS - 1})`);
-    }
-  }
-  log.warn(
-    `[fastagent] telegram: webhook still failing after retries (the tunnel may need another moment). Register manually with url=${webhookUrl}`,
-  );
 }

--- a/core/test/context-buffer.test.ts
+++ b/core/test/context-buffer.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { type BufferEntry, collectAttachments, createContextBuffer } from "../src/channels/telegram/context-buffer.ts";
+
+const dirs: string[] = [];
+const freshPath = (): string => {
+  const d = mkdtempSync(join(tmpdir(), "ctx-buffer-"));
+  dirs.push(d);
+  return join(d, "buffers.json");
+};
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+const entry = (sender: string, body: string, extra: Partial<BufferEntry> = {}): BufferEntry => ({
+  sender,
+  body,
+  ...extra,
+});
+
+describe("context-buffer", () => {
+  it("renders the fold with msg/reply annotations, only when known", () => {
+    const buf = createContextBuffer(freshPath());
+    buf.push("place", entry("@alice", "plain line"));
+    buf.push("place", entry("@bob", "a reply", { messageId: 3, replyTo: 1 }));
+    const { text } = buf.peek("place");
+    expect(text).toBe("@alice: plain line\n@bob (msg 3, reply to msg 1): a reply");
+  });
+
+  it("commit removes ONLY the consumed snapshot (identity) — an entry pushed mid-turn survives", () => {
+    const buf = createContextBuffer(freshPath());
+    buf.push("place", entry("@alice", "before the turn"));
+    const { consumed } = buf.peek("place"); // the turn folds this snapshot
+    buf.push("place", entry("@bob", "arrived while the turn ran"));
+    buf.commit("place", consumed); // turn completed — clear exactly what was folded
+    expect(buf.peek("place").text).toBe("@bob: arrived while the turn ran");
+  });
+
+  it("evicts the OLDEST entries when the rendered fold exceeds the budget", () => {
+    const buf = createContextBuffer(freshPath());
+    for (let i = 0; i < 20; i++) buf.push("place", entry(`@u${i}`, "x".repeat(300))); // ~6000 rendered chars
+    const { text } = buf.peek("place");
+    expect(text.length).toBeLessThanOrEqual(4000 + 320); // budget + at most one entry of slack
+    expect(text).not.toContain("@u0:"); // the oldest fell out
+    expect(text).toContain("@u19:"); // the newest survives
+  });
+
+  it("persists across a restart (a new instance over the same file sees the entries)", () => {
+    const path = freshPath();
+    createContextBuffer(path).push("place", entry("@alice", "durable line"));
+    expect(createContextBuffer(path).peek("place").text).toBe("@alice: durable line");
+  });
+
+  it("a failed pre-ACK persist rolls the push back — memory matches disk, a redelivery re-pushes once", () => {
+    const path = freshPath();
+    const buf = createContextBuffer(path);
+    buf.push("place", entry("@alice", "kept"));
+    rmSync(path);
+    mkdirSync(path); // make the file unwritable (rename onto a directory fails)
+    expect(() => buf.push("place", entry("@bob", "rolled back"))).toThrow();
+    expect(buf.peek("place").text).toBe("@alice: kept"); // the failed entry is NOT in memory either
+  });
+
+  it("collectAttachments: primary-filtered, deduped, capped, and the skipped count is honest", () => {
+    const consumed: BufferEntry[] = [
+      entry("@a", "one", { messageId: 1, fileIds: ["f1"] }),
+      entry("@b", "two", { messageId: 2, fileIds: ["f2", "f2"] }), // duplicate id within the window
+      entry("@c", "three", { messageId: 3, fileIds: ["f3"], imageIds: ["p1"] }),
+      entry("@d", "four", { messageId: 4, fileIds: ["f4"] }),
+      entry("@e", "five", { messageId: 5, fileIds: ["primary"] }), // also on the summoning message
+    ];
+    const got = collectAttachments(consumed, { files: new Set(["primary"]), images: new Set() });
+    // 4 unique non-primary files → cap 3 keeps the most recent, 1 skipped (counted, not silent)
+    expect(got.files.map((f) => f.id)).toEqual(["f2", "f3", "f4"]);
+    expect(got.files[1]).toMatchObject({ id: "f3", from: "@c", msg: 3 }); // attribution rides along
+    expect(got.images.map((i) => i.id)).toEqual(["p1"]);
+    expect(got.skipped).toBe(1);
+  });
+});

--- a/core/test/preview.test.ts
+++ b/core/test/preview.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "../src/agent.ts";
+import { streamReply } from "../src/channels/telegram/preview.ts";
+
+const API = "http://tg.test";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** A push-based event source, so a test controls exactly WHEN each event reaches streamReply. */
+const eventSource = () => {
+  const queue: AgentEvent[] = [];
+  let notify: (() => void) | undefined;
+  let ended = false;
+  const iterable: AsyncIterable<AgentEvent> = {
+    async *[Symbol.asyncIterator]() {
+      while (true) {
+        if (queue.length > 0) {
+          yield queue.shift() as AgentEvent;
+          continue;
+        }
+        if (ended) return;
+        await new Promise<void>((r) => {
+          notify = r;
+        });
+      }
+    },
+  };
+  return {
+    iterable,
+    push(e: AgentEvent): void {
+      queue.push(e);
+      notify?.();
+      notify = undefined;
+    },
+    end(): void {
+      ended = true;
+      notify?.();
+      notify = undefined;
+    },
+  };
+};
+
+/** Record every sendMessage/editMessageText the preview writes, replying ok to all. */
+const recordingFetch = () => {
+  const sends: string[] = [];
+  const edits: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(String(init.body)) as { text?: string }) : {};
+      if (String(url).endsWith("/sendMessage")) sends.push(body.text ?? "");
+      if (String(url).endsWith("/editMessageText")) edits.push(body.text ?? "");
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+    }),
+  );
+  return { sends, edits };
+};
+
+async function* events(...list: AgentEvent[]): AsyncIterable<AgentEvent> {
+  for (const e of list) yield e;
+}
+
+const neutral = (): string => "⚠️ neutral";
+
+describe("streamReply single-writer pump (direct)", () => {
+  it("one edit in flight; frames coalesce to the LATEST view — no stale or out-of-order frame", async () => {
+    vi.useFakeTimers();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const edits: string[] = [];
+    let releaseFirst!: () => void;
+    const firstEditGate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const body = init?.body ? (JSON.parse(String(init.body)) as { text?: string }) : {};
+        if (String(url).endsWith("/editMessageText")) {
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          if (edits.length === 0) await firstEditGate; // hold the FIRST edit in flight
+          edits.push(body.text ?? "");
+          inFlight--;
+        }
+        return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+      }),
+    );
+    const src = eventSource();
+    const turn = streamReply(src.iterable, API, "BOT", { chatId: 1 }, neutral);
+    await vi.advanceTimersByTimeAsync(0); // placeholder sent
+    src.push({ type: "text", delta: "a" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(inFlight).toBe(1); // the edit for "a" is held in flight…
+    src.push({ type: "text", delta: "b" });
+    src.push({ type: "text", delta: "c" }); // …while newer frames arrive
+    await vi.advanceTimersByTimeAsync(0);
+    expect(maxInFlight).toBe(1); // SINGLE writer: nothing stacked behind the held edit
+    releaseFirst();
+    await vi.advanceTimersByTimeAsync(1600); // past the throttle → the next frame is the LATEST view
+    expect(edits).toEqual(["a", "abc"]); // coalesced — never an "ab" intermediate, never out of order
+    src.push({ type: "completed" });
+    src.end();
+    await turn;
+    expect(edits.at(-1)).toBe("abc"); // the authoritative final write lands LAST
+    expect(maxInFlight).toBe(1);
+  });
+});
+
+describe("streamReply terminal writes (direct)", () => {
+  it("completed → the preview message is edited into the final answer", async () => {
+    const { sends, edits } = recordingFetch();
+    await streamReply(
+      events({ type: "text", delta: "the answer" }, { type: "completed" }),
+      API,
+      "BOT",
+      { chatId: 1 },
+      neutral,
+    );
+    expect(sends.length).toBe(1); // ONE preview message, never a second
+    expect(edits.at(-1)).toBe("the answer"); // …edited into the answer in place
+  });
+
+  it("failed → the onError text is delivered and the failure is rethrown for the operator log", async () => {
+    const { edits } = recordingFetch();
+    await expect(
+      streamReply(events({ type: "failed", details: "boom", retryable: true }), API, "BOT", { chatId: 1 }, neutral),
+    ).rejects.toThrow(/agent failed: boom/);
+    expect(edits.at(-1)).toBe("⚠️ neutral"); // the user was told, in the same message
+  });
+
+  it("a stream that ends without a terminal event delivers the neutral notice and throws (SPEC MUST 1)", async () => {
+    const { sends, edits } = recordingFetch();
+    await expect(
+      streamReply(events({ type: "text", delta: "partial…" }), API, "BOT", { chatId: 1 }, neutral),
+    ).rejects.toThrow(/stream ended without a terminal event/);
+    expect([...sends, ...edits]).toContain("⚠️ neutral"); // not silence, not a silent delete of partial work
+  });
+
+  it("takes over a pre-sent message id (the ⏳ notice) instead of sending its own placeholder", async () => {
+    const { sends, edits } = recordingFetch();
+    await streamReply(
+      events({ type: "text", delta: "answer" }, { type: "completed" }),
+      API,
+      "BOT",
+      { chatId: 1 },
+      neutral,
+      77, // an existing message to morph
+    );
+    expect(sends.length).toBe(0); // no second placeholder
+    expect(edits.at(-1)).toBe("answer"); // the notice morphed into the answer
+  });
+});

--- a/core/test/turn-store.test.ts
+++ b/core/test/turn-store.test.ts
@@ -1,0 +1,209 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type TurnRecord, type TurnStore, createTurnStore } from "../src/channels/telegram/turn-store.ts";
+import { log } from "../src/log.ts";
+
+/** The consumer-side record for these tests: one caller-domain field beyond the store's TurnRecord. */
+interface Rec extends TurnRecord {
+  payload: string;
+  previewId?: number;
+}
+const isRec = (r: unknown): r is Rec =>
+  typeof (r as Rec)?.id === "string" &&
+  ((r as Rec).state === "queued" || (r as Rec).state === "started") &&
+  typeof (r as Rec).session === "string" &&
+  typeof (r as Rec).payload === "string";
+
+const rec = (id: string, session = "s", payload = `p${id}`): Rec => ({ id, state: "queued", session, payload });
+
+const dirs: string[] = [];
+const freshDir = (): string => {
+  const d = mkdtempSync(join(tmpdir(), "turn-store-"));
+  dirs.push(d);
+  return d;
+};
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const walPath = (dir: string): string => join(dir, "queue.json");
+const readWal = (dir: string): { pending: Rec[]; tombstones: string[] } =>
+  JSON.parse(readFileSync(walPath(dir), "utf8")) as { pending: Rec[]; tombstones: string[] };
+
+/** Wait until `cond` holds (turns run async on the session chains). */
+const until = async (cond: () => boolean): Promise<void> => {
+  for (let i = 0; i < 200 && !cond(); i++) await new Promise((r) => setTimeout(r, 5));
+};
+
+const makeStore = (
+  dir: string,
+  run: (r: Rec, s: TurnStore<Rec>) => Promise<void>,
+  onQueuedBehind?: (r: Rec, s: TurnStore<Rec>) => void,
+): TurnStore<Rec> =>
+  createTurnStore<Rec>({ path: walPath(dir), label: "[test]", isRecord: isRec, run, onQueuedBehind });
+
+describe("turn-store", () => {
+  it("accept runs the turn and drains it from the WAL", async () => {
+    const dir = freshDir();
+    const ran: string[] = [];
+    const store = makeStore(dir, async (r, s) => {
+      s.started(r.id);
+      ran.push(r.payload);
+    });
+    store.accept(rec("1"));
+    await until(() => ran.length === 1);
+    expect(ran).toEqual(["p1"]);
+    await until(() => readWal(dir).pending.length === 0);
+  });
+
+  it("serializes per session (FIFO) while different sessions run concurrently", async () => {
+    const dir = freshDir();
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+    const store = makeStore(dir, async (r) => {
+      if (r.id === "1") await gate; // park the first turn of session A
+      order.push(r.id);
+    });
+    store.accept(rec("1", "A"));
+    store.accept(rec("2", "A")); // must wait behind 1
+    store.accept(rec("3", "B")); // different session — runs immediately
+    await until(() => order.includes("3"));
+    expect(order).toEqual(["3"]); // 2 is NOT running while 1 is parked
+    releaseFirst();
+    await until(() => order.length === 3);
+    expect(order).toEqual(["3", "1", "2"]); // A's turns in arrival order
+  });
+
+  it("onQueuedBehind fires only when the session is already busy", async () => {
+    const dir = freshDir();
+    const queuedBehind: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const done: string[] = [];
+    const store = makeStore(
+      dir,
+      async (r) => {
+        if (r.id === "1") await gate;
+        done.push(r.id);
+      },
+      (r) => queuedBehind.push(r.id),
+    );
+    store.accept(rec("1"));
+    expect(queuedBehind).toEqual([]); // idle session — no hook
+    store.accept(rec("2"));
+    expect(queuedBehind).toEqual(["2"]); // busy — hook fired synchronously at accept
+    release();
+    await until(() => done.length === 2);
+  });
+
+  it("recovery replays a queued record exactly once and tombstones it (redelivery suppressed)", async () => {
+    const dir = freshDir();
+    writeFileSync(walPath(dir), JSON.stringify({ pending: [rec("9")], tombstones: [] }));
+    const ran: string[] = [];
+    const store = makeStore(dir, async (r) => {
+      ran.push(r.id);
+    });
+    expect(store.suppressed("9")).toBe(true); // tombstoned BEFORE the replay even settles
+    await until(() => ran.length === 1);
+    expect(ran).toEqual(["9"]);
+    await until(() => readWal(dir).pending.length === 0);
+    expect(readWal(dir).tombstones).toEqual(["9"]);
+  });
+
+  it("recovery DROPS a started record — it may already have answered — and tombstones it", async () => {
+    const dir = freshDir();
+    writeFileSync(walPath(dir), JSON.stringify({ pending: [{ ...rec("7"), state: "started" }], tombstones: [] }));
+    const ran: string[] = [];
+    const store = makeStore(dir, async (r) => {
+      ran.push(r.id);
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(ran).toEqual([]); // never replayed
+    expect(store.suppressed("7")).toBe(true);
+    expect(readWal(dir)).toEqual({ pending: [], tombstones: ["7"] }); // dropped record does not survive as pending
+  });
+
+  it("tombstones are bounded: the oldest is evicted past the cap", async () => {
+    const dir = freshDir();
+    const old = Array.from({ length: 50 }, (_, i) => `t${i}`);
+    writeFileSync(walPath(dir), JSON.stringify({ pending: [rec("new")], tombstones: old }));
+    const store = makeStore(dir, async () => {});
+    expect(store.suppressed("t0")).toBe(false); // the oldest fell out when "new" was tombstoned (51st)
+    expect(store.suppressed("t49")).toBe(true);
+    expect(store.suppressed("new")).toBe(true);
+  });
+
+  it("a failed pre-ACK persist rolls the stage back and schedules NOTHING (durable-or-nothing)", async () => {
+    const dir = freshDir();
+    const ran: string[] = [];
+    const store = makeStore(dir, async (r) => {
+      ran.push(r.id);
+    });
+    // Construction persisted fine; now make the WAL path unwritable (rename onto a directory fails).
+    rmSync(walPath(dir));
+    mkdirSync(walPath(dir));
+    expect(() => store.accept(rec("1"))).toThrow(); // the throw is the caller's 500 → redelivery
+    await new Promise((r) => setTimeout(r, 30));
+    expect(ran).toEqual([]); // nothing was scheduled — a redelivery cannot double-run
+  });
+
+  it("update(id, patch) merges into the HELD record and persists it (a replay sees it)", async () => {
+    const dir = freshDir();
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const seen: (number | undefined)[] = [];
+    const store = makeStore(dir, async (r) => {
+      await gate;
+      seen.push(r.previewId); // the runner reads the store's record — the patch is visible
+    });
+    store.accept(rec("1"));
+    store.update("1", { previewId: 42 });
+    expect(readWal(dir).pending[0]?.previewId).toBe(42); // durable — a replay after a crash reuses it
+    release();
+    await until(() => seen.length === 1);
+    expect(seen).toEqual([42]);
+  });
+
+  it("a runner rejection is logged, never an unhandled rejection — and the chain continues", async () => {
+    const dir = freshDir();
+    const errors = vi.spyOn(log, "error").mockImplementation(() => {});
+    // Pin the "never unhandled" half of the name literally: collect any unhandled rejection during the
+    // test window. (The chain-continues assertions below hold even WITHOUT the store's catch —
+    // `prev.then(task, task)` and the `finally` guarantee those — so they must not stand in for it.)
+    const unhandled: unknown[] = [];
+    const onUnhandled = (e: unknown): void => {
+      unhandled.push(e);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const done: string[] = [];
+      const store = makeStore(dir, async (r) => {
+        if (r.id === "1") throw new Error("runner escaped");
+        done.push(r.id);
+      });
+      store.accept(rec("1"));
+      store.accept(rec("2")); // same session — must still run after 1's rejection
+      await until(() => done.length === 1);
+      expect(done).toEqual(["2"]);
+      await until(() => readWal(dir).pending.length === 0); // both drained from the WAL
+      // The discriminating assertions: the catch EXISTS and is LOUD — a silent `catch {}` regression
+      // (exactly the fail-visibly violation this backstop prevents) turns this red.
+      expect(errors).toHaveBeenCalledTimes(1);
+      expect(String(errors.mock.calls[0]?.[0])).toMatch(/turn 1 runner rejected.*runner escaped/);
+      await new Promise((r) => setTimeout(r, 20)); // let Node surface any unhandled rejection
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});


### PR DESCRIPTION
- **refactor(telegram): decompose the channel — each subsystem owns its invariants**
- **refactor(tunnel): telegram webhook registration moves into the channel's domain**
