### PR TITLE
feat(dev): live definition + narrow watch — the agent's own writes never kill its turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ src/
 ├── log.ts                   # leveled logging singleton (dev=debug, start=info)
 ├── observe.ts               # turn-trace logging around an Agent
 ├── tunnel.ts                # `--tunnel`: cloudflared + per-channel webhook dispatch
-├── dev-supervisor.ts        # `dev` watch/restart worker
+├── dev-supervisor.ts        # `dev` supervisor: restart on code-input edits (definition is live-read per invoke)
 ├── proxy.ts                 # HTTPS_PROXY wiring
 ├── workspace.ts, version.ts # neutral helpers (in-workspace guard, ignore files, version)
 ├── host/node.ts             # Node HTTP host: Routes/ChannelHandler/serveNode/router (public surface)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ While the project is pre-1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Changed
+
+- **The folder is live: AGENTS.md and `skills/` are re-read on every invoke** (folder-rung agents:
+  `createPiAgentFromDefinition`, `dev`, `start`). Edits — the author's or the agent's own — take
+  effect on the next turn with no process restart; a broken edit fails that turn visibly instead of
+  the process. `createPiAgent` (typed parts) is unchanged, and `fastagent chat` keeps its startup
+  snapshot — restart it to pick up edits.
+- **`dev` watch scope narrowed to code inputs** (`tools/`, `channels/`, `fastagent.config.*`,
+  `package.json`, `.env`) — the only changes that require a new process (ESM module cache). Files
+  the agent writes into its own workspace no longer kill its in-flight turn with a restart;
+  definition edits no longer restart at all (they are live, above). Helper code imported from
+  outside `tools/`/`channels/` is out of watch scope — keep it under `tools/`, or restart manually.
+
 ## [0.8.1] - 2026-07-04
 
 ### Fixed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,7 +88,9 @@ Authenticates a model provider and stores credentials in the **project-level** `
 fastagent dev [dir] [--port N] [--model provider/modelId] [--no-watch] [--tunnel]
 ```
 
-Assembles the workspace and serves it locally. With watch enabled, a supervisor restarts the worker on edits.
+Assembles the workspace and serves it locally. AGENTS.md/`skills/` are re-read every turn (edits go
+live next turn, no restart); a supervisor restarts the worker on edits to the code inputs —
+`tools/`, `channels/`, `fastagent.config.*`, `package.json`, `.env`.
 
 Options:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -67,7 +67,7 @@ FASTAGENT_MODEL=provider/model-id fastagent dev
 fastagent dev
 ```
 
-`dev` assembles the workspace, serves it on `:8787`, and restarts the worker when files change. The default channel is `POST /invoke`.
+`dev` assembles the workspace and serves it on `:8787`. AGENTS.md/`skills/` edits go live on the next turn; code edits (`tools/`, `channels/`, config) restart the worker. The default channel is `POST /invoke`.
 
 Send one turn:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,9 +81,19 @@ For `start`, hosted environments can set `PORT`.
 
 ## Dev does not pick up changes
 
-`fastagent dev` restarts its worker on workspace edits. It ignores machine-state and dependency directories such as `.fastagent/`, `node_modules/`, and `.git/`.
+`fastagent dev` separates two change classes:
 
