### PR TITLE
Write Telegram webhook secret to gitignored env

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -201,7 +201,7 @@ fastagent add github [dir]
 fastagent add telegram [dir]
 ```
 
-Creates a `channels/<kind>.ts` file with adapter glue and appends env placeholders to `.env.example` when possible. For Telegram, when `.env` is gitignored, it also writes a generated `TELEGRAM_SECRET_TOKEN` to the run-root `.env` and leaves only `TELEGRAM_BOT_TOKEN` for you to paste from BotFather. When `config.agentDir` is set, the channel (and any companion tool) lands under that subdirectory — the same place `dev`/`start` discover channels — while `.env.example` and the secret hygiene stay at the run root, where `.env` is read.
+Creates a `channels/<kind>.ts` file with adapter glue and appends env placeholders to `.env.example` when possible. When `.env` is gitignored, the channel's GENERATED secrets (telegram's `TELEGRAM_SECRET_TOKEN`, github's `GITHUB_WEBHOOK_SECRET` — random strings the user contributes nothing to) are also written to the run-root `.env`, leaving only genuinely-manual values (e.g. `TELEGRAM_BOT_TOKEN` from BotFather) as next steps. When `config.agentDir` is set, the channel (and any companion tool) lands under that subdirectory — the same place `dev`/`start` discover channels — while `.env.example` and the secret hygiene stay at the run root, where `.env` is read.
 
 See:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -201,7 +201,7 @@ fastagent add github [dir]
 fastagent add telegram [dir]
 ```
 
