### PR TITLE
fix(agentDir): validate existence at load; align fire/dev-watch/init with the layout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,7 @@ Supported keys:
 | Key | Meaning |
 |---|---|
 | `model` | Default model spec, in `provider/modelId` form. |
-| `agentDir` | The agent-definition subdirectory (`persona.md`, `skills/`, `tools/`, `channels/`), relative to the config file. Default: the config directory itself (flat). Set it to e.g. `"./agent"` to serve an existing repo as a coding agent — the config directory stays the run root (`cwd`, whose `AGENTS.md` is read as context), while the agent's own surface lives in the subdir and does not collide with the host's `tools/`/`src/`. |
+| `agentDir` | The agent-definition subdirectory (`persona.md`, `skills/`, `tools/`, `channels/`), relative to the config file. Default: the config directory itself (flat). Set it to e.g. `"./agent"` to serve an existing repo as a coding agent — the config directory stays the run root (`cwd`, whose `AGENTS.md` is read as context), while the agent's own surface lives in the subdir and does not collide with the host's `tools/`/`src/`. Must exist, stay inside the config directory, and be a real directory — a missing path is refused at load (a typo would otherwise silently serve an empty agent), and so is a symlink (its target can escape the config directory, where `dev`'s watch would never see edits). |
 | `tools` | Extra programmatic tools appended after default pi tools. Most users should prefer `tools/` discovery. |
 | `http.port` | Default port for `dev` / `start`. |
 | `selfSchedule` | Mount the built-in `wake` tool so the agent can schedule its own follow-up turns (self-scheduling). Off by default — an autonomy capability, opt in when you want it; only active on the serving path (`dev`/`start`, where the scheduler poller runs). |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -324,11 +324,21 @@ async function runFire(): Promise<void> {
   loadDotEnv(fireDir);
   installProxyFetch();
   await resolveFirstRunModel(fireDir);
-  const { schedules, failures } = await loadSchedules(fireDir).catch(failStartup);
+  // Schedules are agent surface — discover them where dev/start/`schedule list` do (agentDir), not the
+  // run root, so `fire` sees the same set the scheduler serves in the kit layout.
+  const { config: fireConfig } = await loadConfig(fireDir).catch(failStartup);
+  const fireAgentDir = resolveAgentDir(fireDir, fireConfig);
+  const { schedules, failures } = await loadSchedules(fireAgentDir).catch(failStartup);
   reportModuleLoadFailures(failures);
   const schedule = schedules.find((s) => s.name === name);
   if (!schedule) {
-    console.error(`unknown schedule "${name}". available: ${schedules.map((s) => s.name).join(", ") || "(none)"}`);
+    // Name the discovery path in the kit layout: a schedule misplaced at the run root should read as
+    // "wrong place", not "broken file".
+    const looked =
+      fireAgentDir === fireDir ? "" : ` (looked in ${relative(fireDir, fireAgentDir).split(sep).join("/")}/schedules)`;
+    console.error(
+      `unknown schedule "${name}"${looked}. available: ${schedules.map((s) => s.name).join(", ") || "(none)"}`,
+    );
     process.exit(1);
   }
   const { agent, modelSpec, authPath } = await createPiAgentFromWorkspace(fireDir, {
@@ -547,8 +557,10 @@ async function runInit(): Promise<void> {
   if (values["agent-dir"]) {
     // Same containment contract loadConfig enforces on config.agentDir: an escaping value would write
     // the kit outside the workspace AND produce a config that can never load — refuse up front.
-    const rel = relative(dir, resolve(dir, values["agent-dir"]));
-    if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    // POSIX-normalized: this lands verbatim in the generated config (agentDir: "./a/b") and the persona
+    // locator note — a Windows `relative()` would write backslashes into both.
+    const rel = relative(dir, resolve(dir, values["agent-dir"])).split(sep).join("/");
+    if (rel === "" || rel === ".." || rel.startsWith("../") || isAbsolute(rel)) {
       failStartup(new Error(`--agent-dir ("${values["agent-dir"]}") must be a subdirectory of ${dir}`));
     }
     agentDir = `./${rel}`;

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -38,12 +38,13 @@ export function devWatchIgnored(dir: string, agentDir: string): (path: string) =
     // Run-root (cwd) inputs: .env + fastagent.config.* live where config lives, not in agentDir.
     if (rel === ".env") return false;
     if (/^fastagent\.config\.[cm]?[jt]s$/.test(rel)) return false;
-    // Agent code inputs live in agentDir: tools/, channels/, package.json (its own deps). Everything
-    // else under agentDir (skills/, persona.md, AGENTS.md) is live-read — pruned, no restart.
+    // Agent code inputs live in agentDir: tools/, channels/, schedules/ (loaded once per worker — a
+    // restart is their only re-read), package.json (its own deps). Everything else under agentDir
+    // (skills/, persona.md, AGENTS.md) is live-read — pruned, no restart.
     const relAgent = relative(agentDir, path);
     if (!relAgent.startsWith("..")) {
       const [head] = relAgent.split(sep);
-      if (head === "tools" || head === "channels") return false;
+      if (head === "tools" || head === "channels" || head === "schedules") return false;
       if (relAgent === "package.json") return false;
     }
     return true;

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -6,7 +6,7 @@
  * the agent's identity or behavior (that lives in AGENTS.md + skills). Deleting the config must
  * still leave a runnable zero-config agent (model via --model / FASTAGENT_MODEL).
  */
-import { existsSync } from "node:fs";
+import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -132,6 +132,38 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
       throw new Error(
         `${path}: "agentDir" ("${c.agentDir}") must be a subdirectory of the config directory, not escape it`,
+      );
+    }
+    // An explicitly declared agentDir that doesn't exist is a typo until proven otherwise ("./agnet"):
+    // without this check every opener would assemble an EMPTY agent (no persona, no skills, no tools)
+    // with zero errors — the worst silent failure this config can produce. Deliberately NOT auto-created:
+    // config load is read-only (no implicit operations), and a mkdir would turn the typo into a served
+    // empty agent plus a junk directory.
+    // lstat, not stat: a symlink would pass the literal containment check above while its TARGET lives
+    // outside the config dir — exactly what that check exists to prevent (dev's watch would silently
+    // never see edits). Same rule as init's parent preflight: reject, don't follow.
+    const agentDirAbs = resolve(dir, c.agentDir);
+    const st = lstatSync(agentDirAbs, { throwIfNoEntry: false });
+    if (!st) {
+      throw new Error(`${path}: "agentDir" ("${c.agentDir}") does not exist — create it, or fix the path`);
+    }
+    if (st.isSymbolicLink()) {
+      // Separate message: to its user a symlink LOOKS like a working directory — name the reason and the fix.
+      throw new Error(
+        `${path}: "agentDir" ("${c.agentDir}") is a symlink — not allowed (its target can live outside the ` +
+          `config directory, where dev's watch would never see edits); use a real directory, or point agentDir at the target's real path`,
+      );
+    }
+    if (!st.isDirectory()) {
+      throw new Error(`${path}: "agentDir" ("${c.agentDir}") is not a directory`);
+    }
+    // The leaf lstat can't see a symlinked INTERMEDIATE segment (agentDir "./a/b" with `a` → outside):
+    // realpath equality covers every segment under the config dir in one comparison. dir itself is
+    // realpath'd on both sides, so a symlinked config-dir path (macOS /tmp) stays legal.
+    if (realpathSync(agentDirAbs) !== resolve(realpathSync(dir), relative(dir, agentDirAbs))) {
+      throw new Error(
+        `${path}: "agentDir" ("${c.agentDir}") resolves through a symlink — not allowed (the target can ` +
+          `live outside the config directory, where dev's watch would never see edits); use the real path`,
       );
     }
   }

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -134,7 +134,13 @@ export async function assertChannelReady(dir: string): Promise<void> {
     raw = await readFile(pkgPath, "utf8");
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`${dir}: not a fastagent code workspace (no package.json) — run \`fastagent init\` here first`);
+      // `dir` is where the kit lives (agentDir when set) — "run init" is only the right advice when no
+      // workspace exists yet; a kit missing its manifest (e.g. a --minimal init) needs the manifest, not init.
+      throw new Error(
+        `${dir}: no package.json — a channel adapter is code and needs the kit's own manifest. ` +
+          `Run \`fastagent init\` for a fresh workspace, or add a package.json with @kid7st/fastagent there ` +
+          `(a --minimal init has none)`,
+      );
     }
     throw e;
   }

--- a/src/scaffold/init.ts
+++ b/src/scaffold/init.ts
@@ -183,6 +183,21 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
     throw new Error(`"${dir}" already has ${conflicts.join(", ")} — already a fastagent workspace`);
   }
 
+  // Never merge the kit into an existing NON-EMPTY directory (a host repo may own an unrelated `agent/`
+  // — common in AI products): wx would keep its files, but persona.md/skills/ landing inside someone
+  // else's code dir is a silent mix. Refuse with the way out. Dotfiles (.DS_Store, .gitkeep) don't
+  // count — same rule as detectHostSignals' occupation check. A SYMLINKED kit path slips past this
+  // readdir (it follows links) — deliberate: the parent preflight below lstat-rejects it before any write.
+  if (options.agentDir) {
+    const occupants = (await readdir(join(dir, kit)).catch(() => [] as string[])).filter((f) => !f.startsWith("."));
+    if (occupants.length > 0) {
+      throw new Error(
+        `"${kit}" already exists and is not empty — if it is unrelated to the agent, pick another name ` +
+          `(--agent-dir <name>) or go flat (--flat); to adopt it as the kit, empty it first`,
+      );
+    }
+  }
+
   // Was the target non-empty BEFORE we wrote anything? (missing dir = empty).
   const intoNonEmpty = (await readdir(dir).catch(() => [] as string[])).length > 0;
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -95,6 +95,23 @@ describe("cli papercuts", () => {
     expect(stderr).toMatch(/available: daily/);
   });
 
+  it("fire discovers schedules from agentDir (where the scheduler serves them), not the run root", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-fire-kit-"));
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { agentDir: "./agent" };\n`);
+    await mkdir(join(dir, "agent", "schedules"), { recursive: true });
+    const scheduleHref = new URL("../src/schedule/schedule.ts", import.meta.url).href;
+    await writeFile(
+      join(dir, "agent", "schedules", "daily.ts"),
+      `import { defineSchedule } from ${JSON.stringify(scheduleHref)};\nexport default defineSchedule({ cron: "0 9 * * *", prompt: "digest" });\n`,
+    );
+    const env = { ...process.env };
+    delete env.FASTAGENT_MODEL;
+    const { code, stderr } = await run(["fire", "nope", dir], undefined, env);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/available: daily/); // found in agent/schedules — the same set dev/start serve
+    expect(stderr).toMatch(/looked in agent\/schedules/); // a misplaced schedule reads as "wrong place", not "broken file"
+  });
+
   it("never clobbers an existing Dockerfile: flags a stale generated one, warns on a hand-written one (G6)", async () => {
     // deploy KEEPS any existing Dockerfile without --force (no silent data loss). A generated one (marker)
     // that drifted from current config is flagged stale; a hand-written one is kept + warned (its apt won't

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
@@ -33,12 +33,41 @@ describe("config: resolveSessionsDirOverride (start's sessions precedence)", () 
 describe("config: loadConfig agentDir validation", () => {
   it("accepts a subdirectory agentDir; rejects one that escapes the config dir (dev watch-scope guard)", async () => {
     const ok = await mkdtemp(join(tmpdir(), "fa-agentdir-ok-"));
+    await mkdir(join(ok, "agent"));
     await writeFile(join(ok, "fastagent.config.mjs"), `export default { agentDir: "./agent" };\n`);
     expect((await loadConfig(ok)).config.agentDir).toBe("./agent");
 
     const bad = await mkdtemp(join(tmpdir(), "fa-agentdir-bad-"));
     await writeFile(join(bad, "fastagent.config.mjs"), `export default { agentDir: "../shared" };\n`);
     await expect(loadConfig(bad)).rejects.toThrow(/agentDir.*subdirectory.*not escape/);
+  });
+
+  it("rejects an agentDir that doesn't exist (a typo would silently serve an EMPTY agent) or is a file", async () => {
+    const typo = await mkdtemp(join(tmpdir(), "fa-agentdir-typo-"));
+    await mkdir(join(typo, "agent"));
+    await writeFile(join(typo, "fastagent.config.mjs"), `export default { agentDir: "./agnet" };\n`);
+    await expect(loadConfig(typo)).rejects.toThrow(/agentDir.*does not exist.*create it, or fix the path/);
+
+    const file = await mkdtemp(join(tmpdir(), "fa-agentdir-file-"));
+    await writeFile(join(file, "agent"), "not a dir");
+    await writeFile(join(file, "fastagent.config.mjs"), `export default { agentDir: "./agent" };\n`);
+    await expect(loadConfig(file)).rejects.toThrow(/agentDir.*is not a directory/);
+
+    // A symlink passes the literal containment check while its target may live outside — rejected (lstat).
+    const sym = await mkdtemp(join(tmpdir(), "fa-agentdir-sym-"));
+    const outside = await mkdtemp(join(tmpdir(), "fa-agentdir-out-"));
+    await symlink(outside, join(sym, "agent"));
+    await writeFile(join(sym, "fastagent.config.mjs"), `export default { agentDir: "./agent" };\n`);
+    await expect(loadConfig(sym)).rejects.toThrow(/agentDir.*is a symlink.*real path/);
+
+    // An INTERMEDIATE symlinked segment ("./a/b" with a → outside): the leaf is a real directory, so
+    // only the realpath-equality check catches the escape.
+    const mid = await mkdtemp(join(tmpdir(), "fa-agentdir-mid-"));
+    const outside2 = await mkdtemp(join(tmpdir(), "fa-agentdir-out2-"));
+    await mkdir(join(outside2, "b"));
+    await symlink(outside2, join(mid, "a"));
+    await writeFile(join(mid, "fastagent.config.mjs"), `export default { agentDir: "./a/b" };\n`);
+    await expect(loadConfig(mid)).rejects.toThrow(/agentDir.*resolves through a symlink/);
   });
 
   it("selfSchedule: accepts a boolean (opt-in to the wake tool), rejects a non-boolean", async () => {

--- a/test/dev-supervisor.test.ts
+++ b/test/dev-supervisor.test.ts
@@ -12,6 +12,7 @@ describe("dev-supervisor: devWatchIgnored (the narrow watch scope)", () => {
     expect(ignored(join(root, "tools", "word-count.ts"))).toBe(false);
     expect(ignored(join(root, "tools", "lib", "helper.ts"))).toBe(false); // nested under tools/
     expect(ignored(join(root, "channels", "telegram.ts"))).toBe(false);
+    expect(ignored(join(root, "schedules", "daily.ts"))).toBe(false); // loaded once per worker — restart is the re-read
     expect(ignored(join(root, "package.json"))).toBe(false);
     expect(ignored(join(root, ".env"))).toBe(false);
     expect(ignored(join(root, "fastagent.config.mjs"))).toBe(false);
@@ -41,6 +42,7 @@ describe("dev-supervisor: devWatchIgnored (the narrow watch scope)", () => {
     expect(ig(agentDir)).toBe(false); // must descend into agentDir to reach its tools/
     expect(ig(join(agentDir, "tools", "foo.ts"))).toBe(false); // the agent's tool → restart
     expect(ig(join(agentDir, "channels", "telegram.ts"))).toBe(false);
+    expect(ig(join(agentDir, "schedules", "daily.ts"))).toBe(false);
     expect(ig(join(agentDir, "package.json"))).toBe(false);
     expect(ig(join(agentDir, "persona.md"))).toBe(true); // live-read, no restart
     expect(ig(join(agentDir, "skills", "x", "SKILL.md"))).toBe(true);

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -221,6 +221,21 @@ describe("init: scaffoldWorkspace", () => {
     }
   });
 
+  it("refuses a non-empty kit target (a host repo's unrelated agent/); dotfiles alone don't block", async () => {
+    const dir = await freshDir();
+    await mkdir(join(dir, "agent"), { recursive: true });
+    await writeFile(join(dir, "agent", "index.ts"), "// the host's own agent code\n");
+    // Never silently mix the kit into someone else's directory — refuse with the way out.
+    await expect(scaffoldWorkspace(dir, { agentDir: "./agent" })).rejects.toThrow(/not empty.*--agent-dir <name>/s);
+    expect(await exists(join(dir, "fastagent.config.mjs"))).toBe(false); // refusal is side-effect-free
+
+    const dir2 = await freshDir();
+    await mkdir(join(dir2, "agent"), { recursive: true });
+    await writeFile(join(dir2, "agent", ".gitkeep"), "");
+    const { agentDir } = await scaffoldWorkspace(dir2, { agentDir: "./agent" }); // dotfiles ≠ occupied
+    expect(agentDir).toBe("./agent");
+  });
+
   it("agentDir layout: the kit lands in ./agent, config at the root points there, host files untouched", async () => {
     const dir = await freshDir();
     await writeFile(join(dir, "AGENTS.md"), "# Host repo spec\n");


### PR DESCRIPTION
Outcome of a full-design review of the post-init agent directory layout (flat vs `./agent` kit): the skeleton is sound (single `resolveAgentDir` computation point, config-as-only-workspace-marker, state/secrets at the run root vs definition surface in the kit), but the consumer matrix had one hole, and two fail-visibly gaps + one merge hazard were confirmed by probe.

## Fixes (each at its single computation point)

| Hole | Fix | Where |
|---|---|---|
| Typo'd `agentDir` ("./agnet") silently serves an **empty agent** (no persona/skills/tools, zero errors) | Load-time validation: must exist, be a real directory, and resolve without symlinks (leaf lstat + realpath equality for intermediate segments). Not auto-created — config load is read-only, and mkdir would turn the typo into a served empty agent plus a junk dir. | `loadConfig` — covers all openers |
| `fire` was the **last consumer** reading schedules from the run root (dev/start/`schedule list`/deploy all read agentDir) — kit-layout `fire x` said "unknown schedule" for a schedule that serves fine | `fire` resolves agentDir; unknown-name error names the discovery path (`looked in agent/schedules`) so a misplaced schedule reads as "wrong place", not "broken file" | `runFire` |
| dev watch didn't include `schedules/` — editing a schedule under dev kept the **old cron firing silently**, contradicting `startSchedules`' own comment (flat layout equally affected) | `schedules` joins the watch allowlist; the comment is true again | `devWatchIgnored` |
| init into a host repo owning an **unrelated `agent/`** dir silently mixed the kit into it (wx kept files, but persona.md landed in someone else's code dir) | Refuse a non-empty kit target with the way out (`--agent-dir <name>` / `--flat`); dotfiles don't count (same rule as the occupation signal). Refusal is side-effect-free. | `scaffoldWorkspace` guard, beside the config-marker refusal |

Plus two papercuts: `--agent-dir a/b` POSIX-normalized before landing in the generated config (Windows), and add-channel's no-package.json error no longer suggests `fastagent init` where init would refuse.

## ⚠️ Breaking

A workspace whose `agentDir` is (or passes through) a **symlink** now refuses to load — previously it "worked" while dev's watch silently never saw edits (the link target can escape the config directory). Migration: point `agentDir` at the real path. Called out for release notes.

## Verify

typecheck + lint + full suite green (**533**, +5: typo/file/leaf-symlink/intermediate-symlink config rejections, kit-layout `fire` discovery via spawn, non-empty-kit refusal + dotfile exemption, `schedules/` watch coverage both layouts). Iterated through `rv` (4 passes to convergence) — it caught the intermediate-symlink escape the leaf-lstat missed, the doc/message gaps, and the Windows path in the new `looked in` hint.
