### PR TITLE
docs: credit open-source stack (pi + MIT deps) + npm metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ While the project is pre-1.0, minor versions may include breaking changes.
 
 ### Added
 
+- **Acknowledgements + npm metadata.** README now credits the open-source stack it builds on — pi
+  (`@earendil-works/pi-*`, the reference engine) and the MIT libraries it depends on — with a
+  "built with pi" badge. `package.json` gains `homepage`, `bugs`, and `author`. All runtime
+  dependencies are MIT and are not bundled, so no third-party license ships in this package's tarball;
+  the one vendored asset (the `writing-great-skills` skill) already includes its license.
 - **First-run model picker.** A scaffolded workspace no longer hard-codes a model. When no model is
   set (flag/`FASTAGENT_MODEL`/config) and a serving command (`dev` / `start` / `invoke`) runs in a
   terminal, FastAgent lists the models of the providers you are logged into (`Models.getAuth` — stored

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/@kid7st/fastagent.svg)](https://www.npmjs.com/package/@kid7st/fastagent)
 [![license](https://img.shields.io/npm/l/@kid7st/fastagent.svg)](LICENSE)
 [![node](https://img.shields.io/node/v/@kid7st/fastagent.svg)](https://nodejs.org)
+[![built with pi](https://img.shields.io/badge/built%20with-pi-0b7285.svg)](https://pi.dev)
 
 **Vibe first. Then FastAgent.** Any folder can become a live agent service. FastAgent takes your local agent folder out of the terminal and serves it in your Next/Astro app, Telegram, GitHub/webhook events, an API endpoint, or your own channel.
 
@@ -164,6 +165,14 @@ FastAgent is pre-1.0. The stable design center is the Agent Handler contract in 
 - [Security policy](SECURITY.md)
 - [Changelog](CHANGELOG.md)
 
+## Acknowledgements
+
+FastAgent stands on open source. The reference implementation is built on **[pi](https://pi.dev)** (`@earendil-works/pi-*`, MIT) — the agent harness, the multi-provider LLM API, and the interactive TUI that `fastagent chat` drives.
+
+It also depends on, and is grateful to, these MIT projects: [zod](https://github.com/colinhacks/zod), [undici](https://github.com/nodejs/undici), [chokidar](https://github.com/paulmillr/chokidar), [giget](https://github.com/unjs/giget), [@clack/prompts](https://github.com/bombshell-dev/clack), [ignore](https://github.com/kaelzhang/node-ignore), and [@octokit/webhooks-*](https://github.com/octokit/webhooks).
+
+The scaffolded `writing-great-skills` skill is vendored from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT), with its license included.
+
 ## License
 
-[MIT](LICENSE)
+[MIT](LICENSE). All runtime dependencies are MIT; FastAgent does not bundle their code (npm installs each separately), so their licenses ship with them.

--- a/package.json
+++ b/package.json
@@ -15,9 +15,14 @@
     "fastagent"
   ],
   "license": "MIT",
+  "author": "the fastagent authors (https://github.com/kid7st/fastagent)",
+  "homepage": "https://github.com/kid7st/fastagent#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kid7st/fastagent.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kid7st/fastagent/issues"
   },
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

Pre-public housekeeping.

- **Acknowledgements** in README crediting **pi** (the reference engine) and the MIT libraries FastAgent depends on, plus a **built with pi** badge linking to pi.dev (mutual recognition).
- **package.json**: add `homepage`, `bugs`, `author` (npm page links).
- CHANGELOG entry.

### Licensing note
All 11 runtime deps are MIT; none are bundled into `dist/` (npm installs each separately, so their licenses ship with them) — no attribution obligation in this tarball. The one vendored asset (the `writing-great-skills` skill, mattpocock/skills MIT) already ships its LICENSE and is credited. This PR is courtesy, not a license fix.

## Validation
- [x] `npm run lint`
- [x] package.json valid JSON
- docs/metadata only