### PR TITLE
fix(scaffold): init/scaffold UX polish (stale state docs, info degrade, add help, persona)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,7 +104,8 @@ function usage(code: number): never {
                    point it at ~/.fastagent/auth.json to share one credential across projects)
          --tunnel  same as dev: a public HTTPS URL + auto-registered webhooks, for hosting a bot from
                    your own box without deploying (the quick-tunnel URL is ephemeral, not for production)
-  add    github | telegram: scaffold channels/<kind>.ts (third-party adapter glue, an on() to edit).
+  add    github | telegram: scaffold channels/<kind>.ts — third-party adapter glue with the policy
+         to edit (github maps events in on(); telegram routes in the optional route()).
          skill <source>: vendor an Agent Skills skill into skills/<name>/ (git ref owner/repo/path, a
          local path, or a bare name from ~/.agents/skills; --update re-fetches, review with git diff)
   login  authenticate a model provider into the project-level <state root>/auth.json — default
@@ -234,7 +235,12 @@ async function runInfo(): Promise<void> {
   const { config, path: configPath } = await loadConfig(dir).catch(failStartup);
   const modelSpec = resolveModelSpec(values.model, config);
   const definition = await loadAgentDefinition(dir).catch(failStartup);
-  const { toolNames, toolCollisions } = await resolveWorkspaceTools(config, dir).catch(failStartup);
+  // A tool that fails to import (typically a missing dep before `npm install`) must NOT abort a
+  // read-only inspect: report it and still show model/skills/channels/state. dev/start keep
+  // failStartup — you cannot serve broken tools, but `info` exists to diagnose "something looks off".
+  const tools = await resolveWorkspaceTools(config, dir)
+    .then((r) => ({ names: r.toolNames, collisions: r.toolCollisions, error: undefined as string | undefined }))
+    .catch((e: unknown) => ({ names: [] as string[], collisions: [], error: (e as Error).message }));
   const channels = await discoverChannelFiles(dir).catch(failStartup);
   // The default sessions/auth paths WITHOUT creating anything (info is read-only; dev/start mkdir/login
   // create them, info must not).
@@ -251,14 +257,15 @@ async function runInfo(): Promise<void> {
           model: modelSpec ?? null,
           instructions: definition.instructions !== undefined,
           skills: definition.skills.map((skill) => ({ name: skill.name, description: skill.description })),
-          tools: toolNames,
+          tools: tools.names,
+          toolError: tools.error ?? null,
           channels,
           stateRoot,
           sessionsDir,
           authPath,
           diagnostics: definition.diagnostics,
           skillCollisions: definition.collisions,
-          toolCollisions,
+          toolCollisions: tools.collisions,
         },
         null,
         2,
@@ -271,12 +278,13 @@ async function runInfo(): Promise<void> {
   console.log(`model:    ${modelSpec ?? "(not set — pass --model, set FASTAGENT_MODEL, or config.model)"}`);
   console.log(`agents:   ${definition.instructions ? "AGENTS.md" : "(none)"}`);
   console.log(`skills:   ${definition.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
-  console.log(`tools:    ${toolNames.join(", ") || "(none)"}`);
+  console.log(`tools:    ${tools.error ? "(could not load — see warning below)" : tools.names.join(", ") || "(none)"}`);
   console.log(`channels: ${channels.join(", ") || "(none)"}`);
   console.log(`state:    ${stateRoot}`);
   console.log(`sessions: ${sessionsDir}`);
   console.log(`auth:     ${authPath}`);
-  reportToolCollisions(toolCollisions);
+  reportToolCollisions(tools.collisions);
+  if (tools.error) log.warn(`[fastagent] ${tools.error}`);
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 }
 

--- a/src/scaffold/templates/AGENTS.md
+++ b/src/scaffold/templates/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent
 
-Your entire definition lives in this folder: `AGENTS.md` (this file — your system prompt) and `skills/` (capabilities you load when a task calls for them). Your `read` / `write` / `edit` / `bash` tools are rooted here, and the folder is re-read every turn — so an edit you make to your own definition takes effect on your next message, no restart.
+Your entire definition lives in this folder: `AGENTS.md` (this file — your system prompt), `skills/` (capabilities you load when a task calls for them), and `tools/` (code tools you can call, added by your author). Your `read` / `write` / `edit` / `bash` tools are rooted here, and the folder is re-read every turn — so an edit you make to your own definition takes effect on your next message, no restart.
 
 You can improve yourself. When a task reveals something durable — a repeatable process, a standing preference, a hard-won fact — write it into your definition instead of losing it:
 

--- a/src/scaffold/templates/env.example
+++ b/src/scaffold/templates/env.example
@@ -15,5 +15,9 @@
 # --- Serving (fastagent start) ---
 # Port precedence: --port > PORT > config.http.port > 8787
 # PORT=8787
-# Where conversations persist (default: ./fastagent-sessions)
-# FASTAGENT_SESSIONS_DIR=./fastagent-sessions
+# Machine-state root: sessions, auth.json, and channel state all derive from it.
+# Default: <dir>/.fastagent. Point it at a mounted volume so a redeploy that replaces the
+# directory keeps conversations and credentials.
+# FASTAGENT_STATE_DIR=/data/fastagent
+# Override just the sessions path (default: <state root>/sessions):
+# FASTAGENT_SESSIONS_DIR=/data/sessions

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -76,6 +76,32 @@ describe("cli papercuts", () => {
     await expect(stat(join(dir, ".fastagent"))).rejects.toThrow(); // read-only: never creates sessions dir
   });
 
+  it("info degrades when a tool can't load (missing dep) — reports it, still shows the surface, exits 0", async () => {
+    // The scaffold ships tools/ that import @kid7st/fastagent; before `npm install` the import fails.
+    // info is read-only diagnosis ("run it first when something looks off") — a broken tool must be
+    // reported, not abort the whole report. dev/start still fail hard (you cannot serve broken tools).
+    const dir = await mkdtemp(join(tmpdir(), "fa-info-toolfail-"));
+    await mkdir(join(dir, "tools"), { recursive: true });
+    await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
+    await writeFile(join(dir, "tools", "broken.ts"), 'import "totally-not-a-real-package-xyz";\nexport default {};\n');
+    const env = { ...process.env };
+    delete env.FASTAGENT_MODEL;
+
+    const { code, stdout } = await run(["info", dir, "--json"], undefined, env);
+    expect(code).toBe(0); // reported, not fatal
+    const info = JSON.parse(stdout);
+    expect(info.tools).toEqual([]); // could not load
+    expect(info.toolError).toMatch(/broken\.ts/); // the reason is surfaced to a JSON consumer
+    expect(info.instructions).toBe(true); // the rest of the surface still shows
+    await expect(stat(join(dir, ".fastagent"))).rejects.toThrow(); // still read-only
+
+    // text mode: the tools line degrades and the reason goes to stderr as a warning
+    const text = await run(["info", dir], undefined, env);
+    expect(text.code).toBe(0);
+    expect(text.stdout).toMatch(/tools:\s+\(could not load/);
+    expect(text.stderr).toMatch(/broken\.ts/);
+  });
+
   it("login self-ignores .fastagent on an adapted dir before it writes the credential file", async () => {
     // login is the command that CREATES the secret, so its self-ignore must fire independently of the
     // opener. A bogus provider fails the auth flow AFTER the self-ignore, so the .gitignore is the


### PR DESCRIPTION
Follow-up polish to the init/scaffold UX (review of the whole init + add-channel/tool flow). Four fixes, no scope beyond them.

## P1 — stale text (factual inconsistencies from the 0.9.0 state-dir merge)

1. **`env.example` state/sessions.** The Serving section still pointed at `./fastagent-sessions` and never mentioned `FASTAGENT_STATE_DIR` (the 0.9.0 machine-state root). It now documents the state root and the real sessions default (`<state>/sessions`), matching `fastagent info` and the `start` help.
2. **usage `add` one-liner.** Said "an on() to edit", but only github uses `on()` — telegram now uses the optional `route()`. Reworded to name both.

## P2 — UX rough edges

3. **`fastagent info` degrades on a tool-load failure.** Before: one tool that can't import (typically a missing dep right after `init --no-install`) aborted the entire read-only report. Now it reports the reason (a warning in text mode; a `toolError` field in `--json`) and still prints model/skills/channels/state, exit 0. `dev`/`start` keep `failStartup` — you cannot serve broken tools, but `info` exists to diagnose "something looks off". Covered by a new test.
4. **AGENTS.md persona mentions `tools/`.** The scaffold ships `tools/fetch-url.ts`, but the persona described the definition as only `AGENTS.md` + `skills/`. Now names `tools/` too, so the shipped tool isn't invisible in the self-improvement story.

## Verify

Full CI commands locally (`lint` + `typecheck` + `test`), run with `dist/` moved aside to match CI's clean checkout: all green, 356 tests. E2E: `init --no-install` then `info` now shows the surface + a warning instead of aborting.
