### PR TITLE
fix(tunnel): never parse cloudflared's API endpoint as the assigned tunnel URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ While the project is pre-1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--tunnel` no longer mistakes cloudflared's API endpoint for the assigned tunnel URL.** Under a
+  flaky network, a cloudflared ERROR line mentioning `https://api.trycloudflare.com/tunnel` parsed
+  as the tunnel URL and the Telegram webhook got registered against Cloudflare's API host — the bot
+  silently received nothing while every log line said success.
+
 ## [0.8.0] - 2026-07-03
 
 ### Breaking

--- a/core/src/tunnel.ts
+++ b/core/src/tunnel.ts
@@ -17,7 +17,11 @@ export interface Tunnel {
   close(): void;
 }
 
-const TUNNEL_URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
+// `(?!api\.)`: cloudflared's ERROR lines mention its request endpoint (`https://api.trycloudflare.com/tunnel`,
+// e.g. "failed to request quick Tunnel: Post ... timeout" under a flaky proxy) — without the exclusion a
+// transient error line parses as the assigned URL and the webhook gets registered against Cloudflare's
+// API host instead of the tunnel (found live in the 0.8.0 release verification).
+const TUNNEL_URL_RE = /https:\/\/(?!api\.)[a-z0-9-]+\.trycloudflare\.com/i;
 
 /** Extract a Cloudflare quick-tunnel URL from a chunk of cloudflared output, if present. */
 export function parseTunnelUrl(chunk: string): string | undefined {

--- a/core/test/tunnel.test.ts
+++ b/core/test/tunnel.test.ts
@@ -105,6 +105,22 @@ describe("tunnel: parseTunnelUrl", () => {
     );
     expect(parseTunnelUrl("starting tunnel, registering connection…")).toBeUndefined();
   });
+
+  it("never mistakes cloudflared's API endpoint in an ERROR line for the assigned tunnel URL", () => {
+    // Seen live (0.8.0 release verification): a flaky proxy made cloudflared print its request
+    // endpoint in an error, and the webhook got registered against Cloudflare's API host.
+    expect(
+      parseTunnelUrl(
+        '2026 ERR failed to request quick Tunnel: Post "https://api.trycloudflare.com/tunnel": context deadline exceeded',
+      ),
+    ).toBeUndefined();
+    // …and an error line followed by the real assigned URL still resolves to the real one.
+    expect(
+      parseTunnelUrl(
+        'ERR Post "https://api.trycloudflare.com/tunnel": timeout\nINF |  https://adams-columbus-organizing-portion.trycloudflare.com  |',
+      ),
+    ).toBe("https://adams-columbus-organizing-portion.trycloudflare.com");
+  });
 });
 
 describe("tunnel: announceWebhooks", () => {


### PR DESCRIPTION
Found live during the 0.8.0 release verification: under a flaky proxy, cloudflared printed an
ERROR line containing its request endpoint ("failed to request quick Tunnel: Post
https://api.trycloudflare.com/tunnel: ..."), and TUNNEL_URL_RE — any host on trycloudflare.com —
matched it. The "tunnel URL" became Cloudflare's API host, the health poll happened to pass, and
setWebhook registered the bot against api.trycloudflare.com/telegram: the bot silently received
nothing while every log line said success.

The assigned quick-tunnel URL is always a generated multi-word host; the API endpoint is always
`api.trycloudflare.com`. The regex now excludes `api.` — an error line parses as nothing (the
retry loop keeps waiting for the real assignment), and an error line followed by the real box
line still resolves to the real URL. Both pinned by tests.
