### PR TITLE
fix(runtime): run under Bun, not only Node

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { parseArgs } from "node:util";
 import type { Agent } from "./agent.ts";
 import { logAgentLoop } from "./observe.ts";
 import { log, setLogLevel } from "./log.ts";
+import { loadEnvFile } from "./env.ts";
 import { installProxyFetch } from "./proxy.ts";
 import { createInvokeHandler } from "./channels/http.ts";
 import { text } from "./channels/respond.ts";
@@ -1128,7 +1129,7 @@ function serve(routes: Routes, port: number, onListening?: (boundPort: number) =
 /** .env (secrets) → process.env. Only a missing file is normal; surface anything else. */
 function loadDotEnv(d: string): void {
   try {
-    process.loadEnvFile(join(d, ".env"));
+    loadEnvFile(join(d, ".env"));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Load a `.env` file into `process.env`, matching Node's `--env-file` / `process.loadEnvFile` precedence
+ * on BOTH axes (verified against Node): a real env var wins over the file (an already-set key is kept),
+ * and within the file a repeated key takes the LAST occurrence. Portable across Node and Bun: Bun has no
+ * `process.loadEnvFile`, so we parse the file ourselves rather than depend on a Node-only entry point.
+ *
+ * Two phases keep the two rules distinct: parse into a map (later line overrides earlier = last-wins),
+ * then apply only the keys `process.env` doesn't already have (env-wins). Minimal parser — `KEY=VALUE`
+ * per line, `#` comments and blank lines skipped, surrounding matched single/double quotes stripped:
+ * enough for the flat secret files fastagent reads (tokens, keys), not a full dotenv dialect (no
+ * multiline, no `export`, no interpolation). A missing file throws ENOENT for the caller to treat as
+ * "no .env"; any other read error propagates.
+ */
+export function loadEnvFile(file: string): void {
+  const content = readFileSync(file, "utf8");
+  const parsed = new Map<string, string>();
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 1) continue; // no `=`, or an empty key
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    const quote = value[0];
+    if ((quote === '"' || quote === "'") && value.at(-1) === quote) value = value.slice(1, -1);
+    parsed.set(key, value); // in-file: last occurrence wins (Map overwrite)
+  }
+  for (const [key, value] of parsed) {
+    if (!(key in process.env)) process.env[key] = value; // env-vs-file: a real env var wins
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,13 +1,24 @@
-import { EnvHttpProxyAgent, install as installUndiciFetch, setGlobalDispatcher } from "undici";
+// Namespace import (not `import { install }`): Bun's `undici` is a native shim that omits `install`, and
+// a STATIC NAMED import of a missing export fails at link time — crashing `fastagent start` under Bun
+// before any code runs. A namespace import binds whatever exports exist; the Bun guard below then never
+// touches the Node-only members.
+import * as undici from "undici";
+
+/** The Bun runtime (`process.versions.bun` is set only there). Bun's native fetch already honors the
+ *  proxy env vars and decompresses gzip, and its `undici` shim has no `install()` — so the Node-only
+ *  undici wiring below is both unnecessary and unavailable there. */
+const isBun = typeof process.versions.bun === "string";
 
 /**
  * Route fetch through HTTPS_PROXY and keep fetch + dispatcher on the SAME undici implementation. Any
- * process that hits a provider or a channel API needs this: Node's fetch does not honor HTTPS_PROXY by
- * itself (so login's OAuth token exchange, model calls, and a webhook setWebhook would go direct,
- * bypassing a region proxy), and Node 26's bundled fetch skips gzip decompression without install()
- * (empty stopReason:"stop"). A process-global side effect — call it once at a command/entry start.
+ * process that hits a provider or a channel API needs this UNDER NODE: Node's fetch does not honor
+ * HTTPS_PROXY by itself (so login's OAuth token exchange, model calls, and a webhook setWebhook would go
+ * direct, bypassing a region proxy), and Node 26's bundled fetch skips gzip decompression without
+ * install() (empty stopReason:"stop"). A process-global side effect — call it once at a command/entry
+ * start. No-op under Bun, whose native fetch already does both (and lacks the undici entry points).
  */
 export function installProxyFetch(): void {
-  setGlobalDispatcher(new EnvHttpProxyAgent());
-  installUndiciFetch();
+  if (isBun) return;
+  undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent());
+  undici.install();
 }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -10,6 +10,7 @@ import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
+import { loadEnvFile } from "./env.ts";
 import { log } from "./log.ts";
 
 export interface Tunnel {
@@ -135,7 +136,7 @@ function channelBasenames(dir: string): string[] {
 export async function announceWebhooks(dir: string, baseUrl: string): Promise<void> {
   log.info(`[fastagent] public URL: ${baseUrl}`);
   try {
-    process.loadEnvFile(join(dir, ".env")); // so telegram registration sees the tokens
+    loadEnvFile(join(dir, ".env")); // so telegram registration sees the tokens
   } catch {
     /* no .env is fine */
   }

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadEnvFile } from "../src/env.ts";
+
+// A portable .env loader (Node has process.loadEnvFile; Bun does not — same parse must run on both).
+describe("loadEnvFile", () => {
+  const write = async (content: string): Promise<string> => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-env-"));
+    const file = join(dir, ".env");
+    await writeFile(file, content);
+    return file;
+  };
+
+  it("loads KEY=VALUE, skips comments/blank lines, strips matched quotes", async () => {
+    const key = `A_${Date.now()}`;
+    const file = await write(`# a comment\n\n${key}_PLAIN=value\n${key}_DQ="quoted spaces"\n${key}_SQ='single'\n`);
+    loadEnvFile(file);
+    expect(process.env[`${key}_PLAIN`]).toBe("value");
+    expect(process.env[`${key}_DQ`]).toBe("quoted spaces"); // surrounding quotes stripped, inner space kept
+    expect(process.env[`${key}_SQ`]).toBe("single");
+  });
+
+  it("keeps a value with '=' and ':' intact (only splits on the first =)", async () => {
+    const key = `B_${Date.now()}`;
+    const file = await write(`${key}=7676:AA=bb-cc_dd\n`);
+    loadEnvFile(file);
+    expect(process.env[key]).toBe("7676:AA=bb-cc_dd");
+  });
+
+  it("does NOT override an already-set var — a real env var wins", async () => {
+    const key = `C_${Date.now()}`;
+    process.env[key] = "from_real_env";
+    const file = await write(`${key}=from_file\n`);
+    loadEnvFile(file);
+    expect(process.env[key]).toBe("from_real_env");
+  });
+
+  it("in-file duplicate key takes the LAST occurrence", async () => {
+    const key = `D_${Date.now()}`;
+    const file = await write(`${key}=first\n${key}=second\n`);
+    loadEnvFile(file);
+    expect(process.env[key]).toBe("second");
+  });
+
+  // The whole Bun fix rests on loadEnvFile being equivalent to Node's process.loadEnvFile. Prove it
+  // DIFFERENTIALLY: feed the SAME file to both and assert process.env agrees. Node-only (Bun, the very
+  // runtime we're porting to, has no process.loadEnvFile) — skipped there.
+  it.skipIf(typeof process.versions.bun === "string")(
+    "matches Node's process.loadEnvFile on the same file (env-wins + in-file last-wins)",
+    async () => {
+      const p = `E_${Date.now()}`; // fresh keys so neither loader collides with real env
+      const preset = `${p}_PRESET`;
+      const keys = [`${p}_PLAIN`, `${p}_DUP`, `${p}_QUOTED`, preset];
+      const content = `${p}_PLAIN=one\n# comment\n${p}_DUP=a\n${p}_DUP=b\n${p}_QUOTED="q v"\n${preset}=from_file\n`;
+      const file = await write(content);
+
+      const run = (load: (f: string) => void): Record<string, string | undefined> => {
+        for (const k of keys) delete process.env[k];
+        process.env[preset] = "real"; // a real env var both loaders must NOT clobber
+        load(file);
+        return Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+      };
+
+      expect(run(loadEnvFile)).toEqual(run(process.loadEnvFile.bind(process)));
+      for (const k of keys) delete process.env[k];
+    },
+  );
+
+  it("propagates ENOENT for a missing file (the caller decides it's normal)", async () => {
+    expect(() => loadEnvFile(join(tmpdir(), `no-such-${Date.now()}`, ".env"))).toThrow(
+      expect.objectContaining({ code: "ENOENT" }),
+    );
+  });
+});


### PR DESCRIPTION
## Run under Bun, not only Node

Deploying a Bun agent (an Astro site whose `AGENTS.md` drives content ops), `bunx fastagent start` crashed before it could serve:

```
SyntaxError: Export named 'install' not found in module 'undici'
```
and, once past that:
```
TypeError: process.loadEnvFile is not a function
```

Two Node-only couplings, both on the entry path:

| File | Node-only | Fix |
|---|---|---|
| `proxy.ts` | `import { install } from "undici"` — Bun's undici is a native shim without `install`, and a **static named** import of a missing export fails at **link time**, crashing before any code runs | Namespace import (binds whatever exists) + a Bun guard. Bun's native fetch already honors proxy env vars and decompresses gzip, so the undici wiring is a Node-only no-op there. |
| `cli.ts`/`tunnel.ts` | `process.loadEnvFile` (Node 20.12+, absent on Bun) | Extract a portable `loadEnvFile` (`env.ts`): parse `KEY=VALUE` ourselves, matching Node's precedence — a real env var wins over the file (verified against Node). |

**Audited all of `src`** for runtime-sensitive APIs: only these two. The `node:` builtins (path/fs/child_process/http/crypto/net/os…) and the bare deps (chokidar, octokit, clack, ignore) are Bun-compatible.

**Verified end-to-end under Bun 1.3**: `info`, `invoke` (a real OAuth model call), and `start` (`/health` 200, telegram channel loaded) all work. 4 new `env.test.ts` cases (parse, first-`=` split, no-override precedence, ENOENT propagation); 435 tests.

Unblocks a single-runtime Bun image (`FROM oven/bun` + `bunx fastagent start`) instead of a Node+Bun dual base.
