### PR TITLE
feat(schedule): time-trigger firing the agent on a cron (Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,12 @@ src/
 │   ├── runner.ts            # the shared host-CLI dispatcher seam (CliRunner + spawnRunner; faked in tests)
 │   ├── fly/     { plan.ts, run.ts }  # Fly: PLAN (artifacts + runbook, pure) + `--run` driver (drives flyctl behind the runner seam)
 │   └── railway/ { plan.ts, run.ts }  # Railway: same two roles — NOT a copy of Fly (thin config, minted URL, no scriptable scale-to-zero)
+├── schedule/               # the N axis, clock form: a time-trigger firing the agent on a cron (schedules/<name>.ts)
+│   ├── schedule.ts         # defineSchedule({ cron, tz?, prompt }) authoring surface + types (no session field — it's runtime-derived)
+│   ├── cron.ts             # the one place touching `croner` (zero-dep, IANA tz/DST): nextRun + cronError
+│   ├── discover.ts         # schedules/ filesystem discovery (loadSchedules/discoverScheduleFiles), isolates a bad file (G2)
+│   ├── scheduler.ts        # lifecycle + fire algorithm (overdue catch-up ONCE, claim-before-invoke) + stable per-schedule session
+│   └── state.ts            # fires.json (last-fired per name) atomic write — durability for the catch-up
 └── engines/pi/              # the pi reference implementation
     ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
     ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -207,6 +207,49 @@ const textHeaders: { readonly "content-type": "text/plain" };
 
 See [Channel development](channel-development.md).
 
+## Schedule authoring
+
+```ts
+interface Schedule {
+  cron: string; // 5-field cron expression
+  tz?: string; // IANA timezone (default "UTC")
+  prompt: string; // the turn's text = the job's instruction
+}
+function defineSchedule(schedule: Schedule): Schedule;
+function loadSchedules(dir: string): Promise<{ schedules: LoadedSchedule[]; failures: ModuleLoadFailure[] }>;
+function createScheduler(opts: SchedulerOptions): Scheduler; // { start(): void; stop(): void }
+function scheduleSession(name: string): string; // the derived stable session id
+```
+
+A workspace declares time-triggers by dropping `schedules/<name>.ts`, mirroring `tools/`/`channels/`;
+the filename becomes the schedule name. Each file default-exports `defineSchedule({ cron, tz?, prompt })`.
+
+```ts
+// schedules/daily-digest.ts        → schedule "daily-digest"
+import { defineSchedule } from "@kid7st/fastagent";
+
+export default defineSchedule({
+  cron: "0 9 * * *",
+  tz: "America/New_York",
+  prompt: "Generate today's digest and send it to the team Telegram.",
+});
+```
+
+The scheduler is a time-trigger (the N axis, clock form): on each cron instant it invokes the agent
+with `prompt` — borrowing the same `Agent` contract as channels, adding none. It:
+
+- **carries no `session` field** — a session id is runtime conversational context, not a build-time
+  value. It derives a stable per-schedule session (`scheduleSession(name)` = `schedule:<name>`), so a
+  schedule's turns share one continuing conversation persisted by the core session store (zero-touch on
+  storage, like the telegram channel deriving a session from `chat.id`);
+- **delivers nothing** — output is the agent's tools' job; the scheduler only fires and logs the outcome;
+- **catches up an overdue run once** — durable `fires.json` under `<stateRoot>/schedule/` records the
+  last fire; a run missed while the process was down fires once on the next start (not per missed slot),
+  claimed before the invoke (at-most-once per slot).
+
+Single-process (like all state today). `createScheduler({ agent, stateRoot, schedules })` is started by
+the serve path (`dev`/`start`); `fastagent fire <name>` runs one schedule's turn immediately for authoring.
+
 ## Config and models
 
 ```ts

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,7 @@ Most commands take an optional workspace directory. When omitted, the current di
 | `dev [dir]` | Serve locally with watch/reload. |
 | `chat [dir]` | Open the same assembled agent in pi's interactive TUI. |
 | `invoke <message> [dir]` | Run one agent turn and exit. |
+| `fire <name> [dir]` | Run one schedule's turn immediately (authoring loop). |
 | `tool <name> <json> [dir]` | Run one discovered tool directly. |
 | `add github|telegram [dir]` | Scaffold a first-party channel. |
 | `add skill <source> [dir]` | Vendor an Agent Skills skill into `skills/`. |
@@ -60,6 +61,7 @@ Prints the assembled surface without starting a server:
 - skills and diagnostics,
 - non-default tools and collisions,
 - channel files,
+- schedule files,
 - session directory.
 
 `info` is read-only: it does not create sessions or modify `.fastagent/`.
@@ -134,6 +136,24 @@ Runs one turn through the same workspace assembly and exits:
 - a `failed` terminal event exits non-zero.
 
 Use this for smoke tests and scripts.
+
+## `fastagent fire`
+
+```bash
+fastagent fire <name> [dir] [--model provider/modelId] [--auth-path file]
+```
+
+Runs ONE schedule's turn immediately — the authoring loop for schedules (like `invoke` is for a
+prompt). Fires `schedules/<name>.ts` now, without waiting for its cron, using the schedule's stable
+session, so you see exactly what the served scheduler would do:
+
+- answer text streams to stdout, tool/diagnostic lines to stderr, a `failed` turn exits non-zero (like `invoke`),
+- no name → usage on stderr, exit 2; an unknown schedule name → exit 1 with the available names,
+- it does **not** advance the schedule's fire state — a test run never makes the running scheduler skip the real next run.
+
+A `schedules/<name>.ts` file default-exports `defineSchedule({ cron, tz?, prompt })`; the scheduler
+fires the agent on that cron when you `dev`/`start`. Output is the agent's tools' job — the scheduler
+only fires and logs. See the [API reference](./api-reference.md#schedule-authoring).
 
 ## `fastagent tool`
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -42,6 +42,8 @@ FastAgent aims to collapse **N triggers × M agents × K hosts** into additive s
 
 The SPEC directly owns N × M. K portability is enabled by core invariants, but each host still needs real target-adapter work.
 
+The N axis has two forms, both on the SAME `invoke` contract (neither adds a new one): **inbound triggers** — channels, driven by an incoming request (§9) — and the **clock trigger** — the scheduler, driven by time (§9.3).
+
 ## 2. Agent definitions and prompt assembly
 
 FastAgent consumes existing definition artifacts:
@@ -179,7 +181,7 @@ If a second invocation arrives for the same session while one is already running
 
 Core does not queue. Dedupe, retry, user-visible “busy” messages, and steering are channel-level decisions because only the channel understands the trigger semantics.
 
-## 9. Channels
+## 9. Triggers: channels and schedules
 
 ### 9.1 HTTP channel
 
@@ -255,6 +257,43 @@ Durable decisions this architecture encodes:
   of growing the hand-rolled surface — `callApi<M>` is shape-compatible with `bot.api.*`, so the
   policy layer survives that swap. The transport rewrite itself applied gramIO's architecture
   lesson (one generic call function, policy as its wrapper, typed errors) without the dependency.
+
+### 9.3 Schedules (the clock trigger)
+
+The scheduler is the N axis in **clock form**: a time-trigger that fires the agent on a cron. A workspace
+declares one by dropping `schedules/<name>.ts` (`defineSchedule({ cron, tz?, prompt })`), mirroring
+`tools/`/`channels/` filesystem discovery — the FILE producer of scheduled invocations (the author's:
+declarative, git-tracked, deploy-guaranteed). It borrows the existing `agent.invoke` contract and adds
+none; it lives in `src/schedule/` (not `channels/`, because a clock trigger mounts a timer, not a route).
+
+Fire model:
+
+- **Stable per-schedule session**, derived at runtime as `schedule:<name>` (like the telegram channel
+  derives one from `chat.id`) — so a schedule's turns share one continuing conversation persisted by the
+  core session store. A session id is runtime conversational context (K side, §7/§10.1), never an
+  authored field; the definition (`schedules/<name>.ts`) carries only `cron/tz/prompt`.
+- **Output is the agent's tools' job.** The scheduler only fires and logs the outcome — it has no reply
+  target of its own (unlike a channel's chat/PR). A cron turn's prompt says "send X to Telegram"; the
+  agent calls a send tool.
+- **Durability = catch up an overdue run ONCE.** `<stateRoot>/schedule/fires.json` (atomic write) records
+  the last fire; on start, if the next instant after it is already past (the process was down across it),
+  fire once and advance — not once per missed slot. `lastFired` is claimed BEFORE the invoke (at-most-once
+  per slot: a crash mid-turn does not re-fire it — "a digest late once" beats "twice"). Strict
+  at-least-once (a per-turn WAL, like the telegram L1 turn store) is a later tier.
+- **Single-process**, like all state today. Cron has no external wake-up (unlike a webhook), so a
+  deployment with schedules must keep one machine running — `deploy` will enforce that (roadmap below).
+
+The cron arithmetic uses `croner` (zero transitive deps + IANA tz/DST — chosen over `cron-parser`, which
+pulls luxon, per the dependency philosophy); the scheduler owns fire control, borrowing only croner's
+next-instant computation. `fastagent fire <name>` runs one schedule's turn immediately (the authoring
+loop, like `invoke`), without advancing fire state.
+
+Roadmap: **Phase 2** — a run audit (`runs.jsonl`, full reply) + `fastagent schedule history`. **Phase 3**
+— `deploy` enforces keep-1-machine when schedules exist. **Phase 4** — the agent's `wake` tool
+(self-scheduling): the SECOND producer of scheduled invocations (agent-created, one-shot or recurring)
+into a unified store, needing a `ToolContext` session injection so a wake can continue the current
+conversation. The file producer (this section) and the tool producer carry different reliability
+contracts — declarative/guaranteed vs runtime/self-managed — so both stay.
 
 ## 10. Running and deployment (design)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@octokit/webhooks-methods": "^6.0.0",
         "@octokit/webhooks-types": "^7.6.1",
         "chokidar": "^5.0.0",
+        "croner": "^9.1.0",
         "giget": "^3.3.0",
         "ignore": "^7.0.5",
         "undici": "^8.6.0",
@@ -3454,6 +3455,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/croner": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-9.1.0.tgz",
+      "integrity": "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@octokit/webhooks-methods": "^6.0.0",
     "@octokit/webhooks-types": "^7.6.1",
     "chokidar": "^5.0.0",
+    "croner": "^9.1.0",
     "giget": "^3.3.0",
     "ignore": "^7.0.5",
     "undici": "^8.6.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,8 @@ import { authSeedBytes, deployFlyRun } from "./deploy/fly/run.ts";
 import { spawnRunner } from "./deploy/runner.ts";
 import { assembleSecrets } from "./deploy/secrets.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
+import { discoverScheduleFiles, loadSchedules } from "./schedule/discover.ts";
+import { createScheduler, scheduleSession } from "./schedule/scheduler.ts";
 
 function usage(code: number): never {
   console.error(`usage:
