### PR TITLE
docs: squash-aware branch cleanup — `git branch -D` after a squash merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,8 +139,11 @@ Full version: `CONTRIBUTING.md`. The essentials:
 4. **Review policy.** Merging is an explicit maintainer decision — agents never merge. Green CI makes a PR eligible; report "ready to merge" and stop. External-contributor PRs are reviewed and merged by a maintainer.
 5. **After merge:**
    ```bash
-   git checkout main && git pull --ff-only && git branch -d <branch> && git fetch --prune origin
+   git checkout main && git pull --ff-only && git branch -D <branch> && git fetch --prune origin
    ```
+   `-D`, not `-d`: after a squash merge the branch tip is never an ancestor of `main`, so `-d` always
+   refuses with "not fully merged". Verify the PR actually merged first (`gh pr view <n> --json state`)
+   — `-D` skips git's own safety check.
 6. **Releases publish via npm Trusted Publishing (OIDC), never a local `npm publish`.** The npm package
    must keep its `publish` trusted-publisher binding to `fastagent-sh/fastagent` / `publish.yml` /
    environment `npm`. Flow:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,13 @@ Tests use faux models by default, so they validate serving mechanics without net
 ```bash
 git checkout main
 git pull --ff-only
-git branch -d <merged-branch>
+git branch -D <merged-branch>
 git fetch --prune origin
 ```
+
+`-D`, not `-d`: after a squash merge the branch tip is never an ancestor of `main`, so `-d` always
+refuses with "not fully merged". Verify the PR actually merged first (`gh pr view <n> --json state`) —
+`-D` skips git's own safety check.
 
 ## Validation before merge
 


### PR DESCRIPTION
## Summary

Follow-up to #236 (raised in its review): the post-merge cleanup still said `git branch -d`, which always refuses with `not fully merged` under the squash-only policy #236 itself adopted — after a squash merge the branch tip is never an ancestor of `main`. Hit twice while landing #234/#237.

Both cleanup blocks (AGENTS.md step 5, CONTRIBUTING "After a PR merges") now use `-D` with a note to verify the PR actually merged first (`gh pr view <n> --json state`), since `-D` skips git's own safety check.

## Validation

- [x] `npm run lint` (doc-link check included)
- [x] Docs-only; no code paths affected

## Checklist

- [x] Public-facing text is in English
- [x] No process-only notes were added
- [x] No secrets, local paths, or machine-specific state were committed