### PR TITLE
chore(release): enforce trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish
 
-# Publish @fastagent-sh/fastagent to npm from a GitHub Release with provenance. Publishing requires
-# the public fastagent-sh/fastagent repository. The 0.12.0 bootstrap uses a temporary NPM_TOKEN because
-# npm cannot configure Trusted Publishing before the package exists; remove it after binding this
-# workflow as the package's trusted publisher. The release tag is the manual gate.
+# Publish @fastagent-sh/fastagent to npm from a GitHub Release via Trusted Publishing (OIDC), with
+# provenance and no NPM_TOKEN. Publishing requires the public fastagent-sh/fastagent repository; the
+# npm trusted publisher must name org fastagent-sh, repo fastagent, workflow publish.yml. The release
+# tag is the manual gate; this job verifies that tag against package.json and reruns the release checks.
 on:
   release:
     types: [published]
@@ -57,6 +57,4 @@ jobs:
         run: npm test
 
       - name: Publish with provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # Bootstrap only; remove after Trusted Publishing is configured.
         run: npm publish --provenance --access public

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,9 +124,10 @@ Full version: `CONTRIBUTING.md`. The essentials:
    ```bash
    git checkout main && git pull --ff-only && git branch -d <branch> && git fetch --prune origin
    ```
-6. **Releases publish via npm Trusted Publishing (OIDC), never a local `npm publish`.** Flow: bump
-   `package.json` in a `chore/release-x.y.z` PR → merge → tag `vX.Y.Z` →
-   create the GitHub Release (its notes are the changelog) — `.github/workflows/publish.yml` re-verifies (typecheck + test) and
+6. **Releases publish via npm Trusted Publishing (OIDC), never a local `npm publish`.** The npm package
+   must keep its `publish` trusted-publisher binding to `fastagent-sh/fastagent` / `publish.yml`. Flow:
+   bump `package.json` in a `chore/release-x.y.z` PR → merge → tag `vX.Y.Z` → create the GitHub Release
+   (its notes are the changelog) — `.github/workflows/publish.yml` re-verifies (typecheck + test) and
    publishes to npm from CI. There is no NPM_TOKEN anywhere; a local `npm publish` fails with 401 by
    design.
 


### PR DESCRIPTION
## Summary

- remove the temporary `NPM_TOKEN` wiring after the successful 0.12.0 bootstrap
- leave npm publishing authenticated only through GitHub OIDC
- record the package-side `fastagent-sh/fastagent` / `publish.yml` binding as a release prerequisite

The npm trusted publisher is verified with `permissions: publish`; the repository secret has already been deleted.

## Validation

- [x] `npm trust list @fastagent-sh/fastagent` shows the expected GitHub publisher and `publish` permission
- [x] `actionlint .github/workflows/publish.yml`
- [x] `npm run lint`
- [x] `~/.pi/agent/scripts/rv.sh local` — No findings
