### PR TITLE
chore: rename package to @fastagent-sh/fastagent

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions, ideas & help
-    url: https://github.com/kid7st/fastagent/discussions
+    url: https://github.com/fastagent-sh/fastagent/discussions
     about: Ask a question or discuss an idea in Discussions — issues are for bugs and concrete feature requests.
   - name: Documentation
-    url: https://github.com/kid7st/fastagent/tree/main/docs
+    url: https://github.com/fastagent-sh/fastagent/tree/main/docs
     about: Setup, configuration, channels, embedding, and the API reference.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 name: Publish
 
-# Publish @kid7st/fastagent to npm when a GitHub Release is published, via npm Trusted Publishing
+# Publish @fastagent-sh/fastagent to npm when a GitHub Release is published, via npm Trusted Publishing
 # (OIDC) — no NPM_TOKEN secret. Provenance is NOT attached: npm requires a PUBLIC source repository to
 # verify a provenance bundle (`422 ... Unsupported ... visibility: "private"`), and this repo is private.
 # Re-add `npm publish --provenance` once the repo is public. Requires a trusted publisher
-# configured on npmjs (org/user kid7st, repo fastagent, workflow publish.yml) and npm >= 11.5.1 (Node 26
+# configured on npmjs (org fastagent-sh, repo fastagent, workflow publish.yml) and npm >= 11.5.1 (Node 26
 # ships 11.12.1). The release tag is the manual gate; the job re-verifies (typecheck + test) before
 # publishing so a non-green tag never ships. Version comes from package.json — bump it before
 # tagging (npm rejects re-publishing an existing version).
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: '26'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@kid7st'
+          scope: '@fastagent-sh'
           cache: npm
           cache-dependency-path: package-lock.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ src/
 ├── index.ts                 # the public API surface (see README "Public API surface & stability")
 ├── cli.ts                   # command entry points (process side effects live here)
 ├── invoke-stream.ts, cli-models.ts, cli-auth.ts # command rendering layers (`invoke` stream → exit code, `models`/auth-report output)
-├── telegram.ts, github.ts   # subpath-export shims (@kid7st/fastagent/telegram etc. — the supported surface)
+├── telegram.ts, github.ts   # subpath-export shims (@fastagent-sh/fastagent/telegram etc. — the supported surface)
 ├── log.ts                   # leveled logging singleton (dev=debug, start=info)
 ├── observe.ts               # turn-trace logging around an Agent
 ├── tunnel.ts                # `--tunnel`: cloudflared + per-channel webhook dispatch

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
-  <a href="https://github.com/kid7st/fastagent"><img src="https://raw.githubusercontent.com/kid7st/fastagent/main/assets/hero.png" alt="FastAgent — Vibe first. Then FastAgent. An agent directory becomes a live service in your app, on GitHub, in Telegram, or any channel." width="860"></a>
+  <a href="https://github.com/fastagent-sh/fastagent"><img src="https://raw.githubusercontent.com/fastagent-sh/fastagent/main/assets/hero.png" alt="FastAgent — Vibe first. Then FastAgent. An agent directory becomes a live service in your app, on GitHub, in Telegram, or any channel." width="860"></a>
 </p>
 
