### PR TITLE
fix(telegram): busy-wait a user turn colliding with an external lease holder (wake)

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -325,9 +325,12 @@ the scheduler: the author's `schedules/` files (declarative, guaranteed) and the
   invokes DIRECTLY, bypassing a channel's turn-queue — so "wake fires while the user is chatting" can
   collide both ways. Each side now waits on telegram: a wake INTO a busy session is deferred by the
   scheduler (above), and a USER turn hitting a lease held by an external turn (the wake) busy-WAITS —
-  telegram's `invokeTurn` retries a fail-fast `session_busy` reject (bounded, ~2 min; the user sees the
-  "Thinking…" placeholder, then the answer) instead of showing "try again". Only a FIRST-event busy
-  retries (the turn never started — replay-safe). A github/http turn colliding with a wake still surfaces
+  telegram's `invokeTurn` retries a fail-fast `session_busy` reject (the user sees the "Thinking…"
+  placeholder, then the answer) instead of showing "try again". Bounded at 10 min — sized to outlast a
+  real wake turn (each retry is a cheap lease-level reject, and the wait ends within seconds of the
+  holder finishing); a holder that outlives the cap still surfaces the busy error (the ceiling exists so
+  a stuck lease can't hang a chat turn forever). Only a FIRST-event busy retries (the turn never started
+  — replay-safe). A github/http turn colliding with a wake still surfaces
   busy immediately (their sessions rarely mix with wake sessions; add the same wait if it bites). The
   structural alternative — one shared per-session serial seam — stays deferred: bounded waits cover the
   real scenario at a fraction of the seam's cost.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -321,12 +321,16 @@ the scheduler: the author's `schedules/` files (declarative, guaranteed) and the
   tools' side effects. The scheduler tells the two apart by the busy event's `code` (`SESSION_BUSY_CODE`, a
   `failed.code` per SPEC §8 failure subdivision — a structured field on the neutral contract, not a text
   match on `details` or an engine import).
-- **The collision is only handled one way (a known Phase 4b gap).** The scheduler invokes DIRECTLY,
-  bypassing a channel's turn-queue (telegram's queue exists precisely to serialize instead of colliding on
-  the lease). So the mirror case is unhandled: while a wake turn holds the lease, a user message on the same
-  session collides and the channel shows its "busy, try again" notice. Both directions of "wake fires while
-  the user is still chatting" are equally likely; only the wake→busy direction defers today. The structural
-  fix — wake turns through the same per-session serial seam as channel turns — is Phase 4b.
+- **Both collision directions are handled for telegram; other channels still fail fast.** The scheduler
+  invokes DIRECTLY, bypassing a channel's turn-queue — so "wake fires while the user is chatting" can
+  collide both ways. Each side now waits on telegram: a wake INTO a busy session is deferred by the
+  scheduler (above), and a USER turn hitting a lease held by an external turn (the wake) busy-WAITS —
+  telegram's `invokeTurn` retries a fail-fast `session_busy` reject (bounded, ~2 min; the user sees the
+  "Thinking…" placeholder, then the answer) instead of showing "try again". Only a FIRST-event busy
+  retries (the turn never started — replay-safe). A github/http turn colliding with a wake still surfaces
+  busy immediately (their sessions rarely mix with wake sessions; add the same wait if it bites). The
+  structural alternative — one shared per-session serial seam — stays deferred: bounded waits cover the
+  real scenario at a fraction of the seam's cost.
 - **Deploy note (a Phase 3 gap):** wake has no external wake-up either, so wake-ups make ANY served agent
   need a machine kept running — not just one with `schedules/`. `deploy`'s keep-1 trigger (Phase 3) must
   count self-scheduling, not only static schedules; today that is unenforced.

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -5,7 +5,7 @@
  * pure) because this half touches the Bot API + disk; split from telegram.ts so the factory keeps only
  * wiring and the per-turn lifecycle.
  */
-import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
+import { type Agent, type AgentEvent, type ImageRef, SESSION_BUSY_CODE } from "../../agent.ts";
 import { log } from "../../log.ts";
 import type { BufferedRef } from "./context-buffer.ts";
 import { type DownloadedFile, resolveFiles, resolveImages } from "./telegram-api.ts";
@@ -101,6 +101,16 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
   return { images: allImages.length ? allImages : undefined, promptSuffix: `${bufferedNote}${manifest}` };
 }
 
