### PR TITLE
feat(telegram): the scaffolded send tool sends messages, not only files

### DIFF
--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -70,6 +70,8 @@ For schedules (run the agent on a cron — daily digest, periodic checks):
   prompt: "..." }) — defineSchedule comes from @kid7st/fastagent; the filename is the schedule name.
 - The prompt must SAY where output goes ("…and send it to the team Telegram"): the scheduler only fires
   the agent — a scheduled turn's plain reply is not delivered anywhere; delivery is a send tool's job.
+  fastagent add telegram scaffolds one (tools/telegram-send.ts: message or file). A scheduled turn runs
+  outside any chat, so include the TARGET CHAT ID in the prompt ("…send it to Telegram chat -100123456").
 - Test with a command that exits: fastagent fire <name> --model provider/id (runs the turn NOW, without
   touching the real cron state). The cron only fires while `dev`/`start` is serving.
 - Check past runs with: fastagent schedule history <name>; see what will fire with: fastagent schedule list.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -278,7 +278,10 @@ Fire model:
 - **Stable per-schedule session**, derived at runtime as `schedule:<name>` (like the telegram channel
   derives one from `chat.id`) — so a schedule's turns share one continuing conversation persisted by the
   core session store. A session id is runtime conversational context (K side, §7/§10.1), never an
-  authored field; the definition (`schedules/<name>.ts`) carries only `cron/tz/prompt`.
+  authored field; the definition (`schedules/<name>.ts`) carries only `cron/tz/prompt`. Known
+  consideration: a forever-session grows without bound (a daily fire is ~365 turns/year of context);
+  fine for now, and the mitigation when it bites is a session rotation policy or engine-side compaction
+  — not a scheduler concern.
 - **Output is the agent's tools' job.** The scheduler only fires and logs the outcome — it has no reply
   target of its own (unlike a channel's chat/PR). A cron turn's prompt says "send X to Telegram"; the
   agent calls a send tool.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -189,7 +189,10 @@ export default defineSchedule({
 ```
 
 The prompt must say where output goes — the scheduler only fires the agent; delivery is a send tool's
-job. Test it immediately (without waiting for the cron, and without touching the real fire state):
+job. `fastagent add telegram` scaffolds one (`tools/telegram-send.ts` sends a message or a file); and
+because a scheduled turn runs outside any chat, the agent has no chat context — **put the target chat
+id in the prompt** ("…send it to Telegram chat -100123456"). Test it immediately (without waiting for
+the cron, and without touching the real fire state):
 
 ```bash
 fastagent fire daily-digest

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -21,7 +21,7 @@ This creates:
 
 ```txt
 channels/telegram.ts      # inbound webhook adapter + routing policy
-tools/telegram-send.ts    # optional outbound file-send tool for the agent
+tools/telegram-send.ts    # optional outbound send tool for the agent (message or file)
 ```
 
 It also appends the required env vars to `.env.example` when possible.
@@ -187,7 +187,7 @@ The state home self-ignores (a nested `.gitignore`), so buffered chat content is
 
 ## Sending files back
 
-`fastagent add telegram` also scaffolds `tools/telegram-send.ts`. Because tool names come from filenames, the agent can call the `telegram-send` tool with a `chatId` from the `[telegram: chat …]` envelope to send a local file back through the bot.
+`fastagent add telegram` also scaffolds `tools/telegram-send.ts`. Because tool names come from filenames, the agent can call the `telegram-send` tool with a `chatId` from the `[telegram: chat …]` envelope to send a text message or a local file back through the bot. It is also the delivery path for turns no channel is carrying — a cron schedule or a self-scheduled wake-up, whose plain reply is not delivered anywhere; those turns have no `[telegram: chat …]` line, so the schedule's prompt (or the wake's) must name the target chat id.
 
 ## Limits
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -185,7 +185,7 @@ The per-session turn queue is **in-memory** (one turn at a time per session; a s
 
 The state home self-ignores (a nested `.gitignore`), so buffered chat content is never committable. A corrupt `buffers.json` or `turns.json` logs a warning and starts empty — the bot boots, the loss is visible. Single-process semantics: two processes must not share a state dir.
 
-## Sending files back
+## Sending messages and files back (`telegram-send`)
 
 `fastagent add telegram` also scaffolds `tools/telegram-send.ts`. Because tool names come from filenames, the agent can call the `telegram-send` tool with a `chatId` from the `[telegram: chat …]` envelope to send a text message or a local file back through the bot. It is also the delivery path for turns no channel is carrying — a cron schedule or a self-scheduled wake-up, whose plain reply is not delivered anywhere; those turns have no `[telegram: chat …]` line, so the schedule's prompt (or the wake's) must name the target chat id.
 

--- a/src/channels/telegram/scaffold/telegram-send.ts
+++ b/src/channels/telegram/scaffold/telegram-send.ts
@@ -7,12 +7,61 @@ import { basename } from "node:path";
 // (schedules/<name>.ts) or a self-scheduled wake-up, whose plain reply is not delivered anywhere.
 // The chatId comes from the [telegram: chat …] context line in a chat turn; a scheduled turn has no
 // such line, so the schedule's prompt must name the target chat id. tools/ is auto-discovered.
+
+// Telegram caps a message at 4096 chars. Splitting is the TOOL's job, not the model's (counting chars
+// is exactly what an LLM can't do — the channel encodes the same constraint in telegram-api.ts): chunk
+// at the last newline under the cap, hard-cut a single overlong line. Plain-text mirror of the channel
+// policy (this template cannot import core internals).
+const MAX_TEXT = 4096;
+function splitPlain(text: string): string[] {
+  const parts: string[] = [];
+  let rest = text;
+  while (rest.length > MAX_TEXT) {
+    let cut = rest.lastIndexOf("\n", MAX_TEXT);
+    if (cut <= 0) cut = MAX_TEXT;
+    parts.push(rest.slice(0, cut));
+    rest = rest.slice(cut).replace(/^\n/, "");
+  }
+  if (rest.length > 0 || parts.length === 0) parts.push(rest);
+  return parts;
+}
+
+// Standalone copy of the channel transport's discipline: an upload timeout so a wedged connection
+// can't hang the tool call (and the turn), named errors, and success gated on the body's own ok.
+// Deliberately NO 429 retry — a tool error goes back to the agent, which can decide to retry;
+// fail-fast beats a silently sleeping tool.
+async function callBotApi(token: string, method: string, form: FormData): Promise<void> {
+  let res: Response;
+  let raw: string;
+  try {
+    res = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+      method: "POST",
+      body: form,
+      signal: AbortSignal.timeout(120_000),
+    });
+    raw = await res.text();
+  } catch (e) {
+    throw new Error(`telegram ${method}: ${String(e)}`, { cause: e });
+  }
+  let data: { ok?: boolean; description?: string };
+  try {
+    data = JSON.parse(raw) as { ok?: boolean; description?: string };
+  } catch {
+    data = {};
+  }
+  if (!res.ok || !data.ok) {
+    throw new Error(
+      `telegram ${method} failed: ${res.status} ${data.description ?? "Bot API response was not the expected JSON"}`,
+    );
+  }
+}
+
 export default defineTool({
   description:
-    "Send to a Telegram chat: a text message (`text`), or a local file (`path` — a document, or a photo " +
-    "if it is an image). Exactly one of text/path. In a chat turn take chatId from the [telegram: chat …] " +
-    "context line; in a scheduled/woken turn (no context line) the chat id must come from your " +
-    "instruction. Telegram caps a message at 4096 chars — split longer text into multiple calls.",
+    "Send to a Telegram chat: a text message (`text` — long text is split into multiple messages " +
+    "automatically), or a local file (`path` — a document, or a photo if it is an image). Exactly one " +
+    "of text/path. In a chat turn take chatId from the [telegram: chat …] context line; in a " +
+    "scheduled/woken turn (no context line) the chat id must come from your instruction.",
   input: z.object({
     chatId: z.union([z.string(), z.number()]).describe("target chat id"),
     text: z.string().optional().describe("message text to send"),
@@ -27,43 +76,32 @@ export default defineTool({
     if ((text === undefined) === (path === undefined)) {
       throw new Error("pass exactly one of `text` (a message) or `path` (a file)");
     }
-    const method = text !== undefined ? "sendMessage" : asPhoto ? "sendPhoto" : "sendDocument";
-    const form = new FormData();
-    form.set("chat_id", String(chatId));
-    if (messageThreadId !== undefined) form.set("message_thread_id", String(messageThreadId));
+    const base = (): FormData => {
+      const form = new FormData();
+      form.set("chat_id", String(chatId));
+      if (messageThreadId !== undefined) form.set("message_thread_id", String(messageThreadId));
+      return form;
+    };
     if (text !== undefined) {
-      form.set("text", text);
-    } else {
-      if (caption) form.set("caption", caption);
-      form.set(asPhoto ? "photo" : "document", new Blob([await readFile(path as string)]), basename(path as string));
+      // A file-only param alongside text would be silently dropped — same parameter-responsibility
+      // class as the XOR above, so it gets the same corrective error, not a silent ignore.
+      if (caption !== undefined || asPhoto !== undefined) {
+        throw new Error("`caption`/`asPhoto` are file-mode only — with `text`, put everything in the text");
+      }
+      const chunks = splitPlain(text);
+      for (const chunk of chunks) {
+        const form = base();
+        form.set("text", chunk);
+        await callBotApi(token, "sendMessage", form);
+      }
+      return chunks.length === 1
+        ? `sent message to chat ${chatId}`
+        : `sent ${chunks.length} messages to chat ${chatId} (split at Telegram's length cap)`;
     }
-    // Standalone copy of the channel transport's discipline (this template cannot import core
-    // internals): an upload timeout so a wedged connection can't hang the tool call (and the turn),
-    // named errors, and success gated on the body's own ok. Deliberately NO 429 retry — a tool error
-    // goes back to the agent, which can decide to retry; fail-fast beats a silently sleeping tool.
-    let res: Response;
-    let raw: string;
-    try {
-      res = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
-        method: "POST",
-        body: form,
-        signal: AbortSignal.timeout(120_000),
-      });
-      raw = await res.text();
-    } catch (e) {
-      throw new Error(`telegram ${method}: ${String(e)}`, { cause: e });
-    }
-    let data: { ok?: boolean; description?: string };
-    try {
-      data = JSON.parse(raw) as { ok?: boolean; description?: string };
-    } catch {
-      data = {};
-    }
-    if (!res.ok || !data.ok) {
-      throw new Error(
-        `telegram ${method} failed: ${res.status} ${data.description ?? "Bot API response was not the expected JSON"}`,
-      );
-    }
-    return text !== undefined ? `sent message to chat ${chatId}` : `sent ${basename(path as string)} to chat ${chatId}`;
+    const form = base();
+    if (caption) form.set("caption", caption);
+    form.set(asPhoto ? "photo" : "document", new Blob([await readFile(path as string)]), basename(path as string));
+    await callBotApi(token, asPhoto ? "sendPhoto" : "sendDocument", form);
+    return `sent ${basename(path as string)} to chat ${chatId}`;
   },
 });

--- a/src/channels/telegram/scaffold/telegram-send.ts
+++ b/src/channels/telegram/scaffold/telegram-send.ts
@@ -2,27 +2,41 @@ import { defineTool, z } from "@kid7st/fastagent";
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 
-// Send a local file back to a Telegram chat. The agent passes a chatId it reads from the
-// [telegram: chat …] context line the channel injects. tools/ is auto-discovered — no registration.
+// Send a message or a local file back to a Telegram chat. In a CHAT turn the channel delivers the
+// reply itself — this tool is for files, and for turns NO channel is carrying: a scheduled turn
+// (schedules/<name>.ts) or a self-scheduled wake-up, whose plain reply is not delivered anywhere.
+// The chatId comes from the [telegram: chat …] context line in a chat turn; a scheduled turn has no
+// such line, so the schedule's prompt must name the target chat id. tools/ is auto-discovered.
 export default defineTool({
   description:
-    "Send a local file to a Telegram chat (a document, or a photo if it is an image). Pass the chatId from the [telegram: chat …] context line.",
+    "Send to a Telegram chat: a text message (`text`), or a local file (`path` — a document, or a photo " +
+    "if it is an image). Exactly one of text/path. In a chat turn take chatId from the [telegram: chat …] " +
+    "context line; in a scheduled/woken turn (no context line) the chat id must come from your " +
+    "instruction. Telegram caps a message at 4096 chars — split longer text into multiple calls.",
   input: z.object({
-    chatId: z.union([z.string(), z.number()]).describe("target chat id (from the [telegram: chat …] context line)"),
-    path: z.string().describe("absolute path of the local file to send"),
-    caption: z.string().optional(),
-    asPhoto: z.boolean().optional().describe("send as a photo (inline) instead of a document"),
+    chatId: z.union([z.string(), z.number()]).describe("target chat id"),
+    text: z.string().optional().describe("message text to send"),
+    path: z.string().optional().describe("absolute path of the local file to send"),
+    caption: z.string().optional().describe("file caption (file mode only)"),
+    asPhoto: z.boolean().optional().describe("send the file as a photo (inline) instead of a document"),
     messageThreadId: z.number().optional().describe("thread to reply into (from the context line), if any"),
   }),
-  async execute({ chatId, path, caption, asPhoto, messageThreadId }) {
+  async execute({ chatId, text, path, caption, asPhoto, messageThreadId }) {
     const token = process.env.TELEGRAM_BOT_TOKEN;
     if (!token) throw new Error("TELEGRAM_BOT_TOKEN is not set");
-    const method = asPhoto ? "sendPhoto" : "sendDocument";
+    if ((text === undefined) === (path === undefined)) {
+      throw new Error("pass exactly one of `text` (a message) or `path` (a file)");
+    }
+    const method = text !== undefined ? "sendMessage" : asPhoto ? "sendPhoto" : "sendDocument";
     const form = new FormData();
     form.set("chat_id", String(chatId));
     if (messageThreadId !== undefined) form.set("message_thread_id", String(messageThreadId));
-    if (caption) form.set("caption", caption);
-    form.set(asPhoto ? "photo" : "document", new Blob([await readFile(path)]), basename(path));
+    if (text !== undefined) {
+      form.set("text", text);
+    } else {
+      if (caption) form.set("caption", caption);
+      form.set(asPhoto ? "photo" : "document", new Blob([await readFile(path as string)]), basename(path as string));
+    }
     // Standalone copy of the channel transport's discipline (this template cannot import core
     // internals): an upload timeout so a wedged connection can't hang the tool call (and the turn),
     // named errors, and success gated on the body's own ok. Deliberately NO 429 retry — a tool error
@@ -50,6 +64,6 @@ export default defineTool({
         `telegram ${method} failed: ${res.status} ${data.description ?? "Bot API response was not the expected JSON"}`,
       );
     }
-    return `sent ${basename(path)} to chat ${chatId}`;
+    return text !== undefined ? `sent message to chat ${chatId}` : `sent ${basename(path as string)} to chat ${chatId}`;
   },
 });

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -47,7 +47,7 @@ const CHANNEL_SCAFFOLDS: Record<ChannelKind, ChannelScaffold> = {
     ],
     steps: [
       "edit channels/telegram.ts — customise routing with route() (optional; the defaults already work)",
-      "the agent can send files back by calling the scaffolded tools/telegram-send.ts tool",
+      "the agent can send messages or files back by calling the scaffolded tools/telegram-send.ts tool",
     ],
   },
 };

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -471,6 +471,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     const sendTool = await readFile(join(dir, "tools", "telegram-send.ts"), "utf8");
     expect(sendTool).toContain('from "@kid7st/fastagent"');
     expect(sendTool).toContain("sendDocument");
+    expect(sendTool).toContain("sendMessage"); // text mode too — the delivery path for scheduled/woken turns
     // next steps carry this channel's env vars (with hints), not github's
     expect(out).toContain("TELEGRAM_BOT_TOKEN");
     expect(out).toContain("@BotFather");

--- a/test/telegram-send-tool.test.ts
+++ b/test/telegram-send-tool.test.ts
@@ -57,12 +57,41 @@ describe("scaffold telegram-send: message-or-file mode switch", () => {
     expect(calls).toHaveLength(0);
   });
 
+  it("file-only params alongside text are a corrective error, not a silent drop", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "tok");
+    const { calls } = stubBotApi();
+    await expect(execute({ chatId: 1, text: "x", caption: "lost?" })).rejects.toThrow(/file-mode only/);
+    await expect(execute({ chatId: 1, text: "x", asPhoto: true })).rejects.toThrow(/file-mode only/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("long text is split by the TOOL (at newlines, ≤4096 each) — counting chars is not the model's job", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "tok");
+    const { calls } = stubBotApi();
+    const line = `${"a".repeat(999)}\n`; // 1000 chars per line → 5000 chars total, newline-splittable
+    const r = await execute({ chatId: 9, text: line.repeat(5).trimEnd() });
+    expect(calls.length).toBe(2); // one send per chunk, sequential
+    const texts = calls.map((c) => String(c.form.get("text")));
+    for (const t of texts) expect(t.length).toBeLessThanOrEqual(4096);
+    expect(texts.join("\n")).toBe(line.repeat(5).trimEnd()); // nothing lost at the seams
+    expect(JSON.stringify(r.details)).toContain("sent 2 messages to chat 9");
+  });
+
+  it("a single overlong line (no newline under the cap) is hard-cut, not an infinite loop", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "tok");
+    const { calls } = stubBotApi();
+    await execute({ chatId: 9, text: "b".repeat(4097) });
+    expect(calls.length).toBe(2);
+    expect(String(calls[0]?.form.get("text"))).toHaveLength(4096);
+    expect(String(calls[1]?.form.get("text"))).toBe("b");
+  });
+
   it("a Bot API error surfaces as a named tool error (fail-fast, no silent ok)", async () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "tok");
     vi.stubGlobal(
       "fetch",
       async () => new Response(JSON.stringify({ ok: false, description: "message is too long" }), { status: 400 }),
     );
