### PR TITLE
fix(deploy): honor proxy for webhook registration

### DIFF
--- a/src/channels/telegram/register-webhook.ts
+++ b/src/channels/telegram/register-webhook.ts
@@ -44,6 +44,7 @@ export async function registerTelegramWebhook(
 
   // Reachable → register. A short retry backstops Telegram's resolver lagging /health by a moment; only
   // network-transient errors retry (a permanent "bad webhook" config error is reported, not retried).
+  let lastTransientError = "unknown transport error";
   for (let attempt = 0; attempt < 3; attempt++) {
     if (attempt > 0) await sleep(opts.retryMs ?? 2000);
     try {
@@ -56,7 +57,11 @@ export async function registerTelegramWebhook(
         log.error(`[fastagent] telegram: setWebhook failed (${error}). Register manually with url=${webhookUrl}`);
         return;
       }
+      lastTransientError = error;
     }
   }
-  log.warn(`[fastagent] telegram: setWebhook still failing after retries. Register manually with url=${webhookUrl}`);
+  log.warn(
+    `[fastagent] telegram: setWebhook still failing after retries (last error: ${lastTransientError}). ` +
+      `Register manually with url=${webhookUrl}`,
+  );
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -793,6 +793,7 @@ async function runDeploy(): Promise<void> {
     process.exit(1);
   }
   loadDotEnv(target); // a custom provider/tool may read a key at config load
+  installProxyFetch(); // post-deploy channel API calls must honor HTTP(S)_PROXY under Node
   const { config } = await loadConfig(target).catch(failStartup);
   const modelSpec = resolveModelSpec(values.model, config);
   // The host-neutral pre-flight (model-travel gate, channel discovery, model-auth probe, container facts +

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -45,6 +46,47 @@ describe("cli papercuts", () => {
     expect(stderr).toMatch(/excludes \.git/); // and the specific preflight warn fired (not force-gated)
     // Kit artifacts land namespaced.
     expect(await readFile(join(dir, "agent", "Dockerfile"), "utf8")).toMatch(/Repo-as-workspace/);
+  });
+
+  it("deploy loads .env and installs its proxy before config-time network work", async () => {
+    // Regression: the Node CLI used to load .env but omit installProxyFetch(), so post-deploy channel
+    // calls bypassed HTTP(S)_PROXY. A config-time fetch gives the real CLI path an early network probe;
+    // the reserved .invalid host can succeed only when the .env-only local proxy was installed first.
+    const requests: string[] = [];
+    const proxy = createServer((req, res) => {
+      requests.push(req.url ?? "");
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("proxied");
+    });
+    await new Promise<void>((resolve, reject) => {
+      proxy.once("error", reject);
+      proxy.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = proxy.address();
+      if (!address || typeof address === "string") throw new Error("proxy did not bind a TCP port");
+      const proxyUrl = `http://127.0.0.1:${address.port}`;
+      const dir = await mkdtemp(join(tmpdir(), "fa-deploy-proxy-"));
+      await writeFile(join(dir, ".env"), `HTTP_PROXY=${proxyUrl}\nHTTPS_PROXY=${proxyUrl}\n`);
+      await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
+      await writeFile(
+        join(dir, "fastagent.config.mjs"),
+        `const response = await fetch("http://deploy-proxy.invalid/probe");\n` +
+          `if (!response.ok) throw new Error("proxy probe failed");\n` +
+          `export default { model: "openai-codex/gpt-5.5" };\n`,
+      );
+      const env = { ...process.env };
+      for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]) {
+        delete env[key]; // the proxy must come from the workspace .env, loaded inside runDeploy()
+      }
+
+      const { code, stderr } = await run(["deploy", "fly", dir], undefined, env);
+      expect(code, stderr).toBe(0);
+      expect(requests).toContain("http://deploy-proxy.invalid/probe");
+    } finally {
+      await new Promise<void>((resolve, reject) => proxy.close((error) => (error ? reject(error) : resolve())));
+    }
   });
 
   it("--version / -v prints the version to stdout and exits 0 (no parse crash)", async () => {

--- a/test/register-webhook.test.ts
+++ b/test/register-webhook.test.ts
@@ -10,6 +10,7 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
   const prevSecret = process.env.TELEGRAM_SECRET_TOKEN;
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     process.env.TELEGRAM_BOT_TOKEN = prevBot;
     process.env.TELEGRAM_SECRET_TOKEN = prevSecret;
   });
@@ -95,6 +96,30 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
     );
     await registerTelegramWebhook("https://app.up.railway.app", { readyTimeoutMs: 5000, readyIntervalMs: 1 });
     expect(setWebhookCalls).toBe(1); // reported, not retried
+  });
+
+  it("reports the last transient error after exhausting setWebhook retries", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "bt";
+    process.env.TELEGRAM_SECRET_TOKEN = "st";
+    let setWebhookCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.endsWith("/health")) return new Response(null, { status: 200 });
+        setWebhookCalls++;
+        throw new Error(`fetch failed attempt ${setWebhookCalls}`);
+      }),
+    );
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await registerTelegramWebhook("https://app.up.railway.app", {
+      readyTimeoutMs: 5000,
+      readyIntervalMs: 1,
+      retryMs: 1,
+    });
+
+    expect(setWebhookCalls).toBe(3);
+    expect(stderr).toHaveBeenCalledWith(expect.stringMatching(/last error: .*fetch failed attempt 3/));
   });
 
   it("missing tokens → manual instruction, no health poll and no setWebhook", async () => {


### PR DESCRIPTION
## Summary

- initialize the Node proxy fetch dispatcher immediately after loading the workspace `.env` in the shared deploy command, covering both Fly and Railway post-deploy channel registration
- include the final transient Telegram transport error when `setWebhook` retries are exhausted
- add a real CLI subprocess regression test using an `.env`-only local proxy, plus coverage for the final retry diagnostic

Node's native `fetch` does not honor `HTTP_PROXY` or `HTTPS_PROXY`. Without this initialization, `fastagent deploy fly --run` and `fastagent deploy railway --run` could deploy successfully but fail to register webhooks on networks that require a proxy.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (683 tests)
- [x] Added or updated the smallest relevant tests

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added (`*_PLAN.md`, `HANDOFF.md`, session notes, etc.)
- [x] Docs were updated when behavior or public APIs changed (not applicable: no public API or documented contract changed)
