### PR TITLE
fix(channels): report terminal webhook-registration failures at ERROR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ src/
 │   ├── turn-store.ts        # SHARED: generic durable turn intent (L1) — record shape/validator/order injected per channel
 │   ├── state.ts             # SHARED: atomic state files under <stateRoot>/channels/<kind>/
 │   ├── wait-health.ts       # SHARED: readiness probe for the webhook registrars (both platforms verify the URL)
+│   ├── registration.ts      # SHARED: registrar outcome type (registered|manual|failed) — registrars report facts, deploy owns gate policy
 │   ├── github/              # github channel (+ scaffold/ bundle)
 │   ├── telegram/            # telegram channel — see docs/design/core.md §9.2
 │   │   ├── telegram.ts      # Telegram wiring: ingress + per-turn lifecycle + composition (pure parsing → parse.ts, run one turn → invoke-turn.ts)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ src/
 │       └── scaffold/        # `add lark` bundle
 ├── deploy/                  # `deploy fly|railway`: host artifacts + runbook + `--run` CLI drive (docs/design/core.md §10.5)
 │   │                        # LAYOUT: neutral kernel at top (horizontal) + one dir per host (vertical) — new host = new dir, copy fly/
+│   ├── registration-gate.ts # host-NEUTRAL step-7 gate policy: registrars report facts (registered|manual|failed), this owns gate-or-not
 │   ├── preflight.ts         # host-NEUTRAL pre-flight: model-travel gate (modelTravelIssue), channel discovery, auth probe, container facts + warnings
 │   ├── container.ts         # portable Dockerfile + .dockerignore (host-neutral) + the generated-marker predicate
 │   ├── secrets.ts           # required-secret NAMES (runbook) + assembleSecrets VALUES (--run credential carry)

