### PR TITLE
fix(schedule): make the cron fire path total; move loader.ts to the neutral top level

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ src/
 ├── proxy.ts                 # HTTPS_PROXY wiring
 ├── env.ts                   # `.env` → process.env loading (missing file is normal; anything else surfaces)
 ├── runtime.ts               # workspace runtime/package-manager detection (node vs bun) + readPackageJson
+├── loader.ts                # neutral ESM module discovery/loading for tools/ channels/ schedules/ config
 ├── workspace.ts, version.ts # neutral helpers (in-workspace guard, ignore files, version)
 ├── host/node.ts             # Node HTTP host: Routes/ChannelHandler/serveNode/router (public surface)
 ├── scaffold/                # `init` / `add <channel>` / `add skill` + templates/ (real files)
@@ -82,7 +83,7 @@ src/
     ├── definition.ts        # AGENTS.md + skills loading and bundling
     ├── config.ts            # fastagent.config.ts loading + model/precedence
     ├── auth.ts, login.ts    # credential store/resolution (project-level auth.json default) + `login` flow
-    ├── models.ts, loader.ts # Models collection wiring; ESM module loading for tools/channels/config
+    ├── models.ts            # Models collection wiring
     ├── report.ts            # startup report (auth/model/skills/tools surface)
     └── sessions.ts          # PiSessionStore port + in-memory/jsonl backends
 test/                        # vitest; faux models by default + reusable SPEC conformance

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -341,7 +341,8 @@ the scheduler: the author's `schedules/` files (declarative, guaranteed) and the
 Every fire is AUDITED: one line per run in `<stateRoot>/schedule/runs.jsonl` (append-only, full reply — an
 immutable per-fire snapshot the rolling session can't give), read by `fastagent schedule history <name>`
 (or `wake`) — the answer to "did last night's run silently fail?". Total: an audit-write failure never
-breaks a fire.
+breaks a fire. The file is UNBOUNDED by design (full replies, never rewritten) — fine at cron/recurring
+frequencies for a long time; rotation/truncation is deliberately deferred until it bites.
 
 Self-scheduling is one-shot (`wake({ in })`) or RECURRING (`wake({ cron, tz? })` — the entry keeps its id;
 each fire re-arms to the next cron instant). Recurring carries heavier guardrails: a minimum gap between

--- a/src/engines/pi/channel.ts
+++ b/src/engines/pi/channel.ts
@@ -8,7 +8,7 @@ import { readdir } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 import { type ChannelContext, type ChannelModule, parseRouteKey, type Routes } from "../../host/node.ts";
 import { assertInsideWorkspace } from "../../workspace.ts";
-import { type ModuleLoadFailure, isModuleFile, loadModuleDir } from "./loader.ts";
+import { type ModuleLoadFailure, isModuleFile, loadModuleDir } from "../../loader.ts";
 
 /** A dropped route: two channels claim the same key. Surfaced, never silent. */
 export interface ChannelCollision {

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -13,7 +13,7 @@ import { pathToFileURL } from "node:url";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { Models } from "@earendil-works/pi-ai";
 import type { AnyModel } from "./harness.ts";
-import { moduleLoadHint } from "./loader.ts";
+import { moduleLoadHint } from "../../loader.ts";
 
 export interface FastagentConfig {
   /** "provider/modelId". Precedence: CLI --model > FASTAGENT_MODEL > config. */

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -22,7 +22,7 @@ import { piHarnessFactory } from "./harness.ts";
 import { createPiModels } from "./models.ts";
 import { reportDefinitionWarnings } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
-import type { ModuleLoadFailure } from "./loader.ts";
+import type { ModuleLoadFailure } from "../../loader.ts";
 import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -5,7 +5,7 @@
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { log } from "../../log.ts";
 import type { SkillCollision } from "./definition.ts";
-import type { ModuleLoadFailure } from "./loader.ts";
+import type { ModuleLoadFailure } from "../../loader.ts";
 import type { ToolCollision } from "./tool.ts";
 
 export function reportDefinitionWarnings(collisions: SkillCollision[], diagnostics: SkillDiagnostic[]): void {

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -13,7 +13,7 @@
 import { join } from "node:path";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { z } from "zod";
-import { type ModuleLoadFailure, loadModuleDir } from "./loader.ts";
+import { type ModuleLoadFailure, loadModuleDir } from "../../loader.ts";
 import { turnContext } from "./tool-context.ts";
 
 export interface ToolContext {

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -22,7 +22,7 @@ import {
 } from "./config.ts";
 import { createPiAgentFromDefinition, resolveWorkspaceTools } from "./create.ts";
 import { withWakeTool } from "./wake-tool.ts";
-import type { ModuleLoadFailure } from "./loader.ts";
+import type { ModuleLoadFailure } from "../../loader.ts";
 import { type LoadedDefinition, ensureStateRootSelfIgnored } from "./definition.ts";
 import { jsonlSessionStore } from "./sessions.ts";
 import type { ToolCollision } from "./tool.ts";

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,3 +1,8 @@
+/**
+ * Generic ESM module discovery + loading for the workspace's code-input dirs (`tools/`, `channels/`,
+ * `schedules/`, config). Pure node stdlib — engine-neutral, so it lives at the top level: the schedule
+ * discovery (src/schedule/) must not reach into `engines/` for what is plain filesystem/import plumbing.
+ */
 import type { Dirent } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { basename, extname, join } from "node:path";

--- a/src/schedule/discover.ts
+++ b/src/schedule/discover.ts
@@ -6,7 +6,7 @@
  */
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
-import { type ModuleLoadFailure, isModuleFile, loadModuleDir } from "../engines/pi/loader.ts";
+import { type ModuleLoadFailure, isModuleFile, loadModuleDir } from "../loader.ts";
 import { assertInsideWorkspace } from "../workspace.ts";
 import { cronError } from "./cron.ts";
 import type { LoadedSchedule, Schedule } from "./schedule.ts";

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -91,27 +91,14 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
   }
 
   /** Fire one schedule's turn: claim the slot (persist lastFired BEFORE invoking) so a crash mid-turn
-   *  does not re-fire this slot on restart, then run the turn. */
+   *  does not re-fire this slot on restart, then run the turn. A state fault while claiming (loadFires or
+   *  saveFires — both before the invoke, so nothing ran) THROWS to the single skip+audit boundary in
+   *  {@link fireThenReArm}; skipping rather than firing unclaimed also avoids an infinite catch-up loop
+   *  on restart. */
   async function fire(s: LoadedSchedule): Promise<void> {
     const fires = loadFires(stateRoot);
     fires[s.name] = now().toISOString();
-    try {
-      saveFires(stateRoot, fires);
-    } catch (e) {
-      // Can't persist the claim → skip this fire rather than risk an infinite catch-up loop on restart.
-      // Still audited: `appendRun` is total and writes a DIFFERENT file (runs.jsonl), so a broken
-      // fires.json must not also make the skip invisible to `schedule history`.
-      log.error(`[schedule] ${s.name}: cannot persist fire state, skipping this run: ${String(e)}`);
-      appendRun(stateRoot, {
-        name: s.name,
-        session: scheduleSession(s.name),
-        firedAt: now().toISOString(),
-        ms: 0,
-        outcome: "failed",
-        error: `run skipped — cannot persist fire state: ${String(e)}`,
-      });
-      return;
-    }
+    saveFires(stateRoot, fires);
     const firedAt = now().toISOString();
     const r = await runTurn(s.name, scheduleSession(s.name), s.prompt);
     appendRun(stateRoot, {
@@ -206,9 +193,9 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
 
   /** Fire, then arm the NEXT run computed from now — so a slow fire never double-fires the same slot and
    *  missed slots collapse to the single catch-up already done. TOTAL, like pumpWakeups: this is
-   *  void-scheduled from a timer, so an escaping throw (a state-IO fault — `loadFires` on an unreadable
-   *  fires.json throws by design) would be an unhandled rejection = the WHOLE service crashing over one
-   *  skipped fire. Log it and keep the schedule armed instead; boot-time state faults still fail `start()`
+   *  void-scheduled from a timer, so an escaping throw (a state-IO fault while claiming — an unreadable
+   *  fires.json, an unpersistable claim) would be an unhandled rejection = the WHOLE service crashing over
+   *  one skipped fire. Log it and keep the schedule armed instead; boot-time state faults still fail `start()`
    *  loudly (an operator fixes those before serving). */
   async function fireThenReArm(s: LoadedSchedule): Promise<void> {
     try {

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -99,7 +99,17 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
       saveFires(stateRoot, fires);
     } catch (e) {
       // Can't persist the claim → skip this fire rather than risk an infinite catch-up loop on restart.
+      // Still audited: `appendRun` is total and writes a DIFFERENT file (runs.jsonl), so a broken
+      // fires.json must not also make the skip invisible to `schedule history`.
       log.error(`[schedule] ${s.name}: cannot persist fire state, skipping this run: ${String(e)}`);
+      appendRun(stateRoot, {
+        name: s.name,
+        session: scheduleSession(s.name),
+        firedAt: now().toISOString(),
+        ms: 0,
+        outcome: "failed",
+        error: `run skipped — cannot persist fire state: ${String(e)}`,
+      });
       return;
     }
     const firedAt = now().toISOString();
@@ -195,9 +205,27 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
   }
 
   /** Fire, then arm the NEXT run computed from now — so a slow fire never double-fires the same slot and
-   *  missed slots collapse to the single catch-up already done. */
+   *  missed slots collapse to the single catch-up already done. TOTAL, like pumpWakeups: this is
+   *  void-scheduled from a timer, so an escaping throw (a state-IO fault — `loadFires` on an unreadable
+   *  fires.json throws by design) would be an unhandled rejection = the WHOLE service crashing over one
+   *  skipped fire. Log it and keep the schedule armed instead; boot-time state faults still fail `start()`
+   *  loudly (an operator fixes those before serving). */
   async function fireThenReArm(s: LoadedSchedule): Promise<void> {
-    await fire(s);
+    try {
+      await fire(s);
+    } catch (e) {
+      // Audited too (appendRun is total, and runs.jsonl ≠ the broken state file) — a skipped fire must
+      // show up in `schedule history`, not only in stderr.
+      log.error(`[schedule] ${s.name}: fire failed (skipping this run, schedule stays armed): ${String(e)}`);
+      appendRun(stateRoot, {
+        name: s.name,
+        session: scheduleSession(s.name),
+        firedAt: now().toISOString(),
+        ms: 0,
+        outcome: "failed",
+        error: `run skipped — fire failed: ${String(e)}`,
+      });
+    }
     const due = nextRun(s.cron, s.tz, now());
     if (due) arm(s, due);
   }

--- a/src/schedule/wakeups.ts
+++ b/src/schedule/wakeups.ts
@@ -198,6 +198,11 @@ export function takeFirstDueWakeup(stateRoot: string, now: Date = new Date()): W
  * {@link MAX_WAKE_ATTEMPTS} — a one-shot has no "next time", so a busy-skip that just dropped it would lose
  * it forever; bounded retries, then give up visibly. A RECURRING occurrence is never deferred: its claim
  * already advanced the entry, and its next occurrence comes by definition — a busy one is skipped + audited.
+ *
+ * Known residual: between the claim (removed from the store) and this re-add there is a microtask-scale
+ * window (the busy reject yields before any harness IO) where an `unwake` for this id reports "not found"
+ * and the defer then resurrects it — the one-shot cousin of the recurring resurrection the advance-in-place
+ * claim eliminated. Accepted: closing it needs a claim-lease with expiry, disproportionate to the window.
  */
 export function deferWakeup(stateRoot: string, w: Wakeup, fireAt: Date): boolean {
   const attempts = (w.attempts ?? 0) + 1;

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmdirSync, writeFileSync } from "node:fs";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -88,6 +88,30 @@ describe("schedule/scheduler: fire algorithm", () => {
     expect(calls).toHaveLength(1);
     await vi.advanceTimersByTimeAsync(60 * 60_000); // → 12:00
     expect(calls).toHaveLength(2);
+    s.stop();
+  });
+
+  it("a state-IO fault at fire time skips the run and keeps the schedule armed (no unhandled rejection)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T10:30:00Z"));
+    const root = await freshRoot();
+    const { agent, calls } = recordingAgent();
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const s = createScheduler({ agent, stateRoot: root, schedules: [hourly()] });
+    s.start();
+    // Sabotage the fire state AFTER arming: a directory at fires.json makes loadFires throw (EISDIR — the
+    // unreadable-state class state.ts throws on by design). fireThenReArm is void-scheduled from a timer,
+    // so without its totality boundary this would be an unhandled rejection = the whole service down.
+    mkdirSync(join(root, "schedule", "fires.json"), { recursive: true });
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1000); // → 11:00: the fire attempt hits the fault
+    expect(calls).toHaveLength(0); // skipped (no claim persistable), not half-fired
+    expect(errors.mock.calls.some((c) => String(c[0]).includes("fire failed"))).toBe(true);
+    // The skip is AUDITED (runs.jsonl is a different file than the broken fires.json) — `schedule history`
+    // must see it, not only stderr.
+    expect(readRuns(root, "job")[0]).toMatchObject({ outcome: "failed", error: expect.stringMatching(/skipped/) });
+    rmdirSync(join(root, "schedule", "fires.json")); // the operator fixes the state…
+    await vi.advanceTimersByTimeAsync(60 * 60_000); // → 12:00
+    expect(calls).toHaveLength(1); // …and the schedule is STILL armed — the fault cost one run, not the service
     s.stop();
   });
 


### PR DESCRIPTION
## What

Follow-ups from a full design/implementation review of the scheduler.

1. **Fire-path totality (the real bug).** `fireThenReArm` is void-scheduled from a timer, but `fire()`'s `loadFires` throws by design on an unreadable `fires.json` (non-ENOENT IO fault) — an escaping throw was an **unhandled rejection**: one broken state file crashing the whole service, channels included. It now has the same totality boundary `pumpWakeups` already had (the same file had one void-scheduled path guarded and one bare): log, audit, skip the run, keep the schedule armed. Boot-time faults still fail `start()` loudly. Both skip paths (fire-state fault, unpersistable claim) now **append a failed run record** — `runs.jsonl` is a different file than the broken `fires.json`, so a skipped fire shows up in `schedule history`, not only stderr.
2. **`loader.ts` moves `engines/pi/` → `src/`.** Pure node stdlib (ESM discovery/loading for tools/channels/schedules/config); `schedule/discover.ts` importing it from `engines/` made the layering read as an engine coupling it never was. Import-path-only change for 7 files.
3. **Companion text**: `deferWakeup` documents the accepted microtask-scale one-shot resurrection window (cousin of the recurring one the advance-in-place claim eliminated); core.md states `runs.jsonl` is unbounded by design.

## Test

Fault-injection test: a directory at `fires.json` (EISDIR — the unreadable-state class) at fire time → the run is skipped **and audited**, no unhandled rejection, and the schedule stays armed (fires normally once the operator fixes the state). 526 total.