### PR TITLE
chore: release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ While the project is pre-1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-04
+
 ### Fixed
 
 - **`--tunnel` no longer mistakes cloudflared's API endpoint for the assigned tunnel URL.** Under a
@@ -111,6 +113,7 @@ While the project is pre-1.0, minor versions may include breaking changes.
 Last release before the open-source documentation pass. Earlier history is in the
 [commit log](https://github.com/kid7st/fastagent/commits/main).
 
-[Unreleased]: https://github.com/kid7st/fastagent/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/kid7st/fastagent/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/kid7st/fastagent/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/kid7st/fastagent/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/kid7st/fastagent/releases/tag/v0.7.1

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Vibe first. Then FastAgent: turn a local agent folder into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Patch release: the --tunnel URL-parse fix (webhook silently registered against Cloudflare's API
host under a flaky network) and provider request retries for retry-capable pi-ai adapters.
