### PR TITLE
docs(schedule): give time triggers a discovery path

### DIFF
--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -65,6 +65,19 @@ For Telegram:
 - Set TELEGRAM_BOT_TOKEN and TELEGRAM_SECRET_TOKEN.
 - Use fastagent dev --tunnel for local webhook testing.
 
+For schedules (run the agent on a cron — daily digest, periodic checks):
+- Create schedules/<name>.ts: export default defineSchedule({ cron: "0 9 * * *", tz: "America/New_York",
+  prompt: "..." }) — defineSchedule comes from @kid7st/fastagent; the filename is the schedule name.
+- The prompt must SAY where output goes ("…and send it to the team Telegram"): the scheduler only fires
+  the agent — a scheduled turn's plain reply is not delivered anywhere; delivery is a send tool's job.
+- Test with a command that exits: fastagent fire <name> --model provider/id (runs the turn NOW, without
+  touching the real cron state). The cron only fires while `dev`/`start` is serving.
+- Check past runs with: fastagent schedule history <name>; see what will fire with: fastagent schedule list.
+- Self-scheduling (the agent sets its own follow-ups via a built-in `wake` tool) is opt-in:
+  selfSchedule: true in fastagent.config.*.
+- Deploying with schedules or selfSchedule keeps one machine always running (no scale-to-zero — a
+  sleeping box misses the instant); `fastagent deploy` handles this, don't fight it.
+
 For embedding:
 - Use createPiAgentFromDefinition or createPiAgentFromWorkspace.
 - Mount createInvokeHandler(agent) in my app route.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ Most commands take an optional workspace directory. When omitted, the current di
 | `invoke <message> [dir]` | Run one agent turn and exit. |
 | `fire <name> [dir]` | Run one schedule's turn immediately (authoring loop). |
 | `schedule history <name> [dir]` | Print the run audit for a schedule (or `wake`). |
-| `schedule list [dir]` | The agent's pending self-scheduled wake-ups. |
+| `schedule list [dir]` | Everything that will fire: static schedules (next instant) + pending wake-ups. |
 | `schedule cancel <id> [dir]` | Remove a pending wake-up (operator kill switch). |
 | `tool <name> <json> [dir]` | Run one discovered tool directly. |
 | `add github|telegram [dir]` | Scaffold a first-party channel. |
@@ -173,9 +173,11 @@ fired, its outcome (`completed` / `failed` / `deferred`), duration, and a previe
 The answer to "did last night's run silently fail?". Read-only (reads `<state root>/schedule/runs.jsonl`,
 written by the serving scheduler); `--json` prints the full records, including the complete reply text.
 
-`fastagent schedule list [dir]` shows the agent's pending self-scheduled wake-ups (id, next fire,
-one-shot/cron, session, prompt); `fastagent schedule cancel <id> [dir]` removes one — the operator's kill
-switch for a runaway recurring wake (the agent's own is the `unwake` tool, which is session-scoped).
+`fastagent schedule list [dir]` shows everything that will fire, from BOTH producers: the static
+`schedules/` files (name + next cron instant) and the agent's pending self-scheduled wake-ups (id, next
+fire, one-shot/cron, session, prompt); `fastagent schedule cancel <id> [dir]` removes one wake-up — the
+operator's kill switch for a runaway recurring wake (the agent's own is the `unwake` tool, which is
+session-scoped).
 
 ## `fastagent tool`
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -52,6 +52,8 @@ fastagent deploy fly --run   # idempotent, resumable; carries your local env sec
 
 Idle behavior defaults to **suspend** (snapshot + fast resume on the next webhook, ~hundreds of ms). Flags: `--stop` (cold-stop instead of suspend), `--no-scale-to-zero` (keep one machine always up), `--force` (overwrite artifacts). A GitHub channel forces one machine to stay up — its fire-and-forget turns have no replay, so scaling the last machine to zero could drop an in-flight review.
 
