### PR TITLE
chore: funnel the issue chooser — questions to Discussions, no blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,8 @@
-blank_issues_enabled: true
-contact_links: []
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, ideas & help
+    url: https://github.com/kid7st/fastagent/discussions
+    about: Ask a question or discuss an idea in Discussions — issues are for bugs and concrete feature requests.
+  - name: Documentation
+    url: https://github.com/kid7st/fastagent/tree/main/docs
+    about: Setup, configuration, channels, embedding, and the API reference.


### PR DESCRIPTION
Turn off blank issues (reports go through bug/feature forms) and add contact links routing questions/ideas to Discussions and readers to docs/.