--- a/src/channels/feishu/register-webhook.ts
+++ b/src/channels/feishu/register-webhook.ts
@@ -28,6 +28,12 @@ import { createFeishuApi, isFeishuConfigApiMissing, isTransientFeishuRegistratio
  * Register `<baseUrl>/<kind>` as the app's event Request URL (webhook mode). Missing credentials print
  * the manual instruction instead of failing. `opts` exist for tests: timeouts + `apiBase` (a fake
  * platform — production derives it from the kind).
+ *
+ * Resolves `false` when this run ends with the event URL NOT registered and acting + re-running can fix
+ * it (health timeout, a permanent config error, exhausted retries) — `deploy --run` turns that into a
+ * gate (non-zero exit). Resolves `true` when registered, or when the manual path is the designed norm
+ * (missing credentials; the cloud-lag 404, where no re-run can ever succeed). The tunnel ignores the
+ * result.
  */
 export interface FeishuManualRegistration {
   consoleUrl: string;
@@ -47,7 +53,7 @@ export async function registerFeishuWebhook(
   baseUrl: string,
   kind: FeishuCloudKind,
   opts: RegisterFeishuWebhookOptions = {},
-): Promise<void> {
+): Promise<boolean> {
   const profile = cloudFor(kind);
   const envPrefix = profile.envPrefix;
   const appId = process.env[`${envPrefix}_APP_ID`];
@@ -59,7 +65,7 @@ export async function registerFeishuWebhook(
     log.info(
       `[fastagent] ${kind}: set ${envPrefix}_APP_ID + ${envPrefix}_APP_SECRET in .env, then re-run to auto-register. Or ${manual}`,
     );
-    return;
+    return true;
   }
 
   // Align registration with the server actually serving: the PATCH triggers the platform's
@@ -72,7 +78,7 @@ export async function registerFeishuWebhook(
     log.error(
       `[fastagent] ${kind}: ${baseUrl}/health did not come up in time — the app may still be starting. ${manual}`,
     );
-    return;
+    return false;
   }
 
   const api = createFeishuApi({ kind, baseUrl: apiBase, appId, appSecret });
@@ -112,7 +118,7 @@ export async function registerFeishuWebhook(
       log.info(
         `[fastagent] ${kind}: if messages do not arrive, publish a version (one click, prompted) — the switch to webhook mode takes effect on publish: ${versionUrl}`,
       );
-      return;
+      return true;
     } catch (e) {
       // A 404 on the config route is the CLOUD lagging, not this app's configuration: the v7 API is
       // live on open.feishu.cn but not yet on open.larksuite.com. Name that — "check your scopes"
@@ -123,7 +129,7 @@ export async function registerFeishuWebhook(
             `manual registration is required`,
         );
         manualRegistration();
-        return;
+        return true; // that cloud has no config API — manual is the norm there, not a gate
       }
       if (!isTransientFeishuRegistrationError(e)) {
         log.error(
@@ -131,7 +137,7 @@ export async function registerFeishuWebhook(
             `The app may lack the "application:application:patch" scope (console → Permissions) or be under review; manual registration is available below.`,
         );
         manualRegistration();
-        return;
+        return false;
       }
     }
   }
@@ -140,4 +146,5 @@ export async function registerFeishuWebhook(
   // manual path is the known norm, not an exceptional failure.
   log.error(`[fastagent] ${kind}: registration still failing after retries — manual registration is required`);
   manualRegistration();
+  return false;
 }

--- a/src/channels/feishu/register-webhook.ts
+++ b/src/channels/feishu/register-webhook.ts
@@ -67,7 +67,9 @@ export async function registerFeishuWebhook(
   log.info(`[fastagent] ${kind}: waiting for ${baseUrl} to be reachable before registering the event URL…`);
   const ready = await waitForHealth(`${baseUrl}/health`, opts.readyTimeoutMs ?? 120_000, opts.readyIntervalMs ?? 3_000);
   if (!ready) {
-    log.warn(
+    // Terminal for this run (registration will not be retried) — error, not warn: the event URL is NOT
+    // registered and the operator must act. Same taxonomy as the permanent PATCH failure below.
+    log.error(
       `[fastagent] ${kind}: ${baseUrl}/health did not come up in time — the app may still be starting. ${manual}`,
     );
     return;
@@ -133,6 +135,9 @@ export async function registerFeishuWebhook(
       }
     }
   }
-  log.warn(`[fastagent] ${kind}: registration still failing after retries — manual registration is required`);
+  // Exhausted retries end in the same state as a permanent error (event URL not registered, manual
+  // action required) — report at the same level. The cloud-lag 404 above stays warn: on that cloud the
+  // manual path is the known norm, not an exceptional failure.
+  log.error(`[fastagent] ${kind}: registration still failing after retries — manual registration is required`);
   manualRegistration();
 }

--- a/src/channels/feishu/register-webhook.ts
+++ b/src/channels/feishu/register-webhook.ts
@@ -20,6 +20,7 @@
  */
 import { setTimeout as sleep } from "node:timers/promises";
 import { log } from "../../log.ts";
+import type { RegistrationOutcome } from "../registration.ts";
 import { waitForHealth } from "../wait-health.ts";
 import { type FeishuCloudKind, cloudFor } from "./cloud.ts";
 import { createFeishuApi, isFeishuConfigApiMissing, isTransientFeishuRegistrationError } from "./feishu-api.ts";
@@ -29,11 +30,7 @@ import { createFeishuApi, isFeishuConfigApiMissing, isTransientFeishuRegistratio
  * the manual instruction instead of failing. `opts` exist for tests: timeouts + `apiBase` (a fake
  * platform — production derives it from the kind).
  *
- * Resolves `false` when this run ends with the event URL NOT registered and acting + re-running can fix
- * it (health timeout, a permanent config error, exhausted retries) — `deploy --run` turns that into a
- * gate (non-zero exit). Resolves `true` when registered, or when the manual path is the designed norm
- * (missing credentials; the cloud-lag 404, where no re-run can ever succeed). The tunnel ignores the
- * result.
+ * Reports its outcome as a {@link RegistrationOutcome} fact; gating policy belongs to the caller.
  */
 export interface FeishuManualRegistration {
   consoleUrl: string;
@@ -53,7 +50,7 @@ export async function registerFeishuWebhook(
   baseUrl: string,
   kind: FeishuCloudKind,
   opts: RegisterFeishuWebhookOptions = {},
-): Promise<boolean> {
+): Promise<RegistrationOutcome> {
   const profile = cloudFor(kind);
   const envPrefix = profile.envPrefix;
   const appId = process.env[`${envPrefix}_APP_ID`];
@@ -65,7 +62,7 @@ export async function registerFeishuWebhook(
     log.info(
       `[fastagent] ${kind}: set ${envPrefix}_APP_ID + ${envPrefix}_APP_SECRET in .env, then re-run to auto-register. Or ${manual}`,
     );
-    return true;
+    return "manual";
   }
 
   // Align registration with the server actually serving: the PATCH triggers the platform's
@@ -78,7 +75,7 @@ export async function registerFeishuWebhook(
     log.error(
       `[fastagent] ${kind}: ${baseUrl}/health did not come up in time — the app may still be starting. ${manual}`,
     );
-    return false;
+    return "failed";
   }
 
   const api = createFeishuApi({ kind, baseUrl: apiBase, appId, appSecret });
@@ -118,7 +115,7 @@ export async function registerFeishuWebhook(
       log.info(
         `[fastagent] ${kind}: if messages do not arrive, publish a version (one click, prompted) — the switch to webhook mode takes effect on publish: ${versionUrl}`,
       );
-      return true;
+      return "registered";
     } catch (e) {
       // A 404 on the config route is the CLOUD lagging, not this app's configuration: the v7 API is
       // live on open.feishu.cn but not yet on open.larksuite.com. Name that — "check your scopes"
@@ -129,7 +126,7 @@ export async function registerFeishuWebhook(
             `manual registration is required`,
         );
         manualRegistration();
-        return true; // that cloud has no config API — manual is the norm there, not a gate
+        return "manual"; // that cloud has no config API — the manual path is the norm there
       }
       if (!isTransientFeishuRegistrationError(e)) {
         log.error(
@@ -137,7 +134,7 @@ export async function registerFeishuWebhook(
             `The app may lack the "application:application:patch" scope (console → Permissions) or be under review; manual registration is available below.`,
         );
         manualRegistration();
-        return false;
+        return "failed";
       }
     }
   }
@@ -146,5 +143,5 @@ export async function registerFeishuWebhook(
   // manual path is the known norm, not an exceptional failure.
   log.error(`[fastagent] ${kind}: registration still failing after retries — manual registration is required`);
   manualRegistration();
-  return false;
+  return "failed";
 }

--- a/src/channels/registration.ts
+++ b/src/channels/registration.ts
@@ -1,0 +1,13 @@
+/**
+ * SHARED: the webhook registrars' outcome. A registrar reports its own FACT; what to do about it (gate
+ * the deploy or not, and with what remediation) is the CALLER's policy — `deploy --run` gates on
+ * "failed", the tunnel (a long-running dev process) ignores the result entirely.
+ *
+ * - "registered": the platform accepted the webhook / event URL.
+ * - "manual": manual setup is the designed path — credentials not configured, or a cloud without the
+ *   config API (the Lark cloud-lag 404). Re-running cannot change it, so it must NOT become a
+ *   re-run-to-clear gate; the caller surfaces the manual step instead.
+ * - "failed": this run ends with the webhook NOT registered, and acting + re-running can fix it
+ *   (health timeout, a permanent config error, exhausted retries).
+ */
+export type RegistrationOutcome = "registered" | "manual" | "failed";

--- a/src/channels/registration.ts
+++ b/src/channels/registration.ts
@@ -4,9 +4,9 @@
  * "failed", the tunnel (a long-running dev process) ignores the result entirely.
  *
  * - "registered": the platform accepted the webhook / event URL.
- * - "manual": this run did not fail, but an operator-facing step remains — the caller surfaces it and
- *   must NOT gate on it. Two sub-states differ on re-runnability: credentials not configured (re-run
- *   after setting .env DOES auto-register; on the deploy path this is pre-gated by missingSecrets and
+ * - "manual": this run did not fail, but an operator-facing step remains (the registrar printed the
+ *   instructions). Two sub-states differ on re-runnability: credentials not configured (re-run after
+ *   setting .env DOES auto-register; on the deploy path this is pre-gated by missingSecrets and
  *   unreachable) and a cloud without the config API (the Lark cloud-lag 404 — no re-run can ever
  *   register it; the console is the only path).
  * - "failed": this run ends with the webhook NOT registered, and acting + re-running can fix it

--- a/src/channels/registration.ts
+++ b/src/channels/registration.ts
@@ -4,9 +4,11 @@
  * "failed", the tunnel (a long-running dev process) ignores the result entirely.
  *
  * - "registered": the platform accepted the webhook / event URL.
- * - "manual": manual setup is the designed path — credentials not configured, or a cloud without the
- *   config API (the Lark cloud-lag 404). Re-running cannot change it, so it must NOT become a
- *   re-run-to-clear gate; the caller surfaces the manual step instead.
+ * - "manual": this run did not fail, but an operator-facing step remains — the caller surfaces it and
+ *   must NOT gate on it. Two sub-states differ on re-runnability: credentials not configured (re-run
+ *   after setting .env DOES auto-register; on the deploy path this is pre-gated by missingSecrets and
+ *   unreachable) and a cloud without the config API (the Lark cloud-lag 404 — no re-run can ever
+ *   register it; the console is the only path).
  * - "failed": this run ends with the webhook NOT registered, and acting + re-running can fix it
  *   (health timeout, a permanent config error, exhausted retries).
  */

--- a/src/channels/telegram/register-webhook.ts
+++ b/src/channels/telegram/register-webhook.ts
@@ -35,7 +35,9 @@ export async function registerTelegramWebhook(
   log.info(`[fastagent] telegram: waiting for ${baseUrl} to be reachable before registering the webhook…`);
   const ready = await waitForHealth(`${baseUrl}/health`, opts.readyTimeoutMs ?? 120_000, opts.readyIntervalMs ?? 3_000);
   if (!ready) {
-    log.warn(
+    // Terminal for this run (registration will not be retried) — error, not warn: the webhook is NOT
+    // registered and the operator must act. Same taxonomy as the permanent setWebhook failure below.
+    log.error(
       `[fastagent] telegram: ${baseUrl}/health did not come up in time — the app may still be starting. ` +
         `Register the webhook manually once it's up: curl "https://api.telegram.org/bot<token>/setWebhook" -d url=${webhookUrl} -d secret_token=<secret>`,
     );
@@ -60,7 +62,9 @@ export async function registerTelegramWebhook(
       lastTransientError = error;
     }
   }
-  log.warn(
+  // Exhausted retries end in the same state as a permanent error (webhook not registered, manual
+  // action required) — report at the same level.
+  log.error(
     `[fastagent] telegram: setWebhook still failing after retries (last error: ${lastTransientError}). ` +
       `Register manually with url=${webhookUrl}`,
   );

--- a/src/channels/telegram/register-webhook.ts
+++ b/src/channels/telegram/register-webhook.ts
@@ -5,6 +5,7 @@
  */
 import { setTimeout as sleep } from "node:timers/promises";
 import { log } from "../../log.ts";
+import type { RegistrationOutcome } from "../registration.ts";
 import { waitForHealth } from "../wait-health.ts";
 import { callApi } from "./telegram-api.ts";
 
@@ -16,15 +17,12 @@ import { callApi } from "./telegram-api.ts";
  * fixes the race that made the first real deploy need a manual `setWebhook`. Missing tokens print the
  * manual instruction instead of failing. `opts` (timeouts) exist for tests; production uses the defaults.
  *
- * Resolves `false` when this run ends with the webhook NOT registered and acting + re-running can fix
- * it (health timeout, a permanent config error, exhausted retries) — `deploy --run` turns that into a
- * gate (non-zero exit). Resolves `true` when registered, or when the manual path is the designed norm
- * (missing tokens). The tunnel (a long-running dev process) ignores the result.
+ * Reports its outcome as a {@link RegistrationOutcome} fact; gating policy belongs to the caller.
  */
 export async function registerTelegramWebhook(
   baseUrl: string,
   opts: { readyTimeoutMs?: number; readyIntervalMs?: number; retryMs?: number } = {},
-): Promise<boolean> {
+): Promise<RegistrationOutcome> {
   const botToken = process.env.TELEGRAM_BOT_TOKEN;
   const secret = process.env.TELEGRAM_SECRET_TOKEN;
   const webhookUrl = `${baseUrl}/telegram`;
@@ -32,7 +30,7 @@ export async function registerTelegramWebhook(
     log.info(
       `[fastagent] telegram: set TELEGRAM_BOT_TOKEN + TELEGRAM_SECRET_TOKEN in .env, then re-run to auto-register. Webhook URL: ${webhookUrl}`,
     );
-    return true;
+    return "manual";
   }
 
   // Align registration with the server actually serving. Don't setWebhook against a URL Telegram can't
@@ -46,7 +44,7 @@ export async function registerTelegramWebhook(
       `[fastagent] telegram: ${baseUrl}/health did not come up in time — the app may still be starting. ` +
         `Register the webhook manually once it's up: curl "https://api.telegram.org/bot<token>/setWebhook" -d url=${webhookUrl} -d secret_token=<secret>`,
     );
-    return false;
+    return "failed";
   }
 
   // Reachable → register. A short retry backstops Telegram's resolver lagging /health by a moment; only
@@ -57,12 +55,12 @@ export async function registerTelegramWebhook(
     try {
       await callApi("https://api.telegram.org", botToken, "setWebhook", { url: webhookUrl, secret_token: secret });
       log.info(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
-      return true;
+      return "registered";
     } catch (e) {
       const error = String(e);
       if (!/resolve host|getaddrinfo|ENOTFOUND|fetch failed|ECONNRESET|timeout/i.test(error)) {
         log.error(`[fastagent] telegram: setWebhook failed (${error}). Register manually with url=${webhookUrl}`);
-        return false;
+        return "failed";
       }
       lastTransientError = error;
     }
@@ -73,5 +71,5 @@ export async function registerTelegramWebhook(
     `[fastagent] telegram: setWebhook still failing after retries (last error: ${lastTransientError}). ` +
       `Register manually with url=${webhookUrl}`,
   );
-  return false;
+  return "failed";
 }

--- a/src/channels/telegram/register-webhook.ts
+++ b/src/channels/telegram/register-webhook.ts
@@ -15,11 +15,16 @@ import { callApi } from "./telegram-api.ts";
  * seconds after the deploy/tunnel command returns. Tracking real readiness (not a fixed timer) is what
  * fixes the race that made the first real deploy need a manual `setWebhook`. Missing tokens print the
  * manual instruction instead of failing. `opts` (timeouts) exist for tests; production uses the defaults.
+ *
+ * Resolves `false` when this run ends with the webhook NOT registered and acting + re-running can fix
+ * it (health timeout, a permanent config error, exhausted retries) — `deploy --run` turns that into a
+ * gate (non-zero exit). Resolves `true` when registered, or when the manual path is the designed norm
+ * (missing tokens). The tunnel (a long-running dev process) ignores the result.
  */
 export async function registerTelegramWebhook(
   baseUrl: string,
   opts: { readyTimeoutMs?: number; readyIntervalMs?: number; retryMs?: number } = {},
-): Promise<void> {
+): Promise<boolean> {
   const botToken = process.env.TELEGRAM_BOT_TOKEN;
   const secret = process.env.TELEGRAM_SECRET_TOKEN;
   const webhookUrl = `${baseUrl}/telegram`;
@@ -27,7 +32,7 @@ export async function registerTelegramWebhook(
     log.info(
       `[fastagent] telegram: set TELEGRAM_BOT_TOKEN + TELEGRAM_SECRET_TOKEN in .env, then re-run to auto-register. Webhook URL: ${webhookUrl}`,
     );
-    return;
+    return true;
   }
 
   // Align registration with the server actually serving. Don't setWebhook against a URL Telegram can't
@@ -41,7 +46,7 @@ export async function registerTelegramWebhook(
       `[fastagent] telegram: ${baseUrl}/health did not come up in time — the app may still be starting. ` +
         `Register the webhook manually once it's up: curl "https://api.telegram.org/bot<token>/setWebhook" -d url=${webhookUrl} -d secret_token=<secret>`,
     );
-    return;
+    return false;
   }
 
   // Reachable → register. A short retry backstops Telegram's resolver lagging /health by a moment; only
@@ -52,12 +57,12 @@ export async function registerTelegramWebhook(
     try {
       await callApi("https://api.telegram.org", botToken, "setWebhook", { url: webhookUrl, secret_token: secret });
       log.info(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
-      return;
+      return true;
     } catch (e) {
       const error = String(e);
       if (!/resolve host|getaddrinfo|ENOTFOUND|fetch failed|ECONNRESET|timeout/i.test(error)) {
         log.error(`[fastagent] telegram: setWebhook failed (${error}). Register manually with url=${webhookUrl}`);
-        return;
+        return false;
       }
       lastTransientError = error;
     }
@@ -68,4 +73,5 @@ export async function registerTelegramWebhook(
     `[fastagent] telegram: setWebhook still failing after retries (last error: ${lastTransientError}). ` +
       `Register manually with url=${webhookUrl}`,
   );
+  return false;
 }

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -18,6 +18,7 @@
  * never land in argv/process listings.
  */
 import type { RegistrationOutcome } from "../../channels/registration.ts";
+import { registrationGate } from "../registration-gate.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
 import type { CliRunner } from "../runner.ts";
 
@@ -138,22 +139,12 @@ export async function deployFlyRun(
   }
 
   // 7. Post-deploy webhook — telegram end-to-end (fastagent has the token + the live URL); github is a
-  //    repo-settings step only a human can do. GATE POLICY (the registrars report facts, this run owns
-  //    the policy): "failed" gates — exit 0 would tell a coding agent "done" while the deployed agent
-  //    cannot receive messages, and steps 1-6 are idempotent so a re-run just retries registration.
-  //    "manual" does NOT gate — re-running can never change it (that would be an unclearable gate
-  //    spinning an agent forever) — but is re-surfaced as the run's LAST line so the operator cannot
-  //    miss it under the registrar's earlier log lines. All channels are attempted first (one failure
-  //    doesn't skip the rest).
-  const unregistered: string[] = [];
-  const manual: string[] = [];
-  const track = (kind: string, outcome: RegistrationOutcome): void => {
-    if (outcome === "failed") unregistered.push(kind);
-    if (outcome === "manual") manual.push(kind);
-  };
+  //    repo-settings step only a human can do. Gate policy is the shared registration-gate kernel
+  //    (registrars report facts, it owns the policy); all channels are attempted first.
+  const reg = registrationGate(log, "re-run to retry registration (steps already done are skipped)");
   if (plan.channels.includes("telegram")) {
     log("registering telegram webhook…");
-    track("telegram", await registerTelegram(`https://${plan.appName}.fly.dev`));
+    reg.track("telegram", await registerTelegram(`https://${plan.appName}.fly.dev`));
   }
   if (plan.channels.includes("github")) {
     log(`github: set the webhook in the repo (Settings → Webhooks) → https://${plan.appName}.fly.dev/webhook`);
@@ -162,21 +153,14 @@ export async function deployFlyRun(
     if (!plan.channels.includes(kind)) continue;
     if (registerFeishu) {
       log(`registering ${kind} event URL…`);
-      track(kind, await registerFeishu(`https://${plan.appName}.fly.dev`, kind));
+      reg.track(kind, await registerFeishu(`https://${plan.appName}.fly.dev`, kind));
     } else {
       log(
         `${kind}: set the event Request URL in the developer console (Events & Callbacks) → https://${plan.appName}.fly.dev/${kind} (the app must be running when you save)`,
       );
     }
   }
-  for (const kind of manual) {
-    log(`${kind}: webhook registration needs a one-time manual step — see the instructions above`);
-  }
-  if (unregistered.length > 0) {
-    return gate(
-      // Composes with cli.ts's "deploy stopped:" prefix — don't say "the deploy succeeded" first.
-      `webhook registration failed for: ${unregistered.join(", ")} — the app itself deployed; fix the error above, then re-run to retry registration (steps already done are skipped)`,
-    );
-  }
+  const registrationGateMsg = reg.gate();
+  if (registrationGateMsg) return gate(registrationGateMsg);
   return { ok: true };
 }

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -174,7 +174,8 @@ export async function deployFlyRun(
   }
   if (unregistered.length > 0) {
     return gate(
-      `the deploy succeeded but webhook registration failed for: ${unregistered.join(", ")} — see the error above, then re-run to retry registration (steps already done are skipped)`,
+      // Composes with cli.ts's "deploy stopped:" prefix — don't say "the deploy succeeded" first.
+      `webhook registration failed for: ${unregistered.join(", ")} — the app itself deployed; fix the error above, then re-run to retry registration (steps already done are skipped)`,
     );
   }
   return { ok: true };

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -3,7 +3,7 @@
  * secrets / deploy) that the plain runbook hands to the operator; `--run` executes it instead, so a
  * coding agent runs ONE command. Idempotent (app/volume check-then-act; channel secrets come from the
  * local env — NOT minted — so a re-run sets the same values) and resumable: it STOPS at a human gate
- * (not logged in, a missing secret value, a taken app name) with one actionable line and a non-zero
+ * (not logged in, a missing secret value, a taken app name, a failed webhook registration) with one actionable line and a non-zero
  * exit, so the agent clears the gate and re-runs. A `generate` channel secret absent from `.env` is a
  * gate too (`missingSecrets`), not a silent mint — fill it in `.env` (use the random string that
  * `add <channel>` prints).
@@ -68,8 +68,8 @@ export async function deployFlyRun(
   plan: FlyRunPlan,
   fly: CliRunner,
   log: (msg: string) => void,
-  registerTelegram: (baseUrl: string) => Promise<void>,
-  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<void>,
+  registerTelegram: (baseUrl: string) => Promise<boolean>,
+  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<boolean>,
 ): Promise<FlyRunOutcome> {
   const gate = (g: string): FlyRunOutcome => ({ ok: false, gate: g });
 
@@ -137,10 +137,14 @@ export async function deployFlyRun(
   }
 
   // 7. Post-deploy webhook — telegram end-to-end (fastagent has the token + the live URL); github is a
-  //    repo-settings step only a human can do.
+  //    repo-settings step only a human can do. A registration that terminally fails is a gate like any
+  //    other step: exit 0 would tell a coding agent "done" while the deployed agent cannot receive
+  //    messages. All channels are attempted first (one failure doesn't skip the rest); the deploy itself
+  //    succeeded and steps 1-6 are idempotent, so a re-run just retries registration.
+  const unregistered: string[] = [];
   if (plan.channels.includes("telegram")) {
     log("registering telegram webhook…");
-    await registerTelegram(`https://${plan.appName}.fly.dev`);
+    if (!(await registerTelegram(`https://${plan.appName}.fly.dev`))) unregistered.push("telegram");
   }
   if (plan.channels.includes("github")) {
     log(`github: set the webhook in the repo (Settings → Webhooks) → https://${plan.appName}.fly.dev/webhook`);
@@ -149,12 +153,17 @@ export async function deployFlyRun(
     if (!plan.channels.includes(kind)) continue;
     if (registerFeishu) {
       log(`registering ${kind} event URL…`);
-      await registerFeishu(`https://${plan.appName}.fly.dev`, kind);
+      if (!(await registerFeishu(`https://${plan.appName}.fly.dev`, kind))) unregistered.push(kind);
     } else {
       log(
         `${kind}: set the event Request URL in the developer console (Events & Callbacks) → https://${plan.appName}.fly.dev/${kind} (the app must be running when you save)`,
       );
     }
+  }
+  if (unregistered.length > 0) {
+    return gate(
+      `the deploy succeeded but webhook registration failed for: ${unregistered.join(", ")} — see the error above, then re-run to retry registration (steps already done are skipped)`,
+    );
   }
   return { ok: true };
 }

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -17,6 +17,7 @@
  * (one machine, the single-machine tier). Secrets go in via `secrets import` over stdin, so values
  * never land in argv/process listings.
  */
+import type { RegistrationOutcome } from "../../channels/registration.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
 import type { CliRunner } from "../runner.ts";
 
@@ -68,8 +69,8 @@ export async function deployFlyRun(
   plan: FlyRunPlan,
   fly: CliRunner,
   log: (msg: string) => void,
-  registerTelegram: (baseUrl: string) => Promise<boolean>,
-  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<boolean>,
+  registerTelegram: (baseUrl: string) => Promise<RegistrationOutcome>,
+  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<RegistrationOutcome>,
 ): Promise<FlyRunOutcome> {
   const gate = (g: string): FlyRunOutcome => ({ ok: false, gate: g });
 
@@ -137,14 +138,22 @@ export async function deployFlyRun(
   }
 
   // 7. Post-deploy webhook — telegram end-to-end (fastagent has the token + the live URL); github is a
-  //    repo-settings step only a human can do. A registration that terminally fails is a gate like any
-  //    other step: exit 0 would tell a coding agent "done" while the deployed agent cannot receive
-  //    messages. All channels are attempted first (one failure doesn't skip the rest); the deploy itself
-  //    succeeded and steps 1-6 are idempotent, so a re-run just retries registration.
+  //    repo-settings step only a human can do. GATE POLICY (the registrars report facts, this run owns
+  //    the policy): "failed" gates — exit 0 would tell a coding agent "done" while the deployed agent
+  //    cannot receive messages, and steps 1-6 are idempotent so a re-run just retries registration.
+  //    "manual" does NOT gate — re-running can never change it (that would be an unclearable gate
+  //    spinning an agent forever) — but is re-surfaced as the run's LAST line so the operator cannot
+  //    miss it under the registrar's earlier log lines. All channels are attempted first (one failure
+  //    doesn't skip the rest).
   const unregistered: string[] = [];
+  const manual: string[] = [];
+  const track = (kind: string, outcome: RegistrationOutcome): void => {
+    if (outcome === "failed") unregistered.push(kind);
+    if (outcome === "manual") manual.push(kind);
+  };
   if (plan.channels.includes("telegram")) {
     log("registering telegram webhook…");
-    if (!(await registerTelegram(`https://${plan.appName}.fly.dev`))) unregistered.push("telegram");
+    track("telegram", await registerTelegram(`https://${plan.appName}.fly.dev`));
   }
   if (plan.channels.includes("github")) {
     log(`github: set the webhook in the repo (Settings → Webhooks) → https://${plan.appName}.fly.dev/webhook`);
@@ -153,12 +162,15 @@ export async function deployFlyRun(
     if (!plan.channels.includes(kind)) continue;
     if (registerFeishu) {
       log(`registering ${kind} event URL…`);
-      if (!(await registerFeishu(`https://${plan.appName}.fly.dev`, kind))) unregistered.push(kind);
+      track(kind, await registerFeishu(`https://${plan.appName}.fly.dev`, kind));
     } else {
       log(
         `${kind}: set the event Request URL in the developer console (Events & Callbacks) → https://${plan.appName}.fly.dev/${kind} (the app must be running when you save)`,
       );
     }
+  }
+  for (const kind of manual) {
+    log(`${kind}: webhook registration needs a one-time manual step — see the instructions above`);
   }
   if (unregistered.length > 0) {
     return gate(

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -148,6 +148,7 @@ export async function deployFlyRun(
   }
   if (plan.channels.includes("github")) {
     log(`github: set the webhook in the repo (Settings → Webhooks) → https://${plan.appName}.fly.dev/webhook`);
+    reg.track("github", "manual"); // always a human step — re-surface it after the registrar output
   }
   for (const kind of ["feishu", "lark"] as const) {
     if (!plan.channels.includes(kind)) continue;
@@ -158,6 +159,7 @@ export async function deployFlyRun(
       log(
         `${kind}: set the event Request URL in the developer console (Events & Callbacks) → https://${plan.appName}.fly.dev/${kind} (the app must be running when you save)`,
       );
+      reg.track(kind, "manual"); // no registrar wired — the console step above is the operator's
     }
   }
   const registrationGateMsg = reg.gate();

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -24,6 +24,7 @@
  * `RAILWAY_API_KEY`), not a project token: `init` creates a project that a project token can't predate.
  */
 import type { RegistrationOutcome } from "../../channels/registration.ts";
+import { registrationGate } from "../registration-gate.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
 import type { CliRunner } from "../runner.ts";
 
@@ -241,19 +242,12 @@ export async function deployRailwayRun(
   if (!url) {
     return gate("couldn't read a domain from `railway domain` — run `railway domain` manually, then set any webhook");
   }
-  // 7. Post-deploy webhook — same gate policy as the Fly runner (fly/run.ts step 7): the registrars
-  //    report facts, this run owns the policy. "failed" gates (exit 0 would tell a coding agent "done"
-  //    while the deployed agent cannot receive messages); "manual" does not gate (re-running can never
-  //    change it) but is re-surfaced as the run's LAST line. All channels are attempted first.
-  const unregistered: string[] = [];
-  const manual: string[] = [];
-  const track = (kind: string, outcome: RegistrationOutcome): void => {
-    if (outcome === "failed") unregistered.push(kind);
-    if (outcome === "manual") manual.push(kind);
-  };
+  // 7. Post-deploy webhook — gate policy is the shared registration-gate kernel (registrars report
+  //    facts, it owns the policy); all channels are attempted first.
+  const reg = registrationGate(log, "re-run with --into-linked to retry registration");
   if (plan.channels.includes("telegram")) {
     log("registering telegram webhook…");
-    track("telegram", await registerTelegram(url));
+    reg.track("telegram", await registerTelegram(url));
   }
   if (plan.channels.includes("github")) {
     log(`github: set the webhook in the repo (Settings → Webhooks) → ${url}/webhook`);
@@ -262,21 +256,14 @@ export async function deployRailwayRun(
     if (!plan.channels.includes(kind)) continue;
     if (registerFeishu) {
       log(`registering ${kind} event URL…`);
-      track(kind, await registerFeishu(url, kind));
+      reg.track(kind, await registerFeishu(url, kind));
     } else {
       log(
         `${kind}: set the event Request URL in the developer console (Events & Callbacks) → ${url}/${kind} (the service must be running when you save)`,
       );
     }
   }
-  for (const kind of manual) {
-    log(`${kind}: webhook registration needs a one-time manual step — see the instructions above`);
-  }
-  if (unregistered.length > 0) {
-    return gate(
-      // Composes with cli.ts's "deploy stopped:" prefix — don't say "the deploy succeeded" first.
-      `webhook registration failed for: ${unregistered.join(", ")} — the app itself deployed; fix the error above, then re-run with --into-linked to retry registration`,
-    );
-  }
+  const registrationGateMsg = reg.gate();
+  if (registrationGateMsg) return gate(registrationGateMsg);
   return { ok: true, url };
 }

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -122,8 +122,8 @@ export async function deployRailwayRun(
   plan: RailwayRunPlan,
   railway: CliRunner,
   log: (msg: string) => void,
-  registerTelegram: (baseUrl: string) => Promise<void>,
-  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<void>,
+  registerTelegram: (baseUrl: string) => Promise<boolean>,
+  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<boolean>,
 ): Promise<RailwayRunOutcome> {
   const gate = (g: string): RailwayRunOutcome => ({ ok: false, gate: g });
   // Every --service below targets plan.name — the name this tool gives BOTH the project and the service
@@ -240,9 +240,14 @@ export async function deployRailwayRun(
   if (!url) {
     return gate("couldn't read a domain from `railway domain` — run `railway domain` manually, then set any webhook");
   }
+  // 7. Post-deploy webhook — a registration that terminally fails is a gate like any other step: exit 0
+  //    would tell a coding agent "done" while the deployed agent cannot receive messages. All channels
+  //    are attempted first (one failure doesn't skip the rest); the deploy itself succeeded, so a re-run
+  //    (or `--into-linked` re-run) just retries registration.
+  const unregistered: string[] = [];
   if (plan.channels.includes("telegram")) {
     log("registering telegram webhook…");
-    await registerTelegram(url);
+    if (!(await registerTelegram(url))) unregistered.push("telegram");
   }
   if (plan.channels.includes("github")) {
     log(`github: set the webhook in the repo (Settings → Webhooks) → ${url}/webhook`);
@@ -251,12 +256,17 @@ export async function deployRailwayRun(
     if (!plan.channels.includes(kind)) continue;
     if (registerFeishu) {
       log(`registering ${kind} event URL…`);
-      await registerFeishu(url, kind);
+      if (!(await registerFeishu(url, kind))) unregistered.push(kind);
     } else {
       log(
         `${kind}: set the event Request URL in the developer console (Events & Callbacks) → ${url}/${kind} (the service must be running when you save)`,
       );
     }
+  }
+  if (unregistered.length > 0) {
+    return gate(
+      `the deploy succeeded but webhook registration failed for: ${unregistered.join(", ")} — see the error above, then re-run with --into-linked to retry registration`,
+    );
   }
   return { ok: true, url };
 }

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -274,7 +274,8 @@ export async function deployRailwayRun(
   }
   if (unregistered.length > 0) {
     return gate(
-      `the deploy succeeded but webhook registration failed for: ${unregistered.join(", ")} — see the error above, then re-run with --into-linked to retry registration`,
+      // Composes with cli.ts's "deploy stopped:" prefix — don't say "the deploy succeeded" first.
+      `webhook registration failed for: ${unregistered.join(", ")} — the app itself deployed; fix the error above, then re-run with --into-linked to retry registration`,
     );
   }
   return { ok: true, url };

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -251,6 +251,7 @@ export async function deployRailwayRun(
   }
   if (plan.channels.includes("github")) {
     log(`github: set the webhook in the repo (Settings → Webhooks) → ${url}/webhook`);
+    reg.track("github", "manual"); // always a human step — re-surface it after the registrar output
   }
   for (const kind of ["feishu", "lark"] as const) {
     if (!plan.channels.includes(kind)) continue;
@@ -261,6 +262,7 @@ export async function deployRailwayRun(
       log(
         `${kind}: set the event Request URL in the developer console (Events & Callbacks) → ${url}/${kind} (the service must be running when you save)`,
       );
+      reg.track(kind, "manual"); // no registrar wired — the console step above is the operator's
     }
   }
   const registrationGateMsg = reg.gate();

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -23,6 +23,7 @@
  * no bulk stdin import like Fly's `secrets import`). Auth needs an ACCOUNT credential (login or
  * `RAILWAY_API_KEY`), not a project token: `init` creates a project that a project token can't predate.
  */
+import type { RegistrationOutcome } from "../../channels/registration.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
 import type { CliRunner } from "../runner.ts";
 
@@ -122,8 +123,8 @@ export async function deployRailwayRun(
   plan: RailwayRunPlan,
   railway: CliRunner,
   log: (msg: string) => void,
-  registerTelegram: (baseUrl: string) => Promise<boolean>,
-  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<boolean>,
+  registerTelegram: (baseUrl: string) => Promise<RegistrationOutcome>,
+  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<RegistrationOutcome>,
 ): Promise<RailwayRunOutcome> {
   const gate = (g: string): RailwayRunOutcome => ({ ok: false, gate: g });
   // Every --service below targets plan.name — the name this tool gives BOTH the project and the service
@@ -240,14 +241,19 @@ export async function deployRailwayRun(
   if (!url) {
     return gate("couldn't read a domain from `railway domain` — run `railway domain` manually, then set any webhook");
   }
-  // 7. Post-deploy webhook — a registration that terminally fails is a gate like any other step: exit 0
-  //    would tell a coding agent "done" while the deployed agent cannot receive messages. All channels
-  //    are attempted first (one failure doesn't skip the rest); the deploy itself succeeded, so a re-run
-  //    (or `--into-linked` re-run) just retries registration.
+  // 7. Post-deploy webhook — same gate policy as the Fly runner (fly/run.ts step 7): the registrars
+  //    report facts, this run owns the policy. "failed" gates (exit 0 would tell a coding agent "done"
+  //    while the deployed agent cannot receive messages); "manual" does not gate (re-running can never
+  //    change it) but is re-surfaced as the run's LAST line. All channels are attempted first.
   const unregistered: string[] = [];
+  const manual: string[] = [];
+  const track = (kind: string, outcome: RegistrationOutcome): void => {
+    if (outcome === "failed") unregistered.push(kind);
+    if (outcome === "manual") manual.push(kind);
+  };
   if (plan.channels.includes("telegram")) {
     log("registering telegram webhook…");
-    if (!(await registerTelegram(url))) unregistered.push("telegram");
+    track("telegram", await registerTelegram(url));
   }
   if (plan.channels.includes("github")) {
     log(`github: set the webhook in the repo (Settings → Webhooks) → ${url}/webhook`);
@@ -256,12 +262,15 @@ export async function deployRailwayRun(
     if (!plan.channels.includes(kind)) continue;
     if (registerFeishu) {
       log(`registering ${kind} event URL…`);
-      if (!(await registerFeishu(url, kind))) unregistered.push(kind);
+      track(kind, await registerFeishu(url, kind));
     } else {
       log(
         `${kind}: set the event Request URL in the developer console (Events & Callbacks) → ${url}/${kind} (the service must be running when you save)`,
       );
     }
+  }
+  for (const kind of manual) {
+    log(`${kind}: webhook registration needs a one-time manual step — see the instructions above`);
   }
   if (unregistered.length > 0) {
     return gate(

--- a/src/deploy/registration-gate.ts
+++ b/src/deploy/registration-gate.ts
@@ -5,8 +5,8 @@
  * - "failed" gates — exit 0 would tell a coding agent "done" while the deployed agent cannot receive
  *   messages, and the runners' earlier steps are idempotent so a re-run just retries registration.
  * - "manual" does NOT gate — re-running can never change it (an unclearable gate would spin a coding
- *   agent forever) — but is re-surfaced as the run's LAST line so the operator cannot miss it under
- *   the registrar's earlier log lines.
+ *   agent forever) — but is re-surfaced after all registrar output (and before any gate message) so
+ *   the operator cannot miss it under the registrar's earlier log lines.
  *
  * The runners attempt ALL channels first (one failure doesn't skip the rest), then apply this policy
  * once. Only the retry remediation differs per host (`retryHint`).

--- a/src/deploy/registration-gate.ts
+++ b/src/deploy/registration-gate.ts
@@ -1,0 +1,40 @@
+/**
+ * Host-NEUTRAL step-7 gate policy, shared by the host runners: the registrars report facts
+ * ({@link RegistrationOutcome}), this module owns what to do about them.
+ *
+ * - "failed" gates — exit 0 would tell a coding agent "done" while the deployed agent cannot receive
+ *   messages, and the runners' earlier steps are idempotent so a re-run just retries registration.
+ * - "manual" does NOT gate — re-running can never change it (an unclearable gate would spin a coding
+ *   agent forever) — but is re-surfaced as the run's LAST line so the operator cannot miss it under
+ *   the registrar's earlier log lines.
+ *
+ * The runners attempt ALL channels first (one failure doesn't skip the rest), then apply this policy
+ * once. Only the retry remediation differs per host (`retryHint`).
+ */
+import type { RegistrationOutcome } from "../channels/registration.ts";
+
+export function registrationGate(
+  log: (msg: string) => void,
+  retryHint: string,
+): {
+  track: (kind: string, outcome: RegistrationOutcome) => void;
+  /** Logs the manual notices; returns the gate message (composes with cli.ts's "deploy stopped:"
+   *  prefix — it leads with the failure, not "the deploy succeeded"), or undefined for no gate. */
+  gate: () => string | undefined;
+} {
+  const unregistered: string[] = [];
+  const manual: string[] = [];
+  return {
+    track(kind, outcome) {
+      if (outcome === "failed") unregistered.push(kind);
+      if (outcome === "manual") manual.push(kind);
+    },
+    gate() {
+      for (const kind of manual) {
+        log(`${kind}: webhook registration needs a one-time manual step — see the instructions above`);
+      }
+      if (unregistered.length === 0) return undefined;
+      return `webhook registration failed for: ${unregistered.join(", ")} — the app itself deployed; fix the error above, then ${retryHint}`;
+    },
+  };
+}

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -24,13 +24,13 @@ const plan = (over: Partial<FlyRunPlan> = {}): FlyRunPlan => ({
   ...over,
 });
 
-const run = (p: FlyRunPlan, fly: CliRunner, tg = vi.fn(async () => {})) => deployFlyRun(p, fly, () => {}, tg);
+const run = (p: FlyRunPlan, fly: CliRunner, tg = vi.fn(async () => true)) => deployFlyRun(p, fly, () => {}, tg);
 
 describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
   it("happy path: auth → create app+volume → set secrets → deploy → telegram webhook", async () => {
     // Fresh account: apps/volumes lists are empty, everything succeeds.
     const { fly, cmds } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
-    const tg = vi.fn(async () => {});
+    const tg = vi.fn(async () => true);
     const out = await run(
       plan({ channels: ["telegram"], secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" } }),
       fly,
@@ -52,13 +52,13 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
 
   it("dispatches Feishu and Lark registration through the per-kind seam", async () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
-    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => {});
+    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => true);
 
     const out = await deployFlyRun(
       plan({ channels: ["feishu", "lark"] }),
       fly,
       () => {},
-      vi.fn(async () => {}),
+      vi.fn(async () => true),
       registerFeishu,
     );
 
@@ -69,6 +69,26 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     ]);
   });
 
+  it("gates when a webhook registration terminally fails — after attempting the remaining channels", async () => {
+    const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
+    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => true);
+
+    const out = await deployFlyRun(
+      plan({ channels: ["telegram", "feishu"] }),
+      fly,
+      () => {},
+      vi.fn(async () => false), // telegram registration ends with the webhook NOT set
+      registerFeishu,
+    );
+
+    // Exit 0 here would tell a coding agent "done" while the agent can't receive messages.
+    expect(out).toEqual({
+      ok: false,
+      gate: expect.stringMatching(/deploy succeeded but webhook registration failed for: telegram/),
+    });
+    expect(registerFeishu).toHaveBeenCalledWith("https://bot.fly.dev", "feishu"); // one failure doesn't skip the rest
+  });
+
   it("prints each Feishu-cloud Request URL when no registrar is supplied", async () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
@@ -77,7 +97,7 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
       plan({ channels: ["feishu", "lark"] }),
       fly,
       (message) => logs.push(message),
-      vi.fn(async () => {}),
+      vi.fn(async () => true),
     );
 
     expect(out).toEqual({ ok: true });

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { type FlyRunPlan, authSeedBytes, deployFlyRun } from "../src/deploy/fly/run.ts";
+import type { RegistrationOutcome } from "../src/channels/registration.ts";
 import type { CliRunner } from "../src/deploy/runner.ts";
 import { assembleSecrets } from "../src/deploy/secrets.ts";
 
@@ -24,13 +25,14 @@ const plan = (over: Partial<FlyRunPlan> = {}): FlyRunPlan => ({
   ...over,
 });
 
-const run = (p: FlyRunPlan, fly: CliRunner, tg = vi.fn(async () => true)) => deployFlyRun(p, fly, () => {}, tg);
+const run = (p: FlyRunPlan, fly: CliRunner, tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered")) =>
+  deployFlyRun(p, fly, () => {}, tg);
 
 describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
   it("happy path: auth → create app+volume → set secrets → deploy → telegram webhook", async () => {
     // Fresh account: apps/volumes lists are empty, everything succeeds.
     const { fly, cmds } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
-    const tg = vi.fn(async () => true);
+    const tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered");
     const out = await run(
       plan({ channels: ["telegram"], secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" } }),
       fly,
@@ -52,13 +54,15 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
 
   it("dispatches Feishu and Lark registration through the per-kind seam", async () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
-    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => true);
+    const registerFeishu = vi.fn(
+      async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
+    );
 
     const out = await deployFlyRun(
       plan({ channels: ["feishu", "lark"] }),
       fly,
       () => {},
-      vi.fn(async () => true),
+      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
       registerFeishu,
     );
 
@@ -71,13 +75,15 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
 
   it("gates when a webhook registration terminally fails — after attempting the remaining channels", async () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
-    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => true);
+    const registerFeishu = vi.fn(
+      async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
+    );
 
     const out = await deployFlyRun(
       plan({ channels: ["telegram", "feishu"] }),
       fly,
       () => {},
-      vi.fn(async () => false), // telegram registration ends with the webhook NOT set
+      vi.fn(async (): Promise<RegistrationOutcome> => "failed"), // telegram registration ends with the webhook NOT set
       registerFeishu,
     );
 
@@ -89,6 +95,23 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     expect(registerFeishu).toHaveBeenCalledWith("https://bot.fly.dev", "feishu"); // one failure doesn't skip the rest
   });
 
+  it("a 'manual' registration outcome does not gate — but is re-surfaced as the run's last line", async () => {
+    // e.g. the Lark cloud-lag 404: re-running can never change it, so gating would spin an agent forever.
+    const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
+    const logs: string[] = [];
+
+    const out = await deployFlyRun(
+      plan({ channels: ["lark"] }),
+      fly,
+      (m) => logs.push(m),
+      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
+    );
+
+    expect(out).toEqual({ ok: true });
+    expect(logs.at(-1)).toMatch(/lark: webhook registration needs a one-time manual step/);
+  });
+
   it("prints each Feishu-cloud Request URL when no registrar is supplied", async () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
@@ -97,7 +120,7 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
       plan({ channels: ["feishu", "lark"] }),
       fly,
       (message) => logs.push(message),
-      vi.fn(async () => true),
+      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
     );
 
     expect(out).toEqual({ ok: true });

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -112,6 +112,25 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     expect(logs.at(-1)).toMatch(/lark: webhook registration needs a one-time manual step/);
   });
 
+  it("mixed outcomes: manual notices are logged AND the failed channels still gate", async () => {
+    const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
+    const logs: string[] = [];
+
+    const out = await deployFlyRun(
+      plan({ channels: ["telegram", "lark"] }),
+      fly,
+      (m) => logs.push(m),
+      vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
+      vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
+    );
+
+    expect(logs.at(-1)).toMatch(/lark: webhook registration needs a one-time manual step/);
+    expect(out).toEqual({
+      ok: false,
+      gate: expect.stringMatching(/webhook registration failed for: telegram/),
+    });
+  });
+
   it("prints each Feishu-cloud Request URL when no registrar is supplied", async () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -90,7 +90,7 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     // Exit 0 here would tell a coding agent "done" while the agent can't receive messages.
     expect(out).toEqual({
       ok: false,
-      gate: expect.stringMatching(/deploy succeeded but webhook registration failed for: telegram/),
+      gate: expect.stringMatching(/webhook registration failed for: telegram/),
     });
     expect(registerFeishu).toHaveBeenCalledWith("https://bot.fly.dev", "feishu"); // one failure doesn't skip the rest
   });

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -95,7 +95,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     // Exit 0 here would tell a coding agent "done" while the agent can't receive messages.
     expect(out).toEqual({
       ok: false,
-      gate: expect.stringMatching(/deploy succeeded but webhook registration failed for: telegram/),
+      gate: expect.stringMatching(/webhook registration failed for: telegram/),
     });
     expect(registerFeishu).toHaveBeenCalledWith("https://bot-production.up.railway.app", "feishu"); // one failure doesn't skip the rest
   });

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -7,6 +7,7 @@ import {
   parseDomainUrl,
   parseHasVolume,
 } from "../src/deploy/railway/run.ts";
+import type { RegistrationOutcome } from "../src/channels/registration.ts";
 import type { CliRunner } from "../src/deploy/runner.ts";
 
 /** A fake railway CLI: records every call, returns per-command scripted results (default code 0, empty). */
@@ -36,8 +37,11 @@ const LINKED = JSON.stringify({ name: "bot", id: "proj-1" });
 // A minted domain, as `railway domain --json` would return it (field name unknown → parser scans values).
 const DOMAIN_JSON = JSON.stringify({ domain: "bot-production.up.railway.app" });
 
-const run = (p: RailwayRunPlan, railway: CliRunner, tg = vi.fn(async () => true)) =>
-  deployRailwayRun(p, railway, () => {}, tg);
+const run = (
+  p: RailwayRunPlan,
+  railway: CliRunner,
+  tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+) => deployRailwayRun(p, railway, () => {}, tg);
 
 describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () => {
   it("fresh (unlinked): auth → init+add+volume → variables → up → domain → telegram webhook", async () => {
@@ -46,7 +50,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       if (a[0] === "domain") return { stdout: DOMAIN_JSON };
       return {};
     });
-    const tg = vi.fn(async () => true);
+    const tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered");
     const out = await run(
       plan({ channels: ["telegram"], secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" } }),
       railway,
@@ -76,13 +80,15 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       if (a[0] === "domain") return { stdout: DOMAIN_JSON };
       return {};
     });
-    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => true);
+    const registerFeishu = vi.fn(
+      async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
+    );
 
     const out = await deployRailwayRun(
       plan({ channels: ["telegram", "feishu"] }),
       railway,
       () => {},
-      vi.fn(async () => false), // telegram registration ends with the webhook NOT set
+      vi.fn(async (): Promise<RegistrationOutcome> => "failed"), // telegram registration ends with the webhook NOT set
       registerFeishu,
     );
 
@@ -100,13 +106,15 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       if (a[0] === "domain") return { stdout: DOMAIN_JSON };
       return {};
     });
-    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => true);
+    const registerFeishu = vi.fn(
+      async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
+    );
 
     const out = await deployRailwayRun(
       plan({ channels: ["feishu", "lark"] }),
       railway,
       () => {},
-      vi.fn(async () => true),
+      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
       registerFeishu,
     );
 
@@ -129,7 +137,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       plan({ channels: ["feishu", "lark"] }),
       railway,
       (message) => logs.push(message),
-      vi.fn(async () => true),
+      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
     );
 
     expect(out).toEqual({ ok: true, url: "https://bot-production.up.railway.app" });
@@ -214,7 +222,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       plan({ intoLinked: true }),
       railway,
       (m) => logs.push(m),
-      vi.fn(async () => true),
+      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
     );
     expect(logs.join("\n")).toMatch(/--into-linked.*isn't linked|creating a fresh/i);
   });

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -36,7 +36,7 @@ const LINKED = JSON.stringify({ name: "bot", id: "proj-1" });
 // A minted domain, as `railway domain --json` would return it (field name unknown → parser scans values).
 const DOMAIN_JSON = JSON.stringify({ domain: "bot-production.up.railway.app" });
 
-const run = (p: RailwayRunPlan, railway: CliRunner, tg = vi.fn(async () => {})) =>
+const run = (p: RailwayRunPlan, railway: CliRunner, tg = vi.fn(async () => true)) =>
   deployRailwayRun(p, railway, () => {}, tg);
 
 describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () => {
@@ -46,7 +46,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       if (a[0] === "domain") return { stdout: DOMAIN_JSON };
       return {};
     });
-    const tg = vi.fn(async () => {});
+    const tg = vi.fn(async () => true);
     const out = await run(
       plan({ channels: ["telegram"], secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" } }),
       railway,
@@ -70,19 +70,43 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     expect(tg).toHaveBeenCalledWith("https://bot-production.up.railway.app");
   });
 
+  it("gates when a webhook registration terminally fails — after attempting the remaining channels", async () => {
+    const { railway } = fakeRailway((a) => {
+      if (a[0] === "status") return { stdout: "" };
+      if (a[0] === "domain") return { stdout: DOMAIN_JSON };
+      return {};
+    });
+    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => true);
+
+    const out = await deployRailwayRun(
+      plan({ channels: ["telegram", "feishu"] }),
+      railway,
+      () => {},
+      vi.fn(async () => false), // telegram registration ends with the webhook NOT set
+      registerFeishu,
+    );
+
+    // Exit 0 here would tell a coding agent "done" while the agent can't receive messages.
+    expect(out).toEqual({
+      ok: false,
+      gate: expect.stringMatching(/deploy succeeded but webhook registration failed for: telegram/),
+    });
+    expect(registerFeishu).toHaveBeenCalledWith("https://bot-production.up.railway.app", "feishu"); // one failure doesn't skip the rest
+  });
+
   it("dispatches Feishu and Lark registration through the per-kind seam", async () => {
     const { railway } = fakeRailway((a) => {
       if (a[0] === "status") return { stdout: "" };
       if (a[0] === "domain") return { stdout: DOMAIN_JSON };
       return {};
     });
-    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => {});
+    const registerFeishu = vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark") => true);
 
     const out = await deployRailwayRun(
       plan({ channels: ["feishu", "lark"] }),
       railway,
       () => {},
-      vi.fn(async () => {}),
+      vi.fn(async () => true),
       registerFeishu,
     );
 
@@ -105,7 +129,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       plan({ channels: ["feishu", "lark"] }),
       railway,
       (message) => logs.push(message),
-      vi.fn(async () => {}),
+      vi.fn(async () => true),
     );
 
     expect(out).toEqual({ ok: true, url: "https://bot-production.up.railway.app" });
@@ -190,7 +214,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       plan({ intoLinked: true }),
       railway,
       (m) => logs.push(m),
-      vi.fn(async () => {}),
+      vi.fn(async () => true),
     );
     expect(logs.join("\n")).toMatch(/--into-linked.*isn't linked|creating a fresh/i);
   });

--- a/test/feishu-register-webhook.test.ts
+++ b/test/feishu-register-webhook.test.ts
@@ -53,7 +53,7 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
       readyIntervalMs: 1,
       apiBase: "http://feishu.test",
     });
-    expect(ok).toBe(true); // registered → no deploy gate
+    expect(ok).toBe("registered");
     expect(health).toBeGreaterThanOrEqual(3); // waited for readiness, not a fixed timer
     expect(patches).toHaveLength(1);
     expect(patches[0]?.url).toContain("http://feishu.test/open-apis/application/v7/applications/cli_app/config");
@@ -110,7 +110,7 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
       readyTimeoutMs: 20,
       readyIntervalMs: 5,
     });
-    expect(ok).toBe(false); // terminal for this run → deploy --run gates
+    expect(ok).toBe("failed"); // terminal for this run → deploy --run gates
     expect(patches).toHaveLength(0);
   });
 
@@ -171,7 +171,7 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
       apiBase: "http://feishu.test",
       onManualRegistration,
     });
-    expect(ok).toBe(false); // terminal for this run → deploy --run gates
+    expect(ok).toBe("failed"); // terminal for this run → deploy --run gates
     expect(patches).toBe(8);
     // Exhausted retries are a terminal failure (event URL not registered) — reported at ERROR.
     expect(errors.join("\n")).toMatch(/still failing after retries/);
@@ -205,7 +205,7 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
       retryMs: 1,
       apiBase: "http://feishu.test",
     });
