### PR TITLE
docs: converge non-goals with README's "What we didn't build"

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -41,13 +41,16 @@ FastAgent deliberately keeps the serving layer small and composable:
 
 See [Design principles](principles.md) for the full rationale and non-goals.
 
-## What FastAgent is not
+## What we didn't build
 
-- Not another agent framework.
-- Not a new agent definition format or DSL.
-- Not a full application framework that owns your routes, database, or deployment layout.
-- Not a durable workflow engine.
-- Not a replacement for the underlying harness engine.
+FastAgent stays a small serving layer, so it never dictates your stack. Capabilities other agent frameworks bake into a platform, we leave to your app, your host, or the agent itself — composed in, not locked in.
+
+- **No new format or DSL** — bring the `AGENTS.md` + `skills/` you already have; no rewrite into our project shape.
+- **No platform to move to** — no dashboard, no control plane, no runtime you deploy *into*.
+- **No framework that owns your app** — your auth, database, routes, and deployment stay yours; FastAgent plugs in.
+- **No workflow engine** — the agent decides its own steps; for deterministic orchestration, call `invoke` from your own queue or workflow.
+- **No engine, model, or cloud lock-in** — one neutral `invoke` contract; swap the engine, the model, or the host without touching the agent.
+- **No build step** — the directory runs directly, with no artifact to drift from source.
 
 ## Two main use cases
 

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -73,6 +73,7 @@ Typed boundaries are product UX, not ceremony. FastAgent applies them where agen
 | Agent-as-a-feature | Agent-as-a-platform | The common job is adding an agent to a product or channel the user already has, not adopting a second framework. |
 | `invoke` as the neutral contract | HTTP handlers as the only contract | The same agent can run behind an app route, GitHub, Telegram, tests, or future channels. |
 | Channel adapters | One-off webhook/bot implementations | Channel code should translate events, not duplicate the agent loop. |
+| The agent's own reasoning as control flow | A bundled workflow/orchestration engine | The agent decides its steps; deterministic multi-step orchestration is the app's job — call `invoke` from your queue or workflow. |
 | Definition-local skills | Global or machine-local skills | Deployment behavior must come from the repo, not a developer's home directory. |
 | No required build step | Generated runtime artifacts | The directory is already the deployable unit; fewer artifacts means less drift. |
 | Host-provided runtime concerns | Framework-owned everything | Secrets, sessions, execution environment, and policy vary by host and app. |


### PR DESCRIPTION
Align the two docs non-goal surfaces with the new README section:
- overview.md: five flat "Not X" bullets → the same six "What we didn't build" items + taste.
- principles.md: keep the deep "Deliberate product choices" table; add the one non-goal it lacked (a bundled workflow engine).

Docs only.