### PR TITLE
chore: release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ While the project is pre-1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-05
+
 ### Changed
 
 - **BREAKING: the channel contract is now `ChannelModule = (ctx: ChannelContext) => Routes`** with
@@ -194,7 +196,8 @@ While the project is pre-1.0, minor versions may include breaking changes.
 Last release before the open-source documentation pass. Earlier history is in the
 [commit log](https://github.com/kid7st/fastagent/commits/main).
 
-[Unreleased]: https://github.com/kid7st/fastagent/compare/v0.8.3...HEAD
+[Unreleased]: https://github.com/kid7st/fastagent/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/kid7st/fastagent/compare/v0.8.3...v0.9.0
 [0.8.3]: https://github.com/kid7st/fastagent/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/kid7st/fastagent/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/kid7st/fastagent/compare/v0.8.0...v0.8.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Vibe first. Then FastAgent: turn a local agent folder into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Release 0.9.0.

Bumps package.json to 0.9.0 and finalizes the CHANGELOG. Contents (all merged to main):

- **BREAKING** channel mount context + one state root (FASTAGENT_STATE_DIR) — #129
- Durable turn intent for the Telegram channel (L1 crash/deploy recovery)

Pre-1.0: a minor version carries the breaking change (SemVer pre-1.0 allowance). No code changes here — version + CHANGELOG only. On merge, tag v0.9.0 + create the GitHub Release; publish.yml re-verifies and publishes via OIDC.