@@ -74,6 +76,7 @@ function usage(code: number): never {
   fastagent info   [dir] [--json] [--auth-path file]
   fastagent tool   <name> '<json-args>' [dir]
   fastagent invoke <message> [dir] [--model provider/modelId] [--auth-path file]
+  fastagent fire   <name> [dir] [--model provider/modelId] [--auth-path file]
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--auth-path file] [--no-watch] [--tunnel]
   fastagent chat   [dir] [--model provider/modelId]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir] [--auth-path file] [--tunnel]
@@ -107,6 +110,8 @@ function usage(code: number): never {
   invoke run ONE turn against the assembled agent and exit — no server, no TUI. The reply streams
          to stdout, tool/diagnostics to stderr, a failed turn exits non-zero. The all-agent
          counterpart of tool, for CI smoke and quick checks. Same model resolution as dev.
+  fire   run ONE schedule's turn immediately (authoring loop, like invoke) — fires schedules/<name>.ts
+         now without waiting for its cron. Reply→stdout; does NOT advance the schedule's fire state.
   start  run the agent in dir (default .) in production posture — the SAME assembly as dev
          (your directory is the agent), just no file-watching. No build step: start reads the
          definition directly; model/http come from fastagent.config.ts (frozen by git).
@@ -190,6 +195,7 @@ else if (command === "chat") await runChat();
 else if (command === "start") await runStart();
 else if (command === "add") await runAdd();
 else if (command === "deploy") await runDeploy();
+else if (command === "fire") await runFire();
 else if (command === "login") await runLogin();
 else usage(1);
 
@@ -270,6 +276,44 @@ async function runInvoke(): Promise<void> {
   process.exit(exitCode);
 }
 
+/**
+ * `fastagent fire <name> [dir]`: run ONE schedule's turn immediately — the authoring loop for schedules
+ * (like `invoke` is for a prompt). Fires `schedules/<name>.ts` now, without waiting for its cron, using
+ * the schedule's stable session (faithful to the served behavior). Does NOT advance the schedule's fire
+ * state — a test run must never make the scheduler skip the real next run.
+ */
+async function runFire(): Promise<void> {
+  const name = positionals[1];
+  if (!name) {
+    console.error(`usage: fastagent fire <name> [dir]`);
+    process.exit(2);
+  }
+  const fireDir = resolve(positionals[2] ?? ".");
+  loadDotEnv(fireDir);
+  installProxyFetch();
+  await resolveFirstRunModel(fireDir);
+  const { schedules, failures } = await loadSchedules(fireDir).catch(failStartup);
+  reportModuleLoadFailures(failures);
+  const schedule = schedules.find((s) => s.name === name);
+  if (!schedule) {
+    console.error(`unknown schedule "${name}". available: ${schedules.map((s) => s.name).join(", ") || "(none)"}`);
+    process.exit(1);
+  }
+  const { agent, modelSpec, authPath } = await createPiAgentFromWorkspace(fireDir, {
+    model: values.model,
+    authPath: resolveAuthPathOverride(values["auth-path"]),
+  }).catch(failStartup);
+  console.error(`[fastagent] fire: ${name} (${modelSpec})`);
+  await reportAuth(modelSpec, authPath);
+  const exitCode = await runInvokeStream(
+    agent.invoke({ session: scheduleSession(name) }, { text: schedule.prompt }),
+    (text) => process.stdout.write(text),
+    (line) => console.error(line),
+  );
+  process.stdout.write("\n");
+  process.exit(exitCode);
+}
+
 /** `fastagent info [dir] [--json]`: print what the directory ASSEMBLES into, WITHOUT booting a server. Read-only. */
 async function runInfo(): Promise<void> {
   loadDotEnv(dir); // skills/tools may read env at load time
@@ -289,6 +333,7 @@ async function runInfo(): Promise<void> {
     }))
     .catch((e: unknown) => ({ names: [] as string[], collisions: [], failures: [], error: (e as Error).message }));
   const channels = await discoverChannelFiles(dir).catch(failStartup);
