### PR TITLE
docs: strip process/history narration from comments and design notes

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -129,13 +129,11 @@ Skills are markdown/file assets. Loading is **definition-only, period**: an agen
 
 The `skills/` format is **Agent Skills** ([agentskills.io](https://agentskills.io)) compatible — a `skills/<name>/SKILL.md` with `name`/`description` frontmatter and progressive disclosure (name+description at startup, the body on activation), as implemented by pi's `loadSkills`. Any standard skill (e.g. from [anthropics/skills](https://github.com/anthropics/skills)) works by **vendoring**: copy the folder into `skills/`, git-tracked, and it Just Works — unsupported optional fields (`license`, `metadata`, `compatibility`) are ignored without error. **There is no registry, and none is needed**: the filesystem is the registry, git is the distribution, and the user owns trust (a vendored skill's `scripts/` is code they audit, like an npm dependency). fastagent is the serving layer, not a skill marketplace.
 
-Loading the machine's global skills (`~/.pi/agent/skills`, `~/.agents/skills`) was removed deliberately. It made the agent depend on ambient machine state and recreated the "works on my machine, breaks deployed" trap fastagent exists to kill. The principle is general: **the definition directory is the agent's only source of truth; nothing the code can't see is loaded into its behavior** (credentials and env are deployment config, not behavior — they stay outside the directory by design). To ship a skill, put it in `skills/`.
+FastAgent deliberately does not load the machine's global skills (`~/.pi/agent/skills`, `~/.agents/skills`): it would make the agent depend on ambient machine state and recreate the "works on my machine, breaks deployed" trap fastagent exists to kill. The principle is general: **the definition directory is the agent's only source of truth; nothing the code can't see is loaded into its behavior** (credentials and env are deployment config, not behavior — they stay outside the directory by design). To ship a skill, put it in `skills/`.
 
 Definition-local skills win name collisions (the deployable unit is authoritative); collisions are surfaced as diagnostics, not swallowed.
 
-Code tools are TypeScript/JavaScript modules. The vibe path is `defineTool` + filesystem discovery: drop a file in `tools/`, default-export `defineTool({ description, input, execute })`, and it is auto-discovered, named from the filename (authoritative), schema-validated, and injected — no `name` field, no manual registration. `defineTool` takes a Zod `input` schema (re-exported as `z` from the package), converts it to JSON Schema for the model, validates the model's arguments before `execute` (a validation failure becomes an error result the model can correct, not a crash), and wraps a plain return value into pi's result shape.
-
-> Reversal: an earlier draft said "FastAgent does not auto-load a magic `tools/` directory." That rationale conflated dependency installation with registration — they are orthogonal. Filesystem discovery is the bigger DX win because it removes both the `name` field and the wiring. So fastagent now auto-discovers `tools/`.
+Code tools are TypeScript/JavaScript modules. The vibe path is `defineTool` + filesystem discovery: drop a file in `tools/`, default-export `defineTool({ description, input, execute })`, and it is auto-discovered, named from the filename (authoritative), schema-validated, and injected — no `name` field, no manual registration. `defineTool` takes a Zod `input` schema (re-exported as `z` from the package), converts it to JSON Schema for the model, validates the model's arguments before `execute` (a validation failure becomes an error result the model can correct, not a crash), and wraps a plain return value into pi's result shape. (Dependency installation and registration are orthogonal: discovery removes the `name` field and the wiring, and does not require the deps a tool imports to be installed — that is the workspace's `npm install`.)
 
 `config.tools` remains as the programmatic/advanced injection path; discovered tools are merged after pi defaults + `config.tools`, deduped by name (existing win; dropped tools are surfaced, not silent). A code-tool workspace must be ESM (`"type": "module"` in package.json) so a tool's `import` resolves. `fastagent tool <name> '<json>'` runs one tool's body directly — no model, no server, no tokens — the tightest authoring feedback loop. Declarative MCP tool mounting via `.mcp.json` is future support, not implemented today.
 
@@ -217,10 +215,9 @@ Durable decisions this architecture encodes:
   *no-redelivery* case. L1 recovers it: `turn-store.ts` persists an accepted turn's intent pre-ACK
   (like the context buffer) and, on the next start, replays anything an interrupted run left mid-flight.
   "Interrupted" is not just a rare crash: `runStart` has no graceful drain, so a SIGTERM — every rolling
-  deploy — exits mid-turn too. This is a per-process WAL by another name, and a deliberate reversal of
-  the earlier "accept the loss" stance — the atomic-rename primitive (`state.ts`) already in the channel
-  makes it cheap enough to be worth the ACKed-but-unfinished window that a single re-ask otherwise
-  costs. It is **at-least-once, not exactly-once**: replay re-runs the whole turn (re-running
+  deploy — exits mid-turn too. This is a per-process WAL: the atomic-rename primitive (`state.ts`)
+  already in the channel makes it cheap enough to be worth the ACKed-but-unfinished window that a single
+  re-ask otherwise costs. It is **at-least-once, not exactly-once**: replay re-runs the whole turn (re-running
   side-effecting tools — so the idempotency bar is judged against DEPLOY frequency, not rare crashes —
   and possibly orphaning a preview), and the pre-ACK window can overlap Telegram redelivery (same
   update_id, no dedup) — a turn may run twice. An execution ceiling drops a poison turn on its own
@@ -279,7 +276,7 @@ Consequence: skills need progressive disclosure (a prompt listing); authored con
 
 The agent's working directory (tool `cwd`, where `read`/`bash`/`write` operate) = the definition directory = the directory holding `AGENTS.md`. With no separate artifact, cwd is a **real, persistent, writable** directory (your repo locally; the COPY'd project in a container) — never an ephemeral build output that a rebuild replaces. Two consequences:
 
-- **No write-to-ephemeral footgun.** Tools write into a durable directory, not one the next build wipes (the old build/artifact made cwd the throwaway `.fastagent/build`).
+- **No write-to-ephemeral footgun.** Tools write into a durable directory, not an ephemeral build output that a rebuild would wipe.
 - **Self-modification is coherent.** An agent that edits its own `AGENTS.md`/`skills/` edits a real, git-versioned directory (revertable, reviewable) — a deliberate option, should it ever be wanted, not an accident of where cwd points.
 
 Durable *runtime output* still belongs outside the directory (object storage / DB / the response), and in a stateless multi-instance deployment the working dir is per-replica scratch — but the *definition* it roots on is the persistent directory, not a throwaway.

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -158,7 +158,7 @@ export async function streamReply(
   // message to the LATEST view() with at most ONE edit in flight, paced by a throttle. One-in-flight is
   // the whole point: concurrent edits can reach Telegram out of order — an older frame landing over a
   // newer one is the "shows 3-4 steps, blanks, re-fills" flicker. Serializing keeps frames monotonic.
-  // (No keepalive: a real message does not expire, unlike the old 30s draft.)
+  // (No keepalive: a real message does not expire, unlike a Bot API `sendMessageDraft` (30s window).)
   let dirty = false;
   let pumping = false;
   let stopped = false;

--- a/src/channels/telegram/turn-store.ts
+++ b/src/channels/telegram/turn-store.ts
@@ -14,10 +14,10 @@
  * "interrupted" is not just a rare crash: `runStart` has no graceful drain (cli.ts), so a SIGTERM exits
  * mid-turn too, i.e. EVERY rolling deploy that catches an in-flight turn. Recovery re-enqueues it next start.
  *
- * This recovers the ACKed-but-unfinished window the in-memory turn-queue drops (turn-queue.ts) — a
- * deliberate reversal of the old "accept the loss" stance. Weigh the trade before trusting it: the loss
- * it replaces was VISIBLE and self-correcting (the turn vanished, the asker re-asks); replay's sharpest
- * cost is the opposite — invisible. It is at-least-once, not exactly-once:
+ * This recovers the ACKed-but-unfinished window the in-memory turn-queue drops (turn-queue.ts). Weigh
+ * the trade before trusting it: the alternative (dropping the turn) fails VISIBLY and self-corrects
+ * (the turn vanished, the asker re-asks); replay's sharpest cost is the opposite — invisible. It is
+ * at-least-once, not exactly-once:
  *   - PRIMARY cost: replay re-runs the WHOLE turn, so every external side effect happens AGAIN — re-sent
  *     messages, re-fired tool actions — and nobody may notice (unlike the visible loss it replaces).
  *     And the trigger is not rare (above): it fires on every deploy that interrupts an in-flight turn,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -597,9 +597,9 @@ async function reportAuth(modelSpec: string, authPath: string): Promise<void> {
   const source = await probeAuthSource(createPiModels({ authPath }), modelSpec);
   log.info(`[fastagent] auth:   ${source === undefined ? "(none found)" : `${source} (${provider})`} — ${authPath}`);
   if (source !== undefined) return;
-  // Lead with `fastagent login`: the default model (openai-codex) is OAuth-only, and the provider-
-  // specific env var name is not exported, so keep the env path generic. login writes to this same
-  // project-level path, so a follow-up `fastagent login` here fixes it in place.
+  // Lead with `fastagent login`: it covers every provider (including OAuth-only ones like openai-codex),
+  // and the provider-specific env var name is not exported, so keep the env path generic. login writes to
+  // this same project-level path, so a follow-up `fastagent login` here fixes it in place.
   log.warn(
     `[fastagent] no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
   );

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -20,7 +20,7 @@ export interface Tunnel {
 // `(?!api\.)`: cloudflared's ERROR lines mention its request endpoint (`https://api.trycloudflare.com/tunnel`,
 // e.g. "failed to request quick Tunnel: Post ... timeout" under a flaky proxy) — without the exclusion a
 // transient error line parses as the assigned URL and the webhook gets registered against Cloudflare's
-// API host instead of the tunnel (found live in the 0.8.0 release verification).
+// API host instead of the tunnel.
 const TUNNEL_URL_RE = /https:\/\/(?!api\.)[a-z0-9-]+\.trycloudflare\.com/i;
 
 /** Extract a Cloudflare quick-tunnel URL from a chunk of cloudflared output, if present. */


### PR DESCRIPTION
Comments/docs should state what the code is and why, not narrate editing history (that lives in git/CHANGELOG). Full-repo sweep for process slop + one stale comment.

- **cli.ts**: fix a stale comment — reportAuth claimed "the default model (openai-codex)", but the first-run picker removed the preset model.
- **tunnel.ts / turn-store.ts / preview.ts**: drop "found live in 0.8.0 verification", "deliberate reversal of the old stance", clarify "old 30s draft" → sendMessageDraft. Durable rationale kept.
- **design/core.md**: delete the "Reversal: an earlier draft said…" note; rephrase past-tense history into present-tense design.

No behavior change; 370 tests green.