-    expect(ok).toBe(false); // a config error the operator must fix → deploy --run gates
+    expect(ok).toBe("failed"); // a config error the operator must fix → deploy --run gates
     expect(patches).toBe(1); // permanent error — no blind retries
   });
 
@@ -243,7 +243,7 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
       apiBase: "http://larksuite.test", // the intl cloud — no v7 config route
       onManualRegistration,
     });
-    expect(ok).toBe(true); // manual is the norm on this cloud — a re-run can never succeed, so no gate
+    expect(ok).toBe("manual"); // the norm on this cloud — a re-run can never succeed, so no re-run gate
     warnSpy.mockRestore();
     infoSpy.mockRestore();
     expect(patches).toBe(1); // a missing route never gets blind retries
@@ -264,7 +264,7 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     const ok = await registerFeishuWebhook("https://x.trycloudflare.com", "lark");
-    expect(ok).toBe(true); // not configured is the designed manual path, not a deploy gate
+    expect(ok).toBe("manual"); // not configured is the designed manual path, not a deploy gate
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/test/feishu-register-webhook.test.ts
+++ b/test/feishu-register-webhook.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerFeishuWebhook } from "../src/channels/feishu/register-webhook.ts";
+import { log } from "../src/log.ts";
 
 // Mirrors the telegram registrar's G5 discipline: the application-v7 config PATCH triggers the
 // platform's url_verification challenge against the new Request URL, so registration must wait until
