### PR TITLE
docs: fix doc/code inconsistencies and add code of conduct

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 
 ## Validation
 
+- [ ] `npm run lint`
 - [ ] `npm run typecheck`
 - [ ] `npm test`
 - [ ] Added or updated the smallest relevant tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ While the project is pre-1.0, minor versions may include breaking changes.
   (`AgentTool`, `Skill`, `SkillDiagnostic`, `Session`, `Model`, `Provider`/`createProvider`).
 - `SECURITY.md`, `CHANGELOG.md`, and `llms.txt` for open-source readiness.
 - README status badges (CI, npm version, license, Node version).
-- `start.md`: an AI-guided setup prompt for coding agents.
+- `ai-start.md`: an AI-guided setup prompt for coding agents.
 - Restructured public docs: `docs/README.md` index, `overview`, `cli`, `configuration`,
   `api-reference`, `troubleshooting`, `principles`, dedicated channel guides
   (`github`, `telegram`, `channel-development`), and maintainer notes under `docs/design/`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by opening a
+private report to the maintainers through GitHub's private reporting
+(repository **Security → Report a vulnerability**), or by contacting the
+repository owner directly. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ This repository follows **GitHub Flow** (single trunk) with a local-first iterat
 
 All repository-facing text — code, comments, docs, commit messages, PR descriptions — is **English**. This is an open-source project for a global audience.
 
