### PR TITLE
refactor(deploy): host-neutral preflight + shared runner seam + per-host directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,13 +25,15 @@ src/
 ├── collect.ts               # buffered consumption helper
 ├── index.ts                 # the public API surface (see README "Public API surface & stability")
 ├── cli.ts                   # command entry points (process side effects live here)
-├── invoke-stream.ts, cli-models.ts # command rendering layers (`invoke` stream → exit code, `models` output)
+├── invoke-stream.ts, cli-models.ts, cli-auth.ts # command rendering layers (`invoke` stream → exit code, `models`/auth-report output)
 ├── telegram.ts, github.ts   # subpath-export shims (@kid7st/fastagent/telegram etc. — the supported surface)
 ├── log.ts                   # leveled logging singleton (dev=debug, start=info)
 ├── observe.ts               # turn-trace logging around an Agent
 ├── tunnel.ts                # `--tunnel`: cloudflared + per-channel webhook dispatch
 ├── dev-supervisor.ts        # `dev` supervisor: restart on code-input edits (definition is live-read per invoke)
 ├── proxy.ts                 # HTTPS_PROXY wiring
+├── env.ts                   # `.env` → process.env loading (missing file is normal; anything else surfaces)
+├── runtime.ts               # workspace runtime/package-manager detection (node vs bun) + readPackageJson
 ├── workspace.ts, version.ts # neutral helpers (in-workspace guard, ignore files, version)
 ├── host/node.ts             # Node HTTP host: Routes/ChannelHandler/serveNode/router (public surface)
 ├── scaffold/                # `init` / `add <channel>` / `add skill` + templates/ (real files)
@@ -51,6 +53,14 @@ src/
 │       ├── state.ts         # atomic state files under .fastagent/channels/telegram/
 │       ├── register-webhook.ts # --tunnel setWebhook registration
 │       └── scaffold/        # `add telegram` bundle (channel.ts + send tool)
+├── deploy/                  # `deploy fly|railway`: host artifacts + runbook + `--run` CLI drive (docs/design/core.md §10.5)
+│   │                        # LAYOUT: neutral kernel at top (horizontal) + one dir per host (vertical) — new host = new dir, copy fly/
+│   ├── preflight.ts         # host-NEUTRAL pre-flight: model-travel gate (modelTravelIssue), channel discovery, auth probe, container facts + warnings
+│   ├── container.ts         # portable Dockerfile + .dockerignore (host-neutral) + the generated-marker predicate
+│   ├── secrets.ts           # required-secret NAMES (runbook) + assembleSecrets VALUES (--run credential carry)
+│   ├── runner.ts            # the shared host-CLI dispatcher seam (CliRunner + spawnRunner; faked in tests)
+│   ├── fly/     { plan.ts, run.ts }  # Fly: PLAN (artifacts + runbook, pure) + `--run` driver (drives flyctl behind the runner seam)
+│   └── railway/ { plan.ts, run.ts }  # Railway: same two roles — NOT a copy of Fly (thin config, minted URL, no scriptable scale-to-zero)
 └── engines/pi/              # the pi reference implementation
     ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
     ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import { parseArgs } from "node:util";
 import type { Agent } from "./agent.ts";
 import { logAgentLoop } from "./observe.ts";
 import { log, setLogLevel } from "./log.ts";
-import { loadEnvFile } from "./env.ts";
+import { loadDotEnv } from "./env.ts";
 import { installProxyFetch } from "./proxy.ts";
 import { createInvokeHandler } from "./channels/http.ts";
 import { text } from "./channels/respond.ts";