-    await expect(execute({ chatId: 1, text: "x".repeat(5000) })).rejects.toThrow(/message is too long/);
+    await expect(execute({ chatId: 1, text: "hello" })).rejects.toThrow(/message is too long/);
   });
 });

--- a/test/telegram-send-tool.test.ts
+++ b/test/telegram-send-tool.test.ts
@@ -1,16 +1,20 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { writeFile } from "node:fs/promises";
-import { mkdtemp } from "node:fs/promises";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import sendTool from "../src/channels/telegram/scaffold/telegram-send.ts";
 
-// The scaffolded send tool is real shipped code (a compiled module, not a text template) — its mode
-// switch is the delivery path for scheduled/woken turns, so the branches get real executions here.
+// The scaffolded send tool is real shipped code — its mode switch is the delivery path for
+// scheduled/woken turns, so the branches get real executions here. The template stays DATA to tsc
+// (excluded from the program — it imports the published "@kid7st/fastagent", unresolvable in-repo), so
+// it is loaded via a non-literal dynamic import; vitest's alias resolves that name to today's source.
 
 type RawExecute = (id: string, params: unknown) => Promise<{ details: unknown }>;
-const execute = (params: unknown): Promise<{ details: unknown }> =>
-  (sendTool as unknown as { execute: RawExecute }).execute("call-1", params);
+let execute: (params: unknown) => Promise<{ details: unknown }>;
+beforeAll(async () => {
+  const templatePath = new URL("../src/channels/telegram/scaffold/telegram-send.ts", import.meta.url).pathname;
+  const mod = (await import(templatePath)) as { default: unknown };
+  execute = (params) => (mod.default as { execute: RawExecute }).execute("call-1", params);
+});
 
 function stubBotApi(): { calls: { url: string; form: FormData }[] } {
   const calls: { url: string; form: FormData }[] = [];

--- a/test/telegram-send-tool.test.ts
+++ b/test/telegram-send-tool.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import sendTool from "../src/channels/telegram/scaffold/telegram-send.ts";
+
+// The scaffolded send tool is real shipped code (a compiled module, not a text template) — its mode
+// switch is the delivery path for scheduled/woken turns, so the branches get real executions here.
+
+type RawExecute = (id: string, params: unknown) => Promise<{ details: unknown }>;
+const execute = (params: unknown): Promise<{ details: unknown }> =>
+  (sendTool as unknown as { execute: RawExecute }).execute("call-1", params);
+
+function stubBotApi(): { calls: { url: string; form: FormData }[] } {
+  const calls: { url: string; form: FormData }[] = [];
+  vi.stubGlobal("fetch", async (url: string | URL, init?: RequestInit) => {
+    calls.push({ url: String(url), form: init?.body as FormData });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  });
+  return { calls };
+}
+
+describe("scaffold telegram-send: message-or-file mode switch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("text → sendMessage with the text in the form", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "tok");
+    const { calls } = stubBotApi();
+    const r = await execute({ chatId: 42, text: "digest ready" });
+    expect(calls[0]?.url).toContain("/bottok/sendMessage");
+    expect(calls[0]?.form.get("chat_id")).toBe("42");
+    expect(calls[0]?.form.get("text")).toBe("digest ready");
+    expect(JSON.stringify(r.details)).toContain("sent message to chat 42");
+  });
+
+  it("path → sendDocument with the file attached (caption rides along)", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "tok");
+    const { calls } = stubBotApi();
+    const dir = await mkdtemp(join(tmpdir(), "fa-send-"));
+    await writeFile(join(dir, "report.txt"), "hi");
+    const r = await execute({ chatId: "7", path: join(dir, "report.txt"), caption: "the report" });
+    expect(calls[0]?.url).toContain("/sendDocument");
+    expect(calls[0]?.form.get("caption")).toBe("the report");
+    expect(calls[0]?.form.get("document")).toBeInstanceOf(Blob);
+    expect(JSON.stringify(r.details)).toContain("sent report.txt to chat 7");
+  });
+
+  it("text AND path — or neither — is rejected before any network call", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "tok");
+    const { calls } = stubBotApi();
+    await expect(execute({ chatId: 1, text: "x", path: "/tmp/y" })).rejects.toThrow(/exactly one/);
+    await expect(execute({ chatId: 1 })).rejects.toThrow(/exactly one/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("a Bot API error surfaces as a named tool error (fail-fast, no silent ok)", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "tok");
+    vi.stubGlobal(
+      "fetch",
+      async () => new Response(JSON.stringify({ ok: false, description: "message is too long" }), { status: 400 }),
+    );
+    await expect(execute({ chatId: 1, text: "x".repeat(5000) })).rejects.toThrow(/message is too long/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,11 @@ import { defineConfig } from "vitest/config";
 // `pool: "forks"` is explicit, not left to the default: it is the process isolation these
 // subprocess / process.env tests assume.
 export default defineConfig({
+  // Scaffold templates import the PUBLISHED "@kid7st/fastagent" (they are copied verbatim into user
+  // workspaces — data to tsc, excluded from the program). Tests that EXECUTE a template resolve that
+  // name to the current source instead: truer than dist/ (asserts the template against today's
+  // defineTool), and dist/ doesn't exist on CI anyway.
+  resolve: { alias: { "@kid7st/fastagent": new URL("./src/index.ts", import.meta.url).pathname } },
   test: {
     pool: "forks",
     testTimeout: 30000,


### PR DESCRIPTION
## What

The DX review traced the flagship schedule scenario end to end and found it **unachievable with what we ship**: docs everywhere say "delivery is a send tool's job" (a scheduled/woken turn's plain reply goes nowhere — the scheduler invokes directly, bypassing the channel), but the only scaffolded delivery tool, `tools/telegram-send.ts`, could send a **file only** (`path` required, sendDocument/sendPhoto). "Daily digest → send to the team Telegram" had no tool that could do it — and a scheduled turn has no `[telegram: chat …]` context line, so nothing told the author the chat id must live in the prompt.

- **`telegram-send`: `text` XOR `path`** — text goes via `sendMessage`; the description covers the no-context-line case (a scheduled turn gets its chat id from the instruction) and Telegram's 4096-char cap (split, don't fail-loop).
- **Connective tissue**: quickstart §8 and ai-start say WHERE the send tool comes from (`add telegram`) and that the target chat id must be IN the schedule's prompt; telegram.md names the tool as the delivery path for turns no channel is carrying.
- **Executed tests, not contain-checks**: the template is a real compiled module — its mode switch runs in tests (sendMessage/sendDocument routing, XOR rejection before any network call, Bot API error surfacing).
- Separate commit: core.md records the forever-session growth consideration for schedules (deliberate; mitigation = rotation policy or engine compaction when it bites).

No overlap with #195 (cli/dev-supervisor/init).

## Test

4 new executions of the scaffold tool + init scaffold assertion. 539 green.
