### PR TITLE
feat(schedule): recurring self-scheduling + unwake + operator list/cancel (Phase 4b)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ src/
 │   ├── cron.ts             # the one place touching `croner` (zero-dep, IANA tz/DST): nextRun + cronError
 │   ├── discover.ts         # schedules/ filesystem discovery (loadSchedules/discoverScheduleFiles), isolates a bad file (G2)
 │   ├── scheduler.ts        # lifecycle + fire algorithm (overdue catch-up ONCE, claim-before-invoke) + stable per-schedule session + wake-up poll
-│   ├── wakeups.ts          # the agent's self-scheduled one-shot wake-ups (2nd producer): engine-neutral store + guardrails (min delay, cap, claim/defer)
+│   ├── wakeups.ts          # the agent's self-scheduled wake-ups, one-shot + recurring (2nd producer): engine-neutral store + guardrails (min delay/gap, cap, claim/defer)
 │   ├── audit.ts            # runs.jsonl append-only run audit (full reply) + `schedule history` reader — "did last night's run silently fail?"
 │   └── state.ts            # atomic schedule state under <stateRoot>/schedule/ (fires.json + wakeups.json)
 └── engines/pi/              # the pi reference implementation

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -261,9 +261,12 @@ the serve path (`dev`/`start`); `fastagent fire <name>` runs one schedule's turn
 **Self-scheduling.** Opt in with `selfSchedule: true` in `fastagent.config` (off by default — an autonomy
 capability, not given to every agent). Then the serving path (`dev`/`start`, where the poller runs — not the
 one-shot `invoke`/`fire`) mounts a built-in **`wake`** tool so the agent can schedule itself: `wake({ in: "30m", prompt })`
-records a one-shot wake-up (persisted under `<stateRoot>/schedule/`) that the scheduler polls and fires back
-into the SAME session, so the agent resumes the conversation. It reads the current session from
-`ToolContext.session`; guardrails cap the minimum delay and the per-session pending count. Recurring is later.
+records a one-shot wake-up — or `wake({ cron: "0 9 * * *", tz?, prompt })` a RECURRING one — persisted under
+`<stateRoot>/schedule/`, polled by the scheduler and fired back into the SAME session, so the agent resumes
+the conversation. It reads the current session from `ToolContext.session`; guardrails cap the minimum delay,
+the recurring frequency (≥10 min between fires), and the per-session pending count. The agent cancels its own
+with `unwake({ id })` (session-scoped); the operator with `fastagent schedule cancel <id>` (`schedule list`
+shows ids).
 
 ## Config and models
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,8 @@ Most commands take an optional workspace directory. When omitted, the current di
 | `invoke <message> [dir]` | Run one agent turn and exit. |
 | `fire <name> [dir]` | Run one schedule's turn immediately (authoring loop). |
 | `schedule history <name> [dir]` | Print the run audit for a schedule (or `wake`). |
+| `schedule list [dir]` | The agent's pending self-scheduled wake-ups. |
+| `schedule cancel <id> [dir]` | Remove a pending wake-up (operator kill switch). |
 | `tool <name> <json> [dir]` | Run one discovered tool directly. |
 | `add github|telegram [dir]` | Scaffold a first-party channel. |
 | `add skill <source> [dir]` | Vendor an Agent Skills skill into `skills/`. |
@@ -170,6 +172,10 @@ Prints the run audit for one schedule — or `wake` for the agent's self-schedul
 fired, its outcome (`completed` / `failed` / `deferred`), duration, and a preview of the reply or error.
 The answer to "did last night's run silently fail?". Read-only (reads `<state root>/schedule/runs.jsonl`,
 written by the serving scheduler); `--json` prints the full records, including the complete reply text.
