### PR TITLE
fix(engine): wire provider request retries — retry-capable adapters no longer fail the turn on a transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ While the project is pre-1.0, minor versions may include breaking changes.
   flaky network, a cloudflared ERROR line mentioning `https://api.trycloudflare.com/tunnel` parsed
   as the tunnel URL and the Telegram webhook got registered against Cloudflare's API host — the bot
   silently received nothing while every log line said success.
+- **Transient provider request failures no longer kill the turn** for providers whose pi-ai
+  adapters implement client-side retries (OpenAI-family / Anthropic / Azure / Codex — request-phase
+  network errors / 429 / 5xx with backoff; all previously defaulted to 0 retries). The google /
+  vertex / bedrock / mistral adapters ignore `maxRetries`, so transients there still fail the
+  turn. Mid-stream drops also still fail the turn — partial output was already streamed and
+  cannot be retracted.
 
 ## [0.8.0] - 2026-07-03
 

--- a/core/src/engines/pi/harness.ts
+++ b/core/src/engines/pi/harness.ts
@@ -35,6 +35,19 @@ export interface PiHarnessFactoryOptions {
   skills?: Skill[];
 }
 
+/**
+ * Provider request retries. The OpenAI-family / Anthropic / Azure / Codex pi-ai adapters
+ * implement client-side retries (429/5xx/request-phase network failures with backoff, honoring
+ * Retry-After; a Codex websocket that fails before the stream starts falls back to SSE) but all
+ * default maxRetries to 0 (even SDK-backed ones override the SDK default), so a single transient
+ * `fetch failed` would otherwise kill the whole turn; 2 matches the OpenAI/Anthropic SDK default.
+ * The google / vertex / bedrock / mistral adapters ignore this option (a pi-ai upstream gap) —
+ * transients there still fail the turn. Mid-stream drops are deliberately NOT retried anywhere on
+ * this path — partial output was already streamed and the SPEC event stream cannot retract it,
+ * so a mid-stream failure surfaces as a `failed` event.
+ */
+const PROVIDER_MAX_RETRIES = 2;
+
 /** Open-or-create the session per invoke: existing → open (history via buildContext); missing → create. */
 export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFactory {
   return async (sessionId) => {
@@ -48,6 +61,7 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
       tools: options.tools,
       systemPrompt: typeof systemPrompt === "function" ? systemPrompt() : systemPrompt,
       resources: options.skills ? { skills: options.skills } : undefined,
+      streamOptions: { maxRetries: PROVIDER_MAX_RETRIES },
     });
   };
 }

--- a/core/test/harness.test.ts
+++ b/core/test/harness.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { inMemorySessionStore } from "../src/index.ts";
+import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { makeFaux } from "./faux.ts";
+
+describe("piHarnessFactory: provider retry wiring", () => {
+  it("built harnesses carry maxRetries — the wiring retry-capable pi-ai adapters honor", async () => {
+    // Retry-capable adapters (OpenAI-family / Anthropic / Azure / Codex) default to 0 retries —
+    // this wiring enables their client-side retries (a transient `fetch failed` killed a whole
+    // turn live in the 0.8.0 release verification). google / vertex / bedrock / mistral ignore
+    // the option; transients there still fail the turn.
+    const { faux, models } = makeFaux();
+    const factory = piHarnessFactory({
+      sessions: inMemorySessionStore(),
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      systemPrompt: "test",
+    });
+    const harness = await factory("s1");
+    expect(harness.getStreamOptions().maxRetries).toBe(2);
+  });
+});


### PR DESCRIPTION
The OpenAI-family / Anthropic / Azure / Codex pi-ai adapters implement client-side retries
(429/5xx/request-phase network errors with backoff, honoring Retry-After; a Codex websocket that
fails before the stream starts falls back to SSE) — but all default maxRetries to 0 (even
SDK-backed ones override the SDK default), and the bare AgentHarness sets nothing. So a single
transient `fetch failed` killed the whole turn (seen live in the 0.8.0 release verification: two
consecutive provider blips each surfaced as a failed turn that the pi CLI would have
auto-retried).

Harnesses are now built with `streamOptions: { maxRetries: 2 }` (the OpenAI/Anthropic SDK
default). Scope limits, both deliberate here:

- The google / vertex / bedrock / mistral adapters ignore `maxRetries` (a pi-ai upstream gap) —
  transients there still fail the turn. Setting the option is harmless where ignored.
- Mid-stream drops are NOT retried: partial output was already streamed and the SPEC event
  stream cannot retract it — a mid-stream failure surfaces as a `failed` event.

## Test
- `test/harness.test.ts`: the factory-built harness carries `maxRetries: 2` (`getStreamOptions()`) — the wiring contract; whether an adapter honors it is pi-ai behavior
- full suite: 327 passed