### PR TITLE
fix(feishu): reuse queued reply cards in place

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -212,12 +212,14 @@ state, logs, and onboarding: `feishuChannel` mounts `POST /feishu`, reads `FEISH
 can mount both. No SDK — wire protocols are fetch-based, with the adoption tripwire documented in
 `feishu-api.ts`. What is platform-different:
 
-- **The live preview is a streaming CARD, not an edited message.** The platform caps text edits at 20
-  per message and sends at 5 QPS per chat; cardkit streaming (50 QPS per app / 10 per card, strictly
-  increasing `sequence`)
-  is its designed AI-output channel. The same card settles into the final Markdown answer. Degrade
-  tiers: card fails → static text placeholder; streaming closed mid-turn → frozen preview, the settle
-  still lands.
+- **The live preview is a streaming CARD, not an edited text message.** The platform caps text edits at
+  20 per message and sends at 5 QPS per chat; cardkit streaming (50 QPS per app / 10 per card, strictly
+  increasing `sequence`) is its designed AI-output channel. A queued turn mounts that same card early
+  with a reply-quoted `⏳ Queued` state; execution takes the entity over in place and the same card
+  settles into the final Markdown answer, so there is no recall tombstone or ambiguous second reply.
+  Per-session execution remains FIFO; quotes keep independently mounted queue cards attributable.
+  Degrade tiers: card fails → static text placeholder; streaming closed mid-turn → frozen preview, the
+  settle still lands.
 - **Verification is modal and fail-closed.** Encrypt Key set: ordinary events require a signature over
   the raw body → AES decrypt, and plaintext is refused. Feishu explicitly excludes Request URL
   verification from event signatures, so its encrypted `url_verification` challenge takes the narrow

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -201,13 +201,13 @@ Topic groups are handled automatically:
 - if the message carries a `thread_id` (a topic group), the default session is `chat:thread` and the reply stays inside the topic (`reply_in_thread`),
 - otherwise the default session is `chat`, and group replies quote the summoning message.
 
-A group answers one shared session: turns are serialized per session (FIFO) instead of failing fast as `session busy`. A summon that keeps waiting gets a "⏳ Queued" notice — **delayed** (default 5s, `queueNoticeDelayMs`): the notice cannot morph into the answer (text vs card), so its cleanup is a recall, which the client renders as a visible "recalled a message" line — a fast turnover therefore sends no notice at all, and only a genuinely long wait pays that tombstone. Different sessions run in parallel.
+A group answers one shared session: turns are serialized per session (FIFO) instead of failing fast as `session busy`; different sessions run in parallel. A summon queued behind another turn immediately gets a reply-quoted "⏳ Queued" card (configure `queueNoticeDelayMs` only if an intentional delay is desired). Each queued card quotes its own source message, including in p2p, so concurrent card mounts remain attributable. When that turn starts, its live preview takes over the same card entity and settles the final answer there: no second reply and no visible "recalled a message" tombstone.
 
 ## Streaming behavior
 
 The live preview is ONE **streaming card** (a card entity in streaming mode):
 
-- an immediate "💭 Thinking…" card, reply-quoted under the asker in groups,
+- an immediate "💭 Thinking…" card, reply-quoted under the asker in groups; or, for a queued turn, the already-mounted reply-quoted "⏳ Queued" card updated in place,
 - tool-call previews + partial answer text, pushed as full-text snapshots (the client renders the typewriter effect),
 - on completion, the same card settles into the final answer as Markdown (streaming off).
 

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -30,7 +30,14 @@ import {
   parseContent,
   placeKey,
 } from "./parse.ts";
-import { type FeishuFailure, defaultErrorMessage, streamFeishuReply } from "./preview.ts";
+import {
+  type FeishuFailure,
+  type MountedFeishuPreview,
+  defaultErrorMessage,
+  mountFeishuPreview,
+  settleFeishuPreview,
+  streamFeishuReply,
+} from "./preview.ts";
 import { createSeenRing } from "./seen.ts";
 
 // Canonical public surface; the Lark subpath aliases these types/functions at its compatibility boundary.
@@ -45,12 +52,13 @@ const MAX_TURN_ATTEMPTS = 3;
 /** Event body cap — events are small JSON; 1 MiB is generous and guards a public endpoint. */
 const MAX_EVENT_BYTES = 1 << 20;
 
-/** How long a turn must WAIT in the queue before the "⏳ Queued" notice is sent. On this platform the
- *  notice cannot morph into the answer (text vs card), so its cleanup is a RECALL — and the client
- *  renders that as a visible "recalled a message" line. Delaying the notice makes fast queue turnover leave no
- *  trace at all; only a genuinely long wait pays the tombstone, where the feedback is worth it.
- *  (Telegram needs no delay: its notice is edited in place into the live preview — no residue.) */
-const QUEUE_NOTICE_DELAY_MS = 5_000;
+/** Queue feedback is immediate by default: it is the user's acknowledgement that this exact ask was
+ *  accepted behind another turn. The same reply-quoted card becomes the preview/final answer, so there
+ *  is no extra message or recall tombstone to avoid. Authors may still configure a delay explicitly. */
+const QUEUE_NOTICE_DELAY_MS = 0;
+
+const QUEUED_PLACEHOLDER = "⏳ Queued — I’ll start once the current task finishes.";
+const DEFERRED_PLACEHOLDER = "⏳ Delayed by a temporary system issue — I’ll retry automatically.";
 
 /** The persisted turn intent (what the runner needs to re-execute it). `seq` is the channel-assigned
  *  arrival number — Feishu message_ids (`om_…`) carry no order, so recovery sorts on this instead. */
@@ -61,6 +69,9 @@ interface StoredFeishuTurn {
   baseText: string;
   chatId: string;
   replyTo?: string;
+  /** Source message to quote when queue feedback mounts. Unlike `replyTo`, this is also set for a p2p
+   *  turn: each queued card must identify its own ask even though ordinary p2p answers are unquoted. */
+  queueReplyTo?: string;
   replyInThread?: boolean;
   parentId?: string;
   images: { msg: string; key: string }[];
@@ -83,6 +94,7 @@ function isStoredFeishuTurn(t: unknown): t is StoredFeishuTurn {
     typeof r.baseText === "string" &&
     typeof r.chatId === "string" &&
     (r.replyTo === undefined || typeof r.replyTo === "string") &&
+    (r.queueReplyTo === undefined || typeof r.queueReplyTo === "string") &&
     (r.replyInThread === undefined || typeof r.replyInThread === "boolean") &&
     (r.parentId === undefined || typeof r.parentId === "string") &&
     refs(r.images) &&
@@ -91,11 +103,11 @@ function isStoredFeishuTurn(t: unknown): t is StoredFeishuTurn {
   );
 }
 
-/** One accepted turn: the persisted intent plus live-only fields (never persisted — a restart's queue
- *  notice is gone, so a replayed turn mounts a fresh preview). */
+/** One accepted turn: the persisted intent plus live-only fields. The mounted queue card/text is not
+ *  persisted; a replayed turn mounts a fresh preview because an old card may have expired. */
 interface PendingFeishuTurn extends Omit<StoredFeishuTurn, "attempts"> {
-  /** The "⏳ queued" notice's message_id, when one was sent — deleted once the preview mounts. */
-  noticeId?: string;
+  /** The queue-status card/text, when its delayed mount fired. The turn's preview takes it over. */
+  preview?: MountedFeishuPreview;
 }
 
 export interface FeishuChannelOptions {
@@ -120,8 +132,8 @@ export interface FeishuChannelOptions {
   /** API origin override (tests / self-hosted gateways). The kind fixes the default —
    *  `feishuChannel` → `https://open.feishu.cn`, `larkChannel` → `https://open.larksuite.com`. */
   baseUrl?: string;
-  /** How long (ms) a turn waits in the queue before the "⏳ Queued" notice is sent (see
-   *  {@link QUEUE_NOTICE_DELAY_MS} for why it is delayed on this platform). 0 = immediately. */
+  /** How long (ms) a turn waits before its reply-quoted "⏳ Queued" card mounts. Defaults to 0
+   *  (immediate); the same card is later taken over by the live preview/final answer. */
   queueNoticeDelayMs?: number;
 }
 
@@ -189,7 +201,7 @@ export function buildFeishuChannel(
     });
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
     const toStored = (r: PendingFeishuTurn): StoredFeishuTurn => {
-      const { noticeId: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
+      const { preview: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
       return { ...intent, attempts: 0 };
     };
 
@@ -198,42 +210,48 @@ export function buildFeishuChannel(
       replyTo: r.replyTo,
       replyInThread: r.replyInThread,
     });
+    const queueTargetOf = (r: PendingFeishuTurn): FeishuTarget => ({
+      chatId: r.chatId,
+      replyTo: r.queueReplyTo,
+      replyInThread: r.replyInThread,
+    });
 
-    // In-memory: the pending "⏳ queued" notice per turn — DELAYED (see QUEUE_NOTICE_DELAY_MS): armed
-    // when the turn queues behind another, sent only if it is still waiting when the timer fires, and
-    // cancelled unsent when its turn starts first. `done` settles either way, awaited at dequeue so the
-    // turn reliably knows the notice id (to delete it) instead of racing a late-arriving send.
+    // In-memory: the pending queue-preview mount per turn. Immediate by default; with an explicit delay,
+    // it mounts only if the turn is still waiting when the timer fires and is cancelled unsent otherwise.
+    // `done` settles either way, awaited at dequeue so the runner reliably receives the mounted preview
+    // instead of racing it and double-posting.
     const notices = new Map<string, { cancel: () => void; done: Promise<void> }>();
     const queue = createTurnQueue<PendingFeishuTurn>({
       label,
       // Queue feedback: when this session already has a turn running/queued, a silent wait reads as
-      // "the bot ignored me" once the current turn runs long — tell the asker (reply-quoted, so it is
-      // clear whose ask is queued), unless the wait is over before the delay (then no trace at all).
-      // Best-effort and post-ACK: a failed notice is a log line, never a failed event delivery. The
-      // preview then deletes this notice once its card mounts.
+      // "the bot ignored me" once the current turn runs long — mount that turn's preview early with a
+      // queue status. It reply-quotes the exact source message (including p2p), then the runner mutates
+      // the SAME card/text into Thinking → final answer. Best-effort and post-ACK: a failed mount is a
+      // log line, never a failed event delivery; the turn later mounts its normal preview.
       onQueuedBehind: (rec) => {
         let fired = false;
         let settle: () => void = () => {};
         const done = new Promise<void>((resolve) => {
           settle = resolve;
         });
-        const timer = setTimeout(() => {
+        const mount = (): void => {
           fired = true;
-          api
-            .sendText(targetOf(rec), "⏳ Queued — I’ll start once the current task finishes.")
+          mountFeishuPreview(api, queueTargetOf(rec), QUEUED_PLACEHOLDER, label)
             .then(
-              (id) => {
-                if (id !== undefined) rec.noticeId = id;
+              (preview) => {
+                rec.preview = preview;
               },
-              (e) => log.warn(`${label} queue notice failed (the turn still runs): ${String(e)}`),
+              (e) => log.warn(`${label} queue preview failed (the turn still runs): ${String(e)}`),
             )
             .finally(settle);
-        }, queueNoticeDelayMs);
+        };
+        const timer = queueNoticeDelayMs > 0 ? setTimeout(mount, queueNoticeDelayMs) : undefined;
+        if (timer === undefined) mount();
         notices.set(rec.id, {
-          // Cancel is a no-op once the timer fired — the send is in flight and `done` settles with it.
+          // Cancel is a no-op once mounting started — the send is in flight and `done` settles with it.
           cancel: () => {
             if (!fired) {
-              clearTimeout(timer);
+              if (timer !== undefined) clearTimeout(timer);
               settle();
             }
           },
@@ -241,9 +259,9 @@ export function buildFeishuChannel(
         });
       },
       run: async (rec) => {
-        // Runs at DEQUEUE time (serialized). The turn's queue wait is over: cancel a not-yet-sent notice
-        // (fast turnover leaves no trace), then settle so rec.noticeId is final — in the common path
-        // this await is instant. BEFORE the ceiling check so a dropped turn's notice is cleared too.
+        // Runs at DEQUEUE time (serialized). The turn's queue wait is over: cancel a not-yet-mounted
+        // preview (fast turnover skips the Queued frame), then settle so rec.preview is final — in the
+        // common path this await is instant. BEFORE the ceiling check so drop/defer can take it over too.
         const notice = notices.get(rec.id);
         notice?.cancel();
         await notice?.done;
@@ -255,10 +273,14 @@ export function buildFeishuChannel(
           return;
         }
         if (decision === "defer") {
-          // Couldn't record the attempt (disk failure): skip this cycle; a restart replays it. Its "⏳"
-          // notice (if any) would falsely read "Queued" forever — delete it best-effort (the eventual
-          // replay mounts a fresh preview).
-          if (rec.noticeId !== undefined) void api.deleteMessage(rec.noticeId).catch(() => {});
+          // Couldn't record the attempt (disk failure): skip this cycle; a restart replays it. Do not
+          // recall an existing queue preview (the client exposes a confusing tombstone): settle it in
+          // place to an honest delayed status. The eventual replay mounts a fresh preview.
+          if (rec.preview !== undefined) {
+            void settleFeishuPreview(api, targetOf(rec), rec.preview, DEFERRED_PLACEHOLDER).catch((e) =>
+              log.warn(`${label} could not update a deferred turn's queue preview: ${String(e)}`),
+            );
+          }
           return;
         }
         const startedAt = Date.now();
@@ -277,7 +299,7 @@ export function buildFeishuChannel(
             api,
             targetOf(rec),
             formatError,
-            rec.noticeId,
+            rec.preview,
             label,
           );
           log.info(`${label} turn done: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms)`);
@@ -307,15 +329,13 @@ export function buildFeishuChannel(
     };
 
     // Tell the asker when a turn is dropped at the execution ceiling: the chain's end needs a signal,
-    // not just an operator log line. Take over the "⏳ Queued" notice in place if the turn had one (else
-    // send fresh) — leaving it pinned at "Queued" while sending a separate failure would double-post.
+    // not just an operator log line. Take over its queue preview in place if present (else send fresh) —
+    // leaving it pinned at "Queued" while sending a separate failure would double-post.
     const notifyDropped = (r: PendingFeishuTurn): void => {
       const body = "⚠️ I couldn’t complete an earlier request — please ask again.";
-      const sent =
-        r.noticeId !== undefined
-          ? api.editTextMessage(r.noticeId, body)
-          : api.sendText(targetOf(r), body).then(() => {});
-      void sent.catch((e) => log.warn(`${label} could not notify a dropped turn (session=${r.session}): ${String(e)}`));
+      void settleFeishuPreview(api, targetOf(r), r.preview, body).catch((e) =>
+        log.warn(`${label} could not notify a dropped turn (session=${r.session}): ${String(e)}`),
+      );
     };
 
     // Re-enqueue turns a prior crash left mid-flight (ACKed but unfinished). Synchronous at construction:
@@ -323,7 +343,7 @@ export function buildFeishuChannel(
     const recovered = store.recover();
     if (recovered.length > 0) log.info(`${label} recovering ${recovered.length} unfinished turn(s) from a prior run`);
     let seqCounter = recovered.reduce((max, r) => Math.max(max, r.seq), 0);
-    for (const { attempts: _a, ...intent } of recovered) submit({ ...intent, noticeId: undefined }, false);
+    for (const { attempts: _a, ...intent } of recovered) submit({ ...intent, preview: undefined }, false);
 
     const handler = async (req: Request): Promise<Response> => {
       if (req.method !== "POST") return text("POST only\n", 405);
@@ -434,6 +454,9 @@ export function buildFeishuChannel(
         // chat: a route that redirects elsewhere must not quote a same-id message in the wrong place.
         const sameTarget = chatId === m.chat_id;
         const replyTo = m.chat_type !== "p2p" && sameTarget ? m.message_id : undefined;
+        // Queue feedback always identifies the exact ask, including p2p. Ordinary p2p answers remain
+        // unquoted unless the turn actually waited long enough for its queue preview to mount.
+        const queueReplyTo = sameTarget ? m.message_id : undefined;
         const content = parseContent(m);
         const baseText = r.text ?? cloudEnvelope(event, kind);
         if (baseText.trim() !== "" || content.imageKeys.length > 0 || content.fileRefs.length > 0) {
@@ -445,6 +468,7 @@ export function buildFeishuChannel(
               baseText,
               chatId,
               replyTo,
+              queueReplyTo,
               replyInThread: replyTo !== undefined && m.thread_id !== undefined ? true : undefined,
               parentId: m.parent_id,
               images: content.imageKeys.map((key) => ({ msg: m.message_id, key })),

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -7,6 +7,11 @@
  * 5 QPS per-chat message quota or
  * the 20-edit cap on text messages, which is why the preview is a card and not an edited text message.
  *
+ * A queued turn mounts this same card early with its queue status, reply-quoted to that turn's source
+ * message; when execution starts the preview takes the entity over in place. This mirrors Telegram's
+ * one-message lifecycle without trying to change a text message into a card (which the platform does
+ * not support), and keeps multiple queued asks attributable even if their card mounts race visually.
+ *
  * Fallback tier (fail visibly, degrade per turn): if the card cannot be created or mounted, the turn
  * runs with a TEXT placeholder and NO live updates (text edits are capped at 20 per message, so the
  * text tier spends them only on terminal writes); if the platform closes streaming mid-turn (idle
@@ -79,11 +84,14 @@ function capBytes(s: string, maxBytes: number): string {
   return truncateUtf8(s, maxBytes);
 }
 
-/** The mounted preview, whichever tier setup reached. */
-type Preview =
+/** A visible preview mounted into the chat. Exported only for the channel wiring: a queued turn mounts
+ * one before execution, then hands the exact entity/message to {@link streamFeishuReply} for takeover. */
+export type MountedFeishuPreview =
   | { kind: "card"; cardId: string; messageId: string }
-  | { kind: "text"; messageId: string }
-  | { kind: "none" }; // nothing mounted (setup failed entirely) — terminal writes send fresh
+  | { kind: "text"; messageId: string };
+
+/** The preview lifecycle also needs a no-message state when setup failed entirely. */
+type Preview = MountedFeishuPreview | { kind: "none" };
 
 /**
  * The terminal-write POLICY: resolve the preview into `text`. One card → settle it in place (final
@@ -137,18 +145,82 @@ async function finalize(
 }
 
 /**
+ * Mount one preview message: preferably a streaming card entity, with a static text message as the
+ * visible fallback. Queue feedback and ordinary turn startup share this constructor so a queued card
+ * has exactly the same shape the stream pump expects to take over later.
+ */
+export async function mountFeishuPreview(
+  api: FeishuApi,
+  target: FeishuTarget,
+  initial: string,
+  label = "[feishu]",
+): Promise<MountedFeishuPreview> {
+  try {
+    const cardId = await api.createCard(streamingCardJson(initial));
+    const content = cardEntityContent(cardId);
+    const mountOnce = (): Promise<string | undefined> =>
+      target.replyTo !== undefined
+        ? api.replyMessage(target.replyTo, "interactive", content, { replyInThread: target.replyInThread })
+        : api.sendMessage(target.chatId, "interactive", content);
+    let messageId: string | undefined;
+    // Field-observed: the mount can reject a JUST-minted card id (code 230099 / "cardid is invalid")
+    // — the entity is not yet visible to the IM side (eventual consistency between cardkit and IM).
+    // That specific rejection gets a short backoff and another try before degrading; anything else
+    // degrades immediately.
+    for (let attempt = 1; ; attempt++) {
+      try {
+        messageId = await mountOnce();
+        break;
+      } catch (e) {
+        if (attempt >= 3 || !/230099|11310|cardid is invalid/i.test(String(e))) throw e;
+        log.warn(
+          `${label} mount rejected the fresh card (card=${cardId}, attempt ${attempt}) — retrying: ${String(e)}`,
+        );
+        await sleep(attempt * 400);
+      }
+    }
+    if (messageId === undefined) throw new Error("interactive send returned ok without a message_id");
+    return { kind: "card", cardId, messageId };
+  } catch (e) {
+    // Card tier failed — degrade to a text placeholder with NO live updates (the text tier's 20-edit
+    // cap is spent on terminal writes only). Visible: the operator learns why the preview is static.
+    log.warn(`${label} streaming card unavailable — live preview degrades to a static placeholder: ${String(e)}`);
+    const messageId =
+      target.replyTo !== undefined
+        ? await api.replyMessage(target.replyTo, "text", JSON.stringify({ text: initial }), {
+            replyInThread: target.replyInThread,
+          })
+        : await api.sendMessage(target.chatId, "text", JSON.stringify({ text: initial }));
+    if (messageId === undefined) throw new Error("text preview send returned ok without a message_id");
+    return { kind: "text", messageId };
+  }
+}
+
+/** Settle an already-mounted queue preview without starting an Agent stream (the poison/defer paths).
+ * Card and text tiers both change in place; only a missing/failed preview sends a fresh message. */
+export async function settleFeishuPreview(
+  api: FeishuApi,
+  target: FeishuTarget,
+  preview: MountedFeishuPreview | undefined,
+  text: string,
+): Promise<void> {
+  let sequence = 0;
+  await finalize(api, target, preview ?? { kind: "none" }, text, () => ++sequence);
+}
+
+/**
  * Consume one turn's event stream into a Feishu-compatible chat, live (see the module header for the preview
  * model). Preview updates are best-effort (logged once if they fail); the final write is authoritative
- * and surfaces a real failure (bad credentials, etc.). `noticeId` is the "⏳ queued" text notice sent
- * while this turn waited — it cannot morph into a card, so it is deleted once the preview is mounted
- * (and by the terminal write otherwise), never left pinned above the answer.
+ * and surfaces a real failure (bad credentials, etc.). `initialPreview`, when present, is the queued
+ * turn's already-mounted card/text message: the pump and terminal write mutate that same message rather
+ * than recalling it and posting another reply.
  */
 export async function streamFeishuReply(
   events: AsyncIterable<AgentEvent>,
   api: FeishuApi,
   target: FeishuTarget,
   formatError: (failed: FeishuFailure) => string | undefined,
-  noticeId?: string,
+  initialPreview?: MountedFeishuPreview,
   label = "[feishu]",
 ): Promise<void> {
   const tools: { label: string; status: "running" | "ok" | "error" }[] = [];
@@ -182,72 +254,23 @@ export async function streamFeishuReply(
     return capBytes(v === "" ? THINKING_PLACEHOLDER : v, CARD_MARKDOWN_MAX_BYTES);
   };
 
-  // The live preview: ONE streaming card, mounted once (setup below), then snapshot-updated in place.
-  // `sequence` must increase strictly per card — the single-writer pump guarantees it by construction.
-  let preview: Preview = { kind: "none" };
-  let setupAttempted = false;
+  // The live preview is ONE message: either the queue card/text handed in by the wiring, or a preview
+  // mounted lazily on this turn's first flush. `sequence` must increase strictly per card — the single-
+  // writer pump guarantees it by construction. A queue card has had no updates yet, so sequence starts
+  // at zero in both paths.
+  let preview: Preview = initialPreview ?? { kind: "none" };
+  let setupAttempted = initialPreview !== undefined;
   let sequence = 0;
   const nextSeq = (): number => ++sequence;
   let streamDead = false; // the platform closed streaming (idle timeout) — freeze the live view
   let finalized = false; // a terminal write (completed/failed) ran — the finally skips its orphan cleanup
   let lastSent = "";
 
-  // The queue notice cannot be taken over (text vs card) — delete it once anything else is visible.
-  let noticePending = noticeId !== undefined;
-  const clearNotice = (): void => {
-    if (!noticePending) return;
-    noticePending = false;
-    if (noticeId !== undefined) void api.deleteMessage(noticeId).catch(() => {});
-  };
-
-  /** Mount the preview ONCE: streaming card, or the text placeholder when the card tier fails. */
-  const mountPreview = async (initial: string): Promise<void> => {
-    setupAttempted = true;
-    try {
-      const cardId = await api.createCard(streamingCardJson(initial));
-      const content = cardEntityContent(cardId);
-      const mountOnce = (): Promise<string | undefined> =>
-        target.replyTo !== undefined
-          ? api.replyMessage(target.replyTo, "interactive", content, { replyInThread: target.replyInThread })
-          : api.sendMessage(target.chatId, "interactive", content);
-      let messageId: string | undefined;
-      // Field-observed: the mount can reject a JUST-minted card id (code 230099 / "cardid is invalid")
-      // — the entity is not yet visible to the IM side (eventual consistency between cardkit and IM).
-      // That specific rejection gets a short backoff and another try before degrading; anything else
-      // degrades immediately.
-      for (let attempt = 1; ; attempt++) {
-        try {
-          messageId = await mountOnce();
-          break;
-        } catch (e) {
-          if (attempt >= 3 || !/230099|11310|cardid is invalid/i.test(String(e))) throw e;
-          log.warn(
-            `${label} mount rejected the fresh card (card=${cardId}, attempt ${attempt}) — retrying: ${String(e)}`,
-          );
-          await sleep(attempt * 400);
-        }
-      }
-      if (messageId === undefined) throw new Error("interactive send returned ok without a message_id");
-      preview = { kind: "card", cardId, messageId };
-    } catch (e) {
-      // Card tier failed — degrade to a text placeholder with NO live updates (the text tier's 20-edit
-      // cap is spent on terminal writes only). Visible: the operator learns why the preview is static.
-      log.warn(`${label} streaming card unavailable — live preview degrades to a static placeholder: ${String(e)}`);
-      const messageId =
-        target.replyTo !== undefined
-          ? await api.replyMessage(target.replyTo, "text", JSON.stringify({ text: THINKING_PLACEHOLDER }), {
-              replyInThread: target.replyInThread,
-            })
-          : await api.sendMessage(target.chatId, "text", JSON.stringify({ text: THINKING_PLACEHOLDER }));
-      preview = messageId !== undefined ? { kind: "text", messageId } : { kind: "none" };
-    }
-    clearNotice();
-  };
-
   const flushPreview = async (): Promise<void> => {
     const text = view();
     if (!setupAttempted) {
-      await mountPreview(text);
+      setupAttempted = true;
+      preview = await mountFeishuPreview(api, target, text, label);
       lastSent = text;
       return;
     }
@@ -328,9 +351,8 @@ export async function streamFeishuReply(
     await pumpDone?.catch(() => {});
   };
 
-  /** Terminal write + notice cleanup (whatever tier the preview reached). */
+  /** Terminal write, whatever tier the preview reached. */
   const settle = async (text: string): Promise<void> => {
-    clearNotice();
     await finalize(api, target, preview, text, nextSeq);
   };
 

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -612,48 +612,86 @@ describe("turn flow", () => {
     expect(JSON.parse(readFileSync(join(home, "turns.json"), "utf8"))).toEqual({});
   });
 
-  it("queues a second ask on the SAME session behind the first and tells the asker (⏳ notice)", async () => {
+  it("keeps queued asks FIFO and takes over each ask's reply-quoted queue card in place", async () => {
     const fx = feishuFetch();
     let release: () => void = () => {};
     const gate = new Promise<void>((r) => {
       release = r;
     });
+    const order: string[] = [];
+    let invocation = 0;
     injectedAgent = {
-      async *invoke(_s: Scope, _p: Prompt): AsyncIterable<AgentEvent> {
-        await gate;
-        yield { type: "text", delta: "done" };
+      async *invoke(_s: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
+        const ask = ["first", "second", "third"].find((x) => prompt.text.includes(`\n${x}`)) ?? "unknown";
+        order.push(ask);
+        if (++invocation === 1) await gate;
+        yield { type: "text", delta: `answer ${ask}` };
         yield { type: "completed" };
       },
     };
-    const { handler } = buildChannel({ queueNoticeDelayMs: 0 }); // send the notice immediately (a long wait, compressed)
+    const { handler, idle } = buildChannel(); // queue feedback is immediate by default
     await handler(feishuRequest(messageEvent({ id: "om_q1", text: "first" })));
     await flush(); // first turn parks on the gate with its preview mounted
     await handler(feishuRequest(messageEvent({ id: "om_q2", text: "second" })));
-    // Even at delay 0 the notice leaves via a timer (one macrotask later than flush() can see) — poll.
+    await handler(feishuRequest(messageEvent({ id: "om_q3", text: "third" })));
+
+    // Each queued turn mounts ONE queue-status card as a reply to ITS source message — even in p2p,
+    // where an ordinary immediate answer is intentionally unquoted. The two mounts may finish in either
+    // visual order; the quote is the stable attribution.
+    const queueCardFor = (messageId: string): string | undefined => {
+      const mount = fx
+        .calls(`/im/v1/messages/${messageId}/reply`, "POST")
+        .find((c) => c.body?.msg_type === "interactive");
+      const content = JSON.parse(String(mount?.body?.content)) as { data?: { card_id?: string } };
+      return content.data?.card_id;
+    };
     await vi.waitFor(() => {
-      const texts = fx
-        .calls("receive_id_type=chat_id", "POST")
-        .map((c) =>
-          c.body?.msg_type === "text" ? (JSON.parse(String(c.body?.content)) as { text: string }).text : "",
-        );
-      expect(texts.some((t) => t.includes("⏳ Queued"))).toBe(true);
+      expect(queueCardFor("om_q2")).toBeDefined();
+      expect(queueCardFor("om_q3")).toBeDefined();
     });
+    const secondCard = queueCardFor("om_q2") as string;
+    const thirdCard = queueCardFor("om_q3") as string;
+    expect(secondCard).not.toBe(thirdCard);
+    const queueCreates = fx.calls("/cardkit/v1/cards", "POST").filter((c) => {
+      const card = JSON.parse(String(c.body?.data)) as { body?: { elements?: { content?: string }[] } };
+      return card.body?.elements?.[0]?.content?.includes("⏳ Queued");
+    });
+    expect(queueCreates).toHaveLength(2);
+
     release();
+    await idle();
+
+    // The per-session queue is FIFO, and each final answer settles the SAME card entity that carried
+    // that ask's queue status: no new preview, no recalled-message tombstone.
+    expect(order).toEqual(["first", "second", "third"]);
+    expect(fx.calls("/cardkit/v1/cards", "POST")).toHaveLength(3); // one entity per turn, not queue+answer
+    for (const [cardId, answer] of [
+      [secondCard, "answer second"],
+      [thirdCard, "answer third"],
+    ] as const) {
+      const settle = fx
+        .calls(`/cardkit/v1/cards/${cardId}`, "PUT")
+        .find((c) => c.url.endsWith(`/cardkit/v1/cards/${cardId}`));
+      const card = JSON.parse(String((settle?.body?.card as Record<string, unknown> | undefined)?.data));
+      expect(card.body.elements[0].content).toBe(answer);
+    }
+    expect(fx.calls("/im/v1/messages/", "DELETE")).toHaveLength(0);
   });
 
-  it("a FAST queue turnover never sends the ⏳ notice — no recall tombstone in the chat", async () => {
-    // Lark renders a deleted message as a visible "recalled a message" line, so the notice is DELAYED:
-    // a turn whose wait ends before the delay leaves no trace (default queueNoticeDelayMs ≫ this test).
+  it("an explicitly delayed queue frame may be skipped on FAST turnover without a recall tombstone", async () => {
+    // Immediate is the default; an author may opt into a delay to suppress Queue on very short waits.
+    // If the wait ends inside that configured delay, no status card was mounted and nothing is recalled.
     const fx = feishuFetch();
-    const { handler, idle } = buildChannel();
+    const { handler, idle } = buildChannel({ queueNoticeDelayMs: 5_000 });
     await handler(feishuRequest(messageEvent({ id: "om_f1", text: "first" })));
-    await handler(feishuRequest(messageEvent({ id: "om_f2", text: "second" }))); // queues behind, arms the notice
-    await idle(); // both turns complete well inside the notice delay
-    const texts = fx
-      .calls("receive_id_type=chat_id", "POST")
-      .map((c) => (c.body?.msg_type === "text" ? (JSON.parse(String(c.body?.content)) as { text: string }).text : ""));
-    expect(texts.some((t) => t.includes("⏳ Queued"))).toBe(false); // never sent …
-    expect(fx.calls("/im/v1/messages/", "DELETE")).toHaveLength(0); // … so nothing was recalled
+    await handler(feishuRequest(messageEvent({ id: "om_f2", text: "second" }))); // queues behind, arms the mount
+    await idle(); // both turns complete well inside the queue-status delay
+    const queueCreates = fx.calls("/cardkit/v1/cards", "POST").filter((c) => {
+      const card = JSON.parse(String(c.body?.data)) as { body?: { elements?: { content?: string }[] } };
+      return card.body?.elements?.[0]?.content?.includes("⏳ Queued");
+    });
+    expect(queueCreates).toHaveLength(0);
+    expect(fx.calls("/im/v1/messages/", "DELETE")).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Mount Feishu/Lark queue feedback as the turn's streaming card, reply-quoted to the exact source message in both group and p2p chats.
- Reuse that card for the thinking preview and final Markdown answer instead of recalling a text notice and posting a second message.
- Show queue feedback immediately by default while retaining `queueNoticeDelayMs` for explicit delayed behavior.
- Keep text fallback, deferred-turn, and poison-turn terminal updates on the same mounted preview when available.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Added or updated the smallest relevant tests

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added (`*_PLAN.md`, `HANDOFF.md`, session notes, etc.)
- [x] Docs were updated when behavior or public APIs changed
