### PR TITLE
docs: DX audit cleanup — persona semantics, state-root guidance, login footguns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ status: current
 
 # FastAgent documentation
 
-FastAgent is the serving layer for local agent directories. It takes a directory out of the terminal and turns it into a running service: embedded in your app, connected to Telegram, handling GitHub/webhook events, exposed as an API endpoint, or running behind your own channel. `AGENTS.md` is recommended for identity, but the directory is the unit.
+FastAgent is the serving layer for local agent directories. It takes a directory out of the terminal and turns it into a running service: embedded in your app, connected to Telegram, handling GitHub/webhook events, exposed as an API endpoint, or running behind your own channel. `persona.md` is recommended for identity (an `AGENTS.md` is project context the agent reads), but the directory is the unit.
 
 ## Recommended path
 
@@ -47,7 +47,7 @@ Using a coding agent? Give it the repository's [`ai-start.md`](ai-start.md) for 
 
 ## Core concepts
 
-- **The directory is the agent.** Runtime behavior comes from the workspace: optional `AGENTS.md`, `skills/`, `tools/`, `channels/`, and markdown context.
+- **The directory is the agent.** Runtime behavior comes from the workspace: optional `persona.md` (identity), `skills/`, `tools/`, `channels/`, `schedules/`, `AGENTS.md` (project context), and markdown context.
 - **`invoke` is the contract.** Every channel or host drives an `Agent` through `invoke(scope, prompt) => AsyncIterable<AgentEvent>`.
 - **Channels are adapters.** A channel receives external events (HTTP, GitHub, Telegram, Slack, …), maps them to one or more agent turns, and returns host-specific responses.
 - **Hosts own runtime state.** Sessions, credentials, execution environment, and locking are runtime concerns, not part of the agent definition.

--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -16,9 +16,12 @@ FastAgent mental model:
 
 How you run FastAgent commands (you are a non-interactive agent, so this matters):
 - A model must be set EXPLICITLY. With no model, `dev`/`start`/`invoke` fall back to an interactive
-  picker you cannot answer, and fail with `missing model`. So: run `fastagent login` (ask me which
-  provider first), list specs with `fastagent models`, then ALWAYS pass `--model provider/id` (or set
-  FASTAGENT_MODEL, or write `model:` into fastagent.config.*). Never rely on the interactive prompt.
+  picker you cannot answer, and fail with `missing model`. Credentials first: `fastagent login` is
+  ALSO interactive (menus + a browser) and fails fast in a non-TTY — so ask ME to run it in a
+  terminal, INSIDE the workspace (it writes the project-level .fastagent/auth.json; a login run in
+  another directory is invisible here). Or ask me for a provider API key and put it in `.env`. Then
+  list specs with `fastagent models`, and ALWAYS pass `--model provider/id` (or set FASTAGENT_MODEL,
+  or write `model:` into fastagent.config.*). Never rely on an interactive prompt.
 - Some commands EXIT, others BLOCK. `info`, `models`, `invoke`, `tool` return — use these for checks
   and smoke tests. `dev` and `start` are long-running servers: do NOT run them in the foreground (you
   will hang waiting) — background them, or let me run them.
