### PR TITLE
fix(pi): restore compatibility with pi 0.80.10 by owning the auth file lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,16 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",
-        "@earendil-works/pi-agent-core": "^0.80.7",
-        "@earendil-works/pi-ai": "^0.80.7",
-        "@earendil-works/pi-coding-agent": "^0.80.7",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-coding-agent": "^0.80.10",
         "@octokit/webhooks-methods": "^6.0.0",
         "@octokit/webhooks-types": "^7.6.1",
         "chokidar": "^5.0.0",
         "croner": "^10.0.1",
         "giget": "^3.3.0",
         "ignore": "^7.0.5",
+        "proper-lockfile": "^4.1.2",
         "undici": "^8.6.0",
         "zod": "^4.4.3"
       },
@@ -27,6 +28,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.2",
+        "@types/proper-lockfile": "^4.1.4",
         "typescript": "^7.0.2",
         "vitest": "^4.1.9"
       },
@@ -129,17 +131,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
-      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -148,15 +150,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
-      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -164,17 +166,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
-      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -182,12 +184,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
-      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -196,23 +198,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
-      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-login": "^3.972.63",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -220,16 +222,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
-      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -237,21 +239,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.67.tgz",
-      "integrity": "sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-ini": "^3.973.1",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -259,15 +261,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
-      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -275,17 +277,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
-      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/token-providers": "3.1083.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -293,16 +295,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1083.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
-      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -310,16 +312,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
-      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -327,14 +329,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.26.tgz",
-      "integrity": "sha512-RE1fu7Nn05vG0EUJM+8Sde2GFecC658WGaC/asPzLF6K4x3H5ZaDBcQtHRE67Gdgb1VZpyUUliYejHFK1qt0Uw==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.29.tgz",
+      "integrity": "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -342,14 +344,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.22.tgz",
-      "integrity": "sha512-jtkgmhevnpzC1WeS+Y/sgymYbaQ6qg7pVOUl5cUT/8MiLptqrtnXQlNV80m+j2WIx5MIL7kVHIZNxxcK2tfUEQ==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
+      "integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -357,17 +359,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.39.tgz",
-      "integrity": "sha512-CS1spxRSezmTmI3PD+3Xrnp6KryTSEz0EefA8u6uGd0s2I0uXseWHALDI/03Wi0IUczXNWo2QrZEaHDuJNby/Q==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.41.tgz",
+      "integrity": "sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -375,18 +377,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
-      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -394,12 +396,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
-      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -408,14 +410,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -440,12 +442,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -465,12 +467,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -699,12 +701,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
-      "integrity": "sha512-EFjyAuoz2kn24sR9Q5A86sZCG6mD+nz58DCsA2I2wxgmS50cF1tSLCBOZaHKI5U9Y3pJs4BefeK3LRkB5TdJag==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
+      "integrity": "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.7",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -714,9 +716,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
-      "integrity": "sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -739,15 +741,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.7.tgz",
-      "integrity": "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.7",
-        "@earendil-works/pi-ai": "^0.80.7",
-        "@earendil-works/pi-tui": "^0.80.7",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1210,11 +1212,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.7.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.7",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1224,8 +1226,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.7.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1241,15 +1243,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.7",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -3058,9 +3060,9 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -3071,12 +3073,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
-      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3085,12 +3087,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
-      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+      "integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3125,12 +3127,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
-      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3220,12 +3222,22 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -4031,6 +4043,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4571,6 +4589,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -4675,6 +4713,12 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -4814,9 +4858,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -5014,9 +5058,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -88,20 +88,22 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.6.0",
-    "@earendil-works/pi-agent-core": "^0.80.7",
-    "@earendil-works/pi-ai": "^0.80.7",
-    "@earendil-works/pi-coding-agent": "^0.80.7",
+    "@earendil-works/pi-agent-core": "^0.80.10",
+    "@earendil-works/pi-ai": "^0.80.10",
+    "@earendil-works/pi-coding-agent": "^0.80.10",
     "@octokit/webhooks-methods": "^6.0.0",
     "@octokit/webhooks-types": "^7.6.1",
     "chokidar": "^5.0.0",
     "croner": "^10.0.1",
     "giget": "^3.3.0",
     "ignore": "^7.0.5",
