### PR TITLE
feat(pi): deferred tools — dynamic tool loading on the serving path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,9 @@ src/
     ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
     ├── workspace.ts         # shared opener: workspace → agent for dev/start/invoke
     ├── chat.ts              # `chat` channel: drive pi's interactive TUI with the assembled agent
-    ├── tool.ts              # defineTool (Zod) + tools/ filesystem discovery
-    ├── tool-context.ts      # ToolContext.session via AsyncLocalStorage (set around the turn; read in execute — the wake tool's seam)
+    ├── tool.ts              # defineTool (Zod, incl. deferred: true) + tools/ filesystem discovery
+    ├── tool-context.ts      # ToolContext.session + tool-activation bridge via AsyncLocalStorage (set around the turn; read in execute — the wake/search_tools seam)
+    ├── search-tools.ts      # built-in search_tools loader for deferred tools (auto-mounted when any tool is deferred; author's wins)
     ├── wake-tool.ts         # the built-in `wake` tool (pi-coupled: defineTool): writes a wake-up into ToolContext.session; withWakeTool mounts it (serving path only)
     ├── channel.ts           # channels/ filesystem discovery (ChannelModule → Routes)
     ├── harness.ts           # pi harness wiring (factory)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -187,11 +187,30 @@ export default defineTool({
 
 `tools/<name>.ts` files are discovered with `loadTools(dir)`, and the filename becomes the tool name.
 
