### PR TITLE
chore(release): 0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## 0.10.1 — real-world hardening of the deploy line

Everything since 0.10.0, driven by deploying an actual repo as a Telegram-reachable agent end-to-end (gaps G1–G8):

- **G1 safety** — `deploy railway --run` only provisions on an UNLINKED dir; a dir linked to a foreign project is refused unless `--into-linked`. Never deploys into someone else's project.
- **G2 isolation** — a broken `tools/`/`channels/` file (import throw, not-a-tool, factory throw) is isolated (skipped + warned), never crashing `start`. A repo that owns those dir names just works.
- **G5 webhook readiness** — the telegram webhook is registered only after `/health` is up (fixes the deploy race where the container isn't routable when `railway up` returns).
- **G4 + G6 declarations** — `fastagent.config` `deploy.secrets` / `deploy.apt`: declare the extra secret env (e.g. `GH_TOKEN`) and system packages (git, ripgrep) an agent needs on the box, carried into the runbook + `--run`.
- **G3 + G8** — the generated `.dockerignore` annotates its `.git` exclusion so a git-using agent can ship its own history; convention-dir collisions are documented.
- **Internal** — `runDeployFly`/`runDeployRailway` take an opts object (positional-arg footgun removed).

No breaking changes. Same OAuth-on-server flow as 0.10.0.
