### PR TITLE
fix(deploy): extend the model-travel hard gate to railway --run

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ FastAgent is the missing bridge from local agent directory to real service.
 - **Channels.** Serve the same agent as a GitHub PR reviewer, a Telegram bot, an HTTP/SSE endpoint, or your own adapter — verified webhooks, streaming replies, group-aware.
 - **Models, tools & skills.** Any model provider (OpenAI, Anthropic, Google, …) via OAuth or API key; typed tools discovered from `tools/` (the filename is the name, Zod-validated); Agent Skills loaded on demand. Built on the open-source [pi](https://github.com/earendil-works/pi) harness.
 - **App embedding — your stack, we plug in.** Like Flask/FastAPI for agents: FastAgent never owns your framework. Mount the agent in your Next / Astro / Hono / Bun / Node route with one handler — your auth, your database, your host.
-- **Deploy anywhere.** Run the directory directly — no build step; `fastagent deploy fly|railway` generates the host config + a runbook and hands off (`fly --run` drives the deploy to completion). Cloud-neutral: the directory is the deployable unit.
+- **Deploy anywhere.** Run the directory directly — no build step; `fastagent deploy fly|railway` generates the host config + a runbook and hands off (`--run` drives the deploy to completion). Cloud-neutral: the directory is the deployable unit.
 
 **Designed for more — [help build it](CONTRIBUTING.md).** FastAgent's neutral contract and injection seams are laid out for the capabilities it is growing into. Honest works-in-progress, open to contributors:
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -239,7 +239,7 @@ Durable decisions this architecture encodes:
 
 ## 10. Running and deployment (design)
 
-The directory IS the agent: there is no build step and no artifact. `dev` and `start` both run the definition directory directly (§4 opener). An agent has no compile output — instructions and skills are markdown, code tools are imported directly in dev and start alike — so packaging was never a *runtime* prerequisite. Packaging for remote deployment (exclude dev cruft, mount state, pin the image) is never a build the author runs by hand to serve; it is what **`fastagent deploy fly`** generates on demand (§10.5) — host artifacts + a runbook, not a step baked into `dev`/`start`.
+The directory IS the agent: there is no build step and no artifact. `dev` and `start` both run the definition directory directly (§4 opener). An agent has no compile output — instructions and skills are markdown, code tools are imported directly in dev and start alike — so packaging was never a *runtime* prerequisite. Packaging for remote deployment (exclude dev cruft, mount state, pin the image) is never a build the author runs by hand to serve; it is what **`fastagent deploy fly|railway`** generates on demand (§10.5) — host artifacts + a runbook, not a step baked into `dev`/`start`.
 
 ### 10.1 What an agent is (the M/K seam)
 
@@ -314,7 +314,7 @@ Resolution order is upstream-owned: a stored credential owns the provider; env i
 
 OAuth refresh tokens are single-use, so refresh is serialized (the file lock) and the new credentials written back — the persistence above. **Single machine/container** is covered by that file lock. **Multi-instance** deployments need a shared credential store with row-locked refresh; that uses the same `CredentialStore` seam and is deferred with the K-axis backends.
 
-### 10.5 Container recipe & `fastagent deploy fly`
+### 10.5 Container recipe & `fastagent deploy fly|railway`
 
 The container is the v1 "machine-state independence" boundary, and with no build step it is trivial:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -443,9 +443,9 @@ async function runDeploy(): Promise<void> {
   // a known crash-loop).
   const modelIssue = modelTravelIssue(config.model, modelSpec);
   if (modelIssue) {
-    // The hard gate is fly-only: `fly --run` would deploy a crash-looping box, so stop it. `railway
-    // --run` already degrades to the manual runbook (Phase 1), so it takes the same warn as the runbook.
-    if (values.run && host === "fly") {
+    // `--run` fully deploys on either host now, so a model that won't travel would ship a known
+    // crash-looping box — hard-stop before that. (Generate-only still just warns, for the runbook.)
+    if (values.run) {
       console.error(`[fastagent] deploy stopped: ${modelIssue}`);
       process.exit(1);
     }


### PR DESCRIPTION
Phase 2 made `railway --run` a full deploy, but the model-travel hard gate stayed fly-only — so `railway --run` with a non-traveling model warned and then shipped a crash-looping box. The gate now fires for any `--run`. Companion text (stale Phase-1 comment, README aside, two fly-only mentions in core.md) updated to fly|railway.

Verified: typecheck + lint clean, 414 tests pass.