### PR TITLE
fix(engine): a broken tool/channel file is isolated, never crashes start (G2)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ import { configuredModelSpecs, createPiModels, probeAuthSource } from "./engines
 import { ensureStateRootSelfIgnored, isUnderDir, loadAgentDefinition } from "./engines/pi/definition.ts";
 import { loadRootIgnore } from "./workspace.ts";
 import { runInvokeStream } from "./invoke-stream.ts";
-import { reportDefinitionWarnings, reportToolCollisions } from "./engines/pi/report.ts";
+import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "./engines/pi/report.ts";
 import { createPiAgentFromWorkspace } from "./engines/pi/workspace.ts";
 import { resolveWorkspaceTools } from "./engines/pi/create.ts";
 import {
@@ -205,12 +205,13 @@ async function runTool(): Promise<void> {
   const { config } = await loadConfig(toolDir).catch(failStartup);
   // The same tool set dev/start mount (defaults + config.tools + discovered, deduped), so the runner
   // exercises exactly what gets served — a shadowed tool is surfaced, not silently run.
-  const { tools, toolCollisions } = await resolveWorkspaceTools(config, toolDir).catch(failStartup);
+  const { tools, toolCollisions, toolFailures } = await resolveWorkspaceTools(config, toolDir).catch(failStartup);
   for (const c of toolCollisions) {
     console.error(
       `[fastagent] warn: tool "${c.name}" (${c.source}) is shadowed by a default/config tool — not mounted`,
     );
   }
+  reportModuleLoadFailures(toolFailures);
   const tool = tools.find((t) => t.name === name);
   if (!tool) {
     console.error(`unknown tool "${name}". available: ${tools.map((t) => t.name).join(", ") || "(none)"}`);
@@ -267,12 +268,18 @@ async function runInfo(): Promise<void> {
   const { config, path: configPath } = await loadConfig(dir).catch(failStartup);
   const modelSpec = resolveModelSpec(values.model, config);
   const definition = await loadAgentDefinition(dir).catch(failStartup);
-  // A tool that fails to import (typically a missing dep before `npm install`) must NOT abort a
-  // read-only inspect: report it and still show model/skills/channels/state. dev/start keep
-  // failStartup — you cannot serve broken tools, but `info` exists to diagnose "something looks off".
+  // A tool that fails to load, for any reason (a missing dep, a top-level throw, or just not being a
+  // tool), is isolated the same way everywhere (G2): info, dev, AND start report it and keep going with
+  // the tools that loaded. The `error`/`.catch` below only fires for a whole-load fault (an unreadable
+  // tools/ dir), not a single bad file.
   const tools = await resolveWorkspaceTools(config, dir)
-    .then((r) => ({ names: r.toolNames, collisions: r.toolCollisions, error: undefined as string | undefined }))
-    .catch((e: unknown) => ({ names: [] as string[], collisions: [], error: (e as Error).message }));
+    .then((r) => ({
+      names: r.toolNames,
+      collisions: r.toolCollisions,
+      failures: r.toolFailures,
+      error: undefined as string | undefined,
+    }))
+    .catch((e: unknown) => ({ names: [] as string[], collisions: [], failures: [], error: (e as Error).message }));
   const channels = await discoverChannelFiles(dir).catch(failStartup);
   // The default sessions/auth paths WITHOUT creating anything (info is read-only; dev/start mkdir/login
   // create them, info must not).
@@ -298,6 +305,7 @@ async function runInfo(): Promise<void> {
           diagnostics: definition.diagnostics,
           skillCollisions: definition.collisions,
           toolCollisions: tools.collisions,
+          toolFailures: tools.failures,
         },
         null,
         2,
@@ -316,6 +324,7 @@ async function runInfo(): Promise<void> {
   console.log(`sessions: ${sessionsDir}`);
   console.log(`auth:     ${authPath}`);
   reportToolCollisions(tools.collisions);
+  reportModuleLoadFailures(tools.failures);
   if (tools.error) log.warn(`[fastagent] ${tools.error}`);
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 }
@@ -894,6 +903,7 @@ function reportAgentsSkillsTools(a: Assembled): void {
   log.info(`[fastagent] skills: ${a.definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
   if (a.toolNames.length > 0) log.info(`[fastagent] tools:  ${a.toolNames.join(", ")}`);
   reportToolCollisions(a.toolCollisions);
+  reportModuleLoadFailures(a.toolFailures);
   reportDefinitionWarnings(a.definition.collisions, a.definition.diagnostics);
 }
 
@@ -988,12 +998,22 @@ async function runStart(): Promise<void> {
 
   // The same opener dev uses (single assembly source), just no watch.
   const sessionsDirOverride = resolveSessionsDirOverride(values["sessions-dir"]);
-  const { agent, definition, config, modelSpec, stateRoot, sessionsDir, authPath, toolNames, toolCollisions } =
-    await createPiAgentFromWorkspace(dir, {
-      model: values.model,
-      sessionsDir: sessionsDirOverride,
-      authPath: authPathOverride,
-    }).catch(failStartup);
+  const {
+    agent,
+    definition,
+    config,
+    modelSpec,
+    stateRoot,
+    sessionsDir,
+    authPath,
+    toolNames,
+    toolCollisions,
+    toolFailures,
+  } = await createPiAgentFromWorkspace(dir, {
+    model: values.model,
+    sessionsDir: sessionsDirOverride,
+    authPath: authPathOverride,
+  }).catch(failStartup);
 
   log.info(`[fastagent] start:  ${dir}`);
   log.info(`[fastagent] model:  ${modelSpec}`);
@@ -1002,6 +1022,7 @@ async function runStart(): Promise<void> {
   log.info(`[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
   if (toolNames.length > 0) log.info(`[fastagent] tools:  ${toolNames.join(", ")}`);
   reportToolCollisions(toolCollisions);
+  reportModuleLoadFailures(toolFailures);
   log.info(`[fastagent] state:  ${stateRoot}`);
   log.info(`[fastagent] sessions: ${sessionsDir}`);
   // State defaults under the definition dir, which a redeploy may replace wholesale. Gate on where the
@@ -1033,12 +1054,13 @@ async function runStart(): Promise<void> {
  * `channels/` — or the default invoke channel at POST /invoke when none are declared.
  */
 async function routesFor(workspaceDir: string, agent: Agent, stateRoot: string): Promise<Routes> {
-  const { routes, collisions } = await loadChannels(workspaceDir, { agent, stateRoot });
+  const { routes, collisions, failures } = await loadChannels(workspaceDir, { agent, stateRoot });
   for (const c of collisions) {
     console.error(
       `[fastagent] warn: channel route "${c.route}" (${c.source}) collides with an earlier channel — not mounted`,
     );
   }
+  reportModuleLoadFailures(failures);
   const channels = Object.keys(routes).length > 0 ? routes : { "POST /invoke": createInvokeHandler(agent) };
   // Add a default GET /health unless a channel already covers it (overlap, not exact-key: an
   // any-method `/health` also handles GET, so the built-in steps aside).

--- a/src/engines/pi/channel.ts
+++ b/src/engines/pi/channel.ts
@@ -8,7 +8,7 @@ import { readdir } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 import { type ChannelContext, type ChannelModule, parseRouteKey, type Routes } from "../../host/node.ts";
 import { assertInsideWorkspace } from "../../workspace.ts";
-import { isModuleFile, loadModuleDir } from "./loader.ts";
+import { type ModuleLoadFailure, isModuleFile, loadModuleDir } from "./loader.ts";
 
 /** A dropped route: two channels claim the same key. Surfaced, never silent. */
 export interface ChannelCollision {
@@ -40,13 +40,17 @@ export async function discoverChannelFiles(dir: string): Promise<string[]> {
 /**
  * Discover channels in `<dir>/channels/`: each `*.ts|.js|.mjs` default-exports a `(ctx) => Routes`
  * factory ({@link ChannelModule}), called here with the mount context; the returned route maps are
- * merged (first file wins a route-key clash, the dropped route surfaced). A file that does not
- * contribute a valid, non-empty Routes object fails visibly.
+ * merged (first file wins a route-key clash, the dropped route surfaced).
+ *
+ * A channel file broken for ANY reason — a failed import, a factory that throws when called (a missing
+ * env var is the common deploy case), or a malformed shape (not a function, not a Routes object, a bad
+ * handler/route key) — is ISOLATED into `failures`: skipped + reported, never crash-looping the server
+ * (G2). Routes are validated fully before any merge, so a throw mounts no partial routes.
  */
 export async function loadChannels(
   dir: string,
   ctx: ChannelContext,
-): Promise<{ routes: Routes; collisions: ChannelCollision[] }> {
+): Promise<{ routes: Routes; collisions: ChannelCollision[]; failures: ModuleLoadFailure[] }> {
   // The contract says stateRoot is absolute; enforce it at the mount boundary so a relative root fails
   // fast HERE instead of silently re-anchoring some channel's state on the process cwd.
   if (!isAbsolute(ctx.stateRoot)) {
@@ -55,62 +59,70 @@ export async function loadChannels(
   // A symlinked channels/ is followed only if it stays inside the workspace, so a deploy that copies
   // the dir includes it (the directory is the agent).
   await assertInsideWorkspace(dir, "channels");
-  const modules = await loadModuleDir(join(dir, "channels"));
+  const { modules, failures } = await loadModuleDir(join(dir, "channels"));
   const routes: Routes = {};
   const collisions: ChannelCollision[] = [];
-  for (const { label, mod } of modules) {
-    const factory = mod.default;
-    if (typeof factory !== "function") {
-      throw new Error(`${label} must default-export (ctx) => Routes`);
-    }
-    let declared: Routes;
+  for (const { label, file, mod } of modules) {
+    // A channel file broken for ANY reason is isolated: an import failure (from loadModuleDir), a factory
+    // that throws when called (a missing/blank env var — the common deploy failure), OR a malformed shape
+    // (not a function, not a Routes object, a bad handler/route key). All → skipped + reported, never a
+    // crash-loop. We can't (and don't try to) tell an operator's misconfig from an author's bug: both
+    // degrade the same way, in dev and on the box, and the loud warning is the feedback. Routes are
+    // VALIDATED fully before any are merged, so a throw mid-validation mounts NO partial routes.
     try {
-      declared = (factory as ChannelModule)(ctx);
-    } catch (error) {
-      throw new Error(`${label}: ${(error as Error).message}`);
-    }
-    // A Promise needs its own branch before the object check: mark it handled (a rejected async setup
-    // must not go unhandled) and reject it with a precise message rather than the zero-routes one.
-    if (
-      declared !== null &&
-      typeof declared === "object" &&
-      typeof (declared as { then?: unknown }).then === "function"
-    ) {
-      (declared as unknown as Promise<unknown>).catch(() => {});
-      throw new Error(`${label} must return Routes synchronously, not a Promise (an async factory is not supported)`);
-    }
-    if (declared === null || typeof declared !== "object") {
-      throw new Error(`${label} must return a Routes object, got ${declared === null ? "null" : typeof declared}`);
-    }
-    const declaredRoutes = Object.entries(declared);
-    if (declaredRoutes.length === 0) {
-      throw new Error(
-        `${label} declared no routes — return a non-empty { "METHOD /path": handler } object (a Promise, Map, array, or {} yields none)`,
-      );
-    }
-    for (const [route, handler] of declaredRoutes) {
-      if (typeof handler !== "function") {
-        throw new Error(`${label}: route "${route}" must map to a handler function, got ${typeof handler}`);
+      const factory = mod.default;
+      if (typeof factory !== "function") {
+        throw new Error(`${label} must default-export (ctx) => Routes`);
       }
-      const parsed = parseRouteKey(route);
-      if (!parsed.path.startsWith("/")) {
-        throw new Error(`${label}: route "${route}" is not a valid route key (expected "METHOD /path" or "/path")`);
+      const declared = (factory as ChannelModule)(ctx) as unknown;
+      // A Promise needs its own branch before the object check: mark it handled (a rejected async setup
+      // must not go unhandled) and reject it with a precise message rather than the zero-routes one.
+      if (
+        declared !== null &&
+        typeof declared === "object" &&
+        typeof (declared as { then?: unknown }).then === "function"
+      ) {
+        (declared as Promise<unknown>).catch(() => {});
+        throw new Error(`${label} must return Routes synchronously, not a Promise (an async factory is not supported)`);
       }
-      // Overlap, not literal-key, equality: the router treats a bare `/path` as any-method, so
-      // `/webhook` and `POST /webhook` clash. `GET /x` vs `POST /x` is fine.
-      const clash = Object.keys(routes).some((k) => {
-        const e = parseRouteKey(k);
-        return (
-          e.path === parsed.path &&
-          (e.method === undefined || parsed.method === undefined || e.method === parsed.method)
+      if (declared === null || typeof declared !== "object") {
+        throw new Error(`${label} must return a Routes object, got ${declared === null ? "null" : typeof declared}`);
+      }
+      const declaredRoutes = Object.entries(declared as Routes);
+      if (declaredRoutes.length === 0) {
+        throw new Error(
+          `${label} declared no routes — return a non-empty { "METHOD /path": handler } object (a Promise, Map, array, or {} yields none)`,
         );
-      });
-      if (clash) {
-        collisions.push({ route, source: label });
-        continue;
       }
-      routes[route] = handler;
+      // Validate every route BEFORE merging any (no partial mount on a later throw).
+      for (const [route, handler] of declaredRoutes) {
+        if (typeof handler !== "function") {
+          throw new Error(`${label}: route "${route}" must map to a handler function, got ${typeof handler}`);
+        }
+        if (!parseRouteKey(route).path.startsWith("/")) {
+          throw new Error(`${label}: route "${route}" is not a valid route key (expected "METHOD /path" or "/path")`);
+        }
+      }
+      for (const [route, handler] of declaredRoutes) {
+        const parsed = parseRouteKey(route);
+        // Overlap, not literal-key, equality: the router treats a bare `/path` as any-method, so
+        // `/webhook` and `POST /webhook` clash. `GET /x` vs `POST /x` is fine.
+        const clash = Object.keys(routes).some((k) => {
+          const e = parseRouteKey(k);
+          return (
+            e.path === parsed.path &&
+            (e.method === undefined || parsed.method === undefined || e.method === parsed.method)
+          );
+        });
+        if (clash) {
+          collisions.push({ route, source: label });
+          continue;
+        }
+        routes[route] = handler;
+      }
+    } catch (error) {
+      failures.push({ label, file, message: (error as Error).message });
     }
   }
-  return { routes, collisions };
+  return { routes, collisions, failures };
 }

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -39,7 +39,7 @@ import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from
 import { createPiModels } from "./models.ts";
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
 import { loadTools, mergeDiscoveredTools } from "./tool.ts";
-import { reportDefinitionWarnings, reportToolCollisions } from "./report.ts";
+import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 
 export interface RunPiChatOptions {
   /** Model spec override (the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -77,6 +77,7 @@ export async function buildChatRuntime(
     const discovered = await loadTools(cwd);
     const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
     reportToolCollisions([...discovered.collisions, ...crossCollisions]);
+    reportModuleLoadFailures(discovered.failures);
     const defaultNames = piDefaultTools(cwd).map((t) => t.name);
     const customTools = tools.filter((t) => !defaultNames.includes(t.name));
     // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts it).

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -23,6 +23,7 @@ import { piHarnessFactory } from "./harness.ts";
 import { createPiModels } from "./models.ts";
 import { reportDefinitionWarnings } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
+import type { ModuleLoadFailure } from "./loader.ts";
 import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 
@@ -51,13 +52,18 @@ export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] 
 export async function resolveWorkspaceTools(
   config: FastagentConfig,
   dir: string,
-): Promise<{ tools: AgentTool[]; toolNames: string[]; toolCollisions: ToolCollision[] }> {
+): Promise<{
+  tools: AgentTool[];
+  toolNames: string[];
+  toolCollisions: ToolCollision[];
+  toolFailures: ModuleLoadFailure[];
+}> {
   const discovered = await loadTools(dir);
   const { tools, collisions } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
   const toolCollisions = [...discovered.collisions, ...collisions];
   const defaultNames = new Set(piDefaultTools(dir).map((t) => t.name));
   const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
-  return { tools, toolNames, toolCollisions };
+  return { tools, toolNames, toolCollisions, toolFailures: discovered.failures };
 }
 
 // ── §2 prompt: four-segment systemPrompt assembly ───────────────────────────

--- a/src/engines/pi/loader.ts
+++ b/src/engines/pi/loader.ts
@@ -19,36 +19,55 @@ export interface DiscoveredModule {
   mod: { default?: unknown };
 }
 
+/** A `tools/`/`channels/` file that failed to LOAD, for any reason. Surfaced as DATA (like skill
+ *  diagnostics), never thrown: one bad file must not crash `start`, so the caller reports it and serves
+ *  the rest. loadModuleDir fills it for IMPORT failures; loadTools/loadChannels add the ones they detect
+ *  (not a tool / not a channel, a factory that throws when called, malformed routes). */
+export interface ModuleLoadFailure {
+  /** "tools/foo.ts"-style label. */
+  label: string;
+  file: string;
+  /** The failure message (an import error carries {@link moduleLoadHint}). */
+  message: string;
+}
+
 /**
- * Import every module file in `subDir`, sorted by name. Missing dir returns none.
- * A failed import names the file and appends {@link moduleLoadHint}.
+ * Import every module file in `subDir`, sorted by name. Missing dir returns none. A file that fails to
+ * IMPORT is ISOLATED — collected into `failures` (with {@link moduleLoadHint}) and skipped, not thrown —
+ * so one bad import can't crash the load; the caller (loadTools/loadChannels) isolates its own per-file
+ * failures the same way. (A missing DIRECTORY still returns empty; an unreadable directory still throws
+ * — that's not a per-file problem.)
  */
-export async function loadModuleDir(subDir: string): Promise<DiscoveredModule[]> {
+export async function loadModuleDir(
+  subDir: string,
+): Promise<{ modules: DiscoveredModule[]; failures: ModuleLoadFailure[] }> {
   let entries: Dirent[];
   try {
     entries = await readdir(subDir, { withFileTypes: true });
   } catch (error) {
     const e = error as NodeJS.ErrnoException;
-    if (e.code === "ENOENT" || e.code === "not_found") return [];
+    if (e.code === "ENOENT" || e.code === "not_found") return { modules: [], failures: [] };
     throw new Error(`cannot read ${subDir}: ${(error as Error).message}`);
   }
   const sub = basename(subDir);
-  const out: DiscoveredModule[] = [];
+  const modules: DiscoveredModule[] = [];
+  const failures: ModuleLoadFailure[] = [];
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     if (!entry.isFile() || !isModuleFile(entry.name)) continue;
     const file = join(subDir, entry.name);
     const label = `${sub}/${entry.name}`;
-    let mod: { default?: unknown };
     try {
-      mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
+      const mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
+      modules.push({ name: basename(entry.name, extname(entry.name)), label, file, mod });
     } catch (error) {
-      throw new Error(
-        `cannot load ${label}: ${(error as Error).message}${moduleLoadHint(error as NodeJS.ErrnoException)}`,
-      );
+      failures.push({
+        label,
+        file,
+        message: `${(error as Error).message}${moduleLoadHint(error as NodeJS.ErrnoException)}`,
+      });
     }
-    out.push({ name: basename(entry.name, extname(entry.name)), label, file, mod });
   }
-  return out;
+  return { modules, failures };
 }
 
 /**

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -5,6 +5,7 @@
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { log } from "../../log.ts";
 import type { SkillCollision } from "./definition.ts";
+import type { ModuleLoadFailure } from "./loader.ts";
 import type { ToolCollision } from "./tool.ts";
 
 export function reportDefinitionWarnings(collisions: SkillCollision[], diagnostics: SkillDiagnostic[]): void {
@@ -19,5 +20,14 @@ export function reportDefinitionWarnings(collisions: SkillCollision[], diagnosti
 export function reportToolCollisions(collisions: ToolCollision[]): void {
   for (const c of collisions) {
     log.warn(`[fastagent] tool "${c.name}" (${c.source}) dropped — a default/config tool already uses that name`);
+  }
+}
+
+/** A `tools/`/`channels/` file that failed to load, for any reason — skipped, not fatal. Loud so it's
+ *  diagnosable: the agent keeps serving without it (e.g. a broken build script sitting in the repo's
+ *  tools/, or a channel whose factory threw on a missing env var). */
+export function reportModuleLoadFailures(failures: ModuleLoadFailure[]): void {
+  for (const f of failures) {
+    log.warn(`[fastagent] ${f.label} failed to load, skipping it — ${f.message}`);
   }
 }

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -13,7 +13,7 @@
 import { join } from "node:path";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { z } from "zod";
-import { loadModuleDir } from "./loader.ts";
+import { type ModuleLoadFailure, loadModuleDir } from "./loader.ts";
 
 export interface ToolContext {
   /** Abort signal for the current turn — honor it to cancel in-flight work on cancellation. */
@@ -62,15 +62,24 @@ export interface ToolCollision {
   source: string;
 }
 
-/** Discover code tools in `<dir>/tools/`: each `*.ts|.js|.mjs` default-exports a tool, named from its filename. */
-export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; collisions: ToolCollision[] }> {
-  const modules = await loadModuleDir(join(dir, "tools"));
+/**
+ * Discover code tools in `<dir>/tools/`: each `*.ts|.js|.mjs` default-exports a tool, named from its
+ * filename. A file broken for ANY reason — a failed import (from {@link loadModuleDir}) or not being a
+ * tool (no `execute`) — is ISOLATED into `failures` (skipped + reported, not thrown) so one broken file
+ * can't crash `start`; the agent serves the tools that loaded. A repo turned into an agent often has a
+ * `tools/` dir of its OWN scripts, which is exactly this case.
+ */
+export async function loadTools(
+  dir: string,
+): Promise<{ tools: AgentTool[]; collisions: ToolCollision[]; failures: ModuleLoadFailure[] }> {
+  const { modules, failures } = await loadModuleDir(join(dir, "tools"));
   const byName = new Map<string, AgentTool>();
   const collisions: ToolCollision[] = [];
-  for (const { name, label, mod } of modules) {
+  for (const { name, label, file, mod } of modules) {
     const tool = mod.default as Partial<AgentTool> | undefined;
     if (!tool || typeof tool.execute !== "function") {
-      throw new Error(`${label} must default-export defineTool({...})`);
+      failures.push({ label, file, message: `${label} must default-export defineTool({...})` });
+      continue;
     }
     if (byName.has(name)) {
       collisions.push({ name, source: label });
@@ -78,7 +87,7 @@ export async function loadTools(dir: string): Promise<{ tools: AgentTool[]; coll
     }
     byName.set(name, { ...(tool as AgentTool), name });
   }
-  return { tools: [...byName.values()], collisions };
+  return { tools: [...byName.values()], collisions, failures };
 }
 
 /**

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -20,6 +20,7 @@ import {
   resolveStateRoot,
 } from "./config.ts";
 import { createPiAgentFromDefinition, resolveWorkspaceTools } from "./create.ts";
+import type { ModuleLoadFailure } from "./loader.ts";
 import { type LoadedDefinition, ensureStateRootSelfIgnored } from "./definition.ts";
 import { jsonlSessionStore } from "./sessions.ts";
 import type { ToolCollision } from "./tool.ts";
@@ -65,6 +66,8 @@ export async function createPiAgentFromWorkspace(
   /** Non-default tool names in effect: config.tools + discovered tools/. */
   toolNames: string[];
   toolCollisions: ToolCollision[];
+  /** `tools/` files that failed to import — skipped, reported by the caller, never fatal. */
+  toolFailures: ModuleLoadFailure[];
 }> {
   const { config, path: configPath }: LoadedConfig = await loadConfig(dir);
   const modelSpec = resolveModelSpec(options.model, config);
@@ -73,7 +76,7 @@ export async function createPiAgentFromWorkspace(
       `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
     );
   }
-  const { tools, toolNames, toolCollisions } = await resolveWorkspaceTools(config, dir);
+  const { tools, toolNames, toolCollisions, toolFailures } = await resolveWorkspaceTools(config, dir);
   // The state root: auth/sessions/channel state all derive from it, so FASTAGENT_STATE_DIR moves the
   // whole machine-state home in one knob (a container mounts one volume); the finer overrides below
   // still win for their specific path.
@@ -105,5 +108,6 @@ export async function createPiAgentFromWorkspace(
     authPath,
     toolNames,
     toolCollisions,
+    toolFailures,
   };
 }

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -13,7 +13,7 @@ const freshDir = () => mkdtemp(join(tmpdir(), "fa-chan-"));
 describe("loadChannels (filesystem discovery)", () => {
   it("discovers channels/* and merges their routes; missing channels/ is empty", async () => {
     const dir = await freshDir();
-    expect(await loadChannels(dir, fakeCtx)).toEqual({ routes: {}, collisions: [] }); // no channels/ yet
+    expect(await loadChannels(dir, fakeCtx)).toEqual({ routes: {}, collisions: [], failures: [] }); // no channels/ yet
 
     await mkdir(join(dir, "channels"));
     await writeFile(
@@ -27,6 +27,43 @@ describe("loadChannels (filesystem discovery)", () => {
     const { routes, collisions } = await loadChannels(dir, fakeCtx);
     expect(Object.keys(routes).sort()).toEqual(["POST /stripe", "POST /webhook"]);
     expect(collisions).toEqual([]);
+  });
+
+  it("ISOLATES a channel that throws on import — reports it in failures, still mounts the others (G2)", async () => {
+    const dir = await freshDir();
+    await mkdir(join(dir, "channels"));
+    await writeFile(
+      join(dir, "channels", "boom.mjs"),
+      `throw new Error("bad top-level init");\nexport default () => ({});`,
+    );
+    await writeFile(
+      join(dir, "channels", "ok.mjs"),
+      `export default () => ({ "POST /ok": () => new Response(null, { status: 202 }) });`,
+    );
+    const { routes, failures } = await loadChannels(dir, fakeCtx);
+    expect(Object.keys(routes)).toEqual(["POST /ok"]); // the good channel still mounts — no crash
+    expect(failures).toHaveLength(1);
+    expect(failures[0]!.label).toBe("channels/boom.mjs");
+    expect(failures[0]!.message).toMatch(/bad top-level init/);
+  });
+
+  it("ISOLATES a channel whose FACTORY throws at init (missing env) — reports it, mounts the rest (G2)", async () => {
+    // The common deploy failure: a factory reads a required env var / validates config and throws. That
+    // must not crash the server — skip the channel, keep serving the rest.
+    const dir = await freshDir();
+    await mkdir(join(dir, "channels"));
+    await writeFile(
+      join(dir, "channels", "needsenv.mjs"),
+      `export default () => { throw new Error("TELEGRAM_SECRET_TOKEN required"); };`,
+    );
+    await writeFile(
+      join(dir, "channels", "ok.mjs"),
+      `export default () => ({ "POST /ok": () => new Response(null, { status: 202 }) });`,
+    );
+    const { routes, failures } = await loadChannels(dir, fakeCtx);
+    expect(Object.keys(routes)).toEqual(["POST /ok"]); // the healthy channel still mounts
+    expect(failures.map((f) => f.label)).toEqual(["channels/needsenv.mjs"]);
+    expect(failures[0]!.message).toMatch(/TELEGRAM_SECRET_TOKEN/);
   });
 
   it("surfaces a route collision (first file wins; the duplicate is dropped, never silent)", async () => {
@@ -103,14 +140,16 @@ describe("loadChannels (filesystem discovery)", () => {
     );
   });
 
-  it("fails visibly when a channel file does not default-export a function", async () => {
+  it("isolates (surfaces, not fatal) a channel file that does not default-export a function", async () => {
     const dir = await freshDir();
     await mkdir(join(dir, "channels"));
     await writeFile(join(dir, "channels", "bad.mjs"), `export const notDefault = 1;`);
-    await expect(loadChannels(dir, fakeCtx)).rejects.toThrow(/must default-export \(ctx\) => Routes/);
+    const { routes, failures } = await loadChannels(dir, fakeCtx);
+    expect(routes).toEqual({}); // not mounted…
+    expect(failures[0]!.message).toMatch(/must default-export \(ctx\) => Routes/); // …but surfaced, never silent
   });
 
-  it("rejects an async factory with a Promise-specific error (and no unhandled rejection)", async () => {
+  it("surfaces an async factory with a Promise-specific message (and no unhandled rejection)", async () => {
     const dir = await freshDir();
     await mkdir(join(dir, "channels"));
     // Rejects after the (microtask) tick — the guard must mark it handled, not leave it unhandled.
@@ -118,7 +157,8 @@ describe("loadChannels (filesystem discovery)", () => {
       join(dir, "channels", "async.mjs"),
       `export default async () => { throw new Error("setup boom"); };`,
     );
-    await expect(loadChannels(dir, fakeCtx)).rejects.toThrow(/not a Promise|async factory is not supported/);
+    const { failures } = await loadChannels(dir, fakeCtx); // isolated; the Promise is marked handled — no unhandled rejection
+    expect(failures[0]!.message).toMatch(/not a Promise|async factory is not supported/);
   });
 
   it("rejects any non-async return that yields no routes (null, primitive, array, Map, {})", async () => {
@@ -134,7 +174,9 @@ describe("loadChannels (filesystem discovery)", () => {
       const dir = await freshDir();
       await mkdir(join(dir, "channels"));
       await writeFile(join(dir, "channels", `${name}.mjs`), body);
-      await expect(loadChannels(dir, fakeCtx)).rejects.toThrow(/must return a Routes object|declared no routes/);
+      const { routes, failures } = await loadChannels(dir, fakeCtx);
+      expect(routes).toEqual({}); // nothing mounted
+      expect(failures[0]!.message).toMatch(/must return a Routes object|declared no routes/);
     }
   });
 
@@ -142,7 +184,8 @@ describe("loadChannels (filesystem discovery)", () => {
     const dir = await freshDir();
     await mkdir(join(dir, "channels"));
     await writeFile(join(dir, "channels", "bad.mjs"), `export default () => ({ "POST /webhook": 42 });`);
-    await expect(loadChannels(dir, fakeCtx)).rejects.toThrow(/must map to a handler function/);
+    const { failures } = await loadChannels(dir, fakeCtx);
+    expect(failures[0]!.message).toMatch(/must map to a handler function/);
   });
 
   it("rejects a malformed route key (a handler array's numeric key, or a missing leading slash)", async () => {
@@ -154,7 +197,9 @@ describe("loadChannels (filesystem discovery)", () => {
       const dir = await freshDir();
       await mkdir(join(dir, "channels"));
       await writeFile(join(dir, "channels", "bad.mjs"), body);
-      await expect(loadChannels(dir, fakeCtx)).rejects.toThrow(/is not a valid route key/);
+      const { routes, failures } = await loadChannels(dir, fakeCtx);
+      expect(routes).toEqual({}); // no partial mount
+      expect(failures[0]!.message).toMatch(/is not a valid route key/);
     }
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -78,8 +78,8 @@ describe("cli papercuts", () => {
 
   it("info degrades when a tool can't load (missing dep) — reports it, still shows the surface, exits 0", async () => {
     // The scaffold ships tools/ that import @kid7st/fastagent; before `npm install` the import fails.
-    // info is read-only diagnosis ("run it first when something looks off") — a broken tool must be
-    // reported, not abort the whole report. dev/start still fail hard (you cannot serve broken tools).
+    // A broken tool file is ISOLATED (skipped + reported, not thrown) so it can't crash the load — info
+    // reports it, and dev/start degrade the SAME way (G2): the agent keeps serving without that one tool.
     const dir = await mkdtemp(join(tmpdir(), "fa-info-toolfail-"));
     await mkdir(join(dir, "tools"), { recursive: true });
     await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
@@ -90,16 +90,17 @@ describe("cli papercuts", () => {
     const { code, stdout } = await run(["info", dir, "--json"], undefined, env);
     expect(code).toBe(0); // reported, not fatal
     const info = JSON.parse(stdout);
-    expect(info.tools).toEqual([]); // could not load
-    expect(info.toolError).toMatch(/broken\.ts/); // the reason is surfaced to a JSON consumer
+    expect(info.tools).toEqual([]); // the broken tool isn't loaded…
+    expect(JSON.stringify(info.toolFailures)).toMatch(/broken\.ts/); // …it's surfaced as a per-file load failure
+    expect(info.toolError).toBeNull(); // isolated, so NOT a whole-load abort
     expect(info.instructions).toBe(true); // the rest of the surface still shows
     await expect(stat(join(dir, ".fastagent"))).rejects.toThrow(); // still read-only
 
     // text mode: the tools line degrades and the reason goes to stderr as a warning
     const text = await run(["info", dir], undefined, env);
     expect(text.code).toBe(0);
-    expect(text.stdout).toMatch(/tools:\s+\(could not load/);
-    expect(text.stderr).toMatch(/broken\.ts/);
+    expect(text.stdout).toMatch(/tools:\s+\(none\)/); // the broken tool was skipped, nothing else to show
+    expect(text.stderr).toMatch(/broken\.ts/); // the reason is a warning on stderr
   });
 
   it("login self-ignores .fastagent on an adapted dir before it writes the credential file", async () => {

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -61,10 +61,30 @@ describe("loadTools (filesystem discovery)", () => {
     expect((await tools[0]!.execute("c", {})).details).toBe("pong");
   });
 
-  it("fails visibly when a tool file does not default-export a tool", async () => {
+  it("isolates (surfaces, not fatal) a tool file that does not default-export a tool", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-tools-"));
     await mkdir(join(dir, "tools"));
     await writeFile(join(dir, "tools", "bad.mjs"), `export const notDefault = 1;`);
-    await expect(loadTools(dir)).rejects.toThrow(/must default-export defineTool/);
+    const { tools, failures } = await loadTools(dir);
+    expect(tools).toEqual([]); // not mounted…
+    expect(failures[0]!.message).toMatch(/must default-export defineTool/); // …but surfaced, never silent
+  });
+
+  it("ISOLATES a tool that throws on import — reports it in failures, still loads the others (G2)", async () => {
+    // A repo turned into an agent may have a tools/ dir of its OWN build scripts that throw at module
+    // top level (the real case: `APP_BASE ?? throw`). One such file must not crash `start` — it's skipped
+    // and reported, the rest load, the agent keeps serving.
+    const dir = await mkdtemp(join(tmpdir(), "fa-tools-"));
+    await mkdir(join(dir, "tools"));
+    await writeFile(join(dir, "tools", "boom.mjs"), `throw new Error("APP_BASE env required");\nexport default {};`);
+    await writeFile(
+      join(dir, "tools", "ok.mjs"),
+      `export default { description: "o", parameters: { type: "object" }, async execute() { return "ok"; } };`,
+    );
+    const { tools, failures } = await loadTools(dir);
+    expect(tools.map((t) => t.name)).toEqual(["ok"]); // the good tool still loads — no crash
+    expect(failures).toHaveLength(1);
+    expect(failures[0]!.label).toBe("tools/boom.mjs");
+    expect(failures[0]!.message).toMatch(/APP_BASE/); // the throw reason is surfaced, not swallowed
   });
 });


### PR DESCRIPTION
## G2 — a broken tool/channel file is isolated, never crashes start

### The bug (real-world validation)

Turning a repo into an agent (B mode), its OWN `tools/` dir had a build script that throws at module top level (`APP_BASE ?? throw`). fastagent loaded it as an agent tool, it threw, and `start` **crashed → ON_FAILURE restart loop → healthcheck failed → the deployed agent never served**.

### Fix — one invariant

A `tools/`/`channels/` file broken for **any** reason is skipped + reported (a loud warning), never crash-looping the server. A repo's own files break in many ways, not just import:

- `loadModuleDir` isolates per-file **import** failures (missing dep, top-level throw).
- `loadTools` isolates a file that imports but **isn't a tool**.
- `loadChannels` isolates a **factory that throws when called** (the common deploy failure — a missing/blank env var, e.g. the telegram channel rejecting an empty secretToken) **and** a **malformed shape** (not a function, not a Routes object, a bad handler/route key). Routes are validated fully before any merge, so a throw mounts no partial routes.

No operator-vs-author split (an earlier revision tried one; the factory catch is unconditional, so it never held). Author bugs and operator misconfig degrade the same way — in dev and on the box — and the warning is the feedback. This aligns tools/channels with **skills**, which already return load diagnostics as data. Failures thread through `loadTools`/`loadChannels`/`resolveWorkspaceTools`/`createPiAgentFromWorkspace`; every report site (start/dev/invoke/info/tool/chat/serveNode) surfaces them via `reportModuleLoadFailures`.

### Behavior change (named)

`start`/`dev` go from **fail-fast on a broken tool/channel** to **isolate + warn**. For a deployed agent this is the point (degraded + diagnosable beats a crash-loop with no service); for dev, the loud warning is the feedback and the dev server stays up.

### Tests

tool + channel isolation for import-throw, factory-init-throw, and every shape error (the shape-error tests that asserted throws now assert the failure is surfaced + nothing mounted); info-degrades asserts `toolFailures`. `npm run typecheck && npm test` → 422 passed. Local review to convergence.

Second of the real-world-validation gaps (G2). Engine loading behavior change — review tier.
