### PR TITLE
feat(config): thinkingLevel — the serving-side counterpart of pi's thinking selector

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ Supported keys:
 | Key | Meaning |
 |---|---|
 | `model` | Default model spec, in `provider/modelId` form. |
+| `thinkingLevel` | Reasoning effort for the model, on pi's scale: `off` \| `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max`. Unset = the engine default. Levels a model doesn't support are clamped by the engine. The serving-side counterpart of the thinking selector authors use in the pi TUI. |
 | `agentDir` | The agent-definition subdirectory (`persona.md`, `skills/`, `tools/`, `channels/`), relative to the config file. Default: the config directory itself (flat). Set it to e.g. `"./agent"` to serve an existing repo as a coding agent — the config directory stays the run root (`cwd`, whose `AGENTS.md` is read as context), while the agent's own surface lives in the subdir and does not collide with the host's `tools/`/`src/`. Must exist, stay inside the config directory, and be a real directory — a missing path is refused at load (a typo would otherwise silently serve an empty agent), and so is a symlink (its target can escape the config directory, where `dev`'s watch would never see edits). |
 | `tools` | Extra programmatic tools appended after default pi tools. Most users should prefer `tools/` discovery. |
 | `http.port` | Default port for `dev` / `start`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ Supported keys:
 | Key | Meaning |
 |---|---|
 | `model` | Default model spec, in `provider/modelId` form. |
-| `thinkingLevel` | Reasoning effort for the model, on pi's scale: `off` \| `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max`. Unset = the engine default. Levels a model doesn't support are clamped by the engine. The serving-side counterpart of the thinking selector authors use in the pi TUI. |
+| `thinkingLevel` | Reasoning effort for the model, on pi's scale: `off` \| `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max`. Default: `medium` — pinned by fastagent to match the pi TUI's default (authors vibe at `medium`, so serving must match; the pin also means an upstream default change cannot silently alter deployments). Levels a model doesn't support are clamped by the engine. |
 | `agentDir` | The agent-definition subdirectory (`persona.md`, `skills/`, `tools/`, `channels/`), relative to the config file. Default: the config directory itself (flat). Set it to e.g. `"./agent"` to serve an existing repo as a coding agent — the config directory stays the run root (`cwd`, whose `AGENTS.md` is read as context), while the agent's own surface lives in the subdir and does not collide with the host's `tools/`/`src/`. Must exist, stay inside the config directory, and be a real directory — a missing path is refused at load (a typo would otherwise silently serve an empty agent), and so is a symlink (its target can escape the config directory, where `dev`'s watch would never see edits). |
 | `tools` | Extra programmatic tools appended after default pi tools. Most users should prefer `tools/` discovery. |
 | `http.port` | Default port for `dev` / `start`. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -517,6 +517,7 @@ async function runInfo(): Promise<void> {
           agentDir,
           configPath: configPath ?? null,
           model: modelSpec ?? null,
+          thinkingLevel: config.thinkingLevel ?? null,
           context: definition.contextFiles.map((f) => f.path),
           persona: definition.persona !== undefined,
           skills: definition.skills.map((skill) => ({ name: skill.name, description: skill.description })),
@@ -544,6 +545,7 @@ async function runInfo(): Promise<void> {
   if (agentDir !== dir) console.log(`agent:    ${agentDir}`);
   console.log(`config:   ${configPath ?? "(none)"}`);
   console.log(`model:    ${modelSpec ?? "(not set — pass --model, set FASTAGENT_MODEL, or config.model)"}`);
+  if (config.thinkingLevel) console.log(`thinking: ${config.thinkingLevel}`);
   console.log(`context:  ${definition.contextFiles.map((f) => f.path).join(", ") || "(none)"}`);
   console.log(`persona:  ${definition.persona ? "persona.md" : "(none)"}`);
   console.log(`skills:   ${definition.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
@@ -1322,7 +1324,9 @@ async function serveOnce(): Promise<void> {
   log.info(`[fastagent] dir:    ${dir}`);
   if (a.agentDir !== dir) log.info(`[fastagent] agent:  ${a.agentDir}`);
   log.info(`[fastagent] config: ${a.configPath ?? "(zero-config)"}`);
-  log.info(`[fastagent] model:  ${a.modelSpec}`);
+  log.info(
+    `[fastagent] model:  ${a.modelSpec}${a.config.thinkingLevel ? ` (thinking: ${a.config.thinkingLevel})` : ""}`,
+  );
   await reportAuth(a.modelSpec, a.authPath);
   reportAgentsSkillsTools(a);
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
@@ -1368,7 +1372,7 @@ async function runStart(): Promise<void> {
 
   log.info(`[fastagent] start:  ${dir}`);
   if (agentDir !== dir) log.info(`[fastagent] agent:  ${agentDir}`);
-  log.info(`[fastagent] model:  ${modelSpec}`);
+  log.info(`[fastagent] model:  ${modelSpec}${config.thinkingLevel ? ` (thinking: ${config.thinkingLevel})` : ""}`);
   await reportAuth(modelSpec, authPath);
   log.info(`[fastagent] context: ${definition.contextFiles.map((f) => f.path).join(", ") || "(none)"}`);
   if (definition.persona) log.info(`[fastagent] persona: persona.md`);

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -10,14 +10,30 @@ import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
-import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Models } from "@earendil-works/pi-ai";
 import type { AnyModel } from "./harness.ts";
 import { moduleLoadHint } from "../../loader.ts";
 
+/** pi's thinking levels (types.d.ts `ThinkingLevel`), as a runtime list for config validation — pi
+ *  exports only the type. A level the selected model does not support is clamped by pi per model. */
+export const THINKING_LEVELS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const satisfies readonly ThinkingLevel[];
+
 export interface FastagentConfig {
   /** "provider/modelId". Precedence: CLI --model > FASTAGENT_MODEL > config. */
   model?: string;
+  /** Reasoning effort for the model, pi's scale ("off" | "minimal" | "low" | "medium" | "high" |
+   *  "xhigh" | "max"). Unset = pi's default. Authors tune thinking in the pi TUI while vibing — this
+   *  is the serving-side counterpart (fidelity). Levels a model doesn't support are clamped by pi. */
+  thinkingLevel?: ThinkingLevel;
   /**
    * The agent-definition subdirectory (persona.md, skills/, tools/, channels/), relative to the config
    * file's directory. Default: the config directory itself (flat — today's behaviour). Point it at a
@@ -108,17 +124,23 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   for (const key of Object.keys(c)) {
     if (
       key !== "model" &&
+      key !== "thinkingLevel" &&
       key !== "agentDir" &&
       key !== "tools" &&
       key !== "http" &&
       key !== "deploy" &&
       key !== "selfSchedule"
     ) {
-      throw new Error(`${path}: unknown key "${key}" (valid keys: model, agentDir, tools, http, deploy, selfSchedule)`);
+      throw new Error(
+        `${path}: unknown key "${key}" (valid keys: model, thinkingLevel, agentDir, tools, http, deploy, selfSchedule)`,
+      );
     }
   }
   if (c.model !== undefined && typeof c.model !== "string") {
     throw new Error(`${path}: "model" must be a "provider/modelId" string`);
+  }
+  if (c.thinkingLevel !== undefined && !(THINKING_LEVELS as readonly string[]).includes(c.thinkingLevel as string)) {
+    throw new Error(`${path}: "thinkingLevel" must be one of ${THINKING_LEVELS.join(", ")}`);
   }
   if (c.agentDir !== undefined && typeof c.agentDir !== "string") {
     throw new Error(`${path}: "agentDir" must be a string (a subdirectory relative to the config file)`);

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -11,7 +11,7 @@
  * they come from the definition; the openers own model/tools — from config resolution).
  */
 import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
-import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
+import type { AgentTool, ExecutionEnv, Skill, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { createCodingTools } from "@earendil-works/pi-coding-agent";
 import type { Provider } from "@earendil-works/pi-ai";
@@ -149,6 +149,7 @@ export function assembleSystemPrompt(options: AssembleSystemPromptOptions): stri
  */
 function buildPiAgent(opts: {
   model: string;
+  thinkingLevel?: ThinkingLevel;
   providers?: Provider[];
   authPath?: string;
   systemPrompt?: string | (() => string);
@@ -168,6 +169,7 @@ function buildPiAgent(opts: {
       env: opts.env ?? new NodeExecutionEnv({ cwd: process.cwd() }),
       models,
       model: resolveModel(models, opts.model),
+      thinkingLevel: opts.thinkingLevel,
       systemPrompt: opts.systemPrompt,
       tools: opts.tools,
       skills: opts.skills,
@@ -198,6 +200,8 @@ function instructionsPrompt(
 export interface CreatePiAgentOptions {
   /** Model spec "provider/modelId" (e.g. "openai-codex/gpt-5.5"), resolved against {@link models}. */
   model: string;
+  /** Reasoning effort (pi's scale). Unset = pi's default; unsupported levels are clamped per model. */
+  thinkingLevel?: ThinkingLevel;
   /**
    * The system prompt itself — verbatim, no engine base and no wrapping (unlike the directory path,
    * which assembles the engine base + AGENTS.md as segment ② + persona.md as segment ①). A plain string
@@ -232,6 +236,7 @@ export interface CreatePiAgentOptions {
 export function createPiAgent(options: CreatePiAgentOptions): Agent {
   return buildPiAgent({
     model: options.model,
+    thinkingLevel: options.thinkingLevel,
     providers: options.providers,
     authPath: options.authPath,
     systemPrompt: instructionsPrompt(options.instructions, options.skills),
@@ -250,6 +255,8 @@ export function createPiAgent(options: CreatePiAgentOptions): Agent {
 export interface CreatePiAgentFromDefinitionOptions {
   /** Model spec "provider/modelId", resolved against {@link models}. */
   model: string;
+  /** Reasoning effort (pi's scale). Unset = pi's default; unsupported levels are clamped per model. */
+  thinkingLevel?: ThinkingLevel;
   /** Override the engine base prompt (segment ①). Defaults to piBasePrompt({ tools, persona }) using the
    *  live-read persona.md; pass base to fully opt out of persona.md. */
   base?: string;
@@ -306,6 +313,7 @@ export async function createPiAgentFromDefinition(
   const tools = options.tools ?? piDefaultTools(env.cwd);
   const agent = buildPiAgent({
     model: options.model,
+    thinkingLevel: options.thinkingLevel,
     providers: options.providers,
     // Dir-aware default: the same state-root-derived file the opener uses for this dir (the opener
     // passes an explicit authPath, so this only affects direct L2 callers).

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -29,8 +29,8 @@ export interface PiHarnessFactoryOptions {
   /** Provider collection for all model requests; {@link model} must belong to it (same provider id). */
   models: Models;
   model: AnyModel;
-  /** Reasoning effort for the model (pi's scale). Unset = pi's default; unsupported levels are clamped
-   *  by pi per model. Applied at harness construction; the session records level changes. */
+  /** Reasoning effort for the model (pi's scale). Unset = fastagent's pinned default ("medium", pi
+   *  TUI parity — see {@link DEFAULT_THINKING_LEVEL}); unsupported levels are clamped by pi per model. */
   thinkingLevel?: ThinkingLevel;
   tools?: AgentTool[];
   /**
@@ -64,6 +64,15 @@ export interface PiHarnessFactoryOptions {
  * so a mid-stream failure surfaces as a `failed` event.
  */
 const PROVIDER_MAX_RETRIES = 2;
+
+/**
+ * The serving default for reasoning effort, pinned to what pi's TUI defaults to (its
+ * DEFAULT_THINKING_LEVEL) — NOT inherited from the bare harness, whose own fallback is "off": an
+ * author vibes at "medium" in pi and must get "medium" when served (fidelity), and pinning the value
+ * here means an upstream default change in either place cannot silently alter deployments. Models
+ * that don't support a level are clamped by pi per model.
+ */
+const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
 
 /**
  * Restore the session's recorded active-tool set for a fresh harness. pi's harness WRITES active-tool
@@ -121,7 +130,7 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
       session,
       models: options.models,
       model: options.model,
-      thinkingLevel: options.thinkingLevel,
+      thinkingLevel: options.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
       tools: options.tools,
       activeToolNames: restoreActiveToolNames(context.activeToolNames, options.tools ?? [], sessionId),
       systemPrompt: prompt,

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -7,7 +7,7 @@
  * historical entries back into context via buildContext().
  */
 import { AgentHarness } from "@earendil-works/pi-agent-core";
-import type { AgentTool, ExecutionEnv, Skill } from "@earendil-works/pi-agent-core";
+import type { AgentTool, ExecutionEnv, Skill, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Model, Models } from "@earendil-works/pi-ai";
 import { log } from "../../log.ts";
 import type { PiSessionStore } from "./sessions.ts";
@@ -29,6 +29,9 @@ export interface PiHarnessFactoryOptions {
   /** Provider collection for all model requests; {@link model} must belong to it (same provider id). */
   models: Models;
   model: AnyModel;
+  /** Reasoning effort for the model (pi's scale). Unset = pi's default; unsupported levels are clamped
+   *  by pi per model. Applied at harness construction; the session records level changes. */
+  thinkingLevel?: ThinkingLevel;
   tools?: AgentTool[];
   /**
    * Final assembled prompt, or a SYNC factory re-evaluated per invoke (how L1 serves dynamic
@@ -118,6 +121,7 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
       session,
       models: options.models,
       model: options.model,
+      thinkingLevel: options.thinkingLevel,
       tools: options.tools,
       activeToolNames: restoreActiveToolNames(context.activeToolNames, options.tools ?? [], sessionId),
       systemPrompt: prompt,

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -108,6 +108,7 @@ export async function createPiAgentFromWorkspace(
   await ensureStateRootSelfIgnored(dir, stateRoot);
   const { agent, definition } = await createPiAgentFromDefinition(agentDir, {
     model: modelSpec,
+    thinkingLevel: config.thinkingLevel,
     cwd: dir,
     tools: mountedTools,
     authPath,

--- a/src/scaffold/templates/fastagent.config.mjs
+++ b/src/scaffold/templates/fastagent.config.mjs
@@ -7,7 +7,7 @@
 // you have access to (`fastagent models` lists them).
 export default {
   // model: "openai-codex/gpt-5.5",
-  // thinkingLevel: "high", // reasoning effort (off|minimal|low|medium|high|xhigh|max); unset = the engine default
+  // thinkingLevel: "high", // reasoning effort (off|minimal|low|medium|high|xhigh|max); default "medium" (pi TUI parity)
   http: { port: 8787 },
   // selfSchedule: true, // mount the built-in `wake` tool: the agent schedules its own follow-up turns
   //                     // ("check the deploy in 10 min"). Cron jobs need no opt-in — drop a schedules/<name>.ts.

--- a/src/scaffold/templates/fastagent.config.mjs
+++ b/src/scaffold/templates/fastagent.config.mjs
@@ -7,6 +7,7 @@
 // you have access to (`fastagent models` lists them).
 export default {
   // model: "openai-codex/gpt-5.5",
+  // thinkingLevel: "high", // reasoning effort (off|minimal|low|medium|high|xhigh|max); unset = the engine default
   http: { port: 8787 },
   // selfSchedule: true, // mount the built-in `wake` tool: the agent schedules its own follow-up turns
   //                     // ("check the deploy in 10 min"). Cron jobs need no opt-in — drop a schedules/<name>.ts.

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -209,6 +209,20 @@ describe("config: loadConfig", () => {
     await expect(loadConfig(dir)).rejects.toThrow(/"http\.port" must be an integer/);
   });
 
+  it("thinkingLevel: a valid pi level loads; an invalid value throws (fail visibly, not a silent default)", async () => {
+    const load = async (body: string) => {
+      const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
+      await writeFile(join(dir, "fastagent.config.mjs"), body);
+      return loadConfig(dir);
+    };
+    const { config } = await load(`export default { thinkingLevel: "high" };`);
+    expect(config.thinkingLevel).toBe("high");
+    await expect(load(`export default { thinkingLevel: "hgih" };`)).rejects.toThrow(
+      /"thinkingLevel" must be one of off, minimal, low, medium, high, xhigh, max/,
+    );
+    await expect(load(`export default { thinkingLevel: 3 };`)).rejects.toThrow(/"thinkingLevel" must be one of/);
+  });
+
   it("unknown top-level keys throw instead of silently degrading to zero-config", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
     await writeFile(join(dir, "fastagent.config.mjs"), `export default { modle: "openai-codex/gpt-5.5" };`);

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -82,3 +82,18 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
     expect(restoreActiveToolNames(["ghost"], tools, "s")).toBeUndefined(); // intent unhonorable → default
   });
 });
+
+describe("piHarnessFactory: thinking-level wiring", () => {
+  it("threads thinkingLevel to the harness (config.thinkingLevel is not a silent no-op)", async () => {
+    const { faux, models } = makeFaux();
+    const factory = piHarnessFactory({
+      sessions: inMemorySessionStore(),
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      thinkingLevel: "high",
+      systemPrompt: "test",
+    });
+    expect((await factory("s1")).getThinkingLevel()).toBe("high");
+  });
+});

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -96,4 +96,19 @@ describe("piHarnessFactory: thinking-level wiring", () => {
     });
     expect((await factory("s1")).getThinkingLevel()).toBe("high");
   });
+
+  it('unset → fastagent\'s pinned default "medium" (pi TUI parity), not the bare harness\'s "off"', async () => {
+    // The bare harness falls back to "off", but authors vibe in the pi TUI whose default is "medium" —
+    // serving must match what they iterated with, and the pin means an upstream default change in
+    // either place cannot silently alter deployments.
+    const { faux, models } = makeFaux();
+    const factory = piHarnessFactory({
+      sessions: inMemorySessionStore(),
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      systemPrompt: "test",
+    });
+    expect((await factory("s1")).getThinkingLevel()).toBe("medium");
+  });
 });


### PR DESCRIPTION
## Summary

Stacked on #234 (needs the 0.80.7 chat-parity test from it; retarget to `main` after #234 merges).

Authors tune reasoning effort in the pi TUI while vibing, but the served agent had no way to set it: `piHarnessFactory` never passed `thinkingLevel`, so every deployment ran at pi's default — a fidelity gap (what you iterate is not what you serve). `AgentHarnessOptions.thinkingLevel` has existed all along; this is a pure pass-through that was missing.

- `config.thinkingLevel`: `off | minimal | low | medium | high | xhigh | max` (pi's scale — includes Fable 5's new `xhigh`/`max` from 0.80.7). Validated at config load (fail visibly on a typo); levels a model doesn't support are clamped by pi per model. Unset = pi's default.
- Threads workspace → L2 `createPiAgentFromDefinition` / L1 `createPiAgent` → `piHarnessFactory` → `AgentHarness`.
- Surfaced in the `dev`/`start` banner (`model: … (thinking: high)`) and `fastagent info` (text + json).
- Scaffold config template + `docs/configuration.md` updated.

## Validation

- [x] `npm run lint` / `npm run typecheck` / `npm test` (688)
- [x] Tests: config validation (valid + typo + non-string), harness threading (`getThinkingLevel() === "high"`), alongside the existing maxRetries wiring guard

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed