### PR TITLE
docs: define maintainer self-merge policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Sensitive surfaces require approval from a code owner; low-risk paths remain self-mergeable.
+# Ownership map for review routing. Maintainer-authored PRs do not require a second maintainer approval.
 
 # The locked contract and its types.
 /docs/SPEC.md            @kid7st @Sukitly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The stable design center is the engine-neutral Agent Handler contract (`docs/SPE
 | `docs/SPEC.md` | The locked v0.1 Agent Handler contract. Do not change its semantics without an explicit decision. |
 | `docs/design/core.md` | The pi reference implementation and current architecture. |
 | `docs/overview.md`, `docs/README.md` | Product overview and documentation index. |
-| `CONTRIBUTING.md` | The full GitHub workflow (branch model, PR loop, merge strategy, review tiers). |
+| `CONTRIBUTING.md` | The full GitHub workflow (branch model, PR loop, merge strategy, review policy). |
 
 Code truth is `src/`.
 
@@ -119,7 +119,7 @@ Full version: `CONTRIBUTING.md`. The essentials:
    ```
 2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`.
 3. **Rebase merge by default** (preserve curated commits); squash only to clean up a WIP branch. Merge commits are disabled. `main` enforces linear history; force-push is forbidden.
-4. **Review tiers.** Docs/refactor/tests self-merge after green CI; SPEC, the `Agent` contract, and public API surface wait for review.
+4. **Review policy.** Maintainer-authored PRs may self-merge after green CI; external-contributor PRs require one maintainer approval and are merged by a maintainer.
 5. **After merge:**
    ```bash
    git checkout main && git pull --ff-only && git branch -d <branch> && git fetch --prune origin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Full version: `CONTRIBUTING.md`. The essentials:
    ```
 2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`.
 3. **Rebase merge by default** (preserve curated commits); squash only to clean up a WIP branch. Merge commits are disabled. `main` enforces linear history; force-push is forbidden.
-4. **Review policy.** Maintainer-authored PRs may self-merge after green CI; external-contributor PRs require one maintainer approval and are merged by a maintainer.
+4. **Review policy.** Maintainer-authored PRs may self-merge after green CI; external-contributor PRs are reviewed and merged by a maintainer.
 5. **After merge:**
    ```bash
    git checkout main && git pull --ff-only && git branch -d <branch> && git fetch --prune origin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,18 +67,15 @@ Add or update the smallest relevant tests that prove the change. Reusable SPEC c
 
 Either way, one branch = one focused change. If a branch grows several unrelated changes, split it into multiple PRs rather than squashing them into an opaque blob.
 
-## Review tiers
+## Review policy
 
-This is a small team; review is risk-based, not mandatory on everything.
+A maintainer is a collaborator with write or admin access.
 
-| Change | Review |
-|---|---|
-| Docs, comments, typos | Self-merge after CI |
-| Semantically-equivalent refactor, added tests | Self-merge after CI |
-| `docs/SPEC.md` (the locked contract), the `Agent` interface, public API surface in `src/index.ts` | Wait for review |
-| Anything that deletes a public export or changes error/terminal semantics | Wait for review |
+- A maintainer-authored PR may be self-merged after all required checks pass. A second maintainer review is optional, including for SPEC and public API changes.
+- A PR from an external contributor requires one approving review from a maintainer before a maintainer merges it.
+- `CODEOWNERS` routes changes to the relevant maintainers; it does not impose an additional approval on maintainer-authored PRs.
 
-Force-pushing to `main` is forbidden. Long-lived PRs (> ~3 days) should be rebased on `main`.
+All changes still go through a PR. Force-pushing to `main` is forbidden. Long-lived PRs (> ~3 days) should be rebased on `main`.
 
 ## Commit and PR messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Either way, one branch = one focused change. If a branch grows several unrelated
 A maintainer is a collaborator with write or admin access.
 
 - A maintainer-authored PR may be self-merged after all required checks pass. A second maintainer review is optional, including for SPEC and public API changes.
-- A PR from an external contributor requires one approving review from a maintainer before a maintainer merges it.
+- A PR from an external contributor must be reviewed and merged by a maintainer; external contributors do not have merge permission.
 - `CODEOWNERS` routes changes to the relevant maintainers; it does not impose an additional approval on maintainer-authored PRs.
 
 All changes still go through a PR. Force-pushing to `main` is forbidden. Long-lived PRs (> ~3 days) should be rebased on `main`.


### PR DESCRIPTION
## Summary
- allow maintainer-authored PRs to self-merge after required checks
- require one maintainer approval for external-contributor PRs
- keep CODEOWNERS as review routing rather than an extra maintainer gate

## Repository configuration
Branch protection now requires one approval, disables required code-owner review, and allows `kid7st` and `Sukitly` to bypass the approval requirement on maintainer-authored PRs. Required status checks and linear history remain enforced.

## Verification
- `npm run lint`
- branch protection API verified
- isolated review finding about unsynchronized protection consciously declined because the protection was updated before this PR.