### PR TITLE
chore: release 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary

- bump `@fastagent-sh/fastagent` from 0.12.1 to 0.13.0
- prepare the first release containing the Feishu and Lark channels

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Existing tests cover the release; no behavioral test change is required for the version-only diff
- [x] Packed and installed the npm tarball; verified Feishu/Lark exports, scaffold assets, CLI help, and version

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added (`*_PLAN.md`, `HANDOFF.md`, session notes, etc.)
- [x] Docs were updated when behavior or public APIs changed
