### PR TITLE
ci: switch CodeQL to advanced setup so fork PRs are scanned

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+# Advanced setup (replaces GitHub's default setup): default setup does not
+# trigger on pull requests from forks, and fork PRs are the norm for this OSS
+# repo. A regular workflow's pull_request event runs for forks too.
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1' # weekly, Monday 03:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          category: '/language:${{ matrix.language }}'
+
+  # Stable-named aggregate gate (same pattern as CI's "Core checks"): branch
+  # protection requires the "CodeQL" context, independent of the language matrix.
+  codeql-gate:
+    name: CodeQL
+    needs: analyze
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require analysis to pass
+        run: '[ "${{ needs.analyze.result }}" = "success" ]'


### PR DESCRIPTION
Default setup does not trigger on pull requests from forks — PR #229's required `CodeQL` check sat at *Expected — Waiting* forever. Fork PRs are the norm for this OSS repo, so this replaces default setup with a committed `codeql.yml` (advanced setup), whose `pull_request` event runs for forks normally.

Coverage is unchanged: `actions` + `javascript-typescript`, default query suite, weekly schedule. A stable-named `CodeQL` gate job (same pattern as CI's `Core checks`) keeps the branch-protection context name intact regardless of the language matrix.

Admin ops already applied via API:
- default setup disabled (it rejects advanced-setup SARIF uploads while enabled)
- branch protection's `CodeQL` required check rebound from the code-scanning app to GitHub Actions

Note: existing fork PRs (e.g. #229) need a new `pull_request` event (push or close/reopen) to get their first CodeQL run.