### PR TITLE
docs: sync architecture docs with the code — repo map, channel design, doc boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,24 +24,47 @@ core/
 ├── src/
 │   ├── agent.ts                 # the Agent Handler contract (pure types, no engine import)
 │   ├── collect.ts               # buffered consumption helper
-│   ├── channels/http.ts         # HTTP/SSE channel (consumes only the Agent contract)
-│   ├── cli.ts                   # `fastagent dev` entry point (process side effects live here)
 │   ├── index.ts                 # the public API surface (see README "API stability")
+│   ├── cli.ts                   # command entry points (process side effects live here)
+│   ├── invoke-stream.ts, cli-models.ts # command rendering layers (`invoke` stream → exit code, `models` output)
+│   ├── telegram.ts, github.ts   # subpath-export shims (@kid7st/fastagent/telegram etc. — the supported surface)
+│   ├── log.ts                   # leveled logging singleton (dev=debug, start=info)
+│   ├── observe.ts               # turn-trace logging around an Agent
+│   ├── tunnel.ts                # `--tunnel`: cloudflared + per-channel webhook dispatch
+│   ├── dev-supervisor.ts        # `dev` watch/restart worker
+│   ├── proxy.ts                 # HTTPS_PROXY wiring
+│   ├── workspace.ts, version.ts # neutral helpers (in-workspace guard, ignore files, version)
+│   ├── host/node.ts             # Node HTTP host: Routes/ChannelHandler/serveNode/router (public surface)
+│   ├── scaffold/                # `init` / `add <channel>` / `add skill` + templates/ (real files)
+│   ├── channels/
+│   │   ├── http.ts              # HTTP/SSE channel (consumes only the Agent contract)
+│   │   ├── body.ts, respond.ts  # channel-authoring kit (body cap, responses)
+│   │   ├── github/              # github channel (+ scaffold/ bundle)
+│   │   └── telegram/            # telegram channel — see docs/design/core.md §9.2
+│   │       ├── telegram.ts      # Telegram domain: ingress, summon policy, envelope, composition
+│   │       ├── turn-store.ts    # durable per-session serial turns (WAL, recovery, dedup)
+│   │       ├── context-buffer.ts# un-summoned group discussion (durable, commit-on-completed)
+│   │       ├── preview.ts       # live-preview pump + terminal-write policy
+│   │       ├── telegram-api.ts  # the single Bot API pipeline + HTML-aware split
+│   │       ├── state.ts         # atomic state files under .fastagent/channels/telegram/
+│   │       ├── register-webhook.ts # --tunnel setWebhook registration
+│   │       └── scaffold/        # `add telegram` bundle (channel.ts + send tool)
 │   └── engines/pi/              # the pi reference implementation
 │       ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
 │       ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
 │       ├── workspace.ts         # shared opener: workspace → agent for dev/start/invoke
 │       ├── chat.ts              # `chat` channel: drive pi's interactive TUI with the assembled agent
-│       ├── scaffold/            # `init`, `add <channel>`, `add skill`, and scaffold templates
 │       ├── tool.ts              # defineTool (Zod) + tools/ filesystem discovery
 │       ├── channel.ts           # channels/ filesystem discovery (ChannelModule → Routes)
 │       ├── harness.ts           # pi harness wiring (factory)
 │       ├── definition.ts        # AGENTS.md + skills loading and bundling
 │       ├── config.ts            # fastagent.config.ts loading + model/precedence
-│       ├── auth.ts              # pi OAuth / env auth resolution
+│       ├── auth.ts, login.ts    # credential store/resolution (project-level auth.json default) + `login` flow
+│       ├── models.ts, loader.ts # Models collection wiring; ESM module loading for tools/channels/config
+│       ├── report.ts            # startup report (auth/model/skills/tools surface)
 │       └── sessions.ts          # PiSessionStore port + in-memory/jsonl backends
 ├── test/                        # vitest; faux models by default
-docs/                            # SPEC, guides, and maintainer design notes
+docs/                            # SPEC, guides, and maintainer design notes (design/core.md = architecture)
 ```
 
 ## DevX Principle Stack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Force-pushing to `main` is forbidden. Long-lived PRs (> ~3 days) should be rebas
 
 Dependabot opens weekly PRs for npm and GitHub Actions. The pi packages (`@earendil-works/pi-*`) share one monorepo and move together — update them as a group. Re-run `npm run typecheck && npm test` before merging any dependency bump.
 
-The `undici` version is load-bearing for proxy/streaming behavior under Node 26; see the dispatcher comment in `core/src/cli.ts` before changing it.
+The `undici` version is load-bearing for proxy/streaming behavior under Node 26; see the `installProxyFetch` docstring in `core/src/proxy.ts` before changing it.
 
 ## Issues
 

--- a/docs/channel-development.md
+++ b/docs/channel-development.md
@@ -9,6 +9,8 @@ This guide is for developers building a new FastAgent channel adapter, either in
 
 A channel is an ingress adapter. It receives an external event, decides whether to invoke the agent, and returns an HTTP response appropriate for that external system.
 
+> This page is the AUTHOR's view — building an adapter. Using the existing channels is covered in [Channels](channels.md); the telegram channel's internal architecture (the reference for a stateful chat channel) is in [design/core.md §9.2](design/core.md).
+
 ## The two layers
 
 Every channel has two layers:

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -9,6 +9,8 @@ A **channel** is an agent's inbound surface: HTTP, GitHub webhooks, Telegram mes
 
 Channels consume only the engine-neutral [Agent contract](SPEC.md). The same channel can drive any conforming agent.
 
+> This page is the USER's view — what channels exist and how to wire them. Building a new channel adapter is a different audience: see [Channel development](channel-development.md).
+
 ## Mental model
 
 ```txt

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -2,7 +2,7 @@
 title: fastagent — Core design
 type: design-doc
 status: current
-updated: 2026-06-29
+updated: 2026-07-03
 ---
 
 # fastagent core design
@@ -162,7 +162,9 @@ If a second invocation arrives for the same session while one is already running
 
 Core does not queue. Dedupe, retry, user-visible “busy” messages, and steering are channel-level decisions because only the channel understands the trigger semantics.
 
-## 9. HTTP channel
+## 9. Channels
+
+### 9.1 HTTP channel
 
 `createInvokeHandler(agent)` implements the minimal dev HTTP channel:
 
@@ -172,6 +174,40 @@ Core does not queue. Dedupe, retry, user-visible “busy” messages, and steeri
 - client disconnect calls `iterator.return()` to trigger invoke cleanup.
 
 The HTTP channel consumes only the neutral `Agent` contract.
+
+### 9.2 Telegram channel architecture
+
+The telegram channel is the reference for a **stateful chat channel**: it bridges a streaming,
+unbounded, fallible agent turn onto discrete messages, multi-user group chats, and at-least-once
+webhook delivery. Its folder (`src/channels/telegram/`) is the future package boundary; each
+subsystem owns its invariants in its own module:
+
+| Module | Owns |
+|---|---|
+| `telegram.ts` | the Telegram DOMAIN: ingress (secret token, body cap), summon policy, envelope/prompt assembly, composition |
+| `turn-store.ts` | durable per-session serial execution: two-state WAL (`queued` replays after a crash, `started` drops loudly — a duplicate answer is worse than a visible loss), tombstoned ids so a Telegram redelivery is ACKed and skipped, pre-ACK durable-or-nothing accept. Channel-neutral by design (`label` names the consumer) |
+| `context-buffer.ts` | un-summoned group discussion: persisted before each webhook ACK (an ACKed update is never redelivered), folded into the next answered turn, cleared only on that turn's `completed` (only then is it provably in the durable session); carries message ids / reply relations / attachment file_ids so later references ("the file Bob sent") resolve |
+| `preview.ts` | the live preview: ONE real message (`sendMessage` → `editMessageText` in place; `sendMessageDraft` is private-only, useless in groups), a single-writer pump (one edit in flight — out-of-order frames are the flicker), and the terminal-write matrix (completed/failed/abnormal × edit/delete+send/suppress) |
+| `telegram-api.ts` | ONE transport pipeline (`callApi`) for every Bot API method — per-method wire code does not exist, so the invariants (per-attempt timeout, bounded 429/flood-wait, success gated on the body's own `ok:true`, self-describing typed errors) hold by construction. Plus the HTML-aware split: a tag-stack balancer that closes/reopens tags (attributes kept) across the 4096 boundary |
+| `state.ts` | atomic state files (tmp+rename) under the channel-state home |
+
+Durable decisions this architecture encodes:
+
+- **Channel-state convention:** engine state lives at the `.fastagent` top level (auth, sessions);
+  channel state lives under `.fastagent/channels/<kind>/` (buffers, WAL, downloaded files),
+  mirroring `src/channels/<kind>/`. The home self-ignores (nested `.gitignore`) — it can carry chat
+  content. Single-process semantics; while the process is DOWN, Telegram itself retries undelivered
+  webhooks, so the WAL only covers the ACKed-but-unfinished window.
+- **Summon = consume the platform's structure, not re-parse it:** @mentions from Telegram's
+  `mention` entities (never a regex over text — code blocks/URLs can't false-summon); reply-to-bot
+  by the bot id parsed synchronously from the token (`<bot_id>:<secret>`, no getMe race); edits
+  never summon. Fail closed without an identity.
+- **Formatting model:** the agent emits Telegram-HTML strings sent with `parse_mode` (the natural
+  fit for LLM output); the entity model is NOT used. **gramIO tripwire** (documented on the `Api`
+  table): if the channel ever needs ~10+ methods or entity-based formatting, adopt gramIO instead
+  of growing the hand-rolled surface — `callApi<M>` is shape-compatible with `bot.api.*`, so the
+  policy layer survives that swap. The transport rewrite itself applied gramIO's architecture
+  lesson (one generic call function, policy as its wrapper, typed errors) without the dependency.
 
 ## 10. Running and deployment (design)
 


### PR DESCRIPTION
Three rule-9/rule-12 debts from the structural scan:

- AGENTS.md's repo map predated the scaffold relocation (#94), the channel folders (#93), and the
  entire telegram arc — it still showed engines/pi/scaffold/ and no channels/telegram/. Rewritten
  to the current tree, with the telegram subsystem modules named.
- docs/design/core.md ("current architecture") contained no channels section at all. §9 becomes
  "Channels": 9.1 HTTP (unchanged), 9.2 the telegram channel architecture — the module/invariant
  table plus the durable decisions that so far lived only in PR bodies: the channel-state
  convention (.fastagent/channels/<kind>/), summon-consumes-platform-structure (entities +
  token-id, fail closed), the HTML-string formatting model, and the gramIO tripwire.
- docs/channels.md vs docs/channel-development.md covered adjacent ground with an undeclared
  boundary; each now states its audience (user wiring vs author building) and links the other.
