### PR TITLE
feat(engine): agentDir + cwd decoupling; project context via pi's loadProjectContextFiles

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -135,7 +135,9 @@ function createPiAgentFromDefinition(
 ): Promise<{ agent: Agent; definition: LoadedDefinition }>;
 ```
 
-Load `AGENTS.md` and `skills/` from a directory, assemble the pi prompt, and return an agent.
+Load `persona.md`/`skills/` from `dir` (the agent-definition dir) and assemble the pi prompt. `②` project context is sourced via pi's `loadProjectContextFiles({ cwd, agentDir: dir })` — the dir's own `AGENTS.md` plus every `AGENTS.md` walking `cwd` (option; default `dir`) up to root. Pass `cwd` to decouple the run/working directory (where tools operate, whose repo `AGENTS.md` is context) from the definition dir.
+
+`LoadedDefinition` carries `contextFiles: Array<{ path; content }>` (the ② files), `persona?` (from `persona.md`, ①), `skills`, and diagnostics/collisions.
 
 ### `createPiAgentFromWorkspace`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ Supported keys:
 | Key | Meaning |
 |---|---|
 | `model` | Default model spec, in `provider/modelId` form. |
+| `agentDir` | The agent-definition subdirectory (`persona.md`, `skills/`, `tools/`, `channels/`), relative to the config file. Default: the config directory itself (flat). Set it to e.g. `"./agent"` to serve an existing repo as a coding agent — the config directory stays the run root (`cwd`, whose `AGENTS.md` is read as context), while the agent's own surface lives in the subdir and does not collide with the host's `tools/`/`src/`. |
 | `tools` | Extra programmatic tools appended after default pi tools. Most users should prefer `tools/` discovery. |
 | `http.port` | Default port for `dev` / `start`. |
 | `deploy.secrets` | Extra secret env-var names the deployed agent needs (e.g. `["GH_TOKEN"]`). `deploy` lists them in the runbook and, under `--run`, carries each value from your local env to the host secret store; a missing value gates the run. |

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -49,25 +49,30 @@ The N axis has two forms, both on the SAME `invoke` contract (neither adds a new
 FastAgent consumes existing definition artifacts:
 
 ```txt
-workspace/
-├── AGENTS.md
-├── skills/
-├── fastagent.config.mjs
-└── .fastagent/          # generated machine state, ignored by git
+workspace/                    # flat: the run root (cwd) IS the agent dir
+├── AGENTS.md                 # ② project context (optional)
+├── persona.md                # ① authored identity (optional)
+├── skills/  tools/  channels/
+├── fastagent.config.mjs      # may set `agentDir: "./agent"` to serve an existing repo (below)
+└── .fastagent/               # generated machine state, ignored by git
 ```
 
-`AGENTS.md` is not the full system prompt. The pi reference implementation assembles the final prompt from four segments:
+The two roots are `cwd` (the run root the tools operate on; where config lives) and `agentDir` (the
+agent's own surface — persona.md/skills/tools/channels). They coincide in the flat layout; `config.agentDir`
+decouples them so a coding agent's definition can live in a subdir of a host repo (§11 / scenario grid).
+
+`AGENTS.md` is not the system prompt. The pi reference implementation assembles the final prompt from four segments:
 
 | Segment | Source | Owner |
 |---|---|---|
-| base prompt | pi engine binding (`piBasePrompt`) | engine asset |
-| project instructions | `AGENTS.md`, wrapped in `<project_instructions>` | agent definition |
-| skills listing | loaded skills, formatted for progressive disclosure | agent definition |
-| environment context | date and cwd | runtime assembly |
+| ① base prompt | pi engine binding (`piBasePrompt`); an authored `persona.md` overrides its identity line, keeping the tool list + guidelines | engine asset / definition |
+| ② project context | `AGENTS.md` files via pi's exported `loadProjectContextFiles({ cwd, agentDir })` — the agentDir's own plus every `AGENTS.md` walking `cwd` up to root; each wrapped `<project_instructions>` | project (cwd) + definition |
+| ③ skills listing | loaded skills, formatted for progressive disclosure | agent definition |
+| ④ environment context | date and cwd | runtime assembly |
 
-`assembleSystemPrompt` is pure: callers provide date/cwd. L2 uses a factory so long-running processes re-evaluate time-sensitive context per invocation.
+`assembleSystemPrompt` is pure (mirrors pi's `buildSystemPrompt`): callers provide the resolved `contextFiles` + date/cwd. L2 uses a factory so long-running processes re-read the definition and re-evaluate context per invocation.
 
-This four-segment assembly is the **directory path** (L2/opener): it wraps `AGENTS.md` and prepends the engine base for fidelity with how the author vibed in local pi. **L1 `createPiAgent` is different on purpose**: its `instructions` ARE the system prompt (verbatim, no engine base, no wrapping) — the skills listing is the only thing appended, and only when skills are mounted. So `AGENTS.md ≡ instructions` in *role* (author-written instructions), but the directory path additionally bases/wraps them; a hand-built agent is not forced into the coding persona.
+Why two authored slots: `persona.md` is the agent's **identity** (①), `AGENTS.md` is **project context** (②) — conflating them (AGENTS.md-as-system-prompt) was the earlier mistake. **L1 `createPiAgent` is different on purpose**: its `instructions` ARE the system prompt (verbatim, no engine base, no wrapping) — the skills listing is the only thing appended. So a hand-built agent is not forced into the coding persona.
 
 ## 3. pi reference implementation
 
@@ -151,6 +156,8 @@ Skills are markdown/file assets. Loading is **definition-only, period**: an agen
 The `skills/` format is **Agent Skills** ([agentskills.io](https://agentskills.io)) compatible — a `skills/<name>/SKILL.md` with `name`/`description` frontmatter and progressive disclosure (name+description at startup, the body on activation), as implemented by pi's `loadSkills`. Any standard skill (e.g. from [anthropics/skills](https://github.com/anthropics/skills)) works by **vendoring**: copy the directory into `skills/`, git-tracked, and it Just Works — unsupported optional fields (`license`, `metadata`, `compatibility`) are ignored without error. **There is no registry, and none is needed**: the filesystem is the registry, git is the distribution, and the user owns trust (a vendored skill's `scripts/` is code they audit, like an npm dependency). fastagent is the serving layer, not a skill marketplace.
 
 FastAgent deliberately does not load the machine's global skills (`~/.pi/agent/skills`, `~/.agents/skills`): it would make the agent depend on ambient machine state and recreate the "works on my machine, breaks deployed" trap fastagent exists to kill. The principle is general: **the definition directory is the agent's only source of truth; nothing the code can't see is loaded into its behavior** (credentials and env are deployment config, not behavior — they stay outside the directory by design). To ship a skill, put it in `skills/`.
+
+**One deliberate exception — ② project context.** Following pi (`loadProjectContextFiles`), `AGENTS.md` context is sourced by **walking `cwd`'s ancestors to root** plus the `agentDir`, not from a single hermetic dir. This is safe under the same principle *because `cwd` is the deployed run root* (the mounted/COPY'd unit), so the walk is deterministic within it — but on a dev box the walk can also pick up an ancestor `~/AGENTS.md`, so dev context can exceed deploy context. Two further notes: `loadProjectContextFiles` reads via node `fs` directly (not the `ExecutionEnv` port — a deviation from this module's portable-IO policy, deferred with the sandbox work), and unlike a broken skill/persona (which fail visibly), an unreadable context file is skipped — pi warns to stderr on a read error, but is **fully silent** when the path itself is inaccessible (its `existsSync` probe swallows the permission error), so no signal reaches fastagent's diagnostics. Deferred with the ExecutionEnv work; a broken persona.md still fails the turn.
 
 Definition-local skills win name collisions (the deployable unit is authoritative); collisions are surfaced as diagnostics, not swallowed.
 
@@ -404,7 +411,7 @@ The rest is Railway-command detail: the volume is check-then-act (a `--into-link
 
 ## 11. Current open work
 
