### PR TITLE
feat(schedule): envelope the woken turn; actionable guardrails; info shows the full time-trigger surface

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -263,7 +263,8 @@ capability, not given to every agent). Then the serving path (`dev`/`start`, whe
 one-shot `invoke`/`fire`) mounts a built-in **`wake`** tool so the agent can schedule itself: `wake({ in: "30m", prompt })`
 records a one-shot wake-up — or `wake({ cron: "0 9 * * *", tz?, prompt })` a RECURRING one — persisted under
 `<stateRoot>/schedule/`, polled by the scheduler and fired back into the SAME session, so the agent resumes
-the conversation. It reads the current session from `ToolContext.session`; guardrails cap the minimum delay,
+the conversation — the woken turn's prompt is enveloped with the wake-up's id and origin ("YOUR
+self-scheduled turn, not a user message"), so the model can tell its own alarm from the user speaking. It reads the current session from `ToolContext.session`; guardrails cap the minimum delay,
 the recurring frequency (≥10 min between fires), and the per-session pending count. The agent cancels its own
 with `unwake({ id })` (session-scoped); the operator with `fastagent schedule cancel <id>` (`schedule list`
 shows ids).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,8 @@ Prints the assembled surface without starting a server:
 - skills and diagnostics,
 - non-default tools and collisions,
 - channel files,
-- schedule files,
+- schedules (name + next fire instant; a broken schedule file is reported here, not first at `dev`),
+- whether self-scheduling (`selfSchedule`) is on,
 - session directory.
 
 `info` is read-only: it does not create sessions or modify `.fastagent/`.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -312,6 +312,11 @@ the scheduler: the author's `schedules/` files (declarative, guaranteed) and the
   deploy-time ambient via closure — is the general rule for tool context.
 - **Persisted + polled.** A wake-up is written to `<stateRoot>/schedule/wakeups.json` (survives restart);
   the scheduler polls (~30s) and fires each DUE one, claiming it (remove-before-fire) so it is at-most-once.
+- **The woken turn's prompt arrives ENVELOPED** (`[wake-up <id> fired — YOUR self-scheduled turn, not a
+  user message] …`, plus the cron + an `unwake` hint for a recurring): without it the model sees its own
+  instruction as a bare user message — in a chat session it may answer a "user" who said nothing — and has
+  no way to know the wake-up's id (buried in a long-past tool result), which `unwake` needs. Static cron
+  fires stay raw: their prompt is the author's instruction in a dedicated session where every turn is a fire.
 - **Guardrails** (self-scheduling is a real runaway surface): a minimum delay (no busy-loop) and a cap on
   pending wake-ups (no unbounded fan-out); a rejected `wake` returns the reason to the model. One-shot is
   naturally bounded (fires once), so recurring self-scheduling — with heavier guardrails — is Phase 4b.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,7 @@ import { authSeedBytes, deployFlyRun } from "./deploy/fly/run.ts";
 import { spawnRunner } from "./deploy/runner.ts";
 import { assembleSecrets } from "./deploy/secrets.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
-import { discoverScheduleFiles, loadSchedules } from "./schedule/discover.ts";
+import { loadSchedules } from "./schedule/discover.ts";
 import { readRuns } from "./schedule/audit.ts";
 import { nextRun } from "./schedule/cron.ts";
 import { listWakeups, removeWakeup } from "./schedule/wakeups.ts";
@@ -468,7 +468,16 @@ async function runInfo(): Promise<void> {
     }))
     .catch((e: unknown) => ({ names: [] as string[], collisions: [], failures: [], error: (e as Error).message }));
   const channels = await discoverChannelFiles(agentDir).catch(failStartup);
-  const schedules = await discoverScheduleFiles(agentDir).catch(failStartup);
+  // Loaded (imported + validated), not just discovered: info's job is "fix only what it reports", so a
+  // broken schedule file (bad cron/tz, failed import) must show up HERE, not first at dev/start — and
+  // loading is what makes the next fire instant printable. Consistent with tools (info imports those too).
+  const sched = await loadSchedules(agentDir).catch(failStartup);
+  const schedules = sched.schedules.map((s) => ({
+    name: s.name,
+    cron: s.cron,
+    tz: s.tz ?? null,
+    next: nextRun(s.cron, s.tz, new Date())?.toISOString() ?? null,
+  }));
   // The default sessions/auth paths WITHOUT creating anything (info is read-only; dev/start mkdir/login
   // create them, info must not).
   const stateRoot = resolveStateRoot(dir);
@@ -490,6 +499,8 @@ async function runInfo(): Promise<void> {
           toolError: tools.error ?? null,
           channels,
           schedules,
+          scheduleFailures: sched.failures,
+          selfSchedule: config.selfSchedule ?? false,
           stateRoot,
           sessionsDir,
           authPath,
@@ -513,12 +524,14 @@ async function runInfo(): Promise<void> {
   console.log(`skills:   ${definition.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
   console.log(`tools:    ${tools.error ? "(could not load — see warning below)" : tools.names.join(", ") || "(none)"}`);
   console.log(`channels: ${channels.join(", ") || "(none)"}`);
-  console.log(`schedules: ${schedules.join(", ") || "(none)"}`);
+  console.log(`schedules: ${schedules.map((s) => `${s.name} (next ${s.next ?? "never"})`).join(", ") || "(none)"}`);
+  console.log(`selfSchedule: ${config.selfSchedule ? "on (mounts the wake tool when serving)" : "off"}`);
   console.log(`state:    ${stateRoot}`);
   console.log(`sessions: ${sessionsDir}`);
   console.log(`auth:     ${authPath}`);
   reportToolCollisions(tools.collisions);
   reportModuleLoadFailures(tools.failures);
+  reportModuleLoadFailures(sched.failures);
   if (tools.error) log.warn(`[fastagent] ${tools.error}`);
   reportDefinitionWarnings(definition.collisions, definition.diagnostics);
 }

