### PR TITLE
chore: release 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kid7st/fastagent",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Version bump for the 0.11.0 release. Notes land on the GitHub Release (tag → publish.yml → npm via OIDC).