### PR TITLE
docs: trim four frontmatter descriptions to snippet length

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,6 +1,6 @@
 ---
 title: Channels
-description: "How channels turn external events into agent invocations: workspace discovery, route tables, the first-party GitHub and Telegram adapters, and local webhook tunneling."
+description: "How channels turn external events into agent invocations: discovery, route tables, the GitHub and Telegram adapters, and local webhook tunneling."
 status: current
 ---
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,6 +1,6 @@
 ---
 title: Embedding
-description: "Use FastAgent as a library: get an agent, consume its event stream, mount the Fetch handler in Next.js, Hono, Express, Fastify, Bun, or Node, and inject your own session store or providers."
+description: "Use FastAgent as a library: get an agent, consume its event stream, and mount the Fetch handler in Next.js, Hono, Express, Fastify, Bun, or Node."
 type: doc
 status: current
 ---

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "What FastAgent is: the serving layer that takes a local agent directory out of the terminal and serves it as a live service — in your app, on GitHub, on Telegram, or behind any channel."
+description: "What FastAgent is: the serving layer that takes a local agent directory out of the terminal and serves it as a live service on any channel."
 status: current
 ---
 

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,6 +1,6 @@
 ---
 title: Design principles
-description: "The design choices behind FastAgent: a small callable contract, app-owned runtime, typed edges, the public concept set, and the non-goals that keep the serving layer small."
+description: "The design choices behind FastAgent: a small callable contract, app-owned runtime, typed edges, and the non-goals that keep the serving layer small."
 status: current
 ---
 


### PR DESCRIPTION
SEO audit follow-up: overview (185 chars), embedding (189), principles (172), and channels (167) exceeded the ~160-character search-snippet budget and truncate mid-sentence on SERPs. Each now fits with the same meaning. `check-doc-links` passes.