### PR TITLE
docs(ai-start): route by three entry paths

### DIFF
--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -1,15 +1,25 @@
 ---
-title: Serve an Agent with FastAgent
+title: Build and Serve an Agent with FastAgent
 status: current
 ---
 
-# Skill: Serve an Agent with FastAgent
+# Skill: Build and Serve an Agent with FastAgent
 
-Use this skill to turn an existing agent directory into a deployable agent service without rewriting it.
+Use this skill to build an agent with FastAgent and serve it — starting from nothing, from files that already exist, or inside an existing application.
 
 ## Goal
 
-Inspect the project first, preserve its existing definition, and make the smallest change that lets FastAgent run it locally, embed it in an app, connect it to a channel, or deploy it.
+Inspect the project first, preserve anything that already exists, and make the smallest change that gives the user a running agent: locally, embedded in their app, connected to a channel, or deployed.
+
+## Choose your path
+
+Decide which job this is before touching anything:
+
+1. **New agent, empty directory.** Nothing agent-shaped exists yet. Run `fastagent init <dir>` (or init the current directory), then flesh out `persona.md`, skills, and tools from what the user wants.
+2. **An existing directory becomes the agent.** The project already has `AGENTS.md`, markdown context, skills, or tools — vibed or handwritten. Do not restructure it: run `fastagent init` in place; init never overwrites existing files and adopts them as the definition.
+3. **Embed an agent into an existing application.** The project is an app (framework config, routes, its own toolchain). Initialize — init chooses `./agent` with `config.agentDir` automatically when the root is claimed — then mount the agent in the app's own route with `createPiAgentFromDefinition` + `createInvokeHandler`. The app keeps auth, database, and deployment.
+
+All three paths continue with the same steps below: inspect, authenticate, initialize once, test, then connect channels or deploy.
 
 ## Mental model
 


### PR DESCRIPTION
## What

`docs/ai-start.md` (served as https://fastagent.sh/start.md, the coding-agent entry point) currently frames the whole guide as "serve an existing agent definition". The website's copy-prompt has moved to the broader "Read start.md and build an agent in this project" — this PR makes the guide route that intent explicitly.

- Title/goal widened: **Build and Serve an Agent with FastAgent** — from nothing, from existing files, or inside an existing app.
- New **Choose your path** section up front:
  1. **New agent, empty directory** — `fastagent init`, then flesh out persona/skills/tools.
  2. **An existing directory becomes the agent** — init in place; init never overwrites and adopts existing files.
  3. **Embed into an existing application** — init picks `./agent` automatically when the root is claimed; mount `createPiAgentFromDefinition` + `createInvokeHandler` in the app's route.
- All three paths funnel into the unchanged operational steps (inspect → auth → init once → test → channels/deploy).

## Why

The prompt on the landing page is intent-agnostic; without routing, a coding agent lands on serve-only framing and has to infer the new-project and embed cases. The three-path section matches `init`'s actual behavior (flat vs `agentDir`, never-overwrite) and the embedding docs.

After merge, fastagent-sh/website pins the new rev so `start.md` regenerates.