+  const schedules = await discoverScheduleFiles(dir).catch(failStartup);
   // The default sessions/auth paths WITHOUT creating anything (info is read-only; dev/start mkdir/login
   // create them, info must not).
   const stateRoot = resolveStateRoot(dir);
@@ -308,6 +353,7 @@ async function runInfo(): Promise<void> {
           tools: tools.names,
           toolError: tools.error ?? null,
           channels,
+          schedules,
           stateRoot,
           sessionsDir,
           authPath,
@@ -330,6 +376,7 @@ async function runInfo(): Promise<void> {
   console.log(`skills:   ${definition.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
   console.log(`tools:    ${tools.error ? "(could not load — see warning below)" : tools.names.join(", ") || "(none)"}`);
   console.log(`channels: ${channels.join(", ") || "(none)"}`);
+  console.log(`schedules: ${schedules.join(", ") || "(none)"}`);
   console.log(`state:    ${stateRoot}`);
   console.log(`sessions: ${sessionsDir}`);
   console.log(`auth:     ${authPath}`);
@@ -984,7 +1031,9 @@ async function serveOnce(): Promise<void> {
   reportAgentsSkillsTools(a);
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
-  const routes = await routesFor(dir, logAgentLoop(a.agent), a.stateRoot).catch(failStartup);
+  const traced = logAgentLoop(a.agent);
+  const routes = await routesFor(dir, traced, a.stateRoot).catch(failStartup);
+  await startSchedules(dir, traced, a.stateRoot);
   serve(routes, portFlag ?? a.config.http?.port ?? 8787, (p) => maybeTunnel(a.definition.dir, p));
 }
 
@@ -1044,7 +1093,9 @@ async function runStart(): Promise<void> {
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 
   // Same debug turn trace as dev; gated out here by the info level (see serveOnce).
-  const routes = await routesFor(dir, logAgentLoop(agent), stateRoot).catch(failStartup);
+  const traced = logAgentLoop(agent);
+  const routes = await routesFor(dir, traced, stateRoot).catch(failStartup);
+  await startSchedules(dir, traced, stateRoot);
   serve(routes, portFlag ?? parsePort(process.env.PORT, "PORT env") ?? config.http?.port ?? 8787, (p) =>
     maybeTunnel(dir, p),
   );
@@ -1091,6 +1142,24 @@ function serve(routes: Routes, port: number, onListening?: (boundPort: number) =
       process.exit(1);
     },
   );
+}
+
+/**
+ * Load and start the workspace's `schedules/` — a time-trigger firing the agent on each cron. No-op when
+ * there are none. The scheduler shares the SAME (trace-wrapped) agent the routes serve, so a scheduled
+ * turn is observed like any other. Best-effort stop on exit; dev's watch restart re-reads schedules with
+ * the worker (schedules are a code input). Single-process (like all state today).
+ */
+async function startSchedules(workspaceDir: string, agent: Agent, stateRoot: string): Promise<void> {
+  const { schedules, failures } = await loadSchedules(workspaceDir).catch(failStartup);
+  reportModuleLoadFailures(failures);
+  if (schedules.length === 0) return;
+  const scheduler = createScheduler({ agent, stateRoot, schedules });
+  scheduler.start();
+  log.info(`[fastagent] schedules: ${schedules.map((s) => s.name).join(", ")}`);
+  const stop = (): void => scheduler.stop();
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,12 @@ export type { AgentTool } from "@earendil-works/pi-agent-core";
 // Channel discovery: a channels/<name>.ts default-exports a ChannelModule ((ctx) => Routes).
 export { loadChannels, type ChannelCollision } from "./engines/pi/channel.ts";
 
+// Schedule authoring + discovery: a schedules/<name>.ts default-exports defineSchedule({ cron, tz?, prompt }).
+// The scheduler is a time-trigger that fires the agent on each cron; it consumes only the Agent contract.
+export { defineSchedule, type Schedule, type LoadedSchedule } from "./schedule/schedule.ts";
+export { loadSchedules, discoverScheduleFiles } from "./schedule/discover.ts";
+export { createScheduler, scheduleSession, type Scheduler, type SchedulerOptions } from "./schedule/scheduler.ts";
+
 // The command opener `dev` and `start` both drive: point at a definition directory → agent.
 export {
   createPiAgentFromWorkspace,

--- a/src/schedule/cron.ts
+++ b/src/schedule/cron.ts
@@ -1,0 +1,33 @@
+/**
+ * The one place that touches the cron library (`croner`). The scheduler owns FIRE control (for
+ * durability / overdue catch-up), so it borrows only croner's next-instant computation, not its
+ * scheduling. croner is chosen for zero transitive dependencies + built-in IANA timezone/DST handling
+ * (wall-clock schedules like "daily 9am America/New_York" need DST-correct arithmetic that hand-rolling
+ * gets wrong at the spring-forward / fall-back boundary).
+ */
+import { Cron } from "croner";
+
+/** The next scheduled instant STRICTLY AFTER `from` (in `tz`, default UTC), or undefined if the
+ *  expression will never fire again. */
+export function nextRun(cron: string, tz: string | undefined, from: Date): Date | undefined {
+  return new Cron(cron, { timezone: tz ?? "UTC" }).nextRun(from) ?? undefined;
+}
+
+/** Why `cron`/`tz` is invalid (for load-time validation), or undefined if valid. croner validates the
+ *  timezone lazily (not at construction), so check it explicitly via Intl (throws on an unknown IANA
+ *  zone); the pattern is validated by constructing the Cron. Both turned into a message, never a throw. */
+export function cronError(cron: string, tz: string | undefined): string | undefined {
+  if (tz !== undefined) {
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    } catch {
+      return `unknown timezone "${tz}"`;
+    }
+  }
+  try {
+    new Cron(cron, { timezone: tz ?? "UTC" });
+    return undefined;
+  } catch (e) {
+    return (e as Error).message;
+  }
+}

--- a/src/schedule/discover.ts
+++ b/src/schedule/discover.ts
@@ -1,0 +1,59 @@
+/**
+ * Schedule discovery (the N axis, clock form): a workspace declares its time-triggers by dropping files
+ * in `schedules/`, mirroring `tools/` and `channels/`. Each file default-exports `defineSchedule({...})`,
+ * named from its filename. This is the FILE producer of scheduled invocations (the author's, declarative,
+ * git-tracked, deploy-guaranteed); the agent's `wake` tool will be the second producer (Phase 4).
+ */
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { type ModuleLoadFailure, isModuleFile, loadModuleDir } from "../engines/pi/loader.ts";
+import { assertInsideWorkspace } from "../workspace.ts";
+import { cronError } from "./cron.ts";
+import type { LoadedSchedule, Schedule } from "./schedule.ts";
+
+/** Schedule file basenames under `<dir>/schedules/` — the authoring view (`fastagent info`), listed
+ *  WITHOUT importing (like {@link import("../engines/pi/channel.ts").discoverChannelFiles}). */
+export async function discoverScheduleFiles(dir: string): Promise<string[]> {
+  await assertInsideWorkspace(dir, "schedules");
+  let names: string[];
+  try {
+    names = await readdir(join(dir, "schedules"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  return names
+    .filter(isModuleFile)
+    .map((n) => n.replace(/\.(ts|js|mjs)$/, ""))
+    .sort();
+}
+
+/**
+ * Discover schedules in `<dir>/schedules/`: each file default-exports a `defineSchedule({...})`, named
+ * from its filename. A file broken for ANY reason — a failed import, not a schedule (no cron/prompt), or
+ * an invalid cron/tz — is ISOLATED into `failures` (skipped + reported, never a crash-loop, G2), the same
+ * way `loadTools`/`loadChannels` isolate theirs. A duplicate name (foo.ts + foo.js) keeps the first and
+ * reports the rest.
+ */
+export async function loadSchedules(
+  dir: string,
+): Promise<{ schedules: LoadedSchedule[]; failures: ModuleLoadFailure[] }> {
+  await assertInsideWorkspace(dir, "schedules");
+  const { modules, failures } = await loadModuleDir(join(dir, "schedules"));
+  const byName = new Map<string, LoadedSchedule>();
+  for (const { name, label, file, mod } of modules) {
+    try {
+      const s = mod.default as Partial<Schedule> | undefined;
+      if (!s || typeof s.cron !== "string" || typeof s.prompt !== "string") {
+        throw new Error(`${label} must default-export defineSchedule({ cron, prompt })`);
+      }
+      const err = cronError(s.cron, s.tz);
+      if (err) throw new Error(`${label}: invalid cron/tz — ${err}`);
+      if (byName.has(name)) throw new Error(`${label}: duplicate schedule name "${name}" — kept the first`);
+      byName.set(name, { name, cron: s.cron, tz: s.tz, prompt: s.prompt });
+    } catch (error) {
+      failures.push({ label, file, message: (error as Error).message });
+    }
+  }
+  return { schedules: [...byName.values()], failures };
+}

--- a/src/schedule/schedule.ts
+++ b/src/schedule/schedule.ts
@@ -1,0 +1,40 @@
+/**
+ * Schedule authoring: `defineSchedule` (the authoring surface). Drop a file in `schedules/`,
+ * default-export `defineSchedule({...})`, and it is discovered, named from the filename, and run by the
+ * scheduler — a time-trigger (the N axis, clock form) that fires the agent on a cron.
+ *
+ *   // schedules/daily-digest.ts        → schedule "daily-digest"
+ *   export default defineSchedule({
+ *     cron: "0 9 * * *",
+ *     tz: "America/New_York",
+ *     prompt: "Generate today's digest and send it to the team Telegram.",
+ *   });
+ *
+ * A schedule carries NO session field: a session id is runtime conversational context (the K side —
+ * host-provided per invoke, core.md §10.1 / §7), not a build-time (M) value. The scheduler derives a
+ * stable per-schedule session from the name at runtime (like
+ * the telegram channel derives one from chat.id), so a schedule's turns share one continuing
+ * conversation, persisted by the core session store. Output is the AGENT's tools' job — the scheduler
+ * only fires and logs, it does not deliver.
+ */
+
+/** A time-triggered invocation: at each `cron` instant (in `tz`, default UTC) the scheduler invokes the
+ *  agent with `prompt`. */
+export interface Schedule {
+  /** 5-field cron expression (`minute hour day-of-month month day-of-week`). */
+  cron: string;
+  /** IANA timezone for the cron (default "UTC"). Wall-clock schedules (daily 9am) need it. */
+  tz?: string;
+  /** The turn's text = the job's instruction. The agent's tools decide where any output goes. */
+  prompt: string;
+}
+
+/** Identity function for typing + IDE completion (like `defineTool`/`defineConfig`). */
+export function defineSchedule(schedule: Schedule): Schedule {
+  return schedule;
+}
+
+/** A loaded schedule: its authored fields plus the name derived from its filename (authoritative). */
+export interface LoadedSchedule extends Schedule {
+  name: string;
+}

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -1,0 +1,133 @@
+/**
+ * The scheduler: a time-trigger that fires the agent on each schedule's cron. SINGLE-PROCESS (like all
+ * fastagent state today) — a deployment with schedules must keep one machine running, since cron has no
+ * external wake-up (Phase 3 makes `deploy` enforce that). Started/stopped by the serve path (dev/start).
+ *
+ * Fire model:
+ *  - **stable session per schedule** (`schedule:<name>`), so a schedule's turns share one continuing
+ *    conversation persisted by the core session store; the scheduler is ZERO-touch on session storage.
+ *  - **output is the agent's tools' job** — the scheduler only fires and logs the outcome.
+ *  - **durability = catch up ONCE** (`state.ts`): on start, if the next instant after the last fire is
+ *    already past (the process was down across it), fire once and advance — not once per missed slot.
+ *    lastFired is claimed BEFORE the invoke (at-most-once per slot: a crash mid-turn won't re-fire it;
+ *    "a digest late once" beats "twice"). Strict at-least-once (a per-turn WAL) is a later tier.
+ */
+import type { Agent } from "../agent.ts";
+import { log } from "../log.ts";
+import { nextRun } from "./cron.ts";
+import type { LoadedSchedule } from "./schedule.ts";
+import { type Fires, loadFires, saveFires } from "./state.ts";
+
+/** A schedule's turns share this stable session — a continuing conversation, like the telegram channel's
+ *  per-chat session. Derived at RUNTIME from the name (never an authored field). */
+export function scheduleSession(name: string): string {
+  return `schedule:${name}`;
+}
+
+export interface Scheduler {
+  /** Arm every schedule (catching up an overdue one once). Idempotent-ish: call once per process. */
+  start(): void;
+  /** Clear all armed timers. Does NOT drain an in-flight fire (SIGTERM exits mid-turn by design; the
+   *  interrupted turn is not re-fired — lastFired was already claimed). A catch-up fire in flight has NO
+   *  timer entry to clear either (the overdue branch fires directly, without arming), so `stop()` simply
+   *  lets it run out or be cut by process exit — same non-drain, and its claim is already persisted. */
+  stop(): void;
+}
+
+export interface SchedulerOptions {
+  agent: Agent;
+  stateRoot: string;
+  schedules: LoadedSchedule[];
+  /** Injectable clock for tests; defaults to the wall clock. */
+  now?: () => Date;
+}
+
+// A single setTimeout maxes out at ~24.8 days and drifts over long sleeps; cap each wait so a long
+// interval (or a suspended machine) re-checks against the wall clock rather than firing wildly early/late.
+const MAX_WAIT_MS = 6 * 60 * 60 * 1000; // 6h
+
+export function createScheduler({ agent, stateRoot, schedules, now = () => new Date() }: SchedulerOptions): Scheduler {
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  let stopped = false;
+
+  /** Fire one schedule's turn: claim the slot (persist lastFired BEFORE invoking), then drive the turn
+   *  and log its outcome. Total — never throws (the timer callback that calls it is void). */
+  async function fire(s: LoadedSchedule): Promise<void> {
+    const session = scheduleSession(s.name);
+    // Claim the slot before the invoke so a crash mid-turn does not re-fire this slot on restart.
+    const fires: Fires = loadFires(stateRoot);
+    fires[s.name] = now().toISOString();
+    try {
+      saveFires(stateRoot, fires);
+    } catch (e) {
+      // Can't persist the claim → skip this fire rather than risk an infinite catch-up loop on restart.
+      log.error(`[schedule] ${s.name}: cannot persist fire state, skipping this run: ${String(e)}`);
+      return;
+    }
+    const startedAt = Date.now();
+    log.info(`[schedule] ${s.name} firing (session=${session})`);
+    try {
+      let failed: string | undefined;
+      for await (const e of agent.invoke({ session }, { text: s.prompt })) {
+        if (e.type === "failed") failed = e.details;
+      }
+      if (failed) log.error(`[schedule] ${s.name} failed (${Date.now() - startedAt}ms): ${failed}`);
+      else log.info(`[schedule] ${s.name} completed (${Date.now() - startedAt}ms)`);
+    } catch (e) {
+      // invoke shouldn't throw (SPEC MUST 2 turns failures into events), but stay total regardless.
+      log.error(`[schedule] ${s.name} errored (${Date.now() - startedAt}ms): ${String(e)}`);
+    }
+  }
+
+  /** Arm a timer for `at`, capped so a long wait re-checks the wall clock instead of trusting one sleep. */
+  function arm(s: LoadedSchedule, at: Date): void {
+    if (stopped) return;
+    const delay = Math.min(Math.max(0, at.getTime() - now().getTime()), MAX_WAIT_MS);
+    timers.set(
+      s.name,
+      setTimeout(() => {
+        if (stopped) return;
+        if (now().getTime() >= at.getTime()) void fireThenReArm(s);
+        else arm(s, at); // woke early (the cap) — keep waiting for the real instant
+      }, delay),
+    );
+  }
+
+  /** Fire, then arm the NEXT run computed from now — so a slow fire never double-fires the same slot and
+   *  missed slots collapse to the single catch-up already done. */
+  async function fireThenReArm(s: LoadedSchedule): Promise<void> {
+    await fire(s);
+    const due = nextRun(s.cron, s.tz, now());
+    if (due) arm(s, due);
+  }
+
+  return {
+    start() {
+      stopped = false;
+      const fires = loadFires(stateRoot);
+      const current = now();
+      for (const s of schedules) {
+        // Anchor on the last fire (catch-up basis), or `now` on a first-ever run so a brand-new schedule
+        // never back-fires before the process first booted.
+        const lastFired = fires[s.name];
+        const anchor = lastFired ? new Date(lastFired) : current;
+        const due = nextRun(s.cron, s.tz, anchor);
+        if (!due) {
+          log.warn(`[schedule] ${s.name}: cron "${s.cron}" will never fire again — not armed`);
+          continue;
+        }
+        if (due.getTime() <= current.getTime()) {
+          log.info(`[schedule] ${s.name}: catching up a missed run`);
+          void fireThenReArm(s); // overdue → fire once, then arm the next
+        } else {
+          arm(s, due);
+        }
+      }
+    },
+    stop() {
+      stopped = true;
+      for (const t of timers.values()) clearTimeout(t);
+      timers.clear();
+    },
+  };
+}

--- a/src/schedule/state.ts
+++ b/src/schedule/state.ts
@@ -1,0 +1,51 @@
+/**
+ * Durable scheduler state for a SINGLE-PROCESS deployment: `<stateRoot>/schedule/fires.json` maps a
+ * schedule name to the ISO time it last fired. A fire missed while the process was down is caught up
+ * ONCE on the next start (overdue → fire, then advance) — not per-slot. Small JSON, atomic (tmp+rename)
+ * so a crash never leaves a torn file. The root state dir already self-ignores (`.fastagent/.gitignore`),
+ * and fires.json holds only names + timestamps (no chat content), so no per-dir .gitignore is needed.
+ *
+ * ponytail: this atomic read/write duplicates channels/telegram/state.ts's primitive (both are KB-JSON
+ * tmp+rename). Extract a neutral src/state.ts and have both import it when a third consumer appears.
+ */
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { log } from "../log.ts";
+
+/** name → last-fired ISO timestamp. */
+export type Fires = Record<string, string>;
+
+function firesPath(stateRoot: string): string {
+  return join(stateRoot, "schedule", "fires.json");
+}
+
+/** Load the fire history. Missing is normal (first run → empty); a corrupt file degrades visibly (warn +
+ *  empty, so at most a duplicate catch-up); an unreadable file (permissions/IO) throws — a real
+ *  environment fault the operator must fix, not something to hide behind silently-empty state. */
+export function loadFires(stateRoot: string): Fires {
+  const path = firesPath(stateRoot);
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw new Error(`schedule state ${path} is unreadable — fix permissions/disk and restart: ${String(e)}`, {
+      cause: e,
+    });
+  }
+  try {
+    const v = JSON.parse(raw);
+    return v && typeof v === "object" && !Array.isArray(v) ? (v as Fires) : {};
+  } catch (e) {
+    log.warn(`[schedule] corrupt state file ${path} — starting with no fire history: ${String(e)}`);
+    return {};
+  }
+}
+
+export function saveFires(stateRoot: string, fires: Fires): void {
+  const path = firesPath(stateRoot);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(fires));
+  renameSync(tmp, path);
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -50,6 +50,30 @@ describe("cli papercuts", () => {
     expect(stdout).toBe(""); // a failure never pollutes stdout
   });
 
+  it("fire without a name prints usage to stderr and exits 2 (stdout clean)", async () => {
+    const { code, stdout, stderr } = await run(["fire"]);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/usage: fastagent fire/);
+    expect(stdout).toBe("");
+  });
+
+  it("fire on an unknown schedule name exits 1 and lists the available schedules", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-fire-"));
+    await mkdir(join(dir, "schedules"), { recursive: true });
+    await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
+    const scheduleHref = new URL("../src/schedule/schedule.ts", import.meta.url).href;
+    await writeFile(
+      join(dir, "schedules", "daily.ts"),
+      `import { defineSchedule } from ${JSON.stringify(scheduleHref)};\nexport default defineSchedule({ cron: "0 9 * * *", prompt: "digest" });\n`,
+    );
+    const env = { ...process.env };
+    delete env.FASTAGENT_MODEL; // unknown-name exits before any model resolution
+    const { code, stderr } = await run(["fire", "nope", dir], undefined, env);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/unknown schedule "nope"/);
+    expect(stderr).toMatch(/available: daily/);
+  });
+
   it("never clobbers an existing Dockerfile: flags a stale generated one, warns on a hand-written one (G6)", async () => {
     // deploy KEEPS any existing Dockerfile without --force (no silent data loss). A generated one (marker)
     // that drifted from current config is flagged stale; a hand-written one is kept + warned (its apt won't

--- a/test/schedule-cron.test.ts
+++ b/test/schedule-cron.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { cronError, nextRun } from "../src/schedule/cron.ts";
+
+describe("schedule/cron", () => {
+  it("nextRun returns the next instant STRICTLY AFTER `from`, timezone-aware", () => {
+    // 9am America/New_York = 13:00 UTC in July (EDT).
+    const n = nextRun("0 9 * * *", "America/New_York", new Date("2026-07-07T00:00:00Z"));
+    expect(n?.toISOString()).toBe("2026-07-07T13:00:00.000Z");
+    // From that instant, the NEXT one is the following day (strictly after, not the same slot).
+    expect(nextRun("0 9 * * *", "America/New_York", n!)?.toISOString()).toBe("2026-07-08T13:00:00.000Z");
+  });
+
+  it("defaults to UTC when tz is omitted", () => {
+    expect(nextRun("0 9 * * *", undefined, new Date("2026-07-07T00:00:00Z"))?.toISOString()).toBe(
+      "2026-07-07T09:00:00.000Z",
+    );
+  });
+
+  it("cronError: undefined for valid, a message for an invalid pattern or timezone", () => {
+    expect(cronError("0 9 * * *", "UTC")).toBeUndefined();
+    expect(cronError("not a cron", undefined)).toBeTruthy();
+    expect(cronError("0 9 * * *", "Not/AZone")).toBeTruthy();
+  });
+});

--- a/test/schedule-discover.test.ts
+++ b/test/schedule-discover.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverScheduleFiles, loadSchedules } from "../src/schedule/discover.ts";
+
+const scheduleHref = new URL("../src/schedule/schedule.ts", import.meta.url).href;
+const def = (cron: string, prompt = "go", tz?: string): string =>
+  `import { defineSchedule } from ${JSON.stringify(scheduleHref)};\n` +
+  `export default defineSchedule({ cron: ${JSON.stringify(cron)}, prompt: ${JSON.stringify(prompt)}${tz ? `, tz: ${JSON.stringify(tz)}` : ""} });\n`;
+
+async function ws(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "fa-sd-"));
+  await mkdir(join(dir, "schedules"), { recursive: true });
+  for (const [name, content] of Object.entries(files)) await writeFile(join(dir, "schedules", name), content);
+  return dir;
+}
+
+describe("schedule/discover", () => {
+  it("loads valid schedules, named from the filename", async () => {
+    const dir = await ws({ "daily.ts": def("0 9 * * *", "digest", "UTC") });
+    const { schedules, failures } = await loadSchedules(dir);
+    expect(failures).toEqual([]);
+    expect(schedules).toEqual([{ name: "daily", cron: "0 9 * * *", tz: "UTC", prompt: "digest" }]);
+    expect(await discoverScheduleFiles(dir)).toEqual(["daily"]);
+  });
+
+  it("isolates a file with an invalid cron — reported, not thrown (G2)", async () => {
+    const dir = await ws({ "bad.ts": def("not a cron"), "ok.ts": def("0 * * * *", "hourly") });
+    const { schedules, failures } = await loadSchedules(dir);
+    expect(schedules.map((s) => s.name)).toEqual(["ok"]); // the good one still loads
+    expect(failures.find((f) => f.label.includes("bad"))?.message).toMatch(/invalid cron/);
+  });
+
+  it("isolates a non-schedule default export", async () => {
+    const dir = await ws({ "x.ts": "export default { nope: true };\n" });
+    const { schedules, failures } = await loadSchedules(dir);
+    expect(schedules).toEqual([]);
+    expect(failures[0]?.message).toMatch(/must default-export defineSchedule/);
+  });
+
+  it("a missing schedules/ dir yields empty (no schedules is normal)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-sd-empty-"));
+    expect(await discoverScheduleFiles(dir)).toEqual([]);
+    expect((await loadSchedules(dir)).schedules).toEqual([]);
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Agent, AgentEvent } from "../src/agent.ts";
+import type { LoadedSchedule } from "../src/schedule/schedule.ts";
+import { createScheduler, scheduleSession } from "../src/schedule/scheduler.ts";
+
+/** A fake agent that records each invoke's session + text and yields the scripted terminal. */
+function recordingAgent(events: AgentEvent[] = [{ type: "completed" }]) {
+  const calls: { session: string; text: string }[] = [];
+  const agent: Agent = {
+    async *invoke(scope, prompt) {
+      calls.push({ session: scope.session, text: prompt.text });
+      for (const e of events) yield e;
+    },
+  };
+  return { agent, calls };
+}
+
+const hourly = (over: Partial<LoadedSchedule> = {}): LoadedSchedule => ({
+  name: "job",
+  cron: "0 * * * *", // top of every hour
+  tz: "UTC",
+  prompt: "go",
+  ...over,
+});
+
+const freshRoot = (): Promise<string> => mkdtemp(join(tmpdir(), "fa-sched-"));
+function seedFires(root: string, fires: Record<string, string>): void {
+  mkdirSync(join(root, "schedule"), { recursive: true });
+  writeFileSync(join(root, "schedule", "fires.json"), JSON.stringify(fires));
+}
+const readFires = async (root: string): Promise<Record<string, string>> =>
+  JSON.parse(await readFile(join(root, "schedule", "fires.json"), "utf8"));
+
+afterEach(() => vi.useRealTimers());
+
+describe("schedule/scheduler: fire algorithm", () => {
+  it("a brand-new schedule does NOT back-fire on first start (no fires.json)", async () => {
+    const root = await freshRoot();
+    const { agent, calls } = recordingAgent();
+    // Next hourly instant (11:00) is in the future → arm, don't fire.
+    const s = createScheduler({
+      agent,
+      stateRoot: root,
+      schedules: [hourly()],
+      now: () => new Date("2026-07-07T10:30:00Z"),
+    });
+    s.start();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(calls).toHaveLength(0);
+    s.stop();
+  });
+
+  it("catches up an overdue run ONCE, claims the slot, session = schedule:<name>", async () => {
+    const root = await freshRoot();
+    seedFires(root, { job: "2026-07-07T08:00:00Z" }); // last fired 08:00; now is past several hourly slots
+    const { agent, calls } = recordingAgent();
+    const s = createScheduler({
+      agent,
+      stateRoot: root,
+      schedules: [hourly()],
+      now: () => new Date("2026-07-07T12:30:00Z"),
+    });
+    s.start();
+    await vi.waitFor(() => expect(calls.length).toBe(1)); // exactly ONE catch-up, not one per missed slot
+    expect(calls[0]).toEqual({ session: scheduleSession("job"), text: "go" });
+    expect((await readFires(root)).job).toBe("2026-07-07T12:30:00.000Z"); // claimed = now
+    s.stop();
+  });
+
+  it("fires when the cron instant arrives, then re-arms for the next", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T10:30:00Z"));
+    const root = await freshRoot();
+    const { agent, calls } = recordingAgent();
+    const s = createScheduler({ agent, stateRoot: root, schedules: [hourly()] }); // default now = the faked clock
+    s.start();
+    expect(calls).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1000); // → 11:00
+    expect(calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(60 * 60_000); // → 12:00
+    expect(calls).toHaveLength(2);
+    s.stop();
+  });
+
+  it("a failed turn still runs and claims the slot (catch-up, not retried)", async () => {
+    const root = await freshRoot();
+    seedFires(root, { job: "2026-07-07T08:00:00Z" });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { agent, calls } = recordingAgent([{ type: "failed", retryable: true, details: "boom" }]);
+    const s = createScheduler({
+      agent,
+      stateRoot: root,
+      schedules: [hourly()],
+      now: () => new Date("2026-07-07T12:30:00Z"),
+    });
+    s.start();
+    await vi.waitFor(() => expect(calls.length).toBe(1));
+    expect((await readFires(root)).job).toBe("2026-07-07T12:30:00.000Z"); // claimed even on failure
+    s.stop();
+  });
+});


### PR DESCRIPTION
## What

Phase 1 of cron/scheduler — the **N axis in clock form**: a time-trigger that fires the agent on a cron. A workspace declares time-triggers by dropping `schedules/<name>.ts`, mirroring `tools/` and `channels/`.

```ts
// schedules/daily-digest.ts        → schedule "daily-digest"
import { defineSchedule } from "@kid7st/fastagent";
export default defineSchedule({
  cron: "0 9 * * *",
  tz: "America/New_York",
  prompt: "Generate today's digest and send it to the team Telegram.",
});
```

## Design (from the co-design thread)

- **Output is the agent's tools' job** — the scheduler only fires + logs. A cron turn's prompt says "send X to Telegram"; the agent calls a send tool.
- **No `session` field** — a session id is runtime conversational context (K side), not a build-time value. The scheduler derives a stable per-schedule session (`schedule:<name>`) so a schedule's turns share one continuing conversation, persisted by the **core session store** (the scheduler is zero-touch on session storage, symmetric to the telegram channel deriving a session from `chat.id`).
- **Durability = catch up an overdue run ONCE** (`fires.json`, atomic write). On start, if the next instant after the last fire is already past (process was down across it), fire once and advance — not once per missed slot. `lastFired` is claimed **before** the invoke (at-most-once per slot: a crash mid-turn won't re-fire it; "a digest late once" beats "twice").
- **`croner`** for cron math — zero transitive deps + IANA tz/DST, chosen over `cron-parser` (pulls luxon) per the dependency philosophy. The scheduler owns fire control (for overdue/durability); it borrows only croner's next-instant computation.

## Surface

| Module | Role |
|---|---|
| `schedule/schedule.ts` | `defineSchedule({ cron, tz?, prompt })` + types |
| `schedule/cron.ts` | the one place touching `croner`: `nextRun` + `cronError` |
| `schedule/discover.ts` | `schedules/` discovery, isolates a bad file (G2) |
| `schedule/scheduler.ts` | lifecycle + fire algorithm (overdue-once, claim-before-invoke) |
| `schedule/state.ts` | `fires.json` atomic write |
| CLI | `dev`/`start` run the scheduler alongside serve; `info` lists schedules; **`fastagent fire <name>`** runs one schedule's turn now (authoring loop, like `invoke`), without advancing fire state |

## Not in Phase 1 (later)
- **Phase 2**: run audit (`runs.jsonl`, full reply) + `schedule history`.
- **Phase 3**: `deploy` enforces keep-1-machine when schedules exist (cron has no external wake-up → scale-to-zero would sleep through it).
- **Phase 4**: the agent `wake` tool (self-scheduling) — the second producer into a unified store; needs a `ToolContext` session-injection (the one gap identified).

Single-process (like all state today).

## Test
`npm run typecheck && npm test` — 477 passed. New: cron (tz-aware next / validate), discovery (isolation, G2), the fire algorithm (no back-fire on first boot, overdue catch-up **once**, claim on failure, periodic fire via fake timers), and the two `fire` CLI branches (usage/exit-2, unknown-name/exit-1).
