### PR TITLE
fix(deploy): ship .git for git-using agents + document convention-dir collisions (G8, G3)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,8 @@ Supported keys:
 
 Unknown keys fail at startup. This catches typos such as `modle` instead of silently running zero-config.
 
+The generated `.dockerignore` excludes `.git` to keep the image small. If your agent runs git over its **own** history (e.g. `git log`/`git blame` on the repo it ships in), delete the `.git` line from the generated `.dockerignore` so that history is included in the image.
+
 ## Model selection
 
 Model specs are strings like:
@@ -144,6 +146,10 @@ tools/lookup-order.ts  ->  lookup-order
 ```
 
 `config.tools` are appended after the default pi tools. Discovered `tools/` are appended after those. Name collisions are surfaced as warnings; existing tools win.
+
+### When the repo already owns `tools/` (or `channels/`)
+
+Turning an existing repo into an agent, those directory names may already hold the repo's OWN scripts, not fastagent tools. That is fine: fastagent imports each file, and any that isn't usable — a failed import, no valid tool/channel export, or (for a channel) a factory that throws when called — is **isolated: reported as a warning and skipped, never crashing `start`**; the agent serves the tools that did load. If you want fastagent tools alongside the repo's `tools/`, declare them with `config.tools` (they don't have to live in the directory).
 
 ## Channels
 

--- a/src/deploy/container.ts
+++ b/src/deploy/container.ts
@@ -71,12 +71,14 @@ CMD ["npx", "fastagent", "start", "/app"]
 }
 
 const DOCKERIGNORE = `node_modules
-.git
 .fastagent
 .env
 .env.*
 !.env.example
 *.log
+# .git is excluded to keep the image small. If your agent runs git on its OWN history
+# (git log/blame over the repo it ships in), delete the next line so that history is in the image.
+.git
 `;
 
 /** The Dockerfile + .dockerignore artifacts — spread into any host's artifact list. */

--- a/test/deploy-railway.test.ts
+++ b/test/deploy-railway.test.ts
@@ -18,8 +18,12 @@ describe("deploy/railway: planRailwayDeploy", () => {
   });
 
   it("ships the shared portable container (Dockerfile + .dockerignore), same as Fly", () => {
-    const paths = planRailwayDeploy({ ...base, modelAuth: undefined, channels: [] }).artifacts.map((a) => a.path);
-    expect(paths).toEqual(["railway.json", "Dockerfile", ".dockerignore"]);
+    const artifacts = planRailwayDeploy({ ...base, modelAuth: undefined, channels: [] }).artifacts;
+    expect(artifacts.map((a) => a.path)).toEqual(["railway.json", "Dockerfile", ".dockerignore"]);
+    // .git must stay an EFFECTIVE ignore line (a size/secret contract), never fumbled into a `# .git`
+    // comment — that would silently ship the whole repo history into the image.
+    const dockerignore = artifacts.find((a) => a.path === ".dockerignore")!.content;
+    expect(dockerignore.split("\n")).toContain(".git");
   });
 
   it("sets the state root as a variable matched to the volume mount, + the secret list", () => {


### PR DESCRIPTION
## G8 + G3 — real repos that own git history and convention dir names

The last two gaps from the end-to-end validation (turning a real repo into a deployed agent). Both P2/nice-to-have; G8 is a small code fix, G3 is documentation of behavior #169 already gave us.

### G8 — a git-using agent lost its history

The generated `.dockerignore` excluded `.git` silently → an agent that runs `git log`/`git blame` over its OWN history failed at **runtime** with a confusing "not a git repository". Kept the size-saving default but **annotated the `.git` line** in the generated `.dockerignore` (and configuration.md) so the trade-off is visible and one deleted line ships the history:

```
# .git is excluded to keep the image small. If your agent runs git on its OWN history
# (git log/blame over the repo it ships in), delete the next line so that history is in the image.
.git
```

### G3 — the repo already owns `tools/` (or `channels/`)

A repo turned into an agent often uses those directory names for its OWN scripts. **#169 (G2) already isolates that** — a file that isn't a valid tool/channel is reported + skipped, never crashing `start`. This documents that behavior + the `config.tools` escape in configuration.md.

**Deliberately NOT adding a `toolsDir`/`channelsDir` relocate knob.** G2 removed the crash; the real validation (ketchup) was never blocked by G3; the residual is warning noise. A config knob would be surface for an unproven need (`channels/` has no explicit-list config, so a symmetric knob is awkward, and a `channels/` collision is rare anyway). If a real user hits pain, add it then — option value preserved.

### Tests

`deploy-railway.test` now asserts the `.dockerignore` **content** keeps `.git` as an effective standalone ignore line (a size/secret contract — distinct from a `# .git` comment); the annotation text itself is a static string, no dedicated test (YAGNI). `npm test` → 431 passed. Local review to convergence (tightened one doc phrase: a factory-that-throws is a `channels/` failure mode, not `tools/`).

