### PR TITLE
chore: drop the mcp keyword (MCP not implemented yet)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "llm",
     "agents.md",
     "agent-skills",
-    "mcp",
     "agent-serving",
     "sse",
     "pi",


### PR DESCRIPTION
Honesty: MCP mounting is future support, not shipped — remove it from package.json keywords (matches dropping the mcp topic and the earlier production-ready fix). Remaining keywords describe what FastAgent does today.