--- a/src/engines/pi/wake-tool.ts
+++ b/src/engines/pi/wake-tool.ts
@@ -54,8 +54,8 @@ export function makeWakeTool(stateRoot: string, now: () => Date = () => new Date
       'duration string with a unit ("30m", "2h", "1d") or a number of seconds — to resume a task after a ' +
       "delay. RECURRING: pass `cron` (5-field, optional `tz`) to wake repeatedly — use sparingly, and " +
       "`unwake` with the returned id when the job is done. Exactly one of `in`/`cron`. When the time " +
-      "comes, a new turn runs in this same session with `prompt` as its instruction — you keep the full " +
-      "context of this conversation. IMPORTANT: the woken turn's plain reply is NOT delivered to anyone — " +
+      "comes, a new turn runs in this same session with `prompt` as its instruction (tagged with the wake-up's " +
+      "id so you can tell it from a user message) — you keep the full context of this conversation. IMPORTANT: the woken turn's plain reply is NOT delivered to anyone — " +
       "to reach the user it must call a delivery tool (e.g. a channel's send tool), exactly as a scheduled " +
       "job would.",
     input: z.object({
@@ -89,7 +89,7 @@ export function makeWakeTool(stateRoot: string, now: () => Date = () => new Date
       const at = new Date(now().getTime() + ms);
       const r = addWakeup(stateRoot, { session: ctx.session, prompt: input.prompt, fireAt: at }, now());
       if (!r.ok) return r.error; // guardrail message the model can act on
-      return `OK — I'll wake up at ${r.fireAt} (id ${r.id}) to: ${input.prompt}`;
+      return `OK — I'll wake up at ${r.fireAt} (id ${r.id}) to: ${input.prompt}. Use unwake({ id: "${r.id}" }) if it becomes unnecessary.`;
     },
   });
 }

--- a/src/schedule/discover.ts
+++ b/src/schedule/discover.ts
@@ -11,8 +11,9 @@ import { assertInsideWorkspace } from "../workspace.ts";
 import { cronError } from "./cron.ts";
 import type { LoadedSchedule, Schedule } from "./schedule.ts";
 