-Creates a `channels/<kind>.ts` file with adapter glue and appends env placeholders to `.env.example` when possible. When `config.agentDir` is set, the channel (and any companion tool) lands under that subdirectory — the same place `dev`/`start` discover channels — while `.env.example` and the secret hygiene stay at the run root, where `.env` is read.
+Creates a `channels/<kind>.ts` file with adapter glue and appends env placeholders to `.env.example` when possible. For Telegram, when `.env` is gitignored, it also writes a generated `TELEGRAM_SECRET_TOKEN` to the run-root `.env` and leaves only `TELEGRAM_BOT_TOKEN` for you to paste from BotFather. When `config.agentDir` is set, the channel (and any companion tool) lands under that subdirectory — the same place `dev`/`start` discover channels — while `.env.example` and the secret hygiene stay at the run root, where `.env` is read.
 
 See:
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -43,18 +43,19 @@ export default githubChannel({
 
 ## Configure GitHub
 
-1. Set a webhook secret locally:
+1. Get a webhook secret. `fastagent add github` already generated one and wrote it to the run-root
+   `.env` when `.env` is gitignored; otherwise set one yourself:
 
    ```bash
-   GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 24)
+   GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 24)   # then put it in .env
    ```
 
-2. Put the same value in your workspace `.env`.
-3. In GitHub, create a repository webhook:
+2. In GitHub, create a repository webhook:
    - Payload URL: `https://<host>/webhook`
    - Content type: `application/json`
    - Secret: the value of `GITHUB_WEBHOOK_SECRET`
    - Events: choose the events your `on()` handler routes.
+3. The webhook's Secret and the `.env` value must match — copy it from `.env`.
 
 For local testing, run:
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -28,10 +28,15 @@ It also appends the required env vars to `.env.example` when possible.
 
 ## Configure Telegram
 
-Create a bot with [@BotFather](https://t.me/BotFather), then set:
+Create a bot with [@BotFather](https://t.me/BotFather), then set the bot token in the run-root `.env`:
 
 ```bash
 TELEGRAM_BOT_TOKEN=...
+```
+
+`fastagent add telegram` writes a generated `TELEGRAM_SECRET_TOKEN` to `.env` when `.env` is gitignored. If it could not write one, add it yourself:
+
+```bash
 TELEGRAM_SECRET_TOKEN=... # any random string; verifies inbound updates
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,7 @@ import { resolveWorkspaceTools } from "./engines/pi/create.ts";
 import {
   type ChannelKind,
   CHANNEL_KINDS,
+  appendChannelDotEnv,
   appendChannelEnv,
   assertChannelReady,
   channelExists,
@@ -644,8 +645,9 @@ async function runAdd(): Promise<void> {
   if (await appendChannelEnv(target, channelKind).catch(failStartup)) {
     console.error(`[fastagent] added ${channelKind} env vars to .env.example`);
   }
-  // Secret-hygiene check (read-only): warn when .env is not ignored, since a deploy that copies the
-  // directory would ship a secret placed there. Warn, not refuse — on() may read a real env var.
+  // Secret-hygiene check: write Telegram's generated webhook secret only when `.env` is already ignored.
+  // Warn, not refuse, when it is exposed — channel glue may read a real env var instead, but the CLI
+  // must not materialize a secret into a committable file.
   const envIgnored = (await loadRootIgnore(target).catch(failStartup))?.ignores(".env") ?? false;
   if (!envIgnored) {
     console.error(
@@ -653,6 +655,16 @@ async function runAdd(): Promise<void> {
     );
   }
   const { env, steps } = channelSetup(channelKind);
+  const generated = Object.fromEntries(
+    env.filter((e) => e.generate).map((e) => [e.name, randomBytes(24).toString("hex")]),
+  );
+  const dotEnv =
+    envIgnored && channelKind === "telegram"
+      ? await appendChannelDotEnv(target, channelKind, generated).catch(failStartup)
+      : undefined;
+  if (dotEnv && dotEnv.written.length > 0) {
+    console.error(`[fastagent] wrote ${dotEnv.written.join(", ")} to .env`);
+  }
   const install =
     detectRuntime(channelHome, await readPackageJson(channelHome)).runtime === "bun" ? "bun install" : "npm install";
   // The kit's manifest lives in channelHome (agentDir when set) — point the install there, not the run root.
@@ -660,10 +672,12 @@ async function runAdd(): Promise<void> {
   console.error(`  next steps:`);
   console.error(`    ${installCmd}                      # if @kid7st/fastagent is not installed yet`);
   for (const e of env) {
-    const value = e.generate ? `=${randomBytes(24).toString("hex")}` : "";
+    if (dotEnv?.alreadySet.includes(e.name) || dotEnv?.written.includes(e.name)) continue;
+    const value = e.generate ? `=${generated[e.name]}` : "";
     console.error(`    set ${e.name}${value} in .env${envIgnored ? " (gitignored)" : ""}   # ${e.hint}`);
   }
-  for (const s of steps) console.error(`    ${s}`);
+  const channelRel = relative(target, file);
+  for (const s of steps) console.error(`    ${s.replace(`channels/${channelKind}.ts`, channelRel)}`);
   console.error(`    fastagent dev --tunnel   # serve locally + a public URL, auto-registering the webhook`);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -645,9 +645,10 @@ async function runAdd(): Promise<void> {
   if (await appendChannelEnv(target, channelKind).catch(failStartup)) {
     console.error(`[fastagent] added ${channelKind} env vars to .env.example`);
   }
-  // Secret-hygiene check: write Telegram's generated webhook secret only when `.env` is already ignored.
-  // Warn, not refuse, when it is exposed — channel glue may read a real env var instead, but the CLI
-  // must not materialize a secret into a committable file.
+  // Secret hygiene: a channel's GENERATED secret (a random string the user contributes nothing to) is
+  // written into `.env` — but only when `.env` is already gitignored: the CLI must never materialize a
+  // secret into a committable file. Warn, not refuse, when it is exposed — channel glue may read a real
+  // env var instead.
   const envIgnored = (await loadRootIgnore(target).catch(failStartup))?.ignores(".env") ?? false;
   if (!envIgnored) {
     console.error(
@@ -658,10 +659,9 @@ async function runAdd(): Promise<void> {
   const generated = Object.fromEntries(
     env.filter((e) => e.generate).map((e) => [e.name, randomBytes(24).toString("hex")]),
   );
-  const dotEnv =
-    envIgnored && channelKind === "telegram"
-      ? await appendChannelDotEnv(target, channelKind, generated).catch(failStartup)
-      : undefined;
+  // Kind-neutral: every channel's generated secrets get the same treatment (github's webhook secret is
+  // the same class of value as telegram's).
+  const dotEnv = envIgnored ? await appendChannelDotEnv(target, channelKind, generated).catch(failStartup) : undefined;
   if (dotEnv && dotEnv.written.length > 0) {
     console.error(`[fastagent] wrote ${dotEnv.written.join(", ")} to .env`);
   }
@@ -672,12 +672,24 @@ async function runAdd(): Promise<void> {
   console.error(`  next steps:`);
   console.error(`    ${installCmd}                      # if @kid7st/fastagent is not installed yet`);
   for (const e of env) {
-    if (dotEnv?.alreadySet.includes(e.name) || dotEnv?.written.includes(e.name)) continue;
+    if (dotEnv?.alreadySet.includes(e.name)) continue; // the user already has it — nothing to do
+    if (dotEnv?.written.includes(e.name)) {
+      // Written, but its hint may still carry an action (github: paste the same value into the webhook
+      // UI) — keep the variable visible instead of silently absorbing it.
+      console.error(`    ${e.name} — generated and written to .env   # ${e.hint}`);
+      continue;
+    }
     const value = e.generate ? `=${generated[e.name]}` : "";
     console.error(`    set ${e.name}${value} in .env${envIgnored ? " (gitignored)" : ""}   # ${e.hint}`);
   }
-  const channelRel = relative(target, file);
-  for (const s of steps) console.error(`    ${s.replace(`channels/${channelKind}.ts`, channelRel)}`);
+  // Steps name workspace-relative paths (the channel file, telegram's companion send tool) — rewrite
+  // them to the real location in the agentDir layout.
+  const kitPrefix = channelHome === target ? "" : `${relative(target, channelHome)}/`;
+  for (const s of steps) {
+    console.error(
+      `    ${s.replace(`channels/${channelKind}.ts`, relative(target, file)).replace("tools/telegram-send.ts", `${kitPrefix}tools/telegram-send.ts`)}`,
+    );
+  }
   console.error(`    fastagent dev --tunnel   # serve locally + a public URL, auto-registering the webhook`);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -682,13 +682,11 @@ async function runAdd(): Promise<void> {
     const value = e.generate ? `=${generated[e.name]}` : "";
     console.error(`    set ${e.name}${value} in .env${envIgnored ? " (gitignored)" : ""}   # ${e.hint}`);
   }
-  // Steps name workspace-relative paths (the channel file, telegram's companion send tool) — rewrite
-  // them to the real location in the agentDir layout.
+  // Steps carry `{channel}`/`{tools}` path placeholders (their filenames are the scaffold's private
+  // knowledge) — resolve them to the real workspace-relative locations (agentDir-aware) here.
   const kitPrefix = channelHome === target ? "" : `${relative(target, channelHome)}/`;
   for (const s of steps) {
-    console.error(
-      `    ${s.replace(`channels/${channelKind}.ts`, relative(target, file)).replace("tools/telegram-send.ts", `${kitPrefix}tools/telegram-send.ts`)}`,
-    );
+    console.error(`    ${s.replace("{channel}", relative(target, file)).replace("{tools}", `${kitPrefix}tools`)}`);
   }
   console.error(`    fastagent dev --tunnel   # serve locally + a public URL, auto-registering the webhook`);
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,7 +15,16 @@ import { join } from "node:path";
  * "no .env"; any other read error propagates.
  */
 export function loadEnvFile(file: string): void {
-  const content = readFileSync(file, "utf8");
+  const parsed = parseEnvContent(readFileSync(file, "utf8"));
+  for (const [key, value] of parsed) {
+    if (!(key in process.env)) process.env[key] = value; // env-vs-file: a real env var wins
+  }
+}
+
+/** Parse .env content into key → value (the dialect above; last occurrence of a key wins). THE parser —
+ *  anything else reading/deciding on .env content (e.g. `add`'s secret pre-fill) must use this, never a
+ *  private re-implementation: two parsers of one dialect diverge silently. */
+export function parseEnvContent(content: string): Map<string, string> {
   const parsed = new Map<string, string>();
   for (const raw of content.split("\n")) {
     const line = raw.trim();
@@ -28,9 +37,7 @@ export function loadEnvFile(file: string): void {
     if ((quote === '"' || quote === "'") && value.at(-1) === quote) value = value.slice(1, -1);
     parsed.set(key, value); // in-file: last occurrence wins (Map overwrite)
   }
-  for (const [key, value] of parsed) {
-    if (!(key in process.env)) process.env[key] = value; // env-vs-file: a real env var wins
-  }
+  return parsed;
 }
 
 /**

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -10,6 +10,7 @@ import { detectRuntime } from "../runtime.ts";
 import { assertInsideWorkspace } from "../workspace.ts";
 import { channelBundleFiles, channelTemplate } from "./templates.ts";
 import { exists } from "./init.ts";
+import { parseEnvContent } from "../env.ts";
 
 export type ChannelKind = "github" | "telegram";
 
@@ -77,7 +78,10 @@ export async function appendChannelEnv(dir: string, kind: ChannelKind): Promise<
   }
   const marker = `# --- ${kind} channel ---`;
   if (current.includes(marker)) return false;
-  const block = `\n${marker}\n${CHANNEL_SCAFFOLDS[kind].env.map((e) => `# ${e.name}=   # ${e.hint}`).join("\n")}\n`;
+  // Hint on its OWN line above the placeholder (like the base env.example template) — never inline
+  // after `=`: loadEnvFile does not strip trailing comments, so an uncommented `KEY=   # hint` (or a
+  // value pasted before the `#`) would carry the hint text into the parsed value.
+  const block = `\n${marker}\n${CHANNEL_SCAFFOLDS[kind].env.map((e) => `# ${e.hint}\n# ${e.name}=`).join("\n")}\n`;
   await appendFile(file, block);
   return true;
 }
@@ -89,26 +93,12 @@ export interface DotEnvWriteResult {
   alreadySet: string[];
 }
 
-function parseEnvValue(line: string, name: string): string | undefined {
-  const trimmed = line.trim();
-  if (!trimmed || trimmed.startsWith("#")) return undefined;
-  const eq = trimmed.indexOf("=");
-  if (eq < 1) return undefined;
-  const key = trimmed.slice(0, eq).trim();
-  if (key !== name) return undefined;
-  let value = trimmed.slice(eq + 1).trim();
-  const quote = value[0];
-  if ((quote === '"' || quote === "'") && value.at(-1) === quote) value = value.slice(1, -1);
-  return value;
-}
-
+/** Whether `.env` content carries a non-empty ACTIVE value for `name` — decided by THE .env parser
+ *  ({@link parseEnvContent}), not a re-implementation, so this check can never disagree with what
+ *  `loadEnvFile` will actually read (a missed match here would append a second assignment that
+ *  last-wins over the user's working secret). */
 function hasActiveEnvValue(content: string, name: string): boolean {
-  let value: string | undefined;
-  for (const line of content.split("\n")) {
-    const parsed = parseEnvValue(line, name);
-    if (parsed !== undefined) value = parsed; // match loadEnvFile: last active assignment wins
-  }
-  return value !== undefined && value.trim() !== "";
+  return (parseEnvContent(content).get(name)?.trim() ?? "") !== "";
 }
 
 function mentionsEnvName(content: string, name: string): boolean {
@@ -144,14 +134,20 @@ export async function appendChannelDotEnv(
       lines.push(`${e.name}=${value}`);
       written.push(e.name);
     } else if (!mentionsEnvName(current, e.name)) {
-      lines.push(`# ${e.name}=   # ${e.hint}`);
+      // Hint above, never inline after `=` — see appendChannelEnv (this IS the file loadEnvFile reads).
+      lines.push(`# ${e.hint}`, `# ${e.name}=`);
     }
   }
   if (lines.length > 0) {
     const marker = `# --- ${kind} channel ---`;
-    if (!current.includes(marker)) lines.unshift(marker);
-    const prefix = current === "" ? "" : current.endsWith("\n") ? "\n" : "\n\n";
-    await appendFile(file, `${prefix}${lines.join("\n")}\n`);
+    if (current.includes(marker)) {
+      // A marker already present (e.g. a .env copied from .env.example) — slot the new lines under it
+      // instead of orphaning them at the end of the file.
+      await writeFile(file, current.replace(marker, `${marker}\n${lines.join("\n")}`));
+    } else {
+      const prefix = current === "" ? "" : current.endsWith("\n") ? "\n" : "\n\n";
+      await appendFile(file, `${prefix}${marker}\n${lines.join("\n")}\n`);
+    }
   }
   return { written, alreadySet };
 }

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -82,6 +82,80 @@ export async function appendChannelEnv(dir: string, kind: ChannelKind): Promise<
   return true;
 }
 
+export interface DotEnvWriteResult {
+  /** Generated secret vars written as active `KEY=value` lines. */
+  written: string[];
+  /** Vars already present with a non-empty active value; left untouched and omitted from next steps. */
+  alreadySet: string[];
+}
+
+function parseEnvValue(line: string, name: string): string | undefined {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return undefined;
+  const eq = trimmed.indexOf("=");
+  if (eq < 1) return undefined;
+  const key = trimmed.slice(0, eq).trim();
+  if (key !== name) return undefined;
+  let value = trimmed.slice(eq + 1).trim();
+  const quote = value[0];
+  if ((quote === '"' || quote === "'") && value.at(-1) === quote) value = value.slice(1, -1);
+  return value;
+}
+
+function hasActiveEnvValue(content: string, name: string): boolean {
+  let value: string | undefined;
+  for (const line of content.split("\n")) {
+    const parsed = parseEnvValue(line, name);
+    if (parsed !== undefined) value = parsed; // match loadEnvFile: last active assignment wins
+  }
+  return value !== undefined && value.trim() !== "";
+}
+
+function mentionsEnvName(content: string, name: string): boolean {
+  return content.split("\n").some((line) => new RegExp(`^\\s*#?\\s*${name}\\s*=`).test(line));
+}
+
+/**
+ * Append generated channel secrets to the run-root `.env` (never `.env.example`) after the CLI has
+ * verified that `.env` is gitignored. Existing non-empty values are kept. Manual values (e.g.
+ * TELEGRAM_BOT_TOKEN from BotFather) are added only as commented placeholders, so the file is ready to
+ * edit while no fake secret is committed to the user's mental model.
+ */
+export async function appendChannelDotEnv(
+  dir: string,
+  kind: ChannelKind,
+  generated: Record<string, string>,
+): Promise<DotEnvWriteResult> {
+  const file = join(dir, ".env");
+  let current = "";
+  try {
+    current = await readFile(file, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  }
+
+  const alreadySet = CHANNEL_SCAFFOLDS[kind].env.filter((e) => hasActiveEnvValue(current, e.name)).map((e) => e.name);
+  const lines: string[] = [];
+  const written: string[] = [];
+  for (const e of CHANNEL_SCAFFOLDS[kind].env) {
+    if (alreadySet.includes(e.name)) continue;
+    const value = generated[e.name];
+    if (value !== undefined) {
+      lines.push(`${e.name}=${value}`);
+      written.push(e.name);
+    } else if (!mentionsEnvName(current, e.name)) {
+      lines.push(`# ${e.name}=   # ${e.hint}`);
+    }
+  }
+  if (lines.length > 0) {
+    const marker = `# --- ${kind} channel ---`;
+    if (!current.includes(marker)) lines.unshift(marker);
+    const prefix = current === "" ? "" : current.endsWith("\n") ? "\n" : "\n\n";
+    await appendFile(file, `${prefix}${lines.join("\n")}\n`);
+  }
+  return { written, alreadySet };
+}
+
 /** The path `add <kind>` scaffolds to. */
 function channelPath(dir: string, kind: ChannelKind): string {
   return join(dir, "channels", `${kind}.ts`);

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -36,8 +36,10 @@ const CHANNEL_SCAFFOLDS: Record<ChannelKind, ChannelScaffold> = {
         generate: true,
       },
     ],
+    // `{channel}` / `{tools}` are path placeholders the CLI resolves to the real workspace-relative
+    // location (agentDir-aware) — the CLI holds no channel-private filenames.
     steps: [
-      "edit channels/github.ts — map events to intents in on()",
+      "edit {channel} — map events to intents in on()",
       "add the webhook in your repo (Settings → Webhooks): Payload URL = <public-url>/webhook, content type application/json",
     ],
   },
@@ -47,8 +49,8 @@ const CHANNEL_SCAFFOLDS: Record<ChannelKind, ChannelScaffold> = {
       { name: "TELEGRAM_SECRET_TOKEN", hint: "any random string; verifies inbound updates", generate: true },
     ],
     steps: [
-      "edit channels/telegram.ts — customise routing with route() (optional; the defaults already work)",
-      "the agent can send messages or files back by calling the scaffolded tools/telegram-send.ts tool",
+      "edit {channel} — customise routing with route() (optional; the defaults already work)",
+      "the agent can send messages or files back by calling the scaffolded {tools}/telegram-send.ts tool",
     ],
   },
 };
@@ -127,16 +129,38 @@ export async function appendChannelDotEnv(
   const alreadySet = CHANNEL_SCAFFOLDS[kind].env.filter((e) => hasActiveEnvValue(current, e.name)).map((e) => e.name);
   const lines: string[] = [];
   const written: string[] = [];
+  const contentLines = current.split("\n");
+  let replacedInPlace = false;
   for (const e of CHANNEL_SCAFFOLDS[kind].env) {
     if (alreadySet.includes(e.name)) continue;
     const value = generated[e.name];
     if (value !== undefined) {
-      lines.push(`${e.name}=${value}`);
+      // An ACTIVE but EMPTY assignment already in the file (an uncommented, unfilled placeholder from
+      // `cp .env.example .env`) must be replaced IN PLACE: a new line written anywhere else either loses
+      // to it or wins by position under last-wins — both silently. Replace the LAST occurrence (the one
+      // the parser would honor). Line-level match uses THE parser, never a hand regex.
+      let idx = -1;
+      for (let i = contentLines.length - 1; i >= 0; i--) {
+        if (parseEnvContent(contentLines[i] as string).has(e.name)) {
+          idx = i;
+          break;
+        }
+      }
+      if (idx >= 0) {
+        contentLines[idx] = `${e.name}=${value}`;
+        replacedInPlace = true;
+      } else {
+        lines.push(`${e.name}=${value}`);
+      }
       written.push(e.name);
     } else if (!mentionsEnvName(current, e.name)) {
       // Hint above, never inline after `=` — see appendChannelEnv (this IS the file loadEnvFile reads).
       lines.push(`# ${e.hint}`, `# ${e.name}=`);
     }
+  }
+  if (replacedInPlace) {
+    current = contentLines.join("\n");
+    await writeFile(file, current);
   }
   if (lines.length > 0) {
     const marker = `# --- ${kind} channel ---`;

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -451,6 +451,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
 
     const out = await cliInit(["add", "telegram"], dir);
     expect(out).toContain(join("agent", "channels", "telegram.ts")); // reported relative to the run root
+    expect(out).toContain(`edit ${join("agent", "channels", "telegram.ts")}`); // next step uses the real agentDir path
     expect(await exists(join(dir, "agent", "channels", "telegram.ts"))).toBe(true); // in the kit…
     expect(await exists(join(dir, "agent", "tools", "telegram-send.ts"))).toBe(true); // …with its companion tool
     expect(await exists(join(dir, "channels"))).toBe(false); // NOT at the run root
@@ -501,15 +502,45 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     expect(out).toContain("--tunnel");
     expect(out).not.toContain("GITHUB_WEBHOOK_SECRET");
 
-    // env vars are injected into .env.example so a copy-to-.env finds them
+    // env vars are injected into .env.example so a copy-to-.env finds them. Because .env is not
+    // gitignored in this workspace, add does NOT materialize the generated secret there.
     const envExample = await readFile(join(dir, ".env.example"), "utf8");
     expect(envExample).toContain("telegram channel");
     expect(envExample).toContain("TELEGRAM_SECRET_TOKEN");
+    expect(await exists(join(dir, ".env"))).toBe(false);
+    expect(out).toMatch(/set TELEGRAM_SECRET_TOKEN=[0-9a-f]{48} in \.env/);
 
     // two channels coexist in one workspace (the discovery/merge mechanism handles many)
     await cliInit(["add", "github"], dir);
     expect(await exists(join(dir, "channels", "github.ts"))).toBe(true);
     expect(await exists(join(dir, "channels", "telegram.ts"))).toBe(true);
+  });
+
+  it("writes generated telegram secret to gitignored .env, leaving only the BotFather token as a manual step", async () => {
+    const dir = await readyWorkspace();
+    await writeFile(join(dir, ".gitignore"), ".env\n");
+    const out = await cliInit(["add", "telegram"], dir);
+
+    expect(out).toContain("wrote TELEGRAM_SECRET_TOKEN to .env");
+    expect(out).toContain("set TELEGRAM_BOT_TOKEN in .env (gitignored)");
+    expect(out).not.toMatch(/set TELEGRAM_SECRET_TOKEN=/);
+    const envFile = await readFile(join(dir, ".env"), "utf8");
+    expect(envFile).toContain("# --- telegram channel ---");
+    expect(envFile).toContain("# TELEGRAM_BOT_TOKEN=");
+    expect(envFile).toMatch(/^TELEGRAM_SECRET_TOKEN=[0-9a-f]{48}$/m);
+  });
+
+  it("keeps an existing non-empty telegram secret in .env", async () => {
+    const dir = await readyWorkspace();
+    await writeFile(join(dir, ".gitignore"), ".env\n");
+    await writeFile(join(dir, ".env"), "TELEGRAM_SECRET_TOKEN=keep-me\n");
+    const out = await cliInit(["add", "telegram"], dir);
+
+    expect(out).not.toContain("wrote TELEGRAM_SECRET_TOKEN to .env");
+    expect(out).not.toMatch(/set TELEGRAM_SECRET_TOKEN=/);
+    const envFile = await readFile(join(dir, ".env"), "utf8");
+    expect(envFile.match(/^TELEGRAM_SECRET_TOKEN=/gm)).toHaveLength(1);
+    expect(envFile).toContain("TELEGRAM_SECRET_TOKEN=keep-me");
   });
 
   it("never clobbers an author's companion tool when scaffolding the channel", async () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -561,6 +561,20 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     expect(envFile).toContain("OPENAI_API_KEY=sk-x"); // untouched
   });
 
+  it("an ACTIVE but EMPTY assignment is replaced IN PLACE — never shadowed by a line elsewhere (last-wins)", async () => {
+    const dir = await readyWorkspace();
+    await writeFile(join(dir, ".gitignore"), ".env\n");
+    // The uncommented-but-unfilled placeholder: marker block present, `KEY=` active and empty, and a
+    // LATER unrelated line — a slot-under-marker write would lose to last-wins here.
+    await writeFile(join(dir, ".env"), "# --- telegram channel ---\nTELEGRAM_SECRET_TOKEN=\nOPENAI_API_KEY=sk-x\n");
+    const out = await cliInit(["add", "telegram"], dir);
+    expect(out).toContain("wrote TELEGRAM_SECRET_TOKEN to .env");
+    const envFile = await readFile(join(dir, ".env"), "utf8");
+    expect(envFile.match(/^TELEGRAM_SECRET_TOKEN=/gm)).toHaveLength(1); // replaced, not duplicated
+    expect(envFile).toMatch(/^TELEGRAM_SECRET_TOKEN=[0-9a-f]{48}$/m); // …with a real value in place
+    expect(envFile).toContain("OPENAI_API_KEY=sk-x");
+  });
+
   it("keeps an existing non-empty telegram secret in .env", async () => {
     const dir = await readyWorkspace();
     await writeFile(join(dir, ".gitignore"), ".env\n");

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -452,6 +452,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     const out = await cliInit(["add", "telegram"], dir);
     expect(out).toContain(join("agent", "channels", "telegram.ts")); // reported relative to the run root
     expect(out).toContain(`edit ${join("agent", "channels", "telegram.ts")}`); // next step uses the real agentDir path
+    expect(out).toContain("agent/tools/telegram-send.ts"); // …and so does the companion-tool step
     expect(await exists(join(dir, "agent", "channels", "telegram.ts"))).toBe(true); // in the kit…
     expect(await exists(join(dir, "agent", "tools", "telegram-send.ts"))).toBe(true); // …with its companion tool
     expect(await exists(join(dir, "channels"))).toBe(false); // NOT at the run root
@@ -528,6 +529,36 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     expect(envFile).toContain("# --- telegram channel ---");
     expect(envFile).toContain("# TELEGRAM_BOT_TOKEN=");
     expect(envFile).toMatch(/^TELEGRAM_SECRET_TOKEN=[0-9a-f]{48}$/m);
+  });
+
+  it("github's generated webhook secret gets the same treatment (kind-neutral), hint kept visible", async () => {
+    const dir = await readyWorkspace();
+    await writeFile(join(dir, ".gitignore"), ".env\n");
+    const out = await cliInit(["add", "github"], dir);
+
+    expect(out).toContain("wrote GITHUB_WEBHOOK_SECRET to .env");
+    // The hint still prints — it carries an ACTION (paste the same value into the GitHub webhook UI),
+    // so a written var is reported, not silently absorbed.
+    expect(out).toMatch(/GITHUB_WEBHOOK_SECRET — generated and written to \.env.*set the same value/);
+    expect(await readFile(join(dir, ".env"), "utf8")).toMatch(/^GITHUB_WEBHOOK_SECRET=[0-9a-f]{48}$/m);
+  });
+
+  it("a .env copied from .env.example (marker present) gets the secret slotted UNDER the marker", async () => {
+    const dir = await readyWorkspace();
+    await writeFile(join(dir, ".gitignore"), ".env\n");
+    // What a user gets from `cp .env.example .env` after a previous add appended the block there.
+    await writeFile(
+      join(dir, ".env"),
+      "# mine\nOPENAI_API_KEY=sk-x\n\n# --- telegram channel ---\n# from @BotFather → /newbot\n# TELEGRAM_BOT_TOKEN=\n",
+    );
+    const out = await cliInit(["add", "telegram"], dir);
+    expect(out).toContain("wrote TELEGRAM_SECRET_TOKEN to .env");
+    const envFile = await readFile(join(dir, ".env"), "utf8");
+    // Slotted under the existing marker — not orphaned at the end of the file.
+    expect(envFile).toMatch(/# --- telegram channel ---\nTELEGRAM_SECRET_TOKEN=[0-9a-f]{48}\n/);
+    // The commented BOT_TOKEN placeholder is mentioned already — not duplicated.
+    expect(envFile.match(/TELEGRAM_BOT_TOKEN/g)).toHaveLength(1);
+    expect(envFile).toContain("OPENAI_API_KEY=sk-x"); // untouched
   });
 
   it("keeps an existing non-empty telegram secret in .env", async () => {


### PR DESCRIPTION
## Summary
- Write a generated TELEGRAM_SECRET_TOKEN to the run-root .env when .env is gitignored
- Preserve existing non-empty Telegram env values and keep unsafe .env files read-only
- Show the real channel path in add-channel next steps for agentDir workspaces
- Document the updated Telegram setup flow

## Tests
- npx biome check src/cli.ts src/scaffold/add-channel.ts test/init.test.ts docs/cli.md docs/telegram.md
- npm run typecheck
- npm test
