### PR TITLE
fix(host): make pump total — a mid-flight stream error no longer crashes the server

### DIFF
--- a/src/channels/http.ts
+++ b/src/channels/http.ts
@@ -79,10 +79,21 @@ export function nodeListener(
   handler: (req: Request) => Promise<Response>,
 ): (req: IncomingMessage, res: ServerResponse) => void {
   return (req, res) => {
-    void pump(handler, req, res);
+    void pump(handler, req, res); // safe: pump is TOTAL (never rejects) — see its contract below
   };
 }
 
+/**
+ * Consume ONE request and drive its response to a terminal state. pump is TOTAL: a SINGLE try/catch wraps
+ * the whole request→response→stream path, so EVERY failure — a handler throw, a non-Response return
+ * (`response.headers` undefined), a header Node rejects, `getReader`, or a body stream that errors
+ * mid-flight — ends the response and the returned promise NEVER rejects, which is what lets the
+ * `void pump(...)` above be safe. Before any byte goes out (headers not sent) it is a clean 500; once the
+ * response is streaming, the only honest signal left is to destroy the socket (truncated stream, not a
+ * hang). The process installs no `unhandledRejection` handler by design: robustness against a background
+ * throw is each fire-and-forget's OWN contract (fail into a terminal HTTP response here), not a global net
+ * that would blanket-swallow.
+ */
 async function pump(
   handler: (req: Request) => Promise<Response>,
   req: IncomingMessage,
@@ -91,16 +102,14 @@ async function pump(
   const controller = new AbortController();
   res.on("close", () => controller.abort());
 
-  const method = req.method ?? "GET";
-  const hasBody = method !== "GET" && method !== "HEAD";
-  const headers = new Headers();
-  for (const [k, v] of Object.entries(req.headers)) {
-    if (Array.isArray(v)) for (const vv of v) headers.append(k, vv);
-    else if (v != null) headers.set(k, v);
-  }
-
-  let response: Response;
   try {
+    const method = req.method ?? "GET";
+    const hasBody = method !== "GET" && method !== "HEAD";
+    const headers = new Headers();
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (Array.isArray(v)) for (const vv of v) headers.append(k, vv);
+      else if (v != null) headers.set(k, v);
+    }
     const request = new Request(`http://${req.headers.host ?? "localhost"}${req.url ?? "/"}`, {
       method,
       headers,
@@ -108,29 +117,20 @@ async function pump(
       duplex: "half",
       signal: controller.signal,
     } as RequestInit & { duplex: "half" });
-    response = await handler(request);
-  } catch (error) {
-    // Log server-side (some channels' only failure sink), but return a generic body — don't leak the
-    // internal message to the client.
-    log.error(`[host] request handler failed: ${String(error)}`);
-    if (!res.headersSent) res.writeHead(500, textHeaders);
-    res.end("internal error\n");
-    return;
-  }
+    const response = await handler(request);
 
-  const outHeaders: Record<string, string> = {};
-  response.headers.forEach((value, key) => {
-    outHeaders[key] = value;
-  });
-  res.writeHead(response.status, outHeaders);
+    const outHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      outHeaders[key] = value;
+    });
+    res.writeHead(response.status, outHeaders);
 
-  if (!response.body) {
-    res.end();
-    return;
-  }
-  const reader = response.body.getReader();
-  res.on("close", () => void reader.cancel());
-  try {
+    if (!response.body) {
+      res.end();
+      return;
+    }
+    const reader = response.body.getReader();
+    res.on("close", () => void reader.cancel());
     for (;;) {
       const { done, value } = await reader.read();
       if (done || res.destroyed) break;
@@ -139,17 +139,32 @@ async function pump(
       // suspend pump() forever (leaking the request/stream).
       if (!res.write(value)) {
         await new Promise<void>((resolve) => {
-          const done = () => {
-            res.off("drain", done);
-            res.off("close", done);
+          const settle = () => {
+            res.off("drain", settle);
+            res.off("close", settle);
             resolve();
           };
-          res.once("drain", done);
-          res.once("close", done);
+          res.once("drain", settle);
+          res.once("close", settle);
         });
       }
     }
-  } finally {
-    if (!res.destroyed) res.end();
+    if (!res.destroyed) res.end(); // normal completion
+  } catch (error) {
+    // The ONE totality boundary: every failure above lands here, so pump never rejects (see the header
+    // doc) — which REQUIRES the catch itself not to throw. Don't leak the internal message to the client.
+    log.error(`[host] request failed: ${String(error)}`);
+    // Never touch an already-terminal res: a client that disconnects during the handler await destroys res
+    // (headers not yet sent), and writeHead/end on a dead socket can throw ERR_STREAM_DESTROYED here — which
+    // WOULD be the unhandled rejection this boundary exists to kill. One named gate states the invariant;
+    // with it the catch is provably non-throwing (writeHead only when !headersSent && !destroyed, destroy is
+    // idempotent).
+    if (res.destroyed) return;
+    if (res.headersSent) {
+      res.destroy(error instanceof Error ? error : undefined); // streaming → truncate (not a hang)
+    } else {
+      res.writeHead(500, textHeaders); // pre-header → a clean 500
+      res.end("internal error\n");
+    }
   }
 }

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { EventEmitter } from "node:events";
 import type { AddressInfo } from "node:net";
@@ -207,6 +207,25 @@ describe("nodeListener (standalone server bridge)", () => {
     }
   });
 