-/** Schedule file basenames under `<dir>/schedules/` — the authoring view (`fastagent info`), listed
- *  WITHOUT importing (like {@link import("../engines/pi/channel.ts").discoverChannelFiles}). */
+/** Schedule file basenames under `<dir>/schedules/` — an existence probe listed WITHOUT importing
+ *  (deploy pre-flight's time-trigger detection; `fastagent info` uses {@link loadSchedules} instead,
+ *  since it also reports broken files and next instants). */
 export async function discoverScheduleFiles(dir: string): Promise<string[]> {
   await assertInsideWorkspace(dir, "schedules");
   let names: string[];

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -113,6 +113,20 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
   }
 
   /**
+   * The woken turn's prompt arrives ENVELOPED: without it the model sees its own instruction as a bare
+   * user message — in a chat session it may answer a "user" who said nothing — and it has no way to know
+   * the wake-up's id (buried in a long-past tool result), which `unwake` needs. Static cron fires stay raw
+   * on purpose: their prompt is the AUTHOR's instruction in a dedicated `schedule:<name>` session, where
+   * every turn is a fire and an envelope would only dilute it.
+   */
+  function wakeEnvelope(w: { id: string; prompt: string; cron?: string; tz?: string }): string {
+    const tag = w.cron
+      ? `[wake-up ${w.id} fired — YOUR recurring self-scheduled turn (cron "${w.cron}"${w.tz ? ` ${w.tz}` : ""}), not a user message; unwake({ id: "${w.id}" }) stops it]`
+      : `[wake-up ${w.id} fired — YOUR self-scheduled turn, not a user message]`;
+    return `${tag} ${w.prompt}`;
+  }
+
+  /**
    * Fire every due self-scheduled wake-up, ONE at a time (claim → fire → claim next) so a crash loses at
    * most one occurrence. Each fires back into the session it was set in. Busy handling splits by kind: a
    * ONE-SHOT that failed because the session was BUSY (`code: session_busy` — the turn never started; the
@@ -128,7 +142,7 @@ export function createScheduler({ agent, stateRoot, schedules, now = () => new D
       if (!w) break;
       const label = `wake ${w.id.slice(0, 8)}`;
       const firedAt = now().toISOString();
-      const r = await runTurn(label, w.session, w.prompt);
+      const r = await runTurn(label, w.session, wakeEnvelope(w));
       // Busy handling differs by kind (busy = the turn never started — replay-safe; every other outcome is
       // terminal for this occurrence, since a turn that DID start may have run side effects). ONE-SHOT: defer (bounded) — it has no "next time", dropping it
       // would lose it forever. RECURRING: the claim already ADVANCED the entry to the next instant (see

--- a/src/schedule/wakeups.ts
+++ b/src/schedule/wakeups.ts
@@ -136,9 +136,17 @@ export function addWakeup(
   const all = load(stateRoot);
   const mine = all.filter((w) => w.session === input.session);
   if (mine.length >= MAX_PENDING_WAKEUPS) {
-    // List what's pending: "unwake one" is only actionable if the model HAS the ids (they were returned
-    // when set, but that may be buried far back in the conversation).
-    const pending = mine.map((w) => `${w.id}${w.cron ? ` (recurring "${w.cron}")` : ""} at ${w.fireAt}`).join("; ");
+    // List what's pending WITH a prompt preview: "unwake one" is only actionable if the model has the
+    // ids AND can choose by meaning — both were returned when set, but that may be buried far back in
+    // the conversation.
+    const pending = mine
+      .map(
+        (w) =>
+          `${w.id}${w.cron ? ` (recurring "${w.cron}")` : ""} at ${w.fireAt}: ${
+            w.prompt.length > 60 ? `${w.prompt.slice(0, 60)}…` : w.prompt
+          }`,
+      )
+      .join("; ");
     return {
       ok: false,
       error: `too many pending wake-ups for this conversation (${MAX_PENDING_WAKEUPS}) — wait for some to fire, or unwake one. Pending: ${pending}`,

--- a/src/schedule/wakeups.ts
+++ b/src/schedule/wakeups.ts
@@ -134,10 +134,14 @@ export function addWakeup(
     fireAtDate = input.fireAt;
   }
   const all = load(stateRoot);
-  if (all.filter((w) => w.session === input.session).length >= MAX_PENDING_WAKEUPS) {
+  const mine = all.filter((w) => w.session === input.session);
+  if (mine.length >= MAX_PENDING_WAKEUPS) {
+    // List what's pending: "unwake one" is only actionable if the model HAS the ids (they were returned
+    // when set, but that may be buried far back in the conversation).
+    const pending = mine.map((w) => `${w.id}${w.cron ? ` (recurring "${w.cron}")` : ""} at ${w.fireAt}`).join("; ");
     return {
       ok: false,
-      error: `too many pending wake-ups for this conversation (${MAX_PENDING_WAKEUPS}) — wait for some to fire, or unwake one, before adding more.`,
+      error: `too many pending wake-ups for this conversation (${MAX_PENDING_WAKEUPS}) — wait for some to fire, or unwake one. Pending: ${pending}`,
     };
   }
   const id = randomUUID();

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -191,6 +191,37 @@ describe("cli papercuts", () => {
     expect(text.stderr).toMatch(/broken\.ts/); // the reason is a warning on stderr
   });
 
+  it("info loads schedules — a broken one is reported (exit 0), a good one carries its next instant", async () => {
+    // Same G2 isolation as tools: a broken schedule file (bad cron) is skipped + reported at info time,
+    // not first at `dev`; the good schedule still shows, with its next fire instant.
+    const dir = await mkdtemp(join(tmpdir(), "fa-info-schedfail-"));
+    await mkdir(join(dir, "schedules"), { recursive: true });
+    await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
+    await writeFile(
+      join(dir, "schedules", "good.mjs"),
+      'export default { cron: "0 9 * * *", tz: "UTC", prompt: "digest" };\n',
+    );
+    await writeFile(join(dir, "schedules", "bad.mjs"), 'export default { cron: "not a cron", prompt: "x" };\n');
+    const env = { ...process.env };
+    delete env.FASTAGENT_MODEL;
+
+    const { code, stdout } = await run(["info", dir, "--json"], undefined, env);
+    expect(code).toBe(0); // reported, not fatal
+    const info = JSON.parse(stdout);
+    expect(info.schedules).toHaveLength(1);
+    expect(info.schedules[0]).toMatchObject({ name: "good", cron: "0 9 * * *" });
+    expect(info.schedules[0].next).toMatch(/T09:00:00\.000Z$/); // loaded → the next instant is printable
+    expect(JSON.stringify(info.scheduleFailures)).toMatch(/bad\.mjs/); // the broken one is surfaced per-file
+    expect(info.selfSchedule).toBe(false); // no config → wake tool won't mount
+
+    // text mode: next instant on the schedules line, the failure as a stderr warning
+    const text = await run(["info", dir], undefined, env);
+    expect(text.code).toBe(0);
+    expect(text.stdout).toMatch(/schedules: good \(next .*T09:00:00\.000Z\)/);
+    expect(text.stdout).toMatch(/selfSchedule: off/);
+    expect(text.stderr).toMatch(/bad\.mjs/);
+  });
+
   it("login self-ignores .fastagent on an adapted dir before it writes the credential file", async () => {
     // login is the command that CREATES the secret, so its self-ignore must fire independently of the
     // opener — and BEFORE the interactive gate below, so the .gitignore is written even though this

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -127,7 +127,12 @@ describe("schedule/scheduler: fire algorithm", () => {
     const s = createScheduler({ agent, stateRoot: root, schedules: [], now: () => new Date("2026-07-07T12:00:00Z") });
     s.start(); // polls wake-ups immediately on start
     await vi.waitFor(() => expect(calls.length).toBe(1));
-    expect(calls[0]).toEqual({ session: "conv-9", text: "resume" }); // fired back into the wake-up's session
+    expect(calls[0]?.session).toBe("conv-9"); // fired back into the wake-up's session
+    // The prompt arrives ENVELOPED (id + "not a user message") so the model can tell its own alarm from
+    // the user speaking; the instruction itself rides along.
+    expect(calls[0]?.text).toMatch(
+      /^\[wake-up [0-9a-f-]+ fired — YOUR self-scheduled turn, not a user message\] resume$/,
+    );
     expect(listWakeups(root)).toHaveLength(0); // claimed + fired, not left pending
     s.stop();
   });
@@ -218,6 +223,10 @@ describe("schedule/scheduler: fire algorithm", () => {
     const s = createScheduler({ agent, stateRoot: root, schedules: [], now: () => new Date("2026-07-07T09:00:30Z") });
     s.start();
     await vi.waitFor(() => expect(calls.length).toBe(1)); // fired
+    // A recurring envelope carries the id AND the unwake instruction — the documented way to stop it is
+    // from inside a woken turn, which otherwise has no way to know its own id.
+    expect(calls[0]?.text).toContain('unwake({ id: "rec1" })');
+    expect(calls[0]?.text).toContain("daily check");
     await vi.waitFor(() => expect(listWakeups(root)).toHaveLength(1)); // NOT consumed — re-armed
     expect(listWakeups(root)[0]).toMatchObject({ id: "rec1", cron: "0 9 * * *" });
     expect(listWakeups(root)[0]?.fireAt).toBe("2026-07-08T09:00:00.000Z"); // next daily instant

--- a/test/wakeups.test.ts
+++ b/test/wakeups.test.ts
@@ -48,7 +48,12 @@ describe("schedule/wakeups store + guardrails", () => {
     }
     const res = addWakeup(r, { session: "s", prompt: "over", fireAt: at(2 * MIN_WAKE_MS) }, NOW);
     expect(res.ok).toBe(false);
-    if (!res.ok) expect(res.error).toMatch(/too many/);
+    // The rejection lists the pending ids — "unwake one" is only actionable if the model HAS them (the
+    // ids were returned when set, but that can be buried far back in the conversation).
+    if (!res.ok) {
+      expect(res.error).toMatch(/too many/);
+      for (const w of listWakeups(r)) expect(res.error).toContain(w.id);
+    }
   });
 
   it("takeFirstDueWakeup claims ONE due (remove+return), leaves future ones, then undefined", async () => {


### PR DESCRIPTION
## What

Agent-experience follow-ups from the cron/scheduler DX review — the served agent's side of the product.

1. **The woken turn's prompt arrives enveloped**: `[wake-up <id> fired — YOUR self-scheduled turn, not a user message] …` (a recurring adds its cron + an `unwake` hint). Without it the model sees its own instruction as a bare user message — in a chat session it may answer a "user" who said nothing — and has no way to know the wake-up's id (buried in a long-past tool result), which `unwake` needs. Static cron fires stay raw on purpose: their prompt is the author's instruction in a dedicated `schedule:<name>` session where every turn is a fire.
2. **Actionable guardrails**: the pending-cap rejection lists the pending ids ("unwake one" is only actionable if the model HAS them); the one-shot success message carries the unwake hint too (recurring already did).
3. **`fastagent info` shows the full time-trigger surface**: schedules are loaded (imported + validated, like tools) instead of filename-listed — a broken schedule file is reported at info time, not first at `dev`; each schedule prints its next fire instant; a `selfSchedule` line shows whether the wake tool mounts.

**Note**: `info --json` `schedules` changes shape (`string[]` → `{name, cron, tz, next}[]`) and gains `scheduleFailures` + `selfSchedule` keys. `info --json` is a diagnostic surface, not a stable API — called out here so the choice is conscious.

## Test

Envelope format (one-shot regex; recurring contains id + unwake hint), cap rejection contains every pending id. 531 green.
