### PR TITLE
chore(release): 0.10.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kid7st/fastagent",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## 0.10.3 — B-mode DevX (turn an existing repo, incl. Bun, into a deployed agent)

From a from-scratch validation: turning a real Bun repo (an Astro site whose `AGENTS.md` drives content ops) into a Telegram-reachable agent.

- **`init` ADOPTS** an existing `AGENTS.md` repo (adds `fastagent.config.mjs` + a secret-safe `.gitignore`, keeps its files, guides with the right package manager) instead of refusing it.
- **Bun-aware Dockerfile** — a `packageManager: bun` / bun-lockfile workspace gets `FROM oven/bun` + `bun install` + `bunx fastagent start`; the markdown path stays `node:22-slim`.
- **`add`** — dep gate + next-steps are package-manager-aware (`bun add` vs `npm install`).
- **`models <search>`** ranks provider-name matches first (`anthropic/*` before `amazon-bedrock/anthropic.*`).
- An **expired login** reports `expired/unusable → fastagent login` instead of a contradictory `(none found)`.
- **`login`** fails fast in a non-TTY (pipe/CI) instead of hanging on a menu.

**Behavior change:** the generated Dockerfile no longer passes `--omit=dev` — a repo-as-agent needs its build/check devDependencies to do its work (correctness over image size). No other breaking changes.
