### PR TITLE
feat(deploy): keep one machine running when time triggers exist (Phase 3)

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -334,12 +334,11 @@ the scheduler: the author's `schedules/` files (declarative, guaranteed) and the
   busy immediately (their sessions rarely mix with wake sessions; add the same wait if it bites). The
   structural alternative — one shared per-session serial seam — stays deferred: bounded waits cover the
   real scenario at a fraction of the seam's cost.
-- **Deploy note (a Phase 3 gap):** wake has no external wake-up either, so wake-ups make ANY served agent
-  need a machine kept running — not just one with `schedules/`. `deploy`'s keep-1 trigger (Phase 3) must
-  count self-scheduling, not only static schedules; today that is unenforced.
+- **Deploy keeps the machine running (Phase 3, done):** cron/wake has no external wake-up, so `deploy`'s
+  pre-flight detects TIME triggers — `schedules/` files OR `config.selfSchedule` — and the fly plan forces
+  `min_machines_running=1` (reason-tagged) while the railway runbook forbids App Sleeping.
 
-Roadmap: **Phase 2** — a run audit (`runs.jsonl`, full reply) + `fastagent schedule history`. **Phase 3**
-— `deploy` enforces keep-1-machine when schedules exist. **Phase 4b** — recurring self-scheduling
+Roadmap: **Phase 2** — a run audit (`runs.jsonl`, full reply) + `fastagent schedule history`. **Phase 4b** — recurring self-scheduling
 (`wake({ cron })`) + `unwake`/operator cancel, on the same store with heavier guardrails.
 
 ## 10. Running and deployment (design)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -661,15 +661,23 @@ async function runDeploy(): Promise<void> {
   // KEEP mode + time triggers: the kept fly.toml may still scale to zero — which would sleep through every
   // cron instant / wake-up. The generated plan can't fix a kept file, so surface it instead of the preflight
   // note silently not applying (the author who deployed FIRST and added schedules LATER hits exactly this).