+**Time triggers keep one machine running.** A cron schedule (`schedules/` files) or self-scheduling (`selfSchedule: true`) has no inbound webhook to wake a scaled-to-zero machine — a sleeping box simply misses the instant. Pre-flight detects time triggers and the generated `fly.toml` forces `min_machines_running = 1` (on Railway, the runbook forbids App Sleeping). If you kept an existing scale-to-zero `fly.toml`, `deploy` warns — and `--run` refuses — until you raise it.
+
 ## Railway
 
 Prereqs: the [Railway CLI](https://docs.railway.com/guides/cli) and `railway login`.
@@ -75,7 +77,7 @@ Or:
 fastagent deploy railway --run   # drives the CLI on an UNLINKED dir; carries your local env secrets
 ```
 
-`--run` refuses a dir already linked to a project unless you pass `--into-linked`. Scale-to-zero (App Sleeping) is a **dashboard-only** toggle Railway exposes no CLI/API for — the runbook states it as a manual step (Settings → Deploy → Serverless → App Sleeping). Don't enable it with a GitHub channel, for the same no-replay reason as Fly.
+`--run` refuses a dir already linked to a project unless you pass `--into-linked`. Scale-to-zero (App Sleeping) is a **dashboard-only** toggle Railway exposes no CLI/API for — the runbook states it as a manual step (Settings → Deploy → Serverless → App Sleeping). Don't enable it with a GitHub channel (the same no-replay reason as Fly) or with time triggers (`schedules/` files or `selfSchedule` — a sleeping box misses the instant).
 
 ## Serving an existing repo (agentDir layout)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,6 +28,7 @@ agent/
 3. **A reference implementation** — pi-based assembly for `AGENTS.md`, Agent Skills, code tools, sessions, auth, and model selection.
 4. **Developer workflow** — `init`, `info`, `dev`, `chat`, `tool`, `invoke`, `start`, and channel scaffolding.
 5. **Composable adapters** — GitHub, Telegram, the default local invoke channel, and a small public kit for third-party channels.
+6. **Time triggers** — cron schedules (`schedules/` files) and opt-in agent self-scheduling (the `wake` tool), with a per-run audit (`fastagent schedule history`).
 
 ## Design choices
 
@@ -96,6 +97,7 @@ fastagent add telegram
 | Use CLI commands | [CLI reference](cli.md) |
 | Embed in an app | [Embedding](embedding.md) |
 | Add webhooks/bots | [Channels](channels.md) |
+| Run the agent on a cron / let it wake itself | [Quickstart §8](quickstart.md#8-run-on-a-clock), [CLI reference](cli.md) |
 | Ship to Fly, Railway, or any Docker host | [Deploy](deploy.md) |
 | Use GitHub webhooks | [GitHub channel](github.md) |
 | Use Telegram bots | [Telegram channel](telegram.md) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -172,6 +172,35 @@ fastagent dev --tunnel
 
 Read [Channels](channels.md) for the channel model, [GitHub channel](github.md) for GitHub webhooks, and [Telegram channel](telegram.md) for Telegram bots.
 
+## 8. Run on a clock
+
+Channels react to requests; **schedules** fire the agent on a cron — a daily digest, a periodic check.
+Drop a file in `schedules/` (mirroring `tools/`), named by its filename:
+
+```ts
+// schedules/daily-digest.ts
+import { defineSchedule } from "@kid7st/fastagent";
+
+export default defineSchedule({
+  cron: "0 9 * * *",
+  tz: "America/New_York",
+  prompt: "Summarize yesterday's activity and send it to the team Telegram.",
+});
+```
+
+The prompt must say where output goes — the scheduler only fires the agent; delivery is a send tool's
+job. Test it immediately (without waiting for the cron, and without touching the real fire state):
+
+```bash
+fastagent fire daily-digest
+```
+
+The cron fires while `dev`/`start` is serving; `fastagent schedule history <name>` answers "did last
+night's run silently fail?", and `fastagent schedule list` shows everything that will fire. Agents can
+also schedule **themselves** (a built-in `wake` tool — "check the deploy in 10 minutes") — opt in with
+`selfSchedule: true` in `fastagent.config.*`. See the [CLI reference](cli.md) and
+[API reference](api-reference.md#schedule-authoring).
+
 ## Where next
 
 - [Embedding](embedding.md) — use FastAgent as a library inside your own app.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -134,7 +134,7 @@ function usage(code: number): never {
   schedule history <name>  print the run audit for a schedule (or "wake" for self-scheduled wake-ups):
          when each run fired, completed/failed/deferred, duration, and the reply/error — the answer to
          "did last night's run silently fail?". --json for the full records (complete reply text).
-  schedule list    the agent's pending self-scheduled wake-ups (id, session, next fire, cron, prompt).
+  schedule list    everything that will fire: static schedules (next instant) + pending wake-ups.
   schedule cancel <id>  remove a pending wake-up — the operator's kill switch for a runaway recurring
          wake (the agent's own is the \`unwake\` tool).
   start  run the agent in dir (default .) in production posture — the SAME assembly as dev

--- a/src/scaffold/templates/fastagent.config.mjs
+++ b/src/scaffold/templates/fastagent.config.mjs
@@ -8,6 +8,8 @@
 export default {
   // model: "openai-codex/gpt-5.5",
   http: { port: 8787 },
+  // selfSchedule: true, // mount the built-in `wake` tool: the agent schedules its own follow-up turns
+  //                     // ("check the deploy in 10 min"). Cron jobs need no opt-in — drop a schedules/<name>.ts.
   // deploy: what the agent needs on the box (so `fastagent deploy` doesn't need a hand-written Dockerfile
   // or hand-set host variables). Uncomment as needed:
   // deploy: {


### PR DESCRIPTION
## What

A design/DX review found the scheduler fully documented in the **reference** docs (cli.md, api-reference.md, configuration.md) but absent from every **narrative** entry point — quickstart, overview, ai-start.md (the coding-agent guide!), deploy.md, and the init scaffold all had zero mentions. The feature was complete but had no door.

- **quickstart.md §8 'Run on a clock'**: defineSchedule example, the "delivery is a send tool's job" rule, the `fire`/`history`/`list` loop, selfSchedule pointer.
- **ai-start.md 'For schedules:'**: the coding-agent entry point, mirroring 'For Telegram' (create file → `fire` to test → deploy keeps one machine).
- **overview.md**: time triggers in 'What FastAgent provides' + a documentation-map row.
- **deploy.md**: the user-facing WHY for keep-one-machine (#189 changed deploy behavior with no user-facing explanation).
- **config template**: commented `selfSchedule` line (the `deploy` key had one; `selfSchedule` didn't).
- **rule-12 fixes**: cli.md's and `--help`'s `schedule list` descriptions still said wakeups-only after #192 widened it to both producers.

Docs + one usage-string line + one template comment; no behavior change. 531 tests green.
