### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Bumps to 0.10.0 for the deploy feature line (fly + railway generate/runbook/`--run`, model-travel gate, OAuth-on-server seed, first-run model picker). Tag `v0.10.0` + GitHub Release after merge → publish.yml publishes via OIDC.

Self-merge tier (version bump) after green CI.