@@ -14,6 +15,7 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
   };
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     process.env.LARK_APP_ID = prev.id;
     process.env.LARK_APP_SECRET = prev.secret;
     process.env.FEISHU_APP_ID = prev.fid;
@@ -152,6 +154,10 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
         return new Response(null, { status: 404 });
       }),
     );
+    const errors: string[] = [];
+    vi.spyOn(log, "error").mockImplementation((m: string) => {
+      errors.push(m);
+    });
     const onManualRegistration = vi.fn();
     await registerFeishuWebhook("https://x.trycloudflare.com", "feishu", {
       readyTimeoutMs: 100,
@@ -161,6 +167,8 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
       onManualRegistration,
     });
     expect(patches).toBe(8);
+    // Exhausted retries are a terminal failure (event URL not registered) — reported at ERROR.
+    expect(errors.join("\n")).toMatch(/still failing after retries/);
     expect(onManualRegistration).toHaveBeenCalledOnce();
     expect(onManualRegistration).toHaveBeenCalledWith({
       consoleUrl: "http://feishu.test/app/cli_app/event",

--- a/test/feishu-register-webhook.test.ts
+++ b/test/feishu-register-webhook.test.ts
@@ -48,11 +48,12 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
         return new Response(null, { status: 404 });
       }),
     );
