### PR TITLE
chore(security): harden repository and releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,20 @@
-# Review ownership. Auto-requests a review on the sensitive surfaces named in
-# CONTRIBUTING.md "Review tiers"; it does not block self-merge for low-risk PRs.
+# Sensitive surfaces require approval from a code owner; low-risk paths remain self-mergeable.
 
 # The locked contract and its types.
-/docs/SPEC.md            @kid7st
-/src/agent.ts            @kid7st
+/docs/SPEC.md            @kid7st @Sukitly
+/src/agent.ts            @kid7st @Sukitly
 
-# The public API surface.
-/src/index.ts            @kid7st
+# Public package boundaries.
+/package.json            @kid7st @Sukitly
+/package-lock.json       @kid7st @Sukitly
+/src/index.ts            @kid7st @Sukitly
+/src/core.ts             @kid7st @Sukitly
+/src/pi.ts               @kid7st @Sukitly
+/src/github.ts           @kid7st @Sukitly
+/src/telegram.ts         @kid7st @Sukitly
+
+# Review and release policy.
+/.github/CODEOWNERS      @kid7st @Sukitly
+/.github/dependabot.yml  @kid7st @Sukitly
+/.github/workflows/      @kid7st @Sukitly
+/SECURITY.md             @kid7st @Sukitly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Review dependency changes
+        if: github.event_name == 'pull_request'
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish
 
 # Publish @fastagent-sh/fastagent to npm from a GitHub Release via Trusted Publishing (OIDC), with
 # provenance and no NPM_TOKEN. Publishing requires the public fastagent-sh/fastagent repository; the
-# npm trusted publisher must name org fastagent-sh, repo fastagent, workflow publish.yml. The release
-# tag is the manual gate; this job verifies that tag against package.json and reruns the release checks.
+# npm trusted publisher must name org fastagent-sh, repo fastagent, workflow publish.yml, environment
+# npm. The protected environment is the manual gate; this job also verifies the tag and commit.
 on:
   release:
     types: [published]
@@ -16,6 +16,7 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - name: Verify public release repository
         env:
@@ -31,6 +32,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Verify release commit is on main
+        run: |
+          git fetch origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor HEAD origin/main || {
+            echo "release tag must point to a commit on main" >&2
+            exit 1
+          }
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 dist/
 .fastagent/
+.env
+.env.*
+!.env.example
 *.log
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,8 @@ Full version: `CONTRIBUTING.md`. The essentials:
    git checkout main && git pull --ff-only && git branch -d <branch> && git fetch --prune origin
    ```
 6. **Releases publish via npm Trusted Publishing (OIDC), never a local `npm publish`.** The npm package
-   must keep its `publish` trusted-publisher binding to `fastagent-sh/fastagent` / `publish.yml`. Flow:
+   must keep its `publish` trusted-publisher binding to `fastagent-sh/fastagent` / `publish.yml` /
+   environment `npm`. Flow:
    bump `package.json` in a `chore/release-x.y.z` PR → merge → tag `vX.Y.Z` → create the GitHub Release
    (its notes are the changelog) — `.github/workflows/publish.yml` re-verifies (typecheck + test) and
    publishes to npm from CI. There is no NPM_TOKEN anywhere; a local `npm publish` fails with 401 by

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -127,7 +127,7 @@ describe("github channel", () => {
     const res = await ch(signed(PR_OPENED.body, PR_OPENED.headers));
     expect(res.status).toBe(202);
     expect(seen).toMatchObject({ event: "pull_request", action: "opened", deliveryId: "d1" });
-    expect((seen?.payload as { repository?: { full_name?: string } }).repository?.full_name).toBe("o/r");
+    expect((seen?.payload as { repository?: { full_name?: string } } | undefined)?.repository?.full_name).toBe("o/r");
 
     await flush(); // the fire-and-forget turn runs (202 returns without awaiting it to completion)
     expect(calls).toEqual([{ session: "pr-o/r#7", text: "Review #7" }]);


### PR DESCRIPTION
## Summary

- ignore local `.env*` files while keeping `.env.example` committable
- expand CODEOWNERS to two maintainers across the contract, package entrypoints, dependencies, workflows, and security policy
- gate npm publishing through the protected `npm` environment and require release tags to point to commits on `main`
- add GitHub Dependency Review for new high-severity vulnerabilities
- make the GitHub channel test pass Biome 2.5.3's safe optional-chaining rule

Repository settings already applied: CodeQL default setup, required action SHA pinning, a reviewed `npm` environment limited to `v*` tags, and an admin-only release-tag ruleset.

After merge: enable required Code Owner reviews and update npm Trusted Publishing to require environment `npm`.

## Validation

- [x] `actionlint .github/workflows/ci.yml .github/workflows/publish.yml`
- [x] `npm run lint`
- [x] `npx @biomejs/biome@2.5.3 check src test`
- [x] `npm run typecheck`
- [x] `npm test` — 51 files / 558 tests
- [x] `~/.pi/agent/scripts/rv.sh local` — No findings