-- **The standalone × code-repo cell, *embedded-in-a-host-repo* form** (scenario grid). Serving a project it does **not** own (a Next/TS repo) needs mechanisms the flat path lacks. **Landed:** an authored persona (`persona.md` → prompt segment ①, §2) — segment ① is no longer a fixed engine base; absent `persona.md` it still falls back to it, and `AGENTS.md` stays segment ② context. **Still direction:** (1) a **definition namespace decoupled from cwd** (`agentDir`) — the authored surface (`tools`/`channels`/`skills`/`persona.md`/config) discovered from `agentDir` so it never collides with the host's same-named dirs or is swept into the host's `tsc`/build, while cwd stays the repo root the agent reads/writes (and the host's root `AGENTS.md` becomes context read from cwd); (2) a **repo-as-workspace deploy model** (ship/mount the target repo as cwd; write back via commit/PR). Undecided: whether `agentDir` self-contains its own `package.json`/deps, and the deploy shape (repo baked into the image vs mounted). The five other cells ship today on the flat `definition = cwd` path and must not inherit the namespace/deploy split.
+- **The standalone × code-repo cell, *embedded-in-a-host-repo* form** (scenario grid). Serving a project it does **not** own (a Next/TS repo). **Landed:** (1) an authored persona (`persona.md` → segment ①, §2); (2) the **`agentDir` decoupling** — `config.agentDir` puts the agent's own surface (`persona.md`/`skills`/`tools`/`channels`) in a subdir while `cwd` stays the run root, so it never collides with the host's same-named dirs; (3) **② context follows pi** (`loadProjectContextFiles({ cwd, agentDir })`) — the host repo's `AGENTS.md` is picked up by the cwd-ancestor walk, `agentDir`'s own too. **Still direction:** a **repo-as-workspace deploy model** (ship/mount the target repo as `cwd`; write back via commit/PR) — undecided: the deploy shape (repo baked into the image vs mounted), and whether the host's `tsc`/build should be helped to exclude `agentDir`. `deploy` discovers channels from `agentDir`, but its container facts (`package.json`/lockfile → the Dockerfile `npm ci`) still read the run root, so an agent whose deps live in a self-contained `agentDir` is part of this open shape, not yet handled. Deferred deviations this cell introduced: `loadProjectContextFiles` bypasses the `ExecutionEnv` port and an unreadable context file warns rather than fails (§6). The five other cells ship on the flat `definition = cwd` path.
 - `fastagent dev` / `fastagent start` per §10 are implemented (single-machine tier, the directory is the agent). `fastagent deploy fly` (§10.5) generates the Fly artifacts + runbook and, with `--run`, drives flyctl to completion (idempotent, resumable, credential-carrying). `fastagent deploy railway` is the second host — generate + runbook and, with `--run`, drives the railway CLI to completion (sharing the neutral container/secret modules; the sequence differs per Railway's model). Further hosts extend the same `deploy <host>` seam.
 - Multi-instance (multiple Fly machines sharing state) needs a K-axis backend — the single-machine + single-volume tier is the documented scope; `deploy fly` warns to keep one machine.
 - Multi-instance credential broker for OAuth refresh (§10.4); single-machine/container credential refresh is covered by the file-backed store.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import {
   isValidPort,
   listModels,
   loadConfig,
+  resolveAgentDir,
   resolveAuthPathOverride,
   resolveModelSpec,
   resolveSessionsDirOverride,
@@ -218,8 +219,12 @@ async function runTool(): Promise<void> {
   loadDotEnv(toolDir); // a tool may read a key from .env
   const { config } = await loadConfig(toolDir).catch(failStartup);
   // The same tool set dev/start mount (defaults + config.tools + discovered, deduped), so the runner
-  // exercises exactly what gets served — a shadowed tool is surfaced, not silently run.
-  const { tools, toolCollisions, toolFailures } = await resolveWorkspaceTools(config, toolDir).catch(failStartup);
+  // exercises exactly what gets served — a shadowed tool is surfaced, not silently run. Resolve agentDir
+  // like the openers so `fastagent tool` finds the SAME tools/ as dev/start when config.agentDir is set.
+  const agentDir = resolveAgentDir(toolDir, config);
+  const { tools, toolCollisions, toolFailures } = await resolveWorkspaceTools(config, agentDir, toolDir).catch(
+    failStartup,
+  );
   for (const c of toolCollisions) {
     console.error(
       `[fastagent] warn: tool "${c.name}" (${c.source}) is shadowed by a default/config tool — not mounted`,
@@ -319,12 +324,14 @@ async function runInfo(): Promise<void> {
   loadDotEnv(dir); // skills/tools may read env at load time
   const { config, path: configPath } = await loadConfig(dir).catch(failStartup);
   const modelSpec = resolveModelSpec(values.model, config);
-  const definition = await loadAgentDefinition(dir).catch(failStartup);
+  // dir = the run root (cwd, whose AGENTS.md is ② context); the agent's own surface lives in agentDir.
+  const agentDir = resolveAgentDir(dir, config);
+  const definition = await loadAgentDefinition(agentDir, { cwd: dir }).catch(failStartup);
   // A tool that fails to load, for any reason (a missing dep, a top-level throw, or just not being a
   // tool), is isolated the same way everywhere (G2): info, dev, AND start report it and keep going with
   // the tools that loaded. The `error`/`.catch` below only fires for a whole-load fault (an unreadable
   // tools/ dir), not a single bad file.
-  const tools = await resolveWorkspaceTools(config, dir)
+  const tools = await resolveWorkspaceTools(config, agentDir, dir)
     .then((r) => ({
       names: r.toolNames,
       collisions: r.toolCollisions,
@@ -332,8 +339,8 @@ async function runInfo(): Promise<void> {
       error: undefined as string | undefined,
     }))
     .catch((e: unknown) => ({ names: [] as string[], collisions: [], failures: [], error: (e as Error).message }));
-  const channels = await discoverChannelFiles(dir).catch(failStartup);
-  const schedules = await discoverScheduleFiles(dir).catch(failStartup);
+  const channels = await discoverChannelFiles(agentDir).catch(failStartup);
+  const schedules = await discoverScheduleFiles(agentDir).catch(failStartup);
   // The default sessions/auth paths WITHOUT creating anything (info is read-only; dev/start mkdir/login
   // create them, info must not).
   const stateRoot = resolveStateRoot(dir);
@@ -345,9 +352,10 @@ async function runInfo(): Promise<void> {
       JSON.stringify(
         {
           dir,
+          agentDir,
           configPath: configPath ?? null,
           model: modelSpec ?? null,
-          instructions: definition.instructions !== undefined,
+          context: definition.contextFiles.map((f) => f.path),
           persona: definition.persona !== undefined,
           skills: definition.skills.map((skill) => ({ name: skill.name, description: skill.description })),
           tools: tools.names,
@@ -369,9 +377,10 @@ async function runInfo(): Promise<void> {
     return;
   }
   console.log(`dir:      ${dir}`);
+  if (agentDir !== dir) console.log(`agent:    ${agentDir}`);
   console.log(`config:   ${configPath ?? "(none)"}`);
   console.log(`model:    ${modelSpec ?? "(not set — pass --model, set FASTAGENT_MODEL, or config.model)"}`);
-  console.log(`agents:   ${definition.instructions ? "AGENTS.md" : "(none)"}`);
+  console.log(`context:  ${definition.contextFiles.map((f) => f.path).join(", ") || "(none)"}`);
   console.log(`persona:  ${definition.persona ? "persona.md" : "(none)"}`);
   console.log(`skills:   ${definition.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
   console.log(`tools:    ${tools.error ? "(could not load — see warning below)" : tools.names.join(", ") || "(none)"}`);
@@ -543,6 +552,7 @@ async function runDeploy(): Promise<void> {
   // stops on its gate; the host branch below adds only the host-specific artifacts + runbook + run drive.
   const pre = await preflightDeploy({
     target,
+    agentDir: resolveAgentDir(target, config),
     config,
     modelSpec,
     run: !!values.run,
@@ -949,7 +959,7 @@ type Assembled = Awaited<ReturnType<typeof createPiAgentFromWorkspace>>;
 
 /** The agents/skills/tools/collisions report lines. */
 function reportAgentsSkillsTools(a: Assembled): void {
-  log.info(`[fastagent] agents: ${a.definition.instructions ? "AGENTS.md" : "(none)"}`);
+  log.info(`[fastagent] context: ${a.definition.contextFiles.map((f) => f.path).join(", ") || "(none)"}`);
   if (a.definition.persona) log.info(`[fastagent] persona: persona.md`);
   log.info(`[fastagent] skills: ${a.definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
   if (a.toolNames.length > 0) log.info(`[fastagent] tools:  ${a.toolNames.join(", ")}`);
@@ -980,7 +990,7 @@ async function runDev(): Promise<void> {
     return;
   }
   parsePort(values.port, "--port"); // flag-shape check before spawning
-  runDevSupervisor(dir, { tunnel: values.tunnel ?? false });
+  await runDevSupervisor(dir, { tunnel: values.tunnel ?? false });
 }
 
 /**
@@ -1024,7 +1034,8 @@ async function serveOnce(): Promise<void> {
     model: values.model,
     authPath: resolveAuthPathOverride(values["auth-path"]),
   }).catch(failStartup);
-  log.info(`[fastagent] dir:    ${a.definition.dir}`);
+  log.info(`[fastagent] dir:    ${dir}`);
+  if (a.agentDir !== dir) log.info(`[fastagent] agent:  ${a.agentDir}`);
   log.info(`[fastagent] config: ${a.configPath ?? "(zero-config)"}`);
   log.info(`[fastagent] model:  ${a.modelSpec}`);
   await reportAuth(a.modelSpec, a.authPath);
@@ -1032,9 +1043,9 @@ async function serveOnce(): Promise<void> {
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const traced = logAgentLoop(a.agent);
-  const routes = await routesFor(dir, traced, a.stateRoot).catch(failStartup);
-  await startSchedules(dir, traced, a.stateRoot);
-  serve(routes, portFlag ?? a.config.http?.port ?? 8787, (p) => maybeTunnel(a.definition.dir, p));
+  const routes = await routesFor(a.agentDir, traced, a.stateRoot).catch(failStartup);
+  await startSchedules(a.agentDir, traced, a.stateRoot);
+  serve(routes, portFlag ?? a.config.http?.port ?? 8787, (p) => maybeTunnel(a.agentDir, p));
 }
 
 async function runStart(): Promise<void> {
@@ -1054,6 +1065,7 @@ async function runStart(): Promise<void> {
   const {
     agent,
     definition,
+    agentDir,
     config,
     modelSpec,
     stateRoot,
@@ -1069,9 +1081,10 @@ async function runStart(): Promise<void> {
   }).catch(failStartup);
 
   log.info(`[fastagent] start:  ${dir}`);
+  if (agentDir !== dir) log.info(`[fastagent] agent:  ${agentDir}`);
   log.info(`[fastagent] model:  ${modelSpec}`);
   await reportAuth(modelSpec, authPath);
-  log.info(`[fastagent] agents: ${definition.instructions ? "AGENTS.md" : "(none)"}`);
+  log.info(`[fastagent] context: ${definition.contextFiles.map((f) => f.path).join(", ") || "(none)"}`);
   if (definition.persona) log.info(`[fastagent] persona: persona.md`);
   log.info(`[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
   if (toolNames.length > 0) log.info(`[fastagent] tools:  ${toolNames.join(", ")}`);
@@ -1094,10 +1107,10 @@ async function runStart(): Promise<void> {
 
   // Same debug turn trace as dev; gated out here by the info level (see serveOnce).
   const traced = logAgentLoop(agent);
-  const routes = await routesFor(dir, traced, stateRoot).catch(failStartup);
-  await startSchedules(dir, traced, stateRoot);
+  const routes = await routesFor(agentDir, traced, stateRoot).catch(failStartup);
+  await startSchedules(agentDir, traced, stateRoot);
   serve(routes, portFlag ?? parsePort(process.env.PORT, "PORT env") ?? config.http?.port ?? 8787, (p) =>
-    maybeTunnel(dir, p),
+    maybeTunnel(agentDir, p),
   );
   // No graceful drain: webhook turns run fire-and-forget; SIGTERM just exits mid-turn. Whether an
   // in-flight turn is LOST depends on the channel: the Telegram channel persists turn intent pre-ACK

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -51,6 +51,9 @@ export type DeployPreflight = { ok: false; gate: string } | ({ ok: true } & Depl
  */
 export async function preflightDeploy(input: {
   target: string;
+  /** The agent-definition dir (config.agentDir resolved against target; = target when unset) — where
+   *  channels are discovered. Container facts (package.json/lockfile) still read `target`, the run root. */
+  agentDir: string;
   config: FastagentConfig;
   modelSpec: string | undefined;
   /** `--run` fully deploys, so a model that won't travel is a GATE (a known crash-loop); else it warns. */
@@ -60,7 +63,7 @@ export async function preflightDeploy(input: {
   /** `--auth-path` / `FASTAGENT_AUTH_PATH`; falls back to the project default `<state root>/auth.json`. */
   authPathOverride: string | undefined;
 }): Promise<DeployPreflight> {
-  const { target, config, modelSpec, run, force, authPathOverride } = input;
+  const { target, agentDir, config, modelSpec, run, force, authPathOverride } = input;
   const messages: DeployMessage[] = [];
 
   // The deployed box resolves the model from fastagent.config.ts ONLY (in the image); a model set via
@@ -73,7 +76,7 @@ export async function preflightDeploy(input: {
 
   // Known channel kinds only — a custom channel's secrets/webhook are unknown to us; note and let the
   // author wire them.
-  const discovered = await discoverChannelFiles(target);
+  const discovered = await discoverChannelFiles(agentDir);
   const channels = discovered.filter((c): c is ChannelKind => (CHANNEL_KINDS as string[]).includes(c));
   for (const c of discovered) {
     if (!channels.includes(c as ChannelKind)) {

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -13,12 +13,13 @@
 import { spawn } from "node:child_process";
 import { relative, sep } from "node:path";
 import { watch as watchTree } from "chokidar";
+import { type FastagentConfig, loadConfig, resolveAgentDir } from "./engines/pi/config.ts";
 import { log } from "./log.ts";
 import { installProxyFetch } from "./proxy.ts";
 import { type Tunnel, announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
 
 /** What the dev watcher restarts on (workspace-relative): the process-bound code inputs only. */
-export const WATCHED_HINT = "tools/, channels/, fastagent.config.*, package.json, .env";
+export const WATCHED_HINT = "tools/, channels/, package.json (agent dir), fastagent.config.*, .env (run root)";
 
 /**
  * chokidar `ignored` matcher for the narrow watch scope (true = ignore). Ignoring a directory prunes
@@ -27,20 +28,45 @@ export const WATCHED_HINT = "tools/, channels/, fastagent.config.*, package.json
  * Helper code imported from OUTSIDE tools//channels/ is out of scope by design (keep it under
  * tools/, or restart manually) — the startup log names the watched set.
  */
-export function devWatchIgnored(root: string): (path: string) => boolean {
+export function devWatchIgnored(dir: string, agentDir: string): (path: string) => boolean {
   return (path: string): boolean => {
-    const rel = relative(root, path);
-    if (rel === "" || rel === ".") return false; // the root itself must not be pruned
-    const [head] = rel.split(sep);
-    if (head === "tools" || head === "channels") return false; // watched subtrees, fully
-    if (rel === "package.json" || rel === ".env") return false;
+    if (path === dir || path === agentDir) return false; // the roots themselves must not be pruned
+    // Never prune a directory on the path from the watch root down to agentDir, so chokidar can descend
+    // into `agentDir/tools` even when agentDir is a subdir (config.agentDir = "./agent").
+    if (agentDir.startsWith(path + sep)) return false;
+    const rel = relative(dir, path);
+    // Run-root (cwd) inputs: .env + fastagent.config.* live where config lives, not in agentDir.
+    if (rel === ".env") return false;
     if (/^fastagent\.config\.[cm]?[jt]s$/.test(rel)) return false;
+    // Agent code inputs live in agentDir: tools/, channels/, package.json (its own deps). Everything
+    // else under agentDir (skills/, persona.md, AGENTS.md) is live-read — pruned, no restart.
+    const relAgent = relative(agentDir, path);
+    if (!relAgent.startsWith("..")) {
+      const [head] = relAgent.split(sep);
+      if (head === "tools" || head === "channels") return false;
+      if (relAgent === "package.json") return false;
+    }
     return true;
   };
 }
 
 /** Spawn the dev worker and restart it on workspace edits; supervise its lifecycle until the process exits. */
-export function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}): void {
+export async function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}): Promise<void> {
+  // The watch root is `dir` (cwd); tools/channels the restart-watch cares about live in agentDir. On a
+  // config error, default agentDir=dir and let the spawned worker surface the real error (fail-visibly).
+  // agentDir is assumed STATIC for the dev session: the supervisor computes it once here and each spawned
+  // worker recomputes its own from the same config — config validation guarantees it stays under `dir`
+  // (so the watch scope is always right); a config edit that changes agentDir mid-session (rare) is out
+  // of scope for watch-scope re-sync (it triggers a worker restart regardless).
+  // A genuine config error (not just a missing agentDir key) — debug-log it here so the silence is not
+  // total before the spawned worker crash-loops and surfaces the real message; default agentDir=dir.
+  const config = await loadConfig(dir)
+    .then((r) => r.config)
+    .catch((err: unknown) => {
+      log.debug(`[fastagent] dev: config load failed while resolving agentDir (worker will report): ${String(err)}`);
+      return {} as FastagentConfig;
+    });
+  const agentDir = resolveAgentDir(dir, config);
   let worker: ReturnType<typeof spawn> | undefined;
   let reloadPending = false;
   let everServed = false; // has any worker successfully bound (sent `ready`) yet?
@@ -68,7 +94,7 @@ export function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}
         void startCloudflareTunnel(m.port).then((t) => {
           if (t) {
             tunnel = t;
-            void announceWebhooks(dir, t.url);
+            void announceWebhooks(agentDir, t.url);
           }
         });
       }
@@ -105,7 +131,7 @@ export function runDevSupervisor(dir: string, options: { tunnel?: boolean } = {}
   // cannot; devWatchIgnored (above) narrows the scope to the process-bound code inputs.
   const watcher = watchTree(dir, {
     ignoreInitial: true, // the startup scan is not a change
-    ignored: devWatchIgnored(dir),
+    ignored: devWatchIgnored(dir, agentDir),
   });
   watcher.on("all", () => {
     clearTimeout(timer);

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -21,7 +21,7 @@
  * apply here, and `createPiModels()` below is used only to RESOLVE the model descriptor (never for auth).
  */
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   type AgentSessionRuntime,
@@ -34,7 +34,7 @@ import {
   createAgentSessionServices,
   getAgentDir,
 } from "@earendil-works/pi-coding-agent";
-import { loadConfig, resolveModel, resolveModelSpec } from "./config.ts";
+import { loadConfig, resolveAgentDir, resolveModel, resolveModelSpec } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
 import { createPiModels } from "./models.ts";
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
@@ -69,12 +69,14 @@ export async function buildChatRuntime(
     // services), so authPath is intentionally not threaded in. See the AUTH note in the header.
     const model = resolveModel(createPiModels(), modelSpec);
     const env = new NodeExecutionEnv({ cwd });
-    const definition = await loadAgentDefinition(cwd, { env });
+    // Same agentDir/cwd split as dev/start: persona/skills/tools from agentDir, ② context walked from cwd.
+    const agentDir = resolveAgentDir(cwd, config);
+    const definition = await loadAgentDefinition(agentDir, { cwd, env });
     reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 
     // Same tool resolution as the dev opener, then split: defaults go to pi by NAME (rebuilt cwd-bound
     // for rich rendering); customs go through pi's `customTools` path so they survive /new, /resume, fork.
-    const discovered = await loadTools(cwd);
+    const discovered = await loadTools(agentDir);
     const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
     reportToolCollisions([...discovered.collisions, ...crossCollisions]);
     reportModuleLoadFailures(discovered.failures);
@@ -93,8 +95,7 @@ export async function buildChatRuntime(
     // them here would duplicate both).
     const systemPrompt = assembleSystemPrompt({
       base: piBasePrompt({ tools, persona: definition.persona }),
-      instructions: definition.instructions,
-      instructionsPath: definition.instructions !== undefined ? join(cwd, "AGENTS.md") : undefined,
+      contextFiles: definition.contextFiles,
     });
 
     return { model, definition, defaultNames, customTools, customToolDefs, systemPrompt };

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -8,7 +8,7 @@
  */
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { Models } from "@earendil-works/pi-ai";
@@ -18,6 +18,14 @@ import { moduleLoadHint } from "./loader.ts";
 export interface FastagentConfig {
   /** "provider/modelId". Precedence: CLI --model > FASTAGENT_MODEL > config. */
   model?: string;
+  /**
+   * The agent-definition subdirectory (persona.md, skills/, tools/, channels/), relative to the config
+   * file's directory. Default: the config directory itself (flat — today's behaviour). Point it at a
+   * sibling like `"./agent"` to serve an existing repo as a coding agent: the config dir stays the run
+   * root (cwd, whose AGENTS.md the agent reads as ② context), while the agent's own surface lives in the
+   * subdir and does not collide with the host's `tools/`/`src/` (core.md scenario grid).
+   */
+  agentDir?: string;
   /** Extra custom tools, appended after pi defaults — never replaces them. */
   tools?: AgentTool[];
   http?: { port?: number };
@@ -94,12 +102,27 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   // Unknown keys throw: defineConfig only type-protects .ts authors; a typo in a .js/.mjs config
   // (`modle:`) must not silently degrade to zero-config.
   for (const key of Object.keys(c)) {
-    if (key !== "model" && key !== "tools" && key !== "http" && key !== "deploy") {
-      throw new Error(`${path}: unknown key "${key}" (valid keys: model, tools, http, deploy)`);
+    if (key !== "model" && key !== "agentDir" && key !== "tools" && key !== "http" && key !== "deploy") {
+      throw new Error(`${path}: unknown key "${key}" (valid keys: model, agentDir, tools, http, deploy)`);
     }
   }
   if (c.model !== undefined && typeof c.model !== "string") {
     throw new Error(`${path}: "model" must be a "provider/modelId" string`);
+  }
+  if (c.agentDir !== undefined && typeof c.agentDir !== "string") {
+    throw new Error(`${path}: "agentDir" must be a string (a subdirectory relative to the config file)`);
+  }
+  if (typeof c.agentDir === "string") {
+    // Enforce the documented "subdirectory of the config dir" contract: an escaping agentDir (e.g.
+    // "../shared") would still resolve for tool/channel/persona discovery, but `dev`'s chokidar only
+    // watches the config dir subtree — edits outside it would silently never trigger a restart. Reject
+    // it here (fail visibly) rather than let hot-reload break without a signal.
+    const rel = relative(dir, resolve(dir, c.agentDir));
+    if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+      throw new Error(
+        `${path}: "agentDir" ("${c.agentDir}") must be a subdirectory of the config directory, not escape it`,
+      );
+    }
   }
   if (c.tools !== undefined && !Array.isArray(c.tools)) {
     throw new Error(`${path}: "tools" must be an array of AgentTool`);
@@ -140,6 +163,16 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   validateStringList(c.deploy?.secrets, "deploy.secrets", /^[A-Z_][A-Z0-9_]*$/, "an UPPER_SNAKE env-var name", path);
   validateStringList(c.deploy?.apt, "deploy.apt", /^[a-z0-9][a-z0-9.+-]*$/, "a Debian package name", path);
   return { config: c, path };
+}
+
+/**
+ * The agent-definition dir from config: `config.agentDir` resolved against `dir`, or `dir` itself when
+ * unset (flat). The ONE place this is computed — every opener (`dev`/`start`/`info`/`tool`/`deploy`/`chat`)
+ * calls it, so the "relative to the config dir, default `.`" rule can never diverge. loadConfig has
+ * already validated that agentDir stays under `dir`.
+ */
+export function resolveAgentDir(dir: string, config: FastagentConfig): string {
+  return resolve(dir, config.agentDir ?? ".");
 }
 
 /** Resolve "provider/modelId" → a pi Model from `models`, so the harness resolves auth from the same collection. */

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -10,7 +10,6 @@
  * `start` drive. Each rung calls the one below; options narrow as you go up (L2 owns systemPrompt/skills —
  * they come from the definition; the openers own model/tools — from config resolution).
  */
-import { join } from "node:path";
 import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
@@ -51,17 +50,20 @@ export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] 
  */
 export async function resolveWorkspaceTools(
   config: FastagentConfig,
-  dir: string,
+  agentDir: string,
+  cwd: string = agentDir,
 ): Promise<{
   tools: AgentTool[];
   toolNames: string[];
   toolCollisions: ToolCollision[];
   toolFailures: ModuleLoadFailure[];
 }> {
-  const discovered = await loadTools(dir);
-  const { tools, collisions } = mergeDiscoveredTools(resolveTools(config, dir), discovered.tools);
+  // Default coding tools (read/bash/edit/write) are rooted at `cwd` (the run root the agent operates on);
+  // discovered `tools/` come from `agentDir` (the agent's own surface). They coincide in the flat case.
+  const discovered = await loadTools(agentDir);
+  const { tools, collisions } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
   const toolCollisions = [...discovered.collisions, ...collisions];
-  const defaultNames = new Set(piDefaultTools(dir).map((t) => t.name));
+  const defaultNames = new Set(piDefaultTools(cwd).map((t) => t.name));
   const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
   return { tools, toolNames, toolCollisions, toolFailures: discovered.failures };
 }
@@ -69,8 +71,8 @@ export async function resolveWorkspaceTools(
 // ── §2 prompt: four-segment systemPrompt assembly ───────────────────────────
 //
 //   systemPrompt = ① base (engine asset; a persona.md persona overrides its identity line)
-//                + ② instructions (AGENTS.md, <project_instructions>-wrapped) + ③ skills listing
-//                + ④ env context (date/cwd)
+//                + ② project context (AGENTS.md files via pi's loadProjectContextFiles, <project_context>-wrapped)
+//                + ③ skills listing + ④ env context (date/cwd)
 //
 // AGENTS.md ≠ system prompt. Pure functions: segment ④ inputs (date/cwd) are caller-provided, so the
 // same inputs always produce the same prompt (testable, reproducible).
@@ -108,10 +110,8 @@ export interface AssembleSystemPromptOptions {
    * "Available tools: (none)" even when tools are mounted. Pass piBasePrompt({ tools }) for pi.
    */
   base: string;
-  /** ② AGENTS.md content (verbatim), injected wrapped — never pasted bare. */
-  instructions?: string;
-  /** Path rendered into the <project_instructions path=…> attribute. */
-  instructionsPath?: string;
+  /** ② project-context files (AGENTS.md et al. from loadProjectContextFiles); each wrapped `<project_instructions path=…>`. */
+  contextFiles?: Array<{ path: string; content: string }>;
   /** ③ Skills for the <available_skills> listing. */
   skills?: Skill[];
   /** ④ Env context, caller-provided (keeps this function pure). Omitted = segment omitted. */
@@ -121,11 +121,14 @@ export interface AssembleSystemPromptOptions {
 
 export function assembleSystemPrompt(options: AssembleSystemPromptOptions): string {
   let prompt = options.base;
-  if (options.instructions) {
-    const pathAttr = options.instructionsPath ? ` path="${options.instructionsPath}"` : "";
-    prompt +=
-      `\n\n<project_context>\n\nProject-specific instructions and guidelines:\n\n` +
-      `<project_instructions${pathAttr}>\n${options.instructions}\n</project_instructions>\n\n</project_context>\n`;
+  const contextFiles = options.contextFiles ?? [];
+  if (contextFiles.length > 0) {
+    // Mirrors pi's system-prompt.js: one <project_context> block, one <project_instructions path=…> per file.
+    prompt += `\n\n<project_context>\n\nProject-specific instructions and guidelines:\n\n`;
+    for (const { path, content } of contextFiles) {
+      prompt += `<project_instructions path="${path}">\n${content}\n</project_instructions>\n\n`;
+    }
+    prompt += `</project_context>\n`;
   }
   if (options.skills && options.skills.length > 0) {
     prompt += `\n${formatSkillsForSystemPrompt(options.skills)}\n`;
@@ -249,6 +252,13 @@ export interface CreatePiAgentFromDefinitionOptions {
   base?: string;
   /** Override tools. Defaults to piDefaultTools (lock down with a custom list). */
   tools?: AgentTool[];
+  /**
+   * The agent's working directory: where the default tools operate AND whose ancestors are walked for
+   * ② project context (AGENTS.md). Defaults to `dir` (flat: the definition dir is also the run root).
+   * Set it to the enclosing repo so a coding agent whose definition lives in `dir` operates on — and
+   * reads the AGENTS.md of — that repo (core.md scenario grid).
+   */
+  cwd?: string;
   /** Extra providers registered on top of the built-ins (your own gateway / self-hosted endpoint). */
   providers?: Provider[];
   /**
@@ -277,10 +287,13 @@ export async function createPiAgentFromDefinition(
   dir: string,
   options: CreatePiAgentFromDefinitionOptions,
 ): Promise<{ agent: Agent; definition: LoadedDefinition }> {
-  const env = options.env ?? new NodeExecutionEnv({ cwd: dir });
+  // `dir` = the agent-definition dir (persona.md/skills/); `cwd` (default = dir) is the run root where
+  // tools operate and whose ancestors are walked for ② context.
+  const cwd = options.cwd ?? dir;
+  const env = options.env ?? new NodeExecutionEnv({ cwd });
   // Boot-time load: fail-visibly at startup on a broken directory, and give callers the snapshot to
   // report (skills/diagnostics/collisions). Serving does NOT close over it — see `live` below.
-  const definition = await loadAgentDefinition(dir, { env });
+  const definition = await loadAgentDefinition(dir, { cwd: env.cwd, env });
   // Findings the caller already reported at boot; `live` re-reports only when the set CHANGES — a
   // runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
   // every turn's log. A log-dedup memo, not session state (stateless invoke holds).
@@ -303,7 +316,7 @@ export async function createPiAgentFromDefinition(
     // not silently vanish from the agent, and a static one must not spam every turn's log. The
     // next good edit heals both.
     live: async () => {
-      const def = await loadAgentDefinition(dir, { env });
+      const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
       const sig = findingsSignature(def);
       if (sig !== reportedFindings) {
         reportedFindings = sig;
@@ -314,8 +327,8 @@ export async function createPiAgentFromDefinition(
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,
           // re-read per turn like AGENTS.md so edits go live; options.base still wins for full control.
           base: options.base ?? piBasePrompt({ tools, persona: def.persona }),
-          instructions: def.instructions,
-          instructionsPath: def.instructions !== undefined ? join(def.dir, "AGENTS.md") : undefined,
+          // ② project context: AGENTS.md files (agentDir + cwd-ancestor walk) via loadProjectContextFiles.
+          contextFiles: def.contextFiles,
           skills: def.skills,
           date: new Date().toISOString().slice(0, 10),
           cwd: env.cwd,

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -2,13 +2,16 @@
  * Definition domain: read an agent definition directory (AGENTS.md + skills/) into memory. Produces
  * data; create.ts consumes it.
  *
- * IO policy: the runtime load path (loadAgentDefinition) does IO only through ExecutionEnv (portable
- * across local/sandbox/remote envs); the invoke path never touches disk. config/auth/sessions and
- * this module's Node helpers are composition-root code and may use node fs.
+ * IO policy: persona.md + skills load through ExecutionEnv (portable across local/sandbox/remote); the
+ * invoke path never touches disk. EXCEPTION — ② project context comes from pi's loadProjectContextFiles,
+ * which reads via node fs DIRECTLY (not the injected `env`) and, on failure, at best warns to stderr and
+ * at worst is fully silent (its `existsSync` probe swallows a permission error) — no structured signal. So under a
+ * non-local ExecutionEnv the ② files still resolve against THIS process's filesystem, not the target env
+ * — a known break in the portability contract, deferred with the sandbox work (core.md §6). config/auth/
+ * sessions and this module's Node helpers are composition-root code and may use node fs.
  *
- * Errors: ExecutionEnv returns Result; this module converts a broken definition to a throw (fail
- * loudly at startup), while non-fatal findings (bad skill files, name collisions) are returned as
- * data for the caller to surface.
+ * Errors: a broken persona.md / unresolvable dir throws (fail loudly at startup); non-fatal findings
+ * (bad skill files, name collisions) are returned as data. An unreadable ② context file only warns (pi).
  */
 import { realpathSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
@@ -17,6 +20,7 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import type { ExecutionEnv, Skill, SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { loadSkills } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { loadProjectContextFiles } from "@earendil-works/pi-coding-agent";
 
 /** A same-name skill collision (the discarded side). Surfaced, never swallowed. */
 export interface SkillCollision {
@@ -27,8 +31,12 @@ export interface SkillCollision {
 
 /** Result of loading a definition directory. Produced by {@link loadAgentDefinition}. */
 export interface LoadedDefinition {
-  /** Verbatim AGENTS.md content (feeds prompt segment ② `<project_instructions>` context); undefined when the file does not exist. */
-  instructions?: string;
+  /**
+   * Project-context files feeding segment ② `<project_context>`, sourced via pi's `loadProjectContextFiles`:
+   * the agentDir's own AGENTS.md/CLAUDE.md FIRST, then every AGENTS.md from root down to `cwd` (so the
+   * file nearest `cwd` comes LAST — pi's array order). Empty when none exist. This WALKS cwd's ancestors (pi's coding-agent behaviour) — see core.md §6.
+   */
+  contextFiles: Array<{ path: string; content: string }>;
   /**
    * Verbatim `persona.md` content — the authored persona that OVERRIDES segment ①'s identity line
    * (piBasePrompt keeps the tool list + guidelines; NOT a full system-prompt replacement — that is L1
@@ -40,34 +48,39 @@ export interface LoadedDefinition {
   diagnostics: SkillDiagnostic[];
   /** Same-name conflicts across mounts (first-wins). */
   collisions: SkillCollision[];
-  /** Absolute definition directory path. AGENTS.md, when present, is at join(dir, "AGENTS.md"). */
+  /** Absolute agent-definition directory path (persona.md/skills/ live here). */
   dir: string;
 }
 
 export interface LoadAgentDefinitionOptions {
+  /**
+   * Working directory whose ancestors are walked for context files (segment ②). Default = `agentDir`
+   * (flat: the agent dir is also the run root). The opener passes the run root so a coding agent that
+   * lives in `agentDir` picks up the host repo's AGENTS.md up the tree (core.md scenario grid).
+   */
+  cwd?: string;
   env?: ExecutionEnv;
 }
 
-/** Read a definition directory. env defaults to local Node (cwd=dir); non-local deployments inject their env. */
+/** Read an agent definition. persona.md/skills come from `agentDir`; ② context = pi's loadProjectContextFiles({ cwd, agentDir }). */
 export async function loadAgentDefinition(
-  dir: string,
+  agentDir: string,
   options: LoadAgentDefinitionOptions = {},
 ): Promise<LoadedDefinition> {
-  const e = options.env ?? new NodeExecutionEnv({ cwd: dir });
-  const rootResult = await e.absolutePath(dir);
+  // One resolved default for the working directory (env cwd AND the context-walk start), so they can
+  // never diverge if a caller passes a relative agentDir.
+  const cwd = options.cwd ?? agentDir;
+  const e = options.env ?? new NodeExecutionEnv({ cwd });
+  const rootResult = await e.absolutePath(agentDir);
   if (!rootResult.ok) {
-    throw new Error(`cannot resolve definition dir "${dir}": ${rootResult.error.message}`);
+    throw new Error(`cannot resolve agent dir "${agentDir}": ${rootResult.error.message}`);
   }
   const root = rootResult.value;
 
-  const agentsPath = join(root, "AGENTS.md");
-  const read = await e.readTextFile(agentsPath);
-  // Only not_found means "no AGENTS.md". Anything else (permission, io) must surface, or the agent
-  // silently runs without instructions.
-  if (!read.ok && read.error.code !== "not_found") {
-    throw new Error(`cannot read ${agentsPath}: ${read.error.message}`);
-  }
-  const instructions = read.ok ? read.value : undefined;
+  // ② project context, following pi: the agentDir's own AGENTS.md + every AGENTS.md walking cwd up to
+  // root (loadProjectContextFiles). It reads via node fs directly (mirrors pi), NOT the ExecutionEnv —
+  // a deliberate, deferred deviation from this module's portable-IO policy (revisit with the sandbox; core.md §6).
+  const contextFiles = loadProjectContextFiles({ cwd, agentDir: root });
 
   // persona.md → segment ① persona (overrides the identity line). Same error policy as AGENTS.md:
   // only not_found means "absent"; any other read error surfaces rather than silently dropping the persona.
@@ -92,7 +105,7 @@ export async function loadAgentDefinition(
     }
   }
 
-  return { instructions, persona, skills: [...byName.values()], diagnostics, collisions, dir: root };
+  return { contextFiles, persona, skills: [...byName.values()], diagnostics, collisions, dir: root };
 }
 
 /**

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -16,6 +16,7 @@ import {
   defaultAuthPath,
   defaultSessionsDir,
   loadConfig,
+  resolveAgentDir,
   resolveModelSpec,
   resolveStateRoot,
 } from "./config.ts";
@@ -57,6 +58,8 @@ export async function createPiAgentFromWorkspace(
   configPath?: string;
   /** The resolved "provider/modelId" spec actually in use. */
   modelSpec: string;
+  /** Absolute agent-definition dir in use (config.agentDir resolved against dir; = dir when unset). Channels/tools/persona come from here. */
+  agentDir: string;
   /** Absolute state root in use (FASTAGENT_STATE_DIR > <dir>/.fastagent) — the ChannelContext's stateRoot. */
   stateRoot: string;
   /** Absolute session store directory in use (for the startup report). */
@@ -76,7 +79,10 @@ export async function createPiAgentFromWorkspace(
       `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
     );
   }
-  const { tools, toolNames, toolCollisions, toolFailures } = await resolveWorkspaceTools(config, dir);
+  // The run root is `dir` (cwd — where config lives, whose AGENTS.md is ② context); the agent's own
+  // surface (persona/skills/tools/channels) lives in `agentDir` (config.agentDir, or `dir` when flat).
+  const agentDir = resolveAgentDir(dir, config);
+  const { tools, toolNames, toolCollisions, toolFailures } = await resolveWorkspaceTools(config, agentDir, dir);
   // The state root: auth/sessions/channel state all derive from it, so FASTAGENT_STATE_DIR moves the
   // whole machine-state home in one knob (a container mounts one volume); the finer overrides below
   // still win for their specific path.
@@ -90,8 +96,9 @@ export async function createPiAgentFromWorkspace(
   // every channel's `channels/<kind>` home), including a custom in-tree `FASTAGENT_STATE_DIR`. A
   // per-path override to an external volume is out-of-tree and correctly left alone.
   await ensureStateRootSelfIgnored(dir, stateRoot);
-  const { agent, definition } = await createPiAgentFromDefinition(dir, {
+  const { agent, definition } = await createPiAgentFromDefinition(agentDir, {
     model: modelSpec,
+    cwd: dir,
     tools,
     authPath,
     // Skills are definition-only (the agent is its directory), so dev mirrors deployment exactly.
@@ -100,6 +107,7 @@ export async function createPiAgentFromWorkspace(
   return {
     agent,
     definition,
+    agentDir,
     config,
     configPath,
     modelSpec,

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -93,6 +93,36 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
     }
   });
 
+  it("resolves config.agentDir: persona/tools from agentDir, ② context walked from cwd", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-chat-agentdir-"));
+    try {
+      await writeFile(join(dir, "AGENTS.md"), "HOST_CTX_MARKER. Repo conventions.\n"); // ② at cwd
+      await writeFile(
+        join(dir, "fastagent.config.mjs"),
+        `export default { agentDir: "./agent", model: "openai-codex/gpt-5.5" };\n`,
+      );
+      const agentDir = join(dir, "agent");
+      await mkdir(join(agentDir, "tools"), { recursive: true });
+      await writeFile(join(agentDir, "persona.md"), "You are PERSONA_MARKER bot.\n"); // ① in agentDir
+      await writeFile(
+        join(agentDir, "tools", "foo.mjs"),
+        `export default { description: "d", parameters: { type: "object", properties: {} }, execute: async () => ({ content: [], details: {} }) };`,
+      );
+
+      const rt = await buildChatRuntime(dir, {}, SessionManager.inMemory());
+      try {
+        const sp = rt.session.agent.state.systemPrompt ?? "";
+        expect(sp).toContain("PERSONA_MARKER"); // ① persona from agentDir
+        expect(sp).toContain("HOST_CTX_MARKER"); // ② context walked from cwd (run root)
+        expect(rt.session.agent.state.tools.map((t) => t.name)).toContain("foo"); // tool from agentDir
+      } finally {
+        rt.session.dispose?.();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("suppresses pi's machine-global APPEND_SYSTEM.md so chat matches what dev/start serve", async () => {
     // getAgentDir() honors PI_CODING_AGENT_DIR; point it at a temp agent dir holding an append
     // prompt. dev/start never read that file, so chat must not either, or fidelity breaks.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -136,7 +136,7 @@ describe("cli papercuts", () => {
     expect(code).toBe(0); // an unset model is reported, not fatal
     const info = JSON.parse(stdout);
     expect(info.model).toBeNull();
-    expect(info.instructions).toBe(true);
+    expect(info.context.length).toBeGreaterThan(0); // the AGENTS.md is loaded as ② project context
     expect(info.skills.map((s: { name: string }) => s.name)).toEqual(["greet"]); // the malformed skill is skipped
     expect(JSON.stringify(info.diagnostics)).toMatch(/description/); // info SURFACES the loader diagnostic to the user
     expect(info.channels).toEqual(["github"]);
@@ -160,7 +160,7 @@ describe("cli papercuts", () => {
     expect(info.tools).toEqual([]); // the broken tool isn't loaded…
     expect(JSON.stringify(info.toolFailures)).toMatch(/broken\.ts/); // …it's surfaced as a per-file load failure
     expect(info.toolError).toBeNull(); // isolated, so NOT a whole-load abort
-    expect(info.instructions).toBe(true); // the rest of the surface still shows
+    expect(info.context.length).toBeGreaterThan(0); // the rest of the surface still shows
     await expect(stat(join(dir, ".fastagent"))).rejects.toThrow(); // still read-only
 
     // text mode: the tools line degrades and the reason goes to stderr as a warning

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -8,6 +8,7 @@ import {
   defaultAuthPath,
   defaultSessionsDir,
   loadConfig,
+  resolveAgentDir,
   resolveAuthPathOverride,
   resolveModelSpec,
   resolveSessionsDirOverride,
@@ -26,6 +27,23 @@ describe("config: resolveSessionsDirOverride (start's sessions precedence)", () 
     expect(resolveSessionsDirOverride(undefined, env)).toBe(resolve("envdir")); // env when no flag
     expect(resolveSessionsDirOverride(undefined, {} as NodeJS.ProcessEnv)).toBeUndefined(); // neither → opener default
     expect(resolveSessionsDirOverride("/mnt/vol", {} as NodeJS.ProcessEnv)).toBe("/mnt/vol"); // absolute kept as-is
+  });
+});
+
+describe("config: loadConfig agentDir validation", () => {
+  it("accepts a subdirectory agentDir; rejects one that escapes the config dir (dev watch-scope guard)", async () => {
+    const ok = await mkdtemp(join(tmpdir(), "fa-agentdir-ok-"));
+    await writeFile(join(ok, "fastagent.config.mjs"), `export default { agentDir: "./agent" };\n`);
+    expect((await loadConfig(ok)).config.agentDir).toBe("./agent");
+
+    const bad = await mkdtemp(join(tmpdir(), "fa-agentdir-bad-"));
+    await writeFile(join(bad, "fastagent.config.mjs"), `export default { agentDir: "../shared" };\n`);
+    await expect(loadConfig(bad)).rejects.toThrow(/agentDir.*subdirectory.*not escape/);
+  });
+
+  it("resolveAgentDir: config.agentDir relative to dir; = dir when unset (the one shared computation)", () => {
+    expect(resolveAgentDir("/repo", { agentDir: "./agent" })).toBe(resolve("/repo", "agent"));
+    expect(resolveAgentDir("/repo", {})).toBe(resolve("/repo"));
   });
 });
 

--- a/test/definition.test.ts
+++ b/test/definition.test.ts
@@ -53,8 +53,8 @@ describe("definition: ensureStateRootSelfIgnored (root-based leak guard)", () =>
 describe("definition: loadAgentDefinition", () => {
   it("loads instructions from AGENTS.md and skills from SKILL.md frontmatter", async () => {
     const def = await loadAgentDefinition(fixtureDir);
-    expect(def.instructions).toContain("Haiku Bot");
-    expect(def.instructions).toContain("5-7-5");
+    expect(def.contextFiles.map((f) => f.content).join("\n")).toContain("Haiku Bot");
+    expect(def.contextFiles.map((f) => f.content).join("\n")).toContain("5-7-5");
     expect(def.dir).toBe(fixtureDir); // AGENTS.md path is derivable: join(dir, "AGENTS.md")
     expect(def.skills).toHaveLength(1);
     expect(def.skills[0]!.name).toBe("season-words");
@@ -65,7 +65,7 @@ describe("definition: loadAgentDefinition", () => {
   it("missing AGENTS.md / skills returns undefined instructions and empty skills without throwing", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-empty-definition-"));
     const def = await loadAgentDefinition(dir);
-    expect(def.instructions).toBeUndefined();
+    expect(def.contextFiles).toEqual([]);
     expect(def.skills).toEqual([]);
   });
 
@@ -74,12 +74,12 @@ describe("definition: loadAgentDefinition", () => {
     await writeFile(join(dir, "AGENTS.md"), "# Repo spec\nProject rules here.\n");
     let def = await loadAgentDefinition(dir);
     expect(def.persona).toBeUndefined(); // no persona.md → segment ① falls back to engine identity
-    expect(def.instructions).toContain("Repo spec"); // AGENTS.md is the ② context field, not persona
+    expect(def.contextFiles.map((f) => f.content).join("\n")).toContain("Repo spec"); // AGENTS.md → ② context, not persona
 
     await writeFile(join(dir, "persona.md"), "You are the Repo Bot. Reply briefly.\n");
     def = await loadAgentDefinition(dir);
     expect(def.persona).toContain("Repo Bot"); // persona.md → persona (①)
-    expect(def.instructions).toContain("Repo spec"); // AGENTS.md unchanged, still ②
+    expect(def.contextFiles.map((f) => f.content).join("\n")).toContain("Repo spec"); // AGENTS.md unchanged, still ②
   });
 
   it("skips a skill whose SKILL.md has no description and surfaces it as a diagnostic (not a crash)", async () => {
@@ -91,20 +91,26 @@ describe("definition: loadAgentDefinition", () => {
     expect(JSON.stringify(def.diagnostics)).toMatch(/description/); // and surfaced, not silently dropped
   });
 
-  it("AGENTS.md read errors other than not_found throw instead of silently becoming missing instructions", async () => {
-    class DeniedEnv extends NodeExecutionEnv {
-      override async readTextFile(path: string) {
-        if (path.endsWith("AGENTS.md")) {
-          return err<string, FileError>(new FileError("permission_denied", "permission denied", path));
-        }
-        return super.readTextFile(path);
-      }
-    }
-    const env = new DeniedEnv({ cwd: fixtureDir });
-    await expect(loadAgentDefinition(fixtureDir, { env })).rejects.toThrow(
-      /cannot read .*AGENTS\.md.*permission denied/,
-    );
+  it("agentDir ≠ cwd: persona from agentDir, ② context walked from cwd (the host repo's AGENTS.md) + agentDir's own", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fa-repo-"));
+    await writeFile(join(root, "AGENTS.md"), "# Host repo spec\n"); // the repo's context, at cwd
+    const agentDir = join(root, "agent");
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(join(agentDir, "persona.md"), "You are the Repo Bot.\n"); // ① identity, in agentDir
+    await writeFile(join(agentDir, "AGENTS.md"), "# Agent own note\n"); // agentDir's own ② too
+
+    const def = await loadAgentDefinition(agentDir, { cwd: root });
+    expect(def.persona).toContain("Repo Bot"); // ① from agentDir
+    expect(def.dir).toBe(agentDir);
+    const paths = def.contextFiles.map((f) => f.path);
+    expect(paths).toContain(join(agentDir, "AGENTS.md")); // agentDir's own
+    expect(paths).toContain(join(root, "AGENTS.md")); // walked up from cwd (the host repo)
+    expect(def.contextFiles.map((f) => f.content).join("\n")).toContain("Host repo spec");
   });
+
+  // Note: AGENTS.md read errors no longer throw — ② context is sourced via pi's loadProjectContextFiles,
+  // which warns and continues on an unreadable file (a deliberate deviation from fastagent's fail-visibly,
+  // deferred with the ExecutionEnv/sandbox work; core.md §6). persona.md (below) still fails visibly.
 
   it("persona.md read errors other than not_found throw instead of silently dropping the persona", async () => {
     class DeniedEnv extends NodeExecutionEnv {
@@ -151,8 +157,7 @@ describe("definition: loadAgentDefinition", () => {
     // Progressive disclosure: name + description in the startup prompt; the body is deferred.
     const prompt = assembleSystemPrompt({
       base: piBasePrompt(),
-      instructions: def.instructions,
-      instructionsPath: join(dir, "AGENTS.md"),
+      contextFiles: def.contextFiles,
       skills: def.skills,
     });
     expect(prompt).toContain("<name>pdf</name>");
@@ -166,8 +171,7 @@ describe("create: assembleSystemPrompt (four segments)", () => {
     const def = await loadAgentDefinition(fixtureDir);
     const prompt = assembleSystemPrompt({
       base: piBasePrompt(), // required: base and toolset must agree, no silent default
-      instructions: def.instructions,
-      instructionsPath: join(fixtureDir, "AGENTS.md"),
+      contextFiles: def.contextFiles,
       skills: def.skills,
       cwd: "/work",
     });
@@ -213,8 +217,7 @@ describe("create: assembleSystemPrompt (four segments)", () => {
     // In a full assembly the persona is ① and AGENTS.md remains ② <project_instructions>.
     const prompt = assembleSystemPrompt({
       base: persona,
-      instructions: "PROJECT CONTEXT LINE",
-      instructionsPath: "/x/AGENTS.md",
+      contextFiles: [{ path: "/x/AGENTS.md", content: "PROJECT CONTEXT LINE" }],
     });
     expect(prompt.indexOf("Repo Bot")).toBeLessThan(prompt.indexOf("<project_instructions"));
     expect(prompt).toContain("PROJECT CONTEXT LINE");
@@ -436,7 +439,7 @@ describe("create L2: the directory is LIVE (definition re-read per invoke)", () 
     class FlakyEnv extends NodeExecutionEnv {
       deny = false;
       override async readTextFile(path: string) {
-        if (this.deny && path.endsWith("AGENTS.md")) {
+        if (this.deny && path.endsWith("persona.md")) {
           return err<string, FileError>(new FileError("permission_denied", "permission denied", path));
         }
         return super.readTextFile(path);
@@ -448,7 +451,7 @@ describe("create L2: the directory is LIVE (definition re-read per invoke)", () 
     const { agent } = await createPiAgentFromDefinition(dir, { providers: [faux.provider], model: "faux/faux-1", env });
     await collect(agent.invoke({ session: "s" }, { text: "hi" }));
 
-    env.deny = true; // the live re-read now throws (unreadable AGENTS.md)
+    env.deny = true; // the live re-read now throws (unreadable persona.md)
     const events: string[] = [];
     let details = "";
     for await (const e of agent.invoke({ session: "s" }, { text: "again" })) {
@@ -456,7 +459,7 @@ describe("create L2: the directory is LIVE (definition re-read per invoke)", () 
       if (e.type === "failed") details = e.details;
     }
     expect(events).toEqual(["failed"]); // SPEC MUST 2: a failed event, not a thrown iteration error
-    expect(details).toMatch(/AGENTS\.md/);
+    expect(details).toMatch(/persona\.md/);
 
     env.deny = false; // the next good edit heals it — same agent, no restart
     const { text } = await collect(agent.invoke({ session: "s" }, { text: "back" }));

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -15,6 +15,7 @@ async function workspace(files: Record<string, string> = {}): Promise<string> {
 const call = (target: string, config: FastagentConfig, over: Partial<Parameters<typeof preflightDeploy>[0]> = {}) =>
   preflightDeploy({
     target,
+    agentDir: target, // flat by default; a test overrides via `over` to exercise config.agentDir
     config,
     modelSpec: config.model,
     run: false,

--- a/test/dev-supervisor.test.ts
+++ b/test/dev-supervisor.test.ts
@@ -4,7 +4,7 @@ import { devWatchIgnored } from "../src/dev-supervisor.ts";
 
 describe("dev-supervisor: devWatchIgnored (the narrow watch scope)", () => {
   const root = join("/work", "agent");
-  const ignored = devWatchIgnored(root);
+  const ignored = devWatchIgnored(root, root); // flat: agentDir === cwd
 
   it("watches exactly the process-bound code inputs", () => {
     expect(ignored(root)).toBe(false); // the root itself must not be pruned
@@ -32,5 +32,21 @@ describe("dev-supervisor: devWatchIgnored (the narrow watch scope)", () => {
   it("root-file names elsewhere do not match (package.json in a subdir is not a code input)", () => {
     expect(ignored(join(root, "out", "package.json"))).toBe(true);
     expect(ignored(join(root, "docs", ".env"))).toBe(true);
+  });
+
+  it("agentDir subdir: the agent's tools/channels are watched; the host repo's own dirs are ignored", () => {
+    const cwd = "/repo";
+    const agentDir = join(cwd, "agent");
+    const ig = devWatchIgnored(cwd, agentDir);
+    expect(ig(agentDir)).toBe(false); // must descend into agentDir to reach its tools/
+    expect(ig(join(agentDir, "tools", "foo.ts"))).toBe(false); // the agent's tool → restart
+    expect(ig(join(agentDir, "channels", "telegram.ts"))).toBe(false);
+    expect(ig(join(agentDir, "package.json"))).toBe(false);
+    expect(ig(join(agentDir, "persona.md"))).toBe(true); // live-read, no restart
+    expect(ig(join(agentDir, "skills", "x", "SKILL.md"))).toBe(true);
+    expect(ig(join(cwd, "tools", "hostonly.ts"))).toBe(true); // the HOST repo's tools/, NOT the agent's
+    expect(ig(join(cwd, "src", "app.tsx"))).toBe(true); // host source ignored
+    expect(ig(join(cwd, ".env"))).toBe(false); // run-root .env still watched
+    expect(ig(join(cwd, "fastagent.config.mjs"))).toBe(false); // run-root config still watched
   });
 });

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -83,7 +83,7 @@ describe("init: scaffoldWorkspace", () => {
     // AGENTS.md + the bundled skill load as a definition offline (loadAgentDefinition does not touch
     // tools/). The skill is a real markdown skill, mounted by the runtime loader.
     const def = await loadAgentDefinition(dir);
-    expect(def.instructions).toBeDefined();
+    expect(def.contextFiles.length).toBeGreaterThan(0);
     expect(def.skills.map((s) => s.name)).toEqual(["writing-great-skills"]);
     expect(def.collisions).toEqual([]);
   });
@@ -224,6 +224,28 @@ describe("init: scaffoldWorkspace", () => {
     await writeFile(join(done, "AGENTS.md"), "# x\n");
     await writeFile(join(done, "fastagent.config.mjs"), "export default {};\n");
     expect(await cliInit(["init"], done)).toMatch(/already has .*refuses to overwrite/);
+  });
+
+  it("createPiAgentFromWorkspace wires config.agentDir end-to-end: persona/tools from agentDir, ② context from cwd", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fa-agentdir-ws-"));
+    await writeFile(join(root, "AGENTS.md"), "# Host repo context\n"); // ② at the run root (cwd)
+    await writeFile(
+      join(root, "fastagent.config.mjs"),
+      `export default { agentDir: "./agent", model: "openai-codex/gpt-5.5" };\n`,
+    );
+    const agentDir = join(root, "agent");
+    await mkdir(join(agentDir, "tools"), { recursive: true });
+    await writeFile(join(agentDir, "persona.md"), "You are the Repo Bot.\n"); // ① in agentDir
+    await writeFile(
+      join(agentDir, "tools", "foo.mjs"),
+      `export default { description: "d", parameters: { type: "object" }, async execute() { return { content: [], details: "" }; } };`,
+    );
+
+    const a = await createPiAgentFromWorkspace(root); // model from config; no invoke, so no auth/network
+    expect(a.agentDir).toBe(agentDir);
+    expect(a.definition.persona).toContain("Repo Bot"); // ① from agentDir
+    expect(a.definition.contextFiles.map((f) => f.content).join("\n")).toContain("Host repo context"); // ② walked from cwd
+    expect(a.toolNames).toContain("foo"); // discovered from agentDir, not cwd
   });
 
   it("prints a `cd <dir>` step for a named target so the dev/.env/config steps are correct", async () => {

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defineTool, loadTools, z } from "../src/index.ts";
+import { resolveWorkspaceTools } from "../src/engines/pi/create.ts";
 
 describe("defineTool", () => {
   it("builds a pi AgentTool: JSON-schema parameters, validated + auto-wrapped execute", async () => {
@@ -59,6 +60,20 @@ describe("loadTools (filesystem discovery)", () => {
     expect(tools.map((t) => t.name)).toEqual(["ping"]); // filename = name
     expect(collisions).toEqual([]);
     expect((await tools[0]!.execute("c", {})).details).toBe("pong");
+  });
+
+  it("resolveWorkspaceTools discovers tools/ from agentDir, NOT from cwd (guards the agentDir/cwd param split)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-ws-cwd-"));
+    const agentDir = join(cwd, "agent");
+    const tool = `export default { description: "d", parameters: { type: "object" }, async execute() { return { content: [], details: "" }; } };`;
+    await mkdir(join(agentDir, "tools"), { recursive: true });
+    await writeFile(join(agentDir, "tools", "foo.mjs"), tool); // the agent's own tool (in agentDir)
+    await mkdir(join(cwd, "tools"), { recursive: true });
+    await writeFile(join(cwd, "tools", "hostonly.mjs"), tool); // the host repo's tool at cwd — must NOT be scanned
+
+    const { toolNames } = await resolveWorkspaceTools({}, agentDir, cwd);
+    expect(toolNames).toContain("foo"); // discovered from agentDir
+    expect(toolNames).not.toContain("hostonly"); // cwd's own tools/ is the host's, not the agent's surface
   });
 
   it("isolates (surfaces, not fatal) a tool file that does not default-export a tool", async () => {


### PR DESCRIPTION
Delivers the **standalone × code-repo, embedded form** cell (the cloud coding agent on a host repo), by following pi's reference model for project context. Builds on the merged persona.md PR.

## What
- **`② project context` now comes from pi's exported `loadProjectContextFiles({ cwd, agentDir })`** instead of a single hermetic `AGENTS.md` read. It sources the `agentDir`'s own `AGENTS.md`/`CLAUDE.md` **plus every `AGENTS.md` walking `cwd` up to root** — pi's coding-agent behaviour. `assembleSystemPrompt` now takes `contextFiles: {path, content}[]` and mirrors pi's `buildSystemPrompt` `<project_context>` loop.
- **`config.agentDir`** (relative to the config file's directory) relocates the agent's own surface — `persona.md`, `skills/`, `tools/`, `channels/` — to a subdir, while `cwd` stays the run root. So a coding agent can serve an existing repo (`config.agentDir: "./agent"`) without its `tools/`/`src/` colliding with the agent's, and the repo's `AGENTS.md` is picked up by the cwd-walk as context. Threaded through the opener, `info`, `dev`, `start`, and `chat`.
- **`createPiAgentFromDefinition(dir, { cwd?, ... })`** — `dir` = the definition dir, `cwd` (default `dir`) = the working root. `resolveWorkspaceTools(config, agentDir, cwd)` roots default tools at `cwd`, discovers `tools/` from `agentDir`.

## Compatibility
- Flat (no `config.agentDir`) → `agentDir = cwd = dir`, byte-for-byte the same **except**: (1) the new cwd-ancestor context walk (an agent nested under a repo/`~` with its own `AGENTS.md` now picks those up — pi's standard behaviour); (2) the `info`/startup label `agents:` → `context:`.
- **Public surface (pre-1.0):** `LoadedDefinition.instructions` (string) → `contextFiles` (list); `createPiAgentFromDefinition` gains `cwd?`; `config.agentDir` added; `info --json` `instructions` bool → `context` (paths) + `agentDir`.

## Deferred deviations (documented in core.md §6 + `definition.ts` header)
`loadProjectContextFiles` reads via node `fs` directly (bypasses the `ExecutionEnv` port) and only **warns** on a read error rather than failing visibly. These are conscious consequences of reusing pi's function; both revisited with the sandbox/ExecutionEnv work. An unreadable context file is rare and still hits stderr; adding structured diagnostics would mean re-implementing the walk (not reusing pi).

## Verify
`typecheck` + `lint` + full suite green (469, +2). New tests: `loadAgentDefinition(agentDir, { cwd })` (persona from agentDir, ② walked from cwd incl. the host repo's AGENTS.md); `resolveWorkspaceTools` discovers `tools/` from `agentDir` not `cwd` (guards the param split). Iterated through `rv` (fresh-context semantic review) to a single remaining finding, consciously deferred per above.