@@ -20,7 +20,7 @@ import { type Routes, parseRouteKey, router, serveNode } from "./host/node.ts";
 import { runDevSupervisor } from "./dev-supervisor.ts";
 import { announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
 import { discoverChannelFiles, loadChannels } from "./engines/pi/channel.ts";
-import { detectRuntime } from "./runtime.ts";
+import { detectRuntime, readPackageJson } from "./runtime.ts";
 import { fastagentVersion } from "./version.ts";
 import {
   defaultAuthPath,
@@ -58,10 +58,12 @@ import {
 import { adoptWorkspace, exists, nextStepCd, scaffoldWorkspace } from "./scaffold/init.ts";
 import { vendorSkill } from "./scaffold/vendor-skill.ts";
 import { isGeneratedDockerfile } from "./deploy/container.ts";
-import { modelTravelIssue, parseFlyAppName, parseFlyRegion, planFlyDeploy, toFlyAppName } from "./deploy/fly.ts";
-import { planRailwayDeploy } from "./deploy/railway.ts";
-import { type RailwayRunner, deployRailwayRun } from "./deploy/railway-run.ts";
-import { type FlyRunner, authSeedBytes, deployFlyRun } from "./deploy/fly-run.ts";
+import { parseFlyAppName, parseFlyRegion, planFlyDeploy, toFlyAppName } from "./deploy/fly/plan.ts";
+import { preflightDeploy } from "./deploy/preflight.ts";
+import { planRailwayDeploy } from "./deploy/railway/plan.ts";
+import { deployRailwayRun } from "./deploy/railway/run.ts";
+import { authSeedBytes, deployFlyRun } from "./deploy/fly/run.ts";
+import { spawnRunner } from "./deploy/runner.ts";
 import { assembleSecrets } from "./deploy/secrets.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
 
@@ -487,89 +489,23 @@ async function runDeploy(): Promise<void> {
   loadDotEnv(target); // a custom provider/tool may read a key at config load
   const { config } = await loadConfig(target).catch(failStartup);
   const modelSpec = resolveModelSpec(values.model, config);
-  // The deployed box resolves the model from fastagent.config.ts ONLY (in the image); a model set via
-  // env/flag/.env doesn't travel. Surface it: warn for the runbook, hard gate for `--run` (don't deploy
-  // a known crash-loop).
-  const modelIssue = modelTravelIssue(config.model, modelSpec);
-  if (modelIssue) {
-    // `--run` fully deploys on either host now, so a model that won't travel would ship a known
-    // crash-looping box — hard-stop before that. (Generate-only still just warns, for the runbook.)
-    if (values.run) {
-      console.error(`[fastagent] deploy stopped: ${modelIssue}`);
-      process.exit(1);
-    }
-    console.error(`[fastagent] warn: ${modelIssue}`);
+  // The host-neutral pre-flight (model-travel gate, channel discovery, model-auth probe, container facts +
+  // their warnings) lives in deploy/preflight.ts — testable in isolation. The CLI prints its messages and
+  // stops on its gate; the host branch below adds only the host-specific artifacts + runbook + run drive.
+  const pre = await preflightDeploy({
+    target,
+    config,
+    modelSpec,
+    run: !!values.run,
+    force: !!values.force,
+    authPathOverride: resolveAuthPathOverride(values["auth-path"]),
+  }).catch(failStartup);
+  if (!pre.ok) {
+    console.error(`[fastagent] deploy stopped: ${pre.gate}`);
+    process.exit(1);
   }
-  // Known channel kinds only — a custom channel's secrets/webhook are unknown to us; warn and let the
-  // author wire them. probeAuthSource is best-effort (default providers): an env key becomes a secret,
-  // a local OAuth/stored login surfaces as guidance, an unknown provider degrades to a generic note.
-  const discovered = await discoverChannelFiles(target).catch(failStartup);
-  const channels = discovered.filter((c): c is ChannelKind => (CHANNEL_KINDS as string[]).includes(c));
-  for (const c of discovered) {
-    if (!channels.includes(c as ChannelKind)) {
-      console.error(`[fastagent] note: channel "${c}" is custom — set its secrets and webhook yourself`);
-    }
-  }
-  // Probe auth from the SAME project-level file the opener/login use (default `<state root>/auth.json`,
-  // or --auth-path / FASTAGENT_AUTH_PATH) — not the global default, which would miss a `fastagent login`
-  // credential and falsely report "none configured".
-  const authPath = resolveAuthPathOverride(values["auth-path"]) ?? defaultAuthPath(resolveStateRoot(target));
-  const modelAuth = modelSpec ? await probeAuthSource(createPiModels({ authPath }), modelSpec) : undefined;
-  // Container facts (shared by every host) + the warnings that follow. The generated Dockerfile targets
-  // the workspace's package manager — bun (packageManager: bun / a bun lockfile) or npm — made EXPLICIT
-  // rather than silently routing a bun/pnpm/yarn workspace through npm.
-  const hasPackageJson = await exists(join(target, "package.json"));
-  const pkg = await readPackageJson(target);
-  const { runtime, bunVersion, hasLockfile } = detectRuntime(target, pkg);
-  const install = runtime === "bun" ? "bun install" : "npm install";
-  const runner = runtime === "bun" ? "bunx fastagent" : "npx fastagent";
-  const hasOtherLock =
-    runtime === "node" && ((await exists(join(target, "pnpm-lock.yaml"))) || (await exists(join(target, "yarn.lock"))));
-  // A code workspace with no lockfile builds via a non-frozen install (ranges resolve at build time) —
-  // not a reproducible redeploy. A pnpm/yarn user gets an accurate message (their lockfile is ignored by
-  // the npm Dockerfile), not the misleading "commit an npm lockfile".
-  if (hasPackageJson && !hasLockfile) {
-    const lock = runtime === "bun" ? "bun.lock" : "package-lock.json";
-    console.error(
-      hasOtherLock
-        ? `[fastagent] warn: the generated Dockerfile is npm-based — your pnpm/yarn lockfile is NOT used (build runs ` +
-            `\`npm install\`, not reproducible). Edit the Dockerfile for your package manager, or vendor a package-lock.json.`
-        : `[fastagent] warn: no ${lock} — the image build resolves deps at build time (not reproducible). ` +
-            `Run \`${install}\` and commit the lockfile for pinned redeploys.`,
-    );
-  }
-  // The code-path Dockerfile runs `${runner}`: that resolves the workspace's OWN dependency, so a
-  // package.json missing it would make the CONTAINER fetch an unpinned build at runtime (offline-fragile,
-  // the failure moved from build to prod). Warn at plan time, like `add`'s dep check (which throws).
-  if (hasPackageJson && !("@kid7st/fastagent" in { ...pkg.dependencies, ...pkg.devDependencies })) {
-    console.error(
-      `[fastagent] warn: package.json does not list @kid7st/fastagent — the image's \`${runner}\` would ` +
-        `fetch it at runtime (offline-fragile, unpinned). Add it to dependencies and re-run \`${install}\`.`,
-    );
-  }
-  const container = {
-    hasPackageJson,
-    runtime,
-    bunVersion,
-    hasLockfile,
-    version: await fastagentVersion(),
-    apt: config.deploy?.apt,
-  };
-  const port = config.http?.port ?? 8787;
-  // What the agent declared it needs on the box (fastagent.config deploy.secrets) — carried like channel
-  // secrets: listed in the runbook, set from the local env under --run, gated if a value is missing.
-  const extraSecrets = config.deploy?.secrets ?? [];
-  // deploy.apt only shapes the GENERATED Dockerfile. Warn ONLY when the kept Dockerfile is HAND-WRITTEN
-  // (its apt won't include these) — a fastagent-generated one is handled by writeArtifacts (kept if current,
-  // flagged stale otherwise). Don't suggest --force here: it would overwrite the user's hand-written file.
-  if (config.deploy?.apt?.length && !values.force && (await exists(join(target, "Dockerfile")))) {
-    if (!isGeneratedDockerfile(await readFile(join(target, "Dockerfile"), "utf8"))) {
-      console.error(
-        `[fastagent] warn: kept your hand-written Dockerfile — deploy.apt (${config.deploy.apt.join(", ")}) is ` +
-          `NOT applied; install those packages in your Dockerfile.`,
-      );
-    }
-  }
+  for (const m of pre.messages) console.error(`[fastagent] ${m.level}: ${m.text}`);
+  const { channels, modelAuth, authPath, container, port, extraSecrets } = pre;
 
   // Railway: thin config file, scale-to-zero is a manual dashboard step, the URL is minted (see
   // planRailwayDeploy). --run drives the railway CLI to completion; otherwise print the runbook.
@@ -676,7 +612,7 @@ async function writeArtifacts(target: string, artifacts: { path: string; content
  * from the local env — the model key (env auth) or the whole auth.json as a `FASTAGENT_AUTH_SEED` seed
  * (OAuth/stored auth: the deployed box materializes it onto the /data volume on first boot, so a
  * personal deploy runs on the SAME subscription) plus channel secrets — then runs the flyctl steps
- * behind the {@link FlyRunner} seam (spawned `fly`, cwd = the workspace so the build context is the agent).
+ * behind the shared {@link spawnRunner} seam (spawned `fly`, cwd = the workspace so the build context is the agent).
  */
 async function runDeployFly(params: {
   target: string;
@@ -688,18 +624,7 @@ async function runDeployFly(params: {
   extraSecrets: string[];
 }): Promise<void> {
   const { target, appName, modelAuth, authPath, channels, flyTomlPath, extraSecrets } = params;
-  const fly: FlyRunner = (args, opts) =>
-    new Promise((res) => {
-      const child = spawn("fly", args, {
-        cwd: target,
-        stdio: [opts?.input ? "pipe" : "inherit", opts?.capture ? "pipe" : "inherit", "inherit"],
-      });
-      let out = "";
-      child.stdout?.on("data", (d) => (out += String(d)));
-      if (opts?.input) child.stdin?.end(opts.input);
-      child.on("close", (code) => res({ code: code ?? 1, stdout: out }));
-      child.on("error", () => res({ code: 127, stdout: "" })); // ENOENT: flyctl not on PATH
-    });
+  const fly = spawnRunner("fly", target);
   // Fail fast if flyctl is absent (spawn ENOENT → 127), with the install link — not a confusing auth gate.
   if ((await fly(["version"], { capture: true })).code === 127) {
     console.error(`[fastagent] flyctl not found — install it: https://fly.io/docs/flyctl/install, then re-run`);
@@ -752,18 +677,7 @@ async function runDeployRailway(params: {
   extraSecrets: string[];
 }): Promise<void> {
   const { target, name, modelAuth, authPath, channels, extraSecrets } = params;
-  const railway: RailwayRunner = (args, opts) =>
-    new Promise((res) => {
-      const child = spawn("railway", args, {
-        cwd: target,
-        stdio: [opts?.input ? "pipe" : "inherit", opts?.capture ? "pipe" : "inherit", "inherit"],
-      });
-      let out = "";
-      child.stdout?.on("data", (d) => (out += String(d)));
-      if (opts?.input) child.stdin?.end(opts.input);
-      child.on("close", (code) => res({ code: code ?? 1, stdout: out }));
-      child.on("error", () => res({ code: 127, stdout: "" })); // ENOENT: railway not on PATH
-    });
+  const railway = spawnRunner("railway", target);
   // Fail fast if the railway CLI is absent (spawn ENOENT → 127), with the install link.
   if ((await railway(["--version"], { capture: true })).code === 127) {
     console.error(`[fastagent] railway CLI not found — install it: https://docs.railway.com/guides/cli, then re-run`);
@@ -1173,28 +1087,6 @@ function serve(routes: Routes, port: number, onListening?: (boundPort: number) =
       process.exit(1);
     },
   );
-}
-
-/** Parse `<dir>/package.json`, or `{}` when absent/malformed (a real build surfaces the actual error). */
-async function readPackageJson(d: string): Promise<{
-  packageManager?: unknown;
-  dependencies?: Record<string, unknown>;
-  devDependencies?: Record<string, unknown>;
-}> {
-  try {
-    return JSON.parse(await readFile(join(d, "package.json"), "utf8"));
-  } catch {
-    return {};
-  }
-}
-
-/** .env (secrets) → process.env. Only a missing file is normal; surface anything else. */
-function loadDotEnv(d: string): void {
-  try {
-    loadEnvFile(join(d, ".env"));
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-  }
 }
 
 /**

--- a/src/deploy/fly/plan.ts
+++ b/src/deploy/fly/plan.ts
@@ -16,9 +16,9 @@
  * snapshot is discarded replays on the next start (the Telegram L1 turn store) — at-least-once, the
  * documented floor. State on the /data volume survives stop/suspend on the same machine.
  */
-import type { ChannelKind } from "../scaffold/add-channel.ts";
-import { type Artifact, type ContainerInput, containerArtifacts } from "./container.ts";
-import { isEnvKey, requiredSecrets } from "./secrets.ts";
+import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
+import { isEnvKey, requiredSecrets } from "../secrets.ts";
 
 export interface FlyPlanInput extends ContainerInput {
   // Container facts (hasPackageJson, runtime, hasLockfile, bunVersion, version, apt) come from
@@ -197,22 +197,6 @@ export function parseFlyAppName(toml: string): string | undefined {
  *  volume lands in the machine's region (fly.toml is the single source; see {@link parseFlyAppName}). */
 export function parseFlyRegion(toml: string): string | undefined {
   return toml.match(/^\s*primary_region\s*=\s*["']([^"']+)["']/m)?.[1];
-}
-
-/**
- * Why the resolved model won't reach the deployed box, or undefined if it will. `fastagent.config.ts`
- * is the model's committed home (config's charter: model / tools / http) and the only source deploy
- * ships — a `--model`/`FASTAGENT_MODEL`/`.env` value is builder-local and doesn't travel (`.env` is
- * dockerignored), so a model NOT in config crash-loops the box with "missing model". The CLI warns
- * (runbook) or gates (`--run`). Single source on purpose: fly.toml `[env]` is NOT advertised as a
- * second home (it would contradict this check and split the source, like the app/region single-source).
- */
-export function modelTravelIssue(configModel: string | undefined, modelSpec: string | undefined): string | undefined {
-  if (configModel) return undefined;
-  return modelSpec
-    ? `model "${modelSpec}" is set via --model/FASTAGENT_MODEL, not fastagent.config.ts — it won't reach ` +
-        `the deployed box. Add \`model: "${modelSpec}"\` to fastagent.config.ts.`
-    : `no model in fastagent.config.ts — the deployed box can't resolve one. Add \`model: "provider/id"\`.`;
 }
 
 /** Sanitize a directory basename into a Fly app name: lowercase, [a-z0-9-], must start with a letter. */

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -8,7 +8,7 @@
  * gate too (`missingSecrets`), not a silent mint — fill it in `.env` (use the random string that
  * `add <channel>` prints).
  *
- * flyctl is behind the {@link FlyRunner} seam — production spawns `fly`, tests inject a fake that
+ * flyctl is behind the shared {@link CliRunner} seam — production spawns `fly`, tests inject a fake that
  * records the command sequence and scripts outputs. That seam is the benchmark: the agent's journey
  * encoded as an asserted command sequence + gate behavior, validated without a real Fly account.
  *
@@ -17,20 +17,8 @@
  * (one machine, the single-machine tier). Secrets go in via `secrets import` over stdin, so values
  * never land in argv/process listings.
  */
-import type { ChannelKind } from "../scaffold/add-channel.ts";
-
-export interface FlyRunResult {
-  code: number;
-  /** Captured stdout, for `--json` queries; empty for streamed (inherited) commands. flyctl's stderr
-   *  is always inherited straight to the terminal, so it is not a field here. */
-  stdout: string;
-}
-
-/**
- * The flyctl dispatcher seam. `capture` collects stdout (for `--json` queries); without it the command
- * streams to the terminal (create/deploy) and stdout is empty. `input` is fed to stdin (secrets import).
- */
-export type FlyRunner = (args: string[], opts?: { capture?: boolean; input?: string }) => Promise<FlyRunResult>;
+import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import type { CliRunner } from "../runner.ts";
 
 /**
  * The bytes to seed to the auth file, or undefined to leave it alone — the pure core of `start`'s
@@ -76,7 +64,7 @@ function listHasName(stdout: string, name: string): boolean {
  */
 export async function deployFlyRun(
   plan: FlyRunPlan,
-  fly: FlyRunner,
+  fly: CliRunner,
   log: (msg: string) => void,
   registerTelegram: (baseUrl: string) => Promise<void>,
 ): Promise<FlyRunOutcome> {

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -1,0 +1,163 @@
+/**
+ * The host-NEUTRAL deploy pre-flight: everything `fastagent deploy <host>` computes and checks BEFORE
+ * the host branch (fly.ts / railway.ts). Model-travel gate, channel discovery, model-auth probe, the
+ * container facts + their warnings, and the hand-written-Dockerfile apt warning are identical on every
+ * host — so they live here, out of the CLI dispatcher, testable in isolation (call it against a temp dir
+ * and assert the gate / messages / facts). The CLI stays thin: run this, print the messages, branch by host.
+ *
+ * It returns messages rather than printing them (the CLI owns stderr) and a `{ ok }` outcome mirroring
+ * the run modules' {@link import("./fly/run.ts").FlyRunOutcome}: a model that won't travel is a GATE the
+ * CLI stops on, distinct from the advisory warnings/notes it prints and proceeds past.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { FastagentConfig } from "../engines/pi/config.ts";
+import { defaultAuthPath, resolveStateRoot } from "../engines/pi/config.ts";
+import { discoverChannelFiles } from "../engines/pi/channel.ts";
+import { createPiModels, probeAuthSource } from "../engines/pi/models.ts";
+import { CHANNEL_KINDS, type ChannelKind } from "../scaffold/add-channel.ts";
+import { exists } from "../scaffold/init.ts";
+import { detectRuntime, readPackageJson } from "../runtime.ts";
+import { fastagentVersion } from "../version.ts";
+import { type ContainerInput, isGeneratedDockerfile } from "./container.ts";
+
+/** A stderr line the CLI prints (`[fastagent] warn: …` / `[fastagent] note: …`). Host-neutral advisories. */
+export interface DeployMessage {
+  level: "warn" | "note";
+  text: string;
+}
+
+/** The resolved facts every host plan needs (the container shape, channels, model auth, ports/secrets). */
+export interface DeployFacts {
+  messages: DeployMessage[];
+  channels: ChannelKind[];
+  /** What satisfies model auth locally ({@link probeAuthSource}) — an env-var name, an OAuth/stored label,
+   *  or undefined. Drives the runbook's secret guidance and `--run`'s credential carry. */
+  modelAuth: string | undefined;
+  /** The project-level auth file `--run` reads to carry the credential (probed with the same path). */
+  authPath: string;
+  /** Container facts shared by the plan and the generated Dockerfile — ONE source, so they can't drift. */
+  container: ContainerInput;
+  port: number;
+  extraSecrets: string[];
+}
+
+/** Done (facts for the host branch), or a hard gate the CLI stops on (a model that won't reach the box). */
+export type DeployPreflight = { ok: false; gate: string } | ({ ok: true } & DeployFacts);
+
+/**
+ * Run the host-neutral pre-flight. Throws on a real fault (an unreadable channels/ dir, a throwing
+ * provider) — the CLI wraps the call in its `failStartup` so the fault surfaces and exits, never silently.
+ */
+export async function preflightDeploy(input: {
+  target: string;
+  config: FastagentConfig;
+  modelSpec: string | undefined;
+  /** `--run` fully deploys, so a model that won't travel is a GATE (a known crash-loop); else it warns. */
+  run: boolean;
+  /** `--force` regenerates artifacts, so the kept-hand-written-Dockerfile apt warning does not apply. */
+  force: boolean;
+  /** `--auth-path` / `FASTAGENT_AUTH_PATH`; falls back to the project default `<state root>/auth.json`. */
+  authPathOverride: string | undefined;
+}): Promise<DeployPreflight> {
+  const { target, config, modelSpec, run, force, authPathOverride } = input;
+  const messages: DeployMessage[] = [];
+
+  // The deployed box resolves the model from fastagent.config.ts ONLY (in the image); a model set via
+  // env/flag/.env doesn't travel. `--run` would ship a known crash-loop — hard gate; generate-only warns.
+  const modelIssue = modelTravelIssue(config.model, modelSpec);
+  if (modelIssue) {
+    if (run) return { ok: false, gate: modelIssue };
+    messages.push({ level: "warn", text: modelIssue });
+  }
+
+  // Known channel kinds only — a custom channel's secrets/webhook are unknown to us; note and let the
+  // author wire them.
+  const discovered = await discoverChannelFiles(target);
+  const channels = discovered.filter((c): c is ChannelKind => (CHANNEL_KINDS as string[]).includes(c));
+  for (const c of discovered) {
+    if (!channels.includes(c as ChannelKind)) {
+      messages.push({ level: "note", text: `channel "${c}" is custom — set its secrets and webhook yourself` });
+    }
+  }
+
+  // Probe auth from the SAME project-level file the opener/login use — not the global default, which would
+  // miss a `fastagent login` credential and falsely report "none configured".
+  const authPath = authPathOverride ?? defaultAuthPath(resolveStateRoot(target));
+  const modelAuth = modelSpec ? await probeAuthSource(createPiModels({ authPath }), modelSpec) : undefined;
+
+  // Container facts (shared by every host) + the warnings that follow. The generated Dockerfile targets
+  // the workspace's package manager — bun or npm — made EXPLICIT rather than silently routing through npm.
+  const hasPackageJson = await exists(join(target, "package.json"));
+  const pkg = await readPackageJson(target);
+  const { runtime, bunVersion, hasLockfile } = detectRuntime(target, pkg);
+  const install = runtime === "bun" ? "bun install" : "npm install";
+  const runner = runtime === "bun" ? "bunx fastagent" : "npx fastagent";
+  const hasOtherLock =
+    runtime === "node" && ((await exists(join(target, "pnpm-lock.yaml"))) || (await exists(join(target, "yarn.lock"))));
+  // A code workspace with no lockfile builds via a non-frozen install (ranges resolve at build time) — not
+  // reproducible. A pnpm/yarn user gets an accurate message (their lockfile is ignored by the npm Dockerfile).
+  if (hasPackageJson && !hasLockfile) {
+    const lock = runtime === "bun" ? "bun.lock" : "package-lock.json";
+    messages.push({
+      level: "warn",
+      text: hasOtherLock
+        ? `the generated Dockerfile is npm-based — your pnpm/yarn lockfile is NOT used (build runs ` +
+          `\`npm install\`, not reproducible). Edit the Dockerfile for your package manager, or vendor a package-lock.json.`
+        : `no ${lock} — the image build resolves deps at build time (not reproducible). ` +
+          `Run \`${install}\` and commit the lockfile for pinned redeploys.`,
+    });
+  }
+  // The code-path Dockerfile runs `${runner}`: that resolves the workspace's OWN dependency, so a
+  // package.json missing it would make the CONTAINER fetch an unpinned build at runtime (offline-fragile).
+  if (hasPackageJson && !("@kid7st/fastagent" in { ...pkg.dependencies, ...pkg.devDependencies })) {
+    messages.push({
+      level: "warn",
+      text:
+        `package.json does not list @kid7st/fastagent — the image's \`${runner}\` would fetch it at runtime ` +
+        `(offline-fragile, unpinned). Add it to dependencies and re-run \`${install}\`.`,
+    });
+  }
+  const container: ContainerInput = {
+    hasPackageJson,
+    runtime,
+    bunVersion,
+    hasLockfile,
+    version: await fastagentVersion(),
+    apt: config.deploy?.apt,
+  };
+  const port = config.http?.port ?? 8787;
+  // What the agent declared it needs on the box (fastagent.config deploy.secrets) — carried like channel
+  // secrets: listed in the runbook, set from the local env under --run, gated if a value is missing.
+  const extraSecrets = config.deploy?.secrets ?? [];
+  // deploy.apt only shapes the GENERATED Dockerfile. Warn ONLY when the kept Dockerfile is HAND-WRITTEN
+  // (its apt won't include these) — a fastagent-generated one is handled by writeArtifacts. Don't suggest
+  // --force here: it would overwrite the user's hand-written file.
+  if (config.deploy?.apt?.length && !force && (await exists(join(target, "Dockerfile")))) {
+    if (!isGeneratedDockerfile(await readFile(join(target, "Dockerfile"), "utf8"))) {
+      messages.push({
+        level: "warn",
+        text:
+          `kept your hand-written Dockerfile — deploy.apt (${config.deploy.apt.join(", ")}) is ` +
+          `NOT applied; install those packages in your Dockerfile.`,
+      });
+    }
+  }
+
+  return { ok: true, messages, channels, modelAuth, authPath, container, port, extraSecrets };
+}
+
+/**
+ * Why the resolved model won't reach the deployed box, or undefined if it will — host-neutral. `fastagent.config.ts`
+ * is the model's committed home (config's charter: model / tools / http) and the only source deploy ships:
+ * a `--model`/`FASTAGENT_MODEL`/`.env` value is builder-local and doesn't travel (`.env` is dockerignored),
+ * so a model NOT in config crash-loops the box with "missing model". The pre-flight warns (runbook) or gates
+ * (`--run`). Single source on purpose — a host env block (fly.toml `[env]`) is NOT advertised as a second home.
+ */
+export function modelTravelIssue(configModel: string | undefined, modelSpec: string | undefined): string | undefined {
+  if (configModel) return undefined;
+  return modelSpec
+    ? `model "${modelSpec}" is set via --model/FASTAGENT_MODEL, not fastagent.config.ts — it won't reach ` +
+        `the deployed box. Add \`model: "${modelSpec}"\` to fastagent.config.ts.`
+    : `no model in fastagent.config.ts — the deployed box can't resolve one. Add \`model: "provider/id"\`.`;
+}

--- a/src/deploy/railway/plan.ts
+++ b/src/deploy/railway/plan.ts
@@ -21,9 +21,9 @@
  * the required-secret list. `railway.json`'s `healthcheckPath=/health` also fixes the "routed before the
  * server is listening" boot race Fly's deploy hit — Railway only routes once /health passes.
  */
-import type { ChannelKind } from "../scaffold/add-channel.ts";
-import { type Artifact, type ContainerInput, containerArtifacts } from "./container.ts";
-import { isEnvKey, requiredSecrets } from "./secrets.ts";
+import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
+import { isEnvKey, requiredSecrets } from "../secrets.ts";
 
 export interface RailwayPlanInput extends ContainerInput {
   // No `port`: Railway injects PORT and the container CMD/railway.json never name one (unlike Fly's

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -2,7 +2,7 @@
  * `fastagent deploy railway --run` — drive the Railway CLI to completion. The middle of the deploy the
  * plain runbook hands to the operator; `--run` executes it so a coding agent runs ONE command.
  *
- * Railway's model forces differences from the Fly runner (fly-run.ts), all validated against CLI 5.15.0:
+ * Railway's model forces differences from the Fly runner (fly/run.ts), all validated against CLI 5.15.0:
  *
  *  - **`--run` PROVISIONS a project and only runs on an UNLINKED directory** — so it can never deploy
  *    into a project it didn't create. `railway init` isn't check-then-act (it ALWAYS makes a new project)
@@ -23,19 +23,8 @@
  * no bulk stdin import like Fly's `secrets import`). Auth needs an ACCOUNT credential (login or
  * `RAILWAY_API_KEY`), not a project token: `init` creates a project that a project token can't predate.
  */
-import type { ChannelKind } from "../scaffold/add-channel.ts";
-
-export interface RailwayRunResult {
-  code: number;
-  /** Captured stdout, for `--json` queries; empty for streamed (inherited) commands. */
-  stdout: string;
-}
-
-/**
- * The `railway` dispatcher seam. `capture` collects stdout (for `--json` queries); without it the command
- * streams to the terminal (up/deploy) and stdout is empty. `input` is fed to stdin (a secret value).
- */
-export type RailwayRunner = (args: string[], opts?: { capture?: boolean; input?: string }) => Promise<RailwayRunResult>;
+import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import type { CliRunner } from "../runner.ts";
 
 export interface RailwayRunPlan {
   /** Names both the project (`railway init --name`) and the service (`railway add --service`). Railway
@@ -129,7 +118,7 @@ export function parseHasVolume(stdout: string, mountPath: string): boolean {
  */
 export async function deployRailwayRun(
   plan: RailwayRunPlan,
-  railway: RailwayRunner,
+  railway: CliRunner,
   log: (msg: string) => void,
   registerTelegram: (baseUrl: string) => Promise<void>,
 ): Promise<RailwayRunOutcome> {

--- a/src/deploy/runner.ts
+++ b/src/deploy/runner.ts
@@ -1,0 +1,37 @@
+/**
+ * The host-CLI dispatcher seam, shared by every `deploy <host> --run` driver (fly/run.ts, railway/run.ts).
+ * WHAT it does — run a CLI, optionally capture stdout or feed stdin — is identical across hosts; only the
+ * binary and the command sequence differ. Tests inject a fake recorder; production spawns the real CLI.
+ */
+import { spawn } from "node:child_process";
+
+export interface RunResult {
+  code: number;
+  /** Captured stdout (for `--json` queries); empty when the command streamed to the terminal. The CLI's
+   *  stderr is always inherited straight to the terminal, so it is not a field here. */
+  stdout: string;
+}
+
+/** Run `bin args`: `capture` collects stdout (for `--json` queries), else the command streams to the
+ *  terminal (create/deploy) and stdout is empty; `input` is fed to stdin (secrets over stdin, never argv). */
+export type CliRunner = (args: string[], opts?: { capture?: boolean; input?: string }) => Promise<RunResult>;
+
+/**
+ * Production {@link CliRunner}: spawn `bin` in `cwd` (the workspace, so a build/upload context is the
+ * agent). stderr is always inherited to the terminal; stdout is inherited unless `capture`. A spawn
+ * ENOENT (the CLI not on PATH) resolves to code 127 so the caller can gate with an install hint.
+ */
+export function spawnRunner(bin: string, cwd: string): CliRunner {
+  return (args, opts) =>
+    new Promise((res) => {
+      const child = spawn(bin, args, {
+        cwd,
+        stdio: [opts?.input ? "pipe" : "inherit", opts?.capture ? "pipe" : "inherit", "inherit"],
+      });
+      let out = "";
+      child.stdout?.on("data", (d) => (out += String(d)));
+      if (opts?.input) child.stdin?.end(opts.input);
+      child.on("close", (code) => res({ code: code ?? 1, stdout: out }));
+      child.on("error", () => res({ code: 127, stdout: "" })); // ENOENT: bin not on PATH
+    });
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 /**
  * Load a `.env` file into `process.env`, matching Node's `--env-file` / `process.loadEnvFile` precedence
@@ -29,5 +30,18 @@ export function loadEnvFile(file: string): void {
   }
   for (const [key, value] of parsed) {
     if (!(key in process.env)) process.env[key] = value; // env-vs-file: a real env var wins
+  }
+}
+
+/**
+ * Load `<dir>/.env` into `process.env` ({@link loadEnvFile}), treating a MISSING file as normal (no .env)
+ * — the workspace-facing entry every command + the tunnel use. Only ENOENT is swallowed; any other read
+ * error (a corrupt/unreadable file) propagates, so a real problem surfaces instead of silently skipping.
+ */
+export function loadDotEnv(dir: string): void {
+  try {
+    loadEnvFile(join(dir, ".env"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 export interface WorkspaceRuntime {
@@ -27,4 +28,18 @@ export function detectRuntime(dir: string, pkg: { packageManager?: unknown }): W
     return { runtime: "bun", bunVersion: pm.match(/^bun@([^+]+)/)?.[1], hasLockfile: bunLock };
   }
   return { runtime: "node", hasLockfile: existsSync(join(dir, "package-lock.json")) };
+}
+
+/** Parse `<dir>/package.json`, or `{}` when absent/malformed (a real build surfaces the actual error).
+ *  The already-parsed input to {@link detectRuntime} and the deploy dep/lockfile checks. */
+export async function readPackageJson(dir: string): Promise<{
+  packageManager?: unknown;
+  dependencies?: Record<string, unknown>;
+  devDependencies?: Record<string, unknown>;
+}> {
+  try {
+    return JSON.parse(await readFile(join(dir, "package.json"), "utf8"));
+  } catch {
+    return {};
+  }
 }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -10,7 +10,7 @@ import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
-import { loadEnvFile } from "./env.ts";
+import { loadDotEnv } from "./env.ts";
 import { log } from "./log.ts";
 
 export interface Tunnel {
@@ -136,9 +136,14 @@ function channelBasenames(dir: string): string[] {
 export async function announceWebhooks(dir: string, baseUrl: string): Promise<void> {
   log.info(`[fastagent] public URL: ${baseUrl}`);
   try {
-    loadEnvFile(join(dir, ".env")); // so telegram registration sees the tokens
-  } catch {
-    /* no .env is fine */
+    loadDotEnv(dir); // telegram registration reads tokens from .env
+  } catch (error) {
+    // best-effort boundary: a MISSING .env is already tolerated by loadDotEnv; an unreadable one (EACCES,
+    // or .env is a directory) must NOT crash the long-running dev/start server — announceWebhooks is
+    // void-called with no unhandledRejection handler, so a throw here would terminate the process. Warn
+    // (surface it, rule 8) and continue best-effort; telegram registration then degrades to its manual
+    // instruction if the token is absent. loadDotEnv keeps throwing for the synchronous command callers.
+    log.warn(`[fastagent] could not read ${join(dir, ".env")}: ${(error as Error).message} — continuing without it`);
   }
   const channels = channelBasenames(dir);
   if (channels.length === 0) return;

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { type FlyRunPlan, type FlyRunner, authSeedBytes, deployFlyRun } from "../src/deploy/fly-run.ts";
+import { type FlyRunPlan, authSeedBytes, deployFlyRun } from "../src/deploy/fly/run.ts";
+import type { CliRunner } from "../src/deploy/runner.ts";
 import { assembleSecrets } from "../src/deploy/secrets.ts";
 
 /** A fake flyctl: records every call, returns per-command scripted results (default code 0, empty out). */
 function fakeFly(script: (args: string[]) => { code?: number; stdout?: string } = () => ({})) {
   const calls: { args: string[]; input?: string }[] = [];
-  const fly: FlyRunner = async (args, opts) => {
+  const fly: CliRunner = async (args, opts) => {
     calls.push({ args, input: opts?.input });
     const r = script(args);
     return { code: r.code ?? 0, stdout: r.stdout ?? "" };
@@ -23,9 +24,9 @@ const plan = (over: Partial<FlyRunPlan> = {}): FlyRunPlan => ({
   ...over,
 });
 
-const run = (p: FlyRunPlan, fly: FlyRunner, tg = vi.fn(async () => {})) => deployFlyRun(p, fly, () => {}, tg);
+const run = (p: FlyRunPlan, fly: CliRunner, tg = vi.fn(async () => {})) => deployFlyRun(p, fly, () => {}, tg);
 
-describe("deploy/fly-run: the coding-agent deploy journey (benchmark)", () => {
+describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
   it("happy path: auth → create app+volume → set secrets → deploy → telegram webhook", async () => {
     // Fresh account: apps/volumes lists are empty, everything succeeds.
     const { fly, cmds } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
@@ -176,7 +177,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
   });
 });
 
-describe("deploy/fly-run: authSeedBytes (the start-side seed guard)", () => {
+describe("deploy/fly/run: authSeedBytes (the start-side seed guard)", () => {
   it("seeds only when the seed is set AND the auth file is absent (absent-only — no rollback)", () => {
     expect(authSeedBytes(undefined, false)).toBeUndefined(); // no seed → no-op
     expect(authSeedBytes(Buffer.from("hi").toString("base64"), true)).toBeUndefined(); // file present → never clobber

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { modelTravelIssue, parseFlyAppName, planFlyDeploy, toFlyAppName } from "../src/deploy/fly.ts";
+import { parseFlyAppName, planFlyDeploy, toFlyAppName } from "../src/deploy/fly/plan.ts";
+import { modelTravelIssue } from "../src/deploy/preflight.ts";
 
 const flyToml = (p: ReturnType<typeof planFlyDeploy>) => p.artifacts.find((a) => a.path === "fly.toml")!.content;
 const dockerfile = (p: ReturnType<typeof planFlyDeploy>) => p.artifacts.find((a) => a.path === "Dockerfile")!.content;

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { preflightDeploy } from "../src/deploy/preflight.ts";
+import type { FastagentConfig } from "../src/engines/pi/config.ts";
+
+async function workspace(files: Record<string, string> = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "fa-preflight-"));
+  await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
+  for (const [name, content] of Object.entries(files)) await writeFile(join(dir, name), content);
+  return dir;
+}
+
+const call = (target: string, config: FastagentConfig, over: Partial<Parameters<typeof preflightDeploy>[0]> = {}) =>
+  preflightDeploy({
+    target,
+    config,
+    modelSpec: config.model,
+    run: false,
+    force: false,
+    authPathOverride: undefined,
+    ...over,
+  });
+
+describe("deploy/preflight: the host-neutral pre-flight", () => {
+  it("gates --run when the model isn't in config (would ship a crash-loop)", async () => {
+    const dir = await workspace();
+    // model resolved via --model/FASTAGENT_MODEL, absent from config → won't travel.
+    const pre = await call(dir, {}, { modelSpec: "openai/gpt-4o-mini", run: true });
+    expect(pre.ok).toBe(false);
+    if (!pre.ok) expect(pre.gate).toMatch(/fastagent\.config/);
+  });
+
+  it("warns (not gates) about the same model issue without --run", async () => {
+    const dir = await workspace();
+    const pre = await call(dir, {}, { modelSpec: "openai/gpt-4o-mini", run: false });
+    expect(pre.ok).toBe(true);
+    if (pre.ok)
+      expect(pre.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/fastagent\.config/) });
+  });
+
+  it("computes container facts and no model message when the model is in config (markdown agent)", async () => {
+    const dir = await workspace();
+    const pre = await call(dir, { model: "openai/gpt-4o-mini" });
+    expect(pre.ok).toBe(true);
+    if (!pre.ok) return;
+    expect(pre.container.hasPackageJson).toBe(false); // markdown/skills agent → global-install path
+    expect(pre.container.runtime).toBe("node");
+    expect(pre.port).toBe(8787);
+    expect(pre.messages.some((m) => /fastagent\.config/.test(m.text))).toBe(false);
+  });
+
+  it("notes a custom channel (its secrets/webhook are the author's to wire)", async () => {
+    const dir = await workspace();
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(join(dir, "channels"), { recursive: true });
+    await writeFile(join(dir, "channels", "slack.ts"), "export default () => ({});\n");
+    const pre = await call(dir, { model: "openai/gpt-4o-mini" });
+    expect(pre.ok).toBe(true);
+    if (pre.ok)
+      expect(pre.messages).toContainEqual({
+        level: "note",
+        text: expect.stringContaining('channel "slack" is custom'),
+      });
+  });
+
+  it("warns a KEPT hand-written Dockerfile that deploy.apt won't reach; --force suppresses it", async () => {
+    const dir = await workspace({ Dockerfile: "FROM python:3.12\n" }); // no generated marker → hand-written
+    const config: FastagentConfig = { model: "openai/gpt-4o-mini", deploy: { apt: ["git"] } };
+
+    const kept = await call(dir, config, { force: false });
+    expect(kept.ok).toBe(true);
+    if (kept.ok) {
+      expect(kept.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/deploy\.apt.*NOT applied/) });
+    }
+
+    // --force regenerates the Dockerfile, so the kept-hand-written warning does not apply.
+    const forced = await call(dir, config, { force: true });
+    expect(forced.ok).toBe(true);
+    if (forced.ok) expect(forced.messages.some((m) => /NOT applied/.test(m.text))).toBe(false);
+  });
+
+  it("warns a code workspace with no lockfile and no @kid7st/fastagent dep", async () => {
+    const dir = await workspace({ "package.json": JSON.stringify({ name: "a", type: "module" }) });
+    const pre = await call(dir, { model: "openai/gpt-4o-mini" });
+    expect(pre.ok).toBe(true);
+    if (!pre.ok) return;
+    expect(pre.messages.some((m) => /no package-lock\.json/.test(m.text) || /not reproducible/.test(m.text))).toBe(
+      true,
+    );
+    expect(pre.messages.some((m) => /does not list @kid7st\/fastagent/.test(m.text))).toBe(true);
+  });
+});

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   type RailwayRunPlan,
-  type RailwayRunner,
   deployRailwayRun,
   isLinked,
   linkedName,
   parseDomainUrl,
   parseHasVolume,
-} from "../src/deploy/railway-run.ts";
+} from "../src/deploy/railway/run.ts";
+import type { CliRunner } from "../src/deploy/runner.ts";
 
 /** A fake railway CLI: records every call, returns per-command scripted results (default code 0, empty). */
 function fakeRailway(script: (args: string[]) => { code?: number; stdout?: string } = () => ({})) {
   const calls: { args: string[]; input?: string }[] = [];
-  const railway: RailwayRunner = async (args, opts) => {
+  const railway: CliRunner = async (args, opts) => {
     calls.push({ args, input: opts?.input });
     const r = script(args);
     return { code: r.code ?? 0, stdout: r.stdout ?? "" };
@@ -36,10 +36,10 @@ const LINKED = JSON.stringify({ name: "bot", id: "proj-1" });
 // A minted domain, as `railway domain --json` would return it (field name unknown → parser scans values).
 const DOMAIN_JSON = JSON.stringify({ domain: "bot-production.up.railway.app" });
 
-const run = (p: RailwayRunPlan, railway: RailwayRunner, tg = vi.fn(async () => {})) =>
+const run = (p: RailwayRunPlan, railway: CliRunner, tg = vi.fn(async () => {})) =>
   deployRailwayRun(p, railway, () => {}, tg);
 
-describe("deploy/railway-run: the coding-agent deploy journey (benchmark)", () => {
+describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () => {
   it("fresh (unlinked): auth → init+add+volume → variables → up → domain → telegram webhook", async () => {
     const { railway, cmds } = fakeRailway((a) => {
       if (a[0] === "status") return { stdout: "" }; // unlinked → create
@@ -204,7 +204,7 @@ describe("deploy/railway-run: the coding-agent deploy journey (benchmark)", () =
   });
 });
 
-describe("deploy/railway-run: pure parsers", () => {
+describe("deploy/railway/run: pure parsers", () => {
   it("isLinked: non-empty stdout = linked; empty = not (status exits 0 either way)", () => {
     expect(isLinked(LINKED)).toBe(true);
     expect(isLinked("weird non-json")).toBe(true); // any non-empty output counts as linked (refuse-safe)

--- a/test/deploy-railway.test.ts
+++ b/test/deploy-railway.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { planRailwayDeploy } from "../src/deploy/railway.ts";
+import { planRailwayDeploy } from "../src/deploy/railway/plan.ts";
 
 const json = (p: ReturnType<typeof planRailwayDeploy>) => p.artifacts.find((a) => a.path === "railway.json")!.content;
 const runbook = (p: ReturnType<typeof planRailwayDeploy>) => p.runbook.join("\n");

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadEnvFile } from "../src/env.ts";
+import { loadDotEnv, loadEnvFile } from "../src/env.ts";
 
 // A portable .env loader (Node has process.loadEnvFile; Bun does not — same parse must run on both).
 describe("loadEnvFile", () => {
@@ -72,5 +72,19 @@ describe("loadEnvFile", () => {
     expect(() => loadEnvFile(join(tmpdir(), `no-such-${Date.now()}`, ".env"))).toThrow(
       expect.objectContaining({ code: "ENOENT" }),
     );
+  });
+});
+
+describe("loadDotEnv (workspace <dir>/.env, missing is normal)", () => {
+  it("a dir with no .env is a no-op, not a throw", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-dotenv-"));
+    expect(() => loadDotEnv(dir)).not.toThrow(); // ENOENT swallowed
+  });
+
+  it("a NON-ENOENT read error propagates (a corrupt/unreadable .env fails visibly, never silently)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-dotenv-bad-"));
+    // A directory AT the .env path makes readFileSync throw EISDIR — a non-ENOENT error that must surface.
+    await mkdir(join(dir, ".env"));
+    expect(() => loadDotEnv(dir)).toThrow(expect.objectContaining({ code: "EISDIR" }));
   });
 });

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -203,6 +203,21 @@ describe("tunnel: announceWebhooks", () => {
     expect(errs.some((e) => /webhook registered/.test(e))).toBe(true);
   });
 
+  it("does not crash the server when .env is unreadable — warns and continues best-effort", async () => {
+    // Regression: loadDotEnv throws on a NON-ENOENT read error (here .env is a directory → EISDIR).
+    // announceWebhooks is void-called with no unhandledRejection handler, so an uncaught throw would
+    // terminate the long-running dev/start server. It must warn (surface the error) and continue.
+    const errs: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((m) => {
+      errs.push(String(m));
+    });
+    const dir = await workspace([]); // no channels → returns right after the .env read
+    await mkdir(join(dir, ".env")); // a directory at the .env path → loadDotEnv throws EISDIR, not ENOENT
+
+    await expect(announceWebhooks(dir, "https://x.trycloudflare.com")).resolves.toBeUndefined(); // no crash
+    expect(errs.some((e) => /could not read/.test(e) && /\.env/.test(e))).toBe(true); // surfaced, not silent
+  });
+
   it("does not retry a permanent setWebhook error; prints the manual URL immediately", async () => {
     const errs: string[] = [];
     vi.spyOn(console, "error").mockImplementation((m) => {


### PR DESCRIPTION
## What

A structural refactor of the `deploy` subsystem, from a post-iteration scan. Behaviour-preserving except one intended fix in the env cleanup (below); typecheck + 459 tests green.

### Why
`deploy`'s orchestration policy lived inline in `cli.ts`'s `runDeploy` (~130 lines). It was the top churn source: every deploy behaviour change edited the CLI dispatcher, and the host-neutral pre-flight had no isolated test surface. This gives it a home.

## Commits

**1. `refactor(env)` — promote `loadDotEnv`, fix tunnel's best-effort `.env` read**
The `<dir>/.env, missing is normal` pattern lived twice. `tunnel.ts` used a `catch {}` that swallowed *every* error (a corrupt/unreadable `.env` failed silently). The fail-visible version (only ENOENT tolerated) is promoted into `env.ts` and shared.

*Behaviour note (a review catch — thanks):* `announceWebhooks` is best-effort and **void-called** (`start --tunnel`, `dev-supervisor`) with no `unhandledRejection` handler, so a bare `loadDotEnv` there would let a non-ENOENT read error (EACCES / `.env` is a directory) crash the long-running dev/start server. The shared `loadDotEnv` keeps throwing (correct for synchronous command callers), and `announceWebhooks` adds a best-effort boundary: **warn and continue** instead of silently swallowing (old) or crashing (the first draft of this PR). So tunnel `.env` handling changes `silent-swallow → warn-and-continue` — a small, intended step toward fail-visible, not a crash.

**2. `refactor(deploy)` — extract preflight + runner seam, per-host dirs**
- `deploy/preflight.ts` — host-neutral pre-flight (model-travel gate, channel discovery, auth probe, container facts + warnings) as a function returning `{ ok:false, gate } | { ok:true, ...facts }`. Now unit-tested directly (`test/deploy-preflight.test.ts`) instead of only via CLI integration. `modelTravelIssue` moves here (it's host-neutral; leaving it in `fly.ts` would make the neutral kernel depend on a host dir).
- `deploy/runner.ts` — `CliRunner` + `spawnRunner`, replacing two verbatim-duplicated spawn wrappers + identical `FlyRunner`/`RailwayRunner` types.
- `readPackageJson` → `runtime.ts` (next to its consumer `detectRuntime`).
- Per-host dirs `fly/{plan,run}.ts`, `railway/{plan,run}.ts` — a hybrid layout: neutral kernel at top (horizontal) + one dir per host (vertical), so `host` is the legible extension axis (new host = new dir, copy `fly/`). Repo map in `AGENTS.md` updated.

## Layout

```
deploy/
├── preflight.ts container.ts secrets.ts runner.ts   # host-neutral kernel
├── fly/     { plan.ts, run.ts }
└── railway/ { plan.ts, run.ts }
```

## Test
`npm run typecheck && npm test` — 459 passed. New: `test/deploy-preflight.test.ts` (gate vs warn, container facts, `--force` suppression, lockfile/dep warnings); `loadDotEnv` cases in `test/env.test.ts` (missing OK / non-ENOENT propagates); a `tunnel.test.ts` regression (an unreadable `.env` warns + continues, never crashes the server).