-[![CI](https://github.com/kid7st/fastagent/actions/workflows/ci.yml/badge.svg)](https://github.com/kid7st/fastagent/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/@kid7st/fastagent.svg)](https://www.npmjs.com/package/@kid7st/fastagent)
-[![license](https://img.shields.io/npm/l/@kid7st/fastagent.svg)](LICENSE)
-[![node](https://img.shields.io/node/v/@kid7st/fastagent.svg)](https://nodejs.org)
+[![CI](https://github.com/fastagent-sh/fastagent/actions/workflows/ci.yml/badge.svg)](https://github.com/fastagent-sh/fastagent/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/@fastagent-sh/fastagent.svg)](https://www.npmjs.com/package/@fastagent-sh/fastagent)
+[![license](https://img.shields.io/npm/l/@fastagent-sh/fastagent.svg)](LICENSE)
+[![node](https://img.shields.io/node/v/@fastagent-sh/fastagent.svg)](https://nodejs.org)
 [![built with pi](https://img.shields.io/badge/built%20with-pi-0b7285.svg)](https://pi.dev)
 
 <p align="center">
@@ -24,7 +24,7 @@ Leave the terminal. Become a real service.
 FastAgent is not another agent framework. It does not ask you to rewrite your agent in a new DSL or project layout. You bring the agent definition; FastAgent provides the serving layer around it.
 
 <p align="center">
-  <img src="https://cdn.jsdelivr.net/gh/kid7st/fastagent@main/assets/demo.svg" alt="fastagent dev boots an existing agent directory (AGENTS.md, skills/, tools/, channels/) into a live service; a GitHub pull_request.opened webhook arrives and the agent reviews PR #42 and posts inline comments." width="860">
+  <img src="https://cdn.jsdelivr.net/gh/fastagent-sh/fastagent@main/assets/demo.svg" alt="fastagent dev boots an existing agent directory (AGENTS.md, skills/, tools/, channels/) into a live service; a GitHub pull_request.opened webhook arrives and the agent reviews PR #42 and posts inline comments." width="860">
 </p>
 
 ## Why FastAgent
@@ -74,8 +74,8 @@ FastAgent stays a small serving layer, so it never dictates your stack. Capabili
 ## Install
 
 ```bash
-npm i -g @kid7st/fastagent   # CLI: fastagent init/dev/start/...
-npm i @kid7st/fastagent      # library API for embedding or code tools
+npm i -g @fastagent-sh/fastagent   # CLI: fastagent init/dev/start/...
+npm i @fastagent-sh/fastagent      # library API for embedding or code tools
 ```
 
 Requires **Node >= 22.19** (the floor is inherited from the reference engine `@earendil-works/pi-agent-core` and `undici`), and also runs under **Bun** (verified on Bun 1.3 — its native fetch replaces the undici path). The npm package ships compiled JavaScript and type declarations.
@@ -107,7 +107,7 @@ There is no FastAgent build step: the directory is the agent.
 ## Embed in an app
 
 ```ts
-import { createInvokeHandler, createPiAgentFromDefinition } from "@kid7st/fastagent";
+import { createInvokeHandler, createPiAgentFromDefinition } from "@fastagent-sh/fastagent";
 
 const { agent } = await createPiAgentFromDefinition("./agent", {
   model: "openai-codex/gpt-5.5",
@@ -119,7 +119,7 @@ export const POST = createInvokeHandler(agent); // Fetch-shaped handler
 No directory? Assemble from typed parts:
 
 ```ts
-import { createPiAgent, defineTool, z } from "@kid7st/fastagent";
+import { createPiAgent, defineTool, z } from "@fastagent-sh/fastagent";
 
 const lookupOrder = defineTool({
   name: "lookup-order",
@@ -169,7 +169,7 @@ The root export intentionally contains the supported surface only.
 | Injection ports | `PiSessionStore`, `inMemorySessionStore`, `jsonlSessionStore`, `Lease`, `Provider`, `createProvider` | Public because options reference them |
 | Not exported | L0 harness adapter, pi harness factory, prompt/config internals | Internal modules; no compatibility promise |
 
-Subpath exports: `@kid7st/fastagent/github` (GitHub webhook channel), `@kid7st/fastagent/telegram`
+Subpath exports: `@fastagent-sh/fastagent/github` (GitHub webhook channel), `@fastagent-sh/fastagent/telegram`
 (Telegram bot channel).
 
 ## Repository layout
@@ -186,7 +186,7 @@ independent dependencies/versioning actually exists.
 
 ## Status
 
-FastAgent is pre-1.0. The stable design center is the Agent Handler contract in `docs/SPEC.md`; the package API may still tighten before 1.0. Notable changes are recorded in the [GitHub Releases](https://github.com/kid7st/fastagent/releases).
+FastAgent is pre-1.0. The stable design center is the Agent Handler contract in `docs/SPEC.md`; the package API may still tighten before 1.0. Notable changes are recorded in the [GitHub Releases](https://github.com/fastagent-sh/fastagent/releases).
 
 ## Project
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ FastAgent is pre-1.0. Security fixes land on the latest published `0.x` release 
 
 Do not open a public issue for a security report.
 
-Use GitHub's private vulnerability reporting: open the repository's **Security → Report a vulnerability** form (`https://github.com/kid7st/fastagent/security/advisories/new`).
+Use GitHub's private vulnerability reporting: open the repository's **Security → Report a vulnerability** form (`https://github.com/fastagent-sh/fastagent/security/advisories/new`).
 
 Please include:
 
@@ -28,7 +28,7 @@ We aim to acknowledge a report within 5 business days and to provide a remediati
 
 In scope:
 
-- the `@kid7st/fastagent` package (CLI, library API, reference implementation),
+- the `@fastagent-sh/fastagent` package (CLI, library API, reference implementation),
 - the first-party channel adapters (`/github`, `/telegram`),
 - credential handling in the project-level `<state root>/auth.json` (default `<dir>/.fastagent/auth.json`; global `~/.fastagent/auth.json` is opt-in) and the OAuth/env auth resolution path.
 

--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -41,6 +41,6 @@
   </g>
 
   <rect x="96" y="556" width="1088" height="1.5" fill="#1e2126"/>
-  <text x="96" y="600" font-family="Menlo, DejaVu Sans Mono, monospace" font-size="26" fill="#d7dbe1">$ npm i -g @kid7st/fastagent</text>
+  <text x="96" y="600" font-family="Menlo, DejaVu Sans Mono, monospace" font-size="26" fill="#d7dbe1">$ npm i -g @fastagent-sh/fastagent</text>
   <text x="1184" y="600" text-anchor="end" font-family="Archivo" font-size="23" font-weight="600" fill="#6a6f77">Built on pi &#183; MIT &#183; Node &#8805; 22.19</text>
 </svg>

--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -52,7 +52,7 @@ For local testing (prefer commands that exit):
 
 For tools:
 - Put tools in tools/<name>.ts.
-- Use defineTool and z from @kid7st/fastagent.
+- Use defineTool and z from @fastagent-sh/fastagent.
 - Test with: fastagent tool <name> '<json>'
 
 For GitHub:
@@ -67,7 +67,7 @@ For Telegram:
 
 For schedules (run the agent on a cron — daily digest, periodic checks):
 - Create schedules/<name>.ts: export default defineSchedule({ cron: "0 9 * * *", tz: "America/New_York",
-  prompt: "..." }) — defineSchedule comes from @kid7st/fastagent; the filename is the schedule name.
+  prompt: "..." }) — defineSchedule comes from @fastagent-sh/fastagent; the filename is the schedule name.
 - The prompt must SAY where output goes ("…and send it to the team Telegram"): the scheduler only fires
   the agent — a scheduled turn's plain reply is not delivered anywhere; delivery is a send tool's job.
   fastagent add telegram scaffolds one (tools/telegram-send.ts: message or file). A scheduled turn runs

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -5,7 +5,7 @@ status: current
 
 # API reference
 
-This is a compact reference for the public TypeScript surface exported by `@kid7st/fastagent`.
+This is a compact reference for the public TypeScript surface exported by `@fastagent-sh/fastagent`.
 
 FastAgent is pre-1.0. The Agent Handler contract is the stable design center; implementation-specific APIs may still tighten before 1.0.
 
@@ -170,7 +170,7 @@ function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): AgentTo
 Use the re-exported `z`:
 
 ```ts
-import { defineTool, z } from "@kid7st/fastagent";
+import { defineTool, z } from "@fastagent-sh/fastagent";
 
 export default defineTool({
   description: "Look up an order.",
@@ -234,7 +234,7 @@ the filename becomes the schedule name. Each file default-exports `defineSchedul
 
 ```ts
 // schedules/daily-digest.ts        → schedule "daily-digest"
-import { defineSchedule } from "@kid7st/fastagent";
+import { defineSchedule } from "@fastagent-sh/fastagent";
 
 export default defineSchedule({
   cron: "0 9 * * *",
@@ -314,8 +314,8 @@ The lease is the same-session concurrency floor. A failed acquisition yields a r
 ## Subpath exports
 
 ```ts
-import { githubChannel } from "@kid7st/fastagent/github";
-import { telegramChannel } from "@kid7st/fastagent/telegram";
+import { githubChannel } from "@fastagent-sh/fastagent/github";
+import { telegramChannel } from "@fastagent-sh/fastagent/telegram";
 ```
 
 See [GitHub channel](github.md) and [Telegram channel](telegram.md).

--- a/docs/channel-development.md
+++ b/docs/channel-development.md
@@ -20,7 +20,7 @@ Every channel has two layers:
 | Adapter | reusable package or first-party module | verify signature, parse body, ACK/retry rules, SDK calls |
 | Glue | the agent workspace | map an event to a session and prompt |
 
-For first-party channels, the adapter is `@kid7st/fastagent/github` or `@kid7st/fastagent/telegram`, and the glue is the scaffolded `channels/*.ts` file.
+For first-party channels, the adapter is `@fastagent-sh/fastagent/github` or `@fastagent-sh/fastagent/telegram`, and the glue is the scaffolded `channels/*.ts` file.
 
 For a community channel, publish the adapter as a separate package and keep the user's glue in their workspace.
 
@@ -29,7 +29,7 @@ For a community channel, publish the adapter as a separate package and keep the 
 A workspace channel is a module in `channels/` that default-exports a `ChannelModule`:
 
 ```ts
-import type { ChannelModule } from "@kid7st/fastagent";
+import type { ChannelModule } from "@fastagent-sh/fastagent";
 
 const channel: ChannelModule = ({ agent, stateRoot }) => ({
   "POST /slack": async (req) => {
@@ -55,7 +55,7 @@ A path overlap is a collision: `/webhook` conflicts with `POST /webhook`; `GET /
 
 ## Public channel-authoring kit
 
-A channel adapter should depend only on the public `@kid7st/fastagent` surface:
+A channel adapter should depend only on the public `@fastagent-sh/fastagent` surface:
 
 | Export | Use |
 |---|---|
@@ -73,7 +73,7 @@ Do not import from `src/engines/*` or `@earendil-works/*` in a channel package. 
 A reusable adapter is usually shaped like this:
 
 ```ts
-import { AgentFailure, type ChannelModule, collect, readBodyCapped, text } from "@kid7st/fastagent";
+import { AgentFailure, type ChannelModule, collect, readBodyCapped, text } from "@fastagent-sh/fastagent";
 
 export interface AcmeChannelOptions {
   secret: string;
@@ -169,7 +169,7 @@ A channel adapter should:
 - tolerate `failed` terminal events,
 - cancel or stop work when the client disconnects if the protocol supports it,
 - avoid importing engine-specific code,
-- keep provider SDK dependencies out of `@kid7st/fastagent` unless the adapter is first-party and lightweight.
+- keep provider SDK dependencies out of `@fastagent-sh/fastagent` unless the adapter is first-party and lightweight.
 
 ## Sessions and concurrency
 
@@ -195,7 +195,7 @@ A reusable channel package should normally look like:
   "name": "fastagent-channel-acme",
   "type": "module",
   "peerDependencies": {
-    "@kid7st/fastagent": "^0.x"
+    "@fastagent-sh/fastagent": "^0.x"
   },
   "dependencies": {
     "@acme/sdk": "^1.0.0"

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -41,7 +41,7 @@ channels/
 Each file default-exports a `ChannelModule`:
 
 ```ts
-import type { ChannelModule } from "@kid7st/fastagent";
+import type { ChannelModule } from "@fastagent-sh/fastagent";
 
 const channel: ChannelModule = ({ agent, stateRoot }) => ({
   "POST /webhook": async (req) => {
@@ -86,13 +86,13 @@ FastAgent ships lightweight first-party adapters as subpath exports.
 
 | Channel | Package import | Docs | Add command |
 |---|---|---|---|
-| GitHub webhook | `@kid7st/fastagent/github` | [GitHub channel](github.md) | `fastagent add github` |
-| Telegram bot | `@kid7st/fastagent/telegram` | [Telegram channel](telegram.md) | `fastagent add telegram` |
+| GitHub webhook | `@fastagent-sh/fastagent/github` | [GitHub channel](github.md) | `fastagent add github` |
+| Telegram bot | `@fastagent-sh/fastagent/telegram` | [Telegram channel](telegram.md) | `fastagent add telegram` |
 
 Example GitHub glue:
 
 ```ts
-import { githubChannel } from "@kid7st/fastagent/github";
+import { githubChannel } from "@fastagent-sh/fastagent/github";
 
 export default githubChannel({
   secret: process.env.GITHUB_WEBHOOK_SECRET ?? "",
@@ -106,7 +106,7 @@ export default githubChannel({
 Example Telegram glue:
 
 ```ts
-import { telegramChannel } from "@kid7st/fastagent/telegram";
+import { telegramChannel } from "@fastagent-sh/fastagent/telegram";
 
 export default telegramChannel({
   secretToken: process.env.TELEGRAM_SECRET_TOKEN ?? "",
@@ -147,12 +147,12 @@ The tunnel is owned by the dev watch supervisor, so the URL survives worker relo
 
 ## Third-party channels
 
-Heavy or long-tail adapters should live outside `@kid7st/fastagent`:
+Heavy or long-tail adapters should live outside `@fastagent-sh/fastagent`:
 
 ```jsonc
 {
   "name": "fastagent-channel-slack",
-  "peerDependencies": { "@kid7st/fastagent": "^0.x" },
+  "peerDependencies": { "@fastagent-sh/fastagent": "^0.x" },
   "dependencies": { "@slack/web-api": "^7" }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ fastagent.config.mjs
 Example:
 
 ```ts
-import { defineConfig } from "@kid7st/fastagent";
+import { defineConfig } from "@fastagent-sh/fastagent";
 
 export default defineConfig({
   model: "openai-codex/gpt-5.5",

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -11,7 +11,7 @@ Use FastAgent as a **library** — the agent is one capability inside a product 
 ## Prerequisites
 
 - **Node ≥ 22.19.** Ships compiled JS + types; no build step for FastAgent itself.
-- **Install as a dependency:** `npm i @kid7st/fastagent`.
+- **Install as a dependency:** `npm i @fastagent-sh/fastagent`.
 - **Model credentials** — `fastagent login` (OAuth, writes the project-level `<cwd>/.fastagent/auth.json`) or a provider API key in the environment (e.g. `OPENAI_API_KEY`). Auth is invisible to your code; see [Auth](#auth) below.
 
 ## The one mental model
@@ -46,7 +46,7 @@ The stream ends with exactly one `completed` / `failed`, or is cancelled by the 
 const { agent } = await createPiAgentFromWorkspace("./agent", { model: "openai-codex/gpt-5.5" });
 
 // B) no directory — Tier 1: three concrete fields
-import { createPiAgent, defineTool, z } from "@kid7st/fastagent";
+import { createPiAgent, defineTool, z } from "@fastagent-sh/fastagent";
 
 const lookupOrder = defineTool({
   name: "lookup-order",                       // set the name explicitly when assembling in code
@@ -64,7 +64,7 @@ const agent = createPiAgent({
 });
 ```
 
-Author tool schemas with the `z` re-exported from `@kid7st/fastagent` (as above), not a separately installed `zod` — `defineTool` converts the schema with its own zod, so a single shared copy avoids version-skew surprises. Every type on this surface (`AgentTool`, `Skill`, `Session`, `Model`, …) is re-exported too, so you never import from `@earendil-works/*` (the one exception is a provider's wire-protocol `api`, see §5).
+Author tool schemas with the `z` re-exported from `@fastagent-sh/fastagent` (as above), not a separately installed `zod` — `defineTool` converts the schema with its own zod, so a single shared copy avoids version-skew surprises. Every type on this surface (`AgentTool`, `Skill`, `Session`, `Model`, …) is re-exported too, so you never import from `@earendil-works/*` (the one exception is a provider's wire-protocol `api`, see §5).
 
 `model` is always a spec string; `fastagent models` (or `listModels`) lists the available ones. `instructions` IS the system prompt — verbatim, no engine persona prepended. (The directory path assembles `AGENTS.md` differently: it adds the pi engine base + skills + env for fidelity with local pi. See [core design §2](design/core.md).)
 
@@ -77,12 +77,12 @@ for await (const e of agent.invoke({ session: "u1" }, { text: "hi" })) {
 }
 
 // (2) buffered JSON — one question, one answer
-import { collect } from "@kid7st/fastagent";
+import { collect } from "@fastagent-sh/fastagent";
 const { text } = await collect(agent.invoke({ session: "u1" }, { text: "hi" }));
 // `collect` throws AgentFailure on a failed turn, and errors if the stream has no terminal event.
 
 // (3) HTTP/SSE — createInvokeHandler is a Fetch handler: mount it in any host route
-import { createInvokeHandler } from "@kid7st/fastagent";
+import { createInvokeHandler } from "@fastagent-sh/fastagent";
 const handler = createInvokeHandler(agent);   // (Request) => Promise<Response>; POST {session,text} → SSE
 ```
 
@@ -100,7 +100,7 @@ Bun.serve({ port: 8787, fetch: (req) =>
   new URL(req.url).pathname === "/chat" ? handler(req) : new Response("not found", { status: 404 }) });
 
 // Plain Node (no native Fetch routing) — the built-in server
-import { serveNode, router } from "@kid7st/fastagent";
+import { serveNode, router } from "@fastagent-sh/fastagent";
 serveNode(router({ "POST /chat": handler }), { port: 8787 });
 ```
 
@@ -145,7 +145,7 @@ Static keys belong in the login file or the environment, not in code — there i
 When you run your own **gateway** or a **self-hosted / OpenAI-compatible** endpoint, register it as a provider; a `model` spec then selects it by id. This is the one case that touches the engine's provider layer — built-in providers cover everything else.
 
 ```ts
-import { createPiAgent, createProvider } from "@kid7st/fastagent";
+import { createPiAgent, createProvider } from "@fastagent-sh/fastagent";
 // the wire-protocol impl comes from pi-ai's api subpath (reuse, don't reimplement)
 import { /* the matching api impl */ } from "@earendil-works/pi-ai/api/openai-responses";
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -20,7 +20,7 @@ fastagent add github
 This creates `channels/github.ts` and appends the required env var to `.env.example` when possible.
 
 ```ts
-import { githubChannel } from "@kid7st/fastagent/github";
+import { githubChannel } from "@fastagent-sh/fastagent/github";
 
 export default githubChannel({
   secret: process.env.GITHUB_WEBHOOK_SECRET ?? "",

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -58,7 +58,7 @@ FastAgent stays a small serving layer, so it never dictates your stack. Capabili
 Use FastAgent as a library, then mount the agent in your own route:
 
 ```ts
-import { createInvokeHandler, createPiAgentFromDefinition } from "@kid7st/fastagent";
+import { createInvokeHandler, createPiAgentFromDefinition } from "@fastagent-sh/fastagent";
 
 const { agent } = await createPiAgentFromDefinition("./agent", {
   model: "openai-codex/gpt-5.5",

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ This guide takes you from an installed CLI to a running local agent service.
 ## Prerequisites
 
 - Node >= 22.19 (`node --version`).
-- FastAgent CLI: `npm i -g @kid7st/fastagent`.
+- FastAgent CLI: `npm i -g @fastagent-sh/fastagent`.
 - Model credentials: run `fastagent login`, or put a provider API key in the workspace `.env`.
 
 List available model specs with:
@@ -120,7 +120,7 @@ Tools are files in `tools/`. The filename is the tool name.
 
 ```ts
 // tools/reverse.ts
-import { defineTool, z } from "@kid7st/fastagent";
+import { defineTool, z } from "@fastagent-sh/fastagent";
 
 export default defineTool({
   description: "Reverse a string.",
@@ -179,7 +179,7 @@ Drop a file in `schedules/` (mirroring `tools/`), named by its filename:
 
 ```ts
 // schedules/daily-digest.ts
-import { defineSchedule } from "@kid7st/fastagent";
+import { defineSchedule } from "@fastagent-sh/fastagent";
 
 export default defineSchedule({
   cron: "0 9 * * *",

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -59,7 +59,7 @@ https://<host>/telegram
 A minimal channel module looks like this:
 
 ```ts
-import { telegramChannel } from "@kid7st/fastagent/telegram";
+import { telegramChannel } from "@fastagent-sh/fastagent/telegram";
 
 export default telegramChannel({
   secretToken: process.env.TELEGRAM_SECRET_TOKEN ?? "",
@@ -95,7 +95,7 @@ A group answers one shared `chat[:thread]` session: everyone talks to the same a
 The buffer needs Telegram **group privacy mode off** (@BotFather → `/setprivacy` → Disable) to receive un-summoned messages at all. The channel resolves the bot's privacy flag once at startup and warns when it is on.
 
 ```ts
-import { defaultTelegramRoute, telegramChannel, telegramEnvelope } from "@kid7st/fastagent/telegram";
+import { defaultTelegramRoute, telegramChannel, telegramEnvelope } from "@fastagent-sh/fastagent/telegram";
 
 const botUsername = "my_bot";
 

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Key facts:
 
-- Install: `npm i -g @kid7st/fastagent` (CLI) or `npm i @kid7st/fastagent` (library). Requires Node >= 22.19 (also runs under Bun).
+- Install: `npm i -g @fastagent-sh/fastagent` (CLI) or `npm i @fastagent-sh/fastagent` (library). Requires Node >= 22.19 (also runs under Bun).
 - The directory is the agent: optional `AGENTS.md`, `skills/`, `tools/`, `channels/`, markdown context, and `fastagent.config.*`. No framework rewrite, no build step.
 - The contract is `invoke(scope, prompt) => AsyncIterable<AgentEvent>` (the Agent Handler SPEC).
 - Core CLI: `fastagent init | info | dev | chat | invoke | tool | start | add | login`.
@@ -12,32 +12,32 @@ Key facts:
 
 ## Start here
 
-- [README](https://raw.githubusercontent.com/kid7st/fastagent/main/README.md): project overview, install, quickstart, features.
-- [AI-guided setup prompt](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/ai-start.md): paste into a coding agent to scaffold or wire a workspace.
-- [Documentation index](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/README.md): the full doc map.
+- [README](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/README.md): project overview, install, quickstart, features.
+- [AI-guided setup prompt](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/ai-start.md): paste into a coding agent to scaffold or wire a workspace.
+- [Documentation index](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/README.md): the full doc map.
 
 ## Guides
 
-- [Overview](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/overview.md): what FastAgent is and is not.
-- [Quickstart](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/quickstart.md): scaffold, run locally, add a tool, and start.
-- [Configuration](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/configuration.md): model, auth, ports, sessions, tools, and channels.
-- [CLI reference](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/cli.md): every command and flag.
-- [Embedding](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/embedding.md): use FastAgent as a library inside your own app.
-- [Channels](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/channels.md): add webhook/bot channels.
-- [GitHub channel](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/github.md): GitHub webhook events.
-- [Telegram channel](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/telegram.md): Telegram bot.
-- [Channel development](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/channel-development.md): build a custom channel adapter.
-- [Deploy](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/deploy.md): ship the directory to Fly, Railway, or any Docker host.
-- [Troubleshooting](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/troubleshooting.md): common setup/runtime issues.
+- [Overview](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/overview.md): what FastAgent is and is not.
+- [Quickstart](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/quickstart.md): scaffold, run locally, add a tool, and start.
+- [Configuration](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/configuration.md): model, auth, ports, sessions, tools, and channels.
+- [CLI reference](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/cli.md): every command and flag.
+- [Embedding](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/embedding.md): use FastAgent as a library inside your own app.
+- [Channels](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/channels.md): add webhook/bot channels.
+- [GitHub channel](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/github.md): GitHub webhook events.
+- [Telegram channel](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/telegram.md): Telegram bot.
+- [Channel development](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/channel-development.md): build a custom channel adapter.
+- [Deploy](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/deploy.md): ship the directory to Fly, Railway, or any Docker host.
+- [Troubleshooting](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/troubleshooting.md): common setup/runtime issues.
 
 ## Reference
 
-- [API reference](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/api-reference.md): public TypeScript exports.
-- [Agent Handler SPEC](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/SPEC.md): the v0.1 protocol contract.
-- [Design principles](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/principles.md): design choices, core primitives, and non-goals.
+- [API reference](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/api-reference.md): public TypeScript exports.
+- [Agent Handler SPEC](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/SPEC.md): the v0.1 protocol contract.
+- [Design principles](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/principles.md): design choices, core primitives, and non-goals.
 
 ## Optional
 
-- [Core design notes](https://raw.githubusercontent.com/kid7st/fastagent/main/docs/design/core.md): pi reference implementation architecture.
-- [Contributing](https://raw.githubusercontent.com/kid7st/fastagent/main/CONTRIBUTING.md): branch model, PR loop, and review tiers.
-- [Security policy](https://raw.githubusercontent.com/kid7st/fastagent/main/SECURITY.md): how to report a vulnerability.
+- [Core design notes](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/design/core.md): pi reference implementation architecture.
+- [Contributing](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/CONTRIBUTING.md): branch model, PR loop, and review tiers.
+- [Security policy](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/SECURITY.md): how to report a vulnerability.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@kid7st/fastagent",
-  "version": "0.10.3",
+  "name": "@fastagent-sh/fastagent",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@kid7st/fastagent",
-      "version": "0.10.3",
+      "name": "@fastagent-sh/fastagent",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kid7st/fastagent",
+  "name": "@fastagent-sh/fastagent",
   "version": "0.11.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
@@ -14,14 +14,14 @@
     "fastagent"
   ],
   "license": "MIT",
-  "author": "the fastagent authors (https://github.com/kid7st/fastagent)",
-  "homepage": "https://github.com/kid7st/fastagent#readme",
+  "author": "the fastagent authors (https://github.com/fastagent-sh/fastagent)",
+  "homepage": "https://github.com/fastagent-sh/fastagent#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kid7st/fastagent.git"
+    "url": "git+https://github.com/fastagent-sh/fastagent.git"
   },
   "bugs": {
-    "url": "https://github.com/kid7st/fastagent/issues"
+    "url": "https://github.com/fastagent-sh/fastagent/issues"
   },
   "type": "module",
   "sideEffects": false,

--- a/src/channels/github/scaffold/channel.ts
+++ b/src/channels/github/scaffold/channel.ts
@@ -1,4 +1,4 @@
-import { githubChannel } from "@kid7st/fastagent/github";
+import { githubChannel } from "@fastagent-sh/fastagent/github";
 
 // A channel = a third-party ADAPTER (githubChannel: verify + parse + ACK) configured with YOUR on() policy.
 // fastagent discovers this file under channels/, mounts POST /webhook, and pipes the agent to the

--- a/src/channels/telegram/scaffold/channel.ts
+++ b/src/channels/telegram/scaffold/channel.ts
@@ -1,4 +1,4 @@
-import { telegramChannel } from "@kid7st/fastagent/telegram";
+import { telegramChannel } from "@fastagent-sh/fastagent/telegram";
 
 // A channel = a third-party ADAPTER (telegramChannel: verify + run + reply) configured with YOUR policy.
 // fastagent discovers this file under channels/, mounts POST /telegram, and pipes the agent + state

--- a/src/channels/telegram/scaffold/telegram-send.ts
+++ b/src/channels/telegram/scaffold/telegram-send.ts
@@ -1,4 +1,4 @@
-import { defineTool, z } from "@kid7st/fastagent";
+import { defineTool, z } from "@fastagent-sh/fastagent";
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -19,7 +19,7 @@
  * Threaded Mode (topics in private chats, a @BotFather toggle) is auto-adapted: an update carrying
  * message_thread_id replies into that thread; without one the chat is linear. Same code, both modes.
  *
- * Authored against the public `@kid7st/fastagent` surface only (the contract + the channel-authoring
+ * Authored against the public `@fastagent-sh/fastagent` surface only (the contract + the channel-authoring
  * kit: readBodyCapped / text), so it is exactly what a third-party `fastagent-channel-*` package would write.
  */
 import { timingSafeEqual } from "node:crypto";
@@ -51,7 +51,7 @@ import { type Target, callApi, editMessageText, sendMessage } from "./telegram-a
 import { createTurnQueue } from "./turn-queue.ts";
 import { type StoredTurn, createTurnStore } from "./turn-store.ts";
 
-// Re-export the public surface authored elsewhere, so `@kid7st/fastagent/telegram` keeps one entry point.
+// Re-export the public surface authored elsewhere, so `@fastagent-sh/fastagent/telegram` keeps one entry point.
 export { defaultTelegramRoute, telegramEnvelope };
 export type { TelegramFailure, TelegramMessage, TelegramRoute, TelegramUpdate };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -671,7 +671,7 @@ async function runAdd(): Promise<void> {
   // The kit's manifest lives in channelHome (agentDir when set) — point the install there, not the run root.
   const installCmd = channelHome === target ? install : `(cd ${relative(target, channelHome)} && ${install})`;
   console.error(`  next steps:`);
-  console.error(`    ${installCmd}                      # if @kid7st/fastagent is not installed yet`);
+  console.error(`    ${installCmd}                      # if @fastagent-sh/fastagent is not installed yet`);
   for (const e of env) {
     if (dotEnv?.alreadySet.includes(e.name)) continue; // the user already has it — nothing to do
     if (dotEnv?.written.includes(e.name)) {

--- a/src/deploy/container.ts
+++ b/src/deploy/container.ts
@@ -57,7 +57,7 @@ function kitDockerfile(input: ContainerInput, kit: string): string {
     return `${GENERATED_DOCKERFILE_MARKER}. Repo-as-workspace: the whole repo is the agent's cwd; the kit lives in ${kit}/.
 FROM node:22-slim
 ${apt}WORKDIR /app
-RUN npm i -g @kid7st/fastagent@${input.version}
+RUN npm i -g @fastagent-sh/fastagent@${input.version}
 COPY . .
 CMD ["fastagent", "start", "/app"]
 `;
@@ -111,7 +111,7 @@ function dockerfile(input: ContainerInput): string {
 # npm-based (a markdown/skills agent installs the pinned CLI globally; node:22-slim has npm).
 FROM node:22-slim
 ${apt}WORKDIR /app
-RUN npm i -g @kid7st/fastagent@${input.version}
+RUN npm i -g @fastagent-sh/fastagent@${input.version}
 COPY . .
 CMD ["fastagent", "start", "/app"]
 `;

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -162,11 +162,11 @@ export async function preflightDeploy(input: {
   }
   // The code-path Dockerfile runs `${runner}`: that resolves the workspace's OWN dependency, so a
   // package.json missing it would make the CONTAINER fetch an unpinned build at runtime (offline-fragile).
-  if (hasPackageJson && !("@kid7st/fastagent" in { ...pkg.dependencies, ...pkg.devDependencies })) {
+  if (hasPackageJson && !("@fastagent-sh/fastagent" in { ...pkg.dependencies, ...pkg.devDependencies })) {
     messages.push({
       level: "warn",
       text:
-        `package.json does not list @kid7st/fastagent — the image's \`${runner}\` would fetch it at runtime ` +
+        `package.json does not list @fastagent-sh/fastagent — the image's \`${runner}\` would fetch it at runtime ` +
         `(offline-fragile, unpinned). Add it to dependencies and re-run \`${install}\`.`,
     });
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,4 @@
-/** `@kid7st/fastagent/github` — the GitHub channel subpath export, kept off the root surface. */
+/** `@fastagent-sh/fastagent/github` — the GitHub channel subpath export, kept off the root surface. */
 export {
   githubChannel,
   type GithubChannelOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,11 @@ export { collect, AgentFailure, type CollectResult } from "./collect.ts";
 
 // Channels (N-side; consume only the Agent contract). createInvokeHandler is Fetch-shaped so it
 // mounts in any host route; nodeListener bridges it onto node:http. The GitHub channel is a subpath
-// export: `@kid7st/fastagent/github`.
+// export: `@fastagent-sh/fastagent/github`.
 export { createInvokeHandler, nodeListener } from "./channels/http.ts";
 // Channel-authoring kit: an adapter (built-in, or a third-party `fastagent-channel-*` package) needs
 // these to read a capped request body and build plain responses — so it depends only on
-// @kid7st/fastagent. `collect` (below) drives the turn; `Routes`/`ChannelHandler` (host) type the return.
+// @fastagent-sh/fastagent. `collect` (below) drives the turn; `Routes`/`ChannelHandler` (host) type the return.
 export { readBodyCapped } from "./channels/body.ts";
 export { text, textHeaders } from "./channels/respond.ts";
 

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -249,7 +249,11 @@ export async function assertChannelReady(dir: string): Promise<void> {
   }
   if (typeof pkg.dependencies?.["@fastagent-sh/fastagent"] !== "string") {
     const add =
-      detectRuntime(dir, pkg).runtime === "bun" ? "bun add @fastagent-sh/fastagent" : "npm install @fastagent-sh/fastagent";
-    throw new Error(`${pkgPath}: @fastagent-sh/fastagent is not a dependency — run \`${add}\` (the channel file imports it)`);
+      detectRuntime(dir, pkg).runtime === "bun"
+        ? "bun add @fastagent-sh/fastagent"
+        : "npm install @fastagent-sh/fastagent";
+    throw new Error(
+      `${pkgPath}: @fastagent-sh/fastagent is not a dependency — run \`${add}\` (the channel file imports it)`,
+    );
   }
 }

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -218,7 +218,7 @@ export async function scaffoldChannel(dir: string, kind: ChannelKind): Promise<s
 
 /**
  * Verify the workspace is ready to host a channel: an ESM package.json that declares
- * `@kid7st/fastagent` (the channel file imports it). `add` checks and guides, never bootstraps — that
+ * `@fastagent-sh/fastagent` (the channel file imports it). `add` checks and guides, never bootstraps — that
  * is `init`'s job.
  */
 export async function assertChannelReady(dir: string): Promise<void> {
@@ -232,7 +232,7 @@ export async function assertChannelReady(dir: string): Promise<void> {
       // workspace exists yet; a kit missing its manifest (e.g. a --minimal init) needs the manifest, not init.
       throw new Error(
         `${dir}: no package.json — a channel adapter is code and needs the kit's own manifest. ` +
-          `Run \`fastagent init\` for a fresh workspace, or add a package.json with @kid7st/fastagent there ` +
+          `Run \`fastagent init\` for a fresh workspace, or add a package.json with @fastagent-sh/fastagent there ` +
           `(a --minimal init has none)`,
       );
     }
@@ -247,9 +247,9 @@ export async function assertChannelReady(dir: string): Promise<void> {
   if (pkg.type !== "module") {
     throw new Error(`${pkgPath}: fastagent channels are ESM — set "type": "module"`);
   }
-  if (typeof pkg.dependencies?.["@kid7st/fastagent"] !== "string") {
+  if (typeof pkg.dependencies?.["@fastagent-sh/fastagent"] !== "string") {
     const add =
-      detectRuntime(dir, pkg).runtime === "bun" ? "bun add @kid7st/fastagent" : "npm install @kid7st/fastagent";
-    throw new Error(`${pkgPath}: @kid7st/fastagent is not a dependency — run \`${add}\` (the channel file imports it)`);
+      detectRuntime(dir, pkg).runtime === "bun" ? "bun add @fastagent-sh/fastagent" : "npm install @fastagent-sh/fastagent";
+    throw new Error(`${pkgPath}: @fastagent-sh/fastagent is not a dependency — run \`${add}\` (the channel file imports it)`);
   }
 }

--- a/src/scaffold/init.ts
+++ b/src/scaffold/init.ts
@@ -290,7 +290,7 @@ export async function scaffoldWorkspace(dir: string, options: ScaffoldOptions = 
       const kitAbs = join(dir, kit);
       const add = detectRuntime(kitAbs, await readPackageJson(kitAbs)).runtime === "bun" ? "bun add" : "npm install";
       warnings.push(
-        `kept the existing ${keptPkg} — run \`${add} @kid7st/fastagent zod\` there so the example tool resolves`,
+        `kept the existing ${keptPkg} — run \`${add} @fastagent-sh/fastagent zod\` there so the example tool resolves`,
       );
     }
   } catch (error) {

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -3,7 +3,7 @@
  * workspace, plus the parametric pieces. Base workspace templates live under ./templates/; each
  * channel's bundle lives WITH the channel at ../channels/<kind>/scaffold/ (so a channel owns its
  * starter kit and could ship as its own package). Both trees are excluded from this package's tsc +
- * biome (they import the published @kid7st/fastagent, not this source) and copied into dist/ by the build.
+ * biome (they import the published @fastagent-sh/fastagent, not this source) and copied into dist/ by the build.
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { basename, resolve } from "node:path";
@@ -47,14 +47,14 @@ export const channelBundleFiles = (kind: string): string[] =>
   readdirSync(channelScaffoldDir(kind)).filter((f) => f.endsWith(".ts"));
 
 /** package.json for the complete agent: ESM + the deps a defineTool tool imports. The
- *  @kid7st/fastagent range tracks THIS build's version, so a fresh workspace installs an API-matching version. */
+ *  @fastagent-sh/fastagent range tracks THIS build's version, so a fresh workspace installs an API-matching version. */
 export function packageJson(name: string, version: string): string {
   return `${JSON.stringify(
     {
       name,
       private: true,
       type: "module",
-      dependencies: { "@kid7st/fastagent": `^${version}`, zod: "^4.0.0" },
+      dependencies: { "@fastagent-sh/fastagent": `^${version}`, zod: "^4.0.0" },
     },
     null,
     2,

--- a/src/scaffold/templates/tools/fetch-url.ts
+++ b/src/scaffold/templates/tools/fetch-url.ts
@@ -1,4 +1,4 @@
-import { defineTool, z } from "@kid7st/fastagent";
+import { defineTool, z } from "@fastagent-sh/fastagent";
 
 // A code tool: filename (fetch-url.ts) is the tool name. tools/ is auto-discovered,
 // so it needs no registration in fastagent.config. Test it without a model:

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,4 +1,4 @@
-/** `@kid7st/fastagent/telegram` — the Telegram bot channel subpath export, kept off the root surface. */
+/** `@fastagent-sh/fastagent/telegram` — the Telegram bot channel subpath export, kept off the root surface. */
 export {
   telegramChannel,
   defaultTelegramRoute,

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 /**
- * This build's own @kid7st/fastagent version. THROWS if unreadable — the version is load-bearing for
+ * This build's own @fastagent-sh/fastagent version. THROWS if unreadable — the version is load-bearing for
  * the scaffolded dependency range (`^${version}`), so init must never scaffold an uninstallable `^0.0.0`.
  */
 export async function fastagentVersion(): Promise<string> {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -182,7 +182,7 @@ describe("cli papercuts", () => {
   });
 
   it("info degrades when a tool can't load (missing dep) — reports it, still shows the surface, exits 0", async () => {
-    // The scaffold ships tools/ that import @kid7st/fastagent; before `npm install` the import fails.
+    // The scaffold ships tools/ that import @fastagent-sh/fastagent; before `npm install` the import fails.
     // A broken tool file is ISOLATED (skipped + reported, not thrown) so it can't crash the load — info
     // reports it, and dev/start degrade the SAME way (G2): the agent keeps serving without that one tool.
     const dir = await mkdtemp(join(tmpdir(), "fa-info-toolfail-"));

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -89,7 +89,7 @@ describe("deploy/fly: planFlyDeploy", () => {
 
   it("pins the global-install Dockerfile to the current version for a pure markdown agent", () => {
     const docker = dockerfile(planFlyDeploy({ ...base, modelAuth: undefined, channels: [], hasPackageJson: false }));
-    expect(docker).toContain("npm i -g @kid7st/fastagent@9.9.9");
+    expect(docker).toContain("npm i -g @fastagent-sh/fastagent@9.9.9");
     expect(docker).not.toContain("npm ci");
   });
 
@@ -106,7 +106,7 @@ describe("deploy/fly: planFlyDeploy", () => {
     );
     expect(docker).toContain("FROM node:22-slim"); // never oven/bun — the global npm i -g needs npm
     expect(docker).not.toContain("oven/bun");
-    expect(docker).toContain("npm i -g @kid7st/fastagent");
+    expect(docker).toContain("npm i -g @fastagent-sh/fastagent");
   });
 
   it("kit layout (kitDir): artifacts namespaced under the kit, kit deps installed, .git shipped, explicit deploy flags", () => {
@@ -162,7 +162,7 @@ describe("deploy/fly: planFlyDeploy", () => {
     });
     const mdDf = md.artifacts.find((a) => a.path === "agent/Dockerfile")?.content ?? "";
     expect(mdDf).toContain("FROM node:22-slim");
-    expect(mdDf).toContain("npm i -g @kid7st/fastagent@9.9.9"); // pinned global — no kit deps to install
+    expect(mdDf).toContain("npm i -g @fastagent-sh/fastagent@9.9.9"); // pinned global — no kit deps to install
     expect(mdDf).not.toContain("npm ci");
     expect(mdDf).toContain(`["fastagent", "start", "/app"]`);
   });

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -37,7 +37,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     const dir = await workspace({ "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n` });
     const agentDir = join(dir, "agent");
     await mkdir(agentDir, { recursive: true });
-    await writeFile(join(agentDir, "package.json"), `{"type":"module","dependencies":{"@kid7st/fastagent":"^1"}}`);
+    await writeFile(join(agentDir, "package.json"), `{"type":"module","dependencies":{"@fastagent-sh/fastagent":"^1"}}`);
 
     // --run: gated with an actionable message (the run drivers don't speak the layout yet).
     const gated = await call(dir, { model: "openai/gpt-4o-mini" }, { agentDir, run: true });
@@ -144,7 +144,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     expect(wake.ok && wake.hasTimeTriggers).toBe(true);
   });
 
-  it("warns a code workspace with no lockfile and no @kid7st/fastagent dep", async () => {
+  it("warns a code workspace with no lockfile and no @fastagent-sh/fastagent dep", async () => {
     const dir = await workspace({ "package.json": JSON.stringify({ name: "a", type: "module" }) });
     const pre = await call(dir, { model: "openai/gpt-4o-mini" });
     expect(pre.ok).toBe(true);
@@ -152,6 +152,6 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     expect(pre.messages.some((m) => /no package-lock\.json/.test(m.text) || /not reproducible/.test(m.text))).toBe(
       true,
     );
-    expect(pre.messages.some((m) => /does not list @kid7st\/fastagent/.test(m.text))).toBe(true);
+    expect(pre.messages.some((m) => /does not list @fastagent-sh\/fastagent/.test(m.text))).toBe(true);
   });
 });

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -37,7 +37,10 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     const dir = await workspace({ "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n` });
     const agentDir = join(dir, "agent");
     await mkdir(agentDir, { recursive: true });
-    await writeFile(join(agentDir, "package.json"), `{"type":"module","dependencies":{"@fastagent-sh/fastagent":"^1"}}`);
+    await writeFile(
+      join(agentDir, "package.json"),
+      `{"type":"module","dependencies":{"@fastagent-sh/fastagent":"^1"}}`,
+    );
 
     // --run: gated with an actionable message (the run drivers don't speak the layout yet).
     const gated = await call(dir, { model: "openai/gpt-4o-mini" }, { agentDir, run: true });

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -77,9 +77,9 @@ describe("init: scaffoldWorkspace", () => {
         version: string;
       }
     ).version;
-    expect(pkg.dependencies["@kid7st/fastagent"]).toBe(`^${realVersion}`);
+    expect(pkg.dependencies["@fastagent-sh/fastagent"]).toBe(`^${realVersion}`);
     expect(pkg.dependencies.zod).toBeDefined();
-    expect(await readFile(join(dir, "tools", "fetch-url.ts"), "utf8")).toContain('from "@kid7st/fastagent"');
+    expect(await readFile(join(dir, "tools", "fetch-url.ts"), "utf8")).toContain('from "@fastagent-sh/fastagent"');
 
     // persona.md + the bundled skill load as a definition offline (loadAgentDefinition does not touch
     // tools/). No AGENTS.md is scaffolded — a fresh agent has no project context (② empty).
@@ -434,7 +434,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     const dir = await freshDir();
     await writeFile(
       join(dir, "package.json"),
-      `${JSON.stringify({ type: "module", dependencies: { "@kid7st/fastagent": "^0.4.0" } }, null, 2)}\n`,
+      `${JSON.stringify({ type: "module", dependencies: { "@fastagent-sh/fastagent": "^0.4.0" } }, null, 2)}\n`,
     );
     return dir;
   }
@@ -446,7 +446,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     await mkdir(join(dir, "agent"), { recursive: true });
     await writeFile(
       join(dir, "agent", "package.json"),
-      `${JSON.stringify({ type: "module", dependencies: { "@kid7st/fastagent": "^0.4.0" } }, null, 2)}\n`,
+      `${JSON.stringify({ type: "module", dependencies: { "@fastagent-sh/fastagent": "^0.4.0" } }, null, 2)}\n`,
     );
 
     const out = await cliInit(["add", "telegram"], dir);
@@ -465,14 +465,14 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     expect(out).toContain("channels/github.ts");
 
     const src = await readFile(join(dir, "channels", "github.ts"), "utf8");
-    expect(src).toContain('from "@kid7st/fastagent/github"'); // the third-party adapter
+    expect(src).toContain('from "@fastagent-sh/fastagent/github"'); // the third-party adapter
     expect(src).toContain("POST /webhook");
     expect(src).toContain("on:"); // the app glue stub the user edits
 
     // add does NOT bootstrap: package.json is untouched and no .npmrc/.gitignore is written.
     expect(JSON.parse(await readFile(join(dir, "package.json"), "utf8"))).toEqual({
       type: "module",
-      dependencies: { "@kid7st/fastagent": "^0.4.0" },
+      dependencies: { "@fastagent-sh/fastagent": "^0.4.0" },
     });
     expect(await exists(join(dir, ".npmrc"))).toBe(false);
 
@@ -488,13 +488,13 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     const out = await cliInit(["add", "telegram"], dir);
     expect(out).toContain("channels/telegram.ts");
     const src = await readFile(join(dir, "channels", "telegram.ts"), "utf8");
-    expect(src).toContain('from "@kid7st/fastagent/telegram"'); // the adapter
+    expect(src).toContain('from "@fastagent-sh/fastagent/telegram"'); // the adapter
     expect(src).toContain("POST /telegram");
     expect(src).toContain("telegramChannel({"); // policy-only glue (agent/stateDir arrive via ctx)
     expect(src).not.toContain("sendDocument"); // the channel file is the channel, NOT the send-tool (no misroute)
     // the companion tool lands in tools/ by the bundle convention (so the agent can send files back)
     const sendTool = await readFile(join(dir, "tools", "telegram-send.ts"), "utf8");
-    expect(sendTool).toContain('from "@kid7st/fastagent"');
+    expect(sendTool).toContain('from "@fastagent-sh/fastagent"');
     expect(sendTool).toContain("sendDocument");
     expect(sendTool).toContain("sendMessage"); // text mode too — the delivery path for scheduled/woken turns
     // next steps carry this channel's env vars (with hints), not github's
@@ -614,7 +614,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
           await writeFile(join(d, "package.json"), `${JSON.stringify({ type: "module" }, null, 2)}\n`);
           return d;
         },
-        /@kid7st\/fastagent is not a dependency.*npm install/, // ESM but missing the dep (node → npm hint)
+        /@fastagent-sh\/fastagent is not a dependency.*npm install/, // ESM but missing the dep (node → npm hint)
       ],
     ];
     for (const [make, msg] of cases) {

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
  * Guards the embed/CLI dependency boundary so a future package split stays a packaging change, not a
  * refactor: the public embed entry (index.ts) must never statically pull a CLI-only dependency.
  *
- * "Statically" = what gets eval-loaded when you `import "@kid7st/fastagent"`. We walk the relative
+ * "Statically" = what gets eval-loaded when you `import "@fastagent-sh/fastagent"`. We walk the relative
  * import graph from an entry and collect the bare package specifiers reachable through STATIC
  * `import`/`export … from`. Lazy `await import("pkg")` is intentionally excluded (e.g. giget stays
  * lazy in init.ts) — that is the whole point of keeping it lazy.

--- a/test/telegram-send-tool.test.ts
+++ b/test/telegram-send-tool.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 
 // The scaffolded send tool is real shipped code — its mode switch is the delivery path for
 // scheduled/woken turns, so the branches get real executions here. The template stays DATA to tsc
-// (excluded from the program — it imports the published "@kid7st/fastagent", unresolvable in-repo), so
+// (excluded from the program — it imports the published "@fastagent-sh/fastagent", unresolvable in-repo), so
 // it is loaded via a non-literal dynamic import; vitest's alias resolves that name to today's source.
 
 type RawExecute = (id: string, params: unknown) => Promise<{ details: unknown }>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
   "include": ["src", "test"],
   // Scaffold payload: real template files copied verbatim into a new workspace (base kit under
   // src/scaffold/templates, per-channel bundles under src/channels/*/scaffold). They import the
-  // published @kid7st/fastagent, not this source, so they are data here, not part of the build.
+  // published @fastagent-sh/fastagent, not this source, so they are data here, not part of the build.
   "exclude": ["src/scaffold/templates", "src/channels/*/scaffold"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,11 +14,11 @@ import { defineConfig } from "vitest/config";
 // `pool: "forks"` is explicit, not left to the default: it is the process isolation these
 // subprocess / process.env tests assume.
 export default defineConfig({
-  // Scaffold templates import the PUBLISHED "@kid7st/fastagent" (they are copied verbatim into user
+  // Scaffold templates import the PUBLISHED "@fastagent-sh/fastagent" (they are copied verbatim into user
   // workspaces — data to tsc, excluded from the program). Tests that EXECUTE a template resolve that
   // name to the current source instead: truer than dist/ (asserts the template against today's
   // defineTool), and dist/ doesn't exist on CI anyway.
-  resolve: { alias: { "@kid7st/fastagent": new URL("./src/index.ts", import.meta.url).pathname } },
+  resolve: { alias: { "@fastagent-sh/fastagent": new URL("./src/index.ts", import.meta.url).pathname } },
   test: {
     pool: "forks",
     testTimeout: 30000,


### PR DESCRIPTION
chore: rename package to @fastagent-sh/fastagent

Move the npm scope from the personal @kid7st to the fastagent-sh org and
point repo URLs at github.com/fastagent-sh/fastagent, ahead of the repo
transfer and first public release.

Renames the npm package from `fastagent` to the scoped `@fastagent-sh/fastagent` across package.json, source, docs, templates, and scaffold output. The bare `fastagent` name on npm belongs to an unrelated third-party package; the scoped name is ours.

Rebased onto current main; typecheck + 553 tests green locally.