### PR TITLE
chore: surface hygiene — unexport TelegramApiError, annotate the scaffold rollback

### DIFF
--- a/core/src/channels/telegram/telegram-api.ts
+++ b/core/src/channels/telegram/telegram-api.ts
@@ -70,8 +70,11 @@ interface Api {
 
 /** A named Bot API failure. `status` 0 = the transport itself failed (network error / timeout) before
  *  any HTTP status existed; otherwise the HTTP status with Telegram's own description (or a note that
- *  the body carried no usable answer). */
-export class TelegramApiError extends Error {
+ *  the body carried no usable answer). Module-private: no EXTERNAL caller matches on the type; it
+ *  stays a typed class (not a plain Error) because this module's own retry logic — sendMessage's
+ *  parse-mode fallback, editMessageText's "not modified" swallow — does `instanceof` + reads
+ *  `.description`. */
+class TelegramApiError extends Error {
   readonly method: string;
   readonly status: number;
   readonly description: string;

--- a/core/src/scaffold/init.ts
+++ b/core/src/scaffold/init.ts
@@ -150,6 +150,8 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
       );
     }
   } catch (error) {
+    // Best-effort rollback of a partial scaffold: a file that won't delete is left behind (the original
+    // error below is the one worth surfacing — a cleanup failure must not mask it).
     for (const rel of created.reverse()) await rm(join(dir, rel), { force: true }).catch(() => {});
     throw error;
   }


### PR DESCRIPTION
Two local findings from the structural scan:

- TelegramApiError was exported with zero importers: the public facade (src/telegram.ts) does not
  re-export it and no caller matches on the type — a half-public surface. It is module-private
  now, with a note to export it THROUGH the facade if a custom channel ever needs typed matching
  (not to leave it dangling in between).
- scaffold/init.ts's rollback swallowed rm() failures without a word; the swallow is correct (a
  cleanup failure must not mask the original scaffold error) but now says so.
