### PR TITLE
docs: stop using "MIT" as an adjective; link pi's monorepo, drop * globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,7 @@ While the project is pre-1.0, minor versions may include breaking changes.
   volume, one machine); the runbook says so.
 
 - **Acknowledgements + npm metadata.** README now credits the open-source stack it builds on — pi
-  (`@earendil-works/pi-*`, the reference engine) and the MIT libraries it depends on — with a
-  "built with pi" badge. `package.json` gains `homepage`, `bugs`, and `author`. All runtime
+  (the reference engine) and the libraries it depends on — with a "built with pi" badge. `package.json` gains `homepage`, `bugs`, and `author`. All runtime
   dependencies are MIT and are not bundled, so no third-party license ships in this package's tarball;
   the one vendored asset (the `writing-great-skills` skill) already includes its license.
 - **First-run model picker.** A scaffolded workspace no longer hard-codes a model. When no model is

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <sub>Built on</sub>
   <a href="https://pi.dev"><img src="https://pi.dev/logo-auto.svg" alt="pi" height="22" /></a>
-  <sub>— the MIT agent harness &amp; multi-provider LLM API (<code>@earendil-works/pi-*</code>)</sub>
+  <sub>— the agent harness &amp; multi-provider LLM API under the hood</sub>
 </p>
 
 **Vibe first. Then FastAgent.** Any folder can become a live agent service. FastAgent takes your local agent folder out of the terminal and serves it in your Next/Astro app, Telegram, GitHub/webhook events, an API endpoint, or your own channel.
@@ -173,12 +173,12 @@ FastAgent is pre-1.0. The stable design center is the Agent Handler contract in 
 
 ## Acknowledgements
 
-FastAgent stands on open source. The reference implementation is built on **[pi](https://pi.dev)** (`@earendil-works/pi-*`, MIT) — the agent harness, the multi-provider LLM API, and the interactive TUI that `fastagent chat` drives.
+FastAgent stands on open source. The reference implementation is built on **[pi](https://github.com/earendil-works/pi)** ([pi.dev](https://pi.dev)) — its agent harness, multi-provider LLM API, and the interactive TUI that `fastagent chat` drives.
 
-It also depends on, and is grateful to, these MIT projects: [zod](https://github.com/colinhacks/zod), [undici](https://github.com/nodejs/undici), [chokidar](https://github.com/paulmillr/chokidar), [giget](https://github.com/unjs/giget), [@clack/prompts](https://github.com/bombshell-dev/clack), [ignore](https://github.com/kaelzhang/node-ignore), and [@octokit/webhooks-*](https://github.com/octokit/webhooks).
+It also depends on, and is grateful to, [zod](https://github.com/colinhacks/zod), [undici](https://github.com/nodejs/undici), [chokidar](https://github.com/paulmillr/chokidar), [giget](https://github.com/unjs/giget), [@clack/prompts](https://github.com/bombshell-dev/clack), [ignore](https://github.com/kaelzhang/node-ignore), and [octokit/webhooks](https://github.com/octokit/webhooks).
 
-The scaffolded `writing-great-skills` skill is vendored from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT), with its license included.
+The scaffolded `writing-great-skills` skill is vendored from [mattpocock/skills](https://github.com/mattpocock/skills), with its license included.
 
 ## License
 
-[MIT](LICENSE). All runtime dependencies are MIT; FastAgent does not bundle their code (npm installs each separately), so their licenses ship with them.
+[MIT](LICENSE). Every runtime dependency is also MIT-licensed, and FastAgent does not bundle their code — npm installs each separately, so their licenses ship with them and none is redistributed here.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,7 +36,7 @@ Most commands take an optional workspace directory. When omitted, the current di
 fastagent init [dir] [--minimal] [--no-install]
 ```
 
-Creates a self-iterating agent — the folder is the agent, and it can edit its own definition (AGENTS.md and skills are re-read every turn). A fresh workspace has `AGENTS.md` (the persona: how to improve yourself), a `writing-great-skills` example skill (from [mattpocock/skills](https://github.com/mattpocock/skills), MIT — the guide to authoring skills), a `fetch-url` example code tool, config, `.env.example`, and `.gitignore`. Everything is written offline; by default it also writes `package.json` and runs `npm install`.
+Creates a self-iterating agent — the folder is the agent, and it can edit its own definition (AGENTS.md and skills are re-read every turn). A fresh workspace has `AGENTS.md` (the persona: how to improve yourself), a `writing-great-skills` example skill (from [mattpocock/skills](https://github.com/mattpocock/skills) — the guide to authoring skills), a `fetch-url` example code tool, config, `.env.example`, and `.gitignore`. Everything is written offline; by default it also writes `package.json` and runs `npm install`.
 
 Options:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,7 +39,7 @@ my-agent/
 └── .gitignore
 ```
 
-`AGENTS.md` teaches the agent to capture durable improvements as new skills; `writing-great-skills` (vendored from [mattpocock/skills](https://github.com/mattpocock/skills), MIT) is the guide it consults to write them. Add more skills with `fastagent add skill <owner/repo/path>`. For a workspace with no code tool or dependencies (AGENTS.md + the skill + config only):
+`AGENTS.md` teaches the agent to capture durable improvements as new skills; `writing-great-skills` (vendored from [mattpocock/skills](https://github.com/mattpocock/skills)) is the guide it consults to write them. Add more skills with `fastagent add skill <owner/repo/path>`. For a workspace with no code tool or dependencies (AGENTS.md + the skill + config only):
 
 ```bash
 fastagent init my-agent --minimal


### PR DESCRIPTION
Readability of the crediting text (flagged in review):

- "MIT" was used as a descriptor ("the MIT agent harness", "these MIT projects"). MIT is a license, not a description. Consolidated to the one place it means something — the License section (deps are MIT + not bundled). Removed as an adjective everywhere else.
- `@earendil-works/pi-*` / `@octokit/webhooks-*` used a `*` glob and were unlinked. pi is a monorepo — linked directly (github.com/earendil-works/pi + pi.dev); octokit/webhooks likewise. No asterisks in prose.

Docs only.