-    await registerFeishuWebhook("https://x.trycloudflare.com", "feishu", {
+    const ok = await registerFeishuWebhook("https://x.trycloudflare.com", "feishu", {
       readyTimeoutMs: 5000,
       readyIntervalMs: 1,
       apiBase: "http://feishu.test",
     });
+    expect(ok).toBe(true); // registered → no deploy gate
     expect(health).toBeGreaterThanOrEqual(3); // waited for readiness, not a fixed timer
     expect(patches).toHaveLength(1);
     expect(patches[0]?.url).toContain("http://feishu.test/open-apis/application/v7/applications/cli_app/config");
@@ -105,7 +106,11 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
         throw new Error("ECONNREFUSED"); // /health never reachable
       }),
     );
-    await registerFeishuWebhook("https://dead.example", "feishu", { readyTimeoutMs: 20, readyIntervalMs: 5 });
+    const ok = await registerFeishuWebhook("https://dead.example", "feishu", {
+      readyTimeoutMs: 20,
+      readyIntervalMs: 5,
+    });
+    expect(ok).toBe(false); // terminal for this run → deploy --run gates
     expect(patches).toHaveLength(0);
   });
 
@@ -159,13 +164,14 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
       errors.push(m);
     });
     const onManualRegistration = vi.fn();