+
+`fastagent schedule list [dir]` shows the agent's pending self-scheduled wake-ups (id, next fire,
+one-shot/cron, session, prompt); `fastagent schedule cancel <id> [dir]` removes one — the operator's kill
+switch for a runaway recurring wake (the agent's own is the `unwake` tool, which is session-scoped).
 
 ## `fastagent tool`
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -343,8 +343,13 @@ immutable per-fire snapshot the rolling session can't give), read by `fastagent 
 (or `wake`) — the answer to "did last night's run silently fail?". Total: an audit-write failure never
 breaks a fire.
 
-Roadmap: **Phase 4b** — recurring self-scheduling (`wake({ cron })`) + `unwake`/operator cancel, on the
-same store with heavier guardrails.
+Self-scheduling is one-shot (`wake({ in })`) or RECURRING (`wake({ cron, tz? })` — the entry keeps its id;
+each fire re-arms to the next cron instant). Recurring carries heavier guardrails: a minimum gap between
+fires (a tight cron is a permanent token burner, stricter than the one-shot floor), and a busy occurrence is
+skipped IMMEDIATELY — no defer/retry (that is one-shot-only, which has no "next time"): the next occurrence
+comes by definition, matching static cron semantics; the skipped one is audited `failed`. Kill switches: the agent's `unwake` tool (session-scoped — a conversation
+can only cancel its OWN wake-ups) and the operator's `fastagent schedule cancel <id>` (unscoped; `schedule
+list` shows ids).
 
 ## 10. Running and deployment (design)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ import { assembleSecrets } from "./deploy/secrets.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
 import { discoverScheduleFiles, loadSchedules } from "./schedule/discover.ts";
 import { readRuns } from "./schedule/audit.ts";
+import { listWakeups, removeWakeup } from "./schedule/wakeups.ts";
 import { createScheduler, scheduleSession } from "./schedule/scheduler.ts";
 
 function usage(code: number): never {
@@ -85,6 +86,8 @@ function usage(code: number): never {
   fastagent invoke <message> [dir] [--model provider/modelId] [--auth-path file]
   fastagent fire   <name> [dir] [--model provider/modelId] [--auth-path file]
   fastagent schedule history <name> [dir] [--json]
+  fastagent schedule list [dir] [--json]
+  fastagent schedule cancel <id> [dir]
   fastagent dev    [dir] [--port N] [--model provider/modelId] [--auth-path file] [--no-watch] [--tunnel]
   fastagent chat   [dir] [--model provider/modelId]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir] [--auth-path file] [--tunnel]
@@ -130,6 +133,9 @@ function usage(code: number): never {
   schedule history <name>  print the run audit for a schedule (or "wake" for self-scheduled wake-ups):
          when each run fired, completed/failed/deferred, duration, and the reply/error — the answer to
          "did last night's run silently fail?". --json for the full records (complete reply text).
+  schedule list    the agent's pending self-scheduled wake-ups (id, session, next fire, cron, prompt).
+  schedule cancel <id>  remove a pending wake-up — the operator's kill switch for a runaway recurring
+         wake (the agent's own is the \`unwake\` tool).
   start  run the agent in dir (default .) in production posture — the SAME assembly as dev
          (your directory is the agent), just no file-watching. No build step: start reads the
          definition directly; model/http come from fastagent.config.ts (frozen by git).
@@ -346,9 +352,11 @@ async function runFire(): Promise<void> {
  */
 function runScheduleCmd(): void {
   const sub = positionals[1];
+  if (sub === "list") return runScheduleList();
+  if (sub === "cancel") return runScheduleCancel();
   const name = positionals[2];
   if (sub !== "history" || !name) {
-    console.error(`usage: fastagent schedule history <name> [dir] [--json]`);
+    console.error(`usage: fastagent schedule history <name> | list | cancel <id>  [dir] [--json]`);
     process.exit(2);
   }
   const target = resolve(positionals[3] ?? ".");
@@ -373,6 +381,50 @@ function runScheduleCmd(): void {
     const detail = r.error ?? r.reply ?? "";
     const preview = detail.replace(/\s+/g, " ").slice(0, 100);
     console.log(`${r.firedAt}  ${r.outcome.padEnd(9)} ${String(r.ms).padStart(6)}ms  ${preview}`);
+  }
+}
+
+/** `fastagent schedule list [dir]`: the agent's pending self-scheduled wake-ups. Read-only. */
+function runScheduleList(): void {
+  const target = resolve(positionals[2] ?? ".");
+  loadDotEnv(target);
+  const wakeups = listWakeups(resolveStateRoot(target));
+  if (values.json) {
+    console.log(JSON.stringify(wakeups, null, 2));
+    return;
+  }
+  if (wakeups.length === 0) {
+    console.error(`no pending wake-ups (state: ${resolveStateRoot(target)})`);
+    return;
+  }
+  for (const w of wakeups) {
+    const kind = w.cron ? `cron ${w.cron}${w.tz ? ` ${w.tz}` : ""}` : "one-shot";
+    console.log(`${w.id}  ${w.fireAt}  ${kind}  session=${w.session}  ${w.prompt.slice(0, 60)}`);
+  }
+}
+
+/** `fastagent schedule cancel <id> [dir]`: remove a pending wake-up — the operator's kill switch (the
+ *  agent's own is the `unwake` tool). Unlike unwake it is NOT session-scoped: the operator owns the box. */
+function runScheduleCancel(): void {
+  const id = positionals[2];
+  if (!id) {
+    console.error(`usage: fastagent schedule cancel <id> [dir]`);
+    process.exit(2);
+  }
+  const target = resolve(positionals[3] ?? ".");
+  loadDotEnv(target);
+  if (removeWakeup(resolveStateRoot(target), id)) {
+    // ponytail: the store's load→save is lock-free — a serving scheduler's claim-advance can race this
+    // write (window = ms around each fire). Tell the operator to verify; a lockfile/CAS is the upgrade
+    // path if it ever bites.
+    console.error(
+      `[fastagent] cancelled wake-up ${id} — if a server is running, verify with \`fastagent schedule list\``,
+    );
+  } else {
+    console.error(
+      `no pending wake-up ${id} (state: ${resolveStateRoot(target)}) — \`fastagent schedule list\` shows ids`,
+    );
+    process.exit(1);
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -223,7 +223,7 @@ else if (command === "start") await runStart();
 else if (command === "add") await runAdd();
 else if (command === "deploy") await runDeploy();
 else if (command === "fire") await runFire();
-else if (command === "schedule") runScheduleCmd();
+else if (command === "schedule") await runScheduleCmd();
 else if (command === "login") await runLogin();
 else usage(1);
 
@@ -351,9 +351,9 @@ async function runFire(): Promise<void> {
  * time, outcome, duration, reply/error. Read-only (reads `<stateRoot>/schedule/runs.jsonl`); the answer
  * to "did last night's run silently fail?". Text mode previews the reply/error; --json is the full record.
  */
-function runScheduleCmd(): void {
+async function runScheduleCmd(): Promise<void> {
   const sub = positionals[1];
-  if (sub === "list") return void runScheduleList();
+  if (sub === "list") return runScheduleList();
   if (sub === "cancel") return runScheduleCancel();
   const name = positionals[2];
   if (sub !== "history" || !name) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ import { assembleSecrets } from "./deploy/secrets.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
 import { discoverScheduleFiles, loadSchedules } from "./schedule/discover.ts";
 import { readRuns } from "./schedule/audit.ts";
+import { nextRun } from "./schedule/cron.ts";
 import { listWakeups, removeWakeup } from "./schedule/wakeups.ts";
 import { createScheduler, scheduleSession } from "./schedule/scheduler.ts";
 
@@ -352,7 +353,7 @@ async function runFire(): Promise<void> {
  */
 function runScheduleCmd(): void {
   const sub = positionals[1];
-  if (sub === "list") return runScheduleList();
+  if (sub === "list") return void runScheduleList();
   if (sub === "cancel") return runScheduleCancel();
   const name = positionals[2];
   if (sub !== "history" || !name) {
@@ -384,22 +385,40 @@ function runScheduleCmd(): void {
   }
 }
 
-/** `fastagent schedule list [dir]`: the agent's pending self-scheduled wake-ups. Read-only. */
-function runScheduleList(): void {
+/** `fastagent schedule list [dir]`: everything that will fire — BOTH producers: the static `schedules/`
+ *  files (with their next instant) and the agent's pending self-scheduled wake-ups. Read-only. */
+async function runScheduleList(): Promise<void> {
   const target = resolve(positionals[2] ?? ".");
   loadDotEnv(target);
+  const { config } = await loadConfig(target).catch(failStartup);
+  const agentDir = resolveAgentDir(target, config);
+  const { schedules, failures } = await loadSchedules(agentDir).catch(failStartup);
+  reportModuleLoadFailures(failures);
   const wakeups = listWakeups(resolveStateRoot(target));
   if (values.json) {
-    console.log(JSON.stringify(wakeups, null, 2));
+    console.log(
+      JSON.stringify(
+        {
+          schedules: schedules.map((s) => ({ ...s, next: nextRun(s.cron, s.tz, new Date())?.toISOString() })),
+          wakeups,
+        },
+        null,
+        2,
+      ),
+    );
     return;
   }
-  if (wakeups.length === 0) {
-    console.error(`no pending wake-ups (state: ${resolveStateRoot(target)})`);
+  if (schedules.length === 0 && wakeups.length === 0) {
+    console.error(`nothing scheduled — no schedules/ files, no pending wake-ups (state: ${resolveStateRoot(target)})`);
     return;
+  }
+  for (const s of schedules) {
+    const next = nextRun(s.cron, s.tz, new Date())?.toISOString() ?? "(never)";
+    console.log(`schedule  ${s.name.padEnd(20)} ${next}  cron ${s.cron}${s.tz ? ` ${s.tz}` : ""}`);
   }
   for (const w of wakeups) {
     const kind = w.cron ? `cron ${w.cron}${w.tz ? ` ${w.tz}` : ""}` : "one-shot";
-    console.log(`${w.id}  ${w.fireAt}  ${kind}  session=${w.session}  ${w.prompt.slice(0, 60)}`);
+    console.log(`wake      ${w.id}  ${w.fireAt}  ${kind}  session=${w.session}  ${w.prompt.slice(0, 60)}`);
   }
 }
 

--- a/src/engines/pi/wake-tool.ts
+++ b/src/engines/pi/wake-tool.ts
@@ -13,7 +13,7 @@
  */
 import { z } from "zod";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { addWakeup } from "../../schedule/wakeups.ts";
+import { addWakeup, removeWakeup } from "../../schedule/wakeups.ts";
 import { defineTool } from "./tool.ts";
 
 /**
@@ -37,8 +37,12 @@ export function parseDelayMs(input: string | number): number | undefined {
  * wins, like any tool collision). The single place the mount decision + collision rule run.
  */
 export function withWakeTool(tools: AgentTool[], stateRoot: string, enabled: boolean): AgentTool[] {
-  if (!enabled || tools.some((t) => t.name === "wake")) return tools;
-  return [...tools, makeWakeTool(stateRoot)];
+  if (!enabled) return tools;
+  // wake/unwake are a PAIR over one store: if the workspace defines EITHER name, mount NEITHER built-in.
+  // Mixing halves would mislead — an author's wake doesn't write our wakeups store, so our unwake could
+  // never cancel what it returns ("not yours" forever); the author owns the whole concept or none of it.
+  if (tools.some((t) => t.name === "wake" || t.name === "unwake")) return tools;
+  return [...tools, makeWakeTool(stateRoot), makeUnwakeTool(stateRoot)];
 }
 
 /** Build the `wake` tool bound to `stateRoot` (where wake-ups persist). */
@@ -46,28 +50,64 @@ export function makeWakeTool(stateRoot: string, now: () => Date = () => new Date
   return defineTool({
     name: "wake",
     description:
-      "Schedule yourself to wake up later and continue in THIS conversation. Use it to resume a task " +
-      "after a delay (e.g. check on something in 10 minutes). `in` is a duration string WITH a unit " +
-      '("30m", "2h", "1d"), or a number of seconds. When the time comes, a new turn runs in this same ' +
-      "session with `prompt` as its instruction — you keep the full context of this conversation. " +
-      "IMPORTANT: the woken turn's plain reply is NOT delivered to anyone — to reach the user it must call " +
-      "a delivery tool (e.g. a channel's send tool), exactly as a scheduled job would.",
+      "Schedule yourself to wake up later and continue in THIS conversation. ONE-SHOT: pass `in` — a " +
+      'duration string with a unit ("30m", "2h", "1d") or a number of seconds — to resume a task after a ' +
+      "delay. RECURRING: pass `cron` (5-field, optional `tz`) to wake repeatedly — use sparingly, and " +
+      "`unwake` with the returned id when the job is done. Exactly one of `in`/`cron`. When the time " +
+      "comes, a new turn runs in this same session with `prompt` as its instruction — you keep the full " +
+      "context of this conversation. IMPORTANT: the woken turn's plain reply is NOT delivered to anyone — " +
+      "to reach the user it must call a delivery tool (e.g. a channel's send tool), exactly as a scheduled " +
+      "job would.",
     input: z.object({
       in: z
         .union([z.string(), z.number()])
-        .describe('delay until wake: a duration string with a unit ("30m" / "2h" / "1d"), or a number of seconds'),
+        .optional()
+        .describe('one-shot delay: a duration string with a unit ("30m" / "2h" / "1d"), or a number of seconds'),
+      cron: z.string().optional().describe('recurring: a 5-field cron expression (e.g. "0 9 * * *")'),
+      tz: z.string().optional().describe('IANA timezone for `cron` (default "UTC")'),
       prompt: z.string().min(1).describe("the instruction for the woken turn (runs in this same conversation)"),
     }),
     execute(input, ctx) {
       if (!ctx.session) return "wake is only available inside a conversation (there is no session to resume).";
-      const ms = parseDelayMs(input.in);
+      if ((input.in === undefined) === (input.cron === undefined)) {
+        return "pass exactly one of `in` (one-shot) or `cron` (recurring).";
+      }
+      if (input.cron !== undefined) {
+        // addWakeup validates the cron and DERIVES the first instant itself — one computation, one truth.
+        const r = addWakeup(
+          stateRoot,
+          { session: ctx.session, prompt: input.prompt, cron: input.cron, tz: input.tz },
+          now(),
+        );
+        if (!r.ok) return r.error; // guardrail message the model can act on
+        return `OK — recurring wake ${r.id} (cron "${input.cron}"${input.tz ? ` ${input.tz}` : ""}), first at ${r.fireAt}: ${input.prompt}. Use unwake({ id: "${r.id}" }) to stop it.`;
+      }
+      const ms = parseDelayMs(input.in as string | number);
       if (ms === undefined) {
         return `couldn't parse "in" (${JSON.stringify(input.in)}) — use a unit like "30m" / "2h" / "1d", or a number of seconds (a bare number as text like "120" is rejected).`;
       }
       const at = new Date(now().getTime() + ms);
       const r = addWakeup(stateRoot, { session: ctx.session, prompt: input.prompt, fireAt: at }, now());
       if (!r.ok) return r.error; // guardrail message the model can act on
-      return `OK — I'll wake up at ${r.fireAt} to: ${input.prompt}`;
+      return `OK — I'll wake up at ${r.fireAt} (id ${r.id}) to: ${input.prompt}`;
+    },
+  });
+}
+
+/** Build the `unwake` tool: cancel one of THIS conversation's pending wake-ups by id (a wake/recurring
+ *  that is no longer needed). Session-scoped — a conversation can never cancel another's. */
+export function makeUnwakeTool(stateRoot: string): AgentTool {
+  return defineTool({
+    name: "unwake",
+    description:
+      "Cancel one of YOUR pending wake-ups (one-shot or recurring) by the id `wake` returned. Use it when " +
+      "a scheduled follow-up is no longer needed — especially to stop a recurring wake once its job is done.",
+    input: z.object({ id: z.string().min(1).describe("the wake-up id (returned by `wake`)") }),
+    execute(input, ctx) {
+      if (!ctx.session) return "unwake is only available inside a conversation.";
+      return removeWakeup(stateRoot, input.id, ctx.session)
+        ? `OK — wake-up ${input.id} cancelled.`
+        : `no pending wake-up ${input.id} in this conversation (already fired, or not yours).`;
     },
   });
 }

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -117,11 +117,12 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
 
   /**
    * Fire every due self-scheduled wake-up, ONE at a time (claim → fire → claim next) so a crash loses at
-   * most one. Each fires back into the session it was set in. A wake is one-shot, so unlike a cron slot a
-   * dropped one has no "next time": ONLY when it failed because the session was BUSY (`code: session_busy`
-   * — the turn never started; the very case "wake me in 10 min" hits while the user is still chatting) defer
-   * it to the next poll rather than losing it; a bounded retry then gives up visibly. Any other failure is
-   * terminal (the turn ran — re-running risks duplicate side effects).
+   * most one occurrence. Each fires back into the session it was set in. Busy handling splits by kind: a
+   * ONE-SHOT that failed because the session was BUSY (`code: session_busy` — the turn never started; the
+   * very case "wake me in 10 min" hits while the user is still chatting) is deferred to the next poll,
+   * bounded, because a dropped one-shot has no "next time"; a RECURRING busy occurrence is skipped
+   * immediately (its claim already advanced the entry — the next occurrence comes by definition). Any
+   * other failure is terminal for that occurrence (the turn ran — re-running risks duplicate side effects).
    */
   async function pollWakeups(): Promise<void> {
     for (;;) {
@@ -134,14 +135,21 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
       // Re-fire ONLY on a busy session (the turn never started — replay-safe). A wake is one-shot, so a
       // busy-skip that just dropped it would lose it forever; defer + bounded retry. Every OTHER outcome is
       // terminal (already claimed/removed) — re-running a turn that DID start risks duplicate side effects.
+      // Busy handling differs by kind. ONE-SHOT: defer (bounded) — it has no "next time", dropping it
+      // would lose it forever. RECURRING: the claim already ADVANCED the entry to the next instant (see
+      // takeFirstDueWakeup), so a busy occurrence is simply SKIPPED and audited — the next one comes by
+      // definition, and never touching the stored entry here is what keeps unwake/cancel race-free.
       let kept = false;
-      if (r.busy) {
+      if (r.busy && !w.cron) {
         kept = deferWakeup(stateRoot, w, new Date(now().getTime() + WAKEUP_POLL_MS));
         if (kept) log.info(`[schedule] ${label}: session busy — retrying next poll`);
         else log.error(`[schedule] ${label}: dropped after too many busy retries`);
+      } else if (r.busy && w.cron) {
+        log.error(`[schedule] ${label}: occurrence skipped (session busy); next fires per cron`);
       }
-      // Audit honesty: `deferred` ONLY when the wake was actually re-scheduled. A busy wake dropped at the
-      // retry ceiling is a FINAL silent loss — exactly what this audit exists to answer — so it is `failed`.
+      // Audit honesty: `deferred` ONLY when the same occurrence was actually re-scheduled. A busy one-shot
+      // dropped at the ceiling, and a busy recurring occurrence (skipped — its recurrence survives), are
+      // both FINAL for that occurrence → `failed`.
       appendRun(stateRoot, {
         name: "wake",
         session: w.session,
@@ -149,7 +157,13 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
         ms: r.ms,
         outcome: r.busy ? (kept ? "deferred" : "failed") : r.failed ? "failed" : "completed",
         reply: r.failed || r.busy ? undefined : r.reply,
-        error: r.busy ? (kept ? undefined : "dropped after too many busy retries") : r.failed,
+        error: r.busy
+          ? kept
+            ? undefined
+            : w.cron
+              ? "occurrence skipped (session busy); the recurrence continues"
+              : "dropped after too many busy retries"
+          : r.failed,
       });
     }
   }

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -132,10 +132,8 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
       const label = `wake ${w.id.slice(0, 8)}`;
       const firedAt = now().toISOString();
       const r = await runTurn(label, w.session, w.prompt);
-      // Re-fire ONLY on a busy session (the turn never started — replay-safe). A wake is one-shot, so a
-      // busy-skip that just dropped it would lose it forever; defer + bounded retry. Every OTHER outcome is
-      // terminal (already claimed/removed) — re-running a turn that DID start risks duplicate side effects.
-      // Busy handling differs by kind. ONE-SHOT: defer (bounded) — it has no "next time", dropping it
+      // Busy handling differs by kind (busy = the turn never started — replay-safe; every other outcome is
+      // terminal for this occurrence, since a turn that DID start may have run side effects). ONE-SHOT: defer (bounded) — it has no "next time", dropping it
       // would lose it forever. RECURRING: the claim already ADVANCED the entry to the next instant (see
       // takeFirstDueWakeup), so a busy occurrence is simply SKIPPED and audited — the next one comes by
       // definition, and never touching the stored entry here is what keeps unwake/cancel race-free.

--- a/src/schedule/wakeups.ts
+++ b/src/schedule/wakeups.ts
@@ -1,15 +1,18 @@
 /**
- * The agent's self-scheduled one-shot wake-ups (Phase 4a) — the SECOND producer of scheduled
- * invocations (the first is the author's `schedules/` files). The `wake` tool writes one here; the
- * scheduler polls and fires it back into the SAME session so the agent resumes the conversation it was
- * in. Persisted (`<stateRoot>/schedule/wakeups.json`) so a wake survives a restart.
+ * The agent's self-scheduled wake-ups — the SECOND producer of scheduled invocations (the first is the
+ * author's `schedules/` files). The `wake` tool writes one here; the scheduler polls and fires it back
+ * into the SAME session so the agent resumes the conversation it was in. Persisted
+ * (`<stateRoot>/schedule/wakeups.json`) so a wake survives a restart. ONE-SHOT (`in`) or RECURRING
+ * (`cron` — the entry keeps its id; each fire re-arms `fireAt` to the next cron instant).
  *
- * Guardrails (self-scheduling is a real runaway surface): a minimum delay (no busy-looping) and a cap
- * on pending wake-ups (no unbounded fan-out). A one-shot wake is naturally bounded — it fires once and
- * is removed — so recurring self-scheduling (with heavier guardrails) is deliberately a later phase.
+ * Guardrails (self-scheduling is a real runaway surface): a minimum one-shot delay (no busy-looping), a
+ * minimum RECURRING gap (a high-frequency recurring burns tokens forever — stricter than one-shot), a
+ * per-session pending cap (no fan-out, no cross-session quota DoS; a recurring occupies a slot for its
+ * whole life), and the agent's `unwake` / the operator's `schedule cancel` as the kill switches.
  */
 import { randomUUID } from "node:crypto";
 import { log } from "../log.ts";
+import { cronError, nextRun } from "./cron.ts";
 import { readScheduleFile, scheduleFile, writeScheduleFile } from "./state.ts";
 
 export interface Wakeup {
@@ -18,11 +21,16 @@ export interface Wakeup {
   session: string;
   /** The instruction for the woken turn. */
   prompt: string;
-  /** When to fire (ISO). */
+  /** When to fire next (ISO). For a recurring wake this advances to the next cron instant on each fire. */
   fireAt: string;
-  /** Re-fire attempts so far. A wake into a BUSY session (a channel mid-turn on the same id) fails with
-   *  `code: session_busy` — the turn never started, so it is deferred (only that case; a failure whose turn
-   *  DID run is terminal); after the cap it is dropped rather than retried forever. */
+  /** RECURRING: the cron expression (5-field). Absent = one-shot (fires once, removed). */
+  cron?: string;
+  /** IANA timezone for `cron` (default UTC). */
+  tz?: string;
+  /** CONSECUTIVE busy-defer attempts for the CURRENT occurrence. A wake into a BUSY session (a channel
+   *  mid-turn on the same id) fails with `code: session_busy` — the turn never started, so it is deferred
+   *  (only that case; a failure whose turn DID run is terminal). At the cap a one-shot is dropped; a
+   *  recurring SKIPS the occurrence and re-arms at the next cron instant (attempts reset). */
   attempts?: number;
 }
 
@@ -34,9 +42,11 @@ export const MIN_WAKE_MS = 60_000; // 1 minute
 export const MAX_PENDING_WAKEUPS = 20;
 /** How many times a busy/transient wake is retried (deferred) before being dropped. At the ~30s poll a
  *  wake into an active conversation fires in the first gap between the user's turns; this generous
- *  ceiling (~1h) only gives up on a pathologically stuck session (then logs, operator-visible — an
- *  in-conversation "couldn't resume" notice is Phase 4b). */
+ *  ceiling (~1h) only gives up on a pathologically stuck session (then logs, operator-visible). */
 export const MAX_WAKE_ATTEMPTS = 120;
+/** The minimum gap between two consecutive fires of a RECURRING wake — stricter than the one-shot floor:
+ *  a recurring runs forever, so a tight cron is a permanent token burner, not a one-time mistake. */
+export const MIN_RECURRING_GAP_MS = 10 * 60_000; // 10 minutes
 
 /** A stored entry is a real Wakeup: the fields are present and `fireAt` is a parseable date. A malformed
  *  one (bad/missing fireAt) would compare NaN <= now = false forever — never due, never cleared, but still
@@ -50,7 +60,9 @@ function isWakeup(e: unknown): e is Wakeup {
     typeof w.prompt === "string" &&
     typeof w.fireAt === "string" &&
     !Number.isNaN(Date.parse(w.fireAt)) &&
-    (w.attempts === undefined || typeof w.attempts === "number") // a non-number would make deferWakeup's count NaN
+    (w.attempts === undefined || typeof w.attempts === "number") && // a non-number would make deferWakeup's count NaN
+    (w.cron === undefined || typeof w.cron === "string") &&
+    (w.tz === undefined || typeof w.tz === "string")
   );
 }
 
@@ -82,28 +94,68 @@ export function listWakeups(stateRoot: string): Wakeup[] {
 export type AddWakeupResult = { ok: true; id: string; fireAt: string } | { ok: false; error: string };
 
 /**
- * Add a wake-up, enforcing the guardrails (min delay, pending cap). Returns a MODEL-facing error string
- * on rejection (the `wake` tool passes it back so the model can adjust), never throws for a bad request.
+ * Add a wake-up — one-shot (`fireAt`) or recurring (`cron`/`tz`, `fireAt` = the first instant) —
+ * enforcing the guardrails (min delay / min recurring gap, per-session pending cap). Returns a
+ * MODEL-facing error string on rejection (the `wake` tool passes it back so the model can adjust),
+ * never throws for a bad request.
  */
 export function addWakeup(
   stateRoot: string,
-  input: { session: string; prompt: string; fireAt: Date },
+  input: { session: string; prompt: string; fireAt?: Date; cron?: string; tz?: string },
   now: Date = new Date(),
 ): AddWakeupResult {
-  if (input.fireAt.getTime() < now.getTime() + MIN_WAKE_MS) {
-    return { ok: false, error: `too soon — the minimum wake delay is ${MIN_WAKE_MS / 1000}s.` };
+  let fireAtDate: Date;
+  if (input.cron !== undefined) {
+    const err = cronError(input.cron, input.tz);
+    if (err) return { ok: false, error: `invalid cron/tz: ${err}` };
+    // A recurring wake runs FOREVER — gate its frequency harder than a one-shot: the gap between the next
+    // two instants must be ≥ the recurring floor. (First-pair heuristic; an irregular cron with one tight
+    // pair can slip through — an accepted ceiling, the per-session cap still bounds total load.)
+    const first = nextRun(input.cron, input.tz, now);
+    const second = first && nextRun(input.cron, input.tz, first);
+    if (!first || !second)
+      return { ok: false, error: "this cron never fires (or fires only once) — use `in` for a one-shot." };
+    if (second.getTime() - first.getTime() < MIN_RECURRING_GAP_MS) {
+      return {
+        ok: false,
+        error: `too frequent — a recurring wake must fire at most every ${MIN_RECURRING_GAP_MS / 60_000} minutes.`,
+      };
+    }
+    fireAtDate = first; // DERIVED from the cron — a caller-passed fireAt can't disagree with the schedule
+  } else {
+    if (!input.fireAt) return { ok: false, error: "a one-shot wake needs its fire time (`in`)." };
+    if (input.fireAt.getTime() < now.getTime() + MIN_WAKE_MS) {
+      return { ok: false, error: `too soon — the minimum wake delay is ${MIN_WAKE_MS / 1000}s.` };
+    }
+    fireAtDate = input.fireAt;
   }
   const all = load(stateRoot);
   if (all.filter((w) => w.session === input.session).length >= MAX_PENDING_WAKEUPS) {
     return {
       ok: false,
-      error: `too many pending wake-ups for this conversation (${MAX_PENDING_WAKEUPS}) — wait for some to fire before adding more.`,
+      error: `too many pending wake-ups for this conversation (${MAX_PENDING_WAKEUPS}) — wait for some to fire, or unwake one, before adding more.`,
     };
   }
   const id = randomUUID();
-  const fireAt = input.fireAt.toISOString();
-  save(stateRoot, [...all, { id, session: input.session, prompt: input.prompt, fireAt }]);
+  const fireAt = fireAtDate.toISOString();
+  save(stateRoot, [
+    ...all,
+    { id, session: input.session, prompt: input.prompt, fireAt, cron: input.cron, tz: input.tz },
+  ]);
   return { ok: true, id, fireAt };
+}
+
+/**
+ * Remove a wake-up by id. `session` (when given — the agent's `unwake`) must ALSO match, so a
+ * conversation can only cancel its OWN wake-ups; the operator's `schedule cancel` passes none.
+ * Returns whether anything was removed.
+ */
+export function removeWakeup(stateRoot: string, id: string, session?: string): boolean {
+  const all = load(stateRoot);
+  const kept = all.filter((w) => !(w.id === id && (session === undefined || w.session === session)));
+  if (kept.length === all.length) return false;
+  save(stateRoot, kept);
+  return true;
 }
 
 /**
@@ -118,16 +170,30 @@ export function takeFirstDueWakeup(stateRoot: string, now: Date = new Date()): W
   const all = load(stateRoot);
   const idx = all.findIndex((w) => new Date(w.fireAt).getTime() <= now.getTime());
   if (idx === -1) return undefined;
-  const [w] = all.splice(idx, 1);
+  const w = all[idx] as Wakeup;
+  if (w.cron !== undefined) {
+    // RECURRING claim = ADVANCE IN PLACE: the entry STAYS in the store with fireAt pushed to the next cron
+    // instant (attempts cleared). So (a) `unwake`/`schedule cancel` work at ANY moment — including inside
+    // the woken turn itself, the documented way to stop a done recurring job (a remove+re-add claim would
+    // resurrect what that turn just cancelled); and (b) a crash mid-fire loses at most ONE occurrence,
+    // never the recurrence — matching the static cron schedules' claim semantics.
+    const next = nextRun(w.cron, w.tz, now);
+    if (next) all[idx] = { ...w, fireAt: next.toISOString(), attempts: undefined };
+    else all.splice(idx, 1); // the cron has no next instant — this is its final occurrence
+    save(stateRoot, all);
+    return { ...w }; // THIS occurrence (original fireAt); the store already holds the next
+  }
+  all.splice(idx, 1);
   save(stateRoot, all);
   return w;
 }
 
 /**
- * Re-schedule a wake whose fire failed TRANSIENTLY (its session was busy — a channel is mid-turn on it),
- * deferred to `fireAt`. Returns false (dropped, NOT re-added) once attempts exceed {@link MAX_WAKE_ATTEMPTS}
- * — a wake is one-shot, so a busy-skip that just dropped it would lose it forever (the failure mode a cron
- * slot does not have); this retries it a bounded number of times, then gives up visibly.
+ * Re-schedule a ONE-SHOT wake whose fire failed TRANSIENTLY (its session was busy — a channel is mid-turn
+ * on it), deferred to `fireAt`. Returns false (dropped, NOT re-added) once attempts exceed
+ * {@link MAX_WAKE_ATTEMPTS} — a one-shot has no "next time", so a busy-skip that just dropped it would lose
+ * it forever; bounded retries, then give up visibly. A RECURRING occurrence is never deferred: its claim
+ * already advanced the entry, and its next occurrence comes by definition — a busy one is skipped + audited.
  */
 export function deferWakeup(stateRoot: string, w: Wakeup, fireAt: Date): boolean {
   const attempts = (w.attempts ?? 0) + 1;

--- a/src/schedule/wakeups.ts
+++ b/src/schedule/wakeups.ts
@@ -27,10 +27,10 @@ export interface Wakeup {
   cron?: string;
   /** IANA timezone for `cron` (default UTC). */
   tz?: string;
-  /** CONSECUTIVE busy-defer attempts for the CURRENT occurrence. A wake into a BUSY session (a channel
-   *  mid-turn on the same id) fails with `code: session_busy` — the turn never started, so it is deferred
-   *  (only that case; a failure whose turn DID run is terminal). At the cap a one-shot is dropped; a
-   *  recurring SKIPS the occurrence and re-arms at the next cron instant (attempts reset). */
+  /** ONE-SHOT ONLY: consecutive busy-defer attempts. A one-shot into a BUSY session (`code: session_busy`
+   *  — the turn never started) is deferred, bounded by {@link MAX_WAKE_ATTEMPTS}, then dropped. A RECURRING
+   *  occurrence never defers (this field never increments for it): a busy one is skipped on FIRST contact
+   *  — its claim already advanced the entry, and the next occurrence comes by definition. */
   attempts?: number;
 }
 
@@ -61,8 +61,12 @@ function isWakeup(e: unknown): e is Wakeup {
     typeof w.fireAt === "string" &&
     !Number.isNaN(Date.parse(w.fireAt)) &&
     (w.attempts === undefined || typeof w.attempts === "number") && // a non-number would make deferWakeup's count NaN
-    (w.cron === undefined || typeof w.cron === "string") &&
-    (w.tz === undefined || typeof w.tz === "string")
+    (w.tz === undefined || typeof w.tz === "string") &&
+    // A stored cron must PARSE: a bad one would throw inside the claim's nextRun — before the advance-save
+    // — so its fireAt never moves, it stays first-due forever, and every wakeup behind it starves (a poison
+    // pill worse than the bad-fireAt zombie this validator already guards).
+    (w.cron === undefined ||
+      (typeof w.cron === "string" && cronError(w.cron, typeof w.tz === "string" ? w.tz : undefined) === undefined))
   );
 }
 

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -174,6 +174,60 @@ describe("schedule/scheduler: fire algorithm", () => {
     s.stop();
   });
 
+  it("a RECURRING wake fires and re-arms at the next cron instant (same id, attempts reset)", async () => {
+    const root = await freshRoot();
+    mkdirSync(join(root, "schedule"), { recursive: true });
+    writeFileSync(
+      join(root, "schedule", "wakeups.json"),
+      JSON.stringify([
+        {
+          id: "rec1",
+          session: "s",
+          prompt: "daily check",
+          fireAt: "2026-07-07T09:00:00Z",
+          cron: "0 9 * * *",
+          tz: "UTC",
+        },
+      ]),
+    );
+    const { agent, calls } = recordingAgent();
+    const s = createScheduler({ agent, stateRoot: root, schedules: [], now: () => new Date("2026-07-07T09:00:30Z") });
+    s.start();
+    await vi.waitFor(() => expect(calls.length).toBe(1)); // fired
+    await vi.waitFor(() => expect(listWakeups(root)).toHaveLength(1)); // NOT consumed — re-armed
+    expect(listWakeups(root)[0]).toMatchObject({ id: "rec1", cron: "0 9 * * *" });
+    expect(listWakeups(root)[0]?.fireAt).toBe("2026-07-08T09:00:00.000Z"); // next daily instant
+    s.stop();
+  });
+
+  it("a busy RECURRING occurrence is SKIPPED (audited failed) — the recurrence continues untouched", async () => {
+    const root = await freshRoot();
+    mkdirSync(join(root, "schedule"), { recursive: true });
+    writeFileSync(
+      join(root, "schedule", "wakeups.json"),
+      JSON.stringify([
+        { id: "rec2", session: "s", prompt: "go", fireAt: "2026-07-07T09:00:00Z", cron: "0 9 * * *", tz: "UTC" },
+      ]),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { agent, calls } = recordingAgent([
+      { type: "failed", retryable: true, code: "session_busy", details: "busy" },
+    ]);
+    const s = createScheduler({ agent, stateRoot: root, schedules: [], now: () => new Date("2026-07-07T10:00:00Z") });
+    s.start();
+    await vi.waitFor(() => expect(calls.length).toBe(1));
+    // The recurrence survives (the CLAIM advanced it in place); THIS occurrence is audited failed (skipped),
+    // never deferred — a recurring has a next occurrence by definition.
+    expect(listWakeups(root)).toHaveLength(1);
+    expect(listWakeups(root)[0]).toMatchObject({ id: "rec2", fireAt: "2026-07-08T09:00:00.000Z" });
+    await vi.waitFor(() => expect(readRuns(root, "wake")).toHaveLength(1));
+    expect(readRuns(root, "wake")[0]).toMatchObject({
+      outcome: "failed",
+      error: expect.stringMatching(/occurrence skipped/),
+    });
+    s.stop();
+  });
+
   it("a busy wake dropped at the retry ceiling is audited FAILED (a final silent loss), not deferred", async () => {
     const root = await freshRoot();
     // Seed the wake already AT the attempt cap — the next busy defer drops it.

--- a/test/wakeups.test.ts
+++ b/test/wakeups.test.ts
@@ -10,6 +10,7 @@ import {
   addWakeup,
   deferWakeup,
   listWakeups,
+  removeWakeup,
   takeFirstDueWakeup,
 } from "../src/schedule/wakeups.ts";
 import { makeWakeTool, parseDelayMs, withWakeTool } from "../src/engines/pi/wake-tool.ts";
@@ -60,6 +61,54 @@ describe("schedule/wakeups store + guardrails", () => {
     expect(takeFirstDueWakeup(r, when)).toBeUndefined(); // nothing else due
   });
 
+  it("recurring: a valid cron is accepted; too-frequent and never-firing crons are rejected", async () => {
+    const r = await root();
+    const daily = addWakeup(r, { session: "s", prompt: "x", fireAt: at(2 * MIN_WAKE_MS), cron: "0 9 * * *" }, NOW);
+    expect(daily.ok).toBe(true);
+    expect(listWakeups(r)[0]).toMatchObject({ cron: "0 9 * * *" });
+
+    const everyMinute = addWakeup(r, { session: "s", prompt: "x", fireAt: at(0), cron: "* * * * *" }, NOW);
+    expect(everyMinute.ok).toBe(false); // < the 10-min recurring floor — a forever token burner
+    if (!everyMinute.ok) expect(everyMinute.error).toMatch(/too frequent/);
+
+    const bad = addWakeup(r, { session: "s", prompt: "x", fireAt: at(0), cron: "not a cron" }, NOW);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error).toMatch(/invalid cron/);
+  });
+
+  it("removeWakeup: session-scoped for the agent's unwake; unscoped for the operator", async () => {
+    const r = await root();
+    const res = addWakeup(r, { session: "mine", prompt: "x", fireAt: at(2 * MIN_WAKE_MS) }, NOW);
+    if (!res.ok) throw new Error("setup");
+    expect(removeWakeup(r, res.id, "other-session")).toBe(false); // another conversation can't cancel it
+    expect(removeWakeup(r, res.id, "mine")).toBe(true); // its own can
+    const res2 = addWakeup(r, { session: "mine", prompt: "x", fireAt: at(2 * MIN_WAKE_MS) }, NOW);
+    if (!res2.ok) throw new Error("setup");
+    expect(removeWakeup(r, res2.id)).toBe(true); // the operator (no session) always can
+  });
+
+  it("recurring claim = ADVANCE IN PLACE: the entry stays (next instant), the occurrence is returned", async () => {
+    const r = await root();
+    const res = addWakeup(r, { session: "s", prompt: "x", cron: "0 9 * * *", tz: "UTC" }, NOW); // NOW=12:00 → first 09:00 tomorrow
+    if (!res.ok) throw new Error("setup");
+    const dayAfter = new Date("2026-07-08T09:00:30Z");
+    const occurrence = takeFirstDueWakeup(r, dayAfter);
+    expect(occurrence).toMatchObject({ id: res.id, fireAt: res.fireAt }); // THIS occurrence, original instant
+    // The entry never left the store — unwake/cancel work even mid-fire — and advanced to the next instant.
+    expect(listWakeups(r)).toHaveLength(1);
+    expect(listWakeups(r)[0]).toMatchObject({ id: res.id, fireAt: "2026-07-09T09:00:00.000Z" });
+    // …so the woken turn CAN cancel its own recurrence (the documented unwake flow).
+    expect(removeWakeup(r, res.id, "s")).toBe(true);
+    expect(listWakeups(r)).toHaveLength(0);
+  });
+
+  it("cron fireAt is DERIVED by addWakeup (a caller-passed fireAt cannot disagree with the schedule)", async () => {
+    const r = await root();
+    const res = addWakeup(r, { session: "s", prompt: "x", fireAt: at(1000), cron: "0 9 * * *", tz: "UTC" }, NOW);
+    if (!res.ok) throw new Error("setup");
+    expect(res.fireAt).toBe("2026-07-08T09:00:00.000Z"); // next 9am UTC after NOW(12:00) — not the bogus at(1000)
+  });
+
   it("drops a malformed stored entry (bad fireAt) instead of letting it poison the store", async () => {
     const r = await root();
     vi.spyOn(console, "error").mockImplementation(() => {}); // silence the boundary warn
@@ -93,12 +142,14 @@ describe("schedule/wake-tool", () => {
     expect(parseDelayMs(-5)).toBeUndefined();
   });
 
-  it("withWakeTool: appends wake only when enabled + absent; the workspace's own wake wins", () => {
+  it("withWakeTool: wake+unwake mount as a PAIR; an author's either-name tool suppresses BOTH built-ins", () => {
     const base = [{ name: "read" }] as AgentTool[];
-    expect(withWakeTool(base, "/r", false).map((t) => t.name)).toEqual(["read"]); // disabled (invoke/fire) → no wake
-    expect(withWakeTool(base, "/r", true).map((t) => t.name)).toEqual(["read", "wake"]); // serving → mounted
+    expect(withWakeTool(base, "/r", false).map((t) => t.name)).toEqual(["read"]); // disabled (invoke/fire) → none
+    expect(withWakeTool(base, "/r", true).map((t) => t.name)).toEqual(["read", "wake", "unwake"]); // serving
+    // The pair is ONE concept over one store: an author's wake doesn't write our store, so our unwake
+    // could never cancel what it returns — mixing halves would mislead. Either name → neither built-in.
     const own = [{ name: "read" }, { name: "wake" }] as AgentTool[];
-    expect(withWakeTool(own, "/r", true).map((t) => t.name)).toEqual(["read", "wake"]); // author's wake wins, no dup
+    expect(withWakeTool(own, "/r", true).map((t) => t.name)).toEqual(["read", "wake"]);
   });
 
   it("the wake tool records a wake-up into the CURRENT session", async () => {


### PR DESCRIPTION
## What

Phase 4b: the agent can wake itself **repeatedly** — `wake({ cron: "0 9 * * *", tz?, prompt })` — plus the kill switches: the agent's **`unwake`** tool and the operator's **`fastagent schedule list` / `schedule cancel <id>`**.

## Key semantics

- **Recurring claim = advance in place.** `takeFirstDueWakeup` pushes the entry's `fireAt` to the next cron instant and LEAVES it in the store, returning this occurrence. So `unwake`/`cancel` work at any moment — **including inside the woken turn itself** (the documented way to stop a done recurring job; a remove+re-add claim would resurrect what that turn just cancelled) — and a crash mid-fire loses at most ONE occurrence, never the recurrence (matching static cron schedules).
- **cron `fireAt` is derived by `addWakeup`** (one computation, one truth) — a caller-passed value cannot disagree with the schedule.
- **A busy recurring occurrence is skipped immediately** (audited `failed`) — no defer: the next occurrence comes by definition. Defer/bounded-retry stays one-shot-only.
- **Heavier guardrails**: `MIN_RECURRING_GAP` (10 min — a tight cron is a permanent token burner, stricter than the one-shot floor); the per-session pending cap counts a recurring for its whole life.
- **`unwake` is session-scoped** (a conversation can only cancel its OWN); `schedule cancel` is the operator's unscoped kill switch (cancel output hints to verify with `schedule list` against a live server — the lock-free store write can race a claim-advance; lockfile is the named upgrade path).
- **wake/unwake mount as a pair**: an author tool named either suppresses BOTH built-ins (mixing halves would mislead — the author's wake doesn't write our store).

## Test
recurring add validation (frequency floor, bad cron, derived fireAt), advance-in-place claim (+ mid-fire unwake works), session-scoped remove, scheduler recurring fire→advance + busy-skip audit, pair-mount rule. 525 total.