### PR TITLE
First-run model picker + retryable classification + API tightening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ While the project is pre-1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- **First-run model picker.** A scaffolded workspace no longer hard-codes a model. When no model is
+  set (flag/`FASTAGENT_MODEL`/config) and a serving command (`dev` / `start` / `invoke`) runs in a
+  terminal, FastAgent lists the models of the providers you are logged into (`Models.getAuth` — stored
+  login or env key) and writes your pick back to the config so the next run is silent. Non-interactive
+  runs (CI, a container) skip the prompt and fail with the clear `missing model` error, unchanged. This
+  removes the old default (`openai-codex/gpt-5.5`) that gated first-run on one specific paid
+  subscription — onboarding now adapts to whatever provider you actually authenticated.
+
 ### Removed
 
 - **Tightened the public API surface** (pre-1.0 cleanup, `src/index.ts`): dropped exports that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ While the project is pre-1.0, minor versions may include breaking changes.
 
 ## [Unreleased]
 
+### Removed
+
+- **Tightened the public API surface** (pre-1.0 cleanup, `src/index.ts`): dropped exports that
+  reference no public signature and only leak engine internals — `scaffoldWorkspace` / `ScaffoldResult`
+  (the `init` implementation, CLI-internal), `piBasePrompt` / `piDefaultTools` (engine assets), and
+  `loadAgentDefinition` / `LoadAgentDefinitionOptions` (the standalone loader; the ladder rungs own
+  loading). `LoadedDefinition` and `SkillCollision` stay — they are load-bearing on the
+  `createPiAgentFrom*` return surface. **Upgrading:** for custom wiring/tests, import these from their
+  modules directly (`./engines/pi/create.ts`, `./engines/pi/definition.ts`, `./scaffold/init.ts`)
+  instead of the package root.
+
 ### Changed
 
 - **`init` now scaffolds a minimal self-iterating agent.** A fresh workspace is `AGENTS.md` (a

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm i -g @kid7st/fastagent   # CLI: fastagent init/dev/start/...
 npm i @kid7st/fastagent      # library API for embedding or code tools
 ```
 
-Requires **Node >= 22.19**. The npm package ships compiled JavaScript and type declarations.
+Requires **Node >= 22.19** — the floor is inherited from the reference engine (`@earendil-works/pi-agent-core`) and `undici`, both of which require it. The npm package ships compiled JavaScript and type declarations.
 
 ## Quickstart
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,6 +92,10 @@ Assembles the workspace and serves it locally. AGENTS.md/`skills/` are re-read e
 live next turn, no restart); a supervisor restarts the worker on edits to the code inputs —
 `tools/`, `channels/`, `fastagent.config.*`, `package.json`, `.env`.
 
+With no model set and a terminal attached, `dev` first prompts you to pick one from the providers you
+are logged into and writes it back to the config (same for `start` / `invoke`); pass `--model` or set
+`FASTAGENT_MODEL` to skip the prompt.
+
 Options:
 
 | Option | Meaning |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,11 @@ Precedence:
 CLI --model > FASTAGENT_MODEL > fastagent.config.* model
 ```
 
+With none of these set, a serving command (`dev` / `start` / `invoke`) run in a terminal prompts you
+to pick from the models of the providers you are logged into, then writes the choice back to the
+config. Non-interactive runs (CI, a container) skip the prompt and fail with a clear `missing model`
+error instead — set one of the sources above.
+
 Examples:
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,7 +53,10 @@ fastagent info
 
 `info` is read-only. It prints the model, loaded `AGENTS.md`, skills, discovered tools, channels, diagnostics, and session path without starting a server.
 
-If no model is set, choose one of:
+A fresh workspace presets no model. On the first `fastagent dev` (or `start` / `invoke`) in a
+terminal, FastAgent lists the models of the providers you are logged into (run `fastagent login`
+first) and writes your pick back to `fastagent.config.mjs`. To set it non-interactively (or in
+CI/deploy, where there is no prompt):
 
 ```bash
 fastagent dev --model provider/model-id

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,10 @@ Common FastAgent setup and runtime issues.
 
 ## `missing model`
 
-FastAgent needs a model spec such as `openai-codex/gpt-5.5`.
+FastAgent needs a model spec such as `openai-codex/gpt-5.5`. In a terminal, `dev` / `start` /
+`invoke` prompt you to pick one from the providers you are logged into (run `fastagent login` first)
+and save it. This error means the run is **non-interactive** (CI, a container, a piped command) with
+no model set.
 
 Check available specs:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@
  */
 import { spawn } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import { autocomplete, isCancel, log as clackLog, password, select, text as clackText } from "@clack/prompts";
 import { parseArgs } from "node:util";
@@ -29,10 +30,11 @@ import {
   resolveAuthPathOverride,
   resolveModelSpec,
   resolveSessionsDirOverride,
+  rewriteConfigModel,
 } from "./engines/pi/config.ts";
 import { formatModelsCommand } from "./cli-models.ts";
 import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
-import { createPiModels, probeAuthSource } from "./engines/pi/models.ts";
+import { configuredModelSpecs, createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 import { ensureStateRootSelfIgnored, isUnderDir, loadAgentDefinition } from "./engines/pi/definition.ts";
 import { loadRootIgnore } from "./workspace.ts";
 import { runInvokeStream } from "./invoke-stream.ts";
@@ -210,6 +212,7 @@ async function runInvoke(): Promise<void> {
   const invokeDir = resolve(positionals[2] ?? ".");
   loadDotEnv(invokeDir);
   installProxyFetch();
+  await resolveFirstRunModel(invokeDir);
   const { agent, modelSpec, authPath } = await createPiAgentFromWorkspace(invokeDir, {
     model: values.model,
     authPath: resolveAuthPathOverride(values["auth-path"]),
@@ -484,6 +487,71 @@ async function reportAuth(modelSpec: string, authPath: string): Promise<void> {
   );
 }
 
+/** Both stdin and stdout are a terminal — the precondition for an interactive prompt. */
+function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+/**
+ * First-run model resolution for the serving commands. When no model is set (flag/env/config), and
+ * we're on a TTY, pick one from the providers the user is logged into and persist the choice. A no-op
+ * when a model is already set; on a non-TTY (CI/deploy) or with nothing configured it stays silent and
+ * lets the opener raise its clear "missing model" error. The pick is exported to FASTAGENT_MODEL so a
+ * spawned `dev` worker inherits it, and best-effort written back to the config so the next run is quiet.
+ */
+async function resolveFirstRunModel(workspaceDir: string): Promise<void> {
+  const { config, path: configPath } = await loadConfig(workspaceDir).catch(failStartup);
+  if (resolveModelSpec(values.model, config)) return; // already set (flag > FASTAGENT_MODEL > config)
+  if (!isInteractive()) return; // CI/deploy: the opener throws the actionable missing-model error
+
+  const authPath = resolveAuthPathOverride(values["auth-path"]);
+  let specs: string[];
+  try {
+    specs = await configuredModelSpecs(createPiModels({ authPath }));
+  } catch (error) {
+    // Enumerating providers/auth threw — a system fault (a corrupt auth store, a throwing provider),
+    // NOT "not logged in". Surface it instead of masking it as the login hint; the opener then still
+    // raises the clear missing-model error.
+    log.warn(`[fastagent] could not list configured models: ${(error as Error).message}`);
+    return;
+  }
+  if (specs.length === 0) {
+    log.warn(
+      `[fastagent] no model set and no authenticated provider — run \`fastagent login\`, then \`fastagent dev\``,
+    );
+    return;
+  }
+  const r = await (specs.length > 7 ? autocomplete : select)({
+    message: "Choose a model for this agent",
+    options: specs.map((s) => ({ value: s, label: s })),
+  });
+  if (isCancel(r)) return; // cancelled: let the opener report the missing model
+  const chosen = r as string;
+  process.env.FASTAGENT_MODEL = chosen; // this process + any spawned dev worker inherits it
+  await persistModelChoice(workspaceDir, configPath, chosen);
+}
+
+/**
+ * Best-effort persist the picked model so the next run does not prompt. Only rewrites the commented
+ * `model:` placeholder the scaffold writes (or an existing `model:` line); anything else (zero-config,
+ * a hand-shaped config) is left untouched with a printed hint. Never throws — persistence is a convenience.
+ */
+async function persistModelChoice(workspaceDir: string, configPath: string | undefined, spec: string): Promise<void> {
+  const hint = (): void =>
+    console.error(
+      `[fastagent] using ${spec} for this run; set \`model: ${JSON.stringify(spec)}\` in your config to persist`,
+    );
+  if (!configPath) return hint();
+  try {
+    const replaced = rewriteConfigModel(await readFile(configPath, "utf8"), spec);
+    if (!replaced) return hint();
+    await writeFile(configPath, replaced);
+    console.error(`[fastagent] saved model ${JSON.stringify(spec)} to ${relative(workspaceDir, configPath)}`);
+  } catch {
+    hint();
+  }
+}
+
 type Assembled = Awaited<ReturnType<typeof createPiAgentFromWorkspace>>;
 
 /** The agents/skills/tools/collisions report lines. */