-If the worker stopped after a broken edit, save another change after fixing the error. The supervisor should retry.
+- **AGENTS.md and `skills/`** are re-read on every turn — edits go live on the next turn with no
+  restart (and no watcher involvement).
+- **Code inputs** (`tools/`, `channels/`, `fastagent.config.*`, `package.json`, `.env`) restart the
+  dev worker — a new process is the only way to drop the ESM module cache.
+
+Nothing else is watched: files the agent itself writes into the workspace (its work product) never
+trigger a restart. Helper code imported from outside `tools/`/`channels/` is out of watch scope —
+keep it under `tools/`, or restart manually. (`fastagent chat` is a startup snapshot — restart it
+to pick up any edit.)
+
+If the worker stopped after a broken code edit, save another change after fixing the error. The supervisor should retry.
 
 Use `--no-watch` to serve once without the supervisor.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,7 +65,10 @@ function usage(code: number): never {
   fastagent login [provider] [--auth-path file]
   fastagent --version
 
-  dev    assemble the agent in dir (default .) and serve a local HTTP channel.
+  dev    assemble the agent in dir (default .) and serve a local HTTP channel. AGENTS.md/skills
+         are re-read every turn (edits go live next turn); edits to code inputs — tools/,
+         channels/, fastagent.config.*, package.json, .env — restart the worker (--no-watch to
+         disable). Files the agent writes as work product never trigger a restart.
          model precedence: --model > FASTAGENT_MODEL > fastagent.config.ts
          --tunnel  expose it on a public HTTPS URL via a Cloudflare quick tunnel (needs cloudflared)
                    and auto-register the webhook channels (telegram setWebhook; github prints the URL)

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -1,14 +1,43 @@
 /**
  * The `fastagent dev` process supervisor: re-spawn the CLI as a worker (`FASTAGENT_DEV_WORKER=1`) and
- * restart it on debounced workspace edits. Each restart is a fresh process (always-latest, no stale
- * module cache). The supervisor never exits on a bad edit — the worker fails loudly and it waits for
- * the next save.
+ * restart it on debounced edits to the workspace's CODE inputs. Each restart is a fresh process
+ * (always-latest, no stale module cache). The supervisor never exits on a bad edit — the worker fails
+ * loudly and it waits for the next save.
+ *
+ * Watch scope is deliberately narrow: only inputs whose changes REQUIRE a new process — imported
+ * code (tools/, channels/), fastagent.config.*, package.json, .env. The definition (AGENTS.md,
+ * skills/) is re-read per invoke by the folder rung, so its edits go live on the next turn with no
+ * restart — and, critically, an agent that writes files into its own workspace (its normal work
+ * product, including editing its own AGENTS.md) never has its in-flight turn killed by the watcher.
  */
 import { spawn } from "node:child_process";
+import { relative, sep } from "node:path";
 import { watch as watchTree } from "chokidar";
 import { log } from "./log.ts";
 import { installProxyFetch } from "./proxy.ts";
 import { type Tunnel, announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
+
+/** What the dev watcher restarts on (workspace-relative): the process-bound code inputs only. */
+export const WATCHED_HINT = "tools/, channels/, fastagent.config.*, package.json, .env";
+
+/**
+ * chokidar `ignored` matcher for the narrow watch scope (true = ignore). Ignoring a directory prunes
+ * the whole subtree, so everything outside the allowlist — .fastagent state, node_modules, .git, and
+ * any file/dir the agent writes as work product — costs no watchers and triggers no restarts.
+ * Helper code imported from OUTSIDE tools//channels/ is out of scope by design (keep it under
+ * tools/, or restart manually) — the startup log names the watched set.
+ */
+export function devWatchIgnored(root: string): (path: string) => boolean {
+  return (path: string): boolean => {
+    const rel = relative(root, path);
+    if (rel === "" || rel === ".") return false; // the root itself must not be pruned
+    const [head] = rel.split(sep);
+    if (head === "tools" || head === "channels") return false; // watched subtrees, fully
+    if (rel === "package.json" || rel === ".env") return false;
+    if (/^fastagent\.config\.[cm]?[jt]s$/.test(rel)) return false;
+    return true;
+  };
+}
 
 /** Spawn the dev worker and restart it on workspace edits; supervise its lifecycle until the process exits. */
 export function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}): void {
@@ -72,14 +101,11 @@ export function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}
     }
   };
 