-    await registerFeishuWebhook("https://x.trycloudflare.com", "feishu", {
+    const ok = await registerFeishuWebhook("https://x.trycloudflare.com", "feishu", {
       readyTimeoutMs: 100,
       readyIntervalMs: 1,
       retryMs: 1,
       apiBase: "http://feishu.test",
       onManualRegistration,
     });
+    expect(ok).toBe(false); // terminal for this run → deploy --run gates
     expect(patches).toBe(8);
     // Exhausted retries are a terminal failure (event URL not registered) — reported at ERROR.
     expect(errors.join("\n")).toMatch(/still failing after retries/);
@@ -193,12 +199,13 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
         return new Response(null, { status: 404 });
       }),
     );
-    await registerFeishuWebhook("https://x.trycloudflare.com", "feishu", {
+    const ok = await registerFeishuWebhook("https://x.trycloudflare.com", "feishu", {
       readyTimeoutMs: 100,
       readyIntervalMs: 1,
       retryMs: 1,
       apiBase: "http://feishu.test",
     });
+    expect(ok).toBe(false); // a config error the operator must fix → deploy --run gates
     expect(patches).toBe(1); // permanent error — no blind retries
   });
 
@@ -229,13 +236,14 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
       informed.push(m);
     });
     const onManualRegistration = vi.fn();