@@ -502,7 +570,17 @@ function reportAgentsSkillsTools(a: Assembled): void {
  */
 async function runDev(): Promise<void> {
   setLogLevel("debug"); // dev posture: verbose, includes the debug turn trace (content) — supervisor and worker both
-  if (process.env.FASTAGENT_DEV_WORKER === "1" || values["no-watch"]) {
+  const isWorker = process.env.FASTAGENT_DEV_WORKER === "1";
+  // Pick a model interactively once, in the parent (both watch and --no-watch have a TTY); a spawned
+  // watch worker inherits the choice via FASTAGENT_MODEL, so it must not prompt again. Load .env and
+  // the proxy FIRST (as invoke/start do): the picker reads FASTAGENT_MODEL and provider keys from
+  // .env, and getAuth's OAuth refresh must go through HTTPS_PROXY. The worker re-loads both in serveOnce.
+  if (!isWorker) {
+    loadDotEnv(dir);
+    installProxyFetch();
+    await resolveFirstRunModel(dir);
+  }
+  if (isWorker || values["no-watch"]) {
     await serveOnce();
     return;
   }
@@ -567,6 +645,7 @@ async function runStart(): Promise<void> {
   const portFlag = parsePort(values.port, "--port");
   loadDotEnv(dir);
   installProxyFetch();
+  await resolveFirstRunModel(dir);
 
   // The same opener dev uses (single assembly source), just no watch.
   const sessionsDirOverride = resolveSessionsDirOverride(values["sessions-dir"]);

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -127,6 +127,22 @@ export function listModels(models: Models): string[] {
   return specs.sort();
 }
 
+/**
+ * Rewrite the `model` in a config file's SOURCE TEXT to `spec`, for the first-run picker's write-back.
+ * Handles the scaffold's commented placeholder (`// model: "…"`) and an existing `model:` line; returns
+ * null when neither is present (zero-config or a hand-shaped config) so the caller falls back to a
+ * printed hint instead of guessing where to insert. Text-level (not AST) on purpose — it only ever
+ * touches a line it recognizes, never reformats the author's file.
+ */
+export function rewriteConfigModel(src: string, spec: string): string | null {
+  const line = `  model: ${JSON.stringify(spec)},`;
+  const commented = /^[ \t]*\/\/[ \t]*model:.*$/m;
+  const active = /^[ \t]*model:[ \t]*["'].*$/m;
+  if (commented.test(src)) return src.replace(commented, line);
+  if (active.test(src)) return src.replace(active, line);
+  return null;
+}
+
 /** Model selection precedence: CLI flag > FASTAGENT_MODEL env > config default. */
 export function resolveModelSpec(
   flag: string | undefined,

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -49,11 +49,82 @@ export function inProcessLease(): Lease {
 }
 
 // ── §2 translate: the single pi↔SPEC translation point ───────────────────────
+//
+// `retryable` = worth re-sending with the same session (SPEC §6: advisory, not a session-atomicity
+// guarantee). Classify from the STRUCTURED signal first, prose only as the last-resort ceiling. What
+// is actually available differs by path, and the two are NOT symmetric:
+//   - thrown error (errorToTerminal): an HTTP `.status`/`.statusCode` AND a network `.code` (incl.
+//     `.cause.code`) — this is where a numeric status genuinely drives the decision.
+//   - failed message (toTerminal): ONLY `diagnostics[].error.code`. pi's `DiagnosticErrorInfo` carries
+//     a `code` (a network code, or a status delivered as a code), with no separate HTTP-status field —
+//     so a message whose provider `code` is a string label (e.g. "rate_limit_exceeded") is not
+//     decisive here and falls to prose.
+// The prose fallback is bounded, not a cop-out: pi-ai already ran its own status-code-based client
+// retries (harness.ts PROVIDER_MAX_RETRIES) before surfacing, so an error that reaches this point has
+// already exhausted the cleanly-retryable cases. The regex is the narrow ceiling, not the classifier.
+// Upstream ask: a first-class `retryable`/`kind` on pi's terminal error would retire the prose path
+// entirely (mirrors the §11 "the deeper fix is upstream in pi" pattern).
 
-/** Whether a failure's `details` is worth re-sending with the same session (transient-looking). */
-const RETRYABLE =
+/** Clearly-transient network error codes (Node/undici), decisive on their own. */
+const RETRYABLE_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EAI_AGAIN",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/** 429 (rate limit) and 5xx (server) are worth retrying; other statuses are decisive NON-retryable. */
+const statusIsRetryable = (status: number): boolean => status === 429 || (status >= 500 && status < 600);
+
+/** Last-resort prose match, used only when no structured status/code is available. */
+const RETRYABLE_MESSAGE =
   /\b(429|5\d\d|timeout|timed out|rate.?limit|overloaded|ECONNRESET|ETIMEDOUT|ENETUNREACH|EAI_AGAIN|socket hang up)\b/i;
-const isRetryable = (details: string): boolean => RETRYABLE.test(details);
+
+/** A structured status/code decision, or `null` when the signal is absent/undecisive → fall to prose. */
+function retryableFromSignal(signal: { status?: number; code?: unknown }): boolean | null {
+  if (typeof signal.status === "number") return statusIsRetryable(signal.status);
+  const { code } = signal;
+  if (typeof code === "number") return statusIsRetryable(code);
+  if (typeof code === "string") {
+    if (RETRYABLE_CODES.has(code)) return true;
+    if (/^\d{3}$/.test(code)) return statusIsRetryable(Number(code)); // a status carried as a string
+  }
+  return null; // no code, or an unknown one — not decisive on its own
+}
+
+/** Classify `retryable`: structured status/code first, message prose only as the last-resort ceiling. */
+export function classifyRetryable(details: string, signal: { status?: number; code?: unknown }): boolean {
+  return retryableFromSignal(signal) ?? RETRYABLE_MESSAGE.test(details);
+}
+
+/** Pull a structured status/code off a thrown error (HTTP status or a network code, incl. its cause). */
+function errorSignal(error: unknown): { status?: number; code?: unknown } {
+  if (!error || typeof error !== "object") return {};
+  const e = error as { status?: unknown; statusCode?: unknown; code?: unknown; cause?: unknown };
+  const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
+  const causeCode = e.cause && typeof e.cause === "object" ? (e.cause as { code?: unknown }).code : undefined;
+  return { status, code: e.code ?? causeCode };
+}
+
+/**
+ * Pull the structured error `code` pi records on a failed message's diagnostics. `diagnostics`
+ * accumulates across attempts (`appendAssistantMessageDiagnostic`), so the terminal cause is the LAST
+ * code-bearing entry — `findLast`, not `find`: an earlier attempt's transient 503 must not classify a
+ * terminal 400/auth failure as retryable. (Reverse scan rather than `findLast` — the tsconfig lib is
+ * ES2022.)
+ */
+function messageSignal(message: AssistantMessage): { status?: number; code?: unknown } {
+  const diagnostics = message.diagnostics ?? [];
+  for (let i = diagnostics.length - 1; i >= 0; i--) {
+    const code = diagnostics[i]?.error?.code;
+    if (code !== undefined) return { code };
+  }
+  return {};
+}
 
 /** In-stream event mapping. Non text/tool_* pi events (turn_start, message_start, …) are dropped. */
 function toAgentEvent(pe: AgentHarnessEvent): AgentEvent | null {
@@ -78,17 +149,17 @@ function toAgentEvent(pe: AgentHarnessEvent): AgentEvent | null {
  * with stopReason "error"/"aborted" rather than throwing, so relying on catch alone would miss this
  * entire failure class (violating SPEC MUST 1).
  */
-function toTerminal(message: AssistantMessage): AgentEvent {
+export function toTerminal(message: AssistantMessage): AgentEvent {
   if (message.stopReason === "error" || message.stopReason === "aborted") {
     const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
-    return { type: "failed", details, retryable: isRetryable(details) };
+    return { type: "failed", details, retryable: classifyRetryable(details, messageSignal(message)) };
   }
   return { type: "completed" };
 }
 
-function errorToTerminal(error: unknown): AgentEvent {
+export function errorToTerminal(error: unknown): AgentEvent {
   const details = error instanceof Error ? error.message : String(error);
-  return { type: "failed", details, retryable: isRetryable(details) };
+  return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
 }
 
 type PiHarness = Awaited<ReturnType<PiHarnessFactory>>;

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -6,6 +6,7 @@
  */
 import { type Models, type Provider, defaultProviderAuthContext } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import { log } from "../../log.ts";
 import { type FastagentAuthOptions, fastagentCredentialStore } from "./auth.ts";
 
 export interface CreatePiModelsOptions extends FastagentAuthOptions {
@@ -30,6 +31,37 @@ export function createPiModels(options: CreatePiModelsOptions = {}): Models {
   });
   for (const provider of options.providers ?? []) models.setProvider(provider);
   return models;
+}
+
+/**
+ * The "provider/modelId" specs whose provider currently has USABLE credentials (a stored login or an
+ * env key) — the menu for the first-run model picker (`fastagent dev`/`start`/`invoke` with no model
+ * set). Auth is provider-scoped, so probe once per provider (any of its models) rather than per model.
+ * A provider that resolves no auth (unconfigured) or rejects it (configured-but-expired) is omitted:
+ * the picker offers only models that would actually run now; `fastagent login` fixes the rest. Sorted.
+ *
+ * pi deliberately has no "best/tier" ranking on Model, so this does not auto-pick — it narrows the menu
+ * to what the user can use and lets them choose (mirroring pi-coding-agent's select-then-persist).
+ */
+export async function configuredModelSpecs(models: Models): Promise<string[]> {
+  const specs: string[] = [];
+  for (const provider of models.getProviders()) {
+    const [probe] = provider.getModels();
+    if (!probe) continue;
+    let usable: boolean;
+    try {
+      usable = (await models.getAuth(probe)) !== undefined;
+    } catch (error) {
+      // Configured-but-broken (expired token, a refresh network failure, a corrupt store): omit it
+      // from the menu, but SAY so — a silent disappearance is the same fail-visibly gap the caller
+      // guards against for the top-level enumeration. `undefined` (plainly unconfigured) stays quiet.
+      log.warn(`[fastagent] skipping provider "${provider.id}": auth check failed (${(error as Error).message})`);
+      continue;
+    }
+    if (!usable) continue;
+    for (const model of provider.getModels()) specs.push(`${provider.id}/${model.id}`);
+  }
+  return specs.sort();
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,6 @@ export {
   type CreatePiAgentFromDefinitionOptions,
 } from "./engines/pi/create.ts";
 
-// init: scaffold a runnable workspace.
-export { scaffoldWorkspace, type ScaffoldResult } from "./scaffold/init.ts";
-
 // Tool authoring: defineTool (+ re-exported z) and tools/ discovery.
 // Re-export rule: the engine-neutral contract (agent.ts) owns its types; the pi reference-impl
 // surface is openly engine-coupled, so every pi type that appears in its signatures is re-exported
@@ -61,18 +58,11 @@ export {
   type CreatePiAgentFromWorkspaceOptions,
 } from "./engines/pi/workspace.ts";
 
-// Definition domain (load).
-export {
-  loadAgentDefinition,
-  type LoadedDefinition,
-  type LoadAgentDefinitionOptions,
-  type SkillCollision,
-} from "./engines/pi/definition.ts";
+// Definition domain: the types on the createPiAgentFrom* return surface (`definition.collisions`,
+// `definition.diagnostics`). The loader itself (loadAgentDefinition) is internal — the ladder rungs
+// own loading; import it from ./engines/pi/definition.ts for custom wiring/tests.
+export type { LoadedDefinition, SkillCollision } from "./engines/pi/definition.ts";
 export type { Skill, SkillDiagnostic } from "@earendil-works/pi-agent-core";
-
-// Engine assets (prompt base + toolset). Internal assembly helpers (assembleSystemPrompt,
-// resolveTools) are NOT public: the ladder rungs own assembly.
-export { piBasePrompt, piDefaultTools } from "./engines/pi/create.ts";
 
 // Config subsystem. loadConfig is internal (L3 owns config loading); resolveModel bridges a
 // "provider/modelId" string to a model for L1/L2 embedders.

--- a/src/scaffold/templates/env.example
+++ b/src/scaffold/templates/env.example
@@ -2,14 +2,15 @@
 # Everything here is OPTIONAL — the defaults work without a .env.
 
 # --- Model auth ---
-# The default model (openai-codex) signs in with OAuth, not an API key: run `fastagent login` once.
-# Switch to an API-key provider? Set its key here — the variable name is provider-specific
-# (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY). Run `fastagent models` to see available specs.
+# Pick auth once: `fastagent login` (a subscription/OAuth provider like openai-codex, or an API key),
+# or set a provider API key here — the variable name is provider-specific (e.g. OPENAI_API_KEY,
+# ANTHROPIC_API_KEY). `fastagent dev` then lets you choose a model from whatever you're logged into.
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=
 
 # --- Model selection (overrides fastagent.config) ---
-# Precedence: --model flag > FASTAGENT_MODEL > config.
+# Precedence: --model flag > FASTAGENT_MODEL > config. `fastagent dev` writes your first-run pick to
+# fastagent.config; set it here to override per-environment.
 # FASTAGENT_MODEL=openai-codex/gpt-5.5
 
 # --- Serving (fastagent start) ---

--- a/src/scaffold/templates/fastagent.config.mjs
+++ b/src/scaffold/templates/fastagent.config.mjs
@@ -1,8 +1,10 @@
 // fastagent.config.mjs — deployment choices only (model / http; code tools auto-discover from tools/).
 // Your agent's identity and behavior live in AGENTS.md + skills/ + tools/, never here.
 // Model precedence: `--model` flag > FASTAGENT_MODEL env > this default.
-// Change "model" to a "provider/modelId" you have access to (`fastagent models` lists them).
+// No model is preset: `fastagent dev` prompts you to pick one from the providers you're logged into
+// (run `fastagent login` first) and writes your choice below. Or set it by hand to a "provider/modelId"
+// you have access to (`fastagent models` lists them).
 export default {
-  model: "openai-codex/gpt-5.5",
+  // model: "openai-codex/gpt-5.5",
   http: { port: 8787 },
 };

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -288,3 +288,23 @@ describe("config: resolveModelSpec (precedence flag > env > config)", () => {
     expect(resolveModelSpec(undefined, {}, {} as NodeJS.ProcessEnv)).toBeUndefined();
   });
 });
+
+describe("rewriteConfigModel (first-run picker write-back)", async () => {
+  const { rewriteConfigModel } = await import("../src/engines/pi/config.ts");
+
+  it("uncomments the scaffold's commented model placeholder", () => {
+    const src = 'export default {\n  // model: "openai-codex/gpt-5.5",\n  http: { port: 8787 },\n};\n';
+    expect(rewriteConfigModel(src, "anthropic/claude-x")).toBe(
+      'export default {\n  model: "anthropic/claude-x",\n  http: { port: 8787 },\n};\n',
+    );
+  });
+
+  it("replaces an existing active model line", () => {
+    const src = 'export default {\n  model: "old/one",\n};\n';
+    expect(rewriteConfigModel(src, "new/two")).toBe('export default {\n  model: "new/two",\n};\n');
+  });
+
+  it("returns null when there is no model line to touch (hand-shaped / zero-config)", () => {
+    expect(rewriteConfigModel("export default { http: { port: 8787 } };\n", "x/y")).toBeNull();
+  });
+});

--- a/test/definition.test.ts
+++ b/test/definition.test.ts
@@ -12,12 +12,10 @@ import {
   collect,
   createPiAgent,
   createPiAgentFromDefinition,
-  loadAgentDefinition,
-  piBasePrompt,
-  piDefaultTools,
   type CreatePiAgentFromDefinitionOptions,
 } from "../src/index.ts";
-import { assembleSystemPrompt } from "../src/engines/pi/create.ts";
+import { assembleSystemPrompt, piBasePrompt, piDefaultTools } from "../src/engines/pi/create.ts";
+import { loadAgentDefinition } from "../src/engines/pi/definition.ts";
 import { log } from "../src/log.ts";
 import { ensureStateRootSelfIgnored, isUnderDir } from "../src/engines/pi/definition.ts";
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -4,7 +4,9 @@ import { access, mkdir, mkdtemp, readFile, readdir, symlink, writeFile } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createPiAgentFromWorkspace, loadAgentDefinition, scaffoldWorkspace } from "../src/index.ts";
+import { createPiAgentFromWorkspace } from "../src/index.ts";
+import { loadAgentDefinition } from "../src/engines/pi/definition.ts";
+import { scaffoldWorkspace } from "../src/scaffold/init.ts";
 import { nextStepCd } from "../src/scaffold/init.ts";
 import { vendorSkill } from "../src/scaffold/vendor-skill.ts";
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -57,10 +57,10 @@ describe("init: scaffoldWorkspace", () => {
     expect(warnings).toEqual([]);
 
     // .env.example documents env knobs without misleading: all-commented (sets nothing), and it
-    // states the default model uses OAuth (`fastagent login`), never implying an API key is required.
+    // frames auth as a choice (`fastagent login` OR a provider API key), never implying a key is required.
     const envExample = await readFile(join(dir, ".env.example"), "utf8");
     expect(envExample).toMatch(/fastagent login/);
-    expect(envExample).toMatch(/OAuth, not an API key/);
+    expect(envExample).toMatch(/set a provider API key/);
     for (const line of envExample.split("\n")) {
       if (line.trim() !== "") expect(line.startsWith("#")).toBe(true); // every non-blank line is a comment
     }
@@ -109,8 +109,9 @@ describe("init: scaffoldWorkspace", () => {
     const def = await loadAgentDefinition(dir);
     expect(def.skills.map((s) => s.name)).toEqual(["writing-great-skills"]);
 
-    // No tool to import → dev assembles with zero edits and zero network.
-    const { agent, modelSpec } = await createPiAgentFromWorkspace(dir);
+    // No tool to import → dev assembles with zero edits and zero network. The scaffold presets no
+    // model (first-run pick writes it back), so assembly is exercised with an explicit spec.
+    const { agent, modelSpec } = await createPiAgentFromWorkspace(dir, { model: "openai-codex/gpt-5.5" });
     expect(typeof agent.invoke).toBe("function");
     expect(modelSpec).toBe("openai-codex/gpt-5.5");
   });

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -4,7 +4,7 @@ import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, fauxThinking, fauxToolCall, Type, type FauxResponseStep } from "@earendil-works/pi-ai";
 import type { AssistantMessage, StopReason, Usage } from "@earendil-works/pi-ai";
 import { inMemorySessionStore, inProcessLease, type AgentEvent } from "../src/index.ts";
-import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { classifyRetryable, createPiAgentFromHarness, errorToTerminal, toTerminal } from "../src/engines/pi/invoke.ts";
 import { type PiHarnessFactory, piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 
@@ -447,5 +447,81 @@ describe("invoke: auto-compaction", () => {
     expect(events.at(-1)).toEqual({ type: "completed" }); // turn still completed
     expect(compact).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/auto-compaction failed/));
+  });
+});
+
+describe("classifyRetryable (structured signal first, prose as last resort)", () => {
+  it("uses HTTP status when present: 429/5xx retryable, other statuses decisively not", () => {
+    // A status wins even when the message prose would match — no false positive from wording.
+    expect(classifyRetryable("bad request mentioning timeout", { status: 400 })).toBe(false);
+    expect(classifyRetryable("nope", { status: 429 })).toBe(true);
+    expect(classifyRetryable("nope", { status: 503 })).toBe(true);
+    expect(classifyRetryable("nope", { status: 401 })).toBe(false);
+  });
+
+  it("uses a network/error code when present (string or numeric status-as-code)", () => {
+    expect(classifyRetryable("x", { code: "ECONNRESET" })).toBe(true);
+    expect(classifyRetryable("x", { code: "ETIMEDOUT" })).toBe(true);
+    expect(classifyRetryable("x", { code: "429" })).toBe(true);
+    expect(classifyRetryable("x", { code: 503 })).toBe(true);
+    expect(classifyRetryable("x", { code: "ENOENT" })).toBe(false); // unknown code, prose "x" → false
+  });
+
+  it("falls back to message prose only when no structured signal exists", () => {
+    expect(classifyRetryable("model is overloaded, try again", {})).toBe(true);
+    expect(classifyRetryable("request timed out", {})).toBe(true);
+    expect(classifyRetryable("invalid api key", {})).toBe(false);
+  });
+});
+
+describe("terminal signal extraction (pins the pi shapes classifyRetryable reads)", () => {
+  // A failed AssistantMessage: only diagnostics[].error.code is available (no HTTP status field).
+  const errorMessage = (over: Partial<AssistantMessage>): AssistantMessage =>
+    ({ role: "assistant", stopReason: "error", ...over }) as unknown as AssistantMessage;
+
+  it("toTerminal reads diagnostics[].error.code as a status, overriding the prose", () => {
+    const msg = errorMessage({
+      errorMessage: "the model said something unrecognizable", // prose alone → not retryable
+      diagnostics: [{ type: "stream_error", timestamp: 0, error: { message: "m", code: 503 } }],
+    });
+    expect(toTerminal(msg)).toEqual({ type: "failed", details: expect.any(String), retryable: true });
+  });
+
+  it("toTerminal uses the LAST code-bearing diagnostic (terminal cause), not an earlier attempt's", () => {
+    // An earlier attempt logged a transient 503; the terminal cause is a fatal 400 — must be non-retryable.
+    const msg = errorMessage({
+      errorMessage: "bad request",
+      diagnostics: [
+        { type: "stream_error", timestamp: 0, error: { message: "transient", code: 503 } },
+        { type: "api_error", timestamp: 1, error: { message: "fatal", code: 400 } },
+      ],
+    });
+    expect((toTerminal(msg) as { retryable: boolean }).retryable).toBe(false);
+  });
+
+  it("toTerminal: a provider string code is not decisive, so it falls to prose", () => {
+    const msg = errorMessage({
+      errorMessage: "quota exhausted", // no retryable token → false
+      diagnostics: [{ type: "api_error", timestamp: 0, error: { message: "m", code: "insufficient_quota" } }],
+    });
+    expect((toTerminal(msg) as { retryable: boolean }).retryable).toBe(false);
+  });
+
+  it("toTerminal on a clean stop is completed", () => {
+    expect(toTerminal(errorMessage({ stopReason: "stop" }))).toEqual({ type: "completed" });
+  });
+
+  it("errorToTerminal reads .status / .statusCode / .cause.code off a thrown error", () => {
+    expect((errorToTerminal(Object.assign(new Error("x"), { status: 500 })) as { retryable: boolean }).retryable).toBe(
+      true,
+    );
+    expect(
+      (errorToTerminal(Object.assign(new Error("x"), { statusCode: 400 })) as { retryable: boolean }).retryable,
+    ).toBe(false); // a decisive non-5xx status wins over any prose
+    expect(
+      (errorToTerminal(Object.assign(new Error("x"), { cause: { code: "ECONNRESET" } })) as { retryable: boolean })
+        .retryable,
+    ).toBe(true);
+    expect((errorToTerminal(new Error("plain failure")) as { retryable: boolean }).retryable).toBe(false);
   });
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Models } from "@earendil-works/pi-ai";
+import { log } from "../src/log.ts";
+import { configuredModelSpecs } from "../src/engines/pi/models.ts";
+
+type FakeProvider = { id: string; models: string[]; auth: "ok" | "none" | "reject" };
+
+/** A minimal Models stub exposing only what configuredModelSpecs touches: getProviders + getAuth. */
+function fakeModels(providers: FakeProvider[]): Models {
+  return {
+    getProviders: () =>
+      providers.map((p) => ({
+        id: p.id,
+        getModels: () => p.models.map((id) => ({ id, provider: p.id })),
+      })),
+    getAuth: async (model: { provider: string }) => {
+      const p = providers.find((x) => x.id === model.provider);
+      if (!p || p.auth === "reject") throw new Error("expired");
+      return p.auth === "ok" ? { source: "test" } : undefined;
+    },
+  } as unknown as Models;
+}
+
+describe("configuredModelSpecs", () => {
+  it("lists only models of providers with usable auth, sorted", async () => {
+    const models = fakeModels([
+      { id: "anthropic", models: ["claude-b", "claude-a"], auth: "ok" },
+      { id: "openai", models: ["gpt-x"], auth: "none" }, // unconfigured → omitted
+    ]);
+    expect(await configuredModelSpecs(models)).toEqual(["anthropic/claude-a", "anthropic/claude-b"]);
+  });
+
+  it("omits a provider whose auth rejects (configured-but-expired) and warns — not a silent drop", async () => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const models = fakeModels([
+      { id: "openai", models: ["gpt-x"], auth: "reject" }, // expired → not offered, but visible
+      { id: "empty", models: [], auth: "ok" }, // no models → skipped
+      { id: "codex", models: ["gpt-5.5"], auth: "ok" },
+    ]);
+    expect(await configuredModelSpecs(models)).toEqual(["codex/gpt-5.5"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('provider "openai": auth check failed'));
+    warn.mockRestore();
+  });
+
+  it("returns empty when nothing is configured", async () => {
+    expect(await configuredModelSpecs(fakeModels([{ id: "openai", models: ["gpt-x"], auth: "none" }]))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Four review findings from the whole-repo / DevX pass, as four focused commits (rebase-merge keeps them intact). Reviewed and iterated with `rv local` until **No findings**.

| Commit | What | Tier |
|---|---|---|
| `fix(invoke)` | **C1** — classify `retryable` from structured status/code, prose as last resort | fix |
| `refactor(api)` | **C2** — tighten the public export surface | ⚠️ public API surface — needs review |
| `feat(cli)` | **A1** — first-run model picker from configured providers | feature |
| `docs` | **A2** — explain the Node >=22.19 floor | docs |

### C1 — retryable classification (`src/engines/pi/invoke.ts`)
`retryable` was reverse-engineered by regex-matching the failure's English prose — lossy, drifts with provider wording, and redundant with pi-ai's own status-code retries. Now classify from the structured signal first: a thrown error's `.status`/`.statusCode`/`.code` (incl. `.cause`), or a failed message's `diagnostics[].error.code` (reverse-scanned — the terminal cause is the *last* diagnostic, not an earlier attempt's transient). Prose is demoted to the narrow last-resort ceiling. Signal extraction is now unit-tested against the real pi shapes.

### C2 — public surface (`src/index.ts`)
Dropped six names that reference no public signature and only leak engine internals: `scaffoldWorkspace`/`ScaffoldResult`, `piBasePrompt`/`piDefaultTools`, `loadAgentDefinition`/`LoadAgentDefinitionOptions`. Kept `LoadedDefinition`/`SkillCollision` (load-bearing on the `createPiAgentFrom*` return). Tests import them from their modules now. **Deletes public exports → review-tier.**

### A1 — first-run model picker (`src/cli.ts`, `models.ts`, scaffold)
The scaffold no longer hard-codes `openai-codex/gpt-5.5` (which gated first-run on one paid subscription). With no model set and a TTY, `dev`/`start`/`invoke` list the models of the providers you're logged into (`Models.getAuth`) and write the pick back to the config; non-interactive runs keep the clear `missing model` error. pi has no "best model" ranking, so this narrows the menu and lets the user choose (pi-coding-agent's select-then-persist shape) rather than inventing a ranking. Auth-enumeration faults surface visibly instead of masquerading as "not logged in".

### A2 — Node floor
`>=22.19.0` is transitively required by `@earendil-works/pi-agent-core` and `undici` — documented so the constraint reads as grounded.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (370 passed) — new coverage: structured signal extraction, last-vs-earlier diagnostic, configuredModelSpecs (configured/expired+warn/empty), rewriteConfigModel

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks
- [x] No secrets/local paths committed
- [x] Docs updated for behavior + public API changes (CHANGELOG, cli/configuration/quickstart/troubleshooting, env.example, scaffold config)