+  it("a handler that returns a non-Response (forgot to return) yields 500, not a server crash", async () => {
+    // The handler is typed (req) => Promise<Response>, but loadChannels loads arbitrary user code: a channel
+    // that forgets to return (undefined) makes response.headers undefined — a TypeError in the gap BETWEEN
+    // the old handler-catch and the stream-try. pump is TOTAL, so this fails into a 500, never escaping as
+    // the unhandled rejection that would crash the server (a crash would hang/error this fetch instead).
+    const badHandler = (async () => undefined) as unknown as (req: Request) => Promise<Response>;
+    const server = createServer(nodeListener(badHandler));
+    await new Promise<void>((r) => server.listen(0, r));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const res = await fetch(`http://localhost:${port}/x`, { method: "POST", body: "{}" });
+      expect(res.status).toBe(500);
+      expect(await res.text()).toBe("internal error\n");
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
   it("client disconnect cancels invoke through the node bridge (SPEC MUST 3)", async () => {
     let cancelled = false;
     let resolveCancelled!: () => void;
@@ -258,6 +277,7 @@ describe("nodeListener (standalone server bridge)", () => {
 });
 
 describe("nodeListener backpressure", () => {
+  afterEach(() => vi.restoreAllMocks());
   /** Minimal IncomingMessage: GET (no body) so the bridge needs no request stream. */
   function fakeReq(): IncomingMessage {
     const req = new EventEmitter() as unknown as IncomingMessage & {
@@ -276,13 +296,71 @@ describe("nodeListener backpressure", () => {
     res.destroyed = false;
     (res as { ended: boolean }).ended = false;
     (res as unknown as { headersSent: boolean }).headersSent = false;
-    (res as unknown as { writeHead: () => ServerResponse }).writeHead = () => res;
+    (res as unknown as { writeHead: () => ServerResponse }).writeHead = () => {
+      (res as { headersSent: boolean }).headersSent = true; // real ServerResponse flips this on writeHead
+      return res;
+    };
     (res as unknown as { write: () => boolean }).write = () => false; // always backpressure
     (res as unknown as { end: () => void }).end = () => {
       (res as { ended: boolean }).ended = true;
     };
+    (res as unknown as { destroy: () => void }).destroy = () => {
+      (res as { destroyed: boolean }).destroyed = true;
+    };
     return res as ServerResponse & { ended: boolean; destroyed: boolean };
   }
+
+  it("catch never writes to an already-destroyed res (client disconnect during the handler await)", async () => {
+    // A client that disconnects while pump awaits the handler destroys res (headers not yet sent) and the
+    // handler throws (AbortError). The catch must NOT writeHead/end on the dead socket — Node can throw
+    // ERR_STREAM_DESTROYED there, which would make the catch itself throw → pump rejects → the very crash.
+    // The stub throws if writeHead/end is called on a destroyed res, so a regression re-appears as an
+    // unhandled rejection vitest surfaces.
+    let touchedDeadSocket = false;
+    const res = fakeRes();
+    (res as { destroyed: boolean }).destroyed = true; // client already disconnected
+    const boom = () => {
+      touchedDeadSocket = true;
+      throw new Error("ERR_STREAM_DESTROYED");
+    };
+    (res as unknown as { writeHead: () => ServerResponse }).writeHead = boom as never;
+    (res as unknown as { end: () => void }).end = boom as never;
+    const handler = (async () => {
+      throw new Error("aborted");
+    }) as unknown as (req: Request) => Promise<Response>;
+
+    nodeListener(handler)(fakeReq(), res);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(touchedDeadSocket).toBe(false); // early-returned; never touched the dead socket (so pump didn't reject)
+  });
+
+  it("a body stream that errors mid-flight is handled, not an unhandled rejection that crashes the server", async () => {
+    // pump is TOTAL: a mid-flight reader error must be caught, logged, and end the response — NEVER escape
+    // as an unhandled rejection (pump is void-called; the process has no unhandledRejection handler). If it
+    // escaped, vitest would surface the rejection and fail this test.
+    const errs: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((m) => {
+      errs.push(String(m));
+    });
+    const handler = async (): Promise<Response> => {
+      let n = 0;
+      const stream = new ReadableStream<Uint8Array>({
+        pull(c) {
+          if (n++ === 0) c.enqueue(new TextEncoder().encode("data: x\n\n"));
+          else throw new Error("stream blew up mid-flight"); // 2nd pull errors the stream
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/event-stream" } });
+    };
+    const req = fakeReq();
+    const res = fakeRes();
+    (res as unknown as { write: () => boolean }).write = () => true; // no backpressure — let pump loop to the 2nd (erroring) pull
+    nodeListener(handler)(req, res);
+
+    await new Promise((r) => setTimeout(r, 30)); // let pump write once, then hit the erroring pull
+    expect(res.destroyed).toBe(true); // destroyed on the stream error
+    expect(errs.some((e) => /request failed/.test(e))).toBe(true); // surfaced (rule 8)
+  });
 
   it("client close during backpressure ends pump (no leak; regression for drain-only wait)", async () => {
     // An endless SSE stream so pump always has more to write and parks on backpressure.


### PR DESCRIPTION
## What

Closes a latent crash on the core HTTP host: no request path can terminate the long-running `dev`/`start` server via an unhandled rejection. Found by a scan for the same class as the tunnel bug (#179).

## The bug

`pump` (the node:http adapter in `channels/http.ts`) is **void-called** by `nodeListener`, and the process installs **no `unhandledRejection` handler**. So any throw that escapes `pump` terminates the server.

`pump` previously guarded only **two** regions — a `handler()` throw (→ 500) and a mid-flight stream error — leaving the code **between** them unguarded:
- `response.headers.forEach(...)` — a non-Response return (a channel that forgot to `return` → `response.headers` undefined → TypeError). The common case, and exactly the "non-conformant channel" threat.
- `res.writeHead(response.status, ...)` — a header value Node rejects.
- `response.body.getReader()`.

A throw there escaped as an unhandled rejection **and**, being pre-headers, left the response hanging.

## The fix (the contract, not another patch)

Collapse to a **single `try/catch` totality boundary** wrapping the whole request→response→stream path. Every failure lands in one `catch` that branches on `res.headersSent`:
- **not sent** → a clean `500` + end (client can retry);
- **already streaming** → `destroy` the socket (truncated stream, not a hang), never leaking the internal message.

`pump`'s returned promise now **never rejects by construction** — so `void pump(...)` is safe *by contract*, stated in the docstring.

**Deliberately not** a global `unhandledRejection` net: robustness against a background throw is each fire-and-forget's own contract (fail into a terminal state), not a blanket swallow that would hide real bugs (rule 8). The scan audited every other `void`-async site — all already total/guarded (`turn-queue` task `try/catch`, `github`/`telegram` `.then(f,r)`, `channel.ts` async-factory guard, `dev-supervisor`'s `process.exit`).

## Tests
Two new regressions in `test/http.test.ts`:
- a **non-Response** handler return (the common "forgot to return" gap) → the client sees `500`, no crash;
- a body stream that **errors mid-flight** → response `destroy`ed + logged.

Neither escapes as an unhandled rejection (vitest would surface it). `npm run typecheck && npm test` — 461 passed.

## Review note
Thanks for catching that the first draft only closed half the totality (the stream loop, not the sibling gap between the handler catch and the stream try). This revision makes the single-boundary structure so "never rejects" is actually true.