+By participating, you agree to uphold the [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Branch model
 
 - `main` is the only long-lived branch. It is protected: linear history, required CI, no force-push, no deletion.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ FastAgent is pre-1.0. The stable design center is the Agent Handler contract in 
 ## Project
 
 - [Contributing](CONTRIBUTING.md)
+- [Code of conduct](CODE_OF_CONDUCT.md)
 - [Security policy](SECURITY.md)
 - [Changelog](CHANGELOG.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ In scope:
 
 - the `@kid7st/fastagent` package (CLI, library API, reference implementation),
 - the first-party channel adapters (`/github`, `/telegram`),
-- credential handling in `~/.fastagent/auth.json` and the OAuth/env auth resolution path.
+- credential handling in the project-level `<state root>/auth.json` (default `<dir>/.fastagent/auth.json`; global `~/.fastagent/auth.json` is opt-in) and the OAuth/env auth resolution path.
 
 Out of scope:
 
@@ -42,7 +42,7 @@ Out of scope:
 
 FastAgent treats credentials and environment as deployment config, never as part of the agent definition:
 
-- keep `.env`, provider keys, and `~/.fastagent/auth.json` out of version control,
+- keep `.env`, provider keys, and the credentials file (`<dir>/.fastagent/auth.json` by default, or `~/.fastagent/auth.json`) out of version control,
 - the scaffolded `.gitignore` excludes `.env`; `fastagent init` warns when a pre-existing `.gitignore` does not,
 - webhook channels require a verification secret (`GITHUB_WEBHOOK_SECRET`, `TELEGRAM_SECRET_TOKEN`) and fail at startup when it is missing, rather than accepting forged deliveries.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -142,14 +142,16 @@ Load `AGENTS.md` and `skills/` from a folder, assemble the pi prompt, and return
 ```ts
 function createPiAgentFromWorkspace(
   dir: string,
-  options?: { model?: string; sessionsDir?: string },
+  options?: { model?: string; sessionsDir?: string; authPath?: string },
 ): Promise<{
   agent: Agent;
   definition: LoadedDefinition;
   config: FastagentConfig;
   configPath?: string;
   modelSpec: string;
+  stateRoot: string;
   sessionsDir: string;
+  authPath: string;
   toolNames: string[];
   toolCollisions: ToolCollision[];
 }>;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,7 +47,7 @@ Options:
 ## `fastagent info`
 
 ```bash
-fastagent info [dir] [--json]
+fastagent info [dir] [--json] [--auth-path file]
 ```
 
 Prints the assembled surface without starting a server:
@@ -75,7 +75,7 @@ Use a listed spec with `--model`, `FASTAGENT_MODEL`, or `fastagent.config.*`.
 ## `fastagent login`
 
 ```bash
-fastagent login [provider]
+fastagent login [provider] [--auth-path file]
 ```
 
 Authenticates a model provider and stores credentials in the **project-level** `<state root>/auth.json` — by default `<cwd>/.fastagent/auth.json` (root override: `FASTAGENT_STATE_DIR`; file override: `--auth-path` / `FASTAGENT_AUTH_PATH`; run it from `$HOME` to write the global `~/.fastagent/auth.json`). There is no implicit fallback between the project and global files — the default is project-level for **isolation** (different agents can use different accounts) and **fail-visibly** (a missing credential surfaces instead of being masked by a machine-global one absent on a fresh box). So `cd` into your agent before logging in. FastAgent uses its own credential file, separate from pi's CLI state.
@@ -85,7 +85,7 @@ Authenticates a model provider and stores credentials in the **project-level** `
 ## `fastagent dev`
 
 ```bash
-fastagent dev [dir] [--port N] [--model provider/modelId] [--no-watch] [--tunnel]
+fastagent dev [dir] [--port N] [--model provider/modelId] [--auth-path file] [--no-watch] [--tunnel]
 ```
 
 Assembles the workspace and serves it locally. AGENTS.md/`skills/` are re-read every turn (edits go
@@ -118,7 +118,7 @@ Opens the same assembled workspace in pi's interactive TUI. This is useful for t
 ## `fastagent invoke`
 
 ```bash
-fastagent invoke <message> [dir] [--model provider/modelId]
+fastagent invoke <message> [dir] [--model provider/modelId] [--auth-path file]
 ```
 
 Runs one turn through the same workspace assembly and exits:
@@ -174,7 +174,7 @@ Use `--update` to overwrite an existing vendored skill. Review the result with `
 ## `fastagent start`
 
 ```bash
-fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir] [--tunnel]
+fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir] [--auth-path file] [--tunnel]
 ```
 
 Runs the workspace in production posture: no watch, same assembly as `dev`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,6 +149,14 @@ channels/telegram.ts
 
 See [Channels](channels.md).
 
+## Logging
+
+Log verbosity is an environment knob, not a config key. `FASTAGENT_LOG_LEVEL` (`debug` | `info` | `warn` | `error`) overrides the per-posture default: `dev` defaults to `debug`, `start` to `info`. Per-turn traces log at `debug`, so `start` keeps end-user content out of production logs unless you opt into `debug`.
+
+```bash
+FASTAGENT_LOG_LEVEL=debug fastagent start
+```
+
 ## What is deliberately not config
 
 The following are library API injection points rather than config keys:


### PR DESCRIPTION
## Summary

Pre-open-source doc review pass. Closes the gaps between the docs and the shipped CLI/API surface, corrects stale text, and adds the one missing GitHub community-standards file. Docs/hygiene only — no code changes.

**Doc/code drift**
- `docs/cli.md`: document the `--auth-path` flag on `info`/`invoke`/`dev`/`start`/`login` (it's in `src/cli.ts` usage + parseArgs, but appeared in no signature block).
- `docs/api-reference.md`: `createPiAgentFromWorkspace` gained an `authPath?` option and `stateRoot`/`authPath` return fields (0.8.0/0.9.0) — now documented.
- `docs/configuration.md`: new `## Logging` section for `FASTAGENT_LOG_LEVEL` (`debug`/`info`/`warn`/`error`; posture defaults dev=debug, start=info) — a real knob that only lived in the changelog.

**Stale / inaccurate**
- `CHANGELOG.md`: the AI-start prompt shipped as `ai-start.md`, not `start.md`.
- `SECURITY.md`: credentials default to project-level `<dir>/.fastagent/auth.json`; global `~/.fastagent/auth.json` is opt-in.
- `.github/pull_request_template.md`: add the `npm run lint` merge gate (CONTRIBUTING lists it as required).

**New file**
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), linked from README + CONTRIBUTING.

Note: the CoC Enforcement section points reporters at GitHub private reporting / the repo owner, since there's no dedicated conduct email. Swap in a dedicated address before launch if desired.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] Added or updated the smallest relevant tests — n/a (docs only)

## Checklist

- [x] Public-facing text is in English
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed
