### PR TITLE
docs: align narrative surfaces with fastagent.sh terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,14 @@ FastAgent is the missing bridge from local agent directory to real service.
 - **Vibe first — a directory is an agent.** Point FastAgent at the `AGENTS.md` + `skills/` you already vibed in a coding agent. Markdown instructions, reusable skills, and TypeScript tools stay as files you inspect, edit, and commit — no new DSL, no framework rewrite.
 - **Channels.** Serve the same agent as a GitHub PR reviewer, a Telegram bot, an HTTP/SSE endpoint, or your own adapter — verified webhooks, streaming replies, group-aware.
 - **Models, tools & skills.** Any model provider (OpenAI, Anthropic, Google, …) via OAuth or API key; typed tools discovered from `tools/` (the filename is the name, Zod-validated); Agent Skills loaded on demand. Built on the open-source [pi](https://github.com/earendil-works/pi) harness.
-- **App embedding — your stack, we plug in.** Like Flask/FastAPI for agents: FastAgent never owns your framework. Mount the agent in your Next / Astro / Hono / Bun / Node route with one handler — your auth, your database, your host.
-- **Deploy anywhere.** Run the directory directly — no build step; `fastagent deploy fly|railway` generates the host config + a runbook and hands off (`--run` drives the deploy to completion). The generated container also runs on other Docker hosts.
-
-Using a coding agent? Ask it to read [`https://fastagent.sh/start.md`](https://fastagent.sh/start.md), inspect your project, and serve its existing agent definition without rewriting it.
+- **App embedding — your stack, we plug in.** Mount the agent in your Next / Astro / Hono / Bun / Node route with one handler, or call `invoke` like any function from your own code — your auth, your database, your infra. FastAgent composes with your app, never owns it.
+- **Deploy anywhere.** No build step — the directory is the deployable unit. `fastagent deploy fly|railway` generates the deploy config + a runbook (`--run` drives it to completion); idle agents scale to zero and resume in hundreds of milliseconds on the next webhook. The generated container runs on any Docker host.
 
 ## Design philosophy
 
 FastAgent is built around a small serving contract, app-owned runtime concerns, typed boundaries, and composable adapters.
 
-- **Small serving core** — `invoke` decouples channels, agents, engines, and hosts.
+- **Small serving core** — `invoke` decouples channels, agents, harnesses, and infra.
 - **App-owned runtime** — no takeover of your auth, database, routes, or deployment.
 - **Typed edges** — typed tools, explicit events, boundary validation.
 - **Agent-native shape** — the directory is the deployable unit, and channels drive the same contract.
@@ -56,21 +54,27 @@ Read the [Design principles](https://fastagent.sh/docs/principles/) for the full
 
 ## What we didn't build
 
-FastAgent stays a small serving layer, so it never dictates your stack. Capabilities other agent frameworks bake into a platform, we leave to your app, your host, or the agent itself — composed in, not locked in.
+FastAgent stays a small serving layer, so it never dictates your stack. Capabilities other agent frameworks bake into a platform, we leave to your app, your infra, or the agent itself — composed in, not locked in.
 
-- **No platform to move to.** No dashboard, no control plane, no runtime you deploy *into* — run it locally, embed it in your app, or ship the directory to any host.
+- **No platform to move to.** No dashboard, no control plane, no runtime you deploy *into* — run it locally, embed it in your app, or ship the directory anywhere.
 - **No new format or DSL.** `AGENTS.md`, Agent Skills, TypeScript tools, HTTP/SSE — FastAgent consumes the standards you already use instead of a parallel ecosystem.
 - **No workflow engine.** The agent decides its own steps; for deterministic multi-step orchestration, call `invoke` from your own queue or workflow.
-- **No model or cloud lock-in.** The Agent Handler contract is engine-neutral, with pi as the reference implementation; another engine can implement the same `Agent` contract without changing channels.
+- **No model or cloud lock-in.** The Agent Handler contract is harness-neutral (the [SPEC](docs/SPEC.md) says *engine* — same seam), with [pi](https://pi.dev) as the built-in harness; bring your own harness and every channel keeps working unchanged.
 
 ## Install
+
+For agents — paste this into Claude Code, Codex, Cursor, or any coding agent that reads the web:
+
+> Read https://fastagent.sh/start.md and build an agent in this project.
+
+For humans:
 
 ```bash
 npm i -g @fastagent-sh/fastagent   # CLI: fastagent init/dev/start/...
 npm i @fastagent-sh/fastagent      # library API for embedding or code tools
 ```
 
-Requires **Node >= 22.19** (the floor is inherited from the pi reference engine and `undici`), and also runs under **Bun** (smoke-tested in CI on Bun 1.3; its native fetch replaces the undici path). The npm package ships compiled JavaScript and type declarations.
+Requires **Node >= 22.19** (the floor is inherited from the pi harness and `undici`), and also runs under **Bun** (smoke-tested in CI on Bun 1.3; its native fetch replaces the undici path). The npm package ships compiled JavaScript and type declarations.
 
 ## Quickstart
 
@@ -191,7 +195,7 @@ The neutral contract leaves room for capabilities that are not complete product 
 - **Durable execution** — Telegram accepted turns replay at least once today; general durability and exactly-once execution remain future backend work.
 - **Sandboxed execution** — `ExecutionEnv` is an assembly seam, but the pi coding tools and project-context loader are still local; a complete sandbox adapter is future work.
 - **Observability export** — leveled logs and per-turn traces exist today; an OpenTelemetry exporter does not.
-- **More reference bindings and channels** — pi is the reference implementation; another engine can implement the Agent contract, and community channels can use the channel kit.
+- **More harness bindings and channels** — pi is the built-in harness; another harness can implement the Agent contract, and community channels can use the channel kit.
 - **More deploy targets** — Fly and Railway ship today; the generated container is the portable path for other hosts.
 
 See [Contributing](CONTRIBUTING.md) if one of these is the problem you want to work on.
@@ -203,7 +207,7 @@ See [Contributing](CONTRIBUTING.md) if one of these is the problem you want to w
 
 ## Acknowledgements
 
-FastAgent stands on open source. The reference implementation is built on **[pi](https://github.com/earendil-works/pi)** ([pi.dev](https://pi.dev)) — its agent harness, multi-provider LLM API, and the interactive TUI that `fastagent chat` drives.
+FastAgent stands on open source. The built-in harness is **[pi](https://github.com/earendil-works/pi)** ([pi.dev](https://pi.dev)) — its agent loop, multi-provider LLM API, and the interactive TUI that `fastagent chat` drives.
 
 It also depends on, and is grateful to, [zod](https://github.com/colinhacks/zod), [undici](https://github.com/nodejs/undici), [chokidar](https://github.com/paulmillr/chokidar), [giget](https://github.com/unjs/giget), [@clack/prompts](https://github.com/bombshell-dev/clack), [ignore](https://github.com/kaelzhang/node-ignore), and [octokit/webhooks](https://github.com/octokit/webhooks).
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,6 +42,8 @@ FastAgent deliberately keeps the serving layer small and composable:
 - **Typed edges** — tools, events, and request bodies are explicit and validated at boundaries.
 - **Filesystem truth** — the deployable definition is the directory, not ambient machine state.
 
+Terminology: these docs and the [SPEC](SPEC.md) say *engine*; the ecosystem — and [fastagent.sh](https://fastagent.sh) — call the same seam the *agent harness*. One concept, one contract.
+
 See [Design principles](principles.md) for the full rationale and non-goals.
 
 ## What we didn't build

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -11,7 +11,7 @@ The design center is **point at directory → live agent capability**. FastAgent
 
 The design choices are deliberate:
 
-- **Small callable contract** — an internal boundary that decouples callers, agents, engines, and hosts.
+- **Small callable contract** — an internal boundary that decouples callers, agents, engines (the *agent harness*, in ecosystem terms), and hosts.
 - **Application composition** — compose with the user's application instead of owning routes, database, auth, deployment, and project layout.
 - **Typed edges** — typed tools, explicit events, and validation at the places where outside input enters the system.
 


### PR DESCRIPTION
The website (fastagent.sh) settled its narrative: **harness** for the engine role, **infra** for the app-side role, composition framing, scale-to-zero deploy selling points, and a For agents / For humans install split. This PR aligns the repo's narrative surfaces so the two front doors tell one story.

- **README** (the repo's marketing surface): harness in prose with an explicit `engine = harness` bridge where the SPEC term appears; `infra` for the app-side role; Flask/FastAPI analogy dropped (requires readers to know Flask — same reason the site dropped it); embedding bullet gains the in-process `invoke` path; deploy bullet leads with scale-to-zero + hundreds-of-ms resume (facts already in docs/deploy.md); install section gains the **For agents** copy-prompt path.
- **overview.md**: one terminology note — docs/SPEC say *engine*, the ecosystem and fastagent.sh say *agent harness*, same seam.
- **principles.md**: minimal gloss at the decoupling bullet.

**Deliberately untouched**: SPEC.md (engine is the precise protocol term under the v0.1 stability promise), and all technical docs where engine appears in runtime-loading contexts. The docs' seven-concept table also stays — the site's five-word set is a curated subset, not a replacement.

Follow-up (separate PR): regenerate assets/demo.svg to the site's three-act vibe → serve → ship storyline.