-The second `execute` argument is a `ToolContext`: `{ signal?, session? }`. `session` is the id of the
-current turn's conversation (undefined outside a turn, e.g. a bare `fastagent tool` run) — a per-turn
+The second `execute` argument is a `ToolContext`: `{ signal?, session?, tools? }`. `session` is the id of
+the current turn's conversation (undefined outside a turn, e.g. a bare `fastagent tool` run) — a per-turn
 value carried via `AsyncLocalStorage`, not a closure (a tool is built once and reused across sessions).
 The built-in **`wake`** tool uses it to self-schedule: `wake({ in, prompt })` records a one-shot wake-up
 that the scheduler fires back into THIS session after the delay (see [Schedule authoring](#schedule-authoring)).
+
+### Deferred tools
+
+For tool-heavy agents, `defineTool({ ..., deferred: true })` registers a tool without activating it:
+its schema stays out of every request (and the model's sight) until discovered. When any deferred tool
+is mounted, fastagent automatically mounts the built-in **`search_tools`** loader (a workspace tool
+named `search_tools` wins — the author owns the concept then): the model searches by keywords, matching
+tools are activated mid-turn, and the activation is recorded in the session, so it survives fastagent's
+per-invoke harness rebuild for the rest of that conversation.
+
+Costs and behavior to know:
+
+- **Discovery rides on the `description`** — a deferred tool the model never searches for effectively
+  does not exist. Write descriptions with the search in mind.
+- On providers with native deferred loading (Anthropic Sonnet/Opus/Fable ≥4.5, OpenAI gpt-5.4+), an
+  activation preserves the provider's prompt-cache prefix; other providers still work but may pay a
+  cache miss on activation.
+- `ToolContext.tools` (`{ active(), registered(), activate(names) }`) is the activation bridge a custom
+  loader can use; `activate` is additive and ignores unknown names.
 
 ## Channel authoring
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -212,6 +212,14 @@ Costs and behavior to know:
   restriction of its own.
 - `ToolContext.tools` (`{ active(), registered(), activate(names) }`) is the activation bridge a custom
   loader can use; `activate` is additive and ignores unknown names.
+- At L1 (`createPiAgent`) the `instructions` are verbatim by contract — fastagent does not inject the
+  discovery note the directory path's base prompt carries. When passing deferred tools at L1, tell the
+  model about `search_tools` in your own instructions (or rely on the loader's description alone,
+  which is weaker).
+- An activation is recorded in the session as "this conversation activated these deferred tools", not
+  as a frozen snapshot: on reopen the active set is rebuilt as the initial set (current non-deferred
+  tools) plus the recorded activations — a tool you add to the workspace later joins existing
+  conversations too.
 - **`fastagent chat` emulates deferral** like the serving path (what you iterate is what you serve):
   the session starts with deferred tools inactive, the same `search_tools` loader discovers and
   activates them (bridged to pi's session instead of the serving harness), and the prompt is

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -223,8 +223,9 @@ Costs and behavior to know:
 - **`fastagent chat` emulates deferral** like the serving path (what you iterate is what you serve):
   the session starts with deferred tools inactive, the same `search_tools` loader discovers and
   activates them (bridged to pi's session instead of the serving harness), and the prompt is
-  identical. One divergence: chat activations live in pi's own chat session, not your served
-  sessions.
+  identical. One divergence: chat activations do not survive `/new`/`/resume` — pi's chat session
+  does not record them, so a resumed conversation re-discovers via `search_tools` (on the serving
+  path activations persist in the session for the conversation's life).
 
 ## Channel authoring
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -212,11 +212,11 @@ Costs and behavior to know:
   restriction of its own.
 - `ToolContext.tools` (`{ active(), registered(), activate(names) }`) is the activation bridge a custom
   loader can use; `activate` is additive and ignores unknown names.
-- **`fastagent chat` does not emulate deferral**: in the local TUI every tool mounts active and the
-  built-in loader is not mounted (an authored `search_tools` mounts as a normal tool, but
-  `ToolContext.tools` is undefined there — chat drives pi's own TUI runtime, not fastagent's invoke
-  path). Deferral takes effect on the serving path (`dev`/`start`/`invoke`); verify discovery
-  behavior with `fastagent dev`, not chat.
+- **`fastagent chat` emulates deferral** like the serving path (what you iterate is what you serve):
+  the session starts with deferred tools inactive, the same `search_tools` loader discovers and
+  activates them (bridged to pi's session instead of the serving harness), and the prompt is
+  identical. One divergence: chat activations live in pi's own chat session, not your served
+  sessions.
 
 ## Channel authoring
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -212,6 +212,9 @@ Costs and behavior to know:
   restriction of its own.
 - `ToolContext.tools` (`{ active(), registered(), activate(names) }`) is the activation bridge a custom
   loader can use; `activate` is additive and ignores unknown names.
+- **`fastagent chat` does not emulate deferral**: in the local TUI every tool mounts active and
+  `search_tools` is not present — deferral is a serving-cost optimization and takes effect on the
+  serving path (`dev`/`start`/`invoke`). Verify discovery behavior with `fastagent dev`, not chat.
 
 ## Channel authoring
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -211,15 +211,21 @@ Costs and behavior to know:
   is pi's (see its Dynamic Tool Loading docs) and evolves with pi releases — fastagent adds no
   restriction of its own.
 - `ToolContext.tools` (`{ active(), registered(), activate(names) }`) is the activation bridge a custom
-  loader can use; `activate` is additive and ignores unknown names.
+  loader can use; `activate` is additive and ignores unknown names. A custom loader must also declare
+  `executionMode: "sequential"` on its tool (pi then serializes the batch — in chat, pi's own
+  before/after diff around SDK tools would otherwise attribute one activation to two parallel calls).
+  Both types are exported: `ToolActivation`, and `FastagentTool` (`AgentTool` + the `deferred` marker —
+  the type `config.tools` and the L1/L2 `tools` options accept, so a raw object literal with
+  `deferred: true` type-checks).
 - At L1 (`createPiAgent`) the `instructions` are verbatim by contract — fastagent does not inject the
   discovery note the directory path's base prompt carries. When passing deferred tools at L1, tell the
   model about `search_tools` in your own instructions (or rely on the loader's description alone,
   which is weaker).
-- An activation is recorded in the session as "this conversation activated these deferred tools", not
-  as a frozen snapshot: on reopen the active set is rebuilt as the initial set (current non-deferred
-  tools) plus the recorded activations — a tool you add to the workspace later joins existing
-  conversations too.
+- An activation is persisted as a dedicated DELTA entry in the session ("this conversation activated
+  these deferred tools"): on reopen the active set is rebuilt as the initial set (current non-deferred
+  tools) plus the accumulated deltas. A tool you add to the workspace later joins existing
+  conversations, and a tool you later flip to `deferred` drops out of sessions that never discovered
+  it.
 - **`fastagent chat` emulates deferral** like the serving path (what you iterate is what you serve):
   the session starts with deferred tools inactive, the same `search_tools` loader discovers and
   activates them (bridged to pi's session instead of the serving harness), and the prompt is

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -212,8 +212,9 @@ Costs and behavior to know:
   restriction of its own.
 - `ToolContext.tools` (`{ active(), registered(), activate(names) }`) is the activation bridge a custom
   loader can use; `activate` is additive and ignores unknown names. A custom loader must also declare
-  `executionMode: "sequential"` on its tool (pi then serializes the batch — in chat, pi's own
-  before/after diff around SDK tools would otherwise attribute one activation to two parallel calls).
+  `executionMode: "sequential"` (a `defineTool` option; pi then serializes the batch — in chat, pi's
+  own before/after diff around SDK tools would otherwise attribute one activation to two parallel
+  calls). A workspace `search_tools` missing the mode gets it forced, with a warning.
   Both types are exported: `ToolActivation`, and `FastagentTool` (`AgentTool` + the `deferred` marker —
   the type `config.tools` and the L1/L2 `tools` options accept, so a raw object literal with
   `deferred: true` type-checks).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -206,9 +206,10 @@ Costs and behavior to know:
 
 - **Discovery rides on the `description`** — a deferred tool the model never searches for effectively
   does not exist. Write descriptions with the search in mind.
-- On providers with native deferred loading (Anthropic Sonnet/Opus/Fable ≥4.5, OpenAI gpt-5.4+), an
-  activation preserves the provider's prompt-cache prefix; other providers still work but may pay a
-  cache miss on activation.
+- On models with native deferred tool loading, an activation preserves the provider's prompt-cache
+  prefix; everywhere else activation still works but may pay a cache miss. The supported-model matrix
+  is pi's (see its Dynamic Tool Loading docs) and evolves with pi releases — fastagent adds no
+  restriction of its own.
 - `ToolContext.tools` (`{ active(), registered(), activate(names) }`) is the activation bridge a custom
   loader can use; `activate` is additive and ignores unknown names.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -212,9 +212,11 @@ Costs and behavior to know:
   restriction of its own.
 - `ToolContext.tools` (`{ active(), registered(), activate(names) }`) is the activation bridge a custom
   loader can use; `activate` is additive and ignores unknown names.
-- **`fastagent chat` does not emulate deferral**: in the local TUI every tool mounts active and
-  `search_tools` is not present — deferral is a serving-cost optimization and takes effect on the
-  serving path (`dev`/`start`/`invoke`). Verify discovery behavior with `fastagent dev`, not chat.
+- **`fastagent chat` does not emulate deferral**: in the local TUI every tool mounts active and the
+  built-in loader is not mounted (an authored `search_tools` mounts as a normal tool, but
+  `ToolContext.tools` is undefined there — chat drives pi's own TUI runtime, not fastagent's invoke
+  path). Deferral takes effect on the serving path (`dev`/`start`/`invoke`); verify discovery
+  behavior with `fastagent dev`, not chat.
 
 ## Channel authoring
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -98,14 +98,13 @@ continuity comes from `PiSessionStore`, not a resident harness. Reopening is fai
 record, not just the messages: pi's harness writes active-tool changes to the session but never reads
 them back (its own TUI harness is resident), so `piHarnessFactory` resolves the active-tool set itself
 (`harness.ts` `resolveHarnessActiveToolNames`): the UNION of the initial set (every non-deferred tool;
-pi's all-active default when nothing is deferred) and the recorded names, filtered to the mounted
-tools (a recorded-but-removed tool would fail construction). A record is deliberately NOT a frozen
-snapshot — on the serving path only the additive activation bridge writes records, so its semantic is
-"which deferred tools this session activated"; replaying a snapshot would freeze later-added tools out
-of old sessions. The corollary is a constraint on future writers: NARROWING the active set via
-`harness.setActiveTools` is not honored across invokes — the union rebuild expands any record back to
-at least the initial set. A capability that needs durable narrowing must change the resolve semantics
-here first, deliberately.
+pi's all-active default when nothing is deferred) and the session's accumulated activation DELTAS —
+dedicated `fastagent:tool-activation` custom entries the activation bridge writes, each carrying
+exactly the names that call activated. pi's own `active_tools_change` entries are full active-set
+snapshots and are deliberately ignored: replaying a snapshot would freeze later-added tools out of old
+sessions and keep a later-`deferred` tool active in sessions that never discovered it. The corollary
+is a constraint on future writers: NARROWING the active set is not representable in this record — a
+capability that needs durable narrowing must change the resolve semantics here first, deliberately.
 
 ## 4. Event translation and terminal discipline
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -96,9 +96,10 @@ parallel implementations.
 Each invocation builds a fresh harness for its session and discards it after the turn. Conversation
 continuity comes from `PiSessionStore`, not a resident harness. Reopening is faithful to the whole
 record, not just the messages: pi's harness writes active-tool changes to the session but never reads
-them back (its own TUI harness is resident), so `piHarnessFactory` restores the recorded active-tool
-set itself — filtered to the mounted tools, since a recorded-but-removed tool would fail construction
-(`harness.ts` `restoreActiveToolNames`).
+them back (its own TUI harness is resident), so `piHarnessFactory` resolves the active-tool set itself
+(`harness.ts` `resolveHarnessActiveToolNames`) — the recorded set filtered to the mounted tools (a
+recorded-but-removed tool would fail construction), and with no record (or an unhonorable one) the
+INITIAL set: every non-deferred tool, which is pi's default when nothing is deferred.
 
 ## 4. Event translation and terminal discipline
 
@@ -129,6 +130,20 @@ Workspace tools are merged in this order:
 3. discovered `tools/*.ts|js|mjs`.
 
 Earlier names win and collisions are reported. Broken discovered tools are reported and skipped.
+
+**Deferred tools** (`defineTool({ deferred: true })`) are registered but not initially active: their
+schemas stay out of the request — and the model's sight — until the built-in `search_tools` loader
+(auto-mounted whenever a deferred tool exists; an authored `search_tools` wins, the wake-pair rule)
+activates them by keyword mid-turn. The activation runs through a per-turn bridge on the turn context
+(`ToolActivation`: additive `setActiveTools`, unknown names filtered — pi throws on them), is stamped
+on that tool call's own result as `addedToolNames` — the load point that lets providers with native
+deferred loading add the definitions at the transcript position without invalidating the cached
+prompt prefix (the stamp comes from that execute's own `activate()` calls, never an active-set
+snapshot diff: batch tool calls run in parallel and a diff would misattribute a sibling's activation)
+— and is recorded in the session, which the per-invoke resolve above carries into later turns. The
+base prompt lists only non-deferred tools plus a discovery note, computed from the static mounted set,
+so activation never rewrites the prompt. `chat` deliberately does not emulate deferral (the author is
+exercising their tools; everything mounts active and the marker is stripped before prompt assembly).
 
 `ExecutionEnv` is a harness assembly seam, not a complete sandbox boundary today. Pi's cwd-bound coding
 tools and `loadProjectContextFiles` still use the local process/filesystem. A future sandbox adapter must

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -102,7 +102,10 @@ pi's all-active default when nothing is deferred) and the recorded names, filter
 tools (a recorded-but-removed tool would fail construction). A record is deliberately NOT a frozen
 snapshot — on the serving path only the additive activation bridge writes records, so its semantic is
 "which deferred tools this session activated"; replaying a snapshot would freeze later-added tools out
-of old sessions.
+of old sessions. The corollary is a constraint on future writers: NARROWING the active set via
+`harness.setActiveTools` is not honored across invokes — the union rebuild expands any record back to
+at least the initial set. A capability that needs durable narrowing must change the resolve semantics
+here first, deliberately.
 
 ## 4. Event translation and terminal discipline
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -142,8 +142,10 @@ prompt prefix (the stamp comes from that execute's own `activate()` calls, never
 snapshot diff: batch tool calls run in parallel and a diff would misattribute a sibling's activation)
 — and is recorded in the session, which the per-invoke resolve above carries into later turns. The
 base prompt lists only non-deferred tools plus a discovery note, computed from the static mounted set,
-so activation never rewrites the prompt. `chat` deliberately does not emulate deferral (the author is
-exercising their tools; everything mounts active and the marker is stripped before prompt assembly).
+so activation never rewrites the prompt. `chat` emulates the same behavior over pi's AgentSession —
+the session is narrowed to the initial active set at build, and the same builtin loader activates
+through a chat-side ToolActivation bridge (`chat.ts` `chatToolActivation`) riding the same
+turn context, so the author debugs exactly what serves.
 
 `ExecutionEnv` is a harness assembly seam, not a complete sandbox boundary today. Pi's cwd-bound coding
 tools and `loadProjectContextFiles` still use the local process/filesystem. A future sandbox adapter must

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -97,9 +97,12 @@ Each invocation builds a fresh harness for its session and discards it after the
 continuity comes from `PiSessionStore`, not a resident harness. Reopening is faithful to the whole
 record, not just the messages: pi's harness writes active-tool changes to the session but never reads
 them back (its own TUI harness is resident), so `piHarnessFactory` resolves the active-tool set itself
-(`harness.ts` `resolveHarnessActiveToolNames`) — the recorded set filtered to the mounted tools (a
-recorded-but-removed tool would fail construction), and with no record (or an unhonorable one) the
-INITIAL set: every non-deferred tool, which is pi's default when nothing is deferred.
+(`harness.ts` `resolveHarnessActiveToolNames`): the UNION of the initial set (every non-deferred tool;
+pi's all-active default when nothing is deferred) and the recorded names, filtered to the mounted
+tools (a recorded-but-removed tool would fail construction). A record is deliberately NOT a frozen
+snapshot — on the serving path only the additive activation bridge writes records, so its semantic is
+"which deferred tools this session activated"; replaying a snapshot would freeze later-added tools out
+of old sessions.
 
 ## 4. Event translation and terminal discipline
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -487,11 +487,18 @@ async function runInfo(): Promise<void> {
   const tools = await resolveWorkspaceTools(config, agentDir, dir)
     .then((r) => ({
       names: r.toolNames,
+      deferred: r.deferredToolNames,
       collisions: r.toolCollisions,
       failures: r.toolFailures,
       error: undefined as string | undefined,
     }))
-    .catch((e: unknown) => ({ names: [] as string[], collisions: [], failures: [], error: (e as Error).message }));
+    .catch((e: unknown) => ({
+      names: [] as string[],
+      deferred: [] as string[],
+      collisions: [],
+      failures: [],
+      error: (e as Error).message,
+    }));
   const channels = await discoverChannelFiles(agentDir).catch(failStartup);
   // Loaded (imported + validated), not just discovered: info's job is "fix only what it reports", so a
   // broken schedule file (bad cron/tz, failed import) must show up HERE, not first at dev/start — and
@@ -522,6 +529,7 @@ async function runInfo(): Promise<void> {
           persona: definition.persona !== undefined,
           skills: definition.skills.map((skill) => ({ name: skill.name, description: skill.description })),
           tools: tools.names,
+          deferredTools: tools.deferred,
           toolError: tools.error ?? null,
           channels,
           schedules,
@@ -550,6 +558,7 @@ async function runInfo(): Promise<void> {
   console.log(`persona:  ${definition.persona ? "persona.md" : "(none)"}`);
   console.log(`skills:   ${definition.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
   console.log(`tools:    ${tools.error ? "(could not load — see warning below)" : tools.names.join(", ") || "(none)"}`);
+  if (tools.deferred.length > 0) console.log(`deferred: ${tools.deferred.join(", ")} (activated via search_tools)`);
   console.log(`channels: ${channels.join(", ") || "(none)"}`);
   console.log(`schedules: ${schedules.map((s) => `${s.name} (next ${s.next ?? "never"})`).join(", ") || "(none)"}`);
   console.log(`selfSchedule: ${config.selfSchedule ? "on (mounts the wake tool when serving)" : "off"}`);
@@ -1249,6 +1258,9 @@ function reportAgentsSkillsTools(a: Assembled): void {
   if (a.definition.persona) log.info(`[fastagent] persona: persona.md`);
   log.info(`[fastagent] skills: ${a.definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
   if (a.toolNames.length > 0) log.info(`[fastagent] tools:  ${a.toolNames.join(", ")}`);
+  if (a.deferredToolNames.length > 0) {
+    log.info(`[fastagent] deferred: ${a.deferredToolNames.join(", ")} (activated via search_tools)`);
+  }
   reportToolCollisions(a.toolCollisions);
   reportModuleLoadFailures(a.toolFailures);
   reportDefinitionWarnings(a.definition.collisions, a.definition.diagnostics);
@@ -1361,6 +1373,7 @@ async function runStart(): Promise<void> {
     sessionsDir,
     authPath,
     toolNames,
+    deferredToolNames,
     toolCollisions,
     toolFailures,
   } = await createPiAgentFromWorkspace(dir, {
@@ -1378,6 +1391,9 @@ async function runStart(): Promise<void> {
   if (definition.persona) log.info(`[fastagent] persona: persona.md`);
   log.info(`[fastagent] skills: ${definition.skills.map((s) => s.name).join(", ") || "(none)"}`);
   if (toolNames.length > 0) log.info(`[fastagent] tools:  ${toolNames.join(", ")}`);
+  if (deferredToolNames.length > 0) {
+    log.info(`[fastagent] deferred: ${deferredToolNames.join(", ")} (activated via search_tools)`);
+  }
   reportToolCollisions(toolCollisions);
   reportModuleLoadFailures(toolFailures);
   log.info(`[fastagent] state:  ${stateRoot}`);

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -207,17 +207,15 @@ export async function buildChatRuntime(
       customTools: customToolDefs,
     });
     sessionRef.current = result.session;
-    // Deferral emulation: pi's TUI session starts with everything active — narrow it to the initial
-    // active set (non-deferred), like a fresh served session. Only when the session still has the
-    // all-active default: a /resume of a session where the loader already activated tools keeps its
-    // narrower recorded set (the corner where a resumed session had ALL tools deliberately active is
-    // re-deferred — chat-local, and search_tools re-activates in one call).
+    // Deferral emulation: pi's TUI session starts with everything active — narrow a FRESH session by
+    // SUBTRACTING the deferred names from whatever is active (robust to pi mounting tools of its own;
+    // an exact-set-equality gate would silently stop narrowing the day pi adds one). A resumed session
+    // (has messages) keeps its recorded set — the loader's earlier activations survive, like serving.
     const deferredNames = customTools.filter(isDeferredTool).map((t) => t.name);
-    if (deferredNames.length > 0) {
-      const allNames = [...defaultNames, ...customTools.map((t) => t.name)];
+    if (deferredNames.length > 0 && result.session.messages.length === 0) {
       const active = result.session.getActiveToolNames();
-      if (active.length === allNames.length && allNames.every((n) => active.includes(n))) {
-        result.session.setActiveToolsByName(allNames.filter((n) => !deferredNames.includes(n)));
+      if (deferredNames.some((n) => active.includes(n))) {
+        result.session.setActiveToolsByName(active.filter((n) => !deferredNames.includes(n)));
       }
     }
     return { ...result, services, diagnostics: services.diagnostics };

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -41,7 +41,7 @@ import { createPiModels } from "./models.ts";
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
 import { isDeferredTool, loadTools, mergeDiscoveredTools } from "./tool.ts";
 import { withSearchTool } from "./search-tools.ts";
-import { type ToolActivation, turnContext } from "./tool-context.ts";
+import { type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
 import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 
 export interface RunPiChatOptions {
@@ -69,9 +69,12 @@ export async function buildChatRuntime(
       active: () => session.getActiveToolNames(),
       registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
       async activate(names) {
-        const registered = new Set(session.getAllTools().map((t) => t.name));
         const current = session.getActiveToolNames();
-        const added = [...new Set(names)].filter((n) => registered.has(n) && !current.includes(n));
+        const added = additiveActivation(
+          session.getAllTools().map((t) => t.name),
+          current,
+          names,
+        );
         if (added.length > 0) session.setActiveToolsByName([...current, ...added]);
         return added;
       },

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -135,7 +135,10 @@ export async function buildChatRuntime(
       parameters: t.parameters,
       execute: (id: string, params: unknown, signal: AbortSignal | undefined) => {
         const bound = sessionRef.current;
-        if (!bound) return t.execute(id, params, signal);
+        // Unreachable by construction (createRuntime sets sessionRef before any turn can run a tool).
+        // Throw rather than silently run outside the turn context — that would disguise a broken
+        // session-lifecycle invariant as a normal out-of-turn call (fail visibly).
+        if (!bound) throw new Error("chat tool executed before its session was built (lifecycle invariant broken)");
         return turnContext.run(
           { session: bound.session.sessionId, tools: bound.activation },
           () => t.execute(id, params, signal) as Promise<unknown>,

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -22,6 +22,7 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   type AgentSessionRuntime,
@@ -38,7 +39,7 @@ import { loadConfig, resolveAgentDir, resolveModel, resolveModelSpec } from "./c
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
 import { createPiModels } from "./models.ts";
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
-import { loadTools, mergeDiscoveredTools } from "./tool.ts";
+import { isDeferredTool, loadTools, mergeDiscoveredTools } from "./tool.ts";
 import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 
 export interface RunPiChatOptions {
@@ -77,7 +78,18 @@ export async function buildChatRuntime(
     // Same tool resolution as the dev opener, then split: defaults go to pi by NAME (rebuilt cwd-bound
     // for rich rendering); customs go through pi's `customTools` path so they survive /new, /resume, fork.
     const discovered = await loadTools(agentDir);
-    const { tools, collisions: crossCollisions } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
+    const merged = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
+    // Chat does NOT emulate deferral — a deliberate, named fidelity gap: deferral is a serving-cost
+    // optimization, and in the local TUI the author is exercising their tools, so every tool mounts
+    // ACTIVE. Strip the marker before the prompt assembly below: piBasePrompt would otherwise hide
+    // the deferred tools and advertise a search_tools loader that is not mounted here — a prompt
+    // that lies about the tool surface.
+    const tools = merged.tools.map((t) => {
+      if (!isDeferredTool(t)) return t;
+      const { deferred: _drop, ...active } = t as AgentTool & { deferred?: boolean };
+      return active as AgentTool;
+    });
+    const crossCollisions = merged.collisions;
     reportToolCollisions([...discovered.collisions, ...crossCollisions]);
     reportModuleLoadFailures(discovered.failures);
     const defaultNames = piDefaultTools(cwd).map((t) => t.name);

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -24,6 +24,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
+  type AgentSession,
   type AgentSessionRuntime,
   type CreateAgentSessionRuntimeFactory,
   InteractiveMode,
@@ -38,7 +39,9 @@ import { loadConfig, resolveAgentDir, resolveModel, resolveModelSpec } from "./c
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
 import { createPiModels } from "./models.ts";
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
-import { loadTools, mergeDiscoveredTools, stripDeferredMarker } from "./tool.ts";
+import { isDeferredTool, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import { withSearchTool } from "./search-tools.ts";
+import { type ToolActivation, turnContext } from "./tool-context.ts";
 import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 
 export interface RunPiChatOptions {
@@ -57,6 +60,24 @@ export async function buildChatRuntime(
   /** Session backend. Defaults to pi's project-scoped store; tests inject SessionManager.inMemory(). */
   sessionManager?: SessionManager,
 ): Promise<AgentSessionRuntime> {
+  /** The turn's {@link ToolActivation} over pi's AgentSession — the chat counterpart of invoke.ts's
+   *  harness bridge, so the SAME builtin search_tools serves both paths. Additive; unknown names
+   *  filtered (`setActiveToolsByName` is authoritative on the session and rebuilds its prompt — our
+   *  static override keeps the prompt identical to serving). */
+  function chatToolActivation(session: AgentSession): ToolActivation {
+    return {
+      active: () => session.getActiveToolNames(),
+      registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
+      async activate(names) {
+        const registered = new Set(session.getAllTools().map((t) => t.name));
+        const current = session.getActiveToolNames();
+        const added = [...new Set(names)].filter((n) => registered.has(n) && !current.includes(n));
+        if (added.length > 0) session.setActiveToolsByName([...current, ...added]);
+        return added;
+      },
+    };
+  }
+
   async function resolveAssembly(cwd: string) {
     const { config } = await loadConfig(cwd);
     const modelSpec = resolveModelSpec(options.model, config);
@@ -78,24 +99,34 @@ export async function buildChatRuntime(
     // for rich rendering); customs go through pi's `customTools` path so they survive /new, /resume, fork.
     const discovered = await loadTools(agentDir);
     const merged = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
-    // Chat does NOT emulate deferral — a deliberate, named fidelity gap: deferral is a serving-cost
-    // optimization, and in the local TUI the author is exercising their tools, so every tool mounts
-    // ACTIVE. Strip the marker before the prompt assembly below: piBasePrompt would otherwise hide
-    // the deferred tools and advertise a search_tools loader that is not mounted here — a prompt
-    // that lies about the tool surface.
-    const tools = merged.tools.map(stripDeferredMarker);
+    // Chat EMULATES deferral, like serving (what you iterate is what you serve): the builtin loader
+    // mounts when a deferred tool exists, the initial active set excludes deferred tools (applied on
+    // the session in createRuntime below — pi's TUI session starts all-active), and the activation
+    // bridge below rides the same turn context the serving path uses, so the SAME search_tools works
+    // against pi's AgentSession instead of fastagent's harness.
+    const tools = withSearchTool(merged.tools);
     const crossCollisions = merged.collisions;
     reportToolCollisions([...discovered.collisions, ...crossCollisions]);
     reportModuleLoadFailures(discovered.failures);
     const defaultNames = piDefaultTools(cwd).map((t) => t.name);
     const customTools = tools.filter((t) => !defaultNames.includes(t.name));
-    // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts it).
+    // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts
+    // it). Each execute runs inside the turn context with the CURRENT session's activation bridge — the
+    // assembly is memoized across /new//resume/fork rebuilds while the session changes, so the bridge
+    // resolves through sessionRef at call time, exactly like the serving path resolves its harness.
     const customToolDefs = customTools.map((t) => ({
       name: t.name,
       label: t.name,
       description: t.description ?? "",
       parameters: t.parameters,
-      execute: (id: string, params: unknown, signal: AbortSignal | undefined) => t.execute(id, params, signal),
+      execute: (id: string, params: unknown, signal: AbortSignal | undefined) => {
+        const session = sessionRef.current;
+        if (!session) return t.execute(id, params, signal);
+        return turnContext.run(
+          { session: session.sessionId, tools: chatToolActivation(session) },
+          () => t.execute(id, params, signal) as Promise<unknown>,
+        );
+      },
     })) as unknown as ToolDefinition[];
 
     // base + instructions ONLY — pi appends the skill section and env (cwd) itself (including
@@ -114,6 +145,9 @@ export async function buildChatRuntime(
   // edits. And keep it workspace-scoped — `.env` is process-global, so a switch to another cwd would
   // leak env or require mutating global env at runtime.
   const rootCwd = canonicalPath(dir);
+  // The CURRENT pi session — rebuilt on /new//resume/fork while the memoized assembly (and its tool
+  // execute closures) stays; the activation bridge reads it at call time.
+  const sessionRef: { current?: AgentSession } = {};
   let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
   const assemblyFor = (cwd: string) => {
     // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
@@ -169,6 +203,20 @@ export async function buildChatRuntime(
       tools: [...defaultNames, ...customTools.map((t) => t.name)],
       customTools: customToolDefs,
     });
+    sessionRef.current = result.session;
+    // Deferral emulation: pi's TUI session starts with everything active — narrow it to the initial
+    // active set (non-deferred), like a fresh served session. Only when the session still has the
+    // all-active default: a /resume of a session where the loader already activated tools keeps its
+    // narrower recorded set (the corner where a resumed session had ALL tools deliberately active is
+    // re-deferred — chat-local, and search_tools re-activates in one call).
+    const deferredNames = customTools.filter(isDeferredTool).map((t) => t.name);
+    if (deferredNames.length > 0) {
+      const allNames = [...defaultNames, ...customTools.map((t) => t.name)];
+      const active = result.session.getActiveToolNames();
+      if (active.length === allNames.length && allNames.every((n) => active.includes(n))) {
+        result.session.setActiveToolsByName(allNames.filter((n) => !deferredNames.includes(n)));
+      }
+    }
     return { ...result, services, diagnostics: services.diagnostics };
   };
 

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -22,7 +22,6 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   type AgentSessionRuntime,
@@ -39,7 +38,7 @@ import { loadConfig, resolveAgentDir, resolveModel, resolveModelSpec } from "./c
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools, resolveTools } from "./create.ts";
 import { createPiModels } from "./models.ts";
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
-import { isDeferredTool, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import { loadTools, mergeDiscoveredTools, stripDeferredMarker } from "./tool.ts";
 import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 
 export interface RunPiChatOptions {
@@ -84,11 +83,7 @@ export async function buildChatRuntime(
     // ACTIVE. Strip the marker before the prompt assembly below: piBasePrompt would otherwise hide
     // the deferred tools and advertise a search_tools loader that is not mounted here — a prompt
     // that lies about the tool surface.
-    const tools = merged.tools.map((t) => {
-      if (!isDeferredTool(t)) return t;
-      const { deferred: _drop, ...active } = t as AgentTool & { deferred?: boolean };
-      return active as AgentTool;
-    });
+    const tools = merged.tools.map(stripDeferredMarker);
     const crossCollisions = merged.collisions;
     reportToolCollisions([...discovered.collisions, ...crossCollisions]);
     reportModuleLoadFailures(discovered.failures);

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -135,7 +135,7 @@ export async function buildChatRuntime(
       parameters: t.parameters,
       // Propagate the execution mode — an activating tool (the builtin loader) declares "sequential"
       // so pi serializes its batch; without this, pi's outer active-set diff double-stamps parallels.
-      executionMode: (t as { executionMode?: "sequential" | "parallel" }).executionMode,
+      executionMode: t.executionMode,
       execute: (id: string, params: unknown, signal: AbortSignal | undefined) => {
         const bound = sessionRef.current;
         // Unreachable by construction (createRuntime sets sessionRef before any turn can run a tool).

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -207,12 +207,15 @@ export async function buildChatRuntime(
       customTools: customToolDefs,
     });
     sessionRef.current = result.session;
-    // Deferral emulation: pi's TUI session starts with everything active — narrow a FRESH session by
-    // SUBTRACTING the deferred names from whatever is active (robust to pi mounting tools of its own;
-    // an exact-set-equality gate would silently stop narrowing the day pi adds one). A resumed session
-    // (has messages) keeps its recorded set — the loader's earlier activations survive, like serving.
+    // Deferral emulation: pi's TUI session starts with everything active — narrow it by SUBTRACTING
+    // the deferred names from whatever is active (robust to pi mounting tools of its own; an
+    // exact-set-equality gate would silently stop narrowing the day pi adds one). Applied on EVERY
+    // build including /resume: pi's chat session does not record activations (its SessionContext has
+    // no activeToolNames), so "restore prior activations" is not implementable here — deferral stays
+    // consistently ON and a resumed conversation re-discovers via search_tools (documented divergence
+    // from serving, where activations persist in the session).
     const deferredNames = customTools.filter(isDeferredTool).map((t) => t.name);
-    if (deferredNames.length > 0 && result.session.messages.length === 0) {
+    if (deferredNames.length > 0) {
       const active = result.session.getActiveToolNames();
       if (deferredNames.some((n) => active.includes(n))) {
         result.session.setActiveToolsByName(active.filter((n) => !deferredNames.includes(n)));

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -65,9 +65,11 @@ export async function buildChatRuntime(
    *  filtered (`setActiveToolsByName` is authoritative on the session and rebuilds its prompt — our
    *  static override keeps the prompt identical to serving). */
   function chatToolActivation(session: AgentSession): ToolActivation {
-    // Same per-turn serialization as invoke.ts's bridge: the read-modify-write below is only race-free
-    // while nothing awaits between read and write, and pi's session setters happening to be synchronous
-    // today is not a contract worth betting parallel tool batches on.
+    // Same serialization as invoke.ts's bridge (there per turn; here per session — chat turns are
+    // interactive, so per-session is equivalent): the read-modify-write below is only race-free while
+    // nothing awaits between read and write, and pi's session setters happening to be synchronous today
+    // is not a contract worth betting parallel tool batches on. Built ONCE per session (createRuntime),
+    // so parallel calls actually share the chain.
     let chain: Promise<string[]> = Promise.resolve([]);
     return {
       active: () => session.getActiveToolNames(),
@@ -132,10 +134,10 @@ export async function buildChatRuntime(
       description: t.description ?? "",
       parameters: t.parameters,
       execute: (id: string, params: unknown, signal: AbortSignal | undefined) => {
-        const session = sessionRef.current;
-        if (!session) return t.execute(id, params, signal);
+        const bound = sessionRef.current;
+        if (!bound) return t.execute(id, params, signal);
         return turnContext.run(
-          { session: session.sessionId, tools: chatToolActivation(session) },
+          { session: bound.session.sessionId, tools: bound.activation },
           () => t.execute(id, params, signal) as Promise<unknown>,
         );
       },
@@ -157,9 +159,12 @@ export async function buildChatRuntime(
   // edits. And keep it workspace-scoped — `.env` is process-global, so a switch to another cwd would
   // leak env or require mutating global env at runtime.
   const rootCwd = canonicalPath(dir);
-  // The CURRENT pi session — rebuilt on /new//resume/fork while the memoized assembly (and its tool
-  // execute closures) stays; the activation bridge reads it at call time.
-  const sessionRef: { current?: AgentSession } = {};
+  // The CURRENT pi session + its activation bridge, BOUND TOGETHER — rebuilt on /new//resume/fork
+  // while the memoized assembly (and its tool execute closures) stays. The bridge must share the
+  // session's lifetime, NOT be rebuilt per tool call: parallel calls in one batch serialize on the
+  // bridge's internal chain, and a per-call bridge would give each call its own chain — a
+  // serialization that serializes nothing.
+  const sessionRef: { current?: { session: AgentSession; activation: ToolActivation } } = {};
   let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
   const assemblyFor = (cwd: string) => {
     // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
@@ -215,7 +220,7 @@ export async function buildChatRuntime(
       tools: [...defaultNames, ...customTools.map((t) => t.name)],
       customTools: customToolDefs,
     });
-    sessionRef.current = result.session;
+    sessionRef.current = { session: result.session, activation: chatToolActivation(result.session) };
     // Deferral emulation: pi's TUI session starts with everything active — narrow it by SUBTRACTING
     // the deferred names from whatever is active (robust to pi mounting tools of its own; an
     // exact-set-equality gate would silently stop narrowing the day pi adds one). Applied on EVERY

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -65,18 +65,27 @@ export async function buildChatRuntime(
    *  filtered (`setActiveToolsByName` is authoritative on the session and rebuilds its prompt — our
    *  static override keeps the prompt identical to serving). */
   function chatToolActivation(session: AgentSession): ToolActivation {
+    // Same per-turn serialization as invoke.ts's bridge: the read-modify-write below is only race-free
+    // while nothing awaits between read and write, and pi's session setters happening to be synchronous
+    // today is not a contract worth betting parallel tool batches on.
+    let chain: Promise<string[]> = Promise.resolve([]);
     return {
       active: () => session.getActiveToolNames(),
       registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
-      async activate(names) {
-        const current = session.getActiveToolNames();
-        const added = additiveActivation(
-          session.getAllTools().map((t) => t.name),
-          current,
-          names,
-        );
-        if (added.length > 0) session.setActiveToolsByName([...current, ...added]);
-        return added;
+      activate(names) {
+        const run = async (): Promise<string[]> => {
+          const current = session.getActiveToolNames();
+          const added = additiveActivation(
+            session.getAllTools().map((t) => t.name),
+            current,
+            names,
+          );
+          if (added.length > 0) session.setActiveToolsByName([...current, ...added]);
+          return added;
+        };
+        const result = chain.then(run, run); // run after the predecessor settles, success or failure
+        chain = result.catch(() => []); // the caller sees a rejection on `result`; the chain stays usable
+        return result;
       },
     };
   }

--- a/src/engines/pi/chat.ts
+++ b/src/engines/pi/chat.ts
@@ -133,6 +133,9 @@ export async function buildChatRuntime(
       label: t.name,
       description: t.description ?? "",
       parameters: t.parameters,
+      // Propagate the execution mode — an activating tool (the builtin loader) declares "sequential"
+      // so pi serializes its batch; without this, pi's outer active-set diff double-stamps parallels.
+      executionMode: (t as { executionMode?: "sequential" | "parallel" }).executionMode,
       execute: (id: string, params: unknown, signal: AbortSignal | undefined) => {
         const bound = sessionRef.current;
         // Unreachable by construction (createRuntime sets sessionRef before any turn can run a tool).
@@ -164,9 +167,10 @@ export async function buildChatRuntime(
   const rootCwd = canonicalPath(dir);
   // The CURRENT pi session + its activation bridge, BOUND TOGETHER — rebuilt on /new//resume/fork
   // while the memoized assembly (and its tool execute closures) stays. The bridge must share the
-  // session's lifetime, NOT be rebuilt per tool call: parallel calls in one batch serialize on the
-  // bridge's internal chain, and a per-call bridge would give each call its own chain — a
-  // serialization that serializes nothing.
+  // session's lifetime, NOT be rebuilt per tool call (a per-call chain serializes nothing). Note on
+  // parallel batches: pi wraps SDK customTools in its own before/after active-set diff, so an
+  // activating tool must carry `executionMode: "sequential"` (the builtin loader does) — pi then runs
+  // the whole batch serially and the outer diff sees correct snapshots.
   const sessionRef: { current?: { session: AgentSession; activation: ToolActivation } } = {};
   let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
   const assemblyFor = (cwd: string) => {

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -10,7 +10,8 @@ import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
-import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { FastagentTool } from "./tool.ts";
 import type { Models } from "@earendil-works/pi-ai";
 import type { AnyModel } from "./harness.ts";
 import { moduleLoadHint } from "../../loader.ts";
@@ -42,8 +43,9 @@ export interface FastagentConfig {
    * subdir and does not collide with the host's `tools/`/`src/` (core.md scenario grid).
    */
   agentDir?: string;
-  /** Extra custom tools, appended after pi defaults — never replaces them. */
-  tools?: AgentTool[];
+  /** Extra custom tools, appended after pi defaults — never replaces them. `FastagentTool` = AgentTool
+   *  plus the optional `deferred` marker (see defineTool). */
+  tools?: FastagentTool[];
   http?: { port?: number };
   /** Mount the built-in `wake` tool so the agent can schedule its OWN follow-up turns (self-scheduling).
    *  Off by default — self-scheduling is an autonomy capability, opt in when you want it. Only takes

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -23,7 +23,8 @@ import { createPiModels } from "./models.ts";
 import { reportDefinitionWarnings } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
-import { type ToolCollision, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import { type ToolCollision, isDeferredTool, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import { withSearchTool } from "./search-tools.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 
 // ── §1 tools ─────────────────────────────────────────────────────────────────
@@ -55,17 +56,30 @@ export async function resolveWorkspaceTools(
 ): Promise<{
   tools: AgentTool[];
   toolNames: string[];
+  /** Tools registered but not initially active (defineTool `deferred: true`) — discovered/activated
+   *  via the built-in `search_tools` loader. Surfaced so the operator can see deferral took effect. */
+  deferredToolNames: string[];
   toolCollisions: ToolCollision[];
   toolFailures: ModuleLoadFailure[];
 }> {
   // Default coding tools (read/bash/edit/write) are rooted at `cwd` (the run root the agent operates on);
   // discovered `tools/` come from `agentDir` (the agent's own surface). They coincide in the flat case.
   const discovered = await loadTools(agentDir);
-  const { tools, collisions } = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
-  const toolCollisions = [...discovered.collisions, ...collisions];
+  const merged = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
+  // The built-in `search_tools` loader mounts here — the one place the workspace's full tool set is
+  // computed — so `dev`/`start`/`info`/`fastagent tool` all see the same surface (idempotent; a
+  // workspace-defined search_tools wins).
+  const tools = withSearchTool(merged.tools);
+  const toolCollisions = [...discovered.collisions, ...merged.collisions];
   const defaultNames = new Set(piDefaultTools(cwd).map((t) => t.name));
   const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
-  return { tools, toolNames, toolCollisions, toolFailures: discovered.failures };
+  return {
+    tools,
+    toolNames,
+    deferredToolNames: tools.filter(isDeferredTool).map((t) => t.name),
+    toolCollisions,
+    toolFailures: discovered.failures,
+  };
 }
 
 // ── §2 prompt: four-segment systemPrompt assembly ───────────────────────────
@@ -88,7 +102,13 @@ export async function resolveWorkspaceTools(
  * `persona` (from persona.md) replaces the default identity line, keeping the tools list + guidelines.
  */
 export function piBasePrompt(options: { tools?: AgentTool[]; persona?: string } = {}): string {
-  const tools = options.tools ?? [];
+  const mounted = options.tools ?? [];
+  // Deferred tools stay OUT of the list: their schemas are not in the request until activated, so
+  // naming them here would invite calls to tools that don't exist yet; discovery is search_tools' job
+  // (which IS listed — it's active). Computed from the static mounted set, so the prompt — the cached
+  // context prefix — does not change when a tool is activated mid-session.
+  const tools = mounted.filter((t) => !isDeferredTool(t));
+  const deferredCount = mounted.length - tools.length;
   const toolsList =
     tools.length > 0 ? tools.map((t) => `- ${t.name}: ${(t.description ?? "").split("\n")[0]}`).join("\n") : "(none)";
   // Segment ① identity: an authored persona (persona.md) replaces the default engine identity line
@@ -96,10 +116,14 @@ export function piBasePrompt(options: { tools?: AgentTool[]; persona?: string } 
   const identity =
     options.persona?.trim() ||
     "You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.";
+  const deferredNote =
+    deferredCount > 0
+      ? `\n\n${deferredCount} additional tool(s) are registered but inactive — use search_tools to discover and activate them before concluding a capability is missing.`
+      : "";
   return `${identity}
 
 Available tools:
-${toolsList}
+${toolsList}${deferredNote}
 
 In addition to the tools above, you may have access to other custom tools depending on the project.
 
@@ -240,7 +264,8 @@ export function createPiAgent(options: CreatePiAgentOptions): Agent {
     providers: options.providers,
     authPath: options.authPath,
     systemPrompt: instructionsPrompt(options.instructions, options.skills),
-    tools: options.tools,
+    // Deferred tools need their loader on every rung (idempotent; the caller's own search_tools wins).
+    tools: options.tools ? withSearchTool(options.tools) : options.tools,
     skills: options.skills,
     sessions: options.sessions,
     env: options.env,
@@ -310,7 +335,9 @@ export async function createPiAgentFromDefinition(
   // runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
   // every turn's log. A log-dedup memo, not session state (stateless invoke holds).
   let reportedFindings = findingsSignature(definition);
-  const tools = options.tools ?? piDefaultTools(env.cwd);
+  // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
+  // it; a caller's own search_tools wins).
+  const tools = withSearchTool(options.tools ?? piDefaultTools(env.cwd));
   const agent = buildPiAgent({
     model: options.model,
     thinkingLevel: options.thinkingLevel,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -70,9 +70,15 @@ export async function resolveWorkspaceTools(
   // computed — so `dev`/`start`/`info`/`fastagent tool` all see the same surface (idempotent; a
   // workspace-defined search_tools wins).
   const tools = withSearchTool(merged.tools);
+  const builtinLoaderMounted = tools !== merged.tools; // withSearchTool returns the input untouched otherwise
   const toolCollisions = [...discovered.collisions, ...merged.collisions];
+  // `toolNames` is the AUTHOR's surface (config.tools + tools/): exclude pi defaults AND the builtin
+  // loader — like the wake pair, a builtin gets its own report line (`deferred: … via search_tools`),
+  // not an anonymous slot in the author's list. An author-DEFINED search_tools still shows.
   const defaultNames = new Set(piDefaultTools(cwd).map((t) => t.name));
-  const toolNames = tools.map((t) => t.name).filter((n) => !defaultNames.has(n));
+  const toolNames = tools
+    .map((t) => t.name)
+    .filter((n) => !defaultNames.has(n) && !(builtinLoaderMounted && n === "search_tools"));
   return {
     tools,
     toolNames,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -72,13 +72,16 @@ export async function resolveWorkspaceTools(
   const tools = withSearchTool(merged.tools);
   const builtinLoaderMounted = tools !== merged.tools; // withSearchTool returns the input untouched otherwise
   const toolCollisions = [...discovered.collisions, ...merged.collisions];
-  // `toolNames` is the AUTHOR's surface (config.tools + tools/): exclude pi defaults AND the builtin
-  // loader — like the wake pair, a builtin gets its own report line (`deferred: … via search_tools`),
-  // not an anonymous slot in the author's list. An author-DEFINED search_tools still shows.
+  // `toolNames` is the AUTHOR's active-by-default surface (config.tools + tools/): exclude pi
+  // defaults, the builtin loader (like wake, a builtin gets its own report line, not an anonymous
+  // slot in the author's list — an author-DEFINED search_tools still shows), and deferred tools —
+  // each name lives in exactly ONE report slot, and deferred names live in `deferredToolNames`.
   const defaultNames = new Set(piDefaultTools(cwd).map((t) => t.name));
   const toolNames = tools
-    .map((t) => t.name)
-    .filter((n) => !defaultNames.has(n) && !(builtinLoaderMounted && n === "search_tools"));
+    .filter(
+      (t) => !defaultNames.has(t.name) && !isDeferredTool(t) && !(builtinLoaderMounted && t.name === "search_tools"),
+    )
+    .map((t) => t.name);
   return {
     tools,
     toolNames,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -23,7 +23,14 @@ import { createPiModels } from "./models.ts";
 import { reportDefinitionWarnings } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
-import { type ToolCollision, isDeferredTool, loadTools, mergeDiscoveredTools } from "./tool.ts";
+import {
+  type DefineToolOptions,
+  type FastagentTool,
+  type ToolCollision,
+  isDeferredTool,
+  loadTools,
+  mergeDiscoveredTools,
+} from "./tool.ts";
 import { withSearchTool } from "./search-tools.ts";
 import { type Lease, createPiAgentFromHarness } from "./invoke.ts";
 
@@ -244,7 +251,8 @@ export interface CreatePiAgentOptions {
    * or a factory re-evaluated per invoke. When {@link skills} are mounted their listing is appended.
    */
   instructions?: string | (() => string);
-  tools?: AgentTool[];
+  /** `FastagentTool` = AgentTool plus the optional `deferred` marker (see {@link DefineToolOptions}). */
+  tools?: FastagentTool[];
   skills?: Skill[];
   // ── Tier 2: injectable ports ───────────────────────────────────────────────
   /**
@@ -297,8 +305,9 @@ export interface CreatePiAgentFromDefinitionOptions {
   /** Override the engine base prompt (segment ①). Defaults to piBasePrompt({ tools, persona }) using the
    *  live-read persona.md; pass base to fully opt out of persona.md. */
   base?: string;
-  /** Override tools. Defaults to piDefaultTools (lock down with a custom list). */
-  tools?: AgentTool[];
+  /** Override tools. Defaults to piDefaultTools (lock down with a custom list). `FastagentTool` =
+   *  AgentTool plus the optional `deferred` marker. */
+  tools?: FastagentTool[];
   /**
    * The agent's working directory: where the default tools operate AND whose ancestors are walked for
    * ② project context (AGENTS.md). Defaults to `dir` (flat: the definition dir is also the run root).

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -70,7 +70,10 @@ export async function resolveWorkspaceTools(
   // computed — so `dev`/`start`/`info`/`fastagent tool` all see the same surface (idempotent; a
   // workspace-defined search_tools wins).
   const tools = withSearchTool(merged.tools);
-  const builtinLoaderMounted = tools !== merged.tools; // withSearchTool returns the input untouched otherwise
+  // Builtin = a search_tools that was ABSENT before withSearchTool (a reference compare would misfire
+  // on the deferred-authored-loader case, where withSearchTool returns a new array without adding one).
+  const builtinLoaderMounted =
+    !merged.tools.some((t) => t.name === "search_tools") && tools.some((t) => t.name === "search_tools");
   const toolCollisions = [...discovered.collisions, ...merged.collisions];
   // `toolNames` is the AUTHOR's active-by-default surface (config.tools + tools/): exclude pi
   // defaults, the builtin loader (like wake, a builtin gets its own report line, not an anonymous

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -14,6 +14,26 @@ import type { PiSessionStore } from "./sessions.ts";
 import { isDeferredTool } from "./tool.ts";
 
 /**
+ * The session custom-entry type recording ONE activation delta: `{ names }` — exactly the deferred
+ * tools a loader activated in that call. The DEDICATED record the resolve below reads: pi's own
+ * `active_tools_change` entries are full active-set SNAPSHOTS (setActiveTools persists everything
+ * active at that moment), and reinterpreting a snapshot as activations would keep a tool active in
+ * old sessions after the author flips it to `deferred` — the session never discovered it. Deltas
+ * carry only what was actually discovered.
+ */
+export const TOOL_ACTIVATION_ENTRY = "fastagent:tool-activation";
+
+/** The session a factory-built harness is bound to — the seam the activation bridge (invoke.ts) uses
+ *  to write {@link TOOL_ACTIVATION_ENTRY} deltas (pi's harness keeps its session private). Absent for
+ *  a harness built outside {@link piHarnessFactory}: activation still works in-turn there, but is not
+ *  recorded — the factory owns persistence. */
+const harnessSessions = new WeakMap<AgentHarness, PiSession>();
+export type PiSession = Awaited<ReturnType<PiSessionStore["openOrCreate"]>>;
+export function harnessSession(harness: AgentHarness): PiSession | undefined {
+  return harnessSessions.get(harness);
+}
+
+/**
  * pi's Model with the API-shape generic erased — fastagent only passes models through to the
  * harness, so the generic carries no information. One alias keeps the `any` auditable.
  */
@@ -112,7 +132,7 @@ export function resolveHarnessActiveToolNames(
   if (missing.length > 0) {
     const emit = warnedRestores.has(`${sessionId}\u0000${missing.join(",")}`) ? log.debug : log.warn;
     warnedRestores.add(`${sessionId}\u0000${missing.join(",")}`);
-    emit(`[fastagent] session ${sessionId}: dropping recorded active tool(s) no longer mounted: ${missing.join(", ")}`);
+    emit(`[fastagent] session ${sessionId}: dropping recorded activation(s) no longer mounted: ${missing.join(", ")}`);
   }
   return [...new Set([...initial, ...known])];
 }
@@ -121,24 +141,36 @@ export function resolveHarnessActiveToolNames(
 export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFactory {
   return async (sessionId) => {
     const session = await options.sessions.openOrCreate(sessionId);
-    // One extra entry walk per invoke to read the recorded active-tool set (buildContext is the only
-    // accessor) — negligible against the model call, same trade as L2's per-invoke definition re-read.
-    const context = await session.buildContext();
+    // One extra entry walk per invoke to collect the activation deltas — negligible against the model
+    // call, same trade as L2's per-invoke definition re-read. Serving sessions never branch, so a flat
+    // getEntries() read (no leaf-path walk) is correct.
+    const entries = await session.getEntries();
+    const activated = entries.flatMap((e) =>
+      e.type === "custom" && e.customType === TOOL_ACTIVATION_ENTRY
+        ? ((e.data as { names?: string[] } | undefined)?.names ?? [])
+        : [],
+    );
     const fresh = options.live ? await options.live() : undefined;
     const { systemPrompt } = options;
     const prompt = fresh ? fresh.systemPrompt : typeof systemPrompt === "function" ? systemPrompt() : systemPrompt;
     const skills = fresh ? fresh.skills : options.skills;
-    return new AgentHarness({
+    const harness = new AgentHarness({
       env: options.env,
       session,
       models: options.models,
       model: options.model,
       thinkingLevel: options.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
       tools: options.tools,
-      activeToolNames: resolveHarnessActiveToolNames(context.activeToolNames, options.tools ?? [], sessionId),
+      activeToolNames: resolveHarnessActiveToolNames(
+        activated.length > 0 ? activated : null,
+        options.tools ?? [],
+        sessionId,
+      ),
       systemPrompt: prompt,
       resources: skills ? { skills } : undefined,
       streamOptions: { maxRetries: PROVIDER_MAX_RETRIES },
     });
+    harnessSessions.set(harness, session);
+    return harness;
   };
 }

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -75,37 +75,35 @@ const PROVIDER_MAX_RETRIES = 2;
  */
 const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
 
-/** The initial active set for a session with NO recorded active-tool state: everything not marked
- *  deferred. undefined when nothing is deferred — pi's default (all active) applies, and today's
- *  behavior is untouched for tool-sets that don't use deferral. */
-function initialActiveToolNames(tools: AgentTool[]): string[] | undefined {
-  return tools.some(isDeferredTool) ? tools.filter((t) => !isDeferredTool(t)).map((t) => t.name) : undefined;
-}
-
 /**
- * Restore the session's recorded active-tool set for a fresh harness. pi's harness WRITES active-tool
- * changes to the session (`setActiveTools` → `active_tools_change`) but its constructor never reads
- * them back — pi's long-lived TUI harness keeps the set in memory, while fastagent builds a FRESH
- * harness per invoke, which would silently reset the session's active set to "all tools" every turn.
- * `null` (never changed) → undefined → pi's default (all mounted tools active).
+ * Resolve the active-tool set for a fresh harness — the ONE place both fallbacks live. pi's harness
+ * WRITES active-tool changes to the session (`setActiveTools` → `active_tools_change`) but its
+ * constructor never reads them back — pi's long-lived TUI harness keeps the set in memory, while
+ * fastagent builds a FRESH harness per invoke, which would silently reset the session's active set
+ * every turn.
  *
- * Names are filtered to the currently-mounted tools: the constructor THROWS on unknown names, so a
- * recorded tool that was since removed from the workspace would otherwise brick every future invoke
- * of that session. An intact EMPTY set is restored as-is (pi allows `setActiveTools([])`; that is a
+ * No record (`null`) → the INITIAL set: every non-deferred tool; undefined when nothing is deferred
+ * (pi's default — all active — applies, and no session entry is ever written; tool-sets without
+ * deferral behave exactly as before deferral existed).
+ *
+ * A recorded set is filtered to the currently-mounted tools: the constructor THROWS on unknown names,
+ * so a recorded tool that was since removed from the workspace would otherwise brick every future
+ * invoke of that session. An intact EMPTY set is restored as-is (pi allows `setActiveTools([])`; a
  * deliberate recorded state, not a degradation). Only a NON-empty set that filters down to empty
- * falls back to the default — the recorded intent cannot be honored, and honoring its empty shadow
- * would be a silent capability loss. Both filter degradations are logged (fail visibly) — ONCE per
- * session+missing set: a fresh harness is built per invoke and channel sessions live for weeks, so an
- * un-deduped warn would repeat every turn and dilute its own signal. A log-dedup memo (like L2's
- * findings memo), not session state — the restore itself stays derived from the session every time.
+ * falls back to the initial set — the recorded intent cannot be honored, and honoring its empty
+ * shadow would be a silent capability loss. Both filter degradations are logged (fail visibly) —
+ * ONCE per session+missing set: a fresh harness is built per invoke and channel sessions live for
+ * weeks, so an un-deduped warn would repeat every turn and dilute its own signal. A log-dedup memo
+ * (like L2's findings memo), not session state — the resolve stays derived from the session.
  */
 const warnedRestores = new Set<string>();
-export function restoreActiveToolNames(
+export function resolveHarnessActiveToolNames(
   recorded: string[] | null,
   tools: AgentTool[],
   sessionId: string,
 ): string[] | undefined {
-  if (recorded === null) return undefined;
+  const initial = tools.some(isDeferredTool) ? tools.filter((t) => !isDeferredTool(t)).map((t) => t.name) : undefined;
+  if (recorded === null) return initial;
   const mounted = new Set(tools.map((t) => t.name));
   const known = recorded.filter((name) => mounted.has(name));
   if (known.length === recorded.length) return known; // intact, including a deliberate []
@@ -114,9 +112,9 @@ export function restoreActiveToolNames(
   warnedRestores.add(`${sessionId}\u0000${missing.join(",")}`);
   if (known.length === 0) {
     emit(
-      `[fastagent] session ${sessionId}: none of its recorded active tools (${missing.join(", ")}) are mounted — falling back to all mounted tools`,
+      `[fastagent] session ${sessionId}: none of its recorded active tools (${missing.join(", ")}) are mounted — falling back to the initial active set (every non-deferred tool)`,
     );
-    return undefined;
+    return initial;
   }
   emit(`[fastagent] session ${sessionId}: dropping recorded active tool(s) no longer mounted: ${missing.join(", ")}`);
   return known;
@@ -140,9 +138,7 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
       model: options.model,
       thinkingLevel: options.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
       tools: options.tools,
-      activeToolNames:
-        restoreActiveToolNames(context.activeToolNames, options.tools ?? [], sessionId) ??
-        initialActiveToolNames(options.tools ?? []),
+      activeToolNames: resolveHarnessActiveToolNames(context.activeToolNames, options.tools ?? [], sessionId),
       systemPrompt: prompt,
       resources: skills ? { skills } : undefined,
       streamOptions: { maxRetries: PROVIDER_MAX_RETRIES },

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -86,12 +86,13 @@ const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
  * (pi's default — all active — applies, and no session entry is ever written; tool-sets without
  * deferral behave exactly as before deferral existed).
  *
- * A recorded set is filtered to the currently-mounted tools: the constructor THROWS on unknown names,
- * so a recorded tool that was since removed from the workspace would otherwise brick every future
- * invoke of that session. An intact EMPTY set is restored as-is (pi allows `setActiveTools([])`; a
- * deliberate recorded state, not a degradation). Only a NON-empty set that filters down to empty
- * falls back to the initial set — the recorded intent cannot be honored, and honoring its empty
- * shadow would be a silent capability loss. Both filter degradations are logged (fail visibly) —
+ * A record is NOT replayed as a frozen snapshot — the active set is rebuilt as the UNION of the
+ * initial set and the recorded names (filtered to the mounted tools: the constructor THROWS on
+ * unknown names, so a recorded-but-removed tool would otherwise brick every future invoke of that
+ * session). On the serving path only the additive activation bridge writes records, so a record's
+ * real semantic is "which deferred tools this session activated" — layered on top of whatever the
+ * workspace mounts TODAY. A snapshot replay would silently freeze a later-added non-deferred tool
+ * out of every session the loader ever touched. Missing recorded names are logged (fail visibly) —
  * ONCE per session+missing set: a fresh harness is built per invoke and channel sessions live for
  * weeks, so an un-deduped warn would repeat every turn and dilute its own signal. A log-dedup memo
  * (like L2's findings memo), not session state — the resolve stays derived from the session.
@@ -102,22 +103,18 @@ export function resolveHarnessActiveToolNames(
   tools: AgentTool[],
   sessionId: string,
 ): string[] | undefined {
-  const initial = tools.some(isDeferredTool) ? tools.filter((t) => !isDeferredTool(t)).map((t) => t.name) : undefined;
-  if (recorded === null) return initial;
+  const anyDeferred = tools.some(isDeferredTool);
+  const initial = tools.filter((t) => !isDeferredTool(t)).map((t) => t.name);
+  if (recorded === null) return anyDeferred ? initial : undefined;
   const mounted = new Set(tools.map((t) => t.name));
   const known = recorded.filter((name) => mounted.has(name));
-  if (known.length === recorded.length) return known; // intact, including a deliberate []
   const missing = recorded.filter((name) => !mounted.has(name));
-  const emit = warnedRestores.has(`${sessionId}\u0000${missing.join(",")}`) ? log.debug : log.warn;
-  warnedRestores.add(`${sessionId}\u0000${missing.join(",")}`);
-  if (known.length === 0) {
-    emit(
-      `[fastagent] session ${sessionId}: none of its recorded active tools (${missing.join(", ")}) are mounted — falling back to the initial active set (every non-deferred tool)`,
-    );
-    return initial;
+  if (missing.length > 0) {
+    const emit = warnedRestores.has(`${sessionId}\u0000${missing.join(",")}`) ? log.debug : log.warn;
+    warnedRestores.add(`${sessionId}\u0000${missing.join(",")}`);
+    emit(`[fastagent] session ${sessionId}: dropping recorded active tool(s) no longer mounted: ${missing.join(", ")}`);
   }
-  emit(`[fastagent] session ${sessionId}: dropping recorded active tool(s) no longer mounted: ${missing.join(", ")}`);
-  return known;
+  return [...new Set([...initial, ...known])];
 }
 
 /** Open-or-create the session per invoke: existing → open (history via buildContext); missing → create. */

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -11,6 +11,7 @@ import type { AgentTool, ExecutionEnv, Skill, ThinkingLevel } from "@earendil-wo
 import type { Model, Models } from "@earendil-works/pi-ai";
 import { log } from "../../log.ts";
 import type { PiSessionStore } from "./sessions.ts";
+import { isDeferredTool } from "./tool.ts";
 
 /**
  * pi's Model with the API-shape generic erased — fastagent only passes models through to the
@@ -74,6 +75,13 @@ const PROVIDER_MAX_RETRIES = 2;
  */
 const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
 
+/** The initial active set for a session with NO recorded active-tool state: everything not marked
+ *  deferred. undefined when nothing is deferred — pi's default (all active) applies, and today's
+ *  behavior is untouched for tool-sets that don't use deferral. */
+function initialActiveToolNames(tools: AgentTool[]): string[] | undefined {
+  return tools.some(isDeferredTool) ? tools.filter((t) => !isDeferredTool(t)).map((t) => t.name) : undefined;
+}
+
 /**
  * Restore the session's recorded active-tool set for a fresh harness. pi's harness WRITES active-tool
  * changes to the session (`setActiveTools` → `active_tools_change`) but its constructor never reads
@@ -132,7 +140,9 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
       model: options.model,
       thinkingLevel: options.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
       tools: options.tools,
-      activeToolNames: restoreActiveToolNames(context.activeToolNames, options.tools ?? [], sessionId),
+      activeToolNames:
+        restoreActiveToolNames(context.activeToolNames, options.tools ?? [], sessionId) ??
+        initialActiveToolNames(options.tools ?? []),
       systemPrompt: prompt,
       resources: skills ? { skills } : undefined,
       streamOptions: { maxRetries: PROVIDER_MAX_RETRIES },

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -17,7 +17,7 @@ import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import { type Agent, type AgentEvent, type Json, type Prompt, type Scope, SESSION_BUSY_CODE } from "../../agent.ts";
 import { log } from "../../log.ts";
 import type { PiHarnessFactory } from "./harness.ts";
-import { turnContext } from "./tool-context.ts";
+import { type ToolActivation, turnContext } from "./tool-context.ts";
 
 // ── §1 Lease: single-writer concurrency floor ───────────────────────────────
 //
@@ -166,6 +166,26 @@ export function errorToTerminal(error: unknown): AgentEvent {
 type PiHarness = Awaited<ReturnType<PiHarnessFactory>>;
 
 /**
+ * The turn's {@link ToolActivation} over the live harness. `activate` is additive and filters to the
+ * registered names first — pi's `setActiveTools` THROWS on unknown names, and a loader must get a
+ * usable "nothing new" answer, not an exception. pi persists the change in the session, so the
+ * per-invoke restore (harness.ts) carries it into later turns.
+ */
+function toolActivation(harness: PiHarness): ToolActivation {
+  return {
+    active: () => harness.getActiveTools().map((t) => t.name),
+    registered: () => harness.getTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
+    async activate(names) {
+      const registered = new Set(harness.getTools().map((t) => t.name));
+      const current = harness.getActiveTools().map((t) => t.name);
+      const added = [...new Set(names)].filter((n) => registered.has(n) && !current.includes(n));
+      if (added.length > 0) await harness.setActiveTools([...current, ...added]);
+      return added;
+    },
+  };
+}
+
+/**
  * After a successful turn, compact the session if its context has grown past pi's threshold — a long
  * shared (group) or 1:1 conversation otherwise overflows the model's window. pi owns the mechanism
  * (`harness.compact()` writes a summary entry into the session, so the next reopen is compacted); the
@@ -292,7 +312,9 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         // (turnContext / ToolContext.session). prompt() starts the async work synchronously here, so the
         // store propagates to the tool calls awaited within it.
         const opts = await toPiPromptOptions(prompt);
-        const run = turnContext.run({ session: scope.session }, () => harness.prompt(prompt.text, opts));
+        const run = turnContext.run({ session: scope.session, tools: toolActivation(harness) }, () =>
+          harness.prompt(prompt.text, opts),
+        );
         yield* queue.drainUntil(run);
         let terminal: AgentEvent;
         try {

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -172,18 +172,27 @@ type PiHarness = Awaited<ReturnType<PiHarnessFactory>>;
  * per-invoke restore (harness.ts) carries it into later turns.
  */
 function toolActivation(harness: PiHarness): ToolActivation {
+  // Serialize activations per turn: "who activated first" must be decided HERE, not by whether pi's
+  // setActiveTools happens to mutate before its first await — parallel tool calls in one batch race
+  // their activate() calls, and the addedToolNames load points must not double-stamp.
+  let chain: Promise<string[]> = Promise.resolve([]);
   return {
     active: () => harness.getActiveTools().map((t) => t.name),
     registered: () => harness.getTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
-    async activate(names) {
-      const current = harness.getActiveTools().map((t) => t.name);
-      const added = additiveActivation(
-        harness.getTools().map((t) => t.name),
-        current,
-        names,
-      );
-      if (added.length > 0) await harness.setActiveTools([...current, ...added]);
-      return added;
+    activate(names) {
+      const run = async (): Promise<string[]> => {
+        const current = harness.getActiveTools().map((t) => t.name);
+        const added = additiveActivation(
+          harness.getTools().map((t) => t.name),
+          current,
+          names,
+        );
+        if (added.length > 0) await harness.setActiveTools([...current, ...added]);
+        return added;
+      };
+      const result = chain.then(run, run); // run after the predecessor settles, success or failure
+      chain = result.catch(() => []); // the caller sees a rejection on `result`; the chain stays usable
+      return result;
     },
   };
 }

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -17,7 +17,7 @@ import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import { type Agent, type AgentEvent, type Json, type Prompt, type Scope, SESSION_BUSY_CODE } from "../../agent.ts";
 import { log } from "../../log.ts";
 import type { PiHarnessFactory } from "./harness.ts";
-import { type ToolActivation, turnContext } from "./tool-context.ts";
+import { type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
 
 // ── §1 Lease: single-writer concurrency floor ───────────────────────────────
 //
@@ -176,9 +176,12 @@ function toolActivation(harness: PiHarness): ToolActivation {
     active: () => harness.getActiveTools().map((t) => t.name),
     registered: () => harness.getTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
     async activate(names) {
-      const registered = new Set(harness.getTools().map((t) => t.name));
       const current = harness.getActiveTools().map((t) => t.name);
-      const added = [...new Set(names)].filter((n) => registered.has(n) && !current.includes(n));
+      const added = additiveActivation(
+        harness.getTools().map((t) => t.name),
+        current,
+        names,
+      );
       if (added.length > 0) await harness.setActiveTools([...current, ...added]);
       return added;
     },

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -16,7 +16,7 @@ import { DEFAULT_COMPACTION_SETTINGS, calculateContextTokens, shouldCompact } fr
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import { type Agent, type AgentEvent, type Json, type Prompt, type Scope, SESSION_BUSY_CODE } from "../../agent.ts";
 import { log } from "../../log.ts";
-import type { PiHarnessFactory } from "./harness.ts";
+import { TOOL_ACTIVATION_ENTRY, harnessSession, type PiHarnessFactory } from "./harness.ts";
 import { type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
 
 // ── §1 Lease: single-writer concurrency floor ───────────────────────────────
@@ -187,7 +187,14 @@ function toolActivation(harness: PiHarness): ToolActivation {
           current,
           names,
         );
-        if (added.length > 0) await harness.setActiveTools([...current, ...added]);
+        if (added.length > 0) {
+          await harness.setActiveTools([...current, ...added]);
+          // Persist the DELTA in a dedicated entry — what the per-invoke resolve (harness.ts) reads.
+          // pi's own active_tools_change record is a full snapshot and is deliberately ignored there.
+          // Absent session (a harness built outside piHarnessFactory): in-turn activation still works,
+          // it just isn't durable — the factory owns persistence.
+          await harnessSession(harness)?.appendCustomEntry(TOOL_ACTIVATION_ENTRY, { names: added });
+        }
         return added;
       };
       const result = chain.then(run, run); // run after the predecessor settles, success or failure

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -57,15 +57,23 @@ export function makeSearchToolsTool(): AgentTool {
         .toLowerCase()
         .split(/[^a-z0-9]+/)
         .filter(Boolean);
+      // AND semantics: EVERY token must hit — "adding a word narrows" must actually hold, or the
+      // over-cap "narrow the query" instruction sends the model in circles (OR would widen with each
+      // word, and a shared prefix like "fetch" could make a whole tool family permanently over-cap).
       const matchesQuery = (t: { name: string; description: string }) => {
         const haystack = `${t.name} ${t.description}`.toLowerCase();
-        return tokens.some((token) => haystack.includes(token));
+        return tokens.every((token) => haystack.includes(token));
       };
       const describe = (t: { name: string; description: string }) => `${t.name} — ${t.description.split("\n")[0]}`;
       const active = new Set(ctx.tools.active());
       const registered = ctx.tools.registered();
-      const activeMatches = registered.filter((t) => active.has(t.name) && matchesQuery(t));
-      const inactiveMatches = registered.filter((t) => !active.has(t.name) && matchesQuery(t));
+      // Exact-name shortcut: the guaranteed escape hatch from the cap — a query that IS a registered
+      // tool name addresses that one tool, no keyword scoring in the way.
+      const exact = registered.find((t) => t.name.toLowerCase() === input.query.trim().toLowerCase());
+      const activeMatches = registered.filter((t) => active.has(t.name) && (t === exact || matchesQuery(t)));
+      const inactiveMatches = exact
+        ? [exact].filter((t) => !active.has(t.name))
+        : registered.filter((t) => !active.has(t.name) && matchesQuery(t));
       const activeNote =
         activeMatches.length > 0 ? `Already active (call directly): ${activeMatches.map(describe).join("; ")}.` : "";
       if (inactiveMatches.length === 0) {

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -37,8 +37,17 @@ const MAX_ACTIVATIONS_PER_SEARCH = 5;
  *  catalog (the thing deferral keeps OUT of the context) back in as a tool result. */
 const MAX_MISS_LISTING = 10;
 
-/** Build the `search_tools` loader. Keyword search over the inactive tools' name+description. */
+/** Build the `search_tools` loader. Keyword search over the inactive tools' name+description.
+ *
+ * `executionMode: "sequential"` — pi turns any batch containing a sequential tool serial. Required for
+ * correct load-point attribution everywhere an OUTER active-set diff exists: pi wraps SDK customTools
+ * (the chat path) in a before/after diff, and two parallel loader calls would both snapshot the
+ * pre-activation set and get stamped with the same activation. Custom loader authors must set it too. */
 export function makeSearchToolsTool(): AgentTool {
+  return Object.assign(searchToolsDefinition(), { executionMode: "sequential" as const });
+}
+
+function searchToolsDefinition(): AgentTool {
   return defineTool({
     name: "search_tools",
     description:

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -1,0 +1,57 @@
+/**
+ * The built-in `search_tools` loader — the discovery surface for deferred tools (defineTool
+ * `deferred: true`). A deferred tool's schema is not in the request and the model cannot see it; this
+ * loader is how it finds and activates one. Mounted automatically (withSearchTool) only when a
+ * deferred tool exists; a workspace tool named `search_tools` wins — the author owns the concept then
+ * (same rule as the wake pair).
+ */
+import { z } from "zod";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { defineTool, isDeferredTool } from "./tool.ts";
+
+/** Mount the built-in loader iff any mounted tool is deferred and the author didn't define their own. */
+export function withSearchTool(tools: AgentTool[]): AgentTool[] {
+  if (!tools.some(isDeferredTool)) return tools;
+  if (tools.some((t) => t.name === "search_tools")) return tools;
+  return [...tools, makeSearchToolsTool()];
+}
+
+/** Build the `search_tools` loader. Keyword search over the inactive tools' name+description. */
+export function makeSearchToolsTool(): AgentTool {
+  return defineTool({
+    name: "search_tools",
+    description:
+      "Discover and activate additional tools. Part of this agent's toolset is inactive until needed: " +
+      "search by keywords (e.g. what you are trying to do), and matching tools are activated and become " +
+      "callable from that point on. ALWAYS search here before concluding a capability is missing.",
+    input: z.object({
+      query: z.string().min(1).describe("keywords describing the capability you need (e.g. 'weather forecast')"),
+    }),
+    async execute(input, ctx) {
+      if (!ctx.tools) return "tool activation is unavailable outside a conversation turn.";
+      const active = new Set(ctx.tools.active());
+      const inactive = ctx.tools.registered().filter((t) => !active.has(t.name));
+      if (inactive.length === 0) return "All tools are already active — nothing to discover.";
+      // ponytail: naive keyword match (any query token as a case-insensitive substring of
+      // name+description); swap in scoring/embeddings if catalogs outgrow it.
+      const tokens = input.query
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean);
+      const matches = inactive.filter((t) => {
+        const haystack = `${t.name} ${t.description}`.toLowerCase();
+        return tokens.some((token) => haystack.includes(token));
+      });
+      if (matches.length === 0) {
+        return `No tools matched "${input.query}". Inactive tools: ${inactive
+          .map((t) => `${t.name} — ${t.description.split("\n")[0]}`)
+          .join("; ")}`;
+      }
+      const activated = await ctx.tools.activate(matches.map((t) => t.name));
+      return `Activated: ${matches
+        .filter((t) => activated.includes(t.name))
+        .map((t) => `${t.name} — ${t.description.split("\n")[0]}`)
+        .join("; ")}. These tools are callable now.`;
+    },
+  });
+}

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -81,8 +81,14 @@ export function makeSearchToolsTool(): AgentTool {
       const inactiveMatches = exact
         ? [exact].filter((t) => !active.has(t.name))
         : registered.filter((t) => !active.has(t.name) && matchesQuery(t));
+      // Same listing cap as every other branch — a wide token can match most of the ACTIVE set too
+      // (in chat that includes pi's default tools), and no answer may pour a catalog into the context.
+      const listedActive = activeMatches.slice(0, MAX_MISS_LISTING);
+      const moreActive = activeMatches.length - listedActive.length;
       const activeNote =
-        activeMatches.length > 0 ? `Already active (call directly): ${activeMatches.map(describe).join("; ")}.` : "";
+        activeMatches.length > 0
+          ? `Already active (call directly): ${listedActive.map(describe).join("; ")}${moreActive > 0 ? ` … and ${moreActive} more` : ""}.`
+          : "";
       if (inactiveMatches.length === 0) {
         if (activeNote) return activeNote;
         const inactive = registered.filter((t) => !active.has(t.name));

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -94,9 +94,13 @@ export function makeSearchToolsTool(): AgentTool {
         return `No tools matched "${input.query}". Inactive tools: ${listed.map(describe).join("; ")}${more > 0 ? ` … and ${more} more — search with different keywords.` : ""}`;
       }
       if (inactiveMatches.length > MAX_ACTIVATIONS_PER_SEARCH) {
-        return `${inactiveMatches.length} inactive tools matched "${input.query}" — too many to activate at once (activation is permanent for this conversation). Narrow the query. Matches: ${inactiveMatches
-          .map(describe)
-          .join("; ")}${activeNote ? ` ${activeNote}` : ""}`;
+        // Same listing cap as the miss path — an over-cap answer must not pour the catalog into the
+        // context either. Names alone suffice: the exact-name escape only needs a name to query.
+        const listed = inactiveMatches.slice(0, MAX_MISS_LISTING);
+        const more = inactiveMatches.length - listed.length;
+        return `${inactiveMatches.length} inactive tools matched "${input.query}" — too many to activate at once (activation is permanent for this conversation). Narrow the query (or query an exact name). Matches: ${listed
+          .map((t) => t.name)
+          .join(", ")}${more > 0 ? ` … and ${more} more` : ""}.${activeNote ? ` ${activeNote}` : ""}`;
       }
       const activated = await ctx.tools.activate(inactiveMatches.map((t) => t.name));
       // Report what actually happened, not what was attempted: a parallel sibling call may have

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -39,16 +39,17 @@ export function makeSearchToolsTool(): AgentTool {
     name: "search_tools",
     description:
       "Discover and activate additional tools. Part of this agent's toolset is inactive until needed: " +
-      "search by keywords (e.g. what you are trying to do), and matching tools are activated and become " +
-      "callable from that point on. ALWAYS search here before concluding a capability is missing.",
+      "search by keywords (e.g. what you are trying to do), and matching inactive tools are activated and " +
+      "become callable from that point on (if too many match, you get the candidates back — narrow the " +
+      "query). ALWAYS search here before concluding a capability is missing.",
     input: z.object({
       query: z.string().min(1).describe("keywords describing the capability you need (e.g. 'weather forecast')"),
     }),
     async execute(input, ctx) {
       if (!ctx.tools) return "tool activation is unavailable outside a conversation turn.";
-      const active = new Set(ctx.tools.active());
-      const inactive = ctx.tools.registered().filter((t) => !active.has(t.name));
-      if (inactive.length === 0) return "All tools are already active — nothing to discover.";
+      // Search the WHOLE registered catalog: the loader is the only discovery surface, and in a long
+      // conversation the model does not remember what it activated — a "No tools matched" answer for
+      // an ALREADY-ACTIVE tool would push it toward the exact wrong conclusion (capability missing).
       // ponytail: naive keyword match (any query token as a case-insensitive substring of
       // name+description) with a hard per-search activation cap above — the two named ceilings are
       // relevance and irreversibility; swap in scoring/embeddings if catalogs outgrow this.
@@ -56,33 +57,41 @@ export function makeSearchToolsTool(): AgentTool {
         .toLowerCase()
         .split(/[^a-z0-9]+/)
         .filter(Boolean);
-      const matches = inactive.filter((t) => {
+      const matchesQuery = (t: { name: string; description: string }) => {
         const haystack = `${t.name} ${t.description}`.toLowerCase();
         return tokens.some((token) => haystack.includes(token));
-      });
-      if (matches.length === 0) {
-        return `No tools matched "${input.query}". Inactive tools: ${inactive
-          .map((t) => `${t.name} — ${t.description.split("\n")[0]}`)
-          .join("; ")}`;
+      };
+      const describe = (t: { name: string; description: string }) => `${t.name} — ${t.description.split("\n")[0]}`;
+      const active = new Set(ctx.tools.active());
+      const registered = ctx.tools.registered();
+      const activeMatches = registered.filter((t) => active.has(t.name) && matchesQuery(t));
+      const inactiveMatches = registered.filter((t) => !active.has(t.name) && matchesQuery(t));
+      const activeNote =
+        activeMatches.length > 0 ? `Already active (call directly): ${activeMatches.map(describe).join("; ")}.` : "";
+      if (inactiveMatches.length === 0) {
+        if (activeNote) return activeNote;
+        const inactive = registered.filter((t) => !active.has(t.name));
+        if (inactive.length === 0) return "All tools are already active — nothing to discover.";
+        return `No tools matched "${input.query}". Inactive tools: ${inactive.map(describe).join("; ")}`;
       }
-      if (matches.length > MAX_ACTIVATIONS_PER_SEARCH) {
-        return `${matches.length} tools matched "${input.query}" — too many to activate at once (activation is permanent for this conversation). Narrow the query. Matches: ${matches
-          .map((t) => `${t.name} — ${t.description.split("\n")[0]}`)
-          .join("; ")}`;
+      if (inactiveMatches.length > MAX_ACTIVATIONS_PER_SEARCH) {
+        return `${inactiveMatches.length} inactive tools matched "${input.query}" — too many to activate at once (activation is permanent for this conversation). Narrow the query. Matches: ${inactiveMatches
+          .map(describe)
+          .join("; ")}${activeNote ? ` ${activeNote}` : ""}`;
       }
-      const activated = await ctx.tools.activate(matches.map((t) => t.name));
+      const activated = await ctx.tools.activate(inactiveMatches.map((t) => t.name));
       // Report what actually happened, not what was attempted: a parallel sibling call may have
       // activated the same matches first, leaving nothing new here — an empty "Activated:" would lie.
       if (activated.length === 0) {
-        return `Matched ${matches.map((t) => t.name).join(", ")} — already active (possibly activated by a concurrent call). Call them directly.`;
+        return `Matched ${inactiveMatches.map((t) => t.name).join(", ")} — already active (possibly activated by a concurrent call). Call them directly.${activeNote ? ` ${activeNote}` : ""}`;
       }
-      const alreadyActive = matches.filter((t) => !activated.includes(t.name));
-      return `Activated: ${matches
+      const raced = inactiveMatches.filter((t) => !activated.includes(t.name));
+      return `Activated: ${inactiveMatches
         .filter((t) => activated.includes(t.name))
-        .map((t) => `${t.name} — ${t.description.split("\n")[0]}`)
+        .map(describe)
         .join(
           "; ",
-        )}.${alreadyActive.length > 0 ? ` Already active: ${alreadyActive.map((t) => t.name).join(", ")}.` : ""} These tools are callable now.`;
+        )}.${raced.length > 0 ? ` Already active: ${raced.map((t) => t.name).join(", ")}.` : ""}${activeNote ? ` ${activeNote}` : ""} These tools are callable now.`;
     },
   });
 }

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -7,12 +7,23 @@
  */
 import { z } from "zod";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
-import { defineTool, isDeferredTool } from "./tool.ts";
+import { log } from "../../log.ts";
+import { defineTool, isDeferredTool, stripDeferredMarker } from "./tool.ts";
 
 /** Mount the built-in loader iff any mounted tool is deferred and the author didn't define their own. */
 export function withSearchTool(tools: AgentTool[]): AgentTool[] {
   if (!tools.some(isDeferredTool)) return tools;
-  if (tools.some((t) => t.name === "search_tools")) return tools;
+  const authored = tools.find((t) => t.name === "search_tools");
+  if (authored) {
+    if (!isDeferredTool(authored)) return tools;
+    // A deferred LOADER is a contradiction — it is the only entry point to the deferred tools, so
+    // nothing could ever activate it (or, through it, them): every deferred tool would be silently
+    // unreachable. Ignore the marker and keep the loader active (fail visibly, keep the capability).
+    log.warn(
+      "[fastagent] search_tools is marked deferred — ignoring the marker: the loader must stay active, or no deferred tool could ever be activated",
+    );
+    return tools.map((t) => (t === authored ? stripDeferredMarker(t) : t));
+  }
   return [...tools, makeSearchToolsTool()];
 }
 

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -48,10 +48,18 @@ export function makeSearchToolsTool(): AgentTool {
           .join("; ")}`;
       }
       const activated = await ctx.tools.activate(matches.map((t) => t.name));
+      // Report what actually happened, not what was attempted: a parallel sibling call may have
+      // activated the same matches first, leaving nothing new here — an empty "Activated:" would lie.
+      if (activated.length === 0) {
+        return `Matched ${matches.map((t) => t.name).join(", ")} — already active (possibly activated by a concurrent call). Call them directly.`;
+      }
+      const alreadyActive = matches.filter((t) => !activated.includes(t.name));
       return `Activated: ${matches
         .filter((t) => activated.includes(t.name))
         .map((t) => `${t.name} — ${t.description.split("\n")[0]}`)
-        .join("; ")}. These tools are callable now.`;
+        .join(
+          "; ",
+        )}.${alreadyActive.length > 0 ? ` Already active: ${alreadyActive.map((t) => t.name).join(", ")}.` : ""} These tools are callable now.`;
     },
   });
 }

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -33,15 +33,22 @@ export function withSearchTool(tools: AgentTool[]): AgentTool[] {
  *  activates; the model gets the candidates and narrows the query. */
 const MAX_ACTIVATIONS_PER_SEARCH = 5;
 
+/** Miss-path listing cap — same rationale as the activation cap: a typo query must not pour the whole
+ *  catalog (the thing deferral keeps OUT of the context) back in as a tool result. */
+const MAX_MISS_LISTING = 10;
+
 /** Build the `search_tools` loader. Keyword search over the inactive tools' name+description. */
 export function makeSearchToolsTool(): AgentTool {
   return defineTool({
     name: "search_tools",
     description:
-      "Discover and activate additional tools. Part of this agent's toolset is inactive until needed: " +
-      "search by keywords (e.g. what you are trying to do), and matching inactive tools are activated and " +
-      "become callable from that point on (if too many match, you get the candidates back — narrow the " +
-      "query). ALWAYS search here before concluding a capability is missing.",
+      // First line short on purpose: the base prompt's tools list truncates at the first newline, and
+      // the discovery guidance below would otherwise flood it (and duplicate its deferred note).
+      "Discover and activate additional tools.\n" +
+      "Part of this agent's toolset is inactive until needed: search by keywords (e.g. what you are " +
+      "trying to do), and matching inactive tools are activated and become callable from that point on " +
+      "(if too many match, you get the candidates back — narrow the query, or query an exact tool " +
+      "name). ALWAYS search here before concluding a capability is missing.",
     input: z.object({
       query: z.string().min(1).describe("keywords describing the capability you need (e.g. 'weather forecast')"),
     }),
@@ -80,7 +87,11 @@ export function makeSearchToolsTool(): AgentTool {
         if (activeNote) return activeNote;
         const inactive = registered.filter((t) => !active.has(t.name));
         if (inactive.length === 0) return "All tools are already active — nothing to discover.";
-        return `No tools matched "${input.query}". Inactive tools: ${inactive.map(describe).join("; ")}`;
+        // Cap the miss listing like the activation cap — both guard the same semantic (don't pour the
+        // catalog back into the context the deferral exists to protect).
+        const listed = inactive.slice(0, MAX_MISS_LISTING);
+        const more = inactive.length - listed.length;
+        return `No tools matched "${input.query}". Inactive tools: ${listed.map(describe).join("; ")}${more > 0 ? ` … and ${more} more — search with different keywords.` : ""}`;
       }
       if (inactiveMatches.length > MAX_ACTIVATIONS_PER_SEARCH) {
         return `${inactiveMatches.length} inactive tools matched "${input.query}" — too many to activate at once (activation is permanent for this conversation). Narrow the query. Matches: ${inactiveMatches

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -14,17 +14,26 @@ import { defineTool, isDeferredTool, stripDeferredMarker } from "./tool.ts";
 export function withSearchTool(tools: AgentTool[]): AgentTool[] {
   if (!tools.some(isDeferredTool)) return tools;
   const authored = tools.find((t) => t.name === "search_tools");
-  if (authored) {
-    if (!isDeferredTool(authored)) return tools;
+  if (!authored) return [...tools, makeSearchToolsTool()];
+  let fixed = authored;
+  if (isDeferredTool(fixed)) {
     // A deferred LOADER is a contradiction — it is the only entry point to the deferred tools, so
     // nothing could ever activate it (or, through it, them): every deferred tool would be silently
     // unreachable. Ignore the marker and keep the loader active (fail visibly, keep the capability).
     log.warn(
       "[fastagent] search_tools is marked deferred — ignoring the marker: the loader must stay active, or no deferred tool could ever be activated",
     );
-    return tools.map((t) => (t === authored ? stripDeferredMarker(t) : t));
+    fixed = stripDeferredMarker(fixed);
   }
-  return [...tools, makeSearchToolsTool()];
+  if ((fixed as { executionMode?: string }).executionMode !== "sequential") {
+    // A non-sequential loader silently revives the parallel double-attribution (pi's diff around SDK
+    // tools in chat) — enforce the mode rather than hope the author read the docs; warn so they know.
+    log.warn(
+      '[fastagent] search_tools lacks executionMode: "sequential" — forcing it: parallel loader calls would misattribute activations',
+    );
+    fixed = { ...fixed, executionMode: "sequential" } as AgentTool;
+  }
+  return fixed === authored ? tools : tools.map((t) => (t === authored ? fixed : t));
 }
 
 /** Activation cap per search: activation is additive, session-persisted, and has NO deactivate path —
@@ -44,12 +53,9 @@ const MAX_MISS_LISTING = 10;
  * (the chat path) in a before/after diff, and two parallel loader calls would both snapshot the
  * pre-activation set and get stamped with the same activation. Custom loader authors must set it too. */
 export function makeSearchToolsTool(): AgentTool {
-  return Object.assign(searchToolsDefinition(), { executionMode: "sequential" as const });
-}
-
-function searchToolsDefinition(): AgentTool {
   return defineTool({
     name: "search_tools",
+    executionMode: "sequential",
     description:
       // First line short on purpose: the base prompt's tools list truncates at the first newline, and
       // the discovery guidance below would otherwise flood it (and duplicate its deferred note).
@@ -83,13 +89,18 @@ function searchToolsDefinition(): AgentTool {
       const describe = (t: { name: string; description: string }) => `${t.name} — ${t.description.split("\n")[0]}`;
       const active = new Set(ctx.tools.active());
       const registered = ctx.tools.registered();
-      // Exact-name shortcut: the guaranteed escape hatch from the cap — a query that IS a registered
-      // tool name addresses that one tool, no keyword scoring in the way.
+      // A query with no searchable tokens (all punctuation/symbols) must not match: `every` over an
+      // empty token list is vacuously true, and a noise query would otherwise activate the catalog.
+      if (tokens.length === 0)
+        return `"${input.query}" contains no searchable keywords — describe the capability you need.`;
+      // Exact-name shortcut: the guaranteed escape hatch from the cap — a query that IS an INACTIVE
+      // registered tool's name addresses that one tool, no keyword scoring in the way. An exact match
+      // on an ACTIVE tool falls through to keyword matching: it must not swallow the discovery of
+      // other, still-inactive keyword matches.
       const exact = registered.find((t) => t.name.toLowerCase() === input.query.trim().toLowerCase());
       const activeMatches = registered.filter((t) => active.has(t.name) && (t === exact || matchesQuery(t)));
-      const inactiveMatches = exact
-        ? [exact].filter((t) => !active.has(t.name))
-        : registered.filter((t) => !active.has(t.name) && matchesQuery(t));
+      const inactiveMatches =
+        exact && !active.has(exact.name) ? [exact] : registered.filter((t) => !active.has(t.name) && matchesQuery(t));
       // Same listing cap as every other branch — a wide token can match most of the ACTIVE set too
       // (in chat that includes pi's default tools), and no answer may pour a catalog into the context.
       const listedActive = activeMatches.slice(0, MAX_MISS_LISTING);

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -27,6 +27,12 @@ export function withSearchTool(tools: AgentTool[]): AgentTool[] {
   return [...tools, makeSearchToolsTool()];
 }
 
+/** Activation cap per search: activation is additive, session-persisted, and has NO deactivate path —
+ *  without a cap, one broad token ("get", "file") would permanently activate half the catalog and
+ *  silently spend the entire deferral benefit for the rest of the conversation. Over the cap nothing
+ *  activates; the model gets the candidates and narrows the query. */
+const MAX_ACTIVATIONS_PER_SEARCH = 5;
+
 /** Build the `search_tools` loader. Keyword search over the inactive tools' name+description. */
 export function makeSearchToolsTool(): AgentTool {
   return defineTool({
@@ -44,7 +50,8 @@ export function makeSearchToolsTool(): AgentTool {
       const inactive = ctx.tools.registered().filter((t) => !active.has(t.name));
       if (inactive.length === 0) return "All tools are already active — nothing to discover.";
       // ponytail: naive keyword match (any query token as a case-insensitive substring of
-      // name+description); swap in scoring/embeddings if catalogs outgrow it.
+      // name+description) with a hard per-search activation cap above — the two named ceilings are
+      // relevance and irreversibility; swap in scoring/embeddings if catalogs outgrow this.
       const tokens = input.query
         .toLowerCase()
         .split(/[^a-z0-9]+/)
@@ -55,6 +62,11 @@ export function makeSearchToolsTool(): AgentTool {
       });
       if (matches.length === 0) {
         return `No tools matched "${input.query}". Inactive tools: ${inactive
+          .map((t) => `${t.name} — ${t.description.split("\n")[0]}`)
+          .join("; ")}`;
+      }
+      if (matches.length > MAX_ACTIVATIONS_PER_SEARCH) {
+        return `${matches.length} tools matched "${input.query}" — too many to activate at once (activation is permanent for this conversation). Narrow the query. Matches: ${matches
           .map((t) => `${t.name} — ${t.description.split("\n")[0]}`)
           .join("; ")}`;
       }

--- a/src/engines/pi/tool-context.ts
+++ b/src/engines/pi/tool-context.ts
@@ -24,8 +24,8 @@ export interface ToolActivation {
   active(): string[];
   /** Every registered tool (active or not) — the discovery corpus for a loader like `search_tools`. */
   registered(): Array<{ name: string; description: string }>;
-  /** ADDITIVE activation. Unknown names are ignored (pi's own contract); resolves the names actually
-   *  newly activated (already-active names don't repeat). */
+  /** ADDITIVE activation. Unknown names are filtered out before reaching pi (whose `setActiveTools`
+   *  THROWS on them); resolves the names actually newly activated (already-active names don't repeat). */
   activate(names: string[]): Promise<string[]>;
 }
 

--- a/src/engines/pi/tool-context.ts
+++ b/src/engines/pi/tool-context.ts
@@ -39,3 +39,12 @@ export interface TurnContext {
 }
 
 export const turnContext = new AsyncLocalStorage<TurnContext>();
+
+/** The additive-activation contract, in ONE place for both bridges (invoke.ts over the harness,
+ *  chat.ts over pi's AgentSession): dedupe → keep registered names only (pi's setters THROW on
+ *  unknown) → exclude already-active → the names to actually add (empty = nothing to set). */
+export function additiveActivation(registered: string[], current: string[], names: string[]): string[] {
+  const known = new Set(registered);
+  const active = new Set(current);
+  return [...new Set(names)].filter((name) => known.has(name) && !active.has(name));
+}

--- a/src/engines/pi/tool-context.ts
+++ b/src/engines/pi/tool-context.ts
@@ -32,7 +32,9 @@ export interface ToolActivation {
 export interface TurnContext {
   /** The session id of the current turn. */
   session: string;
-  /** Tool activation for the current turn's harness. Absent outside a turn (`fastagent tool`). */
+  /** Tool activation for the current turn's harness. Absent outside a SERVING turn — a bare
+   *  `fastagent tool` run, and also `fastagent chat` (which drives pi's own TUI runtime, not
+   *  invoke.ts; chat mounts every tool active, so there is nothing to activate there). */
   tools?: ToolActivation;
 }
 

--- a/src/engines/pi/tool-context.ts
+++ b/src/engines/pi/tool-context.ts
@@ -32,9 +32,9 @@ export interface ToolActivation {
 export interface TurnContext {
   /** The session id of the current turn. */
   session: string;
-  /** Tool activation for the current turn's harness. Absent outside a SERVING turn — a bare
-   *  `fastagent tool` run, and also `fastagent chat` (which drives pi's own TUI runtime, not
-   *  invoke.ts; chat mounts every tool active, so there is nothing to activate there). */
+  /** Tool activation for the current turn. Two producers, one consumer surface: invoke.ts bridges the
+   *  serving harness; chat.ts bridges pi's AgentSession (chat emulates deferral — same loader, same
+   *  semantics). Absent only outside any turn (a bare `fastagent tool` run). */
   tools?: ToolActivation;
 }
 

--- a/src/engines/pi/tool-context.ts
+++ b/src/engines/pi/tool-context.ts
@@ -11,9 +11,29 @@
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 
+/**
+ * The turn's tool-activation bridge — narrow closures over the CURRENT harness (invoke.ts builds it
+ * per turn), so a loader tool can activate deferred tools mid-turn without tool.ts importing the
+ * harness. pi records the change in the session (`active_tools_change`) and the per-invoke restore
+ * (harness.ts) carries it into later turns; defineTool's wrapper stamps the newly-activated names on
+ * the tool result (`addedToolNames`) — the load point native deferred-loading providers preserve the
+ * prompt-cache prefix with.
+ */
+export interface ToolActivation {
+  /** Names of the currently ACTIVE tools. */
+  active(): string[];
+  /** Every registered tool (active or not) — the discovery corpus for a loader like `search_tools`. */
+  registered(): Array<{ name: string; description: string }>;
+  /** ADDITIVE activation. Unknown names are ignored (pi's own contract); resolves the names actually
+   *  newly activated (already-active names don't repeat). */
+  activate(names: string[]): Promise<string[]>;
+}
+
 export interface TurnContext {
   /** The session id of the current turn. */
   session: string;
+  /** Tool activation for the current turn's harness. Absent outside a turn (`fastagent tool`). */
+  tools?: ToolActivation;
 }
 
 export const turnContext = new AsyncLocalStorage<TurnContext>();

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -48,10 +48,15 @@ export interface DefineToolOptions<I extends z.ZodType> {
   execute: (input: z.infer<I>, ctx: ToolContext) => unknown | Promise<unknown>;
 }
 
+/** An AgentTool with fastagent's deferral marker — the type for raw tools handed to fastagent
+ *  (`config.tools`, L1/L2 `tools`): plain `AgentTool` has no `deferred`, so an object literal with the
+ *  marker would fail excess-property checking against upstream's type. `defineTool` produces it. */
+export type FastagentTool = AgentTool & { deferred?: boolean };
+
 /** Read the {@link DefineToolOptions.deferred} marker off a mounted tool (extra property on the
- *  AgentTool object — pi ignores it; config.tools authors can set it on a raw tool too). */
+ *  AgentTool object — pi ignores it). */
 export function isDeferredTool(tool: AgentTool): boolean {
-  return (tool as { deferred?: unknown }).deferred === true;
+  return (tool as FastagentTool).deferred === true;
 }
 
 /** The same tool without the deferred marker — for a loader that must stay active (a deferred loader

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -25,7 +25,9 @@ export interface ToolContext {
    *  fires a later turn back into this same session.) */
   session?: string;
   /** Tool activation for the current turn (a loader tool activates {@link DefineToolOptions.deferred}
-   *  tools with it — the built-in `search_tools` is one consumer). Undefined outside a turn. */
+   *  tools with it — the built-in `search_tools` is one consumer). Undefined outside a serving turn:
+   *  a bare `fastagent tool` run, and `fastagent chat` (pi's own TUI runtime — everything is active
+   *  there, nothing to activate). */
   tools?: ToolActivation;
 }
 
@@ -49,6 +51,14 @@ export interface DefineToolOptions<I extends z.ZodType> {
  *  AgentTool object — pi ignores it; config.tools authors can set it on a raw tool too). */
 export function isDeferredTool(tool: AgentTool): boolean {
   return (tool as { deferred?: unknown }).deferred === true;
+}
+
+/** The same tool without the deferred marker — for surfaces that mount everything active (chat) and
+ *  for a loader that must stay active. */
+export function stripDeferredMarker(tool: AgentTool): AgentTool {
+  if (!isDeferredTool(tool)) return tool;
+  const { deferred: _drop, ...active } = tool as AgentTool & { deferred?: boolean };
+  return active as AgentTool;
 }
 
 /** Wrap a plain return value into pi's tool-result shape; pass a full result through unchanged. */

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { z } from "zod";
 import { type ModuleLoadFailure, loadModuleDir } from "../../loader.ts";
-import { turnContext } from "./tool-context.ts";
+import { type ToolActivation, turnContext } from "./tool-context.ts";
 
 export interface ToolContext {
   /** Abort signal for the current turn — honor it to cancel in-flight work on cancellation. */
@@ -24,6 +24,9 @@ export interface ToolContext {
    *  `fastagent tool` run, or any call with no session). (The built-in `wake` tool is one consumer — it
    *  fires a later turn back into this same session.) */
   session?: string;
+  /** Tool activation for the current turn (a loader tool activates {@link DefineToolOptions.deferred}
+   *  tools with it — the built-in `search_tools` is one consumer). Undefined outside a turn. */
+  tools?: ToolActivation;
 }
 
 export interface DefineToolOptions<I extends z.ZodType> {
@@ -31,7 +34,21 @@ export interface DefineToolOptions<I extends z.ZodType> {
   name?: string;
   description: string;
   input: I;
+  /**
+   * Registered but NOT initially active: the tool's schema stays out of every request (and the model's
+   *  sight) until a loader — the built-in `search_tools`, mounted automatically when any deferred tool
+   *  exists — activates it mid-turn. For tool-heavy agents: fewer schemas per turn, and on providers
+   *  with native deferred loading the activation preserves the prompt-cache prefix. The trade-off:
+   *  discovery rides entirely on this description — write it for the search. Default: false.
+   */
+  deferred?: boolean;
   execute: (input: z.infer<I>, ctx: ToolContext) => unknown | Promise<unknown>;
+}
+
+/** Read the {@link DefineToolOptions.deferred} marker off a mounted tool (extra property on the
+ *  AgentTool object — pi ignores it; config.tools authors can set it on a raw tool too). */
+export function isDeferredTool(tool: AgentTool): boolean {
+  return (tool as { deferred?: unknown }).deferred === true;
 }
 
 /** Wrap a plain return value into pi's tool-result shape; pass a full result through unchanged. */
@@ -49,6 +66,7 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
     name: options.name ?? "",
     description: options.description,
     parameters,
+    ...(options.deferred ? { deferred: true } : {}),
     async execute(_toolCallId: string, rawParams: unknown, signal?: AbortSignal): Promise<AgentToolResult<unknown>> {
       const parsed = options.input.safeParse(rawParams);
       if (!parsed.success) {
@@ -56,7 +74,25 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
         const detail = parsed.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ");
         return { content: [{ type: "text", text: `Invalid arguments: ${detail}` }], details: { error: detail } };
       }
-      return wrapResult(await options.execute(parsed.data, { signal, session: turnContext.getStore()?.session }));
+      const store = turnContext.getStore();
+      const before = store?.tools?.active();
+      const result = wrapResult(
+        await options.execute(parsed.data, { signal, session: store?.session, tools: store?.tools }),
+      );
+      // Stamp tools newly activated DURING this execute on the result — the load point that lets native
+      // deferred-loading providers add the definitions at this transcript position without invalidating
+      // the cached prompt prefix (mirrors pi's extension wrapper). Only a purely-ADDITIVE change is
+      // stamped; a removal in the same turn falls back to pi's full-list path.
+      if (store?.tools && before) {
+        const after = store.tools.active();
+        if (before.every((name) => after.includes(name))) {
+          const added = after.filter((name) => !before.includes(name));
+          if (added.length > 0) {
+            result.addedToolNames = [...new Set([...(result.addedToolNames ?? []), ...added])];
+          }
+        }
+      }
+      return result;
     },
   };
   return tool as unknown as AgentTool;

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -22,7 +22,8 @@ export interface ToolContext {
   /** The session id of the current turn — which conversation this tool is running in. A general tool
    *  capability: partition per-conversation data, tag logs, scope state. Undefined outside a turn (a bare
    *  `fastagent tool` run, or any call with no session). (The built-in `wake` tool is one consumer — it
-   *  fires a later turn back into this same session.) */
+   *  fires a later turn back into this same session.) In a `fastagent chat` turn this is pi's LOCAL
+   *  chat session id, not a served session — serving-coupled consumers like wake are not mounted there. */
   session?: string;
   /** Tool activation for the current turn (a loader tool activates {@link DefineToolOptions.deferred}
    *  tools with it — the built-in `search_tools` is one consumer). Provided by both the serving path

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -53,8 +53,8 @@ export function isDeferredTool(tool: AgentTool): boolean {
   return (tool as { deferred?: unknown }).deferred === true;
 }
 
-/** The same tool without the deferred marker — for surfaces that mount everything active (chat) and
- *  for a loader that must stay active. */
+/** The same tool without the deferred marker — for a loader that must stay active (a deferred loader
+ *  could never be activated and would strand every deferred tool). */
 export function stripDeferredMarker(tool: AgentTool): AgentTool {
   if (!isDeferredTool(tool)) return tool;
   const { deferred: _drop, ...active } = tool as AgentTool & { deferred?: boolean };

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -45,6 +45,10 @@ export interface DefineToolOptions<I extends z.ZodType> {
    *  discovery rides entirely on this description — write it for the search. Default: false.
    */
   deferred?: boolean;
+  /** pi's per-tool execution mode: "sequential" makes pi run any batch containing this tool serially.
+   *  REQUIRED for a tool that activates others (a loader): pi's own diff around SDK tools (chat)
+   *  would attribute one activation to two parallel calls otherwise. */
+  executionMode?: "sequential" | "parallel";
   execute: (input: z.infer<I>, ctx: ToolContext) => unknown | Promise<unknown>;
 }
 
@@ -83,6 +87,7 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
     description: options.description,
     parameters,
     ...(options.deferred ? { deferred: true } : {}),
+    ...(options.executionMode ? { executionMode: options.executionMode } : {}),
     async execute(_toolCallId: string, rawParams: unknown, signal?: AbortSignal): Promise<AgentToolResult<unknown>> {
       const parsed = options.input.safeParse(rawParams);
       if (!parsed.success) {

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -105,7 +105,10 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
         : undefined;
       const result = wrapResult(await options.execute(parsed.data, { signal, session: store?.session, tools }));
       if (added.length > 0) {
-        result.addedToolNames = [...new Set([...(result.addedToolNames ?? []), ...added])];
+        // A copy, not a mutation: wrapResult passes a full AgentToolResult through by REFERENCE, and an
+        // author may legally return a shared/frozen result object — stamping in place would corrupt it
+        // across calls (or throw on frozen), only on the rare activating path.
+        return { ...result, addedToolNames: [...new Set([...(result.addedToolNames ?? []), ...added])] };
       }
       return result;
     },

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -75,22 +75,27 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
         return { content: [{ type: "text", text: `Invalid arguments: ${detail}` }], details: { error: detail } };
       }
       const store = turnContext.getStore();
-      const before = store?.tools?.active();
-      const result = wrapResult(
-        await options.execute(parsed.data, { signal, session: store?.session, tools: store?.tools }),
-      );
-      // Stamp tools newly activated DURING this execute on the result — the load point that lets native
-      // deferred-loading providers add the definitions at this transcript position without invalidating
-      // the cached prompt prefix (mirrors pi's extension wrapper). Only a purely-ADDITIVE change is
-      // stamped; a removal in the same turn falls back to pi's full-list path.
-      if (store?.tools && before) {
-        const after = store.tools.active();
-        if (before.every((name) => after.includes(name))) {
-          const added = after.filter((name) => !before.includes(name));
-          if (added.length > 0) {
-            result.addedToolNames = [...new Set([...(result.addedToolNames ?? []), ...added])];
+      // Stamp tools THIS execute activates on its result — the load point that lets native
+      // deferred-loading providers add the definitions at this transcript position without
+      // invalidating the cached prompt prefix. The names come from this execute's OWN activate()
+      // calls (accumulated below), NOT from an active-set before/after diff: pi runs tool calls of a
+      // batch in parallel, and a snapshot diff would stamp a sibling's activation onto the wrong tool
+      // result, drifting the load point.
+      const added: string[] = [];
+      const tools = store?.tools
+        ? {
+            ...store.tools,
+            activate: async (names: string[]) => {
+              // biome-ignore lint/style/noNonNullAssertion: guarded by the ternary above
+              const activated = await store.tools!.activate(names);
+              added.push(...activated);
+              return activated;
+            },
           }
-        }
+        : undefined;
+      const result = wrapResult(await options.execute(parsed.data, { signal, session: store?.session, tools }));
+      if (added.length > 0) {
+        result.addedToolNames = [...new Set([...(result.addedToolNames ?? []), ...added])];
       }
       return result;
     },

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -25,9 +25,9 @@ export interface ToolContext {
    *  fires a later turn back into this same session.) */
   session?: string;
   /** Tool activation for the current turn (a loader tool activates {@link DefineToolOptions.deferred}
-   *  tools with it — the built-in `search_tools` is one consumer). Undefined outside a serving turn:
-   *  a bare `fastagent tool` run, and `fastagent chat` (pi's own TUI runtime — everything is active
-   *  there, nothing to activate). */
+   *  tools with it — the built-in `search_tools` is one consumer). Provided by both the serving path
+   *  (invoke.ts, over the harness) and chat (over pi's AgentSession); undefined only outside any turn
+   *  (a bare `fastagent tool` run). */
   tools?: ToolActivation;
 }
 

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -75,6 +75,8 @@ export async function createPiAgentFromWorkspace(
   authPath: string;
   /** Non-default tool names in effect: config.tools + discovered tools/. */
   toolNames: string[];
+  /** Tools registered but not initially active (deferred) — activated via search_tools. */
+  deferredToolNames: string[];
   toolCollisions: ToolCollision[];
   /** `tools/` files that failed to import — skipped, reported by the caller, never fatal. */
   toolFailures: ModuleLoadFailure[];
@@ -89,7 +91,11 @@ export async function createPiAgentFromWorkspace(
   // The run root is `dir` (cwd — where config lives, whose AGENTS.md is ② context); the agent's own
   // surface (persona/skills/tools/channels) lives in `agentDir` (config.agentDir, or `dir` when flat).
   const agentDir = resolveAgentDir(dir, config);
-  const { tools, toolNames, toolCollisions, toolFailures } = await resolveWorkspaceTools(config, agentDir, dir);
+  const { tools, toolNames, deferredToolNames, toolCollisions, toolFailures } = await resolveWorkspaceTools(
+    config,
+    agentDir,
+    dir,
+  );
   // The state root: auth/sessions/channel state all derive from it, so FASTAGENT_STATE_DIR moves the
   // whole machine-state home in one knob (a container mounts one volume); the finer overrides below
   // still win for their specific path.
@@ -126,6 +132,7 @@ export async function createPiAgentFromWorkspace(
     sessionsDir,
     authPath,
     toolNames,
+    deferredToolNames,
     toolCollisions,
     toolFailures,
   };

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -73,7 +73,8 @@ export async function createPiAgentFromWorkspace(
   sessionsDir: string;
   /** Absolute credentials file in use (for the startup report). */
   authPath: string;
-  /** Non-default tool names in effect: config.tools + discovered tools/. */
+  /** Non-default, active-by-default tool names in effect: config.tools + discovered tools/. Each name
+   *  lives in exactly one report slot — deferred names are in {@link deferredToolNames} instead. */
   toolNames: string[];
   /** Tools registered but not initially active (deferred) — activated via search_tools. */
   deferredToolNames: string[];

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -10,9 +10,11 @@ export {
   defineTool,
   loadTools,
   type DefineToolOptions,
+  type FastagentTool,
   type ToolCollision,
   type ToolContext,
 } from "./engines/pi/tool.ts";
+export type { ToolActivation } from "./engines/pi/tool-context.ts";
 export { z } from "zod";
 export type { AgentTool, ExecutionEnv, Session, Skill, SkillDiagnostic } from "@earendil-works/pi-agent-core";
 

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -50,6 +50,25 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
         expect(result.content[0]?.text).toMatch(/Activated: lookup_weather/);
         expect(session.getActiveToolNames()).toContain("lookup_weather");
 
+        // Attribution regression (review): pi wraps SDK customTools in its own before/after active-set
+        // diff, so two PARALLEL loader calls would both get stamped with the same activation. The
+        // production guard is pi's batch serialization, triggered by the loader's executionMode —
+        // assert the contract (marker present on the REGISTERED tool) and the serial behavior (second
+        // call reports already-active, exactly one stamp).
+        await rt.newSession();
+        const reSession = rt.session;
+        const loader2 = rt.session.agent.state.tools.find((t) => t.name === "search_tools") as unknown as {
+          executionMode?: string;
+          execute: (id: string, params: unknown) => Promise<{ addedToolNames?: string[] }>;
+        };
+        expect(loader2.executionMode).toBe("sequential"); // what makes pi serialize the batch
+        const r1 = await loader2.execute("p1", { query: "weather" });
+        const r2 = await loader2.execute("p2", { query: "forecast" });
+        const stamped = [r1, r2].filter((r) => (r.addedToolNames ?? []).length > 0);
+        expect(stamped).toHaveLength(1);
+        expect(stamped[0]?.addedToolNames).toEqual(["lookup_weather"]);
+        expect(reSession.getActiveToolNames()).toContain("lookup_weather");
+
         // The documented divergence, as a spec: chat activations do not survive /new — pi's chat
         // session records no activations, so every rebuild re-narrows and discovery starts over.
         await rt.newSession();

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -52,9 +52,9 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
 
         // Attribution regression (review): pi wraps SDK customTools in its own before/after active-set
         // diff, so two PARALLEL loader calls would both get stamped with the same activation. The
-        // production guard is pi's batch serialization, triggered by the loader's executionMode —
-        // assert the contract (marker present on the REGISTERED tool) and the serial behavior (second
-        // call reports already-active, exactly one stamp).
+        // production guard is pi's batch serialization, triggered by the loader's executionMode — the
+        // marker assertion IS the parallel protection (these two awaited calls are serial either way;
+        // they pin the message/stamp behavior UNDER the serialization pi guarantees).
         await rt.newSession();
         const reSession = rt.session;
         const loader2 = rt.session.agent.state.tools.find((t) => t.name === "search_tools") as unknown as {

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -49,6 +49,13 @@ describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's s
         const result = await custom.execute("c1", { query: "weather forecast" });
         expect(result.content[0]?.text).toMatch(/Activated: lookup_weather/);
         expect(session.getActiveToolNames()).toContain("lookup_weather");
+
+        // The documented divergence, as a spec: chat activations do not survive /new — pi's chat
+        // session records no activations, so every rebuild re-narrows and discovery starts over.
+        await rt.newSession();
+        const rebuilt = rt.session;
+        expect(rebuilt.getActiveToolNames()).not.toContain("lookup_weather");
+        expect(rebuilt.getActiveToolNames()).toContain("search_tools");
       } finally {
         await rt.dispose();
       }

--- a/test/chat.test.ts
+++ b/test/chat.test.ts
@@ -11,6 +11,52 @@ import { buildChatRuntime } from "../src/engines/pi/chat.ts";
 // TTY. In-memory sessions keep the test from writing to the machine's pi session store. A raw
 // AgentTool via `config.tools` lets the custom-tool path be tested without installing the package.
 describe("chat: buildChatRuntime injects fastagent's assembled agent into pi's session", () => {
+  it("emulates deferral: deferred tools start inactive, search_tools mounts and activates via pi's session", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-chat-defer-"));
+    try {
+      await writeFile(
+        join(dir, "fastagent.config.mjs"),
+        `export default {
+           model: "openai-codex/gpt-5.5",
+           tools: [{
+             name: "lookup_weather",
+             description: "Look up the weather forecast for a city.",
+             parameters: { type: "object", properties: {} },
+             deferred: true,
+             execute: async () => ({ content: [{ type: "text", text: "sunny" }], details: {} }),
+           }],
+         };\n`,
+      );
+      const rt = await buildChatRuntime(dir, {}, SessionManager.inMemory());
+      try {
+        const session = rt.session;
+        // Initial active set mirrors serving: deferred tool registered but NOT active; loader active.
+        expect(session.getAllTools().map((t) => t.name)).toContain("lookup_weather");
+        const active = session.getActiveToolNames();
+        expect(active).toContain("search_tools");
+        expect(active).not.toContain("lookup_weather");
+
+        // Drive the SAME builtin loader through pi's tool surface: it must activate via the session.
+        const loader = session.getAllTools().find((t) => t.name === "search_tools");
+        expect(loader).toBeDefined();
+        const custom = rt.session.agent.state.tools.find((t) => t.name === "search_tools") as unknown as {
+          execute: (
+            id: string,
+            params: unknown,
+            signal?: AbortSignal,
+          ) => Promise<{ content: Array<{ text?: string }> }>;
+        };
+        const result = await custom.execute("c1", { query: "weather forecast" });
+        expect(result.content[0]?.text).toMatch(/Activated: lookup_weather/);
+        expect(session.getActiveToolNames()).toContain("lookup_weather");
+      } finally {
+        await rt.dispose();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("injects the definition's prompt + skills, the config model, custom tools, definition-only", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-chat-"));
     try {

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -213,6 +213,59 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
     expect((await factory("s4")).getActiveTools().map((t) => t.name)).toEqual(["search_tools"]); // nothing activated
   });
 
+  it("a query matching an ALREADY-ACTIVE tool says so — never 'No tools matched' (capability-missing trap)", async () => {
+    // Long conversations forget what they activated; the loader is the only discovery surface, so it
+    // must answer for the whole catalog, not only the inactive slice.
+    const sessions = inMemorySessionStore();
+    const { agent } = makeAgent(
+      [
+        fauxAssistantMessage(fauxToolCall("search_tools", { query: "echo" }, { id: "c1" })), // echo is ACTIVE
+        fauxAssistantMessage("ok"),
+      ],
+      sessions,
+    );
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session: "s5" }, { text: "go" })) events.push(e);
+    const ended = events.find((e) => e.type === "tool_ended") as Extract<AgentEvent, { type: "tool_ended" }>;
+    const text = JSON.stringify(ended.content);
+    expect(text).toMatch(/Already active \(call directly\): echo/);
+    expect(text).not.toMatch(/No tools matched/);
+  });
+
+  it("stamping copies the result — an author's frozen result object survives an activating call", async () => {
+    const frozen = Object.freeze({ content: [{ type: "text", text: "done" }], details: {} });
+    const loader = defineTool({
+      name: "my_loader",
+      description: "activates the weather tool",
+      input: z.object({}),
+      async execute(_input, ctx) {
+        await ctx.tools?.activate(["lookup_weather"]);
+        return frozen; // shared/frozen result — legal per the defineTool contract
+      },
+    });
+    const { faux, models } = makeFaux();
+    faux.setResponses([fauxAssistantMessage(fauxToolCall("my_loader", {}, { id: "c1" })), fauxAssistantMessage("ok")]);
+    const sessions = inMemorySessionStore();
+    const factory = piHarnessFactory({
+      sessions,
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      tools: [loader, weather()],
+      systemPrompt: "test",
+    });
+    const agent = createPiAgentFromHarness({ harnessFactory: factory });
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session: "s6" }, { text: "go" })) events.push(e);
+    expect(events.at(-1)?.type).toBe("completed"); // no throw on the frozen object
+    expect((frozen as { addedToolNames?: string[] }).addedToolNames).toBeUndefined(); // untouched
+    const { messages } = await (await sessions.openOrCreate("s6")).buildContext();
+    const toolResult = messages.find((m) => (m as { role?: string }).role === "toolResult") as {
+      addedToolNames?: string[];
+    };
+    expect(toolResult.addedToolNames).toEqual(["lookup_weather"]); // the stamped COPY reached the session
+  });
+
   it("search_tools outside a turn (bare `fastagent tool` run) degrades with a clear message", async () => {
     const tool = makeSearchToolsTool() as unknown as {
       execute: (id: string, params: unknown) => Promise<{ content: Array<{ text?: string }> }>;

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -299,6 +299,18 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
     expect(toolResult.addedToolNames).toEqual(["lookup_weather"]); // the stamped COPY reached the session
   });
 
+  it("a noise query (no searchable tokens) activates nothing — vacuous every() must not match the catalog", async () => {
+    const { agent, factory } = makeAgent([
+      fauxAssistantMessage(fauxToolCall("search_tools", { query: "???" }, { id: "c1" })),
+      fauxAssistantMessage("ok"),
+    ]);
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session: "s8" }, { text: "go" })) events.push(e);
+    const ended = events.find((e) => e.type === "tool_ended") as Extract<AgentEvent, { type: "tool_ended" }>;
+    expect(JSON.stringify(ended.content)).toMatch(/no searchable keywords/);
+    expect((await factory("s8")).getActiveTools().map((t) => t.name)).toEqual(["echo", "search_tools"]);
+  });
+
   it("search_tools outside a turn (bare `fastagent tool` run) degrades with a clear message", async () => {
     const tool = makeSearchToolsTool() as unknown as {
       execute: (id: string, params: unknown) => Promise<{ content: Array<{ text?: string }> }>;

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -116,6 +116,41 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
     ]);
   });
 
+  it("parallel batch: two search_tools calls — addedToolNames lands on the activating call only, the other reports already-active", async () => {
+    // pi executes a batch's tool calls in parallel; the stamp must come from each execute's OWN
+    // activate() calls, not an active-set snapshot diff (which would stamp a sibling's activation).
+    const sessions = inMemorySessionStore();
+    const { agent } = makeAgent(
+      [
+        fauxAssistantMessage([
+          fauxToolCall("search_tools", { query: "weather" }, { id: "c1" }),
+          fauxToolCall("search_tools", { query: "forecast" }, { id: "c2" }),
+        ]),
+        fauxAssistantMessage("done"),
+      ],
+      sessions,
+    );
+
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session: "s3" }, { text: "weather?" })) events.push(e);
+    expect(events.at(-1)?.type).toBe("completed");
+
+    const { messages } = await (await sessions.openOrCreate("s3")).buildContext();
+    const results = messages.filter((m) => (m as { role?: string }).role === "toolResult") as Array<{
+      addedToolNames?: string[];
+      content: Array<{ text?: string }>;
+    }>;
+    expect(results).toHaveLength(2);
+    // Exactly ONE result carries the stamp — the call that actually activated the tool.
+    const stamped = results.filter((r) => r.addedToolNames !== undefined);
+    expect(stamped).toHaveLength(1);
+    expect(stamped[0]?.addedToolNames).toEqual(["lookup_weather"]);
+    // The other reports the truth (already active), never an empty "Activated: ." claim.
+    const texts = results.map((r) => r.content[0]?.text ?? "");
+    expect(texts.some((t) => /already active/.test(t))).toBe(true);
+    expect(texts.some((t) => /Activated: \./.test(t))).toBe(false);
+  });
+
   it("no keyword match → reports the inactive catalog instead of activating anything", async () => {
     const { agent, factory } = makeAgent([
       fauxAssistantMessage(fauxToolCall("search_tools", { query: "quantum chess" }, { id: "c1" })),

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -51,6 +51,22 @@ describe("deferred tools: marker + mounting + prompt", () => {
     expect(kept.find((t) => t.name === "search_tools")?.description).toBe("my own loader");
   });
 
+  it("an authored search_tools marked deferred keeps the loader ACTIVE (a deferred loader would strand every deferred tool)", () => {
+    // The loader is the only entry point to the deferred tools — deferring it means nothing could ever
+    // activate anything: silent, permanent capability loss. The marker is ignored (and warned about).
+    const deferredLoader = defineTool({
+      name: "search_tools",
+      description: "my own loader",
+      input: z.object({}),
+      deferred: true,
+      execute: () => "mine",
+    });
+    const mounted = withSearchTool([weather(), deferredLoader]);
+    const loader = mounted.find((t) => t.name === "search_tools");
+    expect(loader?.description).toBe("my own loader"); // still the author's — no builtin swapped in
+    expect(loader && isDeferredTool(loader)).toBe(false); // marker stripped → in the initial active set
+  });
+
   it("piBasePrompt lists only non-deferred tools + a discovery note, so activation never changes the prompt", () => {
     const tools = withSearchTool([echo(), weather()]);
     const prompt = piBasePrompt({ tools });

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { z } from "zod";
+import type { AgentEvent } from "../src/agent.ts";
+import { piBasePrompt } from "../src/engines/pi/create.ts";
+import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { makeSearchToolsTool, withSearchTool } from "../src/engines/pi/search-tools.ts";
+import { defineTool, isDeferredTool } from "../src/engines/pi/tool.ts";
+import { inMemorySessionStore } from "../src/index.ts";
+import { makeFaux } from "./faux.ts";
+
+const weather = () =>
+  defineTool({
+    name: "lookup_weather",
+    description: "Look up the current weather forecast for a city",
+    input: z.object({ city: z.string() }),
+    deferred: true,
+    execute: ({ city }) => `Weather for ${city}: sunny`,
+  });
+
+const echo = () =>
+  defineTool({
+    name: "echo",
+    description: "Echo a value",
+    input: z.object({ value: z.string() }),
+    execute: ({ value }) => value,
+  });
+
+describe("deferred tools: marker + mounting + prompt", () => {
+  it("defineTool({ deferred }) marks the tool; withSearchTool mounts the loader only when needed", () => {
+    expect(isDeferredTool(weather())).toBe(true);
+    expect(isDeferredTool(echo())).toBe(false);
+
+    // No deferred tool → untouched (today's agents never see search_tools).
+    const plain = [echo()];
+    expect(withSearchTool(plain)).toBe(plain);
+    // Deferred tool → loader appended; idempotent; an author-defined search_tools wins.
+    const mounted = withSearchTool([echo(), weather()]);
+    expect(mounted.map((t) => t.name)).toContain("search_tools");
+    expect(withSearchTool(mounted)).toBe(mounted);
+    const authored = defineTool({
+      name: "search_tools",
+      description: "my own loader",
+      input: z.object({}),
+      execute: () => "mine",
+    });
+    const kept = withSearchTool([weather(), authored]);
+    expect(kept.filter((t) => t.name === "search_tools")).toHaveLength(1);
+    expect(kept.find((t) => t.name === "search_tools")?.description).toBe("my own loader");
+  });
+
+  it("piBasePrompt lists only non-deferred tools + a discovery note, so activation never changes the prompt", () => {
+    const tools = withSearchTool([echo(), weather()]);
+    const prompt = piBasePrompt({ tools });
+    expect(prompt).toContain("- echo:");
+    expect(prompt).toContain("- search_tools:");
+    expect(prompt).not.toContain("lookup_weather"); // its schema is not in the request until activated
+    expect(prompt).toMatch(/1 additional tool\(s\) are registered but inactive/);
+    expect(piBasePrompt({ tools: [echo()] })).not.toMatch(/registered but inactive/);
+  });
+});
+
+describe("deferred tools: end-to-end through invoke (faux model)", () => {
+  function makeAgent(
+    responses: Parameters<ReturnType<typeof makeFaux>["faux"]["setResponses"]>[0],
+    sessions = inMemorySessionStore(),
+  ) {
+    const { faux, models } = makeFaux();
+    faux.setResponses(responses);
+    const factory = piHarnessFactory({
+      sessions,
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      tools: withSearchTool([echo(), weather()]),
+      systemPrompt: "test",
+    });
+    return { agent: createPiAgentFromHarness({ harnessFactory: factory }), factory };
+  }
+
+  it("a deferred tool starts inactive; search_tools activates it and stamps addedToolNames; the next turn's fresh harness keeps it active", async () => {
+    const sessions = inMemorySessionStore();
+    const { agent, factory } = makeAgent(
+      [
+        fauxAssistantMessage(fauxToolCall("search_tools", { query: "weather forecast" }, { id: "c1" })),
+        fauxAssistantMessage("found it"),
+      ],
+      sessions,
+    );
+
+    // Fresh session: deferred tool NOT active.
+    expect((await factory("s1")).getActiveTools().map((t) => t.name)).toEqual(["echo", "search_tools"]);
+
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session: "s1" }, { text: "what's the weather?" })) events.push(e);
+    expect(events.at(-1)?.type).toBe("completed");
+
+    // The loader's tool result reports the activation to the model…
+    const ended = events.find((e) => e.type === "tool_ended") as Extract<AgentEvent, { type: "tool_ended" }>;
+    expect(JSON.stringify(ended.content)).toContain("lookup_weather");
+
+    // …the session recorded the activation with the load point (addedToolNames on the toolResult)…
+    const { messages } = await (await sessions.openOrCreate("s1")).buildContext();
+    const toolResult = messages.find((m) => (m as { role?: string }).role === "toolResult") as {
+      addedToolNames?: string[];
+    };
+    expect(toolResult.addedToolNames).toEqual(["lookup_weather"]);
+
+    // …and the NEXT turn's fresh harness restores it (stateless invoke keeps the activation).
+    expect((await factory("s1")).getActiveTools().map((t) => t.name)).toEqual([
+      "echo",
+      "search_tools",
+      "lookup_weather",
+    ]);
+  });
+
+  it("no keyword match → reports the inactive catalog instead of activating anything", async () => {
+    const { agent, factory } = makeAgent([
+      fauxAssistantMessage(fauxToolCall("search_tools", { query: "quantum chess" }, { id: "c1" })),
+      fauxAssistantMessage("ok"),
+    ]);
+
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session: "s2" }, { text: "go" })) events.push(e);
+    const ended = events.find((e) => e.type === "tool_ended") as Extract<AgentEvent, { type: "tool_ended" }>;
+    expect(JSON.stringify(ended.content)).toMatch(/No tools matched .*lookup_weather/);
+    expect((await factory("s2")).getActiveTools().map((t) => t.name)).toEqual(["echo", "search_tools"]);
+  });
+
+  it("search_tools outside a turn (bare `fastagent tool` run) degrades with a clear message", async () => {
+    const tool = makeSearchToolsTool() as unknown as {
+      execute: (id: string, params: unknown) => Promise<{ content: Array<{ text?: string }> }>;
+    };
+    const result = await tool.execute("cli", { query: "weather" });
+    expect(result.content[0]?.text).toMatch(/unavailable outside a conversation turn/);
+  });
+});

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -180,6 +180,39 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
     expect((await factory("s2")).getActiveTools().map((t) => t.name)).toEqual(["echo", "search_tools"]);
   });
 
+  it("a broad query over the activation cap activates NOTHING and asks for a narrower query", async () => {
+    // Activation is additive, session-persisted, and has no deactivate path — one broad token must
+    // not permanently activate the catalog.
+    const many = Array.from({ length: 6 }, (_, i) =>
+      defineTool({
+        name: `fetch_${i}`,
+        description: `Fetch resource kind ${i}`,
+        input: z.object({}),
+        deferred: true,
+        execute: () => "ok",
+      }),
+    );
+    const { faux, models } = makeFaux();
+    faux.setResponses([
+      fauxAssistantMessage(fauxToolCall("search_tools", { query: "fetch" }, { id: "c1" })),
+      fauxAssistantMessage("ok"),
+    ]);
+    const factory = piHarnessFactory({
+      sessions: inMemorySessionStore(),
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      tools: withSearchTool(many),
+      systemPrompt: "test",
+    });
+    const agent = createPiAgentFromHarness({ harnessFactory: factory });
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session: "s4" }, { text: "go" })) events.push(e);
+    const ended = events.find((e) => e.type === "tool_ended") as Extract<AgentEvent, { type: "tool_ended" }>;
+    expect(JSON.stringify(ended.content)).toMatch(/too many to activate at once/);
+    expect((await factory("s4")).getActiveTools().map((t) => t.name)).toEqual(["search_tools"]); // nothing activated
+  });
+
   it("search_tools outside a turn (bare `fastagent tool` run) degrades with a clear message", async () => {
     const tool = makeSearchToolsTool() as unknown as {
       execute: (id: string, params: unknown) => Promise<{ content: Array<{ text?: string }> }>;

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -213,6 +213,39 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
     expect((await factory("s4")).getActiveTools().map((t) => t.name)).toEqual(["search_tools"]); // nothing activated
   });
 
+  it("the cap has a guaranteed escape: an exact tool name activates that one tool", async () => {
+    // After an over-cap answer the model narrows to a name from the candidate list — this second step
+    // must succeed, or a shared-prefix tool family (fetch_*) is permanently unreachable.
+    const many = Array.from({ length: 6 }, (_, i) =>
+      defineTool({
+        name: `fetch_${i}`,
+        description: `Fetch resource kind ${i}`,
+        input: z.object({}),
+        deferred: true,
+        execute: () => "ok",
+      }),
+    );
+    const { faux, models } = makeFaux();
+    faux.setResponses([
+      fauxAssistantMessage(fauxToolCall("search_tools", { query: "fetch_3" }, { id: "c1" })),
+      fauxAssistantMessage("ok"),
+    ]);
+    const factory = piHarnessFactory({
+      sessions: inMemorySessionStore(),
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      tools: withSearchTool(many),
+      systemPrompt: "test",
+    });
+    const agent = createPiAgentFromHarness({ harnessFactory: factory });
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session: "s7" }, { text: "go" })) events.push(e);
+    const ended = events.find((e) => e.type === "tool_ended") as Extract<AgentEvent, { type: "tool_ended" }>;
+    expect(JSON.stringify(ended.content)).toMatch(/Activated: fetch_3/);
+    expect((await factory("s7")).getActiveTools().map((t) => t.name)).toEqual(["search_tools", "fetch_3"]);
+  });
+
   it("a query matching an ALREADY-ACTIVE tool says so — never 'No tools matched' (capability-missing trap)", async () => {
     // Long conversations forget what they activated; the loader is the only discovery surface, so it
     // must answer for the whole catalog, not only the inactive slice.

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -163,7 +163,7 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
     expect(stamped[0]?.addedToolNames).toEqual(["lookup_weather"]);
     // The other reports the truth (already active), never an empty "Activated: ." claim.
     const texts = results.map((r) => r.content[0]?.text ?? "");
-    expect(texts.some((t) => /already active/.test(t))).toBe(true);
+    expect(texts.some((t) => /[Aa]lready active/.test(t))).toBe(true);
     expect(texts.some((t) => /Activated: \./.test(t))).toBe(false);
   });
 

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { inMemorySessionStore } from "../src/index.ts";
-import { piHarnessFactory, restoreActiveToolNames } from "../src/engines/pi/harness.ts";
+import { piHarnessFactory, resolveHarnessActiveToolNames } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 
 const fakeTool = (name: string): AgentTool =>
@@ -74,12 +74,19 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
     expect(second.getActiveTools().map((t) => t.name)).toEqual(["beta"]);
   });
 
-  it("restoreActiveToolNames: null → default; intact [] restored as-is; filter-to-empty → default", () => {
+  it("resolveHarnessActiveToolNames: null → default; intact [] restored as-is; filter-to-empty → default", () => {
     const tools = [fakeTool("alpha")];
-    expect(restoreActiveToolNames(null, tools, "s")).toBeUndefined(); // never changed → pi's default
-    expect(restoreActiveToolNames(["alpha"], tools, "s")).toEqual(["alpha"]);
-    expect(restoreActiveToolNames([], tools, "s")).toEqual([]); // deliberate empty set → faithful
-    expect(restoreActiveToolNames(["ghost"], tools, "s")).toBeUndefined(); // intent unhonorable → default
+    expect(resolveHarnessActiveToolNames(null, tools, "s")).toBeUndefined(); // never changed → pi's default
+    expect(resolveHarnessActiveToolNames(["alpha"], tools, "s")).toEqual(["alpha"]);
+    expect(resolveHarnessActiveToolNames([], tools, "s")).toEqual([]); // deliberate empty set → faithful
+    expect(resolveHarnessActiveToolNames(["ghost"], tools, "s")).toBeUndefined(); // intent unhonorable → default
+
+    // With a deferred tool mounted, both fallbacks resolve to the INITIAL set (non-deferred only) —
+    // never "all mounted", which would silently activate the deferred tool.
+    const deferredTool = Object.assign(fakeTool("lazy"), { deferred: true });
+    const withDeferred = [fakeTool("alpha"), deferredTool];
+    expect(resolveHarnessActiveToolNames(null, withDeferred, "s")).toEqual(["alpha"]);
+    expect(resolveHarnessActiveToolNames(["ghost"], withDeferred, "s2")).toEqual(["alpha"]);
   });
 });
 

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -36,7 +36,8 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
   // pi's harness writes active_tools_change to the session but its constructor never reads it back —
   // fine for pi's long-lived TUI harness, but fastagent builds a fresh harness per invoke: without the
   // restore, a session's active set silently resets to "all tools" on the next turn.
-  it("a fresh harness reopens the session with its recorded active set, not the default", async () => {
+  it("a fresh harness reopens the session with its recorded activations layered on the initial set", async () => {
+    const deferred = Object.assign(fakeTool("lazy"), { deferred: true });
     const { faux, models } = makeFaux();
     const sessions = inMemorySessionStore();
     const factory = piHarnessFactory({
@@ -44,15 +45,39 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
       env: new NodeExecutionEnv({ cwd: process.cwd() }),
       models,
       model: faux.getModel(),
-      tools: [fakeTool("alpha"), fakeTool("beta")],
+      tools: [fakeTool("alpha"), deferred],
       systemPrompt: "test",
     });
     const first = await factory("s1");
-    expect(first.getActiveTools().map((t) => t.name)).toEqual(["alpha", "beta"]); // default: all mounted
-    await first.setActiveTools(["beta"]); // idle phase → persisted to the session immediately
+    expect(first.getActiveTools().map((t) => t.name)).toEqual(["alpha"]); // initial: non-deferred only
+    await first.setActiveTools(["alpha", "lazy"]); // an activation — idle phase → persisted immediately
 
     const second = await factory("s1"); // a fresh harness, as every invoke builds
-    expect(second.getActiveTools().map((t) => t.name)).toEqual(["beta"]);
+    expect(second.getActiveTools().map((t) => t.name)).toEqual(["alpha", "lazy"]);
+  });
+
+  it("a record is not a frozen snapshot: a tool added to the workspace later joins old sessions", async () => {
+    const deferred = Object.assign(fakeTool("lazy"), { deferred: true });
+    const { faux, models } = makeFaux();
+    const sessions = inMemorySessionStore();
+    const base = {
+      sessions,
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      systemPrompt: "test",
+    };
+    const first = await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), deferred] })("s1");
+    await first.setActiveTools(["alpha", "lazy"]); // records TODAY's snapshot
+
+    // The workspace later adds "gamma": a snapshot replay would freeze it out of this session forever.
+    const second = await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), fakeTool("gamma"), deferred] })("s1");
+    expect(
+      second
+        .getActiveTools()
+        .map((t) => t.name)
+        .sort(),
+    ).toEqual(["alpha", "gamma", "lazy"]);
   });
 
   it("a recorded tool that is no longer mounted is dropped instead of bricking the session", async () => {
@@ -74,18 +99,20 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
     expect(second.getActiveTools().map((t) => t.name)).toEqual(["beta"]);
   });
 
-  it("resolveHarnessActiveToolNames: null → default; intact [] restored as-is; filter-to-empty → default", () => {
+  it("resolveHarnessActiveToolNames: null → default; union semantics; missing names dropped + warned", () => {
     const tools = [fakeTool("alpha")];
     expect(resolveHarnessActiveToolNames(null, tools, "s")).toBeUndefined(); // never changed → pi's default
     expect(resolveHarnessActiveToolNames(["alpha"], tools, "s")).toEqual(["alpha"]);
-    expect(resolveHarnessActiveToolNames([], tools, "s")).toEqual([]); // deliberate empty set → faithful
-    expect(resolveHarnessActiveToolNames(["ghost"], tools, "s")).toBeUndefined(); // intent unhonorable → default
+    // UNION semantics: a record contributes activations ON TOP of the initial set (which, with no
+    // deferral, is all mounted tools) — it cannot narrow below it. The record's semantic on the
+    // serving path is "which deferred tools this session activated", not a frozen snapshot.
+    expect(resolveHarnessActiveToolNames([], tools, "s")).toEqual(["alpha"]);
+    expect(resolveHarnessActiveToolNames(["ghost"], tools, "s")).toEqual(["alpha"]); // missing → dropped + warned
 
-    // With a deferred tool mounted, both fallbacks resolve to the INITIAL set (non-deferred only) —
-    // never "all mounted", which would silently activate the deferred tool.
     const deferredTool = Object.assign(fakeTool("lazy"), { deferred: true });
     const withDeferred = [fakeTool("alpha"), deferredTool];
-    expect(resolveHarnessActiveToolNames(null, withDeferred, "s")).toEqual(["alpha"]);
+    expect(resolveHarnessActiveToolNames(null, withDeferred, "s")).toEqual(["alpha"]); // initial excludes deferred
+    expect(resolveHarnessActiveToolNames(["lazy"], withDeferred, "s")).toEqual(["alpha", "lazy"]); // union
     expect(resolveHarnessActiveToolNames(["ghost"], withDeferred, "s2")).toEqual(["alpha"]);
   });
 });

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { inMemorySessionStore } from "../src/index.ts";
-import { piHarnessFactory, resolveHarnessActiveToolNames } from "../src/engines/pi/harness.ts";
+import { TOOL_ACTIVATION_ENTRY, piHarnessFactory, resolveHarnessActiveToolNames } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 
 const fakeTool = (name: string): AgentTool =>
@@ -36,7 +36,7 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
   // pi's harness writes active_tools_change to the session but its constructor never reads it back —
   // fine for pi's long-lived TUI harness, but fastagent builds a fresh harness per invoke: without the
   // restore, a session's active set silently resets to "all tools" on the next turn.
-  it("a fresh harness reopens the session with its recorded activations layered on the initial set", async () => {
+  it("a fresh harness reopens the session with its activation DELTAS layered on the initial set", async () => {
     const deferred = Object.assign(fakeTool("lazy"), { deferred: true });
     const { faux, models } = makeFaux();
     const sessions = inMemorySessionStore();
@@ -50,13 +50,15 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
     });
     const first = await factory("s1");
     expect(first.getActiveTools().map((t) => t.name)).toEqual(["alpha"]); // initial: non-deferred only
-    await first.setActiveTools(["alpha", "lazy"]); // an activation — idle phase → persisted immediately
+    // The dedicated delta entry the activation bridge writes (pi's own active_tools_change snapshot
+    // is deliberately ignored by the resolve).
+    await (await sessions.openOrCreate("s1")).appendCustomEntry(TOOL_ACTIVATION_ENTRY, { names: ["lazy"] });
 
     const second = await factory("s1"); // a fresh harness, as every invoke builds
     expect(second.getActiveTools().map((t) => t.name)).toEqual(["alpha", "lazy"]);
   });
 
-  it("a record is not a frozen snapshot: a tool added to the workspace later joins old sessions", async () => {
+  it("deltas, not snapshots: later-added tools join old sessions; a tool flipped to deferred drops out", async () => {
     const deferred = Object.assign(fakeTool("lazy"), { deferred: true });
     const { faux, models } = makeFaux();
     const sessions = inMemorySessionStore();
@@ -67,20 +69,23 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
       model: faux.getModel(),
       systemPrompt: "test",
     };
-    const first = await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), deferred] })("s1");
-    await first.setActiveTools(["alpha", "lazy"]); // records TODAY's snapshot
+    await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), deferred] })("s1");
+    await (await sessions.openOrCreate("s1")).appendCustomEntry(TOOL_ACTIVATION_ENTRY, { names: ["lazy"] });
 
-    // The workspace later adds "gamma": a snapshot replay would freeze it out of this session forever.
-    const second = await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), fakeTool("gamma"), deferred] })("s1");
+    // The workspace later adds "gamma" (joins — a snapshot would freeze it out) and flips "alpha" to
+    // deferred (drops out — this session never DISCOVERED it; a snapshot would keep it active).
+    const flippedAlpha = Object.assign(fakeTool("alpha"), { deferred: true });
+    const second = await piHarnessFactory({ ...base, tools: [flippedAlpha, fakeTool("gamma"), deferred] })("s1");
     expect(
       second
         .getActiveTools()
         .map((t) => t.name)
         .sort(),
-    ).toEqual(["alpha", "gamma", "lazy"]);
+    ).toEqual(["gamma", "lazy"]);
   });
 
-  it("a recorded tool that is no longer mounted is dropped instead of bricking the session", async () => {
+  it("a recorded activation that is no longer mounted is dropped instead of bricking the session", async () => {
+    const deferred = Object.assign(fakeTool("lazy"), { deferred: true });
     const { faux, models } = makeFaux();
     const sessions = inMemorySessionStore();
     const base = {
@@ -90,13 +95,12 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
       model: faux.getModel(),
       systemPrompt: "test",
     };
-    const first = await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), fakeTool("beta")] })("s1");
-    await first.setActiveTools(["alpha", "beta"]);
+    await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), deferred] })("s1");
+    await (await sessions.openOrCreate("s1")).appendCustomEntry(TOOL_ACTIVATION_ENTRY, { names: ["ghost"] });
 
-    // The workspace removed "alpha": the constructor throws on unknown names, so an unfiltered restore
-    // would fail every future invoke of this session.
-    const second = await piHarnessFactory({ ...base, tools: [fakeTool("beta")] })("s1");
-    expect(second.getActiveTools().map((t) => t.name)).toEqual(["beta"]);
+    // The constructor throws on unknown names, so an unfiltered restore would fail every future invoke.
+    const second = await piHarnessFactory({ ...base, tools: [fakeTool("alpha"), deferred] })("s1");
+    expect(second.getActiveTools().map((t) => t.name)).toEqual(["alpha"]);
   });
 
   it("resolveHarnessActiveToolNames: null → default; union semantics; missing names dropped + warned", () => {


### PR DESCRIPTION
## Summary

For tool-heavy agents, every turn paid every tool schema and the model picked from all of them. This lands pi 0.80.7's dynamic tool loading on the serving path, with fastagent's own authoring surface (the load-bearing wiring — session active-set restore — landed in #234):

- **`defineTool({ deferred: true })`** registers a tool without activating it: its schema stays out of every request (and the model's sight) until discovered. Fresh sessions start with every non-deferred tool active; tool-sets without deferral behave exactly as before.
- **Built-in `search_tools` loader**, auto-mounted only when a deferred tool exists (an authored `search_tools` wins — the wake-pair rule; one marked `deferred` keeps its loader active with a warning). AND keyword matching (adding a word narrows) over the **whole** catalog — an already-active match says "call directly", never the capability-missing trap. Per-search **activation cap (5)** with a guaranteed escape (an exact tool name activates that one tool); every listing (miss / over-cap / active-note) is capped too — no answer pours the catalog back into the context deferral protects.
- **`ToolContext.tools`** (`active/registered/activate`) is the per-turn activation bridge (same ALS seam as `ctx.session`); `search_tools` is its first consumer. Activations are **serialized locally** (per-turn chain — not a bet on pi's setter timing); `addedToolNames` — the native deferred-loading load point — comes from each execute's OWN `activate()` calls (a snapshot diff would misattribute a parallel sibling's activation) and is stamped on a **copy** (an author's frozen result survives).
- **Session semantics: a record contributes activations, not a frozen snapshot.** Reopen rebuilds the active set as initial (current non-deferred tools) ∪ recorded activations — a tool added to the workspace later joins old sessions; the corollary (durable narrowing via `setActiveTools` is not honored) is documented in core.md as a constraint on future writers.
- **`chat` emulates deferral** (what you iterate is what you serve): fresh sessions narrow by subtracting deferred names (robust to pi mounting its own tools), the same loader activates through a session-lifetime bridge with the same serialization, prompt identical to serving. One documented divergence (pinned by test): chat activations don't survive `/new`/`/resume` — pi's chat session records none, so a resumed conversation re-discovers.
- Prompt stability: the tools list comes from the static mounted set + a discovery note; activation never rewrites the prompt. Reporting: `deferred:` line in dev/start banner + `fastagent info` (text + json), one report slot per name.

Docs: api-reference (Deferred tools incl. L1 verbatim-instructions contract), core.md §3/§5, AGENTS.md repo map.

## Validation

- [x] `npm run lint` / `npm run typecheck` / `npm test` (707)
- [x] E2E through invoke (faux model): activation → `addedToolNames` on the toolResult → next turn's fresh harness keeps it active; chat E2E drives the real loader through pi's tool surface, incl. /new re-narrowing
- [x] Failure paths: no-match, over-cap (zero activations) + exact-name escape, outside-turn degradation, parallel-batch stamp attribution, frozen result, deferred authored loader, later-added tool joins old sessions

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed