### PR TITLE
docs: add an animated terminal demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Leave the terminal. Become a real service.
 
 FastAgent is not another agent framework. It does not ask you to rewrite your agent in a new DSL or project layout. You bring the agent definition; FastAgent provides the serving layer around it.
 
+<p align="center">
+  <img src="./assets/demo.svg" alt="fastagent dev boots an existing agent directory (AGENTS.md, skills/, tools/, channels/) into a live service; a GitHub pull_request.opened webhook arrives and the agent reviews PR #42 and posts inline comments." width="860">
+</p>
+
 ## Why FastAgent
 
 Coding agents made it cheap to vibe useful agent directories. The hard part is the next step: local agents live in terminals, but real services receive webhooks, join Telegram, serve product users, and expose stable APIs.

--- a/assets/demo.svg
+++ b/assets/demo.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 496" width="860" height="496" font-family="ui-monospace,'SF Mono',Menlo,Consolas,monospace" font-size="14">
+  <style>
+    .win { fill:#0d0e11; stroke:#26282e; stroke-width:1; }
+    text { white-space:pre; fill:#d7dbe1; }
+    .dim { fill:#6e7681; } .txt { fill:#d7dbe1; } .dir { fill:#58a6ff; }
+    .path { fill:#56d364; } .accent { fill:#39c5cf; } .ok { fill:#56d364; }
+    .tool { fill:#58a6ff; } .reply { fill:#e6edf3; } .purple { fill:#bc8cff; }
+    .title { fill:#6a6f77; } .mark { fill:#e6edf3; font-family:Georgia,'Times New Roman',serif; font-style:italic; font-weight:700; }
+    .l { opacity:0; }
+    .l1{animation:a1 21s infinite} .l2{animation:a2 21s infinite} .l3{animation:a3 21s infinite} .l4{animation:a4 21s infinite} .l5{animation:a5 21s infinite} .l6{animation:a6 21s infinite} .l7{animation:a7 21s infinite} .l8{animation:a8 21s infinite} .l9{animation:a9 21s infinite} .l10{animation:a10 21s infinite} .l11{animation:a11 21s infinite} .l12{animation:a12 21s infinite} .l13{animation:a13 21s infinite} .l14{animation:a14 21s infinite}
+    @keyframes a1 {0%,3%{opacity:0} 5%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a2 {0%,6%{opacity:0} 8%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a3 {0%,12%{opacity:0} 14%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a4 {0%,15%{opacity:0} 17%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a5 {0%,18%{opacity:0} 20%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a6 {0%,21%{opacity:0} 23%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a7 {0%,24%{opacity:0} 26%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a8 {0%,27%{opacity:0} 29%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a9 {0%,40%{opacity:0} 42%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a10 {0%,45%{opacity:0} 47%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a11 {0%,50%{opacity:0} 52%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a12 {0%,56%{opacity:0} 58%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a13 {0%,62%{opacity:0} 64%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+    @keyframes a14 {0%,68%{opacity:0} 70%{opacity:1} 96%{opacity:1} 100%{opacity:0}}
+  </style>
+
+  <rect class="win" x="1" y="1" width="858" height="494" rx="10"/>
+  <circle cx="24" cy="24" r="6" fill="#ff5f56"/>
+  <circle cx="44" cy="24" r="6" fill="#ffbd2e"/>
+  <circle cx="64" cy="24" r="6" fill="#27c93f"/>
+  <text x="430" y="29" text-anchor="middle" class="title"><tspan class="mark" font-size="16">F</tspan> fastagent — an agent directory, live</text>
+  <line x1="1" y1="46" x2="859" y2="46" stroke="#26282e" stroke-width="1"/>
+
+  <text class="l l1" x="20" y="80"><tspan class="path">~/pr-reviewer</tspan><tspan class="dim"> $ </tspan><tspan class="txt">ls</tspan></text>
+  <text class="l l2" x="20" y="106"><tspan class="dir">AGENTS.md</tspan><tspan class="txt">   </tspan><tspan class="dir">skills/</tspan><tspan class="txt">   </tspan><tspan class="dir">tools/</tspan><tspan class="txt">   </tspan><tspan class="dir">channels/</tspan></text>
+  <text class="l l3" x="20" y="148"><tspan class="path">~/pr-reviewer</tspan><tspan class="dim"> $ </tspan><tspan class="txt">fastagent dev</tspan></text>
+  <text class="l l4" x="20" y="174"><tspan class="dim">[fastagent] </tspan><tspan class="dim">model:  </tspan><tspan class="txt">anthropic/claude-sonnet-4-5</tspan></text>
+  <text class="l l5" x="20" y="200"><tspan class="dim">[fastagent] </tspan><tspan class="dim">skills: </tspan><tspan class="txt">review-checklist</tspan></text>
+  <text class="l l6" x="20" y="226"><tspan class="dim">[fastagent] </tspan><tspan class="dim">tools:  </tspan><tspan class="txt">read_diff, post_review</tspan></text>
+  <text class="l l7" x="20" y="252"><tspan class="dim">[fastagent] </tspan><tspan class="dim">http channel on </tspan><tspan class="ok">:8787</tspan></text>
+  <text class="l l8" x="20" y="278"><tspan class="dim">[fastagent] </tspan><tspan class="dim">routes: </tspan><tspan class="txt">GET /health, POST /webhook</tspan></text>
+  <text class="l l9" x="20" y="320"><tspan class="dim">[github] </tspan><tspan class="dim">turn start: session=pr-42 event=</tspan><tspan class="purple">pull_request.opened</tspan></text>
+  <text class="l l10" x="20" y="346"><tspan class="dim">[agent] </tspan><tspan class="accent">▶ turn </tspan><tspan class="dim">← </tspan><tspan class="txt">Review PR #42 "Add retry to fetch"</tspan></text>
+  <text class="l l11" x="20" y="372"><tspan class="dim">[agent]   </tspan><tspan class="accent">tool → </tspan><tspan class="tool">post_review</tspan><tspan class="txt">({"pr":42})</tspan></text>
+  <text class="l l12" x="20" y="398"><tspan class="dim">[agent]   </tspan><tspan class="dim">tool </tspan><tspan class="ok">✓ </tspan><tspan class="tool">post_review</tspan><tspan class="dim"> → </tspan><tspan class="txt">2 inline comments posted</tspan></text>
+  <text class="l l13" x="20" y="424"><tspan class="dim">[agent]   </tspan><tspan class="dim">reply: </tspan><tspan class="reply">Solid — flagged an unhandled reject + a missing timeout.</tspan></text>
+  <text class="l l14" x="20" y="450"><tspan class="dim">[github] </tspan><tspan class="dim">turn done: session=pr-42 </tspan><tspan class="ok">(2.4s)</tspan></text>
+</svg>


### PR DESCRIPTION
Hand-authored CSS-animated SVG (3.8KB, no recording tooling) showing the core loop: `fastagent dev` boots an existing agent directory → a GitHub `pull_request.opened` webhook arrives → the agent reviews PR #42 and posts inline comments. Every line is faithful to real output (dev startup report + turn trace). Wired into README.