### PR TITLE
docs: make fastagent.sh the canonical website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/fastagent-sh/fastagent"><img src="https://raw.githubusercontent.com/fastagent-sh/fastagent/main/assets/hero.png" alt="FastAgent — Vibe first. Then FastAgent. An agent directory becomes a live service in your app, on GitHub, in Telegram, or any channel." width="860"></a>
+  <a href="https://fastagent.sh"><img src="https://raw.githubusercontent.com/fastagent-sh/fastagent/main/assets/hero.png" alt="FastAgent — Vibe first. Then FastAgent. An agent directory becomes a live service in your app, on GitHub, in Telegram, or any channel." width="860"></a>
 </p>
 
 [![CI](https://github.com/fastagent-sh/fastagent/actions/workflows/ci.yml/badge.svg)](https://github.com/fastagent-sh/fastagent/actions/workflows/ci.yml)
@@ -41,7 +41,7 @@ FastAgent is the missing bridge from local agent directory to real service.
 - **App embedding — your stack, we plug in.** Like Flask/FastAPI for agents: FastAgent never owns your framework. Mount the agent in your Next / Astro / Hono / Bun / Node route with one handler — your auth, your database, your host.
 - **Deploy anywhere.** Run the directory directly — no build step; `fastagent deploy fly|railway` generates the host config + a runbook and hands off (`--run` drives the deploy to completion). The generated container also runs on other Docker hosts.
 
-Using a coding agent? Give it [`docs/ai-start.md`](docs/ai-start.md) for an AI-guided setup path.
+Using a coding agent? Ask it to read [`https://fastagent.sh/start.md`](https://fastagent.sh/start.md), inspect your project, and serve its existing agent definition without rewriting it.
 
 ## Design philosophy
 
@@ -52,7 +52,7 @@ FastAgent is built around a small serving contract, app-owned runtime concerns, 
 - **Typed edges** — typed tools, explicit events, boundary validation.
 - **Agent-native shape** — the directory is the deployable unit, and channels drive the same contract.
 
-Read [Design principles](docs/principles.md) for the full rationale.
+Read the [Design principles](https://fastagent.sh/docs/principles/) for the full rationale.
 
 ## What we didn't build
 
@@ -133,20 +133,20 @@ const agent = createPiAgent({
 
 | Document | Purpose |
 |---|---|
-| [docs/README.md](docs/README.md) | Documentation index |
-| [docs/quickstart.md](docs/quickstart.md) | Scaffold, run, add a tool, and start |
-| [docs/configuration.md](docs/configuration.md) | Configure model, auth, ports, sessions, tools, and channels |
-| [docs/principles.md](docs/principles.md) | Design choices, core primitives, and non-goals |
-| [docs/cli.md](docs/cli.md) | CLI reference |
-| [docs/embedding.md](docs/embedding.md) | Use FastAgent as a library inside your own app |
-| [docs/channels.md](docs/channels.md) | Add webhook/bot channels |
-| [docs/deploy.md](docs/deploy.md) | Ship the directory to Fly, Railway, or any Docker host |
-| [docs/github.md](docs/github.md) / [docs/telegram.md](docs/telegram.md) | First-party channel guides |
-| [docs/channel-development.md](docs/channel-development.md) | Build custom channel adapters |
-| [docs/api-reference.md](docs/api-reference.md) | Public TypeScript API reference |
-| [docs/troubleshooting.md](docs/troubleshooting.md) | Common setup/runtime issues |
-| [docs/SPEC.md](docs/SPEC.md) | Agent Handler protocol v0.1 |
-| [docs/design/core.md](docs/design/core.md) | Maintainer architecture notes |
+| [Documentation index](https://fastagent.sh/docs/) | Documentation map |
+| [Quickstart](https://fastagent.sh/docs/quickstart/) | Scaffold, run, add a tool, and start |
+| [Configuration](https://fastagent.sh/docs/configuration/) | Configure model, auth, ports, sessions, tools, and channels |
+| [Design principles](https://fastagent.sh/docs/principles/) | Design choices, core primitives, and non-goals |
+| [CLI reference](https://fastagent.sh/docs/cli/) | CLI commands and flags |
+| [Embedding](https://fastagent.sh/docs/embedding/) | Use FastAgent as a library inside your own app |
+| [Channels](https://fastagent.sh/docs/channels/) | Add webhook/bot channels |
+| [Deploy](https://fastagent.sh/docs/deploy/) | Ship the directory to Fly, Railway, or any Docker host |
+| [GitHub](https://fastagent.sh/docs/github/) / [Telegram](https://fastagent.sh/docs/telegram/) | First-party channel guides |
+| [Channel development](https://fastagent.sh/docs/channel-development/) | Build custom channel adapters |
+| [API reference](https://fastagent.sh/docs/api-reference/) | Public TypeScript API reference |
+| [Troubleshooting](https://fastagent.sh/docs/troubleshooting/) | Common setup/runtime issues |
+| [Agent Handler SPEC](https://fastagent.sh/docs/spec/) | Agent Handler protocol v0.1 |
+| [Core design](https://fastagent.sh/docs/design/core/) | Maintainer architecture notes |
 
 ## Public API surface & stability
 

--- a/llms.txt
+++ b/llms.txt
@@ -12,32 +12,32 @@ Key facts:
 
 ## Start here
 
-- [README](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/README.md): project overview, install, quickstart, features.
-- [AI-guided setup prompt](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/ai-start.md): paste into a coding agent to scaffold or wire a workspace.
-- [Documentation index](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/README.md): the full doc map.
+- [Website](https://fastagent.sh/): project overview, install, and product paths.
+- [AI-guided start](https://fastagent.sh/start.md): executable instructions for a coding agent.
+- [Documentation index](https://fastagent.sh/docs/): the full documentation map.
 
 ## Guides
 
-- [Overview](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/overview.md): what FastAgent is and is not.
-- [Quickstart](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/quickstart.md): scaffold, run locally, add a tool, and start.
-- [Configuration](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/configuration.md): model, auth, ports, sessions, tools, and channels.
-- [CLI reference](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/cli.md): every command and flag.
-- [Embedding](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/embedding.md): use FastAgent as a library inside your own app.
-- [Channels](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/channels.md): add webhook/bot channels.
-- [GitHub channel](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/github.md): GitHub webhook events.
-- [Telegram channel](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/telegram.md): Telegram bot.
-- [Channel development](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/channel-development.md): build a custom channel adapter.
-- [Deploy](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/deploy.md): ship the directory to Fly, Railway, or any Docker host.
-- [Troubleshooting](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/troubleshooting.md): common setup/runtime issues.
+- [Overview](https://fastagent.sh/docs/overview/): what FastAgent is and is not.
+- [Quickstart](https://fastagent.sh/docs/quickstart/): scaffold, run locally, add a tool, and start.
+- [Configuration](https://fastagent.sh/docs/configuration/): model, auth, ports, sessions, tools, and channels.
+- [CLI reference](https://fastagent.sh/docs/cli/): every command and flag.
+- [Embedding](https://fastagent.sh/docs/embedding/): use FastAgent as a library inside your own app.
+- [Channels](https://fastagent.sh/docs/channels/): add webhook/bot channels.
+- [GitHub channel](https://fastagent.sh/docs/github/): GitHub webhook events.
+- [Telegram channel](https://fastagent.sh/docs/telegram/): Telegram bot.
+- [Channel development](https://fastagent.sh/docs/channel-development/): build a custom channel adapter.
+- [Deploy](https://fastagent.sh/docs/deploy/): ship the directory to Fly, Railway, or any Docker host.
+- [Troubleshooting](https://fastagent.sh/docs/troubleshooting/): common setup/runtime issues.
 
 ## Reference
 
-- [API reference](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/api-reference.md): public TypeScript exports.
-- [Agent Handler SPEC](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/SPEC.md): the v0.1 protocol contract.
-- [Design principles](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/principles.md): design choices, core primitives, and non-goals.
+- [API reference](https://fastagent.sh/docs/api-reference/): public TypeScript exports.
+- [Agent Handler SPEC](https://fastagent.sh/docs/spec/): the v0.1 protocol contract.
+- [Design principles](https://fastagent.sh/docs/principles/): design choices, core primitives, and non-goals.
 
 ## Optional
 
-- [Core design notes](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/docs/design/core.md): pi reference implementation architecture.
-- [Contributing](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/CONTRIBUTING.md): branch model, PR loop, and review tiers.
-- [Security policy](https://raw.githubusercontent.com/fastagent-sh/fastagent/main/SECURITY.md): how to report a vulnerability.
+- [Core design notes](https://fastagent.sh/docs/design/core/): pi reference implementation architecture.
+- [Contributing](https://github.com/fastagent-sh/fastagent/blob/main/CONTRIBUTING.md): branch model, PR loop, and review tiers.
+- [Security policy](https://github.com/fastagent-sh/fastagent/security/policy): how to report a vulnerability.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "author": "the fastagent authors (https://github.com/fastagent-sh/fastagent)",
-  "homepage": "https://github.com/fastagent-sh/fastagent#readme",
+  "homepage": "https://fastagent.sh",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fastagent-sh/fastagent.git"


### PR DESCRIPTION
## Summary
- point package and repository discovery at `https://fastagent.sh`
- send README readers to the rendered documentation and AI-guided start
- make the root `llms.txt` index use canonical website routes

## Verification
- `npm run lint`
- `npm run typecheck`
- canonical production URLs return 200
- `rv.sh local` (`No findings.`)