### PR TITLE
fix(pi): restore the session's active-tool set when reopening (stateless invoke)

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -94,7 +94,11 @@ sessions, and state paths. `dev`, `start`, `invoke`, and `fire` share this assem
 parallel implementations.
 
 Each invocation builds a fresh harness for its session and discards it after the turn. Conversation
-continuity comes from `PiSessionStore`, not a resident harness.
+continuity comes from `PiSessionStore`, not a resident harness. Reopening is faithful to the whole
+record, not just the messages: pi's harness writes active-tool changes to the session but never reads
+them back (its own TUI harness is resident), so `piHarnessFactory` restores the recorded active-tool
+set itself — filtered to the mounted tools, since a recorded-but-removed tool would fail construction
+(`harness.ts` `restoreActiveToolNames`).
 
 ## 4. Event translation and terminal discipline
 

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -9,6 +9,7 @@
 import { AgentHarness } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
 import type { Model, Models } from "@earendil-works/pi-ai";
+import { log } from "../../log.ts";
 import type { PiSessionStore } from "./sessions.ts";
 
 /**
@@ -61,10 +62,53 @@ export interface PiHarnessFactoryOptions {
  */
 const PROVIDER_MAX_RETRIES = 2;
 
+/**
+ * Restore the session's recorded active-tool set for a fresh harness. pi's harness WRITES active-tool
+ * changes to the session (`setActiveTools` → `active_tools_change`) but its constructor never reads
+ * them back — pi's long-lived TUI harness keeps the set in memory, while fastagent builds a FRESH
+ * harness per invoke, which would silently reset the session's active set to "all tools" every turn.
+ * `null` (never changed) → undefined → pi's default (all mounted tools active).
+ *
+ * Names are filtered to the currently-mounted tools: the constructor THROWS on unknown names, so a
+ * recorded tool that was since removed from the workspace would otherwise brick every future invoke
+ * of that session. An intact EMPTY set is restored as-is (pi allows `setActiveTools([])`; that is a
+ * deliberate recorded state, not a degradation). Only a NON-empty set that filters down to empty
+ * falls back to the default — the recorded intent cannot be honored, and honoring its empty shadow
+ * would be a silent capability loss. Both filter degradations are logged (fail visibly) — ONCE per
+ * session+missing set: a fresh harness is built per invoke and channel sessions live for weeks, so an
+ * un-deduped warn would repeat every turn and dilute its own signal. A log-dedup memo (like L2's
+ * findings memo), not session state — the restore itself stays derived from the session every time.
+ */
+const warnedRestores = new Set<string>();
+export function restoreActiveToolNames(
+  recorded: string[] | null,
+  tools: AgentTool[],
+  sessionId: string,
+): string[] | undefined {
+  if (recorded === null) return undefined;
+  const mounted = new Set(tools.map((t) => t.name));
+  const known = recorded.filter((name) => mounted.has(name));
+  if (known.length === recorded.length) return known; // intact, including a deliberate []
+  const missing = recorded.filter((name) => !mounted.has(name));
+  const emit = warnedRestores.has(`${sessionId}\u0000${missing.join(",")}`) ? log.debug : log.warn;
+  warnedRestores.add(`${sessionId}\u0000${missing.join(",")}`);
+  if (known.length === 0) {
+    emit(
+      `[fastagent] session ${sessionId}: none of its recorded active tools (${missing.join(", ")}) are mounted — falling back to all mounted tools`,
+    );
+    return undefined;
+  }
+  emit(`[fastagent] session ${sessionId}: dropping recorded active tool(s) no longer mounted: ${missing.join(", ")}`);
+  return known;
+}
+
 /** Open-or-create the session per invoke: existing → open (history via buildContext); missing → create. */
 export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFactory {
   return async (sessionId) => {
     const session = await options.sessions.openOrCreate(sessionId);
+    // One extra entry walk per invoke to read the recorded active-tool set (buildContext is the only
+    // accessor) — negligible against the model call, same trade as L2's per-invoke definition re-read.
+    const context = await session.buildContext();
     const fresh = options.live ? await options.live() : undefined;
     const { systemPrompt } = options;
     const prompt = fresh ? fresh.systemPrompt : typeof systemPrompt === "function" ? systemPrompt() : systemPrompt;
@@ -75,6 +119,7 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
       models: options.models,
       model: options.model,
       tools: options.tools,
+      activeToolNames: restoreActiveToolNames(context.activeToolNames, options.tools ?? [], sessionId),
       systemPrompt: prompt,
       resources: skills ? { skills } : undefined,
       streamOptions: { maxRetries: PROVIDER_MAX_RETRIES },

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from "vitest";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { inMemorySessionStore } from "../src/index.ts";
-import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { piHarnessFactory, restoreActiveToolNames } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
+
+const fakeTool = (name: string): AgentTool =>
+  ({
+    name,
+    description: name,
+    parameters: { type: "object", properties: {} },
+    execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+  }) as unknown as AgentTool;
 
 describe("piHarnessFactory: provider retry wiring", () => {
   it("built harnesses carry maxRetries — the wiring retry-capable pi-ai adapters honor", async () => {
@@ -20,5 +29,56 @@ describe("piHarnessFactory: provider retry wiring", () => {
     });
     const harness = await factory("s1");
     expect(harness.getStreamOptions().maxRetries).toBe(2);
+  });
+});
+
+describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
+  // pi's harness writes active_tools_change to the session but its constructor never reads it back —
+  // fine for pi's long-lived TUI harness, but fastagent builds a fresh harness per invoke: without the
+  // restore, a session's active set silently resets to "all tools" on the next turn.
+  it("a fresh harness reopens the session with its recorded active set, not the default", async () => {
+    const { faux, models } = makeFaux();
+    const sessions = inMemorySessionStore();
+    const factory = piHarnessFactory({
+      sessions,
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      tools: [fakeTool("alpha"), fakeTool("beta")],
+      systemPrompt: "test",
+    });
+    const first = await factory("s1");
+    expect(first.getActiveTools().map((t) => t.name)).toEqual(["alpha", "beta"]); // default: all mounted
+    await first.setActiveTools(["beta"]); // idle phase → persisted to the session immediately
+
+    const second = await factory("s1"); // a fresh harness, as every invoke builds
+    expect(second.getActiveTools().map((t) => t.name)).toEqual(["beta"]);
+  });
+
+  it("a recorded tool that is no longer mounted is dropped instead of bricking the session", async () => {
+    const { faux, models } = makeFaux();
+    const sessions = inMemorySessionStore();
+    const base = {
+      sessions,
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      systemPrompt: "test",
+    };
+    const first = await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), fakeTool("beta")] })("s1");
+    await first.setActiveTools(["alpha", "beta"]);
+
+    // The workspace removed "alpha": the constructor throws on unknown names, so an unfiltered restore
+    // would fail every future invoke of this session.
+    const second = await piHarnessFactory({ ...base, tools: [fakeTool("beta")] })("s1");
+    expect(second.getActiveTools().map((t) => t.name)).toEqual(["beta"]);
+  });
+
+  it("restoreActiveToolNames: null → default; intact [] restored as-is; filter-to-empty → default", () => {
+    const tools = [fakeTool("alpha")];
+    expect(restoreActiveToolNames(null, tools, "s")).toBeUndefined(); // never changed → pi's default
+    expect(restoreActiveToolNames(["alpha"], tools, "s")).toEqual(["alpha"]);
+    expect(restoreActiveToolNames([], tools, "s")).toEqual([]); // deliberate empty set → faithful
+    expect(restoreActiveToolNames(["ghost"], tools, "s")).toBeUndefined(); // intent unhonorable → default
   });
 });


### PR DESCRIPTION
## Summary

> Scope note: this PR originally carried the pi 0.80.7 bump + the no-date prompt-cache fix. Those changes reached `main` as part of #235's merge (its commit message does not mention them — a working-tree mixup between two concurrent sessions; content verified correct on main). After rebasing, this PR is only what main does not have yet.

**Restore the session's recorded active-tool set on reopen.** pi's harness writes active-tool changes to the session (`setActiveTools` → `active_tools_change`) but its constructor never reads them back — pi's own TUI harness is long-lived and keeps the set in memory. fastagent builds a FRESH harness per invoke, so a session's recorded active set silently reset to "all tools" on every turn.

`piHarnessFactory` now restores it from `session.buildContext()`:

- recorded names are **filtered to the mounted tools** — the constructor throws on unknown names, so a tool removed from the workspace would otherwise brick every future invoke of that session
- an intact **empty set is restored as-is** (pi allows `setActiveTools([])`; a deliberate recorded state, not a degradation)
- a non-empty set that **filters down to empty falls back to the default** — the recorded intent cannot be honored, and honoring its empty shadow would be a silent capability loss
- filter degradations **warn once per session+missing set** (fresh harness per invoke × weeks-long channel sessions would otherwise repeat the same warn every turn)

Nothing in fastagent writes `active_tools_change` yet — this makes reopen faithful to whatever the session records, and is the load-bearing wiring for deferred/dynamic tool loading (pi 0.80.7) on the serving path.

Docs: `docs/design/core.md` §3 — the "continuity comes from PiSessionStore" claim now names the active-tool restore.

## Validation

- [x] `npm run lint` / `npm run typecheck` / `npm test`
- [x] Tests: write→reopen restores the set; a removed tool is dropped instead of bricking the session; unit three-state semantics (null → default, intact [] faithful, filter-to-empty → default)

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed