### PR TITLE
feat(schedule): run audit — runs.jsonl + fastagent schedule history (Phase 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ src/
 │   ├── discover.ts         # schedules/ filesystem discovery (loadSchedules/discoverScheduleFiles), isolates a bad file (G2)
 │   ├── scheduler.ts        # lifecycle + fire algorithm (overdue catch-up ONCE, claim-before-invoke) + stable per-schedule session + wake-up poll
 │   ├── wakeups.ts          # the agent's self-scheduled one-shot wake-ups (2nd producer): engine-neutral store + guardrails (min delay, cap, claim/defer)
+│   ├── audit.ts            # runs.jsonl append-only run audit (full reply) + `schedule history` reader — "did last night's run silently fail?"
 │   └── state.ts            # atomic schedule state under <stateRoot>/schedule/ (fires.json + wakeups.json)
 └── engines/pi/              # the pi reference implementation
     ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ Most commands take an optional workspace directory. When omitted, the current di
 | `chat [dir]` | Open the same assembled agent in pi's interactive TUI. |
 | `invoke <message> [dir]` | Run one agent turn and exit. |
 | `fire <name> [dir]` | Run one schedule's turn immediately (authoring loop). |
+| `schedule history <name> [dir]` | Print the run audit for a schedule (or `wake`). |
 | `tool <name> <json> [dir]` | Run one discovered tool directly. |
 | `add github|telegram [dir]` | Scaffold a first-party channel. |
 | `add skill <source> [dir]` | Vendor an Agent Skills skill into `skills/`. |
@@ -158,6 +159,17 @@ session, so you see exactly what the served scheduler would do:
 A `schedules/<name>.ts` file default-exports `defineSchedule({ cron, tz?, prompt })`; the scheduler
 fires the agent on that cron when you `dev`/`start`. Output is the agent's tools' job — the scheduler
 only fires and logs. See the [API reference](./api-reference.md#schedule-authoring).
+
+## `fastagent schedule history`
+
+```bash
+fastagent schedule history <name> [dir] [--json]
+```
+
+Prints the run audit for one schedule — or `wake` for the agent's self-scheduled wake-ups: when each run
+fired, its outcome (`completed` / `failed` / `deferred`), duration, and a preview of the reply or error.
+The answer to "did last night's run silently fail?". Read-only (reads `<state root>/schedule/runs.jsonl`,
+written by the serving scheduler); `--json` prints the full records, including the complete reply text.
 
 ## `fastagent tool`
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -338,8 +338,13 @@ the scheduler: the author's `schedules/` files (declarative, guaranteed) and the
   pre-flight detects TIME triggers — `schedules/` files OR `config.selfSchedule` — and the fly plan forces
   `min_machines_running=1` (reason-tagged) while the railway runbook forbids App Sleeping.
 
-Roadmap: **Phase 2** — a run audit (`runs.jsonl`, full reply) + `fastagent schedule history`. **Phase 4b** — recurring self-scheduling
-(`wake({ cron })`) + `unwake`/operator cancel, on the same store with heavier guardrails.
+Every fire is AUDITED: one line per run in `<stateRoot>/schedule/runs.jsonl` (append-only, full reply — an
+immutable per-fire snapshot the rolling session can't give), read by `fastagent schedule history <name>`
+(or `wake`) — the answer to "did last night's run silently fail?". Total: an audit-write failure never
+breaks a fire.
+
+Roadmap: **Phase 4b** — recurring self-scheduling (`wake({ cron })`) + `unwake`/operator cancel, on the
+same store with heavier guardrails.
 
 ## 10. Running and deployment (design)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -352,6 +352,7 @@ function runScheduleCmd(): void {
     process.exit(2);
   }
   const target = resolve(positionals[3] ?? ".");
+  loadDotEnv(target); // FASTAGENT_STATE_DIR may live in .env — read the SAME state root the scheduler wrote
   const runs = readRuns(resolveStateRoot(target), name);
   if (values.json) {
     console.log(JSON.stringify(runs, null, 2));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,6 +73,7 @@ import { spawnRunner } from "./deploy/runner.ts";
 import { assembleSecrets } from "./deploy/secrets.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
 import { discoverScheduleFiles, loadSchedules } from "./schedule/discover.ts";
+import { readRuns } from "./schedule/audit.ts";
 import { createScheduler, scheduleSession } from "./schedule/scheduler.ts";
 
 function usage(code: number): never {
@@ -83,6 +84,7 @@ function usage(code: number): never {
   fastagent tool   <name> '<json-args>' [dir]
   fastagent invoke <message> [dir] [--model provider/modelId] [--auth-path file]
   fastagent fire   <name> [dir] [--model provider/modelId] [--auth-path file]
+  fastagent schedule history <name> [dir] [--json]
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--auth-path file] [--no-watch] [--tunnel]
   fastagent chat   [dir] [--model provider/modelId]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir] [--auth-path file] [--tunnel]
@@ -125,6 +127,9 @@ function usage(code: number): never {
          counterpart of tool, for CI smoke and quick checks. Same model resolution as dev.
   fire   run ONE schedule's turn immediately (authoring loop, like invoke) — fires schedules/<name>.ts
          now without waiting for its cron. Reply→stdout; does NOT advance the schedule's fire state.
+  schedule history <name>  print the run audit for a schedule (or "wake" for self-scheduled wake-ups):
+         when each run fired, completed/failed/deferred, duration, and the reply/error — the answer to
+         "did last night's run silently fail?". --json for the full records (complete reply text).
   start  run the agent in dir (default .) in production posture — the SAME assembly as dev
          (your directory is the agent), just no file-watching. No build step: start reads the
          definition directly; model/http come from fastagent.config.ts (frozen by git).
@@ -211,6 +216,7 @@ else if (command === "start") await runStart();
 else if (command === "add") await runAdd();
 else if (command === "deploy") await runDeploy();
 else if (command === "fire") await runFire();
+else if (command === "schedule") runScheduleCmd();
 else if (command === "login") await runLogin();
 else usage(1);
 
@@ -331,6 +337,42 @@ async function runFire(): Promise<void> {
   );
   process.stdout.write("\n");
   process.exit(exitCode);
+}
+
+/**
+ * `fastagent schedule history <name> [dir]`: print the run audit for one schedule (or "wake") — fired
+ * time, outcome, duration, reply/error. Read-only (reads `<stateRoot>/schedule/runs.jsonl`); the answer
+ * to "did last night's run silently fail?". Text mode previews the reply/error; --json is the full record.
+ */
+function runScheduleCmd(): void {
+  const sub = positionals[1];
+  const name = positionals[2];
+  if (sub !== "history" || !name) {
+    console.error(`usage: fastagent schedule history <name> [dir] [--json]`);
+    process.exit(2);
+  }
+  const target = resolve(positionals[3] ?? ".");
+  const runs = readRuns(resolveStateRoot(target), name);
+  if (values.json) {
+    console.log(JSON.stringify(runs, null, 2));
+    return;
+  }
+  if (runs.length === 0) {
+    console.error(`no recorded runs for "${name}" (state: ${resolveStateRoot(target)})`);
+    return;
+  }
+  // The question is "did LAST NIGHT's run fail?" — so text mode tails the most recent runs (chronological
+  // within the tail); --json above returns the full history.
+  const TAIL = 20;
+  const shown = runs.slice(-TAIL);
+  if (runs.length > shown.length) {
+    console.error(`(showing the last ${shown.length} of ${runs.length} runs — --json for all)`);
+  }
+  for (const r of shown) {
+    const detail = r.error ?? r.reply ?? "";
+    const preview = detail.replace(/\s+/g, " ").slice(0, 100);
+    console.log(`${r.firedAt}  ${r.outcome.padEnd(9)} ${String(r.ms).padStart(6)}ms  ${preview}`);
+  }
 }
 
 /** `fastagent info [dir] [--json]`: print what the directory ASSEMBLES into, WITHOUT booting a server. Read-only. */

--- a/src/schedule/audit.ts
+++ b/src/schedule/audit.ts
@@ -1,0 +1,68 @@
+/**
+ * The scheduler's run audit: ONE line per fired turn in `<stateRoot>/schedule/runs.jsonl` — the answer
+ * to cron's classic pain, "did last night's run silently fail?". Append-only JSONL (grows, never
+ * rewritten — the same shape as the core session store), carrying the FULL reply text: a run record is
+ * an immutable snapshot of what that fire produced, which the rolling session (where multiple fires
+ * interleave with user turns) cannot give you per-fire. Operational audit only — the conversational
+ * truth stays in the session store.
+ *
+ * Appending is TOTAL (failures are logged, never thrown): the audit must not be able to break a fire.
+ */
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { log } from "../log.ts";
+
+export interface RunRecord {
+  /** The schedule's name for a cron fire; `"wake"` for a self-scheduled wake-up (its session tells which). */
+  name: string;
+  session: string;
+  firedAt: string; // ISO
+  ms: number;
+  /** `deferred` = a wake into a busy session, re-scheduled (not a final outcome for that wake-up). */
+  outcome: "completed" | "failed" | "deferred";
+  /** The turn's full reply text (completed). Delivery is the agent's tools' job — this is the audit copy. */
+  reply?: string;
+  /** The failure details (failed). */
+  error?: string;
+}
+
+function runsPath(stateRoot: string): string {
+  return join(stateRoot, "schedule", "runs.jsonl");
+}
+
+/** Append one run record. Total — an audit-write failure is logged and swallowed (never breaks a fire). */
+export function appendRun(stateRoot: string, record: RunRecord): void {
+  try {
+    const path = runsPath(stateRoot);
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, `${JSON.stringify(record)}\n`);
+  } catch (e) {
+    log.warn(`[schedule] could not append the run audit (the fire itself is unaffected): ${String(e)}`);
+  }
+}
+
+/** Read the run history (optionally filtered by name), oldest first. A malformed line is skipped with a
+ *  warn (fail-visible, like the wakeups store); a missing file is an empty history (first run). */
+export function readRuns(stateRoot: string, name?: string): RunRecord[] {
+  let raw: string;
+  try {
+    raw = readFileSync(runsPath(stateRoot), "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw new Error(`run audit ${runsPath(stateRoot)} is unreadable: ${String(e)}`, { cause: e });
+  }
+  const records: RunRecord[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.trim() === "") continue;
+    try {
+      const r = JSON.parse(line) as RunRecord;
+      if (typeof r.name !== "string" || typeof r.firedAt !== "string" || typeof r.outcome !== "string") {
+        throw new Error("missing fields");
+      }
+      if (name === undefined || r.name === name) records.push(r);
+    } catch {
+      log.warn(`[schedule] skipping a malformed run-audit line: ${line.slice(0, 80)}`);
+    }
+  }
+  return records;
+}

--- a/src/schedule/discover.ts
+++ b/src/schedule/discover.ts
@@ -49,6 +49,10 @@ export async function loadSchedules(
       }
       const err = cronError(s.cron, s.tz);
       if (err) throw new Error(`${label}: invalid cron/tz — ${err}`);
+      // "wake" is reserved: the run audit records self-scheduled wake-ups under that name, so a schedule
+      // named wake would make `schedule history wake` an unreadable mix of two different things.
+      if (name === "wake")
+        throw new Error(`${label}: "wake" is a reserved schedule name (the self-scheduling audit uses it)`);
       if (byName.has(name)) throw new Error(`${label}: duplicate schedule name "${name}" — kept the first`);
       byName.set(name, { name, cron: s.cron, tz: s.tz, prompt: s.prompt });
     } catch (error) {

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -57,10 +57,10 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
   let stopped = false;
 
   /** Drive ONE turn (a cron fire or a wake-up) and log its outcome. Total — never throws (its callers are
-   *  void-scheduled). Output is the agent's tools' job; this only fires and logs. Returns whether the turn
-   *  failed specifically because the session was BUSY (the turn never started) — the ONLY replay-safe reason
-   *  to re-fire a wake-up; every other outcome (completed, or a failure whose side effects may have run) is
-   *  terminal. */
+   *  void-scheduled). Output is the agent's tools' job; this only fires and logs. Returns the turn's audit
+   *  material — `failed` (details, if it failed), the accumulated `reply` text, `ms` — plus `busy`: whether
+   *  it failed specifically because the session was BUSY (the turn never started) — the ONLY replay-safe
+   *  reason to re-fire a wake-up; every other outcome is terminal (side effects may have run). */
   async function runTurn(
     label: string,
     session: string,

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -14,6 +14,7 @@
  */
 import { type Agent, SESSION_BUSY_CODE } from "../agent.ts";
 import { log } from "../log.ts";
+import { appendRun } from "./audit.ts";
 import { nextRun } from "./cron.ts";
 import type { LoadedSchedule } from "./schedule.ts";
 import { loadFires, saveFires } from "./state.ts";
@@ -60,13 +61,19 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
    *  failed specifically because the session was BUSY (the turn never started) — the ONLY replay-safe reason
    *  to re-fire a wake-up; every other outcome (completed, or a failure whose side effects may have run) is
    *  terminal. */
-  async function runTurn(label: string, session: string, prompt: string): Promise<{ busy: boolean }> {
+  async function runTurn(
+    label: string,
+    session: string,
+    prompt: string,
+  ): Promise<{ busy: boolean; failed?: string; reply: string; ms: number }> {
     const startedAt = Date.now();
     log.info(`[schedule] ${label} firing (session=${session})`);
     try {
       let failed: string | undefined;
       let busy = false;
+      let reply = "";
       for await (const e of agent.invoke({ session }, { text: prompt })) {
+        if (e.type === "text") reply += e.delta;
         if (e.type === "failed") {
           failed = e.details;
           busy = e.code === SESSION_BUSY_CODE; // structured (SPEC §8), not a details-text match
@@ -74,12 +81,12 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
       }
       if (failed) log.error(`[schedule] ${label} failed (${Date.now() - startedAt}ms): ${failed}`);
       else log.info(`[schedule] ${label} completed (${Date.now() - startedAt}ms)`);
-      return { busy: failed !== undefined && busy };
+      return { busy: failed !== undefined && busy, failed, reply, ms: Date.now() - startedAt };
     } catch (e) {
       // invoke shouldn't throw (SPEC MUST 2 turns failures into events), but stay total regardless. A throw
       // is not the busy case, so don't defer on it.
       log.error(`[schedule] ${label} errored (${Date.now() - startedAt}ms): ${String(e)}`);
-      return { busy: false };
+      return { busy: false, failed: String(e), reply: "", ms: Date.now() - startedAt };
     }
   }
 
@@ -95,7 +102,17 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
       log.error(`[schedule] ${s.name}: cannot persist fire state, skipping this run: ${String(e)}`);
       return;
     }
-    await runTurn(s.name, scheduleSession(s.name), s.prompt);
+    const firedAt = now().toISOString();
+    const r = await runTurn(s.name, scheduleSession(s.name), s.prompt);
+    appendRun(stateRoot, {
+      name: s.name,
+      session: scheduleSession(s.name),
+      firedAt,
+      ms: r.ms,
+      outcome: r.failed ? "failed" : "completed",
+      reply: r.failed ? undefined : r.reply,
+      error: r.failed,
+    });
   }
 
   /**
@@ -112,15 +129,28 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
       const w = takeFirstDueWakeup(stateRoot, now());
       if (!w) break;
       const label = `wake ${w.id.slice(0, 8)}`;
-      const { busy } = await runTurn(label, w.session, w.prompt);
+      const firedAt = now().toISOString();
+      const r = await runTurn(label, w.session, w.prompt);
       // Re-fire ONLY on a busy session (the turn never started — replay-safe). A wake is one-shot, so a
       // busy-skip that just dropped it would lose it forever; defer + bounded retry. Every OTHER outcome is
       // terminal (already claimed/removed) — re-running a turn that DID start risks duplicate side effects.
-      if (busy) {
-        const kept = deferWakeup(stateRoot, w, new Date(now().getTime() + WAKEUP_POLL_MS));
+      let kept = false;
+      if (r.busy) {
+        kept = deferWakeup(stateRoot, w, new Date(now().getTime() + WAKEUP_POLL_MS));
         if (kept) log.info(`[schedule] ${label}: session busy — retrying next poll`);
         else log.error(`[schedule] ${label}: dropped after too many busy retries`);
       }
+      // Audit honesty: `deferred` ONLY when the wake was actually re-scheduled. A busy wake dropped at the
+      // retry ceiling is a FINAL silent loss — exactly what this audit exists to answer — so it is `failed`.
+      appendRun(stateRoot, {
+        name: "wake",
+        session: w.session,
+        firedAt,
+        ms: r.ms,
+        outcome: r.busy ? (kept ? "deferred" : "failed") : r.failed ? "failed" : "completed",
+        reply: r.failed || r.busy ? undefined : r.reply,
+        error: r.busy ? (kept ? undefined : "dropped after too many busy retries") : r.failed,
+      });
     }
   }
 

--- a/test/schedule-audit.test.ts
+++ b/test/schedule-audit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { appendFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendRun, readRuns } from "../src/schedule/audit.ts";
+
+const root = (): Promise<string> => mkdtemp(join(tmpdir(), "fa-audit-"));
+const rec = (name: string, outcome: "completed" | "failed" | "deferred" = "completed") => ({
+  name,
+  session: `schedule:${name}`,
+  firedAt: "2026-07-07T09:00:00.000Z",
+  ms: 1200,
+  outcome,
+  reply: outcome === "completed" ? "the digest, in full — not capped" : undefined,
+  error: outcome === "failed" ? "boom" : undefined,
+});
+
+describe("schedule/audit (runs.jsonl)", () => {
+  it("appendRun + readRuns roundtrip, oldest first, FULL reply preserved", async () => {
+    const r = await root();
+    appendRun(r, rec("daily"));
+    appendRun(r, rec("daily", "failed"));
+    const runs = readRuns(r, "daily");
+    expect(runs).toHaveLength(2);
+    expect(runs[0]?.reply).toBe("the digest, in full — not capped"); // full text, not a preview
+    expect(runs[1]).toMatchObject({ outcome: "failed", error: "boom" });
+  });
+
+  it("filters by name; no filter returns all; missing file is an empty history", async () => {
+    const r = await root();
+    appendRun(r, rec("a"));
+    appendRun(r, rec("wake"));
+    expect(readRuns(r, "a")).toHaveLength(1);
+    expect(readRuns(r)).toHaveLength(2);
+    expect(readRuns(await root())).toEqual([]); // fresh root, no file
+  });
+
+  it("skips a malformed line with a warn — one bad line can't poison the history", async () => {
+    const r = await root();
+    appendRun(r, rec("a"));
+    appendFileSync(join(r, "schedule", "runs.jsonl"), "not json\n{}\n");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(readRuns(r, "a")).toHaveLength(1); // the good record survives
+    vi.restoreAllMocks();
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -7,6 +7,7 @@ import type { Agent, AgentEvent } from "../src/agent.ts";
 import type { LoadedSchedule } from "../src/schedule/schedule.ts";
 import { createScheduler, scheduleSession } from "../src/schedule/scheduler.ts";
 import { addWakeup, listWakeups } from "../src/schedule/wakeups.ts";
+import { readRuns } from "../src/schedule/audit.ts";
 
 /** A fake agent that records each invoke's session + text and yields the scripted terminal. */
 function recordingAgent(events: AgentEvent[] = [{ type: "completed" }]) {
@@ -69,6 +70,9 @@ describe("schedule/scheduler: fire algorithm", () => {
     await vi.waitFor(() => expect(calls.length).toBe(1)); // exactly ONE catch-up, not one per missed slot
     expect(calls[0]).toEqual({ session: scheduleSession("job"), text: "go" });
     expect((await readFires(root)).job).toBe("2026-07-07T12:30:00.000Z"); // claimed = now
+    // The run audit recorded the fire: name, outcome, and the reply's audit copy.
+    await vi.waitFor(() => expect(readRuns(root, "job")).toHaveLength(1));
+    expect(readRuns(root, "job")[0]).toMatchObject({ outcome: "completed", session: scheduleSession("job") });
     s.stop();
   });
 
@@ -122,6 +126,8 @@ describe("schedule/scheduler: fire algorithm", () => {
     // NOT dropped: re-scheduled (deferred) with a bumped attempt count — a one-shot wake must not vanish.
     await vi.waitFor(() => expect(listWakeups(root)).toHaveLength(1));
     expect(listWakeups(root)[0]).toMatchObject({ session: "busy", attempts: 1 });
+    // Audited as deferred (not failed): honest — the wake was re-scheduled, not finally lost.
+    expect(readRuns(root, "wake")[0]).toMatchObject({ outcome: "deferred", session: "busy" });
     s.stop();
   });
 

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import type { Agent, AgentEvent } from "../src/agent.ts";
 import type { LoadedSchedule } from "../src/schedule/schedule.ts";
 import { createScheduler, scheduleSession } from "../src/schedule/scheduler.ts";
-import { addWakeup, listWakeups } from "../src/schedule/wakeups.ts";
+import { MAX_WAKE_ATTEMPTS, addWakeup, listWakeups } from "../src/schedule/wakeups.ts";
 import { readRuns } from "../src/schedule/audit.ts";
 
 /** A fake agent that records each invoke's session + text and yields the scripted terminal. */
@@ -167,6 +167,36 @@ describe("schedule/scheduler: fire algorithm", () => {
     s.start();
     await vi.waitFor(() => expect(calls.length).toBe(1));
     expect((await readFires(root)).job).toBe("2026-07-07T12:30:00.000Z"); // claimed even on failure
+    // The audit's FAIL path — the branch the audit exists to answer: outcome failed, the error captured.
+    await vi.waitFor(() => expect(readRuns(root, "job")).toHaveLength(1));
+    expect(readRuns(root, "job")[0]).toMatchObject({ outcome: "failed", error: "boom" });
+    expect(readRuns(root, "job")[0]?.reply).toBeUndefined(); // no reply copy on a failed run
+    s.stop();
+  });
+
+  it("a busy wake dropped at the retry ceiling is audited FAILED (a final silent loss), not deferred", async () => {
+    const root = await freshRoot();
+    // Seed the wake already AT the attempt cap — the next busy defer drops it.
+    mkdirSync(join(root, "schedule"), { recursive: true });
+    writeFileSync(
+      join(root, "schedule", "wakeups.json"),
+      JSON.stringify([
+        { id: "w9", session: "s", prompt: "go", fireAt: "2026-07-07T11:00:00Z", attempts: MAX_WAKE_ATTEMPTS },
+      ]),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { agent, calls } = recordingAgent([
+      { type: "failed", retryable: true, code: "session_busy", details: "busy" },
+    ]);
+    const s = createScheduler({ agent, stateRoot: root, schedules: [], now: () => new Date("2026-07-07T12:00:00Z") });
+    s.start();
+    await vi.waitFor(() => expect(calls.length).toBe(1));
+    await vi.waitFor(() => expect(readRuns(root, "wake")).toHaveLength(1));
+    expect(readRuns(root, "wake")[0]).toMatchObject({
+      outcome: "failed",
+      error: expect.stringMatching(/dropped after too many/),
+    });
+    expect(listWakeups(root)).toHaveLength(0); // gone — that's exactly why the audit must say failed
     s.stop();
   });
 });


### PR DESCRIPTION
## What

Phase 2 of the scheduler: a **run audit**. Every fire (cron **and** self-scheduled wake) appends one line to `<stateRoot>/schedule/runs.jsonl`; `fastagent schedule history <name>` (or `wake`) answers cron's classic pain — **did last night's run silently fail?**

## Design

- **Append-only JSONL, full reply** (the session-store shape; storage is cheap). A run record is an immutable per-fire snapshot — the rolling session, where fires interleave with user turns, cannot give you that per-fire. Operational audit only; conversational truth stays in the session store.
- **Total**: an audit-write failure is logged, never breaks a fire.
- **Audit honesty**: a busy wake dropped at the retry ceiling is `failed` (a FINAL silent loss — exactly what the audit exists to catch), not `deferred`; `deferred` only when actually re-scheduled.
- **`wake` is a reserved schedule name** (discover rejects `schedules/wake.ts`) so the audit namespace can't be polluted.
- History text mode **tails the last 20** (the question is about last night, not month one); `--json` = full records incl. complete reply text.

## Test
audit roundtrip (full reply preserved), name filter, malformed-line skip; scheduler records completed/deferred; CLI usage branch. 518 total.