-  // Recursively watch the workspace, structurally ignoring machine-state dirs: the worker writes
-  // jsonl sessions under .fastagent on every invoke (watching it would restart dev on its own
-  // writes); node_modules/.git are noise. Everything else — tools, skills, helper dirs a tool/config
-  // imports — is watched. chokidar gives reliable cross-platform recursion + structural ignore that
-  // native fs.watch cannot.
+  // chokidar gives reliable cross-platform recursion + structural ignore that native fs.watch
+  // cannot; devWatchIgnored (above) narrows the scope to the process-bound code inputs.
   const watcher = watchTree(dir, {
     ignoreInitial: true, // the startup scan is not a change
-    ignored: /(?:^|[\\/])(?:\.fastagent|node_modules|\.git)(?:[\\/]|$)/,
+    ignored: devWatchIgnored(dir),
   });
   watcher.on("all", () => {
     clearTimeout(timer);
@@ -88,7 +114,9 @@ export function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}
   watcher.on("error", (error) =>
     log.warn(`[fastagent] file watching error (${(error as Error).message}); some edits may need a manual restart`),
   );
-  log.info(`[fastagent] watching for changes — edits restart the dev worker (--no-watch to disable)`);
+  log.info(
+    `[fastagent] watching ${WATCHED_HINT} — code edits restart the dev worker (--no-watch to disable); AGENTS.md/skills edits go live next turn without a restart`,
+  );
 
   const shutdown = (): never => {
     worker?.kill("SIGTERM");

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -21,6 +21,7 @@ import { type FastagentConfig, defaultProjectAuthPath, resolveModel } from "./co
 import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { piHarnessFactory } from "./harness.ts";
 import { createPiModels } from "./models.ts";
+import { reportDefinitionWarnings } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
@@ -135,6 +136,8 @@ function buildPiAgent(opts: {
   systemPrompt?: string | (() => string);
   tools?: AgentTool[];
   skills?: Skill[];
+  /** Per-invoke prompt+skills source (see {@link PiHarnessFactoryOptions.live}); supersedes the two above. */
+  live?: () => Promise<{ systemPrompt?: string; skills?: Skill[] }>;
   sessions?: PiSessionStore;
   env?: ExecutionEnv;
   lease?: Lease;
@@ -150,6 +153,7 @@ function buildPiAgent(opts: {
       systemPrompt: opts.systemPrompt,
       tools: opts.tools,
       skills: opts.skills,
+      live: opts.live,
     }),
   });
 }
@@ -244,6 +248,13 @@ export interface CreatePiAgentFromDefinitionOptions {
   lease?: Lease;
 }
 
+/** Stable identity of a definition's non-fatal findings, for change-detection in `live` (dedup only). */
+function findingsSignature(def: LoadedDefinition): string {
+  const collisions = def.collisions.map((c) => `c:${c.name}:${c.winnerPath}:${c.loserPath}`);
+  const diagnostics = def.diagnostics.map((d) => `d:${d.code}:${d.path}`);
+  return [...collisions, ...diagnostics].sort().join("\n");
+}
+
 /**
  * L2: "point at a folder → agent": load + assemble (base + AGENTS.md + skills + env) + L1 in one
  * call. Returns the definition so callers can surface diagnostics/collisions.
@@ -253,7 +264,13 @@ export async function createPiAgentFromDefinition(
   options: CreatePiAgentFromDefinitionOptions,
 ): Promise<{ agent: Agent; definition: LoadedDefinition }> {
   const env = options.env ?? new NodeExecutionEnv({ cwd: dir });
+  // Boot-time load: fail-visibly at startup on a broken folder, and give callers the snapshot to
+  // report (skills/diagnostics/collisions). Serving does NOT close over it — see `live` below.
   const definition = await loadAgentDefinition(dir, { env });
+  // Findings the caller already reported at boot; `live` re-reports only when the set CHANGES — a
+  // runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
+  // every turn's log. A log-dedup memo, not session state (stateless invoke holds).
+  let reportedFindings = findingsSignature(definition);
   const tools = options.tools ?? piDefaultTools(env.cwd);
   const base = options.base ?? piBasePrompt({ tools });
   const agent = buildPiAgent({
@@ -262,19 +279,36 @@ export async function createPiAgentFromDefinition(
     // Dir-aware default: the same project-level file the opener uses for this dir (the opener passes
     // an explicit authPath, so this only affects direct L2 callers).
     authPath: options.authPath ?? defaultProjectAuthPath(dir),
-    // Factory, not a string: re-assembled per invoke so `date` is the date of the turn, not of agent
-    // creation (a long-running deployment would otherwise serve the boot date forever).
-    systemPrompt: () =>
-      assembleSystemPrompt({
-        base,
-        instructions: definition.instructions,
-        instructionsPath: definition.instructions !== undefined ? join(definition.dir, "AGENTS.md") : undefined,
-        skills: definition.skills,
-        date: new Date().toISOString().slice(0, 10),
-        cwd: env.cwd,
-      }),
+    // The folder is the agent, LIVE: re-read the definition on every invoke, so AGENTS.md/skills
+    // edits (the author's, or the agent's own self-modification) take effect on the next turn with
+    // no process restart — restarts are reserved for code (tools/channels/config, module cache).
+    // One read yields prompt AND skills (they can never diverge), `date` is the turn's date, and the
+    // fs cost is a few reads against a model call. Broken edits stay visible: a throw-class problem
+    // (unreadable AGENTS.md) fails that turn's invoke, and the loader's NON-fatal findings (bad
+    // SKILL.md frontmatter, name collisions — returned as data, not thrown) are warned the moment
+    // the finding set changes (boot findings are the baseline) — a runtime-written bad skill must
+    // not silently vanish from the agent, and a static one must not spam every turn's log. The
+    // next good edit heals both.
+    live: async () => {
+      const def = await loadAgentDefinition(dir, { env });
+      const sig = findingsSignature(def);
+      if (sig !== reportedFindings) {
+        reportedFindings = sig;
+        reportDefinitionWarnings(def.collisions, def.diagnostics);
+      }
+      return {
+        systemPrompt: assembleSystemPrompt({
+          base,
+          instructions: def.instructions,
+          instructionsPath: def.instructions !== undefined ? join(def.dir, "AGENTS.md") : undefined,
+          skills: def.skills,
+          date: new Date().toISOString().slice(0, 10),
+          cwd: env.cwd,
+        }),
+        skills: def.skills,
+      };
+    },
     tools,
-    skills: definition.skills,
     sessions: options.sessions,
     env,
     lease: options.lease,

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -29,10 +29,23 @@ export interface PiHarnessFactoryOptions {
   models: Models;
   model: AnyModel;
   tools?: AgentTool[];
-  /** Final assembled prompt, or a factory re-evaluated per invoke so time-sensitive segments stay current. */
+  /**
+   * Final assembled prompt, or a SYNC factory re-evaluated per invoke (how L1 serves dynamic
+   * `instructions` + the skills listing). Distinct from {@link live}, which is the folder rung's
+   * ASYNC re-read of prompt AND skills as one pair — both are exercised, by different rungs.
+   */
   systemPrompt?: string | (() => string);
   /** Skills visible to the model / explicitly invokable (injected as harness resources). */
   skills?: Skill[];
+  /**
+   * Per-invoke source for the prompt+skills PAIR, re-evaluated on every harness build. When set it
+   * supersedes {@link systemPrompt}/{@link skills} — one call yields both, so the skills listing
+   * inside the prompt and the mounted skill resources can never come from two different reads. The
+   * folder rung (L2) uses it to re-read the definition, so AGENTS.md/skills edits — the author's or
+   * the agent's own — take effect on the next turn without a process restart. A rejection surfaces
+   * as that invoke's `failed` event (the factory throw path), never a crash.
+   */
+  live?: () => Promise<{ systemPrompt?: string; skills?: Skill[] }>;
 }
 
 /**
@@ -52,15 +65,18 @@ const PROVIDER_MAX_RETRIES = 2;
 export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFactory {
   return async (sessionId) => {
     const session = await options.sessions.openOrCreate(sessionId);
+    const fresh = options.live ? await options.live() : undefined;
     const { systemPrompt } = options;
+    const prompt = fresh ? fresh.systemPrompt : typeof systemPrompt === "function" ? systemPrompt() : systemPrompt;
+    const skills = fresh ? fresh.skills : options.skills;
     return new AgentHarness({
       env: options.env,
       session,
       models: options.models,
       model: options.model,
       tools: options.tools,
-      systemPrompt: typeof systemPrompt === "function" ? systemPrompt() : systemPrompt,
-      resources: options.skills ? { skills: options.skills } : undefined,
+      systemPrompt: prompt,
+      resources: skills ? { skills } : undefined,
       streamOptions: { maxRetries: PROVIDER_MAX_RETRIES },
     });
   };

--- a/test/definition.test.ts
+++ b/test/definition.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
@@ -17,6 +17,7 @@ import {
   type CreatePiAgentFromDefinitionOptions,
 } from "../src/index.ts";
 import { assembleSystemPrompt } from "../src/engines/pi/create.ts";
+import { log } from "../src/log.ts";
 import { isUnderStateDir } from "../src/engines/pi/definition.ts";
 
 const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "agent");
@@ -273,5 +274,102 @@ describe("create: toolset (real pi tools, fidelity)", () => {
     const r = await read.execute("t1", { path: "AGENTS.md" });
     const text = (r.content[0] as any).text as string;
     expect(text).toContain("Haiku Bot");
+  });
+});
+
+describe("create L2: the folder is LIVE (definition re-read per invoke)", () => {
+  it("an AGENTS.md/skill edit between two invokes reaches the next turn's prompt and skill resources — no restart", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-"));
+    await writeFile(join(dir, "AGENTS.md"), "You are DRAFT-PERSONA.\n");
+    const seen: (string | undefined)[] = [];
+    const { faux } = makeFaux();
+    faux.setResponses([
+      (ctx) => {
+        seen.push(ctx.systemPrompt);
+        return fauxAssistantMessage("one");
+      },
+      (ctx) => {
+        seen.push(ctx.systemPrompt);
+        return fauxAssistantMessage("two");
+      },
+    ]);
+    const { agent } = await createPiAgentFromDefinition(dir, { providers: [faux.provider], model: "faux/faux-1" });
+
+    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
+    // The edit an agent might make to its own workspace mid-conversation: new persona + a new skill.
+    await writeFile(join(dir, "AGENTS.md"), "You are FINAL-PERSONA.\n");
+    await mkdir(join(dir, "skills", "late-skill"), { recursive: true });
+    await writeFile(
+      join(dir, "skills", "late-skill", "SKILL.md"),
+      "---\nname: late-skill\ndescription: added after boot\n---\nBody.\n",
+    );
+    await collect(agent.invoke({ session: "s" }, { text: "again" }));
+
+    expect(seen[0]).toContain("DRAFT-PERSONA");
+    expect(seen[0]).not.toContain("late-skill");
+    expect(seen[1]).toContain("FINAL-PERSONA");
+    expect(seen[1]).not.toContain("DRAFT-PERSONA");
+    expect(seen[1]).toContain("late-skill"); // the listing comes from the SAME re-read as the prompt
+  });
+
+  it("a bad skill written at runtime is surfaced as a warning on the affected turn, never silently dropped", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-bad-"));
+    await writeFile(join(dir, "AGENTS.md"), "You are a bot.\n");
+    const { faux } = makeFaux();
+    faux.setResponses([() => fauxAssistantMessage("one"), () => fauxAssistantMessage("two")]);
+    const { agent } = await createPiAgentFromDefinition(dir, { providers: [faux.provider], model: "faux/faux-1" });
+    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
+
+    // The agent (or author) writes a skill with broken frontmatter mid-conversation. The loader
+    // returns this as a diagnostic (data, not a throw) — the live path must re-report it.
+    await mkdir(join(dir, "skills", "broken"), { recursive: true });
+    await writeFile(join(dir, "skills", "broken", "SKILL.md"), "no frontmatter at all\n");
+    const warn = vi.spyOn(log, "warn");
+    try {
+      const { text } = await collect(agent.invoke({ session: "s" }, { text: "again" }));
+      expect(text).toBe("two"); // non-fatal: the turn still completes
+      const brokenWarns = () => warn.mock.calls.filter((c) => String(c[0]).includes("broken")).length;
+      expect(brokenWarns()).toBeGreaterThan(0);
+
+      // …but an UNCHANGED finding set does not re-warn on the next turn (no per-turn log spam).
+      faux.appendResponses([() => fauxAssistantMessage("three")]);
+      await collect(agent.invoke({ session: "s" }, { text: "once more" }));
+      expect(brokenWarns()).toBe(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("a throw-class broken edit fails THAT turn as a failed event — the agent survives and the next good turn recovers", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-throw-"));
+    await writeFile(join(dir, "AGENTS.md"), "You are a bot.\n");
+    class FlakyEnv extends NodeExecutionEnv {
+      deny = false;
+      override async readTextFile(path: string) {
+        if (this.deny && path.endsWith("AGENTS.md")) {
+          return err<string, FileError>(new FileError("permission_denied", "permission denied", path));
+        }
+        return super.readTextFile(path);
+      }
+    }
+    const env = new FlakyEnv({ cwd: dir });
+    const { faux } = makeFaux();
+    faux.setResponses([() => fauxAssistantMessage("one"), () => fauxAssistantMessage("recovered")]);
+    const { agent } = await createPiAgentFromDefinition(dir, { providers: [faux.provider], model: "faux/faux-1", env });
+    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
+
+    env.deny = true; // the live re-read now throws (unreadable AGENTS.md)
+    const events: string[] = [];
+    let details = "";
+    for await (const e of agent.invoke({ session: "s" }, { text: "again" })) {
+      events.push(e.type);
+      if (e.type === "failed") details = e.details;
+    }
+    expect(events).toEqual(["failed"]); // SPEC MUST 2: a failed event, not a thrown iteration error
+    expect(details).toMatch(/AGENTS\.md/);
+
+    env.deny = false; // the next good edit heals it — same agent, no restart
+    const { text } = await collect(agent.invoke({ session: "s" }, { text: "back" }));
+    expect(text).toBe("recovered");
   });
 });

--- a/test/dev-supervisor.test.ts
+++ b/test/dev-supervisor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+import { devWatchIgnored } from "../src/dev-supervisor.ts";
+
+describe("dev-supervisor: devWatchIgnored (the narrow watch scope)", () => {
+  const root = join("/work", "agent");
+  const ignored = devWatchIgnored(root);
+
+  it("watches exactly the process-bound code inputs", () => {
+    expect(ignored(root)).toBe(false); // the root itself must not be pruned
+    expect(ignored(join(root, "tools"))).toBe(false);
+    expect(ignored(join(root, "tools", "word-count.ts"))).toBe(false);
+    expect(ignored(join(root, "tools", "lib", "helper.ts"))).toBe(false); // nested under tools/
+    expect(ignored(join(root, "channels", "telegram.ts"))).toBe(false);
+    expect(ignored(join(root, "package.json"))).toBe(false);
+    expect(ignored(join(root, ".env"))).toBe(false);
+    expect(ignored(join(root, "fastagent.config.mjs"))).toBe(false);
+    expect(ignored(join(root, "fastagent.config.ts"))).toBe(false);
+  });
+
+  it("ignores the definition (live-read per invoke) and anything the agent writes as work product", () => {
+    expect(ignored(join(root, "AGENTS.md"))).toBe(true); // live-read — a restart would be strictly worse
+    expect(ignored(join(root, "skills"))).toBe(true);
+    expect(ignored(join(root, "skills", "house-style", "SKILL.md"))).toBe(true);
+    expect(ignored(join(root, "report.md"))).toBe(true); // agent work product
+    expect(ignored(join(root, "out"))).toBe(true); // pruned as a directory — its subtree costs nothing
+    expect(ignored(join(root, ".fastagent"))).toBe(true);
+    expect(ignored(join(root, "node_modules"))).toBe(true);
+    expect(ignored(join(root, ".git"))).toBe(true);
+  });
+
+  it("root-file names elsewhere do not match (package.json in a subdir is not a code input)", () => {
+    expect(ignored(join(root, "out", "package.json"))).toBe(true);
+    expect(ignored(join(root, "docs", ".env"))).toBe(true);
+  });
+});


### PR DESCRIPTION
`fastagent dev` watched (almost) the whole workspace and restarted the worker on any change,
because a restart was the ONLY way for an AGENTS.md/skills edit to take effect — the definition
was loaded once at boot and the systemPrompt factory closed over it. That design collapses in the
serving reality this project exists for: an agent with write tools produces files in its own
workspace (its normal work product, including editing its own AGENTS.md), and every such write
SIGTERM'd the worker mid-turn — killing the very turn doing the writing, dropping started turns
via WAL recovery, and reading as "dev is stuck" (found live while operating the telegram-agent
workspace).

The fix separates the two change classes by what they actually require:

- Definition (AGENTS.md, skills/) is now LIVE: the folder rung re-reads it on every invoke via a
  new per-invoke `live` source on the harness factory — one read yields prompt AND skills (they
  can never diverge). Edits go live next turn with zero restart and zero killed turns — strictly
  better than the restart ever was. A broken edit fails that turn visibly (the factory-throw →
  failed-event path), not the process. Boot-time load stays for startup fail-fast + the report
  snapshot. L1 (typed parts) is unchanged.
- The watcher narrows to the process-bound code inputs — tools/, channels/, fastagent.config.*,
  package.json, .env — the only changes a new process is actually needed for (ESM module cache).
  Everything else, including any file the agent writes, is pruned at the directory level. Named
  trade-off (documented in troubleshooting + the startup log): helper code imported from outside
  tools//channels/ no longer auto-restarts — keep it under tools/, or restart manually.

Tests: an e2e proving an AGENTS.md edit + late-added skill between two invokes reaches the second
turn's prompt and resources (19th definition test), and unit tests pinning the watch allowlist
(work-product files/dirs ignored, root-file names in subdirs not matched).