+    "proper-lockfile": "^4.1.2",
     "undici": "^8.6.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.2",
+    "@types/proper-lockfile": "^4.1.4",
     "typescript": "^7.0.2",
     "vitest": "^4.1.9"
   }

--- a/src/engines/pi/auth.ts
+++ b/src/engines/pi/auth.ts
@@ -66,8 +66,10 @@ interface LockResult<T> {
 /**
  * Serialized cross-process read-modify-write of the credentials file: exponential-backoff retries,
  * 30s staleness, and compromise detection (the parameters pi's `FileAuthStorageBackend` used).
- * Ensures the file exists first (0700 dir, 0600 file) because `proper-lockfile` locks an existing
- * path. A compromised lock aborts before the write rather than clobbering a concurrent writer.
+ * Ensures the file exists first (0700 dir, 0600 file, EXCLUSIVE create: a concurrent first write
+ * must never be clobbered by the init) because `proper-lockfile` locks an existing path. A
+ * compromised lock aborts before the write rather than clobbering a concurrent writer, and a
+ * failed unlock after a successful operation rejects instead of leaving a stale lock silently.
  */
 async function withLockedAuthFile<T>(
   authPath: string,
@@ -76,8 +78,14 @@ async function withLockedAuthFile<T>(
   const dir = dirname(authPath);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   if (!existsSync(authPath)) {
-    writeFileSync(authPath, "{}", AUTH_FILE_WRITE_OPTIONS);
-    chmodSync(authPath, 0o600);
+    try {
+      writeFileSync(authPath, "{}", { ...AUTH_FILE_WRITE_OPTIONS, flag: "wx" });
+      chmodSync(authPath, 0o600);
+    } catch (error) {
+      // EEXIST: another process created the file between the existence check and this exclusive
+      // create; its content (possibly already-written credentials) must not be clobbered.
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
   }
 
   let compromised: Error | undefined;
@@ -92,24 +100,55 @@ async function withLockedAuthFile<T>(
       compromised = error;
     },
   });
+  let result: T;
   try {
     throwIfCompromised();
     const current = existsSync(authPath) ? readFileSync(authPath, "utf8") : undefined;
-    const { result, next } = await fn(current);
+    const out = await fn(current);
     throwIfCompromised();
-    if (next !== undefined) {
-      writeFileSync(authPath, next, AUTH_FILE_WRITE_OPTIONS);
+    if (out.next !== undefined) {
+      writeFileSync(authPath, out.next, AUTH_FILE_WRITE_OPTIONS);
       chmodSync(authPath, 0o600);
     }
     throwIfCompromised();
-    return result;
-  } finally {
+    result = out.result;
+  } catch (error) {
+    // The primary failure stays the signal; unlock noise must not mask it.
     try {
       await release();
     } catch {
-      // Unlock can fail when the lock was compromised or reclaimed as stale; the write is done.
+      // Secondary: a compromised or stale-reclaimed lock often cannot release cleanly.
     }
+    throw error;
   }
+  // Success path: a failed release is a real cleanup failure (the leftover auth.json.lock stalls
+  // the next writer for the staleness window with zero diagnostics), so it surfaces instead of
+  // resolving a silently degraded operation. A compromise detected after the last in-band check
+  // surfaces here too.
+  try {
+    await release();
+  } catch (releaseError) {
+    if (compromised === undefined) throw releaseError;
+  }
+  throwIfCompromised();
+  return result;
+}
+
+/**
+ * Decode the credentials JSON, shared by the read and write paths. The root must be a plain
+ * non-null, non-array object: `[]`, `null`, and scalar roots pass JSON.parse but break the record
+ * semantics (an array root even swallows writes, since JSON.stringify drops string keys on arrays).
+ * Structurally invalid = corrupt, exactly like unparsable text.
+ */
+function decodeCreds(raw: string): Creds | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+  return parsed as Creds;
 }
 
 /**
@@ -130,11 +169,10 @@ async function readCreds(authPath: string, warn: (message: string) => void): Pro
       return undefined;
     }
     if (raw !== "") {
-      try {
-        return JSON.parse(raw) as Creds;
-      } catch {
-        // A partial read mid-write parses as garbage; fall through and retry.
-      }
+      const creds = decodeCreds(raw);
+      if (creds !== undefined) return creds;
+      // A partial read mid-write parses as garbage; fall through and retry. A structurally invalid
+      // root lands here too and is reported as corrupt below.
     }
     if (attempt < 2) await sleep(2);
   }
@@ -149,11 +187,11 @@ async function readCreds(authPath: string, warn: (message: string) => void): Pro
  */
 function parseForWrite(raw: string | undefined, where: string): Creds {
   if (!raw) return {};
-  try {
-    return JSON.parse(raw) as Creds;
-  } catch {
-    throw new Error(`refusing to overwrite corrupt auth file ${where} — fix or remove it`);
+  const creds = decodeCreds(raw);
+  if (creds === undefined) {
+    throw new Error(`refusing to overwrite corrupt auth file ${where}: fix or remove it`);
   }
+  return creds;
 }
 
 /** A read-write `CredentialStore` backed by the given credentials file (default {@link GLOBAL_AUTH_PATH};

--- a/src/engines/pi/auth.ts
+++ b/src/engines/pi/auth.ts
@@ -12,23 +12,25 @@
  * token and persisting the new one elsewhere leaves global stale for every other consumer.
  *
  * Sharing is still SAFE the right way: point everything at ONE file (`FASTAGENT_AUTH_PATH` → the
- * global path). One file means one refresh lifecycle under `FileAuthStorageBackend`'s cross-process
- * lock (refresh re-reads the latest token under the lock) — the documented same-machine pattern.
+ * global path). One file means one refresh lifecycle under the store's cross-process write lock
+ * (refresh re-reads the latest token under the lock), the documented same-machine pattern.
  * fastagent's store stays SEPARATE from the pi CLI's `~/.pi/agent/auth.json` for the same single-
  * lifecycle reason: two uncoordinated files over one grant would each rotate and break the other.
  *
- * Persistence + locking reuse pi's `FileAuthStorageBackend` (a cross-process file lock) on the WRITE
- * path only. `read` is pi-ai's per-request hot path, so it stays UNLOCKED; the backend's in-place
- * write opens only a sub-millisecond torn-read window, which `read` absorbs by re-reading. The write
- * path refuses to overwrite a corrupt file (never clobbering other providers' credentials).
+ * Locking is vendored here on `proper-lockfile`, with the same parameters pi's file backend used
+ * before pi 0.80.8 stopped exporting it (upstream's stated migration path for SDK consumers is a
+ * custom pi-ai `CredentialStore`, which this file is). The lock guards the WRITE path only. `read`
+ * is pi-ai's per-request hot path, so it stays UNLOCKED; the in-place locked write opens only a
+ * sub-millisecond torn-read window, which `read` absorbs by re-reading. The write path refuses to
+ * overwrite a corrupt file (never clobbering other providers' credentials).
  */
-import { existsSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { log } from "../../log.ts";
 import { setTimeout as sleep } from "node:timers/promises";
-import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
-import { FileAuthStorageBackend } from "@earendil-works/pi-coding-agent";
+import type { Credential, CredentialInfo, CredentialStore } from "@earendil-works/pi-ai";
+import lockfile from "proper-lockfile";
 
 /**
  * The GLOBAL fastagent credentials file (distinct from pi's `~/.pi`). The project-level default is
@@ -53,9 +55,97 @@ function pick(creds: Creds, providerId: string): Credential | undefined {
   return cred && (cred.type === "oauth" || cred.type === "api_key") ? cred : undefined;
 }
 
+const AUTH_FILE_WRITE_OPTIONS = { encoding: "utf8", mode: 0o600 } as const;
+
+interface LockResult<T> {
+  result: T;
+  /** New file content to persist under the lock; undefined = no write. */
+  next?: string;
+}
+
 /**
- * Parse the credentials JSON for a WRITE: a corrupt file must THROW — serializing `{}` over it would
- * wipe every other provider's credentials. The throw aborts the locked write, leaving the file intact.
+ * Serialized cross-process read-modify-write of the credentials file: exponential-backoff retries,
+ * 30s staleness, and compromise detection (the parameters pi's `FileAuthStorageBackend` used).
+ * Ensures the file exists first (0700 dir, 0600 file) because `proper-lockfile` locks an existing
+ * path. A compromised lock aborts before the write rather than clobbering a concurrent writer.
+ */
+async function withLockedAuthFile<T>(
+  authPath: string,
+  fn: (current: string | undefined) => Promise<LockResult<T>>,
+): Promise<T> {
+  const dir = dirname(authPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  if (!existsSync(authPath)) {
+    writeFileSync(authPath, "{}", AUTH_FILE_WRITE_OPTIONS);
+    chmodSync(authPath, 0o600);
+  }
+
+  let compromised: Error | undefined;
+  const throwIfCompromised = () => {
+    if (compromised) throw compromised;
+  };
+
+  const release = await lockfile.lock(authPath, {
+    retries: { retries: 10, factor: 2, minTimeout: 100, maxTimeout: 10_000, randomize: true },
+    stale: 30_000,
+    onCompromised: (error) => {
+      compromised = error;
+    },
+  });
+  try {
+    throwIfCompromised();
+    const current = existsSync(authPath) ? readFileSync(authPath, "utf8") : undefined;
+    const { result, next } = await fn(current);
+    throwIfCompromised();
+    if (next !== undefined) {
+      writeFileSync(authPath, next, AUTH_FILE_WRITE_OPTIONS);
+      chmodSync(authPath, 0o600);
+    }
+    throwIfCompromised();
+    return result;
+  } finally {
+    try {
+      await release();
+    } catch {
+      // Unlock can fail when the lock was compromised or reclaimed as stale; the write is done.
+    }
+  }
+}
+
+/**
+ * Tolerant UNLOCKED read of the whole credentials file, shared by `read` and `list`. The only race
+ * is a sub-millisecond in-place write during an OAuth rotation, which can yield an empty/partial
+ * file; re-read a few times before concluding it is corrupt. A missing file reads as undefined
+ * silently (normal not-configured); a valid file returns immediately, so the common case costs one
+ * read.
+ */
+async function readCreds(authPath: string, warn: (message: string) => void): Promise<Creds | undefined> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    let raw: string;
+    try {
+      raw = readFileSync(authPath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined; // missing/deleted
+      warn(`[fastagent] cannot read ${authPath}: ${(error as Error).message}`);
+      return undefined;
+    }
+    if (raw !== "") {
+      try {
+        return JSON.parse(raw) as Creds;
+      } catch {
+        // A partial read mid-write parses as garbage; fall through and retry.
+      }
+    }
+    if (attempt < 2) await sleep(2);
+  }
+  warn(`[fastagent] corrupt auth file ${authPath}: fix or remove it`);
+  return undefined;
+}
+
+/**
+ * Parse the credentials JSON for a WRITE: a corrupt file must THROW, because serializing `{}` over
+ * it would wipe every other provider's credentials. The throw aborts the locked write, leaving the
+ * file intact.
  */
 function parseForWrite(raw: string | undefined, where: string): Creds {
   if (!raw) return {};
@@ -73,36 +163,27 @@ export function fastagentCredentialStore(
   options: FastagentAuthOptions = {},
 ): CredentialStore {
   const warn = options.warn ?? ((message: string) => log.warn(message));
-  const backend = new FileAuthStorageBackend(authPath);
 
   return {
     async read(providerId) {
-      // UNLOCKED hot path: the only race is a sub-millisecond in-place write during an OAuth rotation,
-      // which can yield an empty/partial file. Re-read a few times before concluding it is corrupt;
-      // a valid `{}` (provider absent) returns immediately, so a not-configured read costs nothing.
-      for (let attempt = 0; attempt < 3; attempt++) {
-        let raw: string;
-        try {
-          raw = readFileSync(authPath, "utf8");
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined; // missing/deleted
-          warn(`[fastagent] cannot read ${authPath}: ${(error as Error).message}`);
-          return undefined;
+      const creds = await readCreds(authPath, warn);
+      return creds ? pick(creds, providerId) : undefined;
+    },
+    async list() {
+      // Metadata only, never secrets (the pi-ai `list` contract). Foreign/old entries are filtered
+      // with the same validation as `read`, so both surfaces agree on what "configured" means.
+      const creds = await readCreds(authPath, warn);
+      if (!creds) return [];
+      const infos: CredentialInfo[] = [];
+      for (const [providerId, cred] of Object.entries(creds)) {
+        if (cred && (cred.type === "oauth" || cred.type === "api_key")) {
+          infos.push({ providerId, type: cred.type });
         }
-        if (raw !== "") {
-          try {
-            return pick(JSON.parse(raw) as Creds, providerId);
-          } catch {
-            // A partial read mid-write parses as garbage — fall through and retry.
-          }
-        }
-        if (attempt < 2) await sleep(2);
       }
-      warn(`[fastagent] corrupt auth file ${authPath} — fix or remove it`);
-      return undefined;
+      return infos;
     },
     modify(providerId, fn) {
-      return backend.withLockAsync(async (current) => {
+      return withLockedAuthFile(authPath, async (current) => {
         const creds = parseForWrite(current, authPath); // corrupt → throw → no clobber
         const next = await fn(pick(creds, providerId));
         if (next === undefined) return { result: pick(creds, providerId) }; // unchanged: no write
@@ -111,10 +192,10 @@ export function fastagentCredentialStore(
       });
     },
     async delete(providerId) {
-      // No-op when nothing is stored: do NOT take the lock (which would create the file via the
-      // backend's ensureFileExists) on a machine that never stored this provider.
+      // No-op when nothing is stored: do NOT take the lock (which would create the file) on a
+      // machine that never stored this provider.
       if (!existsSync(authPath)) return;
-      await backend.withLockAsync(async (current) => {
+      await withLockedAuthFile(authPath, async (current) => {
         const creds = parseForWrite(current, authPath);
         if (!(providerId in creds)) return { result: undefined }; // absent: no write
         delete creds[providerId];

--- a/src/engines/pi/login.ts
+++ b/src/engines/pi/login.ts
@@ -10,7 +10,7 @@
  */
 import type {
   AuthEvent,
-  AuthLoginCallbacks,
+  AuthInteraction,
   AuthPrompt,
   Credential,
   CredentialStore,
@@ -54,11 +54,11 @@ function anySignal(...signals: Array<AbortSignal | undefined>): AbortSignal | un
 }
 
 /**
- * Map pi-ai's `AuthLoginCallbacks` onto the injected {@link LoginIO}. `doneSignal` fires when the flow
+ * Map pi-ai's `AuthInteraction` onto the injected {@link LoginIO}. `doneSignal` fires when the flow
  * resolves, cancelling a prompt the provider left pending (a manual-code paste racing a callback
  * server it just won) so the one-shot CLI exits instead of hanging on stdin.
  */
-function authCallbacks(io: LoginIO, userSignal: AbortSignal | undefined, doneSignal: AbortSignal): AuthLoginCallbacks {
+function authCallbacks(io: LoginIO, userSignal: AbortSignal | undefined, doneSignal: AbortSignal): AuthInteraction {
   return {
     signal: userSignal,
     prompt: async (p: AuthPrompt): Promise<string> => {

--- a/test/auth-init-race.test.ts
+++ b/test/auth-init-race.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The first-write init race (deterministic): the pre-lock existence check can go stale when another
+ * process creates and fills the file in between. The init write is an EXCLUSIVE create precisely so
+ * that stale check can never clobber the other process's credentials; this simulates the stale
+ * check by mocking existsSync to report the file missing once while it really exists.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { staleExists } = vi.hoisted(() => ({ staleExists: { path: "", armed: false } }));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: (p: unknown) => {
+      if (staleExists.armed && p === staleExists.path) {
+        staleExists.armed = false;
+        return false; // the stale observation: "file does not exist" while it already does
+      }
+      return actual.existsSync(p as Parameters<typeof actual.existsSync>[0]);
+    },
+  };
+});
+
+import { fastagentCredentialStore } from "../src/engines/pi/auth.ts";
+
+describe("first-write init race (stale existence check simulated)", () => {
+  it("exclusive create refuses to clobber a file another process already initialized", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-auth-race-"));
+    const path = join(dir, "auth.json");
+    const existing = { anthropic: { type: "api_key", key: "ka" } };
+    await writeFile(path, JSON.stringify(existing));
+
+    staleExists.path = path;
+    staleExists.armed = true;
+    await fastagentCredentialStore(path).modify("openai", async () => ({ type: "api_key", key: "kb" }));
+
+    const creds = JSON.parse(await readFile(path, "utf8"));
+    expect(Object.keys(creds).sort()).toEqual(["anthropic", "openai"]);
+    expect(creds.anthropic).toEqual(existing.anthropic); // the concurrent first write survived
+  });
+});

--- a/test/auth-lock.test.ts
+++ b/test/auth-lock.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Release discipline of the locked auth-file write (proper-lockfile mocked): a failed unlock after
+ * a successful operation must reject (a leftover auth.json.lock stalls the next writer for the
+ * staleness window with zero diagnostics), while a mutation failure stays the primary error and is
+ * never masked by unlock noise.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { releaseMock, lockMock } = vi.hoisted(() => {
+  const releaseMock = vi.fn<() => Promise<void>>();
+  return { releaseMock, lockMock: vi.fn(async () => releaseMock) };
+});
+
+vi.mock("proper-lockfile", () => ({ default: { lock: lockMock } }));
+
+import { fastagentCredentialStore } from "../src/engines/pi/auth.ts";
+
+beforeEach(() => {
+  releaseMock.mockReset();
+  releaseMock.mockResolvedValue(undefined);
+});
+
+describe("locked auth write: release discipline (mocked proper-lockfile)", () => {
+  it("a failed release after a successful write REJECTS instead of silently succeeding", async () => {
+    releaseMock.mockRejectedValueOnce(new Error("EACCES: cannot remove auth.json.lock"));
+    const dir = await mkdtemp(join(tmpdir(), "fa-auth-rel-"));
+    const path = join(dir, "auth.json");
+    await expect(
+      fastagentCredentialStore(path).modify("anthropic", async () => ({ type: "api_key", key: "sk" })),
+    ).rejects.toThrow(/cannot remove auth\.json\.lock/);
+    // The credential write itself landed before the cleanup failure surfaced (diagnosable state).
+    expect(JSON.parse(await readFile(path, "utf8")).anthropic).toEqual({ type: "api_key", key: "sk" });
+  });
+
+  it("a mutation failure stays the primary error; unlock noise does not mask it", async () => {
+    releaseMock.mockRejectedValueOnce(new Error("unlock noise"));
+    const dir = await mkdtemp(join(tmpdir(), "fa-auth-rel-"));
+    const path = join(dir, "auth.json");
+    await writeFile(path, "{not valid json");
+    await expect(
+      fastagentCredentialStore(path).modify("anthropic", async () => ({ type: "api_key", key: "sk" })),
+    ).rejects.toThrow(/corrupt auth file/);
+  });
+});

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -48,6 +48,27 @@ describe("fastagentCredentialStore (read-write ~/.fastagent/auth.json; fail-visi
     expect(await store.read("openai")).toBeUndefined(); // missing entry
   });
 
+  it("list returns metadata only, filtering foreign entries with read's validation", async () => {
+    const oauth = { type: "oauth", access: "tok", refresh: "r", expires: Date.now() + 60_000 };
+    const apiKey = { type: "api_key", key: "sk-x" };
+    const path = await authPath(JSON.stringify({ anthropic: oauth, cloudflare: apiKey, old: { type: "legacy" } }));
+    const infos = await fastagentCredentialStore(path).list();
+    expect(infos).toEqual([
+      { providerId: "anthropic", type: "oauth" },
+      { providerId: "cloudflare", type: "api_key" },
+    ]);
+    for (const info of infos) expect(Object.keys(info).sort()).toEqual(["providerId", "type"]); // no secrets
+  });
+
+  it("list on a missing file → empty, no warning; corrupt file → empty + warns", async () => {
+    const warn = vi.fn();
+    expect(await fastagentCredentialStore("/nonexistent/auth.json", { warn }).list()).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+    const path = await authPath("{not valid json");
+    expect(await fastagentCredentialStore(path, { warn }).list()).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("corrupt auth file"));
+  });
+
   it("modify PERSISTS the refreshed credential (the rotation write a read-only store would lose)", async () => {
     const path = await authPath(
       JSON.stringify({ anthropic: { type: "oauth", access: "old", refresh: "r0", expires: 1 } }),

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { fastagentCredentialStore } from "../src/index.ts";
 
 afterEach(() => vi.restoreAllMocks());
@@ -118,6 +120,64 @@ describe("fastagentCredentialStore (read-write ~/.fastagent/auth.json; fail-visi
       /corrupt auth file/,
     );
     expect(await readFile(path, "utf8")).toBe(corrupt); // file left intact for the user to fix
+  });
+
+  it("structurally invalid roots (array/null/scalar) read as corrupt: read/list degrade + warn", async () => {
+    for (const root of ["[]", "null", "42"]) {
+      const warn = vi.fn();
+      const path = await authPath(root);
+      const store = fastagentCredentialStore(path, { warn });
+      expect(await store.read("anthropic")).toBeUndefined();
+      expect(await store.list()).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("corrupt auth file"));
+    }
+  });
+
+  it("modify REFUSES structurally invalid roots (an array root would silently swallow the write)", async () => {
+    for (const root of ["[]", "null", "42"]) {
+      const path = await authPath(root);
+      const store = fastagentCredentialStore(path);
+      await expect(store.modify("anthropic", async () => ({ type: "api_key", key: "sk" }))).rejects.toThrow(
+        /corrupt auth file/,
+      );
+      expect(await readFile(path, "utf8")).toBe(root); // file left intact for the user to fix
+    }
+  });
+
+  it("concurrent modify on one absent file serializes under the lock; both first writes survive", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-auth-"));
+    const path = join(dir, "auth.json"); // does not exist yet: exercises init + lock together
+    await Promise.all([
+      fastagentCredentialStore(path).modify("anthropic", async () => ({ type: "api_key", key: "ka" })),
+      fastagentCredentialStore(path).modify("openai", async () => ({ type: "api_key", key: "kb" })),
+    ]);
+    const creds = JSON.parse(await readFile(path, "utf8"));
+    expect(Object.keys(creds).sort()).toEqual(["anthropic", "openai"]);
+  });
+
+  it("two PROCESSES first-writing an absent file keep both providers (cross-process init + lock)", {
+    timeout: 20_000,
+  }, async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-auth-mp-"));
+    const path = join(dir, "auth.json");
+    const authModule = fileURLToPath(new URL("../src/engines/pi/auth.ts", import.meta.url));
+    const script = join(dir, "write.mjs");
+    await writeFile(
+      script,
+      `import { fastagentCredentialStore } from ${JSON.stringify(authModule)};\n` +
+        `const [path, provider] = process.argv.slice(2);\n` +
+        `await fastagentCredentialStore(path).modify(provider, async () => ({ type: "api_key", key: provider }));\n`,
+    );
+    const run = (provider: string): Promise<void> =>
+      new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [script, path, provider], { stdio: ["ignore", "ignore", "pipe"] });
+        let stderr = "";
+        child.stderr.on("data", (d) => (stderr += d));
+        child.on("close", (code) => (code === 0 ? resolve() : reject(new Error(`exit ${code}: ${stderr}`))));
+      });
+    await Promise.all([run("anthropic"), run("openai")]);
+    const creds = JSON.parse(await readFile(path, "utf8"));
+    expect(Object.keys(creds).sort()).toEqual(["anthropic", "openai"]);
   });
 
   it("delete of a missing entry / file is a no-op that does not create the file", async () => {

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AuthLoginCallbacks, Credential, Provider } from "@earendil-works/pi-ai";
+import type { AuthInteraction, Credential, Provider } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { fastagentCredentialStore } from "../src/engines/pi/auth.ts";
 import type { IoOption, LoginIO } from "../src/engines/pi/login.ts";
@@ -22,7 +22,7 @@ const OAUTH_CRED: Credential = { type: "oauth", access: "tok", refresh: "rt", ex
 /** A fake provider: an oauth login returning a fixed credential, and/or an api-key login that prompts. */
 function fakeProvider(
   id: string,
-  opts: { oauth?: boolean; apiKeyLogin?: boolean; onOauthLogin?: (cb: AuthLoginCallbacks) => Promise<Credential> } = {},
+  opts: { oauth?: boolean; apiKeyLogin?: boolean; onOauthLogin?: (cb: AuthInteraction) => Promise<Credential> } = {},
 ): Provider {
   return {
     id,
@@ -32,7 +32,7 @@ function fakeProvider(
       apiKey: opts.apiKeyLogin
         ? {
             name: `${id} API key`,
-            login: async (cb: AuthLoginCallbacks): Promise<Credential> => ({
+            login: async (cb: AuthInteraction): Promise<Credential> => ({
               type: "api_key",
               key: await cb.prompt({ type: "secret", message: "API key" }),
             }),


### PR DESCRIPTION
Every fresh install is currently broken: `npm i @fastagent-sh/fastagent` resolves the `^0.80.7` pi range to 0.80.10 and fails at import time with `SyntaxError: The requested module '@earendil-works/pi-coding-agent' does not provide an export named 'FileAuthStorageBackend'`. The same failure gates the "Packed package smoke" CI job on every open PR (first seen on #248, a docs-only change).

## Root cause

pi 0.80.8 shipped a documented Breaking Change in the ModelRuntime refactor: `AuthStorage` and its storage backends are no longer exported, and the stated migration path for SDK consumers is a custom pi-ai `CredentialStore`. fastagent already implements exactly that; the only borrowed piece was the backend's cross-process file lock. Two smaller changes ride the same range: pi-ai's `CredentialStore` gained a required `list()` member, and `AuthLoginCallbacks` was renamed to `AuthInteraction` (identical members).

## Changes

- **`src/engines/pi/auth.ts`**: vendor the locked read-modify-write on `proper-lockfile` directly (the same library and parameters pi's backend used: exponential backoff, 30s staleness, compromise detection, 0700 dir / 0600 file modes). The shared tolerant reader now backs both `read()` and the new `list()` implementation, which returns `{ providerId, type }` metadata only and filters foreign entries with the same validation as `read`.
- **`src/engines/pi/login.ts` + `test/login.test.ts`**: `AuthLoginCallbacks` renamed to `AuthInteraction` (verified member-identical in pi's source).
- **`package.json`**: pi packages move to `^0.80.10` (the code now uses the 0.80.10 surface); `proper-lockfile` becomes a direct dependency (it was already in the tree transitively), plus its types as a dev dependency.
- **`test/auth.test.ts`**: two new cases locking `list()` behavior (metadata only, foreign-entry filtering, missing file silent, corrupt file warns).

## Trade-off

Owning ~50 lines of lock code removes the dependence on a pi internal that upstream is free to reshape, and matches upstream's own migration guidance. Pinning 0.80.7 instead would still require a release to take effect, would block Kimi K3 and later fixes, and would keep the fragile import.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test`: 755 passed (753 + 2 new).
- Local replica of the CI packed-package smoke: `npm pack`, fresh install (resolves pi 0.80.10), all five entrypoint imports OK, `fastagent --version` OK.
- Full test suite was also run against 0.80.10 before the fix to confirm the failure surface: all 89 failures traced to the single removed export; no other runtime regressions.

## Follow-up (maintainer)

After merge, a 0.13.1 patch release is needed so published installs stop resolving into the broken combination. #248 needs a rebase to pick up the green smoke.
