### PR TITLE
docs: align copy with the settled fastagent.sh narrative

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What this is
 
-fastagent is "Vibe first. Then FastAgent" for agent directories: it turns a file-defined agent (`persona.md` identity, `skills/`, tools, and existing `AGENTS.md` project context) into a running service inside an app, on GitHub, in Telegram, or behind a custom channel without a new authoring DSL.
+fastagent is "Vibe first. Then FastAgent" for agent directories: it turns a file-defined agent (`persona.md` identity, `skills/`, tools, and existing `AGENTS.md` project context) into a live service inside an app, on GitHub, in Telegram, or behind a custom channel without a new authoring DSL.
 
 The stable design center is the engine-neutral Agent Handler contract (`docs/SPEC.md`); pi (`@earendil-works/pi-*`) is the reference implementation.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,11 @@
 ---
-title: FastAgent documentation
+title: Documentation
 status: current
 ---
 
-# FastAgent documentation
+# Documentation
 
-FastAgent is the serving layer for local agent directories. It takes a directory out of the terminal and turns it into a running service: embedded in your app, connected to Telegram, handling GitHub/webhook events, exposed as an API endpoint, or running behind your own channel. `persona.md` is recommended for identity (an `AGENTS.md` is project context the agent reads), but the directory is the unit.
+FastAgent is the serving layer for local agent directories. It takes a directory out of the terminal and serves it as a live service: embedded in your app, connected to Telegram, handling GitHub/webhook events, exposed as an API endpoint, or running behind your own channel. `persona.md` is recommended for identity (an `AGENTS.md` is project context the agent reads), but the directory is the unit.
 
 ## Recommended path
 

--- a/docs/channel-development.md
+++ b/docs/channel-development.md
@@ -9,7 +9,7 @@ This guide is for developers building a new FastAgent channel adapter, either in
 
 A channel is an ingress adapter. It receives an external event, decides whether to invoke the agent, and returns an HTTP response appropriate for that external system.
 
-> This page is the AUTHOR's view — building an adapter. Using the existing channels is covered in [Channels](channels.md); the telegram channel's internal architecture (the reference for a stateful chat channel) is in [design/core.md §9.2](design/core.md).
+> This page is the AUTHOR's view — building an adapter. Using the existing channels is covered in [Channels](channels.md); the telegram channel's internal architecture (the reference for a stateful chat channel) is in [design/core.md §7](design/core.md).
 
 ## The two layers
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -5,7 +5,7 @@ status: current
 
 # Channels
 
-A **channel** is an agent's inbound surface: HTTP, GitHub webhooks, Telegram messages, Slack events, scheduled jobs, and so on.
+A **channel** is an agent's inbound surface — it turns an external event into invocations: HTTP, GitHub webhooks, Telegram messages, Slack events, even the clock ([schedules](quickstart.md#8-run-on-a-clock)).
 
 Channels consume only the engine-neutral [Agent contract](SPEC.md). The same channel can drive any conforming agent.
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -1,11 +1,11 @@
 ---
-title: FastAgent core design
+title: Core design
 type: design-doc
 status: current
 updated: 2026-07-10
 ---
 
-# FastAgent core design
+# Core design
 
 This document explains the architecture of FastAgent's pi reference implementation. The normative
 protocol is [Agent Handler SPEC v0.1](../SPEC.md); code in `src/` is the implementation source of

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -86,7 +86,7 @@ import { createInvokeHandler } from "@fastagent-sh/fastagent";
 const handler = createInvokeHandler(agent);   // (Request) => Promise<Response>; POST {session,text} → SSE
 ```
 
-The Fetch handler mounts wherever your host speaks `(Request) => Response`:
+The Fetch handler mounts wherever your host speaks `(Request) => Response` — and `nodeListener` bridges hosts that speak Node's `(req, res)`:
 
 ```ts
 // Next.js App Router — app/api/chat/route.ts
@@ -94,6 +94,21 @@ export const POST = handler;
 
 // Hono — c.req.raw is a Web Request
 app.post("/chat", (c) => handler(c.req.raw));
+
+// Express — nodeListener bridges (req, res) to the Fetch handler; it reads the raw
+// body stream, so don't put a body parser on this route
+import { nodeListener } from "@fastagent-sh/fastagent";
+app.post("/chat", nodeListener(handler));
+
+// Fastify — same bridge on the raw req/res: keep the body stream unread, hijack the reply
+app.register(async (scope) => {
+  scope.removeAllContentTypeParsers();
+  scope.addContentTypeParser("*", (_req, payload, done) => done(null, payload));
+  scope.post("/chat", (req, reply) => {
+    reply.hijack();
+    nodeListener(handler)(req.raw, reply.raw);
+  });
+});
 
 // Bun
 Bun.serve({ port: 8787, fetch: (req) =>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,13 +1,13 @@
 ---
-title: FastAgent overview
+title: Overview
 status: current
 ---
 
-# FastAgent overview
+# Overview
 
 **Vibe first. Then FastAgent.** FastAgent is the serving layer for local agent directories: take a directory out of the terminal, then run it inside your app, connect it to Telegram, handle GitHub/webhook events, expose it as an API endpoint, or put it behind your own channel.
 
-It does not ask you to rewrite an agent into a framework-specific project. Start with any directory; add `persona.md`, `skills/`, `tools/`, channels, and markdown context as the agent grows. FastAgent gives that directory a running service shape.
+It does not ask you to rewrite an agent into a framework-specific project. Start with any directory; add `persona.md`, `skills/`, `tools/`, channels, and markdown context as the agent grows. FastAgent serves that directory as a live service.
 
 Coding agents made it cheap to vibe useful agent directories. The next gap is serving: local agents live in terminals, but real services receive webhooks, join Telegram, serve product users, and expose stable APIs. FastAgent connects those directories to real triggers and runtimes.
 

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,5 +1,5 @@
 ---
-title: FastAgent design principles
+title: Design principles
 status: current
 ---
 
@@ -35,12 +35,12 @@ A feature is not real product surface until users can name it and reason about i
 
 | Concept | Meaning |
 |---|---|
-| **Definition** | The directory that describes the agent: optional `persona.md`, `skills/`, authored context, tools/channels, and config; `AGENTS.md` contributes project context. |
+| **Agent Definition** | The directory that describes the agent: optional `persona.md`, `skills/`, authored context, tools/channels, and config; `AGENTS.md` contributes project context. |
 | **Agent Handler** | The callable contract: `invoke(scope, prompt) => AsyncIterable<AgentEvent>`. |
 | **Event** | The streamed output shape every channel can consume: text, thinking, tool lifecycle, completion, or failure. |
 | **Tool** | A typed action the model can call, validated before execution. |
 | **Skill** | Reusable markdown expertise loaded from the definition, not from global machine state. |
-| **Channel** | An adapter that turns an external event into one or more invocations. |
+| **Channel** | An adapter that turns an external event — a webhook, a message, even the clock — into one or more invocations. |
 | **Session** | Runtime conversation state, owned by the host/session store rather than baked into the definition. |
 
 That concept set is intentionally smaller than the implementation. Sandboxes, durable queues, evals, registries, hosted deployment, and multi-instance backends can be added later, but they should not appear as core concepts until the product can support them honestly.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ status: current
 
 # Quickstart
 
-This guide takes you from an installed CLI to a running local agent service.
+This guide takes you from an installed CLI to a live local agent service.
 
 ## Prerequisites
 
@@ -178,8 +178,8 @@ Read [Channels](channels.md) for the channel model, [GitHub channel](github.md) 
 
 ## 8. Run on a clock
 
-Channels react to requests; **schedules** fire the agent on a cron — a daily digest, a periodic check.
-Drop a file in `schedules/` (mirroring `tools/`), named by its filename:
+Channels turn external events into invocations; **schedules** do the same for the clock — firing the
+agent on a cron: a daily digest, a periodic check. Drop a file in `schedules/` (mirroring `tools/`), named by its filename:
 
 ```ts
 // schedules/daily-digest.ts

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fastagent-sh/fastagent",
   "version": "0.12.0",
-  "description": "Vibe first. Then FastAgent: turn a local agent directory into a running service in your app, on GitHub, in Telegram, or behind any channel.",
+  "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",
     "ai-agent",


### PR DESCRIPTION
Closes the copy drift between fastagent.sh (settled landing narrative) and the rendered docs.

## Copy alignment
- **Clock → channel narrative**: the site defines a Channel as turning an external event — a webhook, a message, even the clock — into invocations. `channels.md` lede, `quickstart.md` §8, and the `principles.md` concept table now tell that one story instead of contrasting channels vs schedules.
- **"live service"**: the settled selling term replaces "running service" in the docs index, overview, quickstart lede, `AGENTS.md`, and the package description (repo README already used it).
- **"Agent Definition"**: the principles concept table adopts the site's concept name (was "Definition").
- **Doc titles de-prefixed**: "FastAgent documentation/overview/design principles/core design" → "Documentation/Overview/Design principles/Core design" — the prefix is redundant in the site sidebar and any FastAgent-branded surface.
- **Stale ref**: channel-development pointed at design/core.md §9.2; Telegram architecture lives in §7.

## New content
- **Embedding: Express and Fastify mounts.** fastagent.sh lists both as embed targets; the docs only showed Fetch-native hosts. `nodeListener` (already public API) bridges `(req, res)` hosts — Express as direct middleware, Fastify via unread body stream + `reply.hijack()`.

`node scripts/check-doc-links.mjs` passes (23 files). The fastagent.sh pin will be bumped after this merges.