### PR TITLE
docs: launch prep — deployment guide, ai-start hardening, llms.txt raw links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ dist/
 .fastagent/
 *.log
 .DS_Store
-.brooks-lint-history.json

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ npm i -g @kid7st/fastagent   # CLI: fastagent init/dev/start/...
 npm i @kid7st/fastagent      # library API for embedding or code tools
 ```
 
-Requires **Node >= 22.19** — the floor is inherited from the reference engine (`@earendil-works/pi-agent-core`) and `undici`, both of which require it. The npm package ships compiled JavaScript and type declarations.
+Requires **Node >= 22.19** (the floor is inherited from the reference engine `@earendil-works/pi-agent-core` and `undici`), and also runs under **Bun** (verified on Bun 1.3 — its native fetch replaces the undici path). The npm package ships compiled JavaScript and type declarations.
 
 ## Quickstart
 
@@ -148,6 +148,7 @@ const agent = createPiAgent({
 | [docs/cli.md](docs/cli.md) | CLI reference |
 | [docs/embedding.md](docs/embedding.md) | Use FastAgent as a library inside your own app |
 | [docs/channels.md](docs/channels.md) | Add webhook/bot channels |
+| [docs/deploy.md](docs/deploy.md) | Ship the directory to Fly, Railway, or any Docker host |
 | [docs/github.md](docs/github.md) / [docs/telegram.md](docs/telegram.md) | First-party channel guides |
 | [docs/channel-development.md](docs/channel-development.md) | Build custom channel adapters |
 | [docs/api-reference.md](docs/api-reference.md) | Public TypeScript API reference |

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Using a coding agent? Give it the repository's [`ai-start.md`](ai-start.md) for 
 | Configure model, auth, ports, sessions, tools, and channels | [Configuration](configuration.md) |
 | Embed an agent in an existing app or route | [Embedding](embedding.md) |
 | Connect GitHub, Telegram, or another channel | [Channels](channels.md) |
+| Ship the agent to a host | [Deploy](deploy.md) |
 
 ## Channel guides
 

--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -9,8 +9,19 @@ Goal: turn an existing agent directory into a deployable agent without rewriting
 
 FastAgent mental model:
 - The directory is the agent: AGENTS.md + skills/ + optional tools/ + optional channels/.
-- FastAgent can run it locally, embed it in my app, or connect it to channels like GitHub and Telegram.
+- FastAgent can run it locally, embed it in my app, connect it to channels like GitHub and Telegram, or deploy it to a host.
 - Do not invent a new framework layout unless I ask. Prefer the existing directory.
+
+How you run FastAgent commands (you are a non-interactive agent, so this matters):
+- A model must be set EXPLICITLY. With no model, `dev`/`start`/`invoke` fall back to an interactive
+  picker you cannot answer, and fail with `missing model`. So: run `fastagent login` (ask me which
+  provider first), list specs with `fastagent models`, then ALWAYS pass `--model provider/id` (or set
+  FASTAGENT_MODEL, or write `model:` into fastagent.config.*). Never rely on the interactive prompt.
+- Some commands EXIT, others BLOCK. `info`, `models`, `invoke`, `tool` return — use these for checks
+  and smoke tests. `dev` and `start` are long-running servers: do NOT run them in the foreground (you
+  will hang waiting) — background them, or let me run them.
+- Secrets live in `.env` (copy from `.env.example`) or come from `fastagent login`. Ask me before
+  adding one; never commit `.env`, credentials, sessions, or `.fastagent/` machine state.
 
 First inspect my project:
 1. Check whether AGENTS.md exists.
@@ -18,17 +29,21 @@ First inspect my project:
 3. Check package.json for "type": "module" if code tools are present.
 4. Ask before choosing a model provider or adding secrets.
 
-If I do not have a workspace yet:
-- Run: fastagent init <dir>
-- Then explain the generated files.
+Set up (init is the single entry point — the same command whether or not I already have a workspace):
+- Run: fastagent init <dir> (default: current dir). It adopts an existing AGENTS.md, keeps an existing
+  config, and only fills the missing pieces — idempotent, never clobbers. On a fresh dir it scaffolds a
+  full example agent.
+- Then run: fastagent info (read-only) — it shows what the directory assembles into (model, AGENTS.md,
+  skills, tools, channels). Fix only what it reports.
+- Adopting a directory that is ALSO a TypeScript project? Its tsconfig `include` may compile the
+  scaffolded/added `.ts` tools and channels against deps it doesn't have — keep the agent in a subdir,
+  or add `tools`/`channels` to the host tsconfig `exclude`.
 
-If I already have a workspace:
-- Run: fastagent info
-- Fix only the issues it reports.
-
-For local testing:
-- Run: fastagent dev
-- Send a test turn to POST /invoke, or run: fastagent invoke "hello"
+For local testing (prefer commands that exit):
+- Smoke-test one turn: fastagent invoke "hello" --model provider/id
+- Test one tool without a model: fastagent tool <name> '<json>'
+- Only if I want a live server: fastagent dev --model provider/id (long-running — background it or let
+  me run it), then send a turn to POST /invoke.
 
 For tools:
 - Put tools in tools/<name>.ts.
@@ -50,10 +65,19 @@ For embedding:
 - Mount createInvokeHandler(agent) in my app route.
 - Keep my app's auth/database/session ownership in my app.
 
+For deploy:
+- Run: fastagent deploy fly (or: fastagent deploy railway). Add --run to drive the host CLI to
+  completion; without it, follow the printed runbook.
+- The model MUST be in fastagent.config.* — a --model/FASTAGENT_MODEL/.env value is builder-local and
+  won't reach the deployed box (it would crash-loop with `missing model`).
+- Declare any extra host secrets in config.deploy.secrets; register channel webhooks at the live URL.
+
 Before finishing:
 - Run fastagent info.
-- Run the smallest useful smoke test: fastagent invoke "hello" or a channel-specific local test.
+- Run the smallest useful smoke test that EXITS: fastagent invoke "hello" --model provider/id (or a
+  channel-specific local test). Do not leave `dev`/`start` running in the foreground.
 - Do not commit .env, credentials, sessions, or .fastagent machine state.
+- If a command fails, read docs/troubleshooting.md before guessing.
 ```
 
 References:
