### PR TITLE
chore: release 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ While the project is pre-1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-07-04
+
 ### Changed
 
 - **The folder is live: AGENTS.md and `skills/` are re-read on every invoke** (folder-rung agents:
@@ -126,7 +128,8 @@ While the project is pre-1.0, minor versions may include breaking changes.
 Last release before the open-source documentation pass. Earlier history is in the
 [commit log](https://github.com/kid7st/fastagent/commits/main).
 
-[Unreleased]: https://github.com/kid7st/fastagent/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/kid7st/fastagent/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/kid7st/fastagent/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/kid7st/fastagent/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/kid7st/fastagent/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/kid7st/fastagent/releases/tag/v0.7.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Vibe first. Then FastAgent: turn a local agent folder into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
The live-definition + narrow-watch dev redesign (verified on a live telegram-agent workload
before release: agent work-product writes no longer restart the worker, AGENTS.md edits go live
next turn), plus the repo flatten.
