### PR TITLE
fix(deploy): run the container from the local bin, never npx/bunx bare `fastagent`

### DIFF
--- a/src/deploy/container.ts
+++ b/src/deploy/container.ts
@@ -27,7 +27,7 @@ export interface ContainerInput {
   /** Whether the workspace has a package.json (a code workspace); else a pure markdown/skills agent. */
   hasPackageJson: boolean;
   /** The package manager the generated image targets: `bun` (packageManager: bun / a bun lockfile) gets an
-   *  `oven/bun` base + `bun install` + `bunx fastagent`; otherwise npm on `node:22-slim`. */
+   *  `oven/bun` base + `bun install` + `bun run fastagent`; otherwise npm on `node:22-slim`. */
   runtime: "node" | "bun";
   /** Whether the runtime's lockfile exists (package-lock.json for npm, bun.lock/bun.lockb for bun) — a
    *  frozen/ci install needs it; without it the build resolves versions at build time (not reproducible). */
@@ -75,7 +75,7 @@ ${apt}WORKDIR /app
     return `${head}COPY ${kit}/package.json ${kit}/bun.lock* ./${kit}/
 RUN cd ${kit} && ${install}
 COPY . .
-CMD ["sh", "-c", "cd ${kit} && bunx fastagent start /app"]
+CMD ["sh", "-c", "cd ${kit} && bun run fastagent start /app"]
 `;
   }
   const install = input.hasLockfile ? "npm ci" : "npm install";
@@ -119,7 +119,7 @@ CMD ["fastagent", "start", "/app"]
   const isBun = input.runtime === "bun";
   const base = isBun ? `oven/bun:${input.bunVersion ?? "1"}` : "node:22-slim";
   const note = isBun
-    ? "# Bun-based (packageManager: bun / a bun lockfile detected). fastagent runs under Bun (bunx)."
+    ? "# Bun-based (packageManager: bun / a bun lockfile detected). fastagent runs under Bun (bun run)."
     : "# npm-based — for pnpm/yarn, adapt the install line + the lockfile COPY (corepack enable, etc.).";
   const head = `${GENERATED_DOCKERFILE_MARKER}. The directory IS the agent — no build step.
 ${note}
@@ -132,22 +132,28 @@ ${apt}WORKDIR /app
   if (isBun) {
     // `--frozen-lockfile` needs bun.lock and hard-fails without it; fall back to a plain `bun install`
     // (resolves at build time — not reproducible; the CLI warns to commit the lockfile).
+    // `bun run` executes the LOCAL node_modules/.bin entry only — never the registry. A bare
+    // `bunx fastagent` would fall back to installing the npm package named `fastagent`, which is an
+    // unrelated third-party package (ours is the scoped @fastagent-sh/fastagent).
     const install = input.hasLockfile ? "bun install --frozen-lockfile" : "bun install";
     return `${head}COPY package.json bun.lock* ./
 RUN ${install}
 COPY . .
-CMD ["bunx", "fastagent", "start", "/app"]
+CMD ["bun", "run", "fastagent", "start", "/app"]
 `;
   }
   // `npm ci` requires a lockfile and hard-fails without one (a common `init --no-install` workspace);
   // fall back to `npm install` when there is none so the build never breaks. Caveat: `npm install`
   // resolves caret ranges at build time, so THIS branch is NOT reproducible — unlike the pinned
   // `npm ci` (lockfile) and pinned global (markdown) paths. The CLI warns to commit a lockfile.
+  // The explicit local bin, not `npx fastagent`: npx falls back to fetching the npm package named
+  // `fastagent` when the dep is absent — an unrelated third-party package (ours is scoped). The local
+  // path fails fast and visibly instead.
   const install = input.hasLockfile ? "npm ci" : "npm install";
   return `${head}COPY package.json package-lock.json* ./
 RUN ${install}
 COPY . .
-CMD ["npx", "fastagent", "start", "/app"]
+CMD ["./node_modules/.bin/fastagent", "start", "/app"]
 `;
 }
 

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -128,7 +128,7 @@ export async function preflightDeploy(input: {
   const pkg = await readPackageJson(factsDir);
   const { runtime, bunVersion, hasLockfile } = detectRuntime(factsDir, pkg);
   const install = runtime === "bun" ? "bun install" : "npm install";
-  const runner = runtime === "bun" ? "bunx fastagent" : "npx fastagent";
+  const runner = runtime === "bun" ? "bun run fastagent" : "./node_modules/.bin/fastagent";
   const hasOtherLock =
     runtime === "node" &&
     ((await exists(join(factsDir, "pnpm-lock.yaml"))) || (await exists(join(factsDir, "yarn.lock"))));
@@ -160,14 +160,14 @@ export async function preflightDeploy(input: {
           `Run \`${install}\` and commit the lockfile for pinned redeploys.`,
     });
   }
