### PR TITLE
docs: per-page frontmatter descriptions; npm keywords for discovery

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 ---
 title: Documentation
+description: "The FastAgent documentation map: quickstart, configuration, embedding, channels, deployment, and reference for serving agent directories as live services."
 status: current
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,5 +1,6 @@
 ---
 title: Agent Handler — Protocol Specification
+description: "Agent Handler protocol v0.1: one invoke function and a small set of MUSTs so any caller can drive any agent without knowing its engine, model, or deployment shape."
 type: spec
 status: locked
 version: 0.1

--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -1,5 +1,6 @@
 ---
 title: Build and Serve an Agent with FastAgent
+description: "An executable setup path for coding agents: build and serve a FastAgent agent starting from nothing, from existing files, or inside an existing application."
 status: current
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,5 +1,6 @@
 ---
 title: API reference
+description: "The public TypeScript surface of @fastagent-sh/fastagent: the Agent contract, assembly functions, channel and host kit, typed tools, sessions, and providers."
 status: current
 ---
 

--- a/docs/channel-development.md
+++ b/docs/channel-development.md
@@ -1,5 +1,6 @@
 ---
 title: Channel development
+description: "Build a FastAgent channel adapter: the adapter/glue split, the ChannelModule contract, packaging third-party channels, and testing guidance."
 status: current
 ---
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,5 +1,6 @@
 ---
 title: Channels
+description: "How channels turn external events into agent invocations: workspace discovery, route tables, the first-party GitHub and Telegram adapters, and local webhook tunneling."
 status: current
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,6 @@
 ---
 title: CLI reference
+description: "The fastagent CLI reference: init, info, dev, chat, invoke, tool, start, login, models, add, fire, schedule, and deploy commands with flags."
 status: current
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: "Configure a FastAgent workspace: model selection, auth, ports, sessions, tools, channels, state paths, and deploy options in fastagent.config.*."
 status: current
 ---
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,5 +1,6 @@
 ---
 title: Deploy
+description: "Ship the directory: fastagent deploy for Fly.io and Railway, the generated Dockerfile for any Docker host, secrets, persistent state, and scale-to-zero behavior."
 status: current
 ---
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,5 +1,6 @@
 ---
 title: Design notes
+description: "What belongs in FastAgent's public design notes, and what is normative: the Agent Handler SPEC, the code, and the user docs."
 status: current
 ---
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -1,5 +1,6 @@
 ---
 title: Core design
+description: "Architecture of FastAgent's pi reference implementation: the assembly ladder, prompt assembly, event translation, sessions, channels, schedules, and state."
 type: design-doc
 status: current
 updated: 2026-07-10

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,5 +1,6 @@
 ---
 title: Embedding
+description: "Use FastAgent as a library: get an agent, consume its event stream, mount the Fetch handler in Next.js, Hono, Express, Fastify, Bun, or Node, and inject your own session store or providers."
 type: doc
 status: current
 ---

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,5 +1,6 @@
 ---
 title: GitHub channel
+description: "Connect GitHub webhooks to your agent: setup, signature verification, mapping events to agent turns, and operational notes for PR review bots."
 status: current
 ---
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: "What FastAgent is: the serving layer that takes a local agent directory out of the terminal and serves it as a live service — in your app, on GitHub, on Telegram, or behind any channel."
 status: current
 ---
 

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,5 +1,6 @@
 ---
 title: Design principles
+description: "The design choices behind FastAgent: a small callable contract, app-owned runtime, typed edges, the public concept set, and the non-goals that keep the serving layer small."
 status: current
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart
+description: "From an installed CLI to a live local agent service: scaffold a workspace, run it, add a typed tool, connect channels, and put the agent on a clock."
 status: current
 ---
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -1,5 +1,6 @@
 ---
 title: Telegram channel
+description: "Serve your agent as a Telegram bot: setup, webhook registration, live streamed replies, group-chat behavior, and durable at-least-once turn replay."
 status: current
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: "Fixes for common FastAgent setup and runtime issues: missing model, login and auth, ports, webhooks, sessions, schedules, and deployment."
 status: current
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "agents.md",
     "agent-skills",
     "agent-serving",
+    "telegram",
+    "github",
+    "webhook",
     "sse",
     "pi",
     "fastagent"


### PR DESCRIPTION
SEO follow-up from the site review:

- **Per-page `description` frontmatter for all 18 docs.** The rendered pages on fastagent.sh all shared the site-wide meta description (Starlight's fallback), so every search snippet was identical. Each page now describes its own content; Starlight picks it up for `<meta name=description>` and `og:description` automatically after the site's pin bump.
- **npm keywords**: add `telegram`, `github`, `webhook` — rides the next release.

`node scripts/check-doc-links.mjs` passes; frontmatter is plain YAML strings (quoted).