### PR TITLE
chore(release): 0.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## 0.10.2 — Bun runtime support

fastagent now runs under **Bun**, not only Node. Deploying a Bun agent, `bunx fastagent start` crashed on two Node-only couplings:

- **`proxy.ts`** did `import { install } from "undici"` — Bun's undici is a native shim without `install`, and a static named import of a missing export fails at **link time** (crash before any code runs). Now a namespace import + a Bun guard: Bun's native fetch already honors proxy env vars and decompresses gzip.
- **`process.loadEnvFile`** (Node 20.12+, absent on Bun) → a portable `loadEnvFile` that matches Node's precedence on both axes (a real env var wins over the file; an in-file duplicate takes the last), verified **differentially** against `process.loadEnvFile`.

Audited all of `src`: only these two. Verified end-to-end under Bun 1.3 — `info`, `invoke` (real model call), `start` (`/health` 200, telegram channel). Enables a single-runtime Bun image (`FROM oven/bun` + `bunx fastagent start`).

No breaking changes.