-  // The code-path Dockerfile runs `${runner}`: that resolves the workspace's OWN dependency, so a
-  // package.json missing it would make the CONTAINER fetch an unpinned build at runtime (offline-fragile).
+  // The code-path Dockerfile runs `${runner}` — the workspace's OWN local dependency, never the
+  // registry — so a package.json missing it means the container fails at start (no bin to run).
   if (hasPackageJson && !("@fastagent-sh/fastagent" in { ...pkg.dependencies, ...pkg.devDependencies })) {
     messages.push({
       level: "warn",
       text:
-        `package.json does not list @fastagent-sh/fastagent — the image's \`${runner}\` would fetch it at runtime ` +
-        `(offline-fragile, unpinned). Add it to dependencies and re-run \`${install}\`.`,
+        `package.json does not list @fastagent-sh/fastagent — the image's \`${runner}\` has no local bin to run, ` +
+        `so the container fails at start. Add it to dependencies and re-run \`${install}\`.`,
     });
   }
   // A kept host root .dockerignore silently replaces KIT_DOCKERIGNORE's two protections — read it and

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -138,7 +138,7 @@ describe("deploy/fly: planFlyDeploy", () => {
     expect(runbook(p)).toMatch(/Write-back mechanics/);
   });
 
-  it("kit layout: bun kit uses the bun base + cd-install + bunx; markdown-only kit uses the pinned global CLI", () => {
+  it("kit layout: bun kit uses the bun base + cd-install + bun run; markdown-only kit uses the pinned global CLI", () => {
     const bun = planFlyDeploy({
       ...base,
       runtime: "bun",
@@ -151,7 +151,7 @@ describe("deploy/fly: planFlyDeploy", () => {
     expect(bunDf).toContain("FROM oven/bun:1.3.13");
     expect(bunDf).toContain("COPY agent/package.json agent/bun.lock* ./agent/");
     expect(bunDf).toContain("cd agent && bun install --frozen-lockfile");
-    expect(bunDf).toContain(`"sh", "-c", "cd agent && bunx fastagent start /app"`);
+    expect(bunDf).toContain(`"sh", "-c", "cd agent && bun run fastagent start /app"`);
 
     const md = planFlyDeploy({
       ...base,
@@ -174,13 +174,20 @@ describe("deploy/fly: planFlyDeploy", () => {
     expect(dockerfile(planFlyDeploy({ ...base, modelAuth: undefined, channels: [] }))).toMatch(/RUN npm ci\n/);
   });
 
-  it("generates a Bun Dockerfile for a bun workspace (oven/bun base, bun install, bunx)", () => {
+  it("code-workspace CMD runs the LOCAL bin, never npx/bunx (bare `fastagent` on npm is a third party)", () => {
+    const npm = dockerfile(planFlyDeploy({ ...base, modelAuth: undefined, channels: [] }));
+    expect(npm).toContain('CMD ["./node_modules/.bin/fastagent", "start", "/app"]');
+    expect(npm).not.toContain("npx");
+  });
+
+  it("generates a Bun Dockerfile for a bun workspace (oven/bun base, bun install, bun run)", () => {
     const bun = dockerfile(
       planFlyDeploy({ ...base, modelAuth: undefined, channels: [], runtime: "bun", bunVersion: "1.3.13" }),
     );
     expect(bun).toContain("FROM oven/bun:1.3.13");
     expect(bun).toContain("bun install --frozen-lockfile"); // base.hasLockfile: true → frozen
-    expect(bun).toContain('CMD ["bunx", "fastagent", "start", "/app"]');
+    // The LOCAL bin, never the registry — the npm package named `fastagent` is an unrelated third party.
+    expect(bun).toContain('CMD ["bun", "run", "fastagent", "start", "/app"]');
     expect(bun).not.toContain("node:22-slim");
     // Unpinned bun (a bun lockfile but no packageManager version) → oven/bun:1; no lockfile → plain install.
     const unpinned = dockerfile(


### PR DESCRIPTION
Supersedes #206 (auto-closed when its stacked base branch was deleted at #205's merge). Same change, rebased onto main.

The npm package named `fastagent` belongs to an unrelated third party. The generated Dockerfile CMDs used `npx fastagent` / `bunx fastagent`: fine while the local dep exists, but the registry fallback would fetch and run the foreign package for any workspace that never listed `@fastagent-sh/fastagent` in its deps.

- npm code path: `CMD ["./node_modules/.bin/fastagent", …]` — same pattern the kit layout already used
- bun paths: `bun run fastagent` — resolves `node_modules/.bin` only, no registry fallback
- preflight's missing-dep warning reworded: the container now fails fast at start (no bin) instead of fetching an unpinned build at runtime

Verified: typecheck + lint + deploy suites green; new assertion locks the npm CMD to the local bin. rv local pass: no findings.