### PR TITLE
chore(release): bootstrap 0.12.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish
 
-# Publish @fastagent-sh/fastagent to npm from a GitHub Release via Trusted Publishing (OIDC), with
-# provenance and no NPM_TOKEN. Publishing requires the public fastagent-sh/fastagent repository; the
-# npm trusted publisher must name org fastagent-sh, repo fastagent, workflow publish.yml. The release
-# tag is the manual gate; this job verifies that tag against package.json and reruns the release checks.
+# Publish @fastagent-sh/fastagent to npm from a GitHub Release with provenance. Publishing requires
+# the public fastagent-sh/fastagent repository. The 0.12.0 bootstrap uses a temporary NPM_TOKEN because
+# npm cannot configure Trusted Publishing before the package exists; remove it after binding this
+# workflow as the package's trusted publisher. The release tag is the manual gate.
 on:
   release:
     types: [published]
@@ -57,4 +57,6 @@ jobs:
         run: npm test
 
       - name: Publish with provenance
-        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # Bootstrap only; remove after Trusted Publishing is configured.
+        run: npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a running service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary

- bump the first `@fastagent-sh/fastagent` release to 0.12.0
- temporarily authenticate the first GitHub Actions publication with the short-lived `NPM_TOKEN`
- publish as public with provenance

npm cannot bind a Trusted Publisher before the package exists. Immediately after this release succeeds, bind `fastagent-sh/fastagent/.github/workflows/publish.yml`, delete the token and repository secret, and remove the temporary workflow wiring in a follow-up PR.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 51 files / 558 tests
- [x] `actionlint .github/workflows/publish.yml`
- [x] `npm pack --dry-run`
- [x] `~/.pi/agent/scripts/rv.sh local` — temporary-token finding consciously accepted for package bootstrap; the workflow comment and this PR define its removal gate