@@ -62,4 +86,5 @@ References:
 - [Configuration](configuration.md)
 - [Embedding](embedding.md)
 - [Channels](channels.md)
+- [Deploy](deploy.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,96 @@
+---
+title: Deploy
+status: current
+---
+
+# Deploy
+
+FastAgent has **no build step** — the directory is the deployable unit. Deployment is: copy the workspace to a host with Node >= 22.19 (or Bun), install dependencies, and run `fastagent start`. The `deploy` command wraps that for a specific host: it generates the host config + container recipe from your resolved definition and prints an ordered, values-filled runbook. `--run` drives the host CLI to completion instead of handing you the runbook.
+
+```bash
+fastagent deploy fly       # generate artifacts + print a flyctl runbook
+fastagent deploy fly --run # drive flyctl to completion
+fastagent deploy railway
+fastagent deploy railway --run
+```
+
+Two ends only FastAgent can compute are generated for you — the definition-aware artifacts (state root → volume, the exact secret list, autostop tuned to the turn model) and the post-deploy webhook step. The middle (the host CLI) is either a runbook you (or a coding agent) run, or `--run`.
+
+## Before you deploy
+
+Three things must be true, or the deployed box crash-loops on boot:
+
+| Requirement | Why | How |
+|---|---|---|
+| **Model is in `fastagent.config.*`** | A `--model` flag, `FASTAGENT_MODEL`, or `.env` value is builder-local and does **not** travel (`.env` is dockerignored). Only the config file ships. | `model: "provider/id"` in `fastagent.config.mjs`. `deploy` warns (or, under `--run`, gates) if it's missing. |
+| **Secrets are declared** | The host needs the model API key and every channel's verification secret. | Env-key model auth + channel secrets are auto-listed; declare anything else in `config.deploy.secrets` (see [Configuration](configuration.md)). |
+| **State goes on a volume** | Sessions, `auth.json`, and channel state live under one root; a redeploy that replaces the directory wipes them otherwise. | Both recipes mount a volume at `/data` and set `FASTAGENT_STATE_DIR=/data`. |
+
+Model auth: if your local auth is an **env key** (e.g. `OPENAI_API_KEY`), `deploy` lists it as a host secret automatically. If it's an OAuth/stored login, the plan can't read its value — set a provider API key as a host secret, or place `auth.json` on the volume yourself.
+
+## Fly.io
+
+Prereqs: [flyctl](https://fly.io/docs/flyctl/install) installed and `fly auth login`.
+
+```bash
+fastagent deploy fly
+```
+
+Generates `fly.toml`, `Dockerfile`, `.dockerignore`, then prints a first-deploy runbook:
+
+1. `fly apps create <name>` — one-time (Fly app names are globally unique; if taken, edit `app` in `fly.toml` and re-run `deploy`).
+2. `fly volumes create data --region <region> --size 1` — one-time; the region **must** match `primary_region` in `fly.toml`.
+3. `fly secrets set …` — the model key + each channel's secrets, with `<value>` placeholders to fill.
+4. `fly deploy` — build and ship. **A redeploy is this step alone.**
+5. Register each channel's webhook at the live URL (`https://<name>.fly.dev/telegram`, `/webhook`).
+
+Or let the CLI do all of it:
+
+```bash
+fastagent deploy fly --run   # idempotent, resumable; carries your local env secrets to Fly
+```
+
+Idle behavior defaults to **suspend** (snapshot + fast resume on the next webhook, ~hundreds of ms). Flags: `--stop` (cold-stop instead of suspend), `--no-scale-to-zero` (keep one machine always up), `--force` (overwrite artifacts). A GitHub channel forces one machine to stay up — its fire-and-forget turns have no replay, so scaling the last machine to zero could drop an in-flight review.
+
+## Railway
+
+Prereqs: the [Railway CLI](https://docs.railway.com/guides/cli) and `railway login`.
+
+```bash
+fastagent deploy railway
+```
+
+Generates `railway.json` (with `healthcheckPath=/health`), `Dockerfile`, `.dockerignore`, then prints the runbook. Railway's source of truth is the linked **project's platform state**, not a committed file, so setup is ordered CLI steps:
+
+1. `railway init` — create + link a project (or `railway link` to attach an existing one).
+2. `railway add --service <name>` — the volume and variables are service-scoped; the service must exist first.
+3. `railway volume add --mount-path /data` — persistent state.
+4. `railway variables set FASTAGENT_STATE_DIR=/data <SECRETS>` — **before** the first deploy, or the box boots without them.
+5. `railway up` — upload + build the Dockerfile on Railway (no local Docker). **A redeploy is this step alone.**
+6. `railway domain` — mint the public URL (Railway's `*.up.railway.app` is not deterministic; read it back), then register each channel's webhook against it.
+
+Or:
+
+```bash
+fastagent deploy railway --run   # drives the CLI on an UNLINKED dir; carries your local env secrets
+```
+
+`--run` refuses a dir already linked to a project unless you pass `--into-linked`. Scale-to-zero (App Sleeping) is a **dashboard-only** toggle Railway exposes no CLI/API for — the runbook states it as a manual step (Settings → Deploy → Serverless → App Sleeping). Don't enable it with a GitHub channel, for the same no-replay reason as Fly.
+
+## Any Docker host
+
+The generated `Dockerfile` runs the directory on any container platform — the `deploy` targets above just wire the platform specifics around it. Bring your own host by using the `Dockerfile` directly and providing, yourself, what the recipes automate: a persistent volume mounted where `FASTAGENT_STATE_DIR` points, the secrets as env vars, and the channel webhooks.
+
+`config.deploy.apt` bakes extra apt packages into the image; a package needing a custom apt repo or a different base image means providing your own `Dockerfile` (`deploy` keeps an existing one). See [Configuration](configuration.md#config-file).
+
+If your agent runs git over its **own** history (`git log`/`git blame` on the repo it ships in), delete the `.git` line from the generated `.dockerignore` so history is included.
+
+## Single-machine tier
+
+All shipped recipes are single-machine: state lives on **one** volume tied to **one** machine/service. Scaling to multiple instances gives each its own volume and splits sessions/turns — that needs a shared/external backend on the `PiSessionStore` / `Lease` seams (see [Embedding](embedding.md)), not this recipe. Don't scale past one instance.
+
+## Where next
+
+- [CLI reference](cli.md) — the full `deploy` flag list.
+- [Configuration](configuration.md) — `deploy.secrets`, `deploy.apt`, and state-root knobs.
+- [Channels](channels.md) — webhook registration and the fire-and-forget vs replay model.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -96,6 +96,7 @@ fastagent add telegram
 | Use CLI commands | [CLI reference](cli.md) |
 | Embed in an app | [Embedding](embedding.md) |
 | Add webhooks/bots | [Channels](channels.md) |
+| Ship to Fly, Railway, or any Docker host | [Deploy](deploy.md) |
 | Use GitHub webhooks | [GitHub channel](github.md) |
 | Use Telegram bots | [Telegram channel](telegram.md) |
 | Build a channel adapter | [Channel development](channel-development.md) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -174,5 +174,6 @@ Read [Channels](channels.md) for the channel model, [GitHub channel](github.md) 
 
 - [Embedding](embedding.md) — use FastAgent as a library inside your own app.
 - [Channels](channels.md) — webhook and bot adapters.
+- [Deploy](deploy.md) — ship the directory to Fly, Railway, or any Docker host.
 - [Agent Handler SPEC](SPEC.md) — the event stream contract.
 - [Core design](design/core.md) — maintainer architecture notes.

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Key facts:
 
-- Install: `npm i -g @kid7st/fastagent` (CLI) or `npm i @kid7st/fastagent` (library). Requires Node >= 22.19.
+- Install: `npm i -g @kid7st/fastagent` (CLI) or `npm i @kid7st/fastagent` (library). Requires Node >= 22.19 (also runs under Bun).
 - The directory is the agent: optional `AGENTS.md`, `skills/`, `tools/`, `channels/`, markdown context, and `fastagent.config.*`. No framework rewrite, no build step.
 - The contract is `invoke(scope, prompt) => AsyncIterable<AgentEvent>` (the Agent Handler SPEC).
 - Core CLI: `fastagent init | info | dev | chat | invoke | tool | start | add | login`.
@@ -12,31 +12,32 @@ Key facts:
 
 ## Start here
 
-- [README](https://github.com/kid7st/fastagent/blob/main/README.md): project overview, install, quickstart, features.
-- [AI-guided setup prompt](https://github.com/kid7st/fastagent/blob/main/docs/ai-start.md): paste into a coding agent to scaffold or wire a workspace.
-- [Documentation index](https://github.com/kid7st/fastagent/blob/main/docs/README.md): the full doc map.
+- [README](https://raw.githubusercontent.com/kid7st/fastagent/main/README.md): project overview, install, quickstart, features.
+- [AI-guided setup prompt](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/ai-start.md): paste into a coding agent to scaffold or wire a workspace.
+- [Documentation index](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/README.md): the full doc map.
 
 ## Guides
 
-- [Overview](https://github.com/kid7st/fastagent/blob/main/docs/overview.md): what FastAgent is and is not.
-- [Quickstart](https://github.com/kid7st/fastagent/blob/main/docs/quickstart.md): scaffold, run locally, add a tool, and start.
-- [Configuration](https://github.com/kid7st/fastagent/blob/main/docs/configuration.md): model, auth, ports, sessions, tools, and channels.
-- [CLI reference](https://github.com/kid7st/fastagent/blob/main/docs/cli.md): every command and flag.
-- [Embedding](https://github.com/kid7st/fastagent/blob/main/docs/embedding.md): use FastAgent as a library inside your own app.
-- [Channels](https://github.com/kid7st/fastagent/blob/main/docs/channels.md): add webhook/bot channels.
-- [GitHub channel](https://github.com/kid7st/fastagent/blob/main/docs/github.md): GitHub webhook events.
-- [Telegram channel](https://github.com/kid7st/fastagent/blob/main/docs/telegram.md): Telegram bot.
-- [Channel development](https://github.com/kid7st/fastagent/blob/main/docs/channel-development.md): build a custom channel adapter.
-- [Troubleshooting](https://github.com/kid7st/fastagent/blob/main/docs/troubleshooting.md): common setup/runtime issues.
+- [Overview](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/overview.md): what FastAgent is and is not.
+- [Quickstart](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/quickstart.md): scaffold, run locally, add a tool, and start.
+- [Configuration](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/configuration.md): model, auth, ports, sessions, tools, and channels.
+- [CLI reference](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/cli.md): every command and flag.
+- [Embedding](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/embedding.md): use FastAgent as a library inside your own app.
+- [Channels](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/channels.md): add webhook/bot channels.
+- [GitHub channel](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/github.md): GitHub webhook events.
+- [Telegram channel](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/telegram.md): Telegram bot.
+- [Channel development](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/channel-development.md): build a custom channel adapter.
+- [Deploy](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/deploy.md): ship the directory to Fly, Railway, or any Docker host.
+- [Troubleshooting](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/troubleshooting.md): common setup/runtime issues.
 
 ## Reference
 
-- [API reference](https://github.com/kid7st/fastagent/blob/main/docs/api-reference.md): public TypeScript exports.
-- [Agent Handler SPEC](https://github.com/kid7st/fastagent/blob/main/docs/SPEC.md): the v0.1 protocol contract.
-- [Design principles](https://github.com/kid7st/fastagent/blob/main/docs/principles.md): design choices, core primitives, and non-goals.
+- [API reference](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/api-reference.md): public TypeScript exports.
+- [Agent Handler SPEC](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/SPEC.md): the v0.1 protocol contract.
+- [Design principles](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/principles.md): design choices, core primitives, and non-goals.
 
 ## Optional
 
-- [Core design notes](https://github.com/kid7st/fastagent/blob/main/docs/design/core.md): pi reference implementation architecture.
-- [Contributing](https://github.com/kid7st/fastagent/blob/main/CONTRIBUTING.md): branch model, PR loop, and review tiers.
-- [Security policy](https://github.com/kid7st/fastagent/blob/main/SECURITY.md): how to report a vulnerability.
+- [Core design notes](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/design/core.md): pi reference implementation architecture.
+- [Contributing](https://raw.githubusercontent.com/kid7st/fastagent/main/CONTRIBUTING.md): branch model, PR loop, and review tiers.
+- [Security policy](https://raw.githubusercontent.com/kid7st/fastagent/main/SECURITY.md): how to report a vulnerability.


### PR DESCRIPTION
Launch-readiness docs + one hygiene fix. Pure docs/meta, no code.

## What
- **`docs/deploy.md` (new)** — the deployment guide the README markets but docs lacked. Happy-path for `deploy fly` / `deploy railway` (prereqs, first-deploy runbook, `--run`, idle/scale behavior), "any Docker host", and the single-machine tier. Wired into `README.md`, `docs/README.md`, `docs/overview.md`, `docs/quickstart.md`.
- **`docs/ai-start.md`** — hardened for the actual executor (a non-interactive coding agent): a model must be set explicitly (the interactive picker cannot be answered → `missing model`); `dev`/`start` are long-running and block, so prefer exit-on-completion commands for smoke tests; added a deploy section and `.env`/BotFather guidance.
- **`llms.txt`** — links switched from GitHub `blob` (HTML chrome) to `raw.githubusercontent` markdown (better for LLM ingestion); added the deploy guide + a Bun runtime note.
- **`README.md`** — note that it also runs under Bun; deploy doc added to the table.
- **`.gitignore`** — dropped an internal lint tool's filename (kept in repo-local `.git/info/exclude`).

## Not included
- The `package.json` author tweak was dropped: it is the only file that conflicts with upstream, and `main` deliberately keeps the collective "the fastagent authors" attribution across a release.

## Verify
No code touched; biome lints only `src`/`test`. All relative doc links resolve; `llms.txt` raw URLs all map to real repo files.