-    await registerFeishuWebhook("https://x.trycloudflare.com", "lark", {
+    const ok = await registerFeishuWebhook("https://x.trycloudflare.com", "lark", {
       readyTimeoutMs: 100,
       readyIntervalMs: 1,
       retryMs: 1,
       apiBase: "http://larksuite.test", // the intl cloud — no v7 config route
       onManualRegistration,
     });
+    expect(ok).toBe(true); // manual is the norm on this cloud — a re-run can never succeed, so no gate
     warnSpy.mockRestore();
     infoSpy.mockRestore();
     expect(patches).toBe(1); // a missing route never gets blind retries
@@ -255,7 +263,8 @@ describe("registerFeishuWebhook: waits for /health, then PATCHes the event subsc
     delete process.env.LARK_APP_SECRET;
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
-    await registerFeishuWebhook("https://x.trycloudflare.com", "lark");
+    const ok = await registerFeishuWebhook("https://x.trycloudflare.com", "lark");
+    expect(ok).toBe(true); // not configured is the designed manual path, not a deploy gate
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/test/register-webhook.test.ts
+++ b/test/register-webhook.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerTelegramWebhook } from "../src/channels/telegram/register-webhook.ts";
+import { log } from "../src/log.ts";
 
 // G5: the webhook must be registered only AFTER the server is reachable — Telegram verifies the URL when
 // you set it, and a fresh deploy's container (or tunnel DNS) isn't routable for some seconds after the
@@ -120,6 +121,41 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
 
     expect(setWebhookCalls).toBe(3);
     expect(stderr).toHaveBeenCalledWith(expect.stringMatching(/last error: .*fetch failed attempt 3/));
+  });
+
+  it("terminal failures log at ERROR (webhook not registered → operator must act, same level as a permanent error)", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "bt";
+    process.env.TELEGRAM_SECRET_TOKEN = "st";
+    const errors: string[] = [];
+    vi.spyOn(log, "error").mockImplementation((m: string) => {
+      errors.push(m);
+    });
+
+    // Transient setWebhook failures exhaust all retries.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.endsWith("/health")) return new Response(null, { status: 200 });
+        throw new Error("fetch failed");
+      }),
+    );
+    await registerTelegramWebhook("https://app.up.railway.app", {
+      readyTimeoutMs: 5000,
+      readyIntervalMs: 1,
+      retryMs: 1,
+    });
+    expect(errors.join("\n")).toMatch(/still failing after retries.*Register manually/);
+
+    // /health never comes up.
+    errors.length = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+    await registerTelegramWebhook("https://dead.up.railway.app", { readyTimeoutMs: 20, readyIntervalMs: 5 });
+    expect(errors.join("\n")).toMatch(/did not come up in time.*Register the webhook manually/);
   });
 
   it("missing tokens → manual instruction, no health poll and no setWebhook", async () => {

--- a/test/register-webhook.test.ts
+++ b/test/register-webhook.test.ts
@@ -39,7 +39,7 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
       readyTimeoutMs: 5000,
       readyIntervalMs: 1,
     });
