### PR TITLE
test(telegram): drain turns deterministically to kill the preview-test flake

### DIFF
--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -431,6 +431,10 @@ export function telegramChannel({
       }
       return new Response(null, { status: 200 });
     };
+    // Test/observability seam: await the fire-and-forget turns this handler enqueues. Inert in production
+    // (nothing reads it; the runtime never drains — see turn-queue), it lets a test await a turn
+    // deterministically instead of polling for side effects to settle.
+    (handler as typeof handler & { turnsIdle?: () => Promise<void> }).turnsIdle = () => queue.idle();
     return { "POST /telegram": handler };
   };
 }

--- a/src/channels/telegram/turn-queue.ts
+++ b/src/channels/telegram/turn-queue.ts
@@ -15,6 +15,10 @@ import { log } from "../../log.ts";
 export interface TurnQueue<T> {
   /** Schedule onto the session's serial chain (runs after that session's previous turn). */
   accept(rec: T): void;
+  /** Resolve once no turn is in flight (every per-session chain has drained). A test/observability seam
+   *  — the production runtime does NOT drain on shutdown (SIGTERM exits mid-turn by design; see the module
+   *  header), so this is not a graceful-drain hook; it just lets a caller await the fire-and-forget turns. */
+  idle(): Promise<void>;
 }
 
 export function createTurnQueue<T extends { session: string }>(opts: {
@@ -52,6 +56,12 @@ export function createTurnQueue<T extends { session: string }>(opts: {
       void next.finally(() => {
         if (chains.get(rec.session) === next) chains.delete(rec.session); // drop the entry when drained
       });
+    },
+    async idle() {
+      // Await outstanding chains until none remain — a chain may schedule a follow-up turn, and each
+      // deletes its own map entry on settle, so an emptied map means every turn ran to completion. The
+      // tasks catch their own rejections, but allSettled keeps idle() itself total regardless.
+      while (chains.size > 0) await Promise.allSettled([...chains.values()]);
     },
   };
 }

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -28,7 +28,16 @@ function replyingAgent(reply = "") {
  *  several hops, so rather than couple to a fixed tick count, settle until the Bot API mock goes quiet
  *  (no new fetch for a full tick) — robust to adding/removing an await. (Real-timer tests only; the
  *  fake-timer tests drive their own clock with advanceTimersByTimeAsync.) */
+// Channels built via the test helper register their turn-queue `idle()` here so afterEach can drain a
+// test's fire-and-forget turns BEFORE unstubbing fetch (see afterEach). flush() stays a heuristic: some
+// tests call it to observe a MID-FLIGHT side effect (an "⏳ queued" notice while a turn is parked on a
+// gate), so it must NOT block on full completion.
+const channelIdles = new Set<() => Promise<void>>();
+
 const flush = async () => {
+  // Settle async up to where the fetch-call count stops changing. Intra-test only — the cross-test leak
+  // this used to cause (an early return under load letting a late call land on the next test's mock) is
+  // closed deterministically by the afterEach drain, not by making flush() wait for full completion.
   const f = globalThis.fetch as unknown as { mock?: { calls: unknown[] } };
   let prev = -1;
   for (let i = 0; i < 100 && (f.mock?.calls.length ?? 0) !== prev; i++) {
@@ -71,10 +80,16 @@ function okFetch() {
   });
 }
 
-afterEach(() => {
-  vi.useRealTimers();
+afterEach(async () => {
+  vi.useRealTimers(); // real timers so a turn parked on the preview throttle can fire during the drain
+  // Drain this test's in-flight turns BEFORE unstubbing fetch, so a background turn's late call runs
+  // against THIS test's mock and can't leak onto the next test's (the cross-test contamination that made
+  // the preview tests flaky under CI load). Bounded: a test that deliberately parks a turn without
+  // releasing it must not hang teardown — that is its own leak to fix, not a reason to stall every run.
+  await Promise.race([Promise.all([...channelIdles].map((idle) => idle())), new Promise((r) => setTimeout(r, 2000))]);
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  channelIdles.clear();
   for (const d of stateDirs.splice(0)) rmSync(d, { recursive: true, force: true });
 });
 
@@ -99,7 +114,11 @@ const telegramChannel = (agent: Agent, { stateDir, ...opts }: TelegramChannelOpt
   const home = stateDir ?? freshStateDir();
   const root = rootOfHome.get(home);
   if (!root) throw new Error("test stateDir must come from freshStateDir()");
-  return buildTelegramChannel(opts)({ agent, stateRoot: root })["POST /telegram"]!;
+  const handler = buildTelegramChannel(opts)({ agent, stateRoot: root })["POST /telegram"]!;
+  // Register the turn-queue idle so flush() awaits this channel's fire-and-forget turns deterministically.
+  const idle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
+  if (idle) channelIdles.add(idle);
+  return handler;
 };
 
 describe("durable group buffer (single-process restarts)", () => {

--- a/test/turn-queue.test.ts
+++ b/test/turn-queue.test.ts
@@ -31,6 +31,34 @@ describe("turn-queue", () => {
     expect(ran).toEqual(["p1"]);
   });
 
+  it("idle() resolves only after every in-flight turn has run to completion", async () => {
+    // The deterministic drain the telegram test harness relies on: a gated turn keeps idle() pending;
+    // releasing it lets idle() resolve. Without this, tests fall back to polling side effects (racy).
+    const done: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const queue = makeQueue(async (r) => {
+      await gate;
+      done.push(r.id);
+    });
+    queue.accept(rec("1"));
+    queue.accept(rec("2", "other")); // a different session runs concurrently; both gate on `gate`
+
+    let settled = false;
+    const idle = queue.idle().then(() => (settled = true));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).toBe(false); // turns are still parked — idle() must NOT have resolved
+
+    release();
+    await idle;
+    expect(settled).toBe(true);
+    expect(done.sort()).toEqual(["1", "2"]); // resolved only once both chains drained
+  });
+
+  it("idle() resolves immediately when the queue is empty", async () => {
+    await expect(makeQueue(async () => {}).idle()).resolves.toBeUndefined();
+  });
+
   it("serializes per session (FIFO) while different sessions run concurrently", async () => {
     const order: string[] = [];
     let releaseFirst!: () => void;


### PR DESCRIPTION
## What

Kills the flaky preview test on CI (Node 22, under load): `expect(deleteMessage).toHaveLength(1)` intermittently got `2`. `test/telegram.test.ts:1704`.

## Root cause — cross-test contamination

Telegram turns run **fire-and-forget**: the handler ACKs `200`, the turn-queue runs the turn async. The test harness's `flush()` drained by **polling the fetch-call count** until it stopped changing. Under CI load a background turn's next call can be delayed past one tick, so `flush()` saw a momentarily-stable count and **returned early**. The turn's later call (a `finalize` `deleteMessage`) then landed on the **next test's** fetch mock after `afterEach` unstubbed → an extra `deleteMessage`.

Passes in isolation and locally (even 10× stress) — only reproduces under the concurrency/scheduling of full CI, which is why it read as random.

## Fix — drain deterministically at the test boundary

- `turn-queue.ts` gains **`idle()`** — resolves once every per-session chain has drained. A test/observability seam; the production runtime never drains (SIGTERM exits mid-turn by design), so it is not a graceful-drain hook.
- `telegramChannel`'s handler exposes it as **`turnsIdle`** (a test seam, inert in production — nothing reads it).
- `afterEach` awaits every registered channel's `idle()` **before** unstubbing `fetch`, so a test's turns complete against **their own** mock and can't leak forward. Bounded (2 s) so a test that parks a turn without releasing it can't hang teardown.
- `flush()` stays a heuristic **on purpose**: some tests observe a **mid-flight** side effect (an "⏳ queued" notice while a turn is gated), so it must not block on full completion.

Deterministic (awaits the actual turn promise), not another heuristic — so it holds under any load.

## Test
- `turn-queue` `idle()` units: pending until a gated turn completes; instant when empty.
- Local: full suite 464 passed; telegram suite **0/10 flakes** over a stress loop.
