### PR TITLE
chore: release 0.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Patch release: everything since v0.12.0 is docs/metadata/assets plus one dependabot group bump — no runtime code changes.

The point of cutting it now: the npm registry page still shows pre-alignment copy (description "running service", homepage `github#readme`, README with dead relative links and the old "real service" line). #221/#224/#225 fixed all of that in git; this release propagates it to npmjs.com.

After merge: publish the `v0.12.1` GitHub Release → `publish.yml` ships to npm via trusted publishing.