-    expect(ok).toBe(true); // registered → no deploy gate
+    expect(ok).toBe("registered");
     expect(health).toBeGreaterThanOrEqual(3); // waited for readiness, not a fixed timer
     expect(setWebhook).toHaveLength(1); // registered once, AFTER /health returned 200
   });
@@ -59,7 +59,7 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
       }),
     );
     const ok = await registerTelegramWebhook("https://dead.up.railway.app", { readyTimeoutMs: 20, readyIntervalMs: 5 });
-    expect(ok).toBe(false); // terminal for this run → deploy --run gates
+    expect(ok).toBe("failed"); // terminal for this run → deploy --run gates
     expect(setWebhook).toHaveLength(0); // no registration against a URL Telegram couldn't reach either
   });
 
@@ -84,7 +84,7 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
       readyTimeoutMs: 5000,
       readyIntervalMs: 1,
     });
-    expect(ok).toBe(true);
+    expect(ok).toBe("registered");
     expect(setWebhookCalls).toBe(2); // retried the transient failure, then succeeded
   });
 
@@ -108,7 +108,7 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
       readyTimeoutMs: 5000,
       readyIntervalMs: 1,
     });
-    expect(ok).toBe(false); // a config error the operator must fix → deploy --run gates
+    expect(ok).toBe("failed"); // a config error the operator must fix → deploy --run gates
     expect(setWebhookCalls).toBe(1); // reported, not retried
   });
 
@@ -157,7 +157,7 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
       readyIntervalMs: 1,
       retryMs: 1,
     });
-    expect(exhausted).toBe(false);
+    expect(exhausted).toBe("failed");
     expect(errors.join("\n")).toMatch(/still failing after retries.*Register manually/);
 
     // /health never comes up.
@@ -178,7 +178,7 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
     const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }));
     vi.stubGlobal("fetch", fetchSpy);
     const ok = await registerTelegramWebhook("https://x.up.railway.app");
-    expect(ok).toBe(true); // not configured is the designed manual path, not a deploy gate
+    expect(ok).toBe("manual"); // not configured is the designed manual path, not a deploy gate
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/register-webhook.test.ts
+++ b/test/register-webhook.test.ts
@@ -35,7 +35,11 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
         return new Response(null, { status: 404 });
       }),
     );
-    await registerTelegramWebhook("https://app.up.railway.app", { readyTimeoutMs: 5000, readyIntervalMs: 1 });
+    const ok = await registerTelegramWebhook("https://app.up.railway.app", {
+      readyTimeoutMs: 5000,
+      readyIntervalMs: 1,
+    });
+    expect(ok).toBe(true); // registered → no deploy gate
     expect(health).toBeGreaterThanOrEqual(3); // waited for readiness, not a fixed timer
     expect(setWebhook).toHaveLength(1); // registered once, AFTER /health returned 200
   });
@@ -54,7 +58,8 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
         throw new Error("ECONNREFUSED"); // /health never reachable
       }),
     );
-    await registerTelegramWebhook("https://dead.up.railway.app", { readyTimeoutMs: 20, readyIntervalMs: 5 });
+    const ok = await registerTelegramWebhook("https://dead.up.railway.app", { readyTimeoutMs: 20, readyIntervalMs: 5 });
+    expect(ok).toBe(false); // terminal for this run → deploy --run gates
     expect(setWebhook).toHaveLength(0); // no registration against a URL Telegram couldn't reach either
   });
 
@@ -75,7 +80,11 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
         return new Response(null, { status: 404 });
       }),
     );
-    await registerTelegramWebhook("https://app.up.railway.app", { readyTimeoutMs: 5000, readyIntervalMs: 1 });
+    const ok = await registerTelegramWebhook("https://app.up.railway.app", {
+      readyTimeoutMs: 5000,
+      readyIntervalMs: 1,
+    });
+    expect(ok).toBe(true);
     expect(setWebhookCalls).toBe(2); // retried the transient failure, then succeeded
   });
 
@@ -95,7 +104,11 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
         return new Response(null, { status: 404 });
       }),
     );
-    await registerTelegramWebhook("https://app.up.railway.app", { readyTimeoutMs: 5000, readyIntervalMs: 1 });
+    const ok = await registerTelegramWebhook("https://app.up.railway.app", {
+      readyTimeoutMs: 5000,
+      readyIntervalMs: 1,
+    });
+    expect(ok).toBe(false); // a config error the operator must fix → deploy --run gates
     expect(setWebhookCalls).toBe(1); // reported, not retried
   });
 
@@ -139,11 +152,12 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
         throw new Error("fetch failed");
       }),
     );
-    await registerTelegramWebhook("https://app.up.railway.app", {
+    const exhausted = await registerTelegramWebhook("https://app.up.railway.app", {
       readyTimeoutMs: 5000,
       readyIntervalMs: 1,
       retryMs: 1,
     });
+    expect(exhausted).toBe(false);
     expect(errors.join("\n")).toMatch(/still failing after retries.*Register manually/);
 
     // /health never comes up.
@@ -163,7 +177,8 @@ describe("registerTelegramWebhook: waits for /health before setWebhook", () => {
     delete process.env.TELEGRAM_SECRET_TOKEN;
     const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }));
     vi.stubGlobal("fetch", fetchSpy);
-    await registerTelegramWebhook("https://x.up.railway.app");
+    const ok = await registerTelegramWebhook("https://x.up.railway.app");
+    expect(ok).toBe(true); // not configured is the designed manual path, not a deploy gate
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Two layers of the same fail-visibly gap in webhook registration, found while reviewing #229:

**L1 — log level.** A registration run that ends with the webhook NOT registered (exhausted transient retries, /health never up) left the operator in the same state as a permanent config error but was reported at `warn` while the permanent path used `error`. Terminal failures now log at ERROR in both the telegram and feishu registrars.

**L2 — exit code.** `deploy --run`'s contract is the gate model (every step that leaves the operator with work stops with one actionable line and a non-zero exit), but step 7 (post-deploy webhook registration) was outside it: a terminal registration failure returned `{ ok: true }` → exit 0 — a coding agent reports "deployed" while the bot cannot receive messages.

Design (registrars report facts, deploy owns policy):

- Registrars return `RegistrationOutcome = "registered" | "manual" | "failed"` (`src/channels/registration.ts`) — a fact at their own layer. The tunnel (long-running dev) ignores it.
- The shared host-neutral kernel `src/deploy/registration-gate.ts` owns the policy: `"failed"` gates (steps 1-6 are idempotent, so a re-run just retries registration); `"manual"` does not gate — re-running can never change it (an unclearable gate would spin a coding agent forever: the Lark cloud-lag 404 has no API path on that cloud) — but every remaining manual step (including github's repo webhook and unwired feishu/lark) is re-surfaced after all registrar output so it cannot be buried.
- The gate message composes with cli.ts's `deploy stopped:` prefix (leads with the failure; notes the app itself deployed).

Note: one-line overlap with #229 on the telegram exhausted-retries line (it enriches the message, this changes the level). Whichever lands second rebases; the merged form is `log.error(...last error: ...)`.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (686 tests)
- [x] Tests: ERROR level on terminal registrar paths; three-state outcomes per path (incl. "manual" for missing creds / cloud-lag 404); runners gate on "failed" after attempting all channels; mixed manual+failed composition; "manual" surfaces without gating

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (AGENTS.md repo map: registration.ts + registration-gate.ts)