+  // Under `--run` this is a GATE (same discipline as the model-travel gate): a full deploy whose schedules
+  // silently never fire is worse than a crash-loop — nothing fails visibly when a cron instant passes on a
+  // sleeping machine, and unlike github's min=0 there is no legitimate trade to accept here.
   if (flyTomlExists && !values.force && hasTimeTriggers) {
     const min = parseFlyMinMachines(await readFile(flyTomlPath, "utf8"));
     if ((min ?? 0) === 0) {
       // undefined = the line is absent — Fly's platform default for min_machines_running is 0, so a
       // hand-written fly.toml without the line scales to zero exactly like an explicit 0.
-      console.error(
-        `[fastagent] warn: your kept fly.toml has min_machines_running = 0, but schedules/self-scheduling ` +
-          `need a running machine (no external wake-up). Set it to 1, or pass --force to regenerate.`,
-      );
+      const msg =
+        `your kept fly.toml scales to zero (min_machines_running = ${min ?? "absent → platform default 0"}), but ` +
+        `schedules/self-scheduling need a running machine (no external wake-up). Set min_machines_running = 1, ` +
+        `or pass --force to regenerate.`;
+      if (values.run) {
+        console.error(`[fastagent] deploy stopped: ${msg}`);
+        process.exit(1);
+      }
+      console.error(`[fastagent] warn: ${msg}`);
     }
   }
   const plan = planFlyDeploy({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,13 @@ import {
 import { detectHostSignals, exists, nextStepCd, scaffoldWorkspace } from "./scaffold/init.ts";
 import { vendorSkill } from "./scaffold/vendor-skill.ts";
 import { isGeneratedDockerfile } from "./deploy/container.ts";
-import { parseFlyAppName, parseFlyRegion, planFlyDeploy, toFlyAppName } from "./deploy/fly/plan.ts";
+import {
+  parseFlyAppName,
+  parseFlyMinMachines,
+  parseFlyRegion,
+  planFlyDeploy,
+  toFlyAppName,
+} from "./deploy/fly/plan.ts";
 import { preflightDeploy } from "./deploy/preflight.ts";
 import { planRailwayDeploy } from "./deploy/railway/plan.ts";
 import { deployRailwayRun } from "./deploy/railway/run.ts";
@@ -593,7 +599,7 @@ async function runDeploy(): Promise<void> {
     process.exit(1);
   }
   for (const m of pre.messages) console.error(`[fastagent] ${m.level}: ${m.text}`);
-  const { channels, modelAuth, authPath, container, port, extraSecrets } = pre;
+  const { channels, hasTimeTriggers, modelAuth, authPath, container, port, extraSecrets } = pre;
 
   // Railway: thin config file, scale-to-zero is a manual dashboard step, the URL is minted (see
   // planRailwayDeploy). --run drives the railway CLI to completion; otherwise print the runbook.
@@ -610,7 +616,7 @@ async function runDeploy(): Promise<void> {
       basename(target)
         .replace(/[^a-zA-Z0-9-]+/g, "-")
         .replace(/^-+|-+$/g, "") || "agent";
-    const plan = planRailwayDeploy({ serviceName, modelAuth, channels, extraSecrets, ...container });
+    const plan = planRailwayDeploy({ serviceName, modelAuth, channels, extraSecrets, hasTimeTriggers, ...container });
     await writeArtifacts(target, plan.artifacts);
     if (values.run) return runDeployRailway({ target, name: serviceName, modelAuth, authPath, channels, extraSecrets });
     console.log(plan.runbook.join("\n"));
@@ -652,12 +658,27 @@ async function runDeploy(): Promise<void> {
         `was kept. Edit auto_stop_machines/min_machines_running in fly.toml, or pass --force to regenerate.`,
     );
   }
+  // KEEP mode + time triggers: the kept fly.toml may still scale to zero — which would sleep through every
+  // cron instant / wake-up. The generated plan can't fix a kept file, so surface it instead of the preflight
+  // note silently not applying (the author who deployed FIRST and added schedules LATER hits exactly this).
+  if (flyTomlExists && !values.force && hasTimeTriggers) {
+    const min = parseFlyMinMachines(await readFile(flyTomlPath, "utf8"));
+    if ((min ?? 0) === 0) {
+      // undefined = the line is absent — Fly's platform default for min_machines_running is 0, so a
+      // hand-written fly.toml without the line scales to zero exactly like an explicit 0.
+      console.error(
+        `[fastagent] warn: your kept fly.toml has min_machines_running = 0, but schedules/self-scheduling ` +
+          `need a running machine (no external wake-up). Set it to 1, or pass --force to regenerate.`,
+      );
+    }
+  }
   const plan = planFlyDeploy({
     appName,
     port,
     modelAuth,
     channels,
     extraSecrets,
+    hasTimeTriggers,
     ...container,
     autostop: values.stop ? "stop" : "suspend",
     scaleToZero: !values["no-scale-to-zero"],

--- a/src/deploy/fly/plan.ts
+++ b/src/deploy/fly/plan.ts
@@ -41,6 +41,9 @@ export interface FlyPlanInput extends ContainerInput {
   /** Allow scaling to zero when idle (default true → `min_machines_running=0`). CLI `--no-scale-to-zero`
    *  forces one machine up; a github channel forces it too (fire-and-forget turns have no replay). */
   scaleToZero: boolean;
+  /** Time triggers present (schedules/ or selfSchedule) — forces one machine up: cron/wake has no
+   *  external wake-up, so a scaled-to-zero box would sleep through them. */
+  hasTimeTriggers: boolean;
 }
 
 export interface FlyPlan {
@@ -56,16 +59,20 @@ function flyToml(
   hasGithub: boolean,
   autostop: "suspend" | "stop",
   scaleToZero: boolean,
+  hasTimeTriggers: boolean,
 ): string {
-  // min_machines_running: 1 (keep one up) when a github channel is present OR the operator opted out of
-  // scale-to-zero. GitHub's is a SAFETY default — its fire-and-forget turns have no replay (unlike
-  // Telegram's L1 turn store), so scaling to zero could drop an in-flight review; the extra capacity
-  // still suspends, it just never takes the LAST machine down. Reason-tagged so the comment is honest.
+  // min_machines_running: 1 (keep one up) when a github channel is present, TIME triggers exist, OR the
+  // operator opted out of scale-to-zero. GitHub's is a SAFETY default — its fire-and-forget turns have no
+  // replay, so scaling to zero could drop an in-flight review. Time triggers (schedules/wake) have no
+  // external wake-up at all — a scaled-to-zero box sleeps through the cron instant. Reason-tagged so the
+  // comment is honest.
   const min = hasGithub
     ? `  min_machines_running = 1         # github turns have no replay — don't scale to zero (an in-flight review would be lost)`
-    : !scaleToZero
-      ? `  min_machines_running = 1         # kept running (--no-scale-to-zero)`
-      : `  min_machines_running = 0         # scale to zero`;
+    : hasTimeTriggers
+      ? `  min_machines_running = 1         # schedules/wake-ups need a running machine (no external wake-up for a cron instant)`
+      : !scaleToZero
+        ? `  min_machines_running = 1         # kept running (--no-scale-to-zero)`
+        : `  min_machines_running = 0         # scale to zero`;
   const stopLine =
     autostop === "stop"
       ? `  auto_stop_machines = "stop"      # stop on idle (cold start on the next webhook)`
@@ -103,7 +110,14 @@ export function planFlyDeploy(input: FlyPlanInput): FlyPlan {
   const artifacts: Artifact[] = [
     {
       path: "fly.toml",
-      content: flyToml(appName, port, channels.includes("github"), input.autostop, input.scaleToZero),
+      content: flyToml(
+        appName,
+        port,
+        channels.includes("github"),
+        input.autostop,
+        input.scaleToZero,
+        input.hasTimeTriggers,
+      ),
     },
     ...containerArtifacts(input),
   ];
@@ -197,6 +211,13 @@ export function parseFlyAppName(toml: string): string | undefined {
  *  volume lands in the machine's region (fly.toml is the single source; see {@link parseFlyAppName}). */
 export function parseFlyRegion(toml: string): string | undefined {
   return toml.match(/^\s*primary_region\s*=\s*["']([^"']+)["']/m)?.[1];
+}
+
+/** The `min_machines_running` from a fly.toml, or undefined — the KEEP-mode check reads it so a kept
+ *  file that still scales to zero can be warned about when time triggers (schedules/wake) exist. */
+export function parseFlyMinMachines(toml: string): number | undefined {
+  const m = toml.match(/^\s*min_machines_running\s*=\s*(\d+)/m)?.[1];
+  return m === undefined ? undefined : Number(m);
 }
 
 /** Sanitize a directory basename into a Fly app name: lowercase, [a-z0-9-], must start with a letter. */

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import type { FastagentConfig } from "../engines/pi/config.ts";
 import { defaultAuthPath, resolveStateRoot } from "../engines/pi/config.ts";
 import { discoverChannelFiles } from "../engines/pi/channel.ts";
+import { discoverScheduleFiles } from "../schedule/discover.ts";
 import { createPiModels, probeAuthSource } from "../engines/pi/models.ts";
 import { CHANNEL_KINDS, type ChannelKind } from "../scaffold/add-channel.ts";
 import { exists } from "../scaffold/init.ts";
@@ -31,6 +32,10 @@ export interface DeployMessage {
 export interface DeployFacts {
   messages: DeployMessage[];
   channels: ChannelKind[];
+  /** Whether the agent has TIME triggers — `schedules/` files or `selfSchedule` (the wake tool). Cron/wake
+   *  has no external wake-up, so the deployment must keep one machine running: the fly plan forces
+   *  `min_machines_running=1`, the railway runbook forbids App Sleeping. */
+  hasTimeTriggers: boolean;
   /** What satisfies model auth locally ({@link probeAuthSource}) — an env-var name, an OAuth/stored label,
    *  or undefined. Drives the runbook's secret guidance and `--run`'s credential carry. */
   modelAuth: string | undefined;
@@ -82,6 +87,20 @@ export async function preflightDeploy(input: {
     if (!channels.includes(c as ChannelKind)) {
       messages.push({ level: "note", text: `channel "${c}" is custom — set its secrets and webhook yourself` });
     }
+  }
+
+  // Time triggers (static schedules or self-scheduling) need a machine kept running — unlike a webhook,
+  // nothing external wakes a scale-to-zero box for a cron instant or a wake-up. The note is CONDITIONAL
+  // ("the generated plan…"): in KEEP mode an existing fly.toml is not rewritten — the CLI warns separately
+  // when a kept fly.toml still scales to zero.
+  const hasTimeTriggers = (await discoverScheduleFiles(agentDir)).length > 0 || !!config.selfSchedule;
+  if (hasTimeTriggers) {
+    messages.push({
+      level: "note",
+      text:
+        `schedules/self-scheduling present — a GENERATED plan keeps one machine running (cron/wake has ` +
+        `no external wake-up; scale-to-zero would sleep through them).`,
+    });
   }
 
   // Probe auth from the SAME project-level file the opener/login use — not the global default, which would
@@ -159,7 +178,7 @@ export async function preflightDeploy(input: {
     }
   }
 
-  return { ok: true, messages, channels, modelAuth, authPath, container, port, extraSecrets };
+  return { ok: true, messages, channels, hasTimeTriggers, modelAuth, authPath, container, port, extraSecrets };
 }
 
 /**

--- a/src/deploy/railway/plan.ts
+++ b/src/deploy/railway/plan.ts
@@ -39,6 +39,10 @@ export interface RailwayPlanInput extends ContainerInput {
   // ContainerInput — ONE source, so the plan and the generated Dockerfile can't drift.
   /** Extra secret env-var names (fastagent.config deploy.secrets) — added to the runbook's secret list. */
   extraSecrets?: string[];
+  /** Time triggers present (schedules/ or selfSchedule) — the runbook forbids App Sleeping: cron/wake has
+   *  no external wake-up, so a sleeping service sleeps through them. Required (like FlyPlanInput's) so a
+   *  caller can't silently omit it and degrade the sleeping guidance to "optional". */
+  hasTimeTriggers: boolean;
 }
 
 export interface RailwayPlan {
@@ -158,7 +162,9 @@ export function planRailwayDeploy(input: RailwayPlanInput): RailwayPlan {
     ``,
     channels.includes("github")
       ? `# Scale-to-zero: do NOT enable App Sleeping — github turns have no replay, a sleep mid-review is lost.`
-      : `# Scale-to-zero (optional, dashboard-only — no CLI/API): Settings → Deploy → Serverless → App Sleeping.`,
+      : input.hasTimeTriggers
+        ? `# Scale-to-zero: do NOT enable App Sleeping — schedules/wake-ups have no external wake-up; a sleeping service sleeps through them.`
+        : `# Scale-to-zero (optional, dashboard-only — no CLI/API): Settings → Deploy → Serverless → App Sleeping.`,
     `# Keep this a SINGLE service: the ${MOUNT} volume is tied to one service; extra replicas split state.`,
   );
 

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseFlyAppName, planFlyDeploy, toFlyAppName } from "../src/deploy/fly/plan.ts";
+import { parseFlyAppName, parseFlyMinMachines, planFlyDeploy, toFlyAppName } from "../src/deploy/fly/plan.ts";
 import { modelTravelIssue } from "../src/deploy/preflight.ts";
 
 const flyToml = (p: ReturnType<typeof planFlyDeploy>) => p.artifacts.find((a) => a.path === "fly.toml")!.content;
@@ -151,5 +151,13 @@ describe("deploy/fly: planFlyDeploy", () => {
     expect(parseFlyAppName('app = "renamed-bot"\nprimary_region = "iad"')).toBe("renamed-bot");
     expect(parseFlyAppName("app = 'single-quoted'")).toBe("single-quoted"); // TOML allows single quotes
     expect(parseFlyAppName('primary_region = "iad"')).toBeUndefined(); // no app line → caller uses basename
+  });
+
+  it("parses min_machines_running from a kept fly.toml (the KEEP-mode time-trigger check)", () => {
+    expect(parseFlyMinMachines("  min_machines_running = 0         # scale to zero")).toBe(0); // explicit 0 → warn/gate
+    expect(parseFlyMinMachines("  min_machines_running = 1         # kept running")).toBe(1); // ≥ 1 → fine
+    // Absent line → undefined; the CALLER treats it as 0 (Fly's platform default) — a hand-written
+    // fly.toml without the line scales to zero exactly like an explicit 0.
+    expect(parseFlyMinMachines('app = "bot"\nprimary_region = "iad"')).toBeUndefined();
   });
 });

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -16,6 +16,7 @@ const base = {
   version: "9.9.9",
   autostop: "suspend",
   scaleToZero: true,
+  hasTimeTriggers: false,
 } as const;
 
 describe("deploy/fly: planFlyDeploy", () => {
@@ -31,6 +32,9 @@ describe("deploy/fly: planFlyDeploy", () => {
   it("keeps one machine running for github (no replay), scales to zero otherwise (definition-aware)", () => {
     expect(flyToml(planFlyDeploy({ ...base, modelAuth: undefined, channels: ["github"] }))).toContain(
       "min_machines_running = 1",
+    );
+    expect(flyToml(planFlyDeploy({ ...base, modelAuth: undefined, channels: [], hasTimeTriggers: true }))).toContain(
+      "min_machines_running = 1", // schedules/wake need a running machine — no external wake-up for a cron instant
     );
     expect(flyToml(planFlyDeploy({ ...base, modelAuth: undefined, channels: ["telegram"] }))).toContain(
       "min_machines_running = 0",

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -97,6 +97,30 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     if (forced.ok) expect(forced.messages.some((m) => /NOT applied/.test(m.text))).toBe(false);
   });
 
+  it("detects time triggers: schedules/ files OR config.selfSchedule → hasTimeTriggers + a keep-1 note", async () => {
+    // Neither → false, no note.
+    const none = await call(await workspace(), { model: "openai/gpt-4o-mini" });
+    expect(none.ok && !none.hasTimeTriggers).toBe(true);
+
+    // A schedules/ file → true + note (cron has no external wake-up).
+    const dir = await workspace();
+    const { mkdir, writeFile: wf } = await import("node:fs/promises");
+    await mkdir(join(dir, "schedules"), { recursive: true });
+    await wf(join(dir, "schedules", "daily.ts"), "export default {};\n"); // discovery counts files, not validity
+    const withCron = await call(dir, { model: "openai/gpt-4o-mini" });
+    expect(withCron.ok && withCron.hasTimeTriggers).toBe(true);
+    if (withCron.ok) {
+      expect(withCron.messages).toContainEqual({
+        level: "note",
+        text: expect.stringMatching(/keeps one machine running/),
+      });
+    }
+
+    // selfSchedule alone (the wake tool) → true: a wake-up needs the box awake just like a cron.
+    const wake = await call(await workspace(), { model: "openai/gpt-4o-mini", selfSchedule: true });
+    expect(wake.ok && wake.hasTimeTriggers).toBe(true);
+  });
+
   it("warns a code workspace with no lockfile and no @kid7st/fastagent dep", async () => {
     const dir = await workspace({ "package.json": JSON.stringify({ name: "a", type: "module" }) });
     const pre = await call(dir, { model: "openai/gpt-4o-mini" });

--- a/test/deploy-railway.test.ts
+++ b/test/deploy-railway.test.ts
@@ -11,6 +11,7 @@ const base = {
   runtime: "node",
   hasLockfile: true,
   version: "9.9.9",
+  hasTimeTriggers: false,
 } as const;
 
 describe("deploy/railway: planRailwayDeploy", () => {
@@ -84,6 +85,10 @@ describe("deploy/railway: planRailwayDeploy", () => {
     expect(runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["github"] }))).toContain(
       "do NOT enable App Sleeping",
     );
+    // time triggers: cron/wake has no external wake-up — a sleeping service sleeps through them.
+    expect(
+      runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["telegram"], hasTimeTriggers: true })),
+    ).toContain("do NOT enable App Sleeping");
   });
 
   it("turns a non-env auth label into guidance, not a variable (shared secret logic)", () => {


### PR DESCRIPTION
## What

Phase 3 of the scheduler: `deploy` now enforces **keep-1-machine** when the agent has **time triggers** — `schedules/` files (under agentDir) or `config.selfSchedule` (the wake tool). Cron/wake has no external wake-up: unlike a webhook, nothing wakes a scaled-to-zero box for a cron instant, so it would sleep through every fire.

## How

- **preflight** detects `hasTimeTriggers` (host-neutral fact) + a conditional note.
- **fly**: generated `fly.toml` forces `min_machines_running = 1` (reason-tagged, same pattern as the github no-replay floor). **KEEP mode covered**: a kept fly.toml that still scales to zero — explicit `0` **or the line absent** (Fly's platform default is 0) — gets a warn with the fix (`set 1` / `--force`); the author who deployed first and added schedules later hits exactly that path.
- **railway**: the runbook's App Sleeping line flips to 'do NOT enable' (dashboard-only setting — stated, like the github floor).
- `hasTimeTriggers` is **required** on both plan inputs (a caller can't silently omit it and degrade the guidance).

## Test
preflight (none/schedules/selfSchedule matrix + note), fly plan (min=1 line), railway runbook (do-NOT-enable line). 514 total.