### PR TITLE
docs: the local-first verify command includes lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Full version: `CONTRIBUTING.md`. The essentials:
 
 1. **Local-first.** Verify locally before opening a PR; do not push to discover bugs in CI.
    ```bash
-   npm run typecheck && npm test
+   npm run lint && npm run typecheck && npm test
    ```
 2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`.
 3. **Rebase merge by default** (preserve curated commits); squash only to clean up a WIP branch. Merge commits are disabled. `main` enforces linear history; force-push is forbidden.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Force-pushing to `main` is forbidden. Long-lived PRs (> ~3 days) should be rebas
 
 ## Dependencies
 
-Dependabot opens weekly PRs for npm and GitHub Actions. The pi packages (`@earendil-works/pi-*`) share one monorepo and move together — update them as a group. Re-run `npm run typecheck && npm test` before merging any dependency bump.
+Dependabot opens weekly PRs for npm and GitHub Actions. The pi packages (`@earendil-works/pi-*`) share one monorepo and move together — update them as a group. Re-run `npm run lint && npm run typecheck && npm test` before merging any dependency bump.
 
 The `undici` version is load-bearing for proxy/streaming behavior under Node 26; see the `installProxyFetch` docstring in `src/proxy.ts` before changing it.
 


### PR DESCRIPTION
AGENTS.md's local-first verify line (`npm run typecheck && npm test`) omitted the biome lint gate CI enforces — exactly how #205 shipped a format failure discovered only in CI. Align AGENTS.md and CONTRIBUTING's dependency-bump line with the actual CI gate (CONTRIBUTING's main PR loop already had it).