### PR TITLE
docs: sweep summary surfaces for Feishu/Lark, schedules, and troubleshooting gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ src/
 │   ├── wait-health.ts       # SHARED: readiness probe for the webhook registrars (both platforms verify the URL)
 │   ├── registration.ts      # SHARED: registrar outcome type (registered|manual|failed) — registrars report facts, deploy owns gate policy
 │   ├── github/              # github channel (+ scaffold/ bundle)
-│   ├── telegram/            # telegram channel — see docs/design/core.md §9.2
+│   ├── telegram/            # telegram channel: see docs/design/core.md §7
 │   │   ├── telegram.ts      # Telegram wiring: ingress + per-turn lifecycle + composition (pure parsing → parse.ts, run one turn → invoke-turn.ts)
 │   │   ├── parse.ts         # pure protocol parsing: field extraction, prompt envelope, summon/route policy (no state/IO)
 │   │   ├── invoke-turn.ts   # run one turn: assemble inputs (resolve attachments: download/vision) + stream agent.invoke
@@ -64,6 +64,9 @@ src/
 │   │   ├── cloud.ts         # explicit Feishu-reference / Lark-compatibility capability profiles
 │   │   ├── model.ts, normalize.ts, parse.ts, crypto.ts, card.ts # protocol model/content normalization/policy + security/card
 │   │   ├── invoke-turn.ts, preview.ts, seen.ts # turn IO, streaming-card delivery, delivery dedup
+│   │   ├── owned-threads.ts # durable index of Agent-created group threads (admits bare continuations)
+│   │   ├── context-buffer.ts# unsummoned group/thread discussion (durable, commit-on-completed)
+│   │   ├── text.ts          # Unicode-safe code-point slicing for card/text rendering
 │   │   ├── feishu-api.ts    # canonical Open API pipeline (token cache, retry, cardkit)
 │   │   ├── register-app.ts  # `add feishu`: scan-to-create device flow
 │   │   ├── register-webhook.ts, bootstrap-token.ts # event URL + token automation
@@ -72,13 +75,14 @@ src/
 │       ├── lark.ts          # thin branded adapter bound to LARK_COMPAT_CLOUD
 │       ├── onboard.ts       # unbound launcher + credentials + manual config fallback
 │       └── scaffold/        # `add lark` bundle
-├── deploy/                  # `deploy fly|railway`: host artifacts + runbook + `--run` CLI drive (docs/design/core.md §10.5)
+├── deploy/                  # `deploy docker|fly|railway`: host artifacts + runbook + `--run` CLI drive (docs/design/core.md §9)
 │   │                        # LAYOUT: neutral kernel at top (horizontal) + one dir per host (vertical) — new host = new dir, copy fly/
 │   ├── registration-gate.ts # host-NEUTRAL step-7 gate policy: registrars report facts (registered|manual|failed), this owns gate-or-not
 │   ├── preflight.ts         # host-NEUTRAL pre-flight: model-travel gate (modelTravelIssue), channel discovery, auth probe, container facts + warnings
 │   ├── container.ts         # portable Dockerfile + .dockerignore (host-neutral) + the generated-marker predicate
 │   ├── secrets.ts           # required-secret NAMES (runbook) + assembleSecrets VALUES (--run credential carry)
 │   ├── runner.ts            # the shared host-CLI dispatcher seam (CliRunner + spawnRunner; faked in tests)
+│   ├── docker/  { plan.ts, run.ts }  # Local Docker: Compose topology (agent + optional Quick Tunnel) + `--run` compose driver
 │   ├── fly/     { plan.ts, run.ts }  # Fly: PLAN (artifacts + runbook, pure) + `--run` driver (drives flyctl behind the runner seam)
 │   └── railway/ { plan.ts, run.ts }  # Railway: same two roles — NOT a copy of Fly (thin config, minted URL, no scriptable scale-to-zero)
 ├── schedule/               # the N axis, clock form: a time-trigger firing the agent on a cron (schedules/<name>.ts)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ FastAgent is the missing bridge from local agent directory to live service.
 ## Features
 
 - **Vibe first — a directory is an agent.** Point FastAgent at the `AGENTS.md` + `skills/` you already vibed in a coding agent. Markdown instructions, reusable skills, and TypeScript tools stay as files you inspect, edit, and commit — no new DSL, no framework rewrite.
-- **Channels.** Serve the same agent as a GitHub PR reviewer, a Telegram bot, an HTTP/SSE endpoint, or your own adapter — verified webhooks, streaming replies, group-aware.
+- **Channels.** Serve the same agent as a GitHub PR reviewer, a Telegram bot, a Feishu or Lark bot, an HTTP/SSE endpoint, or your own adapter: verified webhooks, streaming replies, group-aware.
 - **Models, tools & skills.** Any model provider (OpenAI, Anthropic, Google, …) via OAuth or API key; typed tools discovered from `tools/` (the filename is the name, Zod-validated); Agent Skills loaded on demand. Built on the open-source [pi](https://github.com/earendil-works/pi) harness.
 - **App embedding — your stack, we plug in.** Mount the agent in your Next / Astro / Hono / Bun / Node route with one handler, or call `invoke` like any function from your own code — your auth, your database, your infra. FastAgent composes with your app, never owns it.
 - **Deploy anywhere.** No application build step — the directory is the deployable unit. `fastagent deploy docker|fly|railway` generates the container + target config and a runbook (`--run` drives it to completion). Local Docker gets user-owned Compose + durable state; optional `--tunnel` adds an ephemeral Quick Tunnel service for webhook channels. Durable ingress remains yours.
@@ -194,7 +194,7 @@ FastAgent is pre-1.0. The stable design center is the Agent Handler contract in 
 
 The neutral contract leaves room for capabilities that are not complete product features yet:
 
-- **Durable execution** — Telegram accepted turns replay at least once today; general durability and exactly-once execution remain future backend work.
+- **Durable execution**: Telegram and Feishu accepted turns replay at least once today; general durability and exactly-once execution remain future backend work.
 - **Sandboxed execution** — `ExecutionEnv` is an assembly seam, but the pi coding tools and project-context loader are still local; a complete sandbox adapter is future work.
 - **Observability export** — leveled logs and per-turn traces exist today; an OpenTelemetry exporter does not.
 - **More harness bindings and channels** — pi is the built-in harness; another harness can implement the Agent contract, and community channels can use the channel kit.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ FastAgent is the serving layer for local agent directories. It takes a directory
 2. Run the [Quickstart](quickstart.md) to create and serve a workspace.
 3. Use [Configuration](configuration.md) when choosing models, auth, ports, sessions, tools, and channels.
 4. Pick the integration path you need: [Embedding](embedding.md) or [Channels](channels.md).
+5. Ship the directory with [Deploy](deploy.md) when the agent should run on a host.
 
 Using a coding agent? Give it the repository's [`ai-start.md`](ai-start.md) for an AI-guided setup path.
 
@@ -27,6 +28,7 @@ Using a coding agent? Give it the repository's [`ai-start.md`](ai-start.md) for 
 | Configure model, auth, ports, sessions, tools, and channels | [Configuration](configuration.md) |
 | Embed an agent in an existing app or route | [Embedding](embedding.md) |
 | Connect GitHub, Telegram, or another channel | [Channels](channels.md) |
+| Run the agent on a cron, or let it wake itself | [Quickstart §8](quickstart.md#8-run-on-a-clock), [API reference](api-reference.md#schedule-authoring) |
 | Ship the agent to a host | [Deploy](deploy.md) |
 
 ## Channel guides

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -208,5 +208,6 @@ Read [Channel development](channel-development.md) for adapter design, packaging
 
 - [GitHub channel](github.md)
 - [Telegram channel](telegram.md)
+- [Feishu channel (Lark compatibility)](feishu.md)
 - [Channel development](channel-development.md)
 - [Embedding](embedding.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,7 +27,7 @@ Most commands take an optional workspace directory. When omitted, the current di
 | `invoke <message> [dir]` | Run one agent turn and exit. |
 | `fire <name> [dir]` | Run one schedule's turn immediately (authoring loop). |
 | `schedule history <name> [dir]` | Print the run audit for a schedule (or `wake`). |
-| `schedule list [dir]` | Everything that will fire: static schedules (next instant) + pending wake-ups. |
+| `schedule list [dir] [--json]` | Everything that will fire: static schedules (next instant) + pending wake-ups. |
 | `schedule cancel <id> [dir]` | Remove a pending wake-up (operator kill switch). |
 | `tool <name> <json> [dir]` | Run one discovered tool directly. |
 | `add github|telegram|feishu|lark [dir]` | Scaffold a first-party channel. Feishu is the canonical implementation; Lark international is its protocol-compatible, control-plane-degraded profile. `add feishu` scan-creates/configures the app, persists ID/Secret before Token bootstrap, and resumes a stored pair instead of creating twice. `add lark` opens the intl launcher only for a new/partial pair, validates the App-scoped credentials, probes Feishu's webhook/token automation, and falls back to manual mode/URL setup on the known config-route 404. |
@@ -116,6 +116,7 @@ Options:
 |---|---|
 | `--port N` | Override `http.port` / default `8787`. |
 | `--model spec` | Override model selection. |
+| `--auth-path file` | Override the credential file (default `<state root>/auth.json`). |
 | `--no-watch` | Serve once without the watch supervisor. |
 | `--tunnel` | Open a Cloudflare quick tunnel for webhook testing. |
 | `--no-input` | Never prompt (CI/scripts) — e.g. the first-run model pick becomes an actionable error instead of a question. |
@@ -179,7 +180,8 @@ written by the serving scheduler); `--json` prints the full records, including t
 
 `fastagent schedule list [dir]` shows everything that will fire, from BOTH producers: the static
 `schedules/` files (name + next cron instant) and the agent's pending self-scheduled wake-ups (id, next
-fire, one-shot/cron, session, prompt); `fastagent schedule cancel <id> [dir]` removes one wake-up — the
+fire, one-shot/cron, session, prompt), with `--json` for the machine-readable form;
+`fastagent schedule cancel <id> [dir]` removes one wake-up: the
 operator's kill switch for a runaway recurring wake (the agent's own is the `unwake` tool, which is
 session-scoped).
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -332,6 +332,7 @@ would silently miss clock events.
 ├── auth.json
 ├── sessions/
 ├── channels/telegram/
+├── channels/feishu/
 └── schedule/
 ```
 
@@ -352,7 +353,7 @@ The following are explicit limits, not implied capabilities:
 
 - pi is the reference implementation; additional engine bindings can implement the same Agent contract;
 - `ExecutionEnv` alone is not a complete sandbox for directory agents;
-- GitHub post-ACK work has no replay; Telegram replay is at-least-once;
+- GitHub post-ACK work has no replay; Telegram and Feishu replay is at-least-once;
 - file-backed state is single-process;
 - the repo-as-workspace deploy path is experimental;
 - observability is logs/traces, without an OpenTelemetry exporter.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,7 +30,7 @@ agent/
 2. **A contract** — [Agent Handler SPEC](SPEC.md), centered on `invoke(scope, prompt) => AsyncIterable<AgentEvent>`.
 3. **A reference implementation** — pi-based assembly for `persona.md`, `AGENTS.md` context, Agent Skills, code tools, sessions, auth, and model selection.
 4. **Developer workflow** — `init`, `info`, `dev`, `chat`, `tool`, `invoke`, `fire`, `schedule`, `start`, `login`, `models`, channel scaffolding, and `deploy`.
-5. **Composable adapters** — GitHub, Telegram, the default local invoke channel, and a small public kit for third-party channels.
+5. **Composable adapters**: GitHub, Telegram, Feishu with Lark compatibility, the default local invoke channel, and a small public kit for third-party channels.
 6. **Time triggers** — cron schedules (`schedules/` files) and opt-in agent self-scheduling (the `wake` tool), with a per-run audit (`fastagent schedule history`).
 
 ## Design choices
@@ -121,13 +121,14 @@ Implemented today:
 - Agent Handler v0.1 reference implementation over pi.
 - Directory assembly from `persona.md`, `AGENTS.md` project context, `skills/`, discovered `tools/`, and `fastagent.config.*`.
 - HTTP/SSE invoke channel.
-- GitHub and Telegram channel adapters.
-- `dev`, `chat`, `invoke`, `tool`, `info`, `start`, and `deploy docker` / `deploy fly` / `deploy railway` (`--run` drives Docker Compose or the host CLI end-to-end).
+- GitHub, Telegram, and Feishu channel adapters (Lark international rides the same engine as a compatibility profile).
+- Cron schedules (`schedules/` files) and opt-in agent self-scheduling (the `wake` tool), with a per-run audit.
+- `dev`, `chat`, `invoke`, `tool`, `info`, `fire`, `schedule`, `start`, and `deploy docker` / `deploy fly` / `deploy railway` (`--run` drives Docker Compose or the host CLI end-to-end).
 - jsonl session persistence with restart continuity.
 - CLI login backed by a project-level `<state root>/auth.json` (default `<dir>/.fastagent/auth.json`; override: `--auth-path` / `FASTAGENT_AUTH_PATH`, root: `FASTAGENT_STATE_DIR`).
 
 Not implemented yet:
 
-- General durable post-ACK execution for every webhook channel (Telegram has an at-least-once intent layer; GitHub does not).
+- General durable post-ACK execution for every webhook channel (Telegram and Feishu have an at-least-once intent layer; GitHub does not).
 - Multi-instance session/lease/auth backends out of the box (the single-machine tier is the shipped scope).
 - Additional engine reference bindings beyond pi.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -167,6 +167,8 @@ Add a first-party channel:
 ```bash
 fastagent add github
 fastagent add telegram
+fastagent add feishu     # 飞书 (open.feishu.cn)
+fastagent add lark       # Lark international
 ```
 
 Then run locally with a public tunnel for webhook testing:
@@ -175,7 +177,7 @@ Then run locally with a public tunnel for webhook testing:
 fastagent dev --tunnel
 ```
 
-Read [Channels](channels.md) for the channel model, [GitHub channel](github.md) for GitHub webhooks, and [Telegram channel](telegram.md) for Telegram bots.
+Read [Channels](channels.md) for the channel model, [GitHub channel](github.md) for GitHub webhooks, [Telegram channel](telegram.md) for Telegram bots, and [Feishu channel (Lark compatibility)](feishu.md) for Feishu and Lark bots.
 
 ## 8. Run on a clock
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -158,7 +158,7 @@ Check:
 
 - `cloudflared` is installed,
 - the public URL printed by FastAgent is the one configured in the provider,
-- the route path matches the channel (`/webhook` for GitHub scaffold, `/telegram` for Telegram scaffold),
+- the route path matches the channel (`/webhook` for the GitHub scaffold, `/telegram` for Telegram, `/feishu` for Feishu, `/lark` for Lark),
 - the provider secret matches your `.env`,
 - your `.env` is loaded from the workspace directory.
 
@@ -197,6 +197,66 @@ Telegram documents/audio/video are downloaded under:
 ```
 
 The path is appended to the prompt. Make sure the agent has filesystem tools enabled and the file still exists. Long-running bots should mount or clean this directory deliberately.
+
+## Feishu URL verification fails
+
+When you save the event Request URL, Feishu sends a `url_verification` challenge that the running
+channel must answer.
+
+Check:
+
+- `fastagent dev --tunnel` (or the deployed service) is running and reachable at the URL you saved,
+- the path matches the channel route (`/feishu` for the Feishu scaffold, `/lark` for Lark),
+- `FEISHU_VERIFICATION_TOKEN` (or `LARK_VERIFICATION_TOKEN`) matches the app's Verification Token,
+- `FEISHU_ENCRYPT_KEY` matches the console's Encrypt Key setting: set both or neither. With an
+  Encrypt Key configured, the channel refuses plaintext events entirely, so a missing or stale key
+  value makes every event fail verification.
+
+`fastagent add feishu` writes these values to `.env` automatically; re-check them after rotating
+keys in the developer console.
+
+## Feishu bot ignores group messages
+
+With only the `im:message.group_at_msg:readonly` scope, the platform delivers just the messages that
+@mention the bot. Unmentioned group or thread discussion never reaches the channel, so it cannot be
+buffered, and bare continuations inside Agent-created threads are not delivered either.
+
+To receive them, add the sensitive `im:message.group_msg` scope (custom apps only, tenant-admin
+approval) and publish a new app version. See the [Feishu channel](feishu.md) guide.
+
+## Schedule did not fire
+
+Cron schedules fire only while a serving process is up:
+
+- `fastagent dev` or `fastagent start` must be running at the cron instant; `invoke` and `fire` do
+  not start the scheduler,
+- a run missed while the process was down is caught up once on the next start, not once per missed
+  slot,
+- a scaled-to-zero deployment sleeps through cron instants; keep one machine running (see
+  [Deploy](deploy.md)).
+
+Diagnose with commands that exit:
+
+```bash
+fastagent schedule list             # everything that will fire, with the next instant
+fastagent schedule history <name>   # did last night's run silently fail?
+fastagent fire <name>               # run the schedule's turn now, without touching cron state
+```
+
+A broken `schedules/<name>.ts` file is reported by `fastagent info` before it ever reaches `dev`.
+
+## Deployed agent crash-loops with `missing model`
+
+The deployed box reads the model only from `fastagent.config.*`. A builder-local `--model` flag,
+`FASTAGENT_MODEL`, or `.env` value does not travel (`.env` is dockerignored). Set
+`model: "provider/id"` in the config file and redeploy. See [Deploy](deploy.md).
+
+## Webhooks stop working after a tunnel restart
+
+Quick Tunnel URLs are ephemeral. Restarting the tunnel container, the Docker daemon, or
+`fastagent dev --tunnel` mints a new URL, and the old webhook registration points at a dead one.
+Re-run `fastagent dev --tunnel` (or `fastagent deploy docker --tunnel --run`) to register the new
+URL. For a stable endpoint, bring your own named tunnel or reverse proxy.
 
 ## Proxy / network issues
 


### PR DESCRIPTION
A documentation review against the current codebase found one navigation gap and a recurring drift pattern: feature PRs update their own guide page and design/core.md, but not the cross-cutting summary surfaces. This PR sweeps those surfaces. No code changes.

## Navigation

- docs/README.md: add a schedules row to the guides index (the schedule content in Quickstart §8, the CLI reference, and the API reference was not reachable from the index) and a fifth recommended-path step pointing at Deploy.
- docs/channels.md: add the Feishu guide to "Where next".

## Feishu/Lark sweep (behind #215/#242)

- docs/overview.md: "Implemented today" now lists the Feishu/Lark adapters, schedules/self-scheduling, and the `fire`/`schedule` commands; "Not implemented yet" notes that Feishu also has the at-least-once intent layer; the adapter list in "What FastAgent provides" names Feishu.
- README.md: the Channels feature bullet mentions Feishu/Lark bots; "Durable execution" names Telegram and Feishu.
- docs/quickstart.md §7: add `fastagent add feishu` / `fastagent add lark` and the Feishu guide link.
- docs/design/core.md: add `channels/feishu/` to the §9 state tree; the §10 replay boundary names both channels.

## Troubleshooting

The frontmatter promised schedules and deployment coverage; the body had neither. Five new sections: Feishu URL verification, Feishu group-message scope, schedule did not fire, `missing model` crash loop on a deployed box, and webhook loss after a tunnel restart. The local webhook checklist now lists the `/feishu` and `/lark` routes.

## Reference drift

- docs/cli.md: `schedule list` accepts `--json`; the `dev` options table was missing `--auth-path`.
- AGENTS.md repo map: add the feishu files from #242 (`owned-threads.ts`, `context-buffer.ts`, `text.ts`) and `deploy/docker/` from #230; fix two stale design/core.md section pointers (telegram §7, deploy §9).

## Verification

- All relative doc links and anchors resolve (scripted check, 0 broken).
- `npm run lint` (includes the Markdown check), `npm run typecheck`, and `npm test` (753 passed) are green locally.
