### PR TITLE
feat(devx): B-mode on-ramp (init adopt) + bun-aware generated Dockerfile

### DIFF
--- a/src/cli-auth.ts
+++ b/src/cli-auth.ts
@@ -1,0 +1,40 @@
+/**
+ * CLI presenter for the auth-status line `reportAuth` prints (invoke/dev/start). Kept out of cli.ts —
+ * which self-executes on import — so the expired-vs-missing DECISION is unit-testable without a real
+ * credential round-trip, mirroring cli-models.ts.
+ */
+
+/** A stored credential as `reportAuth` needs it: just its kind, for the status line. */
+export interface StoredCredentialInfo {
+  type: string;
+}
+
+/**
+ * Format the auth status for `spec`'s provider. `source` is {@link probeAuthSource}'s label (an env-var
+ * name, "OAuth", a stored-key label) or undefined when nothing currently SATISFIES auth. Undefined has
+ * TWO causes probeAuthSource can't distinguish (it swallows the throw): nothing stored, OR a credential
+ * that IS stored but couldn't be made usable (an expired/revoked OAuth whose refresh failed). `stored`
+ * — a refresh-FREE store read the caller does only in that case — tells them apart, so an expired login
+ * reports "expired/unusable → `fastagent login`" instead of a misleading "(none found)" (which would then
+ * be contradicted by the actual "OAuth refresh failed"). A malformed/unreadable store also reads as
+ * undefined `stored` and lands in "(none found)" — but the store's own read warns about the corrupt file,
+ * so the real signal is surfaced there; this line stays about credential PRESENCE.
+ */
+export function formatAuthReport(
+  provider: string,
+  authPath: string,
+  source: string | undefined,
+  stored: StoredCredentialInfo | undefined,
+): { line: string; warn?: string } {
+  if (source !== undefined) return { line: `auth:   ${source} (${provider}) — ${authPath}` };
+  if (stored) {
+    return {
+      line: `auth:   stored ${provider} ${stored.type}, expired/unusable — ${authPath}`,
+      warn: `the "${provider}" login is expired or unusable — run \`fastagent login\` to refresh it`,
+    };
+  }
+  return {
+    line: `auth:   (none found) — ${authPath}`,
+    warn: `no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
+  };
+}

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -9,6 +9,11 @@
 export function formatModelsCommand(specs: string[], search?: string): { lines: string[]; error?: string } {
   if (!search) return { lines: specs };
   const q = search.toLowerCase();
-  const lines = specs.filter((spec) => spec.toLowerCase().includes(q));
-  return lines.length === 0 ? { lines, error: `no model matches "${search}"` } : { lines };
+  const matches = specs.filter((spec) => spec.toLowerCase().includes(q));
+  if (matches.length === 0) return { lines: matches, error: `no model matches "${search}"` };
+  // Rank a PROVIDER-name match (query in the part before "/") above an incidental model-id match, so
+  // `models anthropic` leads with anthropic/* rather than burying it under amazon-bedrock/anthropic.*
+  // and google-vertex/…-anthropic-… (which only match in the model id). Order within each group is kept.
+  const providerMatch = (spec: string) => spec.slice(0, spec.indexOf("/")).toLowerCase().includes(q);
+  return { lines: [...matches.filter(providerMatch), ...matches.filter((s) => !providerMatch(s))] };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { type Routes, parseRouteKey, router, serveNode } from "./host/node.ts";
 import { runDevSupervisor } from "./dev-supervisor.ts";
 import { announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
 import { discoverChannelFiles, loadChannels } from "./engines/pi/channel.ts";
+import { detectRuntime } from "./runtime.ts";
 import { fastagentVersion } from "./version.ts";
 import {
   defaultAuthPath,
@@ -51,7 +52,7 @@ import {
   channelSetup,
   scaffoldChannel,
 } from "./scaffold/add-channel.ts";
-import { exists, nextStepCd, scaffoldWorkspace } from "./scaffold/init.ts";
+import { adoptWorkspace, exists, nextStepCd, scaffoldWorkspace } from "./scaffold/init.ts";
 import { vendorSkill } from "./scaffold/vendor-skill.ts";
 import { isGeneratedDockerfile } from "./deploy/container.ts";
 import { modelTravelIssue, parseFlyAppName, parseFlyRegion, planFlyDeploy, toFlyAppName } from "./deploy/fly.ts";
@@ -332,6 +333,12 @@ async function runInfo(): Promise<void> {
 }
 
 async function runInit(): Promise<void> {
+  // An existing repo (AGENTS.md) with no fastagent.config → ADOPT it (the B-mode on-ramp), don't refuse:
+  // the repo IS the agent, so add the missing config + guide, keeping AGENTS.md/skills/tools untouched.
+  const configNames = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"];
+  const hasConfig = (await Promise.all(configNames.map((n) => exists(join(dir, n))))).some(Boolean);
+  if (!hasConfig && (await exists(join(dir, "AGENTS.md")))) return runAdopt();
+
   const minimal = values.minimal ?? false;
   const { complete, created, skipped, intoNonEmpty, warnings } = await scaffoldWorkspace(dir, { minimal }).catch(
     failStartup,
@@ -364,6 +371,28 @@ async function runInit(): Promise<void> {
   console.error(`    fastagent add skill <owner/repo/path>   # vendor more skills from GitHub`);
 }
 
+/** `fastagent init` on an existing AGENTS.md repo: adopt it (add config + guide), keeping its own files. */
+async function runAdopt(): Promise<void> {
+  const r = await adoptWorkspace(dir).catch(failStartup);
+  console.error(`[fastagent] adopted ${dir} — kept your AGENTS.md`);
+  // --minimal shapes a fresh scaffold; adopt writes only the missing config, so it has no effect here.
+  // Say so rather than silently ignore the flag (the user may think they got a minimal scaffold).
+  if (values.minimal) console.error(`  note: --minimal ignored — adopting an existing repo, not scaffolding`);
+  if (r.created.length > 0) console.error(`  created: ${r.created.join(", ")}`);
+  if (r.patched.length > 0) console.error(`  updated: ${r.patched.join(", ")}`);
+  const add = r.runtime === "bun" ? "bun add @kid7st/fastagent" : "npm install @kid7st/fastagent";
+  console.error(`  next steps:`);
+  const cdTarget = nextStepCd(process.cwd(), dir);
+  if (cdTarget) console.error(`    cd ${cdTarget}`);
+  console.error(`    set model in fastagent.config.mjs   # \`fastagent models\` lists the specs`);
+  if (!r.hasPackageJson) {
+    console.error(`    ${r.runtime === "bun" ? "bun init" : "npm init -y"}   # a channel needs a package.json`);
+  }
+  if (!r.hasFastagentDep) console.error(`    ${add}   # a channel file imports it`);
+  console.error(`    fastagent add telegram   # or github — a channel to serve on`);
+  console.error(`    fastagent dev            # serve locally and iterate`);
+}
+
 /** `fastagent add <channel> [dir]`: scaffold `channels/<kind>.ts` — the adapter import plus a starter `on()`. */
 async function runAdd(): Promise<void> {
   const kind = positionals[1];
@@ -393,8 +422,10 @@ async function runAdd(): Promise<void> {
     );
   }
   const { env, steps } = channelSetup(channelKind);
+  const install =
+    detectRuntime(target, await readPackageJson(target)).runtime === "bun" ? "bun install" : "npm install";
   console.error(`  next steps:`);
-  console.error(`    npm install                      # if @kid7st/fastagent is not installed yet`);
+  console.error(`    ${install}                      # if @kid7st/fastagent is not installed yet`);
   for (const e of env) {
     const value = e.generate ? `=${randomBytes(24).toString("hex")}` : "";
     console.error(`    set ${e.name}${value} in .env${envIgnored ? " (gitignored)" : ""}   # ${e.hint}`);
@@ -482,43 +513,46 @@ async function runDeploy(): Promise<void> {
   // credential and falsely report "none configured".
   const authPath = resolveAuthPathOverride(values["auth-path"]) ?? defaultAuthPath(resolveStateRoot(target));
   const modelAuth = modelSpec ? await probeAuthSource(createPiModels({ authPath }), modelSpec) : undefined;
-  // Container facts (shared by every host) + the warnings that follow. The generated Dockerfile is
-  // npm-based (npm ci/install + npx); a pnpm/yarn workspace has no package-lock.json, so the npm-only
-  // assumption is made EXPLICIT rather than silently routing them to `npm install`.
+  // Container facts (shared by every host) + the warnings that follow. The generated Dockerfile targets
+  // the workspace's package manager — bun (packageManager: bun / a bun lockfile) or npm — made EXPLICIT
+  // rather than silently routing a bun/pnpm/yarn workspace through npm.
   const hasPackageJson = await exists(join(target, "package.json"));
-  const hasLockfile = await exists(join(target, "package-lock.json"));
-  const hasOtherLock = (await exists(join(target, "pnpm-lock.yaml"))) || (await exists(join(target, "yarn.lock")));
-  // A code workspace with no package-lock.json builds via `npm install` (caret ranges resolve at build
-  // time) — not a reproducible redeploy. A pnpm/yarn user gets an accurate message (their lockfile is
-  // ignored by the npm Dockerfile), not the misleading "commit an npm lockfile".
+  const pkg = await readPackageJson(target);
+  const { runtime, bunVersion, hasLockfile } = detectRuntime(target, pkg);
+  const install = runtime === "bun" ? "bun install" : "npm install";
+  const runner = runtime === "bun" ? "bunx fastagent" : "npx fastagent";
+  const hasOtherLock =
+    runtime === "node" && ((await exists(join(target, "pnpm-lock.yaml"))) || (await exists(join(target, "yarn.lock"))));
+  // A code workspace with no lockfile builds via a non-frozen install (ranges resolve at build time) —
+  // not a reproducible redeploy. A pnpm/yarn user gets an accurate message (their lockfile is ignored by
+  // the npm Dockerfile), not the misleading "commit an npm lockfile".
   if (hasPackageJson && !hasLockfile) {
+    const lock = runtime === "bun" ? "bun.lock" : "package-lock.json";
     console.error(
       hasOtherLock
         ? `[fastagent] warn: the generated Dockerfile is npm-based — your pnpm/yarn lockfile is NOT used (build runs ` +
             `\`npm install\`, not reproducible). Edit the Dockerfile for your package manager, or vendor a package-lock.json.`
-        : `[fastagent] warn: no package-lock.json — the image build resolves deps at build time (not reproducible). ` +
-            `Run \`npm install\` and commit the lockfile for pinned redeploys.`,
+        : `[fastagent] warn: no ${lock} — the image build resolves deps at build time (not reproducible). ` +
+            `Run \`${install}\` and commit the lockfile for pinned redeploys.`,
     );
   }
-  // The code-path Dockerfile runs `npx fastagent`: that resolves the workspace's OWN dependency, so a
+  // The code-path Dockerfile runs `${runner}`: that resolves the workspace's OWN dependency, so a
   // package.json missing it would make the CONTAINER fetch an unpinned build at runtime (offline-fragile,
   // the failure moved from build to prod). Warn at plan time, like `add`'s dep check (which throws).
-  if (hasPackageJson) {
-    let hasDep = false;
-    try {
-      const pkg = JSON.parse(await readFile(join(target, "package.json"), "utf8"));
-      hasDep = "@kid7st/fastagent" in { ...pkg.dependencies, ...pkg.devDependencies };
-    } catch {
-      /* malformed package.json — the build would surface it; skip this check */
-    }
-    if (!hasDep) {
-      console.error(
-        `[fastagent] warn: package.json does not list @kid7st/fastagent — the image's \`npx fastagent\` would ` +
-          `fetch it at runtime (offline-fragile, unpinned). Add it to dependencies and re-run \`npm install\`.`,
-      );
-    }
+  if (hasPackageJson && !("@kid7st/fastagent" in { ...pkg.dependencies, ...pkg.devDependencies })) {
+    console.error(
+      `[fastagent] warn: package.json does not list @kid7st/fastagent — the image's \`${runner}\` would ` +
+        `fetch it at runtime (offline-fragile, unpinned). Add it to dependencies and re-run \`${install}\`.`,
+    );
   }
-  const container = { hasPackageJson, hasLockfile, version: await fastagentVersion(), apt: config.deploy?.apt };
+  const container = {
+    hasPackageJson,
+    runtime,
+    bunVersion,
+    hasLockfile,
+    version: await fastagentVersion(),
+    apt: config.deploy?.apt,
+  };
   const port = config.http?.port ?? 8787;
   // What the agent declared it needs on the box (fastagent.config deploy.secrets) — carried like channel
   // secrets: listed in the runbook, set from the local env under --run, gated if a value is missing.
@@ -1124,6 +1158,19 @@ function serve(routes: Routes, port: number, onListening?: (boundPort: number) =
       process.exit(1);
     },
   );
+}
+
+/** Parse `<dir>/package.json`, or `{}` when absent/malformed (a real build surfaces the actual error). */
+async function readPackageJson(d: string): Promise<{
+  packageManager?: unknown;
+  dependencies?: Record<string, unknown>;
+  devDependencies?: Record<string, unknown>;
+}> {
+  try {
+    return JSON.parse(await readFile(join(d, "package.json"), "utf8"));
+  } catch {
+    return {};
+  }
 }
 
 /** .env (secrets) → process.env. Only a missing file is normal; surface anything else. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ import {
   WORKSPACE_CONFIG_NAMES,
 } from "./engines/pi/config.ts";
 import { formatModelsCommand } from "./cli-models.ts";
+import { formatAuthReport } from "./cli-auth.ts";
 import { fastagentCredentialStore } from "./engines/pi/auth.ts";
 import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
 import { configuredModelSpecs, createPiModels, probeAuthSource } from "./engines/pi/models.ts";
@@ -903,28 +904,17 @@ function parsePort(value: string | undefined, source: string): number | undefine
 async function reportAuth(modelSpec: string, authPath: string): Promise<void> {
   const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
   const source = await probeAuthSource(createPiModels({ authPath }), modelSpec);
-  if (source !== undefined) {
-    log.info(`[fastagent] auth:   ${source} (${provider}) — ${authPath}`);
-    return;
-  }
-  // A `source` of undefined has TWO causes probeAuthSource can't tell apart (it swallows the throw): no
-  // credential at all, OR one that IS stored but couldn't be made usable — an expired/revoked OAuth whose
-  // refresh failed. Read the store WITHOUT triggering a refresh to distinguish them, so neither the status
-  // line nor the hint says "(none found)" when a login is merely stale (the actual failure would then be a
-  // contradictory "OAuth refresh failed"). Lead with `fastagent login` — it covers every provider (incl.
-  // OAuth-only ones) and writes this same path, fixing it in place.
-  const stored = await fastagentCredentialStore(authPath)
-    .read(provider)
-    .catch(() => undefined);
-  if (stored) {
-    log.info(`[fastagent] auth:   stored ${provider} ${stored.type}, expired/unusable — ${authPath}`);
-    log.warn(`[fastagent] the "${provider}" login is expired or unusable — run \`fastagent login\` to refresh it`);
-  } else {
-    log.info(`[fastagent] auth:   (none found) — ${authPath}`);
-    log.warn(
-      `[fastagent] no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
-    );
-  }
+  // Only when nothing satisfies auth do we read the store (refresh-FREE) to tell "nothing stored" from
+  // "stored but unusable" — see formatAuthReport for why. store.read warns on a corrupt file itself.
+  const stored =
+    source === undefined
+      ? await fastagentCredentialStore(authPath)
+          .read(provider)
+          .catch(() => undefined)
+      : undefined;
+  const report = formatAuthReport(provider, authPath, source, stored);
+  log.info(`[fastagent] ${report.line}`);
+  if (report.warn) log.warn(`[fastagent] ${report.warn}`);
 }
 
 /** Both stdin and stdout are a terminal — the precondition for an interactive prompt. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ import {
   resolveModelSpec,
   resolveSessionsDirOverride,
   rewriteConfigModel,
+  WORKSPACE_CONFIG_NAMES,
 } from "./engines/pi/config.ts";
 import { formatModelsCommand } from "./cli-models.ts";
 import { fastagentCredentialStore } from "./engines/pi/auth.ts";
@@ -336,8 +337,7 @@ async function runInfo(): Promise<void> {
 async function runInit(): Promise<void> {
   // An existing repo (AGENTS.md) with no fastagent.config → ADOPT it (the B-mode on-ramp), don't refuse:
   // the repo IS the agent, so add the missing config + guide, keeping AGENTS.md/skills/tools untouched.
-  const configNames = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"];
-  const hasConfig = (await Promise.all(configNames.map((n) => exists(join(dir, n))))).some(Boolean);
+  const hasConfig = (await Promise.all(WORKSPACE_CONFIG_NAMES.map((n) => exists(join(dir, n))))).some(Boolean);
   if (!hasConfig && (await exists(join(dir, "AGENTS.md")))) return runAdopt();
 
   const minimal = values.minimal ?? false;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ import {
   rewriteConfigModel,
 } from "./engines/pi/config.ts";
 import { formatModelsCommand } from "./cli-models.ts";
+import { fastagentCredentialStore } from "./engines/pi/auth.ts";
 import { type LoginIO, loginFlow } from "./engines/pi/login.ts";
 import { configuredModelSpecs, createPiModels, probeAuthSource } from "./engines/pi/models.ts";
 import { ensureStateRootSelfIgnored, isUnderDir, loadAgentDefinition } from "./engines/pi/definition.ts";
@@ -819,6 +820,16 @@ async function runLogin(): Promise<void> {
   // actually lands under the in-tree root. An external `--auth-path`/`FASTAGENT_AUTH_PATH` writes
   // nothing in-tree (don't create an empty `.fastagent`); the guard also skips the HOME-global root.
   if (isUnderDir(authPath, stateRoot)) await ensureStateRootSelfIgnored(loginDir, stateRoot);
+  // login is inherently interactive — loginFlow renders provider/method menus and opens a browser (or
+  // prompts for a key). In a non-TTY (a pipe, CI, a coding-agent shell) the menu can't receive keystrokes
+  // and would hang. Fail fast with the reason instead of stalling on an unanswerable prompt. (After the
+  // secret-hygiene self-ignore above, which is cheap prep, so a later terminal login is safe.)
+  if (!isInteractive()) {
+    console.error(
+      `[fastagent] login is interactive (it shows a menu and opens a browser) — run it in a terminal, not a pipe/CI`,
+    );
+    process.exit(1);
+  }
   const io = terminalLoginIO();
   const result = await loginFlow(io, { provider: positionals[1], authPath }).catch(failStartup);
   console.error(`[fastagent] logged in to ${result.provider} (${result.method}) — saved to ${authPath}`);
@@ -892,14 +903,28 @@ function parsePort(value: string | undefined, source: string): number | undefine
 async function reportAuth(modelSpec: string, authPath: string): Promise<void> {
   const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
   const source = await probeAuthSource(createPiModels({ authPath }), modelSpec);
-  log.info(`[fastagent] auth:   ${source === undefined ? "(none found)" : `${source} (${provider})`} — ${authPath}`);
-  if (source !== undefined) return;
-  // Lead with `fastagent login`: it covers every provider (including OAuth-only ones like openai-codex),
-  // and the provider-specific env var name is not exported, so keep the env path generic. login writes to
-  // this same project-level path, so a follow-up `fastagent login` here fixes it in place.
-  log.warn(
-    `[fastagent] no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
-  );
+  if (source !== undefined) {
+    log.info(`[fastagent] auth:   ${source} (${provider}) — ${authPath}`);
+    return;
+  }
+  // A `source` of undefined has TWO causes probeAuthSource can't tell apart (it swallows the throw): no
+  // credential at all, OR one that IS stored but couldn't be made usable — an expired/revoked OAuth whose
+  // refresh failed. Read the store WITHOUT triggering a refresh to distinguish them, so neither the status
+  // line nor the hint says "(none found)" when a login is merely stale (the actual failure would then be a
+  // contradictory "OAuth refresh failed"). Lead with `fastagent login` — it covers every provider (incl.
+  // OAuth-only ones) and writes this same path, fixing it in place.
+  const stored = await fastagentCredentialStore(authPath)
+    .read(provider)
+    .catch(() => undefined);
+  if (stored) {
+    log.info(`[fastagent] auth:   stored ${provider} ${stored.type}, expired/unusable — ${authPath}`);
+    log.warn(`[fastagent] the "${provider}" login is expired or unusable — run \`fastagent login\` to refresh it`);
+  } else {
+    log.info(`[fastagent] auth:   (none found) — ${authPath}`);
+    log.warn(
+      `[fastagent] no credentials for "${provider}" — run \`fastagent login\`, or set the provider's API key in .env; invokes will fail until then`,
+    );
+  }
 }
 
 /** Both stdin and stdout are a terminal — the precondition for an interactive prompt. */

--- a/src/deploy/container.ts
+++ b/src/deploy/container.ts
@@ -26,8 +26,14 @@ export function isGeneratedDockerfile(content: string): boolean {
 export interface ContainerInput {
   /** Whether the workspace has a package.json (a code workspace); else a pure markdown/skills agent. */
   hasPackageJson: boolean;
-  /** Whether a package-lock.json exists — `npm ci` needs it; without it the Dockerfile uses `npm install`. */
+  /** The package manager the generated image targets: `bun` (packageManager: bun / a bun lockfile) gets an
+   *  `oven/bun` base + `bun install` + `bunx fastagent`; otherwise npm on `node:22-slim`. */
+  runtime: "node" | "bun";
+  /** Whether the runtime's lockfile exists (package-lock.json for npm, bun.lock/bun.lockb for bun) — a
+   *  frozen/ci install needs it; without it the build resolves versions at build time (not reproducible). */
   hasLockfile: boolean;
+  /** For `runtime: "bun"`, the `FROM oven/bun:<tag>` version (from packageManager `bun@x`), else `"1"`. */
+  bunVersion?: string;
   /** This fastagent version, to PIN the global install on the markdown path (reproducible redeploys). */
   version: string;
   /** Extra apt packages (fastagent.config deploy.apt) baked in for the agent's tools — git, ripgrep, …. */
@@ -45,24 +51,42 @@ function dockerfile(input: ContainerInput): string {
  && rm -rf /var/lib/apt/lists/*
 `
       : "";
+  const isBun = input.runtime === "bun";
+  const base = isBun ? `oven/bun:${input.bunVersion ?? "1"}` : "node:22-slim";
+  const note = isBun
+    ? "# Bun-based (packageManager: bun / a bun lockfile detected). fastagent runs under Bun (bunx)."
+    : "# npm-based — for pnpm/yarn, adapt the install line + the lockfile COPY (corepack enable, etc.).";
   const head = `${GENERATED_DOCKERFILE_MARKER}. The directory IS the agent — no build step.
-# npm-based — for pnpm/yarn, adapt the install line + the lockfile COPY (corepack enable, etc.).
-FROM node:22-slim
+${note}
+FROM ${base}
 ${apt}WORKDIR /app
 `;
   // No package.json → pure markdown/skills agent: install the CLI globally, PINNED for reproducible
-  // redeploys (the code path is pinned by its lockfile; this path has no other lock).
+  // redeploys (a markdown agent has no packageManager, so this is always the Node/npm path).
   if (!input.hasPackageJson) {
     return `${head}RUN npm i -g @kid7st/fastagent@${input.version}
 COPY . .
 CMD ["fastagent", "start", "/app"]
 `;
   }
+  // Install ALL deps (no --omit=dev / --production): a repo-as-agent (e.g. an Astro site it operates on)
+  // needs its full toolchain — the build/check tools that live in devDependencies — to do its work, and
+  // we can't tell a repo-as-agent from a purpose-built workspace, so the safe default keeps everything.
+  if (isBun) {
+    // `--frozen-lockfile` needs bun.lock and hard-fails without it; fall back to a plain `bun install`
+    // (resolves at build time — not reproducible; the CLI warns to commit the lockfile).
+    const install = input.hasLockfile ? "bun install --frozen-lockfile" : "bun install";
+    return `${head}COPY package.json bun.lock* ./
+RUN ${install}
+COPY . .
+CMD ["bunx", "fastagent", "start", "/app"]
+`;
+  }
   // `npm ci` requires a lockfile and hard-fails without one (a common `init --no-install` workspace);
   // fall back to `npm install` when there is none so the build never breaks. Caveat: `npm install`
   // resolves caret ranges at build time, so THIS branch is NOT reproducible — unlike the pinned
   // `npm ci` (lockfile) and pinned global (markdown) paths. The CLI warns to commit a lockfile.
-  const install = input.hasLockfile ? "npm ci --omit=dev" : "npm install --omit=dev";
+  const install = input.hasLockfile ? "npm ci" : "npm install";
   return `${head}COPY package.json package-lock.json* ./
 RUN ${install}
 COPY . .

--- a/src/deploy/container.ts
+++ b/src/deploy/container.ts
@@ -51,6 +51,21 @@ function dockerfile(input: ContainerInput): string {
  && rm -rf /var/lib/apt/lists/*
 `
       : "";
+  // No package.json → pure markdown/skills agent: install the pinned CLI GLOBALLY and run `fastagent`
+  // from PATH. That needs npm + a global bin, which live on node:22-slim, NOT on oven/bun — so this path
+  // pins node:22-slim regardless of input.runtime (a stray bun lockfile with no package.json would
+  // otherwise select a bun base here and crash the `npm i -g` build). input.runtime is meaningful only
+  // for a code workspace, so the bun-vs-node base below is scoped to that path.
+  if (!input.hasPackageJson) {
+    return `${GENERATED_DOCKERFILE_MARKER}. The directory IS the agent — no build step.
+# npm-based (a markdown/skills agent installs the pinned CLI globally; node:22-slim has npm).
+FROM node:22-slim
+${apt}WORKDIR /app
+RUN npm i -g @kid7st/fastagent@${input.version}
+COPY . .
+CMD ["fastagent", "start", "/app"]
+`;
+  }
   const isBun = input.runtime === "bun";
   const base = isBun ? `oven/bun:${input.bunVersion ?? "1"}` : "node:22-slim";
   const note = isBun
@@ -61,14 +76,6 @@ ${note}
 FROM ${base}
 ${apt}WORKDIR /app
 `;
-  // No package.json → pure markdown/skills agent: install the CLI globally, PINNED for reproducible
-  // redeploys (a markdown agent has no packageManager, so this is always the Node/npm path).
-  if (!input.hasPackageJson) {
-    return `${head}RUN npm i -g @kid7st/fastagent@${input.version}
-COPY . .
-CMD ["fastagent", "start", "/app"]
-`;
-  }
   // Install ALL deps (no --omit=dev / --production): a repo-as-agent (e.g. an Astro site it operates on)
   // needs its full toolchain — the build/check tools that live in devDependencies — to do its work, and
   // we can't tell a repo-as-agent from a purpose-built workspace, so the safe default keeps everything.

--- a/src/deploy/fly.ts
+++ b/src/deploy/fly.ts
@@ -17,10 +17,12 @@
  * documented floor. State on the /data volume survives stop/suspend on the same machine.
  */
 import type { ChannelKind } from "../scaffold/add-channel.ts";
-import { type Artifact, containerArtifacts } from "./container.ts";
+import { type Artifact, type ContainerInput, containerArtifacts } from "./container.ts";
 import { isEnvKey, requiredSecrets } from "./secrets.ts";
 
-export interface FlyPlanInput {
+export interface FlyPlanInput extends ContainerInput {
+  // Container facts (hasPackageJson, runtime, hasLockfile, bunVersion, version, apt) come from
+  // ContainerInput — ONE source, so the plan and the generated Dockerfile can't drift.
   /** Fly app name — globally unique, lowercase; the CLI sanitizes it from the dir basename. */
   appName: string;
   /** The port the app listens on (config.http.port ?? 8787); fly.toml routes to it. */
@@ -32,14 +34,6 @@ export interface FlyPlanInput {
   modelAuth: string | undefined;
   /** Channels discovered in the workspace — each contributes its required secrets + webhook step. */
   channels: ChannelKind[];
-  /** Whether the workspace has a package.json (a code workspace); else a pure markdown/skills agent. */
-  hasPackageJson: boolean;
-  /** Whether a package-lock.json exists — `npm ci` needs it; without it the Dockerfile uses `npm install`. */
-  hasLockfile: boolean;
-  /** This fastagent version, to PIN the global install on the markdown path (reproducible redeploys). */
-  version: string;
-  /** Extra apt packages for the image (fastagent.config deploy.apt). */
-  apt?: string[];
   /** Extra secret env-var names (fastagent.config deploy.secrets) — added to the runbook's secret list. */
   extraSecrets?: string[];
   /** `auto_stop_machines` — `"suspend"` (default, fast resume) or `"stop"` (cold start). CLI `--stop`. */

--- a/src/deploy/fly.ts
+++ b/src/deploy/fly.ts
@@ -145,7 +145,7 @@ export function planFlyDeploy(input: FlyPlanInput): FlyPlan {
     runbook.push(
       ``,
       modelAuth === undefined
-        ? `# Model auth: none configured locally.`
+        ? `# Model auth: none found at the local auth path — a global \`fastagent login\` isn't read here; pass --auth-path <file> (e.g. ~/.fastagent/auth.json), or \`--run\` carries it automatically.`
         : `# Model auth: your local auth is "${modelAuth}" — the plan can't read its value to set as a secret.`,
       `#   Set your provider API key as a Fly secret (fly secrets set KEY=...), OR place auth.json on the /data volume.`,
     );

--- a/src/deploy/railway.ts
+++ b/src/deploy/railway.ts
@@ -112,7 +112,7 @@ export function planRailwayDeploy(input: RailwayPlanInput): RailwayPlan {
   if (!isEnvKey(modelAuth)) {
     runbook.push(
       modelAuth === undefined
-        ? `# Model auth: none configured locally.`
+        ? `# Model auth: none found at the local auth path — a global \`fastagent login\` isn't read here; pass --auth-path <file> (e.g. ~/.fastagent/auth.json), or \`--run\` carries it automatically.`
         : `# Model auth: your local auth is "${modelAuth}" — the plan can't read its value to set as a variable.`,
       `#   Set your provider API key as a variable (railway variables set KEY=...), OR place auth.json on the ${MOUNT} volume.`,
     );

--- a/src/deploy/railway.ts
+++ b/src/deploy/railway.ts
@@ -22,10 +22,10 @@
  * server is listening" boot race Fly's deploy hit — Railway only routes once /health passes.
  */
 import type { ChannelKind } from "../scaffold/add-channel.ts";
-import { type Artifact, containerArtifacts } from "./container.ts";
+import { type Artifact, type ContainerInput, containerArtifacts } from "./container.ts";
 import { isEnvKey, requiredSecrets } from "./secrets.ts";
 
-export interface RailwayPlanInput {
+export interface RailwayPlanInput extends ContainerInput {
   // No `port`: Railway injects PORT and the container CMD/railway.json never name one (unlike Fly's
   // internal_port) — the server binds $PORT at runtime. Nothing here would use it.
   /** The service name to create (`railway add --service`). Railway service names are project-scoped, not
@@ -35,11 +35,8 @@ export interface RailwayPlanInput {
   modelAuth: string | undefined;
   /** Channels discovered in the workspace — each contributes its required secrets + webhook step. */
   channels: ChannelKind[];
-  hasPackageJson: boolean;
-  hasLockfile: boolean;
-  version: string;
-  /** Extra apt packages for the image (fastagent.config deploy.apt). */
-  apt?: string[];
+  // Container facts (hasPackageJson, runtime, hasLockfile, bunVersion, version, apt) come from
+  // ContainerInput — ONE source, so the plan and the generated Dockerfile can't drift.
   /** Extra secret env-var names (fastagent.config deploy.secrets) — added to the runbook's secret list. */
   extraSecrets?: string[];
 }

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -63,10 +63,14 @@ function validateStringList(value: unknown, key: string, shape: RegExp, desc: st
   }
 }
 
+/** The config filenames that make a directory a fastagent workspace, in load precedence. ONE source: the
+ *  loader (below), `init`'s adopt-vs-scaffold routing, and `scaffoldWorkspace`'s refuse check all read
+ *  this, so "is there a config?" can't diverge between them when the set changes. */
+export const WORKSPACE_CONFIG_NAMES = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"] as const;
+
 /** Load `<dir>/fastagent.config.ts|.js|.mjs`. No file = zero-config; a wrong-shape file throws. */
 export async function loadConfig(dir: string): Promise<LoadedConfig> {
-  const names = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"];
-  const found = names.map((name) => join(dir, name)).filter((path) => existsSync(path));
+  const found = WORKSPACE_CONFIG_NAMES.map((name) => join(dir, name)).filter((path) => existsSync(path));
   if (found.length === 0) return { config: {} };
   if (found.length > 1) {
     throw new Error(

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,30 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface WorkspaceRuntime {
+  /** The JS runtime the workspace targets — drives the generated Dockerfile base + install/run commands
+   *  and the package-manager hints in `init`/`add`. */
+  runtime: "node" | "bun";
+  /** For `runtime: "bun"`, the version from package.json's `packageManager: "bun@x"` (undefined if a bun
+   *  lockfile made it bun but no version is pinned). */
+  bunVersion?: string;
+  /** Whether the runtime's lockfile is present (package-lock.json for node, bun.lock/bun.lockb for bun). */
+  hasLockfile: boolean;
+}
+
+/**
+ * Detect which JS runtime a workspace targets: `bun` when package.json's `packageManager` is `bun@…` OR a
+ * bun lockfile (bun.lock/bun.lockb) is present, else `node`. `pkg` is the already-parsed package.json (or
+ * `{}` when there is none / it is malformed). One source for the deploy Dockerfile and the CLI hints, so
+ * they agree on what the workspace is.
+ */
+export function detectRuntime(dir: string, pkg: { packageManager?: unknown }): WorkspaceRuntime {
+  const pm = typeof pkg.packageManager === "string" ? pkg.packageManager : "";
+  const bunLock = existsSync(join(dir, "bun.lock")) || existsSync(join(dir, "bun.lockb"));
+  if (pm.startsWith("bun@") || bunLock) {
+    // corepack pins as `bun@1.3.13+sha256.<hash>`; the version (a Docker tag for oven/bun) is the part
+    // BEFORE `+` — keeping the hash would build an invalid `FROM oven/bun:1.3.13+sha256…` tag.
+    return { runtime: "bun", bunVersion: pm.match(/^bun@([^+]+)/)?.[1], hasLockfile: bunLock };
+  }
+  return { runtime: "node", hasLockfile: existsSync(join(dir, "package-lock.json")) };
+}

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -6,6 +6,7 @@
  */
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { detectRuntime } from "../runtime.ts";
 import { assertInsideWorkspace } from "../workspace.ts";
 import { channelBundleFiles, channelTemplate } from "./templates.ts";
 import { exists } from "./init.ts";
@@ -137,7 +138,7 @@ export async function assertChannelReady(dir: string): Promise<void> {
     }
     throw e;
   }
-  let pkg: { type?: string; dependencies?: Record<string, string> };
+  let pkg: { type?: string; packageManager?: unknown; dependencies?: Record<string, string> };
   try {
     pkg = JSON.parse(raw);
   } catch {
@@ -147,8 +148,8 @@ export async function assertChannelReady(dir: string): Promise<void> {
     throw new Error(`${pkgPath}: fastagent channels are ESM — set "type": "module"`);
   }
   if (typeof pkg.dependencies?.["@kid7st/fastagent"] !== "string") {
-    throw new Error(
-      `${pkgPath}: add "@kid7st/fastagent" to dependencies (then \`npm install\`) — the channel file imports it`,
-    );
+    const add =
+      detectRuntime(dir, pkg).runtime === "bun" ? "bun add @kid7st/fastagent" : "npm install @kid7st/fastagent";
+    throw new Error(`${pkgPath}: @kid7st/fastagent is not a dependency — run \`${add}\` (the channel file imports it)`);
   }
 }

--- a/src/scaffold/init.ts
+++ b/src/scaffold/init.ts
@@ -12,8 +12,9 @@
  * Sibling scaffold modules: add-channel.ts (`add <channel>`), vendor-skill.ts (`add skill`). The files
  * this module writes are real templates under templates/, read through templates.ts.
  */
-import { access, lstat, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { access, appendFile, lstat, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import { detectRuntime } from "../runtime.ts";
 import { loadRootIgnore } from "../workspace.ts";
 import { baseTemplate, packageJson, toPackageName } from "./templates.ts";
 import { fastagentVersion } from "../version.ts";
@@ -59,6 +60,65 @@ export async function exists(p: string): Promise<boolean> {
     () => true,
     () => false,
   );
+}
+
+export interface AdoptResult {
+  dir: string;
+  /** Files created by adopt (fastagent.config.mjs, and .gitignore if there was none). */
+  created: string[];
+  /** Files appended to (.gitignore, to exclude secrets/state). */
+  patched: string[];
+  /** The workspace's JS runtime — drives the dep-install hint (bun add vs npm install). */
+  runtime: "node" | "bun";
+  /** Whether a package.json is present (a channel needs one). */
+  hasPackageJson: boolean;
+  /** Whether @kid7st/fastagent is already a dependency (a channel imports it). */
+  hasFastagentDep: boolean;
+}
+
+/**
+ * ADOPT an existing repo (it already has AGENTS.md) into a fastagent workspace, instead of refusing it.
+ * This is the B-mode on-ramp: the repo IS the agent, so adopt adds ONLY the missing fastagent piece —
+ * `fastagent.config.mjs` — and makes secrets safe (.gitignore excludes `.env`/`.fastagent`). It never
+ * writes or clobbers AGENTS.md / skills / tools (the repo's own), and never hand-edits package.json (the
+ * package manager owns the lockfile — the caller PRINTS the right `bun add`/`npm install` for {@link
+ * AdoptResult.runtime} instead). Precondition (caller-checked): AGENTS.md present, no fastagent.config.*.
+ */
+export async function adoptWorkspace(dir: string): Promise<AdoptResult> {
+  const created: string[] = [];
+  const patched: string[] = [];
+
+  // The one missing piece for an existing-AGENTS.md repo: the config (model + deploy knobs).
+  await writeFile(join(dir, "fastagent.config.mjs"), baseTemplate("fastagent.config.mjs"), { flag: "wx" });
+  created.push("fastagent.config.mjs");
+
+  // Secrets/state must not ship in a deploy copy: ensure .gitignore excludes .env and .fastagent.
+  const rootIgnore = await loadRootIgnore(dir);
+  const need = [".env", ".fastagent"].filter((p) => !rootIgnore?.ignores(p));
+  if (need.length > 0) {
+    const gitignore = join(dir, ".gitignore");
+    const had = await exists(gitignore);
+    await appendFile(gitignore, `${had ? "\n" : ""}# fastagent\n${need.join("\n")}\n`);
+    (had ? patched : created).push(".gitignore");
+  }
+
+  // Runtime + dep status for the caller's next-steps (adopt guides; it does not touch package.json).
+  const hasPackageJson = await exists(join(dir, "package.json"));
+  let pkg: {
+    packageManager?: unknown;
+    dependencies?: Record<string, unknown>;
+    devDependencies?: Record<string, unknown>;
+  } = {};
+  if (hasPackageJson) {
+    try {
+      pkg = JSON.parse(await readFile(join(dir, "package.json"), "utf8"));
+    } catch {
+      /* malformed — the runtime hint degrades to node; the user's build would surface the real error */
+    }
+  }
+  const { runtime } = detectRuntime(dir, pkg);
+  const hasFastagentDep = "@kid7st/fastagent" in { ...pkg.dependencies, ...pkg.devDependencies };
+  return { dir, created, patched, runtime, hasPackageJson, hasFastagentDep };
 }
 
 /**

--- a/src/scaffold/init.ts
+++ b/src/scaffold/init.ts
@@ -14,6 +14,7 @@
  */
 import { access, appendFile, lstat, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import { WORKSPACE_CONFIG_NAMES } from "../engines/pi/config.ts";
 import { detectRuntime } from "../runtime.ts";
 import { loadRootIgnore } from "../workspace.ts";
 import { baseTemplate, packageJson, toPackageName } from "./templates.ts";
@@ -152,11 +153,11 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
   }
 
   // Guard on the identity files: their presence means "already a workspace". Fail visibly
-  // rather than overwrite authored content.
-  const configNames = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"];
+  // rather than overwrite authored content. Same WORKSPACE_CONFIG_NAMES the CLI's adopt-vs-scaffold
+  // routing reads, so routing and refusal never disagree about whether a config exists.
   const conflicts: string[] = [];
   if (await exists(join(dir, "AGENTS.md"))) conflicts.push("AGENTS.md");
-  for (const name of configNames) if (await exists(join(dir, name))) conflicts.push(name);
+  for (const name of WORKSPACE_CONFIG_NAMES) if (await exists(join(dir, name))) conflicts.push(name);
   if (conflicts.length > 0) {
     throw new Error(`"${dir}" already has ${conflicts.join(", ")} — init refuses to overwrite an existing workspace`);
   }

--- a/test/cli-auth.test.ts
+++ b/test/cli-auth.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { formatAuthReport } from "../src/cli-auth.ts";
+
+// The #5 fix: an expired/revoked login must NOT report the contradictory "(none found)". This pins the
+// three-branch decision so flipping stored/none (or a probe/store contract change) can't silently regress.
+describe("cli-auth: formatAuthReport", () => {
+  const P = "anthropic";
+  const PATH = "/x/auth.json";
+
+  it("a usable source → just the source line, no warning", () => {
+    expect(formatAuthReport(P, PATH, "OAuth", undefined)).toEqual({ line: "auth:   OAuth (anthropic) — /x/auth.json" });
+    expect(formatAuthReport("openai", PATH, "OPENAI_API_KEY", undefined)).toEqual({
+      line: "auth:   OPENAI_API_KEY (openai) — /x/auth.json",
+    });
+  });
+
+  it("no source but a STORED credential → expired/unusable + re-login (NOT '(none found)')", () => {
+    const r = formatAuthReport(P, PATH, undefined, { type: "oauth" });
+    expect(r.line).toContain("stored anthropic oauth, expired/unusable");
+    expect(r.line).not.toContain("(none found)");
+    expect(r.warn).toMatch(/expired or unusable.*fastagent login/);
+  });
+
+  it("no source and nothing stored → (none found) + no-credentials hint", () => {
+    const r = formatAuthReport(P, PATH, undefined, undefined);
+    expect(r.line).toContain("(none found)");
+    expect(r.warn).toMatch(/no credentials for "anthropic"/);
+  });
+});

--- a/test/cli-models.test.ts
+++ b/test/cli-models.test.ts
@@ -8,4 +8,20 @@ describe("cli-models: formatModelsCommand (`fastagent models [search]` stdout/st
     expect(formatModelsCommand(specs, "OpenAI")).toEqual({ lines: ["openai/gpt-5", "openai/o3"] }); // case-insensitive
     expect(formatModelsCommand(specs, "zzznope")).toEqual({ lines: [], error: 'no model matches "zzznope"' }); // miss
   });
+
+  it("ranks a provider-name match above an incidental model-id match (anthropic/* before bedrock/anthropic.*)", () => {
+    const specs = [
+      "amazon-bedrock/anthropic.claude-opus", // matches "anthropic" only in the model id
+      "anthropic/claude-opus", // matches in the PROVIDER
+      "google-vertex/claude-anthropic", // model id only
+      "anthropic/claude-sonnet", // provider
+    ];
+    // Provider matches lead (order within the group preserved); incidental id matches follow.
+    expect(formatModelsCommand(specs, "anthropic").lines).toEqual([
+      "anthropic/claude-opus",
+      "anthropic/claude-sonnet",
+      "amazon-bedrock/anthropic.claude-opus",
+      "google-vertex/claude-anthropic",
+    ]);
+  });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -148,15 +148,23 @@ describe("cli papercuts", () => {
 
   it("login self-ignores .fastagent on an adapted dir before it writes the credential file", async () => {
     // login is the command that CREATES the secret, so its self-ignore must fire independently of the
-    // opener. A bogus provider fails the auth flow AFTER the self-ignore, so the .gitignore is the
-    // proof the leak guard ran. Adapted dir = no root .gitignore (the feature's core use case).
+    // opener — and BEFORE the interactive gate below, so the .gitignore is written even though this
+    // non-TTY spawn then fails fast. That .gitignore is the proof the leak guard ran. Adapted dir = no
+    // root .gitignore (the feature's core use case).
     const cwd = await mkdtemp(join(tmpdir(), "fa-login-cli-"));
     const env = { ...process.env };
     delete env.FASTAGENT_AUTH_PATH; // ensure the in-tree default (not a dev's global override)
     const { code } = await run(["login", "no-such-provider"], cwd, env);
-    expect(code).not.toBe(0); // unknown provider fails the flow
+    expect(code).not.toBe(0);
     const { readFile } = await import("node:fs/promises");
     expect(await readFile(join(cwd, ".fastagent", ".gitignore"), "utf8")).toBe("*\n");
+  });
+
+  it("login fails fast in a non-TTY (a pipe/CI) instead of hanging on the interactive menu", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-login-tty-"));
+    const { code, stderr } = await run(["login", "openai-codex"], cwd); // run() pipes stdio → not a TTY
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/login is interactive.*run it in a terminal/);
   });
 
   it("login from $HOME does NOT self-ignore the HOME-global ~/.fastagent (a dotfiles repo may track it)", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -77,6 +77,7 @@ describe("cli papercuts", () => {
     // An up-to-date generated Dockerfile (built with the SAME inputs deploy uses) → kept quietly, no stale flag.
     const current = containerArtifacts({
       hasPackageJson: false,
+      runtime: "node",
       hasLockfile: false,
       version: await fastagentVersion(),
       apt: ["git"],

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -88,6 +88,22 @@ describe("deploy/fly: planFlyDeploy", () => {
     expect(docker).not.toContain("npm ci");
   });
 
+  it("markdown path ALWAYS uses node:22-slim (npm i -g), even if runtime is somehow bun (oven/bun has no npm)", () => {
+    const docker = dockerfile(
+      planFlyDeploy({
+        ...base,
+        modelAuth: undefined,
+        channels: [],
+        hasPackageJson: false,
+        runtime: "bun",
+        bunVersion: "1.3.13",
+      }),
+    );
+    expect(docker).toContain("FROM node:22-slim"); // never oven/bun — the global npm i -g needs npm
+    expect(docker).not.toContain("oven/bun");
+    expect(docker).toContain("npm i -g @kid7st/fastagent");
+  });
+
   it("falls back to npm install when a code workspace has no lockfile (npm ci would hard-fail)", () => {
     expect(dockerfile(planFlyDeploy({ ...base, modelAuth: undefined, channels: [], hasLockfile: false }))).toMatch(
       /RUN npm install\n/, // no lockfile → npm install; all deps (no --omit=dev — the agent needs its toolchain)

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -10,6 +10,7 @@ const base = {
   appName: "bot",
   port: 8787,
   hasPackageJson: true,
+  runtime: "node",
   hasLockfile: true,
   version: "9.9.9",
   autostop: "suspend",
@@ -88,10 +89,26 @@ describe("deploy/fly: planFlyDeploy", () => {
   });
 
   it("falls back to npm install when a code workspace has no lockfile (npm ci would hard-fail)", () => {
-    expect(dockerfile(planFlyDeploy({ ...base, modelAuth: undefined, channels: [], hasLockfile: false }))).toContain(
-      "npm install --omit=dev",
+    expect(dockerfile(planFlyDeploy({ ...base, modelAuth: undefined, channels: [], hasLockfile: false }))).toMatch(
+      /RUN npm install\n/, // no lockfile → npm install; all deps (no --omit=dev — the agent needs its toolchain)
     );
-    expect(dockerfile(planFlyDeploy({ ...base, modelAuth: undefined, channels: [] }))).toContain("npm ci --omit=dev");
+    expect(dockerfile(planFlyDeploy({ ...base, modelAuth: undefined, channels: [] }))).toMatch(/RUN npm ci\n/);
+  });
+
+  it("generates a Bun Dockerfile for a bun workspace (oven/bun base, bun install, bunx)", () => {
+    const bun = dockerfile(
+      planFlyDeploy({ ...base, modelAuth: undefined, channels: [], runtime: "bun", bunVersion: "1.3.13" }),
+    );
+    expect(bun).toContain("FROM oven/bun:1.3.13");
+    expect(bun).toContain("bun install --frozen-lockfile"); // base.hasLockfile: true → frozen
+    expect(bun).toContain('CMD ["bunx", "fastagent", "start", "/app"]');
+    expect(bun).not.toContain("node:22-slim");
+    // Unpinned bun (a bun lockfile but no packageManager version) → oven/bun:1; no lockfile → plain install.
+    const unpinned = dockerfile(
+      planFlyDeploy({ ...base, modelAuth: undefined, channels: [], runtime: "bun", hasLockfile: false }),
+    );
+    expect(unpinned).toContain("FROM oven/bun:1\n");
+    expect(unpinned).toMatch(/RUN bun install\n/); // no --frozen-lockfile without a lockfile
   });
 
   it("flags a model that won't travel — config.model is the deployed box's only source", () => {

--- a/test/deploy-railway.test.ts
+++ b/test/deploy-railway.test.ts
@@ -5,7 +5,13 @@ const json = (p: ReturnType<typeof planRailwayDeploy>) => p.artifacts.find((a) =
 const runbook = (p: ReturnType<typeof planRailwayDeploy>) => p.runbook.join("\n");
 
 /** Defaults for the fields a test doesn't care about (a code workspace with a lockfile). */
-const base = { serviceName: "bot", hasPackageJson: true, hasLockfile: true, version: "9.9.9" } as const;
+const base = {
+  serviceName: "bot",
+  hasPackageJson: true,
+  runtime: "node",
+  hasLockfile: true,
+  version: "9.9.9",
+} as const;
 
 describe("deploy/railway: planRailwayDeploy", () => {
   it("generates a thin railway.json — build from Dockerfile, healthcheck /health (no boot-race routing)", () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createPiAgentFromWorkspace } from "../src/index.ts";
 import { loadAgentDefinition } from "../src/engines/pi/definition.ts";
-import { scaffoldWorkspace } from "../src/scaffold/init.ts";
+import { adoptWorkspace, scaffoldWorkspace } from "../src/scaffold/init.ts";
 import { nextStepCd } from "../src/scaffold/init.ts";
 import { vendorSkill } from "../src/scaffold/vendor-skill.ts";
 
@@ -168,6 +168,64 @@ describe("init: scaffoldWorkspace", () => {
     await expect(scaffoldWorkspace(dir2)).rejects.toThrow(/already has fastagent\.config\.ts/);
   });
 
+  it("adopts an existing repo (AGENTS.md, no config): adds config + secret-safe .gitignore, keeps the repo's files, bun-aware", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, "AGENTS.md"), "# My real agent\n"); // the repo IS the agent
+    await writeFile(join(dir, "package.json"), `{"type":"module","packageManager":"bun@1.3.13","dependencies":{}}`);
+    await writeFile(join(dir, ".gitignore"), "dist/\n"); // pre-existing, without .env
+
+    const r = await adoptWorkspace(dir);
+    expect(await readFile(join(dir, "AGENTS.md"), "utf8")).toBe("# My real agent\n"); // NEVER touched
+    expect(await exists(join(dir, "fastagent.config.mjs"))).toBe(true); // the one missing piece
+    expect(r.created).toContain("fastagent.config.mjs");
+    const gitignore = await readFile(join(dir, ".gitignore"), "utf8");
+    expect(gitignore).toContain("dist/"); // kept
+    expect(gitignore).toMatch(/^\.env$/m); // secrets now excluded
+    expect(gitignore).toMatch(/^\.fastagent$/m);
+    expect(r.runtime).toBe("bun"); // drives the `bun add` hint the CLI prints
+    expect(r.hasFastagentDep).toBe(false);
+    // No example skill/tool/package.json written — adopt adds only what's missing, not a scaffold.
+    expect(await exists(join(dir, "tools"))).toBe(false);
+    expect(await exists(join(dir, "skills"))).toBe(false);
+  });
+
+  it("adopt's secret-safe .gitignore: creates one when absent, skips when .env is already ignored", async () => {
+    // No .gitignore → adopt CREATES it (the `created` branch) so the secret-safe invariant still holds.
+    const none = await freshDir();
+    await writeFile(join(none, "AGENTS.md"), "# a\n");
+    const r1 = await adoptWorkspace(none);
+    expect(r1.created).toContain(".gitignore");
+    expect(await readFile(join(none, ".gitignore"), "utf8")).toMatch(/^\.env$/m);
+
+    // .env already ignored → adopt neither creates nor patches (no duplicate line).
+    const covered = await freshDir();
+    await writeFile(join(covered, "AGENTS.md"), "# a\n");
+    await writeFile(join(covered, ".gitignore"), ".env\n.fastagent\n");
+    const r2 = await adoptWorkspace(covered);
+    expect([...r2.created, ...r2.patched]).not.toContain(".gitignore");
+    expect((await readFile(join(covered, ".gitignore"), "utf8")).match(/^\.env$/gm)).toHaveLength(1);
+  });
+
+  it("`init` ROUTES to adopt vs scaffold vs refuse by what's already there", async () => {
+    // AGENTS.md, no config → ADOPT (not scaffold: keeps AGENTS.md, writes NO example skill).
+    const repo = await freshDir();
+    await writeFile(join(repo, "AGENTS.md"), "# My real agent\n");
+    const adopt = await cliInit(["init"], repo);
+    expect(adopt).toMatch(/adopted/);
+    expect(await readFile(join(repo, "AGENTS.md"), "utf8")).toBe("# My real agent\n");
+    expect(await exists(join(repo, "skills"))).toBe(false); // scaffold would have written the example skill
+
+    // Fresh dir → SCAFFOLD (writes AGENTS.md + the example skill).
+    const fresh = await cliInit(["init", "--no-install"], await freshDir());
+    expect(fresh).toMatch(/initialized/);
+
+    // AGENTS.md + a config → already a workspace → REFUSE (adopt only fires when there's no config).
+    const done = await freshDir();
+    await writeFile(join(done, "AGENTS.md"), "# x\n");
+    await writeFile(join(done, "fastagent.config.mjs"), "export default {};\n");
+    expect(await cliInit(["init"], done)).toMatch(/already has .*refuses to overwrite/);
+  });
+
   it("prints a `cd <dir>` step for a named target so the dev/.env/config steps are correct", async () => {
     const base = await freshDir();
     // init into a subdir from `base` as cwd: the next steps must lead with `cd my-agent`.
@@ -317,7 +375,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
           await writeFile(join(d, "package.json"), `${JSON.stringify({ type: "module" }, null, 2)}\n`);
           return d;
         },
-        /@kid7st\/fastagent.*dependencies/, // ESM but missing the dep
+        /@kid7st\/fastagent is not a dependency.*npm install/, // ESM but missing the dep (node → npm hint)
       ],
     ];
     for (const [make, msg] of cases) {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectRuntime } from "../src/runtime.ts";
+
+describe("detectRuntime", () => {
+  const freshDir = () => mkdtemp(join(tmpdir(), "fa-rt-"));
+
+  it("is bun via packageManager, with the version — and strips corepack's +hash (invalid Docker tag)", async () => {
+    const dir = await freshDir();
+    expect(detectRuntime(dir, { packageManager: "bun@1.3.13" })).toMatchObject({
+      runtime: "bun",
+      bunVersion: "1.3.13",
+    });
+    // corepack format: FROM oven/bun:<version> must not carry the +sha256 suffix.
+    expect(detectRuntime(dir, { packageManager: "bun@1.3.13+sha256.deadbeef" })).toMatchObject({
+      runtime: "bun",
+      bunVersion: "1.3.13",
+    });
+  });
+
+  it("is bun via a bun lockfile even without packageManager (version undefined → oven/bun:1)", async () => {
+    const dir = await freshDir();
+    await writeFile(join(dir, "bun.lock"), "");
+    expect(detectRuntime(dir, {})).toEqual({ runtime: "bun", bunVersion: undefined, hasLockfile: true });
+  });
+
+  it("is node otherwise; hasLockfile tracks package-lock.json", async () => {
+    const dir = await freshDir();
+    expect(detectRuntime(dir, {})).toEqual({ runtime: "node", hasLockfile: false });
+    await writeFile(join(dir, "package-lock.json"), "{}");
+    expect(detectRuntime(dir, { packageManager: "npm@10" })).toEqual({ runtime: "node", hasLockfile: true });
+  });
+});


### PR DESCRIPTION
## B-mode on-ramp (init adopt) + bun-aware generated Dockerfile

Turning a real **Bun** repo (an Astro site whose `AGENTS.md` drives content ops) into a deployed agent surfaced two dead-ends the whole B-mode pitch ("existing repo → agent, without rewriting it") stumbles on.

### 1. On-ramp — no smooth path for an existing repo

`init` refused an existing-`AGENTS.md` repo (the B-mode case), and `add` gated on a dep with **npm-only** guidance on a **bun** project. Now:

- **`fastagent init` on an `AGENTS.md` repo with no config ADOPTS it**: adds the one missing piece (`fastagent.config.mjs`) + a secret-safe `.gitignore` (`.env`/`.fastagent`), keeps `AGENTS.md`/`skills`/`tools` **untouched**, and guides with the RIGHT package manager (`bun add` vs `npm install`). Never hand-edits `package.json` — the pm owns the lockfile. `--minimal` is a no-op here (noted, not silently dropped).
- **`add`'s dep gate + next-steps are package-manager-aware.**
- Routing: AGENTS.md + no config → adopt; fresh → scaffold; has config → refuse (tested end-to-end).

### 2. Bun Dockerfile — the generated one was npm/node-only

A bun workspace (`packageManager: bun` / a bun lockfile) now gets `FROM oven/bun` + `bun install` + `bunx fastagent start` (works since 0.10.2's Bun runtime support), instead of forcing a hand-written Dockerfile. `bunVersion` strips corepack's `+sha256` suffix (an invalid Docker tag).

### Behavior change (all node deploys)

The generated Dockerfile **no longer passes `--omit=dev`** — it installs devDependencies too. A repo-as-agent runs its own build/check toolchain (which lives in devDependencies) to do its work, and we can't tell a repo-as-agent from a purpose-built workspace, so the safe default installs everything (correctness over image size). Applies to both runtimes.

### Structure

New neutral `src/runtime.ts` (`detectRuntime`) is the ONE source both the Dockerfile and the CLI hints read. `FlyPlanInput`/`RailwayPlanInput` now `extends ContainerInput` — the container facts were duplicated in 3 places, and that drift is what broke the build when a field was added.

444 tests (new: runtime detection incl. corepack, adopt + its secret-safe .gitignore branches, init routing, bun Dockerfile).


---

## Also: the 🟡 secondary frictions from the same validation

| # | Fix |
|---|---|
| #3 | `models <search>` ranks a **provider-name** match above an incidental model-id match — `models anthropic` leads with `anthropic/*`, not `amazon-bedrock/anthropic.*`. |
| #5 | An expired/revoked OAuth reported a contradictory `auth: (none found)` then `OAuth refresh failed`. `reportAuth` now reads the store **without a refresh** to tell "nothing stored" from "stored but unusable", reporting the latter as expired → `fastagent login`. |
| #6 | The generate-mode runbook's `Model auth: none configured locally` now hints that a **global** login isn't read there — pass `--auth-path`, or `--run` carries it. |
| #9 | `login` in a non-TTY (pipe/CI/agent shell) hung on a menu it couldn't answer; it now **fails fast** with the reason, after the secret-hygiene self-ignore. |