@@ -37,7 +40,7 @@ Set up (run init ONCE per directory — it refuses an already-initialized worksp
   as project context, and refuses a dir that already has a fastagent.config.* (already a workspace).
 - Layout is decided automatically: flat by default; if an existing toolchain/deploy claims the dir
   (tsconfig/framework config, a non-JS build manifest like go.mod/pyproject.toml/Cargo.toml,
-  Dockerfile/fly/railway, occupied tools//channels//skills/), the kit goes
+  Dockerfile/fly/railway, occupied tools/, channels/, or skills/), the kit goes
   into ./agent with config.agentDir pointing there — init prints the reason. Override on the FIRST
   run: --flat / --agent-dir <name> (a re-run is refused once the config exists). To change the layout
   afterwards: move the kit files yourself and update (or remove) config.agentDir to match.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -117,12 +117,12 @@ Common options:
 
 | Option | Meaning |
 |---|---|
-| `model` | Required `provider/modelId` spec. |
+| `model` | Required `provider/modelId` spec (an `AnyModel` object is also accepted). |
 | `instructions` | String or function returning the system prompt. |
 | `tools` | Agent tools. |
 | `skills` | Loaded Agent Skills. |
 | `sessions` | `PiSessionStore`. |
-| `env` | Tool execution environment. |
+| `env` | Tool execution environment (`ExecutionEnv`). |
 | `lease` | Same-session concurrency lease. |
 | `providers` | Extra model providers. |
 
@@ -137,7 +137,7 @@ function createPiAgentFromDefinition(
 
 Load `persona.md`/`skills/` from `dir` (the agent-definition dir) and assemble the pi prompt. `②` project context is sourced via pi's `loadProjectContextFiles({ cwd, agentDir: dir })` — the dir's own `AGENTS.md` plus every `AGENTS.md` walking `cwd` (option; default `dir`) up to root. Pass `cwd` to decouple the run/working directory (where tools operate, whose repo `AGENTS.md` is context) from the definition dir.
 
-`LoadedDefinition` carries `contextFiles: Array<{ path; content }>` (the ② files), `persona?` (from `persona.md`, ①), `skills`, and diagnostics/collisions.
+`LoadedDefinition` carries `contextFiles: Array<{ path; content }>` (the ② files), `persona?` (from `persona.md`, ①), `skills`, and diagnostics/collisions (`SkillDiagnostic[]` / `SkillCollision[]` — both exported).
 
 ### `createPiAgentFromWorkspace`
 
@@ -225,6 +225,7 @@ interface Schedule {
 }
 function defineSchedule(schedule: Schedule): Schedule;
 function loadSchedules(dir: string): Promise<{ schedules: LoadedSchedule[]; failures: ModuleLoadFailure[] }>;
+function discoverScheduleFiles(dir: string): Promise<string[]>; // the schedules/ file paths, without importing
 function createScheduler(opts: SchedulerOptions): Scheduler; // { start(): void; stop(): void }
 function scheduleSession(name: string): string; // the derived stable session id
 ```
@@ -278,6 +279,17 @@ function resolveModel(models: Models, spec: string): Model;
 function createPiModels(options?: CreatePiModelsOptions): Models;
 function probeAuthSource(models: Models, spec: string): Promise<string | undefined>;
 ```
+
+Auth:
+
+```ts
+const GLOBAL_AUTH_PATH: string; // ~/.fastagent/auth.json — the cross-project share target
+function fastagentCredentialStore(authPath?: string, options?: FastagentAuthOptions): CredentialStore;
+```
+
+`fastagent login` writes the **project-level** `<state root>/auth.json` by default; `GLOBAL_AUTH_PATH`
+is `createPiModels`'s default when no `authPath` is passed, and the explicit one-file share target
+(`FASTAGENT_AUTH_PATH=~/.fastagent/auth.json`).
 
 Provider injection:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -225,7 +225,8 @@ interface Schedule {
 }
 function defineSchedule(schedule: Schedule): Schedule;
 function loadSchedules(dir: string): Promise<{ schedules: LoadedSchedule[]; failures: ModuleLoadFailure[] }>;
-function discoverScheduleFiles(dir: string): Promise<string[]>; // the schedules/ file paths, without importing
+function discoverScheduleFiles(dir: string): Promise<string[]>; // existence probe: file basenames, no import
+// (deploy preflight's time-trigger detection; prefer loadSchedules to also surface broken files)
 function createScheduler(opts: SchedulerOptions): Scheduler; // { start(): void; stop(): void }
 function scheduleSession(name: string): string; // the derived stable session id
 ```
@@ -289,7 +290,9 @@ function fastagentCredentialStore(authPath?: string, options?: FastagentAuthOpti
 
 `fastagent login` writes the **project-level** `<state root>/auth.json` by default; `GLOBAL_AUTH_PATH`
 is `createPiModels`'s default when no `authPath` is passed, and the explicit one-file share target
-(`FASTAGENT_AUTH_PATH=~/.fastagent/auth.json`).
+(`FASTAGENT_AUTH_PATH=~/.fastagent/auth.json`). Note the two defaults differ: an embedder calling
+`createPiModels()` bare reads the global file, not a project-level `login` — pass `authPath` explicitly
+to read the project's credential (the `createPiAgentFrom*` openers already do).
 
 Provider injection:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,7 +43,7 @@ fastagent init [dir] [--minimal] [--no-install] [--flat] [--agent-dir <name>]
 
 Creates a self-iterating agent — the directory is the agent, and it can edit its own definition (persona.md and skills are re-read every turn). A fresh workspace has `persona.md` (the agent's identity: how to improve yourself), a `writing-great-skills` example skill (from [mattpocock/skills](https://github.com/mattpocock/skills) — the guide to authoring skills), a `fetch-url` example code tool, config, `.env.example`, and `.gitignore`. No `AGENTS.md` is scaffolded (it is project context, not identity); an existing one is kept untouched. Everything is written offline; by default it also writes `package.json` and runs `npm install`. Ignore files follow the layout: flat workspaces use the root `.gitignore` for `.env`, `.fastagent`, and `node_modules/`; `--agent-dir` workspaces keep root state/secrets in the root `.gitignore` and kit dependencies in `<agentDir>/.gitignore`.
 
-**Layout** — flat by default ("a directory is an agent"). When an existing system already claims the directory — a toolchain/build manifest (`tsconfig.json`, `next|vite|astro|svelte|nuxt|remix|webpack|rollup.config.*`, or a non-JS ecosystem's — `go.mod`, `Cargo.toml`, `pyproject.toml`, `setup.py`, `requirements.txt`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `CMakeLists.txt`), a deploy manifest (`Dockerfile`, `fly.toml`, `railway.toml`, `vercel.json`, `netlify.toml`), or occupied `tools//channels//skills/` — the agent kit goes into `./agent` with `config.agentDir` pointing there, and the reason is printed (no prompt). The agent kit self-contains its `package.json`, so a host repo's manifest and lockfile are never touched. `init` never overwrites existing files and refuses only a directory that already has a `fastagent.config.*`.
+**Layout** — flat by default ("a directory is an agent"). When an existing system already claims the directory — a toolchain/build manifest (`tsconfig.json`, `next|vite|astro|svelte|nuxt|remix|webpack|rollup.config.*`, or a non-JS ecosystem's — `go.mod`, `Cargo.toml`, `pyproject.toml`, `setup.py`, `requirements.txt`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `CMakeLists.txt`), a deploy manifest (`Dockerfile`, `fly.toml`, `railway.toml`, `vercel.json`, `netlify.toml`), or occupied `tools/`, `channels/`, or `skills/` — the agent kit goes into `./agent` with `config.agentDir` pointing there, and the reason is printed (no prompt). The agent kit self-contains its `package.json`, so a host repo's manifest and lockfile are never touched. `init` never overwrites existing files and refuses only a directory that already has a `fastagent.config.*`.
 
 Options:
 
@@ -243,10 +243,10 @@ FASTAGENT_STATE_DIR      > <dir>/.fastagent            (the whole machine-state 
 --sessions-dir > FASTAGENT_SESSIONS_DIR > <state root>/sessions
 ```
 
-For deployments, point sessions at durable storage:
+For deployments, point the whole state root (auth, sessions, channel state) at durable storage:
 
 ```bash
-FASTAGENT_SESSIONS_DIR=/data/sessions fastagent start
+FASTAGENT_STATE_DIR=/data/fastagent fastagent start
 ```
 
 ## Global options

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ status: current
 
 FastAgent keeps behavior and deployment choices separate:
 
-- agent behavior lives in `AGENTS.md`, `skills/`, and `tools/`,
+- agent behavior lives in `persona.md` (identity), `skills/`, `tools/`, and `AGENTS.md` project context,
 - deployment choices live in `fastagent.config.*`, CLI flags, and environment variables,
 - secrets live in `.env`, provider env vars, or the project-level `<state root>/auth.json` (default `<dir>/.fastagent/auth.json`).
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -37,7 +37,7 @@ The stream ends with exactly one `completed` / `failed`, or is cancelled by the 
 
 | You have | Use | Returns |
 |---|---|---|
-| An agent directory (`AGENTS.md` + `skills/` + `tools/` + config) | `createPiAgentFromWorkspace(dir, { model? })` | `{ agent, definition, modelSpec, … }` — auto-discovers everything |
+| An agent directory (`persona.md` + `skills/` + `tools/` + config) | `createPiAgentFromWorkspace(dir, { model? })` | `{ agent, definition, modelSpec, … }` — auto-discovers everything |
 | A definition directory, but you want to control the K ports | `createPiAgentFromDefinition(dir, { model, … })` | `{ agent, definition }` |
 | No directory — assemble from code | `createPiAgent({ model, instructions, tools })` | `agent` |
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,26 +7,28 @@ status: current
 
 **Vibe first. Then FastAgent.** FastAgent is the serving layer for local agent directories: take a directory out of the terminal, then run it inside your app, connect it to Telegram, handle GitHub/webhook events, expose it as an API endpoint, or put it behind your own channel.
 
-It does not ask you to rewrite an agent into a framework-specific project. Start with any directory; add `AGENTS.md`, `skills/`, `tools/`, channels, and markdown context as the agent grows. FastAgent gives that directory a running service shape.
+It does not ask you to rewrite an agent into a framework-specific project. Start with any directory; add `persona.md`, `skills/`, `tools/`, channels, and markdown context as the agent grows. FastAgent gives that directory a running service shape.
 
 Coding agents made it cheap to vibe useful agent directories. The next gap is serving: local agents live in terminals, but real services receive webhooks, join Telegram, serve product users, and expose stable APIs. FastAgent connects those directories to real triggers and runtimes.
 
 ```txt
 agent/
-├── AGENTS.md           # optional identity and standing instructions
+├── persona.md          # optional identity and standing instructions
 ├── skills/             # optional reusable markdown expertise
 ├── tools/              # optional code tools
 ├── channels/           # optional webhook/bot adapters
+├── schedules/          # optional cron time triggers
+├── AGENTS.md           # optional project context (yours, or a host repo's)
 ├── reference.md        # optional markdown context (any file layout)
 └── fastagent.config.mjs # optional deployment choices
 ```
 
 ## What FastAgent provides
 
-1. **Your directory is the agent** — `AGENTS.md`, `skills/`, `tools/`, `channels/`, and markdown context stay as files you can inspect, edit, and commit. `AGENTS.md` is recommended for identity, not a rewrite requirement.
+1. **Your directory is the agent** — `persona.md` (identity), `skills/`, `tools/`, `channels/`, and markdown context stay as files you can inspect, edit, and commit. An `AGENTS.md` is *project context* the agent reads (its own, or a host repo's) — not a rewrite requirement.
 2. **A contract** — [Agent Handler SPEC](SPEC.md), centered on `invoke(scope, prompt) => AsyncIterable<AgentEvent>`.
-3. **A reference implementation** — pi-based assembly for `AGENTS.md`, Agent Skills, code tools, sessions, auth, and model selection.
-4. **Developer workflow** — `init`, `info`, `dev`, `chat`, `tool`, `invoke`, `start`, and channel scaffolding.
+3. **A reference implementation** — pi-based assembly for `persona.md`, `AGENTS.md` context, Agent Skills, code tools, sessions, auth, and model selection.
+4. **Developer workflow** — `init`, `info`, `dev`, `chat`, `tool`, `invoke`, `fire`, `schedule`, `start`, `login`, `models`, channel scaffolding, and `deploy`.
 5. **Composable adapters** — GitHub, Telegram, the default local invoke channel, and a small public kit for third-party channels.
 6. **Time triggers** — cron schedules (`schedules/` files) and opt-in agent self-scheduling (the `wake` tool), with a per-run audit (`fastagent schedule history`).
 
@@ -112,7 +114,7 @@ fastagent add telegram
 Implemented today:
 
 - Agent Handler v0.1 reference implementation over pi.
-- Directory assembly from `AGENTS.md`, `skills/`, discovered `tools/`, and `fastagent.config.*`.
+- Directory assembly from `persona.md`, `AGENTS.md` project context, `skills/`, discovered `tools/`, and `fastagent.config.*`.
 - HTTP/SSE invoke channel.
 - GitHub and Telegram channel adapters.
 - `dev`, `chat`, `invoke`, `tool`, `info`, `start`, and `deploy fly` / `deploy railway` (`--run` drives flyctl / the railway CLI end-to-end).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,9 @@ This guide takes you from an installed CLI to a running local agent service.
 
 - Node >= 22.19 (`node --version`).
 - FastAgent CLI: `npm i -g @fastagent-sh/fastagent`.
-- Model credentials: run `fastagent login`, or put a provider API key in the workspace `.env`.
+- Model credentials: `fastagent login` stores them **per project** (`<cwd>/.fastagent/auth.json`, no
+  global fallback) — run it *inside the workspace* after step 1, or put a provider API key in the
+  workspace `.env`.
 
 List available model specs with:
 
@@ -53,7 +55,7 @@ fastagent info
 
 `info` is read-only. It prints the model, persona, context files (`AGENTS.md`), skills, discovered tools, channels, diagnostics, and session path without starting a server.
 
-**Initializing inside an existing project?** When the directory is already claimed by a toolchain or deploy setup (a `tsconfig.json`/framework config, a non-JS build manifest like `go.mod`/`pyproject.toml`/`Cargo.toml`, a `Dockerfile`/`fly.toml`/`railway.toml`, or occupied `tools//channels//skills/`), `init` puts the agent kit into `./agent` instead of flat, writes `agentDir: "./agent"` into the config, and prints the reason — the host's build and the agent's surface never sweep each other, and the repo's own `AGENTS.md` is read as project context. Override with `--flat` or `--agent-dir <name>`.
+**Initializing inside an existing project?** When the directory is already claimed by a toolchain or deploy setup (a `tsconfig.json`/framework config, a non-JS build manifest like `go.mod`/`pyproject.toml`/`Cargo.toml`, a `Dockerfile`/`fly.toml`/`railway.toml`, or occupied `tools/`, `channels/`, or `skills/`), `init` puts the agent kit into `./agent` instead of flat, writes `agentDir: "./agent"` into the config, and prints the reason — the host's build and the agent's surface never sweep each other, and the repo's own `AGENTS.md` is read as project context. Override with `--flat` or `--agent-dir <name>`.
 
 A fresh workspace presets no model. On the first `fastagent dev` (or `start` / `invoke`) in a
 terminal, FastAgent lists the models of the providers you are logged into (run `fastagent login`
@@ -147,13 +149,13 @@ fastagent start
 
 `start` uses the same assembly as `dev`, but does not watch files. There is no build step: copy the workspace to a host with Node >= 22.19, install dependencies, and run `fastagent start`.
 
-For deployments, put sessions on durable storage:
+For deployments, point the whole machine-state root (auth, sessions, **and** channel state — Telegram's durable turn replay lives there too) at durable storage:
 
 ```bash
-FASTAGENT_SESSIONS_DIR=/data/sessions fastagent start
-# or
-fastagent start --sessions-dir /data/sessions
+FASTAGENT_STATE_DIR=/data/fastagent fastagent start
 ```
+
+(`FASTAGENT_SESSIONS_DIR` / `--sessions-dir` override just the sessions path; they do not move channel state.)
 
 ## 7. Add channels
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,9 +11,9 @@ This guide takes you from an installed CLI to a running local agent service.
 
 - Node >= 22.19 (`node --version`).
 - FastAgent CLI: `npm i -g @fastagent-sh/fastagent`.
-- Model credentials: `fastagent login` stores them **per project** (`<cwd>/.fastagent/auth.json`, no
-  global fallback) — run it *inside the workspace* after step 1, or put a provider API key in the
-  workspace `.env`.
+
+Model credentials come in step 2 — after the workspace exists, because `fastagent login` stores them
+**per project**.
 
 List available model specs with:
 
@@ -57,9 +57,11 @@ fastagent info
 
 **Initializing inside an existing project?** When the directory is already claimed by a toolchain or deploy setup (a `tsconfig.json`/framework config, a non-JS build manifest like `go.mod`/`pyproject.toml`/`Cargo.toml`, a `Dockerfile`/`fly.toml`/`railway.toml`, or occupied `tools/`, `channels/`, or `skills/`), `init` puts the agent kit into `./agent` instead of flat, writes `agentDir: "./agent"` into the config, and prints the reason — the host's build and the agent's surface never sweep each other, and the repo's own `AGENTS.md` is read as project context. Override with `--flat` or `--agent-dir <name>`.
 
-A fresh workspace presets no model. On the first `fastagent dev` (or `start` / `invoke`) in a
-terminal, FastAgent lists the models of the providers you are logged into (run `fastagent login`
-first) and writes your pick back to `fastagent.config.mjs`. To set it non-interactively (or in
+A fresh workspace presets no model. Log in first, **inside the workspace** — `fastagent login` stores
+credentials per project (`<cwd>/.fastagent/auth.json`, no global fallback), so a login run elsewhere is
+invisible here (alternative: a provider API key in the workspace `.env`). Then on the first
+`fastagent dev` (or `start` / `invoke`) in a terminal, FastAgent lists the models of the providers you
+are logged into and writes your pick back to `fastagent.config.mjs`. To set it non-interactively (or in
 CI/deploy, where there is no prompt):
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,10 +38,14 @@ Precedence:
 
 The selected provider has no credentials.
 
+Most common cause: you ran `fastagent login` **from a different directory**. Login is project-level —
+it writes `<cwd>/.fastagent/auth.json`, and there is no fallback to the global file. Run it inside the
+workspace, or point every project at one shared file with `FASTAGENT_AUTH_PATH=~/.fastagent/auth.json`.
+
 Options:
 
 ```bash
-fastagent login
+cd <workspace> && fastagent login
 ```
 
 or set a provider API key in `.env` / environment, for example:
@@ -102,19 +106,20 @@ Use `--no-watch` to serve once without the supervisor.
 
 ## Sessions disappear after redeploy
 
-By default, sessions live under the workspace:
+By default, all machine state (auth, sessions, channel state) lives under the workspace:
 
 ```txt
-<state root>/sessions   # default <workspace>/.fastagent/sessions; root override: FASTAGENT_STATE_DIR
+<state root>   # default <workspace>/.fastagent
 ```
 
-A redeploy that replaces the workspace can wipe them. Point sessions at durable storage:
+A redeploy that replaces the workspace wipes it. Point the whole state root at durable storage:
 
 ```bash
-FASTAGENT_SESSIONS_DIR=/data/sessions fastagent start
-# or
-fastagent start --sessions-dir /data/sessions
+FASTAGENT_STATE_DIR=/data/fastagent fastagent start
 ```
+
+Moving only sessions (`FASTAGENT_SESSIONS_DIR` / `--sessions-dir`) is not enough for channel-backed
+deployments — Telegram's durable turn state also lives under the state root.
 
 ## `session busy`
 

--- a/llms.txt
+++ b/llms.txt
@@ -5,9 +5,9 @@
 Key facts:
 
 - Install: `npm i -g @fastagent-sh/fastagent` (CLI) or `npm i @fastagent-sh/fastagent` (library). Requires Node >= 22.19 (also runs under Bun).
-- The directory is the agent: optional `AGENTS.md`, `skills/`, `tools/`, `channels/`, markdown context, and `fastagent.config.*`. No framework rewrite, no build step.
+- The directory is the agent: optional `persona.md` (identity), `skills/`, `tools/`, `channels/`, `schedules/` (cron triggers), `AGENTS.md` (project context, not identity), markdown context, and `fastagent.config.*`. No framework rewrite, no build step.
 - The contract is `invoke(scope, prompt) => AsyncIterable<AgentEvent>` (the Agent Handler SPEC).
-- Core CLI: `fastagent init | info | dev | chat | invoke | tool | start | add | login`.
+- Core CLI: `fastagent init | info | models | login | dev | chat | invoke | tool | fire | schedule | start | add | deploy`.
 - Channels: HTTP/SSE (default), GitHub, Telegram, plus custom adapters.
 
 ## Start here

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,6 +95,7 @@ function usage(code: number): never {
   fastagent chat   [dir] [--model provider/modelId]
   fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir] [--auth-path file] [--tunnel]
   fastagent add   github | telegram | skill <source> [dir]
+  fastagent deploy fly|railway [dir] [--run] [--force] [--stop] [--no-scale-to-zero] [--into-linked]
   fastagent login [provider] [--auth-path file]
   fastagent --version
 
@@ -114,7 +115,7 @@ function usage(code: number): never {
          existing AGENTS.md is kept as project context. Layout: flat by default ("a directory is an
          agent"); when an existing toolchain/deploy claims the directory (tsconfig/framework config,
          a non-JS build manifest like go.mod/pyproject.toml/Cargo.toml, Dockerfile/fly/railway, or
-         occupied tools//channels//skills/), the kit goes into ./agent
+         occupied tools/, channels/, or skills/), the kit goes into ./agent
          and config.agentDir points there — the reason is printed, no prompt.
          --minimal           persona.md + the example skill + config only (no code tool / package.json)
          --no-install        scaffold everything but skip npm install
@@ -734,7 +735,7 @@ async function runAddSkill(): Promise<void> {
  * webhook step), and hands the middle to a coding agent (or human) as a precise, values-resolved
  * runbook. The pre-flight (config/model/channels/container facts) is host-neutral; the host branch adds
  * its config file + runbook. Read-only on the definition; the only writes are the generated artifacts
- * (never clobbered without --force). `--run` (fly today) drives the host CLI instead of printing.
+ * (never clobbered without --force). `--run` drives the host CLI instead of printing.
  */
 async function runDeploy(): Promise<void> {
   const host = positionals[1];


### PR DESCRIPTION
Stacked on #205 (touches lines carrying the scoped package name).

Findings from a full DX/docs audit, grouped:

**persona/AGENTS.md semantic drift** — overview.md (layout tree said `AGENTS.md # optional identity`), docs/README.md, llms.txt, configuration.md, embedding.md still carried the pre-split semantics. All now say: `persona.md` = identity, `AGENTS.md` = project context; overview's tree gains `persona.md` + `schedules/`.

**Durable-state guidance conflict** — quickstart §6, troubleshooting 'Sessions disappear', and cli.md's start section taught `FASTAGENT_SESSIONS_DIR=/data/sessions` for deployments, while start's own runtime note and .env.example say `FASTAGENT_STATE_DIR` is the ONE root (channel state — Telegram's durable turn replay — is not moved by a sessions-only override). Docs now lead with `FASTAGENT_STATE_DIR`.

**Login footguns** — `fastagent login` is project-level with no global fallback, but quickstart's prerequisites had you log in before the workspace exists; troubleshooting's `auth: (none found)` never named the logged-in-elsewhere cause; ai-start.md told a non-TTY coding agent to run the interactive login itself (which fails fast by design). All three fixed.

**Small ones** — usage synopsis gains the missing `deploy` line; stale '(fly today)' docstring dropped (railway --run ships); the `tools//channels//skills/` rendering fixed in 4 places; api-reference documents the 7 exported-but-undocumented names; llms.txt/overview CLI lists gain `deploy | fire | schedule | models`.

Verified: typecheck + 553 tests green; an export-coverage check against src/index.ts now reports zero undocumented names.