+/** How the busy-wait paces: retry the invoke every `delayMs` while the session's lease is held by an
+ *  EXTERNAL turn (a self-scheduled wake, a concurrent embedder invoke), up to `maxWaitMs` total. The
+ *  channel's own turns never collide (the turn-queue serializes per session), so a busy reject here is
+ *  always an outside holder — wait for it like a queued turn, instead of erroring at the user. */
+export interface BusyRetry {
+  delayMs: number;
+  maxWaitMs: number;
+}
+const DEFAULT_BUSY_RETRY: BusyRetry = { delayMs: 5_000, maxWaitMs: 120_000 };
+
 /**
  * Run one turn: resolve its attachments, then stream agent.invoke. A primary-attachment failure surfaces
  * as a `failed` event (never a silent drop). `onCompleted` (if given) fires on the turn's `completed`
@@ -108,6 +118,13 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
  * so a failure or crash at ANY earlier point leaves the buffer intact for the next summon (a re-folded
  * block beats lost context). The caller uses it to remove the turn intent AND commit the context buffer,
  * in that order (see the call site) so a crash between the two clears cannot replay a context-stripped turn.
+ *
+ * BUSY-WAIT: a `failed{code: session_busy}` FIRST event means an external turn (e.g. a self-scheduled
+ * wake) holds this session's lease and OUR turn never started — replay-safe. Retry (bounded) instead of
+ * yielding it: the user sees the "Thinking…" placeholder while waiting (the mirror of the scheduler
+ * deferring a wake INTO a busy session), and only an exhausted wait surfaces the busy failure. Only a
+ * FIRST-event busy retries — attachments are already resolved, and a fail-fast reject is the only shape
+ * the engine emits it in, so nothing that started is ever re-run.
  */
 export async function* invokeTurn(
   agent: Agent,
@@ -116,6 +133,7 @@ export async function* invokeTurn(
   transport: TurnTransport,
   attachments: TurnAttachments,
   onCompleted?: () => void,
+  busyRetry: BusyRetry = DEFAULT_BUSY_RETRY,
 ): AsyncIterable<AgentEvent> {
   let resolved: ResolvedAttachments;
   try {
@@ -124,11 +142,22 @@ export async function* invokeTurn(
     yield { type: "failed", details: `could not load attachment: ${String(e)}`, retryable: true };
     return;
   }
-  for await (const e of agent.invoke(
-    { session },
-    { text: `${text}${resolved.promptSuffix}${HTML_INSTRUCTION}`, images: resolved.images },
-  )) {
-    if (e.type === "completed") onCompleted?.(); // the turn is durably in the session — commit point
-    yield e;
+  const prompt = { text: `${text}${resolved.promptSuffix}${HTML_INSTRUCTION}`, images: resolved.images };
+  const deadline = Date.now() + busyRetry.maxWaitMs;
+  for (;;) {
+    let retryBusy = false;
+    let first = true;
+    for await (const e of agent.invoke({ session }, prompt)) {
+      if (first && e.type === "failed" && e.code === SESSION_BUSY_CODE && Date.now() + busyRetry.delayMs < deadline) {
+        retryBusy = true; // fail-fast reject — the stream ends after this event; wait and re-invoke
+        break;
+      }
+      first = false;
+      if (e.type === "completed") onCompleted?.(); // the turn is durably in the session — commit point
+      yield e;
+    }
+    if (!retryBusy) return;
+    log.info(`[telegram] session ${session} is busy (an external turn holds it) — retrying in ${busyRetry.delayMs}ms`);
+    await new Promise((r) => setTimeout(r, busyRetry.delayMs));
   }
 }

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -109,7 +109,12 @@ export interface BusyRetry {
   delayMs: number;
   maxWaitMs: number;
 }
-const DEFAULT_BUSY_RETRY: BusyRetry = { delayMs: 5_000, maxWaitMs: 120_000 };
+// Each retry is a lease-check-level reject (tryAcquire runs before harness assembly) — waiting is nearly
+// free, and the loop exits within one delay of the holder finishing. So the cap is sized to outlast a
+// real tool-using wake turn (minutes), not to be short: 10 min. CEILING: a holder that runs longer than
+// this still surfaces the busy error to the user — the bound exists so a stuck lease can't hang a chat
+// turn forever.
+const DEFAULT_BUSY_RETRY: BusyRetry = { delayMs: 5_000, maxWaitMs: 600_000 };
 
 /**
  * Run one turn: resolve its attachments, then stream agent.invoke. A primary-attachment failure surfaces

--- a/test/invoke-turn-busy.test.ts
+++ b/test/invoke-turn-busy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type Agent, type AgentEvent, SESSION_BUSY_CODE } from "../src/agent.ts";
+import { type BusyRetry, invokeTurn } from "../src/channels/telegram/invoke-turn.ts";
+
+/** A fake agent scripted per-invoke: call N yields script[N] (the last entry repeats). */
+function scriptedAgent(script: AgentEvent[][]) {
+  let calls = 0;
+  const agent: Agent = {
+    async *invoke() {
+      const events = script[Math.min(calls++, script.length - 1)] ?? [];
+      for (const e of events) yield e;
+    },
+  };
+  return { agent, invokes: () => calls };
+}
+
+const busyEvent: AgentEvent = {
+  type: "failed",
+  details: "session busy: a turn is already in flight",
+  retryable: true,
+  code: SESSION_BUSY_CODE,
+};
+const ok: AgentEvent[] = [{ type: "text", delta: "answer" }, { type: "completed" }];
+
+const FAST: BusyRetry = { delayMs: 10, maxWaitMs: 500 };
+const noAttachments = { primary: {}, buffered: { files: [], images: [], skipped: 0 } };
+
+async function run(agent: Agent, retry: BusyRetry = FAST): Promise<AgentEvent[]> {
+  const transport = { api: "http://t.test", botToken: "B", chatId: 1, filesDir: await mkdtemp(join(tmpdir(), "fa-")) };
+  const out: AgentEvent[] = [];
+  for await (const e of invokeTurn(agent, "s", "hi", transport, noAttachments, undefined, retry)) out.push(e);
+  return out;
+}
+
+describe("invokeTurn busy-wait (the reverse of the scheduler's wake defer)", () => {
+  it("a fail-fast busy reject retries (bounded) and the user gets the ANSWER, not an error", async () => {
+    // Invoke 1: busy (an external wake turn holds the lease). Invoke 2: the lease freed — normal turn.
+    const { agent, invokes } = scriptedAgent([[busyEvent], ok]);
+    const events = await run(agent);
+    expect(invokes()).toBe(2); // waited + re-invoked
+    expect(events.map((e) => e.type)).toEqual(["text", "completed"]); // the busy failure never surfaced
+  });
+
+  it("an exhausted busy wait surfaces the busy failure (bounded, not forever)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { agent, invokes } = scriptedAgent([[busyEvent]]); // always busy
+    const events = await run(agent, { delayMs: 20, maxWaitMs: 100 });
+    expect(events.at(-1)).toMatchObject({ type: "failed", code: SESSION_BUSY_CODE }); // surfaced after the wait
+    expect(invokes()).toBeGreaterThan(1); // it did retry before giving up
+    expect(invokes()).toBeLessThan(10); // …boundedly
+    vi.restoreAllMocks();
+  });
+
+  it("a non-busy failure is yielded immediately — no retry (side effects may have run)", async () => {
+    const failed: AgentEvent = { type: "failed", details: "provider 500", retryable: true };
+    const { agent, invokes } = scriptedAgent([[failed]]);
+    const events = await run(agent);
+    expect(invokes()).toBe(1);
+    expect(events).toEqual([failed]);
+  });
+
+  it("a busy event AFTER the first is passed through, never retried (the turn already started)", async () => {
+    const { agent, invokes } = scriptedAgent([[{ type: "text", delta: "partial" }, busyEvent]]);
+    const events = await run(agent);
+    expect(invokes()).toBe(1); // no re-run of a started turn
+    expect(events.map((e) => e.type)).toEqual(["text", "failed"]);
+  });
+});


### PR DESCRIPTION
## What

Closes the **reverse collision** left open by #186: while a self-scheduled wake turn holds a session's lease, a user message on the same session collided and got '⚠️ Temporary problem — please try again' — a user-visible error in wake's flagship scenario ('wake me in 10 min while I'm still chatting'). #186 handled wake→busy (scheduler defers); this handles user→busy (channel waits).

## How

telegram's own turns never collide (the turn-queue serializes per session), so a busy reject in `invokeTurn` is always an **external** holder. A fail-fast `session_busy` **first** event (the turn never started — replay-safe, discriminated by `failed.code` from #186) is now retried boundedly (5 s pace, 2 min cap) instead of surfaced: attachments are already resolved (no re-download), the user sees the Thinking… placeholder, then the answer. Only a first-event busy retries — nothing that started is ever re-run. An exhausted wait surfaces the busy failure as before.

Scoped to telegram; github/http colliding with a wake still fail fast (noted in core.md — their sessions rarely mix with wake sessions; add the same wait if it bites). The structural alternative (one shared per-session serial seam) stays deferred: two bounded waits cover the real scenario at a fraction of the seam's cost.

## Test
4 new units on `invokeTurn` (injectable retry pace): busy→retry→answer (no error surfaced); exhausted wait surfaces busy; non-busy failure immediate (no replay); mid-stream busy passed through (started turn never re-run). 513 total.