### PR TITLE
fix(auth): drop the pre-0.x global-credential migration hint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,6 @@ import {
   resolveSessionsDirOverride,
 } from "./engines/pi/config.ts";
 import { formatModelsCommand } from "./cli-models.ts";
-import { GLOBAL_AUTH_PATH } from "./engines/pi/auth.ts";
 import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
 import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 import { ensureInTreeStateSelfIgnored, loadAgentDefinition } from "./engines/pi/definition.ts";
@@ -211,8 +210,6 @@ async function runInvoke(): Promise<void> {
     authPath: resolveAuthPathOverride(values["auth-path"]),
   }).catch(failStartup);
   console.error(`[fastagent] invoke: ${invokeDir} (${modelSpec})`);
-  // Same auth report as dev/start (incl. the global-credential migration hint) — otherwise an upgraded
-  // user's first `invoke` hits a bare turn failure with no pointer to their existing global credential.
   await reportAuth(modelSpec, authPath);
   // Fresh session per invoke (one-shot, no resume). runInvokeStream maps events→IO: reply→stdout,
   // tool/failure→stderr, exit 1 iff the turn failed (so CI can gate on it).
@@ -460,19 +457,6 @@ async function reportAuth(modelSpec: string, authPath: string): Promise<void> {
   const source = await probeAuthSource(createPiModels({ authPath }), modelSpec);
   log.info(`[fastagent] auth:   ${source === undefined ? "(none found)" : `${source} (${provider})`} — ${authPath}`);
   if (source !== undefined) return;
-  // Migration aid: a pre-0.x user logged in under the OLD global default; the new project-level
-  // default reads empty and would silently "lose" their credential. If the global file still has it,
-  // point them at it (sharing one file is safe) rather than only telling them to log in again.
-  if (authPath !== GLOBAL_AUTH_PATH) {
-    const global = await probeAuthSource(createPiModels({ authPath: GLOBAL_AUTH_PATH }), modelSpec);
-    if (global !== undefined) {
-      log.warn(
-        `[fastagent] no project credentials for "${provider}", but the global ${GLOBAL_AUTH_PATH} has them — ` +
-          `set FASTAGENT_AUTH_PATH=${GLOBAL_AUTH_PATH} to use them here, or run \`fastagent login\` for a project-level credential`,
-      );
-      return;
-    }
-  }
   // Lead with `fastagent login`: the default model (openai-codex) is OAuth-only, and the provider-
   // specific env var name is not exported, so keep the env path generic. login writes to this same
   // project-level path, so a follow-up `fastagent login` here fixes it in place.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -117,25 +117,4 @@ describe("cli papercuts", () => {
     expect(code).not.toBe(0);
     await expect(stat(join(cwd, ".fastagent", ".gitignore"))).rejects.toThrow(); // external path won → no in-tree self-ignore
   });
-
-  it("invoke points an upgraded user at their global credential when the project file is empty", async () => {
-    // The breaking change's safety net: project auth defaults empty, but a pre-upgrade global login
-    // still has the credential — the startup report must say so (set FASTAGENT_AUTH_PATH) instead of a
-    // bare turn failure. HOME override makes GLOBAL_AUTH_PATH resolve into the temp home.
-    const home = await mkdtemp(join(tmpdir(), "fa-home-"));
-    await mkdir(join(home, ".fastagent"), { recursive: true });
-    await writeFile(
-      join(home, ".fastagent", "auth.json"),
-      JSON.stringify({ anthropic: { type: "api_key", key: "sk-test" } }),
-    );
-    const proj = await mkdtemp(join(tmpdir(), "fa-proj-"));
-    await writeFile(join(proj, "fastagent.config.mjs"), `export default { model: "anthropic/claude-sonnet-4-5" };`);
-    const env: NodeJS.ProcessEnv = { ...process.env, HOME: home };
-    delete env.ANTHROPIC_API_KEY; // else the project probe finds env creds and the hint never fires
-    delete env.FASTAGENT_AUTH_PATH;
-    delete env.FASTAGENT_MODEL;
-    const { stderr } = await run(["invoke", "hi", proj], undefined, env);
-    expect(stderr).toMatch(/global .*has them/i); // the migration hint fired
-    expect(stderr).toMatch(/FASTAGENT_AUTH_PATH=/); // with the actionable env-var fix
-  });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -28,9 +28,9 @@ describe("config: resolveSessionsDirOverride (start's sessions precedence)", () 
 
 describe("models: createPiModels honors authPath (the project-level credential seam)", () => {
   it("reads a stored credential from the GIVEN file, not the global default or env", async () => {
-    // The foundation of both the feature and the migration hint: point createPiModels at a path and it
-    // must read THAT file. "stored credential" (not the "ANTHROPIC_API_KEY" env label) proves the file
-    // at authPath won — so an empty project file genuinely reads as not-configured (what the hint keys on).
+    // Point createPiModels at a path and it must read THAT file. "stored credential" (not the
+    // "ANTHROPIC_API_KEY" env label) proves the file at authPath won — so an empty project file
+    // genuinely reads as not-configured, which is what the startup auth report keys on.
     const path = join(await mkdtemp(join(tmpdir(), "fa-auth-")), "auth.json");
     await writeFile(path, JSON.stringify({ anthropic: { type: "api_key", key: "sk-test" } }));
     expect(await probeAuthSource(createPiModels({ authPath: path }), "anthropic/claude-sonnet-4-5")).toBe(


### PR DESCRIPTION
## Summary

The startup auth report probed `GLOBAL_AUTH_PATH` whenever the project-level auth file was empty and pointed a pre-0.x upgrader at it (`set FASTAGENT_AUTH_PATH=…`). That was a backward-compat aid with no place in a pre-release — removed.

Deleted along with it: the now-dead `GLOBAL_AUTH_PATH` import in `cli.ts`, the one test that covered the hint, and the stale companion comments (the `invoke` call-site note + the migration block's own). The report falls back to the generic `fastagent login` hint, consistent with the fail-visibly, no-implicit project/global fallback design (`auth.ts` / `docs/design/core.md` §10.4).

Net: source -16, tests -21.

## Validation

- [x] `npm run typecheck`
- [x] `npm test`
- [x] Added or updated the smallest relevant tests (removed the test for the deleted behavior)

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (none needed — core.md §10.4 already describes the no-fallback design this aligns to)
