### PR TITLE
feat: first-run model picker shows the full catalog and logs in inline

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,6 +94,11 @@ fastagent login [provider] [--auth-path file] [--no-input]
 
 Authenticates a model provider and stores credentials in the **project-level** `<state root>/auth.json` — by default `<cwd>/.fastagent/auth.json` (root override: `FASTAGENT_STATE_DIR`; file override: `--auth-path` / `FASTAGENT_AUTH_PATH`; run it from `$HOME` to write the global `~/.fastagent/auth.json`). There is no implicit fallback between the project and global files — the default is project-level for **isolation** (different agents can use different accounts) and **fail-visibly** (a missing credential surfaces instead of being masked by a machine-global one absent on a fresh box). So `cd` into your agent before logging in. FastAgent uses its own credential file, separate from pi's CLI state.
 
+An API-key login is verified immediately with one minimal request (OAuth needs no check — completing
+the flow proves the credential): a definitive rejection (HTTP 401) removes the just-stored key and
+exits non-zero, so a mistyped key fails at login time instead of at the first invoke; an inconclusive
+failure (network, quota, permissions) keeps the key and prints the provider's message.
+
 **Running several agents off one account on your dev machine?** Point them all at the one global file: set `FASTAGENT_AUTH_PATH=~/.fastagent/auth.json` (a `.env` entry, a shell env var, or `--auth-path`), or just `login`/run from `$HOME`. A leading `~` is expanded to your home dir in `--auth-path` and `FASTAGENT_AUTH_PATH` (shell variables like `$HOME` are not — use `~` or an absolute path). Sharing **one file** is safe — a single cross-process lock serializes OAuth refresh, so concurrent instances always read the latest token. (What is *not* safe is copying the file around: two files over one grant each rotate the single-use refresh token and break the other.)
 
 ## `fastagent dev`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,9 +95,10 @@ fastagent login [provider] [--auth-path file] [--no-input]
 Authenticates a model provider and stores credentials in the **project-level** `<state root>/auth.json` — by default `<cwd>/.fastagent/auth.json` (root override: `FASTAGENT_STATE_DIR`; file override: `--auth-path` / `FASTAGENT_AUTH_PATH`; run it from `$HOME` to write the global `~/.fastagent/auth.json`). There is no implicit fallback between the project and global files — the default is project-level for **isolation** (different agents can use different accounts) and **fail-visibly** (a missing credential surfaces instead of being masked by a machine-global one absent on a fresh box). So `cd` into your agent before logging in. FastAgent uses its own credential file, separate from pi's CLI state.
 
 An API-key login is verified immediately with one minimal request (OAuth needs no check — completing
-the flow proves the credential): a definitive rejection (HTTP 401) removes the just-stored key and
-exits non-zero, so a mistyped key fails at login time instead of at the first invoke; an inconclusive
-failure (network, quota, permissions) keeps the key and prints the provider's message.
+the flow proves the credential): a definitive rejection (HTTP 401) removes the bad key and prompts
+for it again on the spot (cancel to stop), so a mistyped key is corrected at login time instead of
+failing at the first invoke; an inconclusive failure (network, quota, permissions) keeps the key and
+prints the provider's message.
 
 **Running several agents off one account on your dev machine?** Point them all at the one global file: set `FASTAGENT_AUTH_PATH=~/.fastagent/auth.json` (a `.env` entry, a shell env var, or `--auth-path`), or just `login`/run from `$HOME`. A leading `~` is expanded to your home dir in `--auth-path` and `FASTAGENT_AUTH_PATH` (shell variables like `$HOME` are not — use `~` or an absolute path). Sharing **one file** is safe — a single cross-process lock serializes OAuth refresh, so concurrent instances always read the latest token. (What is *not* safe is copying the file around: two files over one grant each rotate the single-use refresh token and break the other.)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,9 +106,11 @@ Assembles the workspace and serves it locally. persona.md/AGENTS.md/`skills/` ar
 live next turn, no restart); a supervisor restarts the worker on edits to the code inputs —
 `tools/`, `channels/`, `fastagent.config.*`, `package.json`, `.env`.
 
-With no model set and a terminal attached, `dev` first prompts you to pick one from the providers you
-are logged into and writes it back to the config (same for `start` / `invoke`); pass `--model` or set
-`FASTAGENT_MODEL` to skip the prompt.
+With no model set and a terminal attached, `dev` first shows the full model catalog — models whose
+provider already has credentials are listed first and annotated with the source (e.g. `ready —
+OPENAI_API_KEY`); picking one that needs auth runs the login flow inline — then writes the choice
+back to the config (same for `start` / `invoke`). Pass `--model` or set `FASTAGENT_MODEL` to skip
+the prompt.
 
 Options:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,8 +72,8 @@ CLI --model > FASTAGENT_MODEL > fastagent.config.* model
 ```
 
 With none of these set, a serving command (`dev` / `start` / `invoke`) run in a terminal prompts you
-to pick from the models of the providers you are logged into, then writes the choice back to the
-config. Non-interactive runs (CI, a container) skip the prompt and fail with a clear `missing model`
+to pick from the full model catalog (ready providers first, annotated with the credential source;
+a pick that needs auth runs `login` inline), then writes the choice back to the config. Non-interactive runs (CI, a container) skip the prompt and fail with a clear `missing model`
 error instead — set one of the sources above.
 
 Examples:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,12 +58,13 @@ fastagent info
 
 **Initializing inside an existing project?** When the directory is already claimed by a toolchain or deploy setup (a `tsconfig.json`/framework config, a non-JS build manifest like `go.mod`/`pyproject.toml`/`Cargo.toml`, a `Dockerfile`/`fly.toml`/`railway.toml`, or occupied `tools/`, `channels/`, or `skills/`), `init` puts the agent kit into `./agent` instead of flat, writes `agentDir: "./agent"` into the config, and prints the reason — the host's build and the agent's surface never sweep each other, and the repo's own `AGENTS.md` is read as project context. Override with `--flat` or `--agent-dir <name>`.
 
-A fresh workspace presets no model. Log in first, **inside the workspace** — `fastagent login` stores
-credentials per project (`<cwd>/.fastagent/auth.json`, no global fallback), so a login run elsewhere is
-invisible here (alternative: a provider API key in the workspace `.env`). Then on the first
-`fastagent dev` (or `start` / `invoke`) in a terminal, FastAgent lists the models of the providers you
-are logged into and writes your pick back to `fastagent.config.mjs`. To set it non-interactively (or in
-CI/deploy, where there is no prompt):
+A fresh workspace presets no model. On the first `fastagent dev` (or `start` / `invoke`) in a
+terminal, FastAgent shows the full model catalog — models whose provider already has credentials (a
+stored login, or a provider API key in your env/`.env`) come first, annotated with the source; picking
+one that needs auth runs the login flow right there — and writes your pick back to
+`fastagent.config.mjs`. Credentials are stored per project (`<cwd>/.fastagent/auth.json`, no global
+fallback), so a login from another directory is invisible here. To set the model non-interactively
+(or in CI/deploy, where there is no prompt):
 
 ```bash
 fastagent dev --model provider/model-id

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,9 +11,9 @@ Common FastAgent setup and runtime issues.
 ## `missing model`
 
 FastAgent needs a model spec such as `openai-codex/gpt-5.5`. In a terminal, `dev` / `start` /
-`invoke` prompt you to pick one from the providers you are logged into (run `fastagent login` first)
-and save it. This error means the run is **non-interactive** (CI, a container, a piped command) with
-no model set.
+`invoke` prompt you to pick one from the full catalog (logging you in inline when the pick needs
+auth) and save it. This error means the run is **non-interactive** (CI, a container, a piped
+command) with no model set.
 
 Check available specs:
 

--- a/src/channels/http.ts
+++ b/src/channels/http.ts
@@ -20,6 +20,10 @@ const MAX_BODY_BYTES = 1 << 20;
 
 const encoder = new TextEncoder();
 
+/** A valid example request body for the invoke handler — lives HERE, next to the shape check it must
+ *  satisfy, so the CLI's "try it" hint can't drift from the protocol. */
+export const INVOKE_EXAMPLE_BODY = '{"session":"dev","text":"hello"}';
+
 /**
  * Fetch-shaped invoke handler. Mount it at any route in the host app; it accepts POST only.
  * Returns SSE (`text/event-stream`) with one `data:` line per AgentEvent.
@@ -41,6 +45,7 @@ export function createInvokeHandler(agent: Agent): (req: Request) => Promise<Res
     if (typeof session !== "string" || typeof promptText !== "string") {
       return text('need { "session": string, "text": string }\n', 400);
     }
+    // ^ the request shape INVOKE_EXAMPLE_BODY (below) must keep satisfying.
 
     // Take the iterator explicitly so the stream's cancel() (consumer disconnect) can return() it and
     // run invoke's cancellation cleanup (SPEC MUST 3). pull = backpressure: the next event is produced on demand.

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -5,6 +5,7 @@
  * spawning the CLI.
  */
 import { providerOf } from "./engines/pi/config.ts";
+import type { InteractiveLoginKind } from "./engines/pi/login.ts";
 import type { ProviderAuthStatus } from "./engines/pi/models.ts";
 
 /** One first-run picker entry (@clack/prompts option shape). */
@@ -14,10 +15,11 @@ export interface ModelPickerOption {
   hint: string;
 }
 
-/** The remedy hint for a non-ready provider: only promise `login` where an interactive flow exists;
- *  an env-key-only provider is told to set the env var instead. */
-function remedy(interactiveLogin: boolean): string {
-  return interactiveLogin ? "login required" : "API key required — set the provider's env var";
+/** The remedy hint for a non-ready provider, by what picking it actually does: an OAuth flow →
+ *  "login required"; an interactive key prompt → "API key required"; no flow at all → the env var. */
+function remedy(login: InteractiveLoginKind): string {
+  if (login === "oauth") return "login required";
+  return login === "api_key" ? "API key required" : "API key required — set the provider's env var";
 }
 
 /**
@@ -41,10 +43,10 @@ export function buildModelPickerOptions(
       rest.push({
         value: spec,
         label: spec,
-        hint: `${remedy(status.interactiveLogin)} — stored auth unusable: ${status.message}`,
+        hint: `${remedy(status.login)} — stored auth unusable: ${status.message}`,
       });
     } else if (status) {
-      rest.push({ value: spec, label: spec, hint: remedy(status.interactiveLogin) });
+      rest.push({ value: spec, label: spec, hint: remedy(status.login) });
     } else {
       // Unreachable when `specs` and `statuses` come from the same Models (every listed provider is
       // probed); if a caller ever mixes sources, promise nothing — neutral wording, no login claim.

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -1,8 +1,58 @@
 /**
- * CLI presenter for `fastagent models [search]`: the stdout/stderr output DECISION, kept out of the
- * engine config layer (config.ts owns model resolution / listModels) so this process-boundary behavior
- * is unit-testable without spawning the CLI.
+ * CLI presenter for the model-facing commands: `fastagent models [search]` output and the first-run
+ * picker's option list. Output DECISIONS live here, out of the engine config layer (config.ts owns
+ * model resolution / listModels), so this process-boundary behavior is unit-testable without
+ * spawning the CLI.
  */
+import { providerOf } from "./engines/pi/config.ts";
+import type { ProviderAuthStatus } from "./engines/pi/models.ts";
+
+/** One first-run picker entry (@clack/prompts option shape). */
+export interface ModelPickerOption {
+  value: string;
+  label: string;
+  hint: string;
+}
+
+/** The remedy hint for a non-ready provider: only promise `login` where an interactive flow exists;
+ *  an env-key-only provider is told to set the env var instead. */
+function remedy(interactiveLogin: boolean): string {
+  return interactiveLogin ? "login required" : "API key required — set the provider's env var";
+}
+
+/**
+ * The first-run picker menu: the FULL model catalog, each spec annotated with its provider's auth
+ * status — ready first (usable now, with the credential source so "which account pays" is visible at
+ * the decision point), then the rest with their remedy. Order within each group preserves `specs`
+ * (sorted by the caller). A broken provider (expired/corrupt credential) is annotated, not dropped —
+ * fail visibly.
+ */
+export function buildModelPickerOptions(
+  specs: string[],
+  statuses: Map<string, ProviderAuthStatus>,
+): ModelPickerOption[] {
+  const ready: ModelPickerOption[] = [];
+  const rest: ModelPickerOption[] = [];
+  for (const spec of specs) {
+    const status = statuses.get(providerOf(spec));
+    if (status?.state === "ready") {
+      ready.push({ value: spec, label: spec, hint: status.source ? `ready — ${status.source}` : "ready" });
+    } else if (status?.state === "broken") {
+      rest.push({
+        value: spec,
+        label: spec,
+        hint: `${remedy(status.interactiveLogin)} — stored auth unusable: ${status.message}`,
+      });
+    } else if (status) {
+      rest.push({ value: spec, label: spec, hint: remedy(status.interactiveLogin) });
+    } else {
+      // Unreachable when `specs` and `statuses` come from the same Models (every listed provider is
+      // probed); if a caller ever mixes sources, promise nothing — neutral wording, no login claim.
+      rest.push({ value: spec, label: spec, hint: "auth required" });
+    }
+  }
+  return [...ready, ...rest];
+}
 
 /** The output of `fastagent models [search]`: the spec `lines` to print to stdout (a case-insensitive
  *  substring filter; no search → all), and an stderr `error` diagnostic when a search matches nothing. */
@@ -14,6 +64,6 @@ export function formatModelsCommand(specs: string[], search?: string): { lines: 
   // Rank a PROVIDER-name match (query in the part before "/") above an incidental model-id match, so
   // `models anthropic` leads with anthropic/* rather than burying it under amazon-bedrock/anthropic.*
   // and google-vertex/…-anthropic-… (which only match in the model id). Order within each group is kept.
-  const providerMatch = (spec: string) => spec.slice(0, spec.indexOf("/")).toLowerCase().includes(q);
+  const providerMatch = (spec: string) => providerOf(spec).toLowerCase().includes(q);
   return { lines: [...matches.filter(providerMatch), ...matches.filter((s) => !providerMatch(s))] };
 }

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -40,10 +40,15 @@ export function buildModelPickerOptions(
     if (status?.state === "ready") {
       ready.push({ value: spec, label: spec, hint: status.source ? `ready — ${status.source}` : "ready" });
     } else if (status?.state === "broken") {
+      // A broken stored credential OWNS the provider (env is consulted only when nothing is stored),
+      // so with no login flow the remedy is fixing the store — not the env var (which can't win here).
       rest.push({
         value: spec,
         label: spec,
-        hint: `${remedy(status.login)} — stored auth unusable: ${status.message}`,
+        hint:
+          status.login === "none"
+            ? `stored auth unusable: ${status.message} — fix or remove the stored credential`
+            : `${remedy(status.login)} — stored auth unusable: ${status.message}`,
       });
     } else if (status) {
       rest.push({ value: spec, label: spec, hint: remedy(status.login) });

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -70,9 +70,9 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const traced = logAgentLoop(a.agent);
-  const routes = await routesFor(a.agentDir, traced, a.stateRoot).catch(failStartup);
+  const routed = await routesFor(a.agentDir, traced, a.stateRoot).catch(failStartup);
   await startSchedules(a.agentDir, traced, a.stateRoot, a.config.selfSchedule ?? false);
-  serve(routes, portFlag ?? a.config.http?.port ?? 8787, (p) => maybeTunnel(a.agentDir, p, opts.tunnel ?? false));
+  serve(routed, portFlag ?? a.config.http?.port ?? 8787, (p) => maybeTunnel(a.agentDir, p, opts.tunnel ?? false));
 }
 
 type Assembled = Awaited<ReturnType<typeof createPiAgentFromWorkspace>>;

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -8,15 +8,13 @@
  * so the secret can never land untracked — a flow that then fails (bad provider, abort) leaves that
  * empty state dir behind, by design (no secret without its `.gitignore`). Skipped for the HOME-global dir.
  */
-import { autocomplete, isCancel, log as clackLog, password, select, text as clackText } from "@clack/prompts";
 import { loadDotEnv } from "../../env.ts";
 import { defaultAuthPath, resolveAuthPathOverride, resolveStateRoot } from "../../engines/pi/config.ts";
 import { ensureStateRootSelfIgnored, isUnderDir } from "../../engines/pi/definition.ts";
-import { type LoginIO, loginFlow } from "../../engines/pi/login.ts";
-import { openExternalUrl } from "../../open-url.ts";
+import { LoginCancelled, loginFlow } from "../../engines/pi/login.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { failStartup } from "../fail.ts";
-import { isInteractive } from "../shared.ts";
+import { isInteractive, terminalLoginIO } from "../shared.ts";
 
 export interface LoginOptions {
   authPath?: string;
@@ -48,25 +46,14 @@ export async function runLogin(provider: string | undefined, opts: LoginOptions)
     );
   }
   const io = terminalLoginIO();
-  const result = await loginFlow(io, { provider, authPath }).catch(failStartup);
+  const result = await loginFlow(io, { provider, authPath }).catch((error: unknown) => {
+    if (error instanceof LoginCancelled) {
+      // A decision, not a failure — neutral wording; non-zero exit because no credential was stored.
+      console.error(`[fastagent] login cancelled`);
+      process.exit(1);
+    }
+    failStartup(error);
+  });
   console.error(`[fastagent] logged in to ${result.provider} (${result.method}) — saved to ${authPath}`);
   process.exit(0); // the undici proxy agent's keep-alive sockets would otherwise hold the event loop open
-}
-
-/** Login terminal IO via @clack/prompts: a searchable list once long, a hidden prompt for keys. */
-function terminalLoginIO(): LoginIO {
-  return {
-    async select(message, options) {
-      const r = await (options.length > 7 ? autocomplete : select)({ message, options });
-      return isCancel(r) ? undefined : (r as string);
-    },
-    async prompt(message, opts) {
-      const r = opts?.hidden
-        ? await password({ message, signal: opts.signal })
-        : await clackText({ message, signal: opts?.signal });
-      return isCancel(r) ? undefined : (r as string);
-    },
-    note: (message) => clackLog.info(message),
-    openUrl: openExternalUrl,
-  };
 }

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -11,10 +11,10 @@
 import { loadDotEnv } from "../../env.ts";
 import { defaultAuthPath, resolveAuthPathOverride, resolveStateRoot } from "../../engines/pi/config.ts";
 import { ensureStateRootSelfIgnored, isUnderDir } from "../../engines/pi/definition.ts";
-import { LoginCancelled, loginFlow } from "../../engines/pi/login.ts";
+import { LoginCancelled } from "../../engines/pi/login.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { failStartup } from "../fail.ts";
-import { isInteractive, terminalLoginIO, verifyApiKeyLogin } from "../shared.ts";
+import { isInteractive, loginWithKeyCheck } from "../shared.ts";
 
 export interface LoginOptions {
   authPath?: string;
@@ -45,8 +45,9 @@ export async function runLogin(provider: string | undefined, opts: LoginOptions)
       new Error(`login is interactive (it shows a menu and opens a browser) — run it in a terminal, not a pipe/CI`),
     );
   }
-  const io = terminalLoginIO();
-  const result = await loginFlow(io, { provider, authPath }).catch((error: unknown) => {
+  // loginWithKeyCheck: an entered API key is verified with one minimal request; a rejected key (401)
+  // re-prompts in place, so a returned result is always a stored-and-not-definitively-bad credential.
+  const result = await loginWithKeyCheck(provider, authPath).catch((error: unknown) => {
     if (error instanceof LoginCancelled) {
       // A decision, not a failure — neutral wording; non-zero exit because no credential was stored.
       console.error(`[fastagent] login cancelled`);
@@ -54,12 +55,6 @@ export async function runLogin(provider: string | undefined, opts: LoginOptions)
     }
     failStartup(error);
   });
-  // Quick-fail an entered key before declaring success — a definitive rejection (HTTP 401) removed
-  // the credential inside verifyApiKeyLogin, so exit non-zero: nothing usable was stored.
-  if (result.method === "api_key") {
-    const verdict = await verifyApiKeyLogin(result.provider, authPath).catch(failStartup);
-    if (verdict === "rejected") process.exit(1);
-  }
   console.error(`[fastagent] logged in to ${result.provider} (${result.method}) — saved to ${authPath}`);
   process.exit(0); // the undici proxy agent's keep-alive sockets would otherwise hold the event loop open
 }

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -14,7 +14,7 @@ import { ensureStateRootSelfIgnored, isUnderDir } from "../../engines/pi/definit
 import { LoginCancelled, loginFlow } from "../../engines/pi/login.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { failStartup } from "../fail.ts";
-import { isInteractive, terminalLoginIO } from "../shared.ts";
+import { isInteractive, terminalLoginIO, verifyApiKeyLogin } from "../shared.ts";
 
 export interface LoginOptions {
   authPath?: string;
@@ -54,6 +54,12 @@ export async function runLogin(provider: string | undefined, opts: LoginOptions)
     }
     failStartup(error);
   });
+  // Quick-fail an entered key before declaring success — a definitive rejection (HTTP 401) removed
+  // the credential inside verifyApiKeyLogin, so exit non-zero: nothing usable was stored.
+  if (result.method === "api_key") {
+    const verdict = await verifyApiKeyLogin(result.provider, authPath).catch(failStartup);
+    if (verdict === "rejected") process.exit(1);
+  }
   console.error(`[fastagent] logged in to ${result.provider} (${result.method}) — saved to ${authPath}`);
   process.exit(0); // the undici proxy agent's keep-alive sockets would otherwise hold the event loop open
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -98,9 +98,9 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
 
   // Same debug turn trace as dev; gated out here by the info level (see dev.ts serveOnce).
   const traced = logAgentLoop(agent);
-  const routes = await routesFor(agentDir, traced, stateRoot).catch(failStartup);
+  const routed = await routesFor(agentDir, traced, stateRoot).catch(failStartup);
   await startSchedules(agentDir, traced, stateRoot, config.selfSchedule ?? false);
-  serve(routes, portFlag ?? parsePort(process.env.PORT, "PORT env", "env") ?? config.http?.port ?? 8787, (p) =>
+  serve(routed, portFlag ?? parsePort(process.env.PORT, "PORT env", "env") ?? config.http?.port ?? 8787, (p) =>
     maybeTunnel(agentDir, p, opts.tunnel ?? false),
   );
   // No graceful drain: webhook turns run fire-and-forget; SIGTERM just exits mid-turn. Whether an

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -4,7 +4,7 @@
  * tunnel. Bodies moved verbatim from cli.ts; `values.tunnel` became a parameter.
  */
 import type { Agent } from "../agent.ts";
-import { createInvokeHandler } from "../channels/http.ts";
+import { INVOKE_EXAMPLE_BODY, createInvokeHandler } from "../channels/http.ts";
 import { text } from "../channels/respond.ts";
 import { loadChannels } from "../engines/pi/channel.ts";
 import { reportModuleLoadFailures } from "../engines/pi/report.ts";
@@ -19,8 +19,14 @@ import { failStartup } from "./fail.ts";
 /**
  * The routes this deployment serves: a default `GET /health` plus the workspace's discovered
  * `channels/` — or the default invoke channel at POST /invoke when none are declared.
+ * `builtinInvoke` records which of the two it was: the "try it" curl hint holds only for the
+ * built-in handler (a user channel at the same key may speak a different body shape).
  */
-export async function routesFor(workspaceDir: string, agent: Agent, stateRoot: string): Promise<Routes> {
+export async function routesFor(
+  workspaceDir: string,
+  agent: Agent,
+  stateRoot: string,
+): Promise<{ routes: Routes; builtinInvoke: boolean }> {
   const { routes, collisions, failures } = await loadChannels(workspaceDir, { agent, stateRoot });
   for (const c of collisions) {
     console.error(
@@ -34,23 +40,39 @@ export async function routesFor(workspaceDir: string, agent: Agent, stateRoot: s
         `fix it, or rename an intentionally disabled file to *.disabled`,
     );
   }
-  const channels = Object.keys(routes).length > 0 ? routes : { "POST /invoke": createInvokeHandler(agent) };
+  const builtinInvoke = Object.keys(routes).length === 0;
+  const channels = builtinInvoke ? { "POST /invoke": createInvokeHandler(agent) } : routes;
   // Add a default GET /health unless a channel already covers it (overlap, not exact-key: an
   // any-method `/health` also handles GET, so the built-in steps aside).
   const healthCovered = Object.keys(channels).some((k) => {
     const e = parseRouteKey(k);
     return e.path === "/health" && (e.method === undefined || e.method === "GET");
   });
-  return healthCovered ? channels : { "GET /health": () => text("ok\n", 200), ...channels };
+  return {
+    routes: healthCovered ? channels : { "GET /health": () => text("ok\n", 200), ...channels },
+    builtinInvoke,
+  };
 }
 
 /** Serve `routes` via the Node host. serveNode owns binding; the CLI owns policy (errors, ready signal, log). */
-export function serve(routes: Routes, port: number, onListening?: (boundPort: number) => void): void {
+export function serve(
+  { routes, builtinInvoke }: { routes: Routes; builtinInvoke: boolean },
+  port: number,
+  onListening?: (boundPort: number) => void,
+): void {
   serveNode(router(routes), { port }).listening.then(
     (boundPort) => {
       process.send?.({ type: "ready", port: boundPort }); // tell the dev supervisor we bound + on which port
       log.info(`[fastagent] http channel on :${boundPort}`);
       log.info(`[fastagent] routes: ${Object.keys(routes).join(", ") || "(none)"}`);
+      // Proof of life: end setup with an observable success, not an inferred one. Only for the
+      // BUILT-IN invoke handler — its body ships from the http channel (INVOKE_EXAMPLE_BODY, pinned
+      // by test); a user channel at the same key may speak a different shape, so no hint there.
+      if (builtinInvoke) {
+        log.info(
+          `[fastagent] try it: curl -s localhost:${boundPort}/invoke -X POST -H 'content-type: application/json' -d '${INVOKE_EXAMPLE_BODY}'`,
+        );
+      }
       onListening?.(boundPort);
     },
     (error: NodeJS.ErrnoException) => {

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -105,7 +105,7 @@ export async function resolveFirstRunModel(
   const chosen = r as string;
   const provider = providerOf(chosen);
   const status = statuses.get(provider);
-  if (status && status.state !== "ready" && !status.interactiveLogin) {
+  if (status && status.state !== "ready" && status.login === "none") {
     // No login flow exists for this provider — the model choice is still valid (its validity is
     // independent of credentials), so KEEP it and name the remedy; the startup auth report warns too.
     log.warn(`[fastagent] "${provider}" has no interactive login — set its API key env var; invokes fail until then`);

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -1,22 +1,29 @@
 /**
  * Helpers shared across command modules: interactivity gates, port parsing, the startup auth report,
- * and first-run model resolution. Bodies moved verbatim from cli.ts; the module-scoped flag access
- * (`values.*`) became parameters.
+ * first-run model resolution, and the login terminal IO. Bodies moved verbatim from cli.ts; the
+ * module-scoped flag access (`values.*`) became parameters.
  */
 import { readFile, writeFile } from "node:fs/promises";
 import { relative } from "node:path";
-import { autocomplete, isCancel, select } from "@clack/prompts";
+import { autocomplete, isCancel, log as clackLog, password, select, text as clackText } from "@clack/prompts";
+import { buildModelPickerOptions } from "../cli-models.ts";
 import { fastagentCredentialStore } from "../engines/pi/auth.ts";
 import {
   isValidPort,
+  listModels,
   loadConfig,
+  providerOf,
   resolveAuthPath,
   resolveModelSpec,
+  resolveStateRoot,
   rewriteConfigModel,
 } from "../engines/pi/config.ts";
-import { configuredModelSpecs, createPiModels, probeAuthSource } from "../engines/pi/models.ts";
+import { ensureStateRootSelfIgnored, isUnderDir } from "../engines/pi/definition.ts";
+import { LoginCancelled, type LoginIO, loginFlow } from "../engines/pi/login.ts";
+import { createPiModels, probeAuthSource, providerAuthStatuses } from "../engines/pi/models.ts";
 import { formatAuthReport } from "../cli-auth.ts";
 import { log } from "../log.ts";
+import { openExternalUrl } from "../open-url.ts";
 import { failStartup, failUsage } from "./fail.ts";
 
 /** Both stdin and stdout are a terminal — the precondition for an interactive prompt. */
@@ -44,7 +51,7 @@ export function parsePort(value: string | undefined, source: string, from: "flag
 
 /** Report which source provides the model's credentials, surfacing a remediation hint at startup. Non-blocking. */
 export async function reportAuth(modelSpec: string, authPath: string): Promise<void> {
-  const provider = modelSpec.slice(0, modelSpec.indexOf("/"));
+  const provider = providerOf(modelSpec);
   const source = await probeAuthSource(createPiModels({ authPath }), modelSpec);
   // Only when nothing satisfies auth do we read the store (refresh-FREE) to tell "nothing stored" from
   // "stored but unusable" — see formatAuthReport for why. store.read warns on a corrupt file itself.
@@ -60,12 +67,14 @@ export async function reportAuth(modelSpec: string, authPath: string): Promise<v
 }
 
 /**
- * First-run model resolution for the serving commands. When no model is set (flag/env/config), and
- * we're on a TTY, pick one from the providers the user is logged into and persist the choice. A no-op
- * when a model is already set; on a non-TTY (CI/deploy), or with `--no-input`, or with nothing
- * configured it stays silent and lets the opener raise its clear "missing model" error. The pick is
- * exported to FASTAGENT_MODEL so a spawned `dev` worker inherits it, and best-effort written back to
- * the config so the next run is quiet.
+ * First-run model resolution for the serving commands: ONE funnel, no dead ends. When no model is set
+ * (flag/env/config) and we're on a TTY, show the FULL catalog annotated per provider — ready (with the
+ * credential source, so which account pays is visible at the decision point) or login-required — and,
+ * when the choice needs auth, run the login flow INLINE instead of exiting with "run `fastagent login`
+ * and come back". A no-op when a model is already set; on a non-TTY (CI/deploy), with `--no-input`, on
+ * cancel, or on a failed login it stays quiet and lets the opener raise its clear "missing model"
+ * error. The pick is exported to FASTAGENT_MODEL so a spawned `dev` worker inherits it, and
+ * best-effort written back to the config so the next run is quiet.
  */
 export async function resolveFirstRunModel(
   workspaceDir: string,
@@ -77,30 +86,68 @@ export async function resolveFirstRunModel(
   if (!isInteractive()) return; // CI/deploy: the opener throws the actionable missing-model error
 
   const authPath = resolveAuthPath(workspaceDir, options.authPath);
-  let specs: string[];
+  const models = createPiModels({ authPath });
+  let statuses: Awaited<ReturnType<typeof providerAuthStatuses>>;
   try {
-    specs = await configuredModelSpecs(createPiModels({ authPath }));
+    statuses = await providerAuthStatuses(models);
   } catch (error) {
-    // Enumerating providers/auth threw — a system fault (a corrupt auth store, a throwing provider),
-    // NOT "not logged in". Surface it instead of masking it as the login hint; the opener then still
-    // raises the clear missing-model error.
-    log.warn(`[fastagent] could not list configured models: ${(error as Error).message}`);
+    // Per-provider auth throws are captured as `broken` INSIDE providerAuthStatuses; reaching here
+    // means the enumeration itself failed (getProviders / a provider with no probe-able surface) — a
+    // system fault. Surface it; the opener then still raises the clear missing-model error.
+    log.warn(`[fastagent] could not probe provider auth: ${(error as Error).message}`);
     return;
   }
-  if (specs.length === 0) {
-    log.warn(
-      `[fastagent] no model set and no authenticated provider — run \`fastagent login\`, then \`fastagent dev\``,
-    );
-    return;
-  }
-  const r = await (specs.length > 7 ? autocomplete : select)({
+  const r = await autocomplete({
     message: "Choose a model for this agent",
-    options: specs.map((s) => ({ value: s, label: s })),
+    options: buildModelPickerOptions(listModels(models), statuses),
   });
   if (isCancel(r)) return; // cancelled: let the opener report the missing model
   const chosen = r as string;
+  const provider = providerOf(chosen);
+  const status = statuses.get(provider);
+  if (status && status.state !== "ready" && !status.interactiveLogin) {
+    // No login flow exists for this provider — the model choice is still valid (its validity is
+    // independent of credentials), so KEEP it and name the remedy; the startup auth report warns too.
+    log.warn(`[fastagent] "${provider}" has no interactive login — set its API key env var; invokes fail until then`);
+  } else if (status?.state !== "ready") {
+    // Inline login. Same leak guard as `login`: self-ignore the state root BEFORE a credential
+    // can land in-tree, so the secret is never untracked-but-committable.
+    const stateRoot = resolveStateRoot(workspaceDir);
+    if (isUnderDir(authPath, stateRoot)) await ensureStateRootSelfIgnored(workspaceDir, stateRoot);
+    try {
+      await loginFlow(terminalLoginIO(), { provider, authPath });
+      console.error(`[fastagent] logged in to ${provider} — saved to ${authPath}`);
+    } catch (error) {
+      if (error instanceof LoginCancelled) return; // user backed out — discard the choice, like a picker cancel
+      // A FAILED login keeps the choice (same policy as the env-only branch above: model validity is
+      // independent of credentials) — the pick persists, the startup auth report names the remedy,
+      // and a later `fastagent login` fixes auth without re-picking the model.
+      log.warn(
+        `[fastagent] login for "${provider}" failed: ${(error as Error).message} — model saved; run \`fastagent login\` to fix auth`,
+      );
+    }
+  }
   process.env.FASTAGENT_MODEL = chosen; // this process + any spawned dev worker inherits it
   await persistModelChoice(workspaceDir, configPath, chosen);
+}
+
+/** Login terminal IO via @clack/prompts: a searchable list once long, a hidden prompt for keys. Shared
+ *  by the `login` command and the first-run picker's inline login. */
+export function terminalLoginIO(): LoginIO {
+  return {
+    async select(message, options) {
+      const r = await (options.length > 7 ? autocomplete : select)({ message, options });
+      return isCancel(r) ? undefined : (r as string);
+    },
+    async prompt(message, opts) {
+      const r = opts?.hidden
+        ? await password({ message, signal: opts.signal })
+        : await clackText({ message, signal: opts?.signal });
+      return isCancel(r) ? undefined : (r as string);
+    },
+    note: (message) => clackLog.info(message),
+    openUrl: openExternalUrl,
+  };
 }
 
 /**

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -20,7 +20,7 @@ import {
   rewriteConfigModel,
 } from "../engines/pi/config.ts";
 import { ensureStateRootSelfIgnored, isUnderDir } from "../engines/pi/definition.ts";
-import { LoginCancelled, type LoginIO, loginFlow } from "../engines/pi/login.ts";
+import { LoginCancelled, type LoginIO, type LoginMethod, type LoginResult, loginFlow } from "../engines/pi/login.ts";
 import { createPiModels, probeApiKey, probeAuthSource, providerAuthStatuses } from "../engines/pi/models.ts";
 import { formatAuthReport } from "../cli-auth.ts";
 import { log } from "../log.ts";
@@ -116,12 +116,10 @@ export async function resolveFirstRunModel(
     const stateRoot = resolveStateRoot(workspaceDir);
     if (isUnderDir(authPath, stateRoot)) await ensureStateRootSelfIgnored(workspaceDir, stateRoot);
     try {
-      const result = await loginFlow(terminalLoginIO(), { provider, authPath });
+      // Verified against the CHOSEN model — the exact request the agent is about to make; a rejected
+      // key re-prompts inside the loop, so reaching here means a usable (or at worst unverifiable) key.
+      await loginWithKeyCheck(provider, authPath, chosen);
       console.error(`[fastagent] logged in to ${provider} — saved to ${authPath}`);
-      // Quick-fail an entered key with the CHOSEN model — the exact request the agent is about to
-      // make. A rejection keeps the model (same policy as a failed login below) with the credential
-      // removed; the remedy is already printed.
-      if (result.method === "api_key") await verifyApiKeyLogin(provider, authPath, chosen);
     } catch (error) {
       if (error instanceof LoginCancelled) return; // user backed out — discard the choice, like a picker cancel
       // A FAILED login keeps the choice (same policy as the env-only branch above: model validity is
@@ -137,14 +135,41 @@ export async function resolveFirstRunModel(
 }
 
 /**
+ * Interactive login with the api_key quick-fail probe closed into a LOOP: a definitively rejected key
+ * (HTTP 401) deletes the bad credential and RE-PROMPTS immediately — the user's hands are on the
+ * keyboard NOW; parking the failure for a later `fastagent login` would waste that. The loop exits on
+ * a verified/unverifiable key (kept), an OAuth login (completing the flow already proved the
+ * credential), or cancel (LoginCancelled propagates to the caller's cancel policy). Used by both the
+ * `login` command and the first-run picker's inline login.
+ */
+export async function loginWithKeyCheck(
+  provider: string | undefined,
+  authPath: string,
+  spec?: string,
+): Promise<LoginResult> {
+  const io = terminalLoginIO();
+  let method: LoginMethod | undefined;
+  for (;;) {
+    const result = await loginFlow(io, { provider, authPath, method });
+    if (result.method !== "api_key") return result;
+    const verdict = await verifyApiKeyLogin(result.provider, authPath, spec);
+    if (verdict !== "rejected") return result;
+    // Retry re-asks ONLY the key: the provider/method choices weren't the mistake, the keystrokes were.
+    provider = result.provider;
+    method = "api_key";
+  }
+}
+
+/**
  * Quick-fail check after an api_key login (OAuth needs none — completing the flow already proved the
  * credential): probe the stored key with one minimal request against `spec`, or the provider's first
  * model. Policy over {@link probeApiKey}'s verdict: `rejected` (definitive HTTP 401) DELETES the
- * just-stored credential — a mistyped key must not persist as plausible state — while `unknown`
- * (network, quota, permissions) keeps it and prints the provider's message: the key may still be
- * right, and wrongly destroying a good credential costs more than keeping a doubtful one.
+ * just-stored credential — a mistyped key must not persist as plausible state — and the caller
+ * ({@link loginWithKeyCheck}) re-prompts; `unknown` (network, quota, permissions) keeps it and prints
+ * the provider's message: the key may still be right, and wrongly destroying a good credential costs
+ * more than keeping a doubtful one.
  */
-export async function verifyApiKeyLogin(
+async function verifyApiKeyLogin(
   provider: string,
   authPath: string,
   spec?: string,
@@ -156,13 +181,14 @@ export async function verifyApiKeyLogin(
     return "unknown";
   }
   const label = `${model.provider}/${model.id}`;
+  console.error(`[fastagent] verifying the key with ${label}…`);
   const probe = await probeApiKey(models, model);
   if (probe.state === "ok") {
     console.error(`[fastagent] key verified — ${label} responded`);
   } else if (probe.state === "rejected") {
     await fastagentCredentialStore(authPath).delete(provider);
     console.error(
-      `[fastagent] ${provider} rejected the API key (HTTP 401): ${probe.message} — removed; run \`fastagent login ${provider}\` to retry`,
+      `[fastagent] ${provider} rejected the API key (HTTP 401): ${probe.message} — enter it again (or cancel)`,
     );
   } else {
     console.error(

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -218,9 +218,10 @@ export function terminalLoginIO(): LoginIO {
 }
 
 /**
- * Best-effort persist the picked model so the next run does not prompt. Only rewrites the commented
- * `model:` placeholder the scaffold writes (or an existing `model:` line); anything else (zero-config,
- * a hand-shaped config) is left untouched with a printed hint. Never throws — persistence is a convenience.
+ * Best-effort persist the picked model so the next run does not prompt. Rewrites the commented
+ * `model:` placeholder the scaffold writes / an existing `model:` line, or re-inserts the line into a
+ * scaffold-shaped config (the hand-deleted-to-reset case); anything else (zero-config, a hand-shaped
+ * config) is left untouched with a printed hint. Never throws — persistence is a convenience.
  */
 async function persistModelChoice(workspaceDir: string, configPath: string | undefined, spec: string): Promise<void> {
   const hint = (): void =>

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -14,13 +14,14 @@ import {
   loadConfig,
   providerOf,
   resolveAuthPath,
+  resolveModel,
   resolveModelSpec,
   resolveStateRoot,
   rewriteConfigModel,
 } from "../engines/pi/config.ts";
 import { ensureStateRootSelfIgnored, isUnderDir } from "../engines/pi/definition.ts";
 import { LoginCancelled, type LoginIO, loginFlow } from "../engines/pi/login.ts";
-import { createPiModels, probeAuthSource, providerAuthStatuses } from "../engines/pi/models.ts";
+import { createPiModels, probeApiKey, probeAuthSource, providerAuthStatuses } from "../engines/pi/models.ts";
 import { formatAuthReport } from "../cli-auth.ts";
 import { log } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
@@ -115,8 +116,12 @@ export async function resolveFirstRunModel(
     const stateRoot = resolveStateRoot(workspaceDir);
     if (isUnderDir(authPath, stateRoot)) await ensureStateRootSelfIgnored(workspaceDir, stateRoot);
     try {
-      await loginFlow(terminalLoginIO(), { provider, authPath });
+      const result = await loginFlow(terminalLoginIO(), { provider, authPath });
       console.error(`[fastagent] logged in to ${provider} — saved to ${authPath}`);
+      // Quick-fail an entered key with the CHOSEN model — the exact request the agent is about to
+      // make. A rejection keeps the model (same policy as a failed login below) with the credential
+      // removed; the remedy is already printed.
+      if (result.method === "api_key") await verifyApiKeyLogin(provider, authPath, chosen);
     } catch (error) {
       if (error instanceof LoginCancelled) return; // user backed out — discard the choice, like a picker cancel
       // A FAILED login keeps the choice (same policy as the env-only branch above: model validity is
@@ -129,6 +134,42 @@ export async function resolveFirstRunModel(
   }
   process.env.FASTAGENT_MODEL = chosen; // this process + any spawned dev worker inherits it
   await persistModelChoice(workspaceDir, configPath, chosen);
+}
+
+/**
+ * Quick-fail check after an api_key login (OAuth needs none — completing the flow already proved the
+ * credential): probe the stored key with one minimal request against `spec`, or the provider's first
+ * model. Policy over {@link probeApiKey}'s verdict: `rejected` (definitive HTTP 401) DELETES the
+ * just-stored credential — a mistyped key must not persist as plausible state — while `unknown`
+ * (network, quota, permissions) keeps it and prints the provider's message: the key may still be
+ * right, and wrongly destroying a good credential costs more than keeping a doubtful one.
+ */
+export async function verifyApiKeyLogin(
+  provider: string,
+  authPath: string,
+  spec?: string,
+): Promise<"ok" | "rejected" | "unknown"> {
+  const models = createPiModels({ authPath });
+  const model = spec ? resolveModel(models, spec) : models.getProvider(provider)?.getModels()[0];
+  if (!model) {
+    console.error(`[fastagent] cannot verify the key: provider "${provider}" lists no models — kept as stored`);
+    return "unknown";
+  }
+  const label = `${model.provider}/${model.id}`;
+  const probe = await probeApiKey(models, model);
+  if (probe.state === "ok") {
+    console.error(`[fastagent] key verified — ${label} responded`);
+  } else if (probe.state === "rejected") {
+    await fastagentCredentialStore(authPath).delete(provider);
+    console.error(
+      `[fastagent] ${provider} rejected the API key (HTTP 401): ${probe.message} — removed; run \`fastagent login ${provider}\` to retry`,
+    );
+  } else {
+    console.error(
+      `[fastagent] could not verify the key with ${label}: ${probe.message} — kept; invokes surface the provider's error`,
+    );
+  }
+  return probe.state;
 }
 
 /** Login terminal IO via @clack/prompts: a searchable list once long, a hidden prompt for keys. Shared

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -108,8 +108,16 @@ export async function resolveFirstRunModel(
   const status = statuses.get(provider);
   if (status && status.state !== "ready" && status.login === "none") {
     // No login flow exists for this provider — the model choice is still valid (its validity is
-    // independent of credentials), so KEEP it and name the remedy; the startup auth report warns too.
-    log.warn(`[fastagent] "${provider}" has no interactive login — set its API key env var; invokes fail until then`);
+    // independent of credentials), so KEEP it and name the remedy. The remedy depends on WHY it is
+    // not ready: a BROKEN stored credential still owns the provider (env is consulted only when
+    // nothing is stored — createPiModels), so "set the env var" would not help there.
+    if (status.state === "broken") {
+      log.warn(
+        `[fastagent] stored auth for "${provider}" is unusable: ${status.message} — fix or remove it in ${authPath}; invokes fail until then`,
+      );
+    } else {
+      log.warn(`[fastagent] "${provider}" has no interactive login — set its API key env var; invokes fail until then`);
+    }
   } else if (status?.state !== "ready") {
     // Inline login. Same leak guard as `login`: self-ignore the state root BEFORE a credential
     // can land in-tree, so the secret is never untracked-but-committable.
@@ -146,13 +154,24 @@ export async function loginWithKeyCheck(
   provider: string | undefined,
   authPath: string,
   spec?: string,
+  // Test seams: this loop DESTROYS credential state on `rejected`, so its policy (rejected → delete →
+  // re-ask ONLY the key) is pinned by a test through fake flow/verify; production callers omit both.
+  seams: {
+    flow?: (
+      io: LoginIO,
+      options: { provider?: string; authPath?: string; method?: LoginMethod },
+    ) => Promise<LoginResult>;
+    verify?: (provider: string, authPath: string, spec?: string) => Promise<"ok" | "rejected" | "unknown">;
+  } = {},
 ): Promise<LoginResult> {
+  const flow = seams.flow ?? loginFlow;
+  const verify = seams.verify ?? verifyApiKeyLogin;
   const io = terminalLoginIO();
   let method: LoginMethod | undefined;
   for (;;) {
-    const result = await loginFlow(io, { provider, authPath, method });
+    const result = await flow(io, { provider, authPath, method });
     if (result.method !== "api_key") return result;
-    const verdict = await verifyApiKeyLogin(result.provider, authPath, spec);
+    const verdict = await verify(result.provider, authPath, spec);
     if (verdict !== "rejected") return result;
     // Retry re-asks ONLY the key: the provider/method choices weren't the mistake, the keystrokes were.
     provider = result.provider;

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -245,6 +245,14 @@ export function resolveAgentDir(dir: string, config: FastagentConfig): string {
   return resolve(dir, config.agentDir ?? ".");
 }
 
+/** The provider prefix of a "provider/modelId" spec. A spec without "/" returns whole — downstream
+ *  lookups then miss visibly (an unknown-provider error / a login-required hint), never a mangled id
+ *  (`slice(0, indexOf("/"))` silently drops the last char when "/" is absent). */
+export function providerOf(spec: string): string {
+  const slash = spec.indexOf("/");
+  return slash > 0 ? spec.slice(0, slash) : spec;
+}
+
 /** Resolve "provider/modelId" → a pi Model from `models`, so the harness resolves auth from the same collection. */
 export function resolveModel(models: Models, spec: string): AnyModel {
   const slash = spec.indexOf("/");

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -292,6 +292,12 @@ export function rewriteConfigModel(src: string, spec: string): string | null {
   const active = /^[ \t]*model:[ \t]*["'].*$/m;
   if (commented.test(src)) return src.replace(commented, line);
   if (active.test(src)) return src.replace(active, line);
+  // No model line at all — the natural state after "picked once, then hand-deleted the line to reset".
+  // Re-INSERT at the top of the default-export object while the config still has the scaffold's block
+  // shape; anything else (a wrapper call, a one-liner, a computed export) is hand-shaped — leave it
+  // untouched (the caller prints the set-it-yourself hint).
+  const opener = /^export default[ \t]*\{[ \t]*$/m;
+  if (opener.test(src)) return src.replace(opener, (open) => `${open}\n${line}`);
   return null;
 }
 

--- a/src/engines/pi/login.ts
+++ b/src/engines/pi/login.ts
@@ -47,11 +47,16 @@ export type LoginMethod = "oauth" | "api_key";
  *  the login command) match on this to report neutrally instead of as a login "failure". */
 export class LoginCancelled extends Error {}
 
-/** Whether the provider offers ANY interactive login (OAuth, or an API-key entry flow) — i.e. whether
- *  `loginFlow` can do something for it; otherwise its API key must come from the provider's env var.
- *  The first-run picker uses this to annotate honestly ("login required" vs "set the env var"). */
-export function hasInteractiveLogin(p: Provider): boolean {
-  return Boolean(p.auth.oauth || p.auth.apiKey?.login);
+/** What `loginFlow` can offer a provider interactively: an OAuth flow, an API-key ENTRY prompt, or
+ *  nothing ("none" — the key must come from the provider's env var). */
+export type InteractiveLoginKind = LoginMethod | "none";
+
+/** The provider's {@link InteractiveLoginKind}. OAuth wins when both exist (methodForProvider still
+ *  asks at login time); the first-run picker annotates with this so the hint predicts what picking
+ *  actually does — a browser login ("oauth"), a key prompt ("api_key"), or neither. */
+export function interactiveLoginKind(p: Provider): InteractiveLoginKind {
+  if (p.auth.oauth) return "oauth";
+  return p.auth.apiKey?.login ? "api_key" : "none";
 }
 export interface LoginResult {
   provider: string;

--- a/src/engines/pi/login.ts
+++ b/src/engines/pi/login.ts
@@ -42,6 +42,17 @@ export interface LoginIO {
 }
 
 export type LoginMethod = "oauth" | "api_key";
+
+/** The user backed out of a prompt/menu — a decision, not a failure. Callers (the first-run picker,
+ *  the login command) match on this to report neutrally instead of as a login "failure". */
+export class LoginCancelled extends Error {}
+
+/** Whether the provider offers ANY interactive login (OAuth, or an API-key entry flow) — i.e. whether
+ *  `loginFlow` can do something for it; otherwise its API key must come from the provider's env var.
+ *  The first-run picker uses this to annotate honestly ("login required" vs "set the env var"). */
+export function hasInteractiveLogin(p: Provider): boolean {
+  return Boolean(p.auth.oauth || p.auth.apiKey?.login);
+}
 export interface LoginResult {
   provider: string;
   method: LoginMethod;
@@ -67,12 +78,12 @@ function authCallbacks(io: LoginIO, userSignal: AbortSignal | undefined, doneSig
           p.message,
           p.options.map((o) => ({ value: o.id, label: o.label, hint: o.description })),
         );
-        if (v === undefined) throw new Error("cancelled");
+        if (v === undefined) throw new LoginCancelled("cancelled");
         return v;
       }
       const signal = anySignal(p.signal, userSignal, doneSignal);
       const v = await io.prompt(p.message, { hidden: p.type === "secret", signal });
-      if (v === undefined) throw new Error("cancelled");
+      if (v === undefined) throw new LoginCancelled("cancelled");
       return v;
     },
     notify: (e: AuthEvent): void => {
@@ -100,7 +111,7 @@ async function selectMethod(io: LoginIO): Promise<LoginMethod> {
     { value: "oauth", label: "Use a subscription (OAuth)" },
     { value: "api_key", label: "Use an API key" },
   ]);
-  if (v !== "oauth" && v !== "api_key") throw new Error("no authentication method selected");
+  if (v !== "oauth" && v !== "api_key") throw new LoginCancelled("no authentication method selected");
   return v;
 }
 
@@ -131,7 +142,7 @@ async function selectProvider(
     }),
   );
   const id = await io.select("Select a provider", options);
-  if (!id) throw new Error("no provider selected");
+  if (!id) throw new LoginCancelled("no provider selected");
   return id;
 }
 

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -6,8 +6,8 @@
  */
 import { type Models, type Provider, defaultProviderAuthContext } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
-import { log } from "../../log.ts";
 import { type FastagentAuthOptions, fastagentCredentialStore } from "./auth.ts";
+import { hasInteractiveLogin } from "./login.ts";
 
 export interface CreatePiModelsOptions extends FastagentAuthOptions {
   /** Credentials file path. Defaults to the global `~/.fastagent/auth.json`; the directory opener passes
@@ -33,35 +33,40 @@ export function createPiModels(options: CreatePiModelsOptions = {}): Models {
   return models;
 }
 
+/** Per-provider auth status for the first-run model picker: usable now (with the source label), not
+ *  configured, or configured-but-broken (expired token, refresh failure, corrupt store — kept as DATA
+ *  so the picker can show it instead of silently dropping the provider). Non-ready states carry
+ *  whether `loginFlow` can actually fix them ({@link hasInteractiveLogin}), so the picker's hint
+ *  never promises a login that doesn't exist (env-key-only providers). */
+export type ProviderAuthStatus =
+  | { state: "ready"; source?: string }
+  | { state: "unconfigured"; interactiveLogin: boolean }
+  | { state: "broken"; message: string; interactiveLogin: boolean };
+
 /**
- * The "provider/modelId" specs whose provider currently has USABLE credentials (a stored login or an
- * env key) — the menu for the first-run model picker (`fastagent dev`/`start`/`invoke` with no model
- * set). Auth is provider-scoped, so probe once per provider (any of its models) rather than per model.
- * A provider that resolves no auth (unconfigured) or rejects it (configured-but-expired) is omitted:
- * the picker offers only models that would actually run now; `fastagent login` fixes the rest. Sorted.
- *
- * pi deliberately has no "best/tier" ranking on Model, so this does not auto-pick — it narrows the menu
- * to what the user can use and lets them choose (mirroring pi-coding-agent's select-then-persist).
+ * Probe every provider's auth once (auth is provider-scoped, so any of its models works as the probe)
+ * — the status map behind the first-run model picker (`fastagent dev`/`start`/`invoke` with no model
+ * set). The picker shows the FULL catalog annotated with these statuses, so "what fastagent supports"
+ * and "what is authenticated on this machine" stay distinguishable; a needs-login choice triggers an
+ * inline `loginFlow`. Providers with no models are omitted (nothing to pick).
  */
-export async function configuredModelSpecs(models: Models): Promise<string[]> {
-  const specs: string[] = [];
+export async function providerAuthStatuses(models: Models): Promise<Map<string, ProviderAuthStatus>> {
+  const statuses = new Map<string, ProviderAuthStatus>();
   for (const provider of models.getProviders()) {
     const [probe] = provider.getModels();
     if (!probe) continue;
-    let usable: boolean;
+    const interactiveLogin = hasInteractiveLogin(provider);
     try {
-      usable = (await models.getAuth(probe)) !== undefined;
+      const auth = await models.getAuth(probe);
+      statuses.set(
+        provider.id,
+        auth ? { state: "ready", source: auth.source } : { state: "unconfigured", interactiveLogin },
+      );
     } catch (error) {
-      // Configured-but-broken (expired token, a refresh network failure, a corrupt store): omit it
-      // from the menu, but SAY so — a silent disappearance is the same fail-visibly gap the caller
-      // guards against for the top-level enumeration. `undefined` (plainly unconfigured) stays quiet.
-      log.warn(`[fastagent] skipping provider "${provider.id}": auth check failed (${(error as Error).message})`);
-      continue;
+      statuses.set(provider.id, { state: "broken", message: (error as Error).message, interactiveLogin });
     }
-    if (!usable) continue;
-    for (const model of provider.getModels()) specs.push(`${provider.id}/${model.id}`);
   }
-  return specs.sort();
+  return statuses;
 }
 
 /**

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -101,7 +101,7 @@ export async function probeApiKey(models: Models, model: Model<Api>): Promise<Ke
   try {
     reply = await models.complete(
       model,
-      { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+      { messages: [{ role: "user", content: "ping", timestamp: Date.now() }] },
       {
         maxTokens: 16,
         timeoutMs: 15_000,

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -7,7 +7,7 @@
 import { type Models, type Provider, defaultProviderAuthContext } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { type FastagentAuthOptions, fastagentCredentialStore } from "./auth.ts";
-import { hasInteractiveLogin } from "./login.ts";
+import { type InteractiveLoginKind, interactiveLoginKind } from "./login.ts";
 
 export interface CreatePiModelsOptions extends FastagentAuthOptions {
   /** Credentials file path. Defaults to the global `~/.fastagent/auth.json`; the directory opener passes
@@ -35,13 +35,13 @@ export function createPiModels(options: CreatePiModelsOptions = {}): Models {
 
 /** Per-provider auth status for the first-run model picker: usable now (with the source label), not
  *  configured, or configured-but-broken (expired token, refresh failure, corrupt store — kept as DATA
- *  so the picker can show it instead of silently dropping the provider). Non-ready states carry
- *  whether `loginFlow` can actually fix them ({@link hasInteractiveLogin}), so the picker's hint
- *  never promises a login that doesn't exist (env-key-only providers). */
+ *  so the picker can show it instead of silently dropping the provider). Non-ready states carry the
+ *  provider's {@link InteractiveLoginKind}, so the picker's hint predicts what picking does — an
+ *  OAuth login, an API-key prompt, or (env-key-only providers) neither. */
 export type ProviderAuthStatus =
   | { state: "ready"; source?: string }
-  | { state: "unconfigured"; interactiveLogin: boolean }
-  | { state: "broken"; message: string; interactiveLogin: boolean };
+  | { state: "unconfigured"; login: InteractiveLoginKind }
+  | { state: "broken"; message: string; login: InteractiveLoginKind };
 
 /**
  * Probe every provider's auth once (auth is provider-scoped, so any of its models works as the probe)
@@ -55,15 +55,12 @@ export async function providerAuthStatuses(models: Models): Promise<Map<string, 
   for (const provider of models.getProviders()) {
     const [probe] = provider.getModels();
     if (!probe) continue;
-    const interactiveLogin = hasInteractiveLogin(provider);
+    const login = interactiveLoginKind(provider);
     try {
       const auth = await models.getAuth(probe);
-      statuses.set(
-        provider.id,
-        auth ? { state: "ready", source: auth.source } : { state: "unconfigured", interactiveLogin },
-      );
+      statuses.set(provider.id, auth ? { state: "ready", source: auth.source } : { state: "unconfigured", login });
     } catch (error) {
-      statuses.set(provider.id, { state: "broken", message: (error as Error).message, interactiveLogin });
+      statuses.set(provider.id, { state: "broken", message: (error as Error).message, login });
     }
   }
   return statuses;

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -4,7 +4,7 @@
  * it into the harness alongside the selected `model`; the two must come from the same collection so
  * the model's provider auth is in scope.
  */
-import { type Models, type Provider, defaultProviderAuthContext } from "@earendil-works/pi-ai";
+import { type Api, type Model, type Models, type Provider, defaultProviderAuthContext } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { type FastagentAuthOptions, fastagentCredentialStore } from "./auth.ts";
 import { type InteractiveLoginKind, interactiveLoginKind } from "./login.ts";
@@ -79,4 +79,44 @@ export async function probeAuthSource(models: Models, spec: string): Promise<str
   if (!model) return undefined;
   const auth = await models.getAuth(model).catch(() => undefined);
   return auth?.source;
+}
+
+/** Verdict of {@link probeApiKey}: `rejected` is DEFINITIVE (the provider answered HTTP 401 — the key
+ *  is wrong); everything else non-ok is `unknown` — a 403 can be a VALID key without model permission,
+ *  a 429/5xx/network failure says nothing about the key — so callers must only destroy state on
+ *  `rejected`. */
+export type KeyProbe = { state: "ok" } | { state: "rejected" | "unknown"; message: string };
+
+/**
+ * Quick-fail probe for a just-stored API key: one minimal real request through the standard auth
+ * resolution path (the same path invokes take), so a mistyped key surfaces at login time, not at the
+ * first turn. `complete` reports provider errors as `stopReason: "error"` rather than throwing; the
+ * HTTP status arrives via `onResponse` — when a provider path never calls it (SDK transports), fall
+ * back to a conservative "401" match in the error text. Short timeout, no retries: feedback speed
+ * over transient-failure tolerance (a transient lands on `unknown`, which keeps the key).
+ */
+export async function probeApiKey(models: Models, model: Model<Api>): Promise<KeyProbe> {
+  let status: number | undefined;
+  let reply: Awaited<ReturnType<Models["complete"]>>;
+  try {
+    reply = await models.complete(
+      model,
+      { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+      {
+        maxTokens: 16,
+        timeoutMs: 15_000,
+        maxRetries: 0,
+        onResponse: (r) => {
+          status = r.status;
+        },
+      },
+    );
+  } catch (error) {
+    // Thrown = before/around the request (auth resolution, transport setup) — not a provider verdict.
+    return { state: "unknown", message: (error as Error).message };
+  }
+  if (reply.stopReason !== "error" && reply.stopReason !== "aborted") return { state: "ok" };
+  const message = reply.errorMessage ?? `stopReason "${reply.stopReason}"`;
+  const unauthorized = status === 401 || (status === undefined && /(^|\D)401(\D|$)/.test(message));
+  return { state: unauthorized ? "rejected" : "unknown", message };
 }

--- a/src/scaffold/templates/fastagent.config.mjs
+++ b/src/scaffold/templates/fastagent.config.mjs
@@ -2,9 +2,9 @@
 // Your agent's identity lives in persona.md; its capabilities in skills/ + tools/ — never here.
 // An AGENTS.md at the workspace root (yours or the host repo's) is read as project context.
 // Model precedence: `--model` flag > FASTAGENT_MODEL env > this default.
-// No model is preset: `fastagent dev` prompts you to pick one from the providers you're logged into
-// (run `fastagent login` first) and writes your choice below. Or set it by hand to a "provider/modelId"
-// you have access to (`fastagent models` lists them).
+// No model is preset: `fastagent dev` shows the full model catalog (models you already have
+// credentials for come first; picking one that needs auth logs you in inline) and writes your choice
+// below. Or set it by hand to a "provider/modelId" (`fastagent models` lists them).
 export default {
   // model: "openai-codex/gpt-5.5",
   // thinkingLevel: "high", // reasoning effort (off|minimal|low|medium|high|xhigh|max); default "medium" (pi TUI parity)

--- a/test/cli-models.test.ts
+++ b/test/cli-models.test.ts
@@ -14,11 +14,20 @@ describe("cli-models: formatModelsCommand (`fastagent models [search]` stdout/st
     const statuses = new Map<string, ProviderAuthStatus>([
       ["openai", { state: "ready", source: "OPENAI_API_KEY" }],
       ["oauthy", { state: "ready" }], // no source label → plain "ready"
-      ["anthropic", { state: "unconfigured", interactiveLogin: true }],
-      ["envonly", { state: "unconfigured", interactiveLogin: false }], // no login flow → don't promise one
-      ["codex", { state: "broken", message: "expired", interactiveLogin: true }],
+      ["anthropic", { state: "unconfigured", login: "oauth" }], // OAuth flow → "login required"
+      ["keyentry", { state: "unconfigured", login: "api_key" }], // interactive key prompt → "API key required"
+      ["envonly", { state: "unconfigured", login: "none" }], // no flow at all → point at the env var
+      ["codex", { state: "broken", message: "expired", login: "oauth" }],
     ]);
-    const specs = ["anthropic/claude", "codex/gpt-5.5", "envonly/m1", "oauthy/m1", "openai/gpt-5", "unknown/m2"];
+    const specs = [
+      "anthropic/claude",
+      "codex/gpt-5.5",
+      "envonly/m1",
+      "keyentry/m1",
+      "oauthy/m1",
+      "openai/gpt-5",
+      "unknown/m2",
+    ];
     expect(buildModelPickerOptions(specs, statuses)).toEqual([
       // ready group leads, input order preserved within each group
       { value: "oauthy/m1", label: "oauthy/m1", hint: "ready" },
@@ -26,6 +35,7 @@ describe("cli-models: formatModelsCommand (`fastagent models [search]` stdout/st
       { value: "anthropic/claude", label: "anthropic/claude", hint: "login required" },
       { value: "codex/gpt-5.5", label: "codex/gpt-5.5", hint: "login required — stored auth unusable: expired" },
       { value: "envonly/m1", label: "envonly/m1", hint: "API key required — set the provider's env var" },
+      { value: "keyentry/m1", label: "keyentry/m1", hint: "API key required" },
       { value: "unknown/m2", label: "unknown/m2", hint: "auth required" }, // absent from the map → neutral, no login claim
     ]);
   });

--- a/test/cli-models.test.ts
+++ b/test/cli-models.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatModelsCommand } from "../src/cli-models.ts";
+import { buildModelPickerOptions, formatModelsCommand } from "../src/cli-models.ts";
+import type { ProviderAuthStatus } from "../src/engines/pi/models.ts";
 
 describe("cli-models: formatModelsCommand (`fastagent models [search]` stdout/stderr)", () => {
   it("no search → all lines; a substring filters; a miss → empty lines + an stderr diagnostic", () => {
@@ -7,6 +8,26 @@ describe("cli-models: formatModelsCommand (`fastagent models [search]` stdout/st
     expect(formatModelsCommand(specs)).toEqual({ lines: specs }); // no search → all, no error
     expect(formatModelsCommand(specs, "OpenAI")).toEqual({ lines: ["openai/gpt-5", "openai/o3"] }); // case-insensitive
     expect(formatModelsCommand(specs, "zzznope")).toEqual({ lines: [], error: 'no model matches "zzznope"' }); // miss
+  });
+
+  it("buildModelPickerOptions: ready first (annotated with the source), remedy-annotated after, broken visible", () => {
+    const statuses = new Map<string, ProviderAuthStatus>([
+      ["openai", { state: "ready", source: "OPENAI_API_KEY" }],
+      ["oauthy", { state: "ready" }], // no source label → plain "ready"
+      ["anthropic", { state: "unconfigured", interactiveLogin: true }],
+      ["envonly", { state: "unconfigured", interactiveLogin: false }], // no login flow → don't promise one
+      ["codex", { state: "broken", message: "expired", interactiveLogin: true }],
+    ]);
+    const specs = ["anthropic/claude", "codex/gpt-5.5", "envonly/m1", "oauthy/m1", "openai/gpt-5", "unknown/m2"];
+    expect(buildModelPickerOptions(specs, statuses)).toEqual([
+      // ready group leads, input order preserved within each group
+      { value: "oauthy/m1", label: "oauthy/m1", hint: "ready" },
+      { value: "openai/gpt-5", label: "openai/gpt-5", hint: "ready — OPENAI_API_KEY" },
+      { value: "anthropic/claude", label: "anthropic/claude", hint: "login required" },
+      { value: "codex/gpt-5.5", label: "codex/gpt-5.5", hint: "login required — stored auth unusable: expired" },
+      { value: "envonly/m1", label: "envonly/m1", hint: "API key required — set the provider's env var" },
+      { value: "unknown/m2", label: "unknown/m2", hint: "auth required" }, // absent from the map → neutral, no login claim
+    ]);
   });
 
   it("ranks a provider-name match above an incidental model-id match (anthropic/* before bedrock/anthropic.*)", () => {

--- a/test/cli-models.test.ts
+++ b/test/cli-models.test.ts
@@ -18,10 +18,12 @@ describe("cli-models: formatModelsCommand (`fastagent models [search]` stdout/st
       ["keyentry", { state: "unconfigured", login: "api_key" }], // interactive key prompt → "API key required"
       ["envonly", { state: "unconfigured", login: "none" }], // no flow at all → point at the env var
       ["codex", { state: "broken", message: "expired", login: "oauth" }],
+      ["deadenv", { state: "broken", message: "corrupt", login: "none" }], // broken + no flow → fix the STORE, not the env
     ]);
     const specs = [
       "anthropic/claude",
       "codex/gpt-5.5",
+      "deadenv/m3",
       "envonly/m1",
       "keyentry/m1",
       "oauthy/m1",
@@ -34,6 +36,13 @@ describe("cli-models: formatModelsCommand (`fastagent models [search]` stdout/st
       { value: "openai/gpt-5", label: "openai/gpt-5", hint: "ready — OPENAI_API_KEY" },
       { value: "anthropic/claude", label: "anthropic/claude", hint: "login required" },
       { value: "codex/gpt-5.5", label: "codex/gpt-5.5", hint: "login required — stored auth unusable: expired" },
+      {
+        value: "deadenv/m3",
+        label: "deadenv/m3",
+        // NOT the env-var wording: a broken stored credential owns the provider (env is only consulted
+        // when nothing is stored), so the remedy must point at the store.
+        hint: "stored auth unusable: corrupt — fix or remove the stored credential",
+      },
       { value: "envonly/m1", label: "envonly/m1", hint: "API key required — set the provider's env var" },
       { value: "keyentry/m1", label: "keyentry/m1", hint: "API key required" },
       { value: "unknown/m2", label: "unknown/m2", hint: "auth required" }, // absent from the map → neutral, no login claim

--- a/test/cli-shared.test.ts
+++ b/test/cli-shared.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { loginWithKeyCheck } from "../src/cli/shared.ts";
+import { LoginCancelled, type LoginMethod } from "../src/engines/pi/login.ts";
+
+/** Record every flow call's (provider, method) and pop canned results/verdicts in order. */
+function fakes(
+  results: Array<{ provider: string; method: LoginMethod }>,
+  verdicts: Array<"ok" | "rejected" | "unknown">,
+) {
+  const flowCalls: Array<{ provider?: string; method?: LoginMethod }> = [];
+  const verifyCalls: string[] = [];
+  return {
+    flowCalls,
+    verifyCalls,
+    flow: async (_io: unknown, options: { provider?: string; method?: LoginMethod }) => {
+      flowCalls.push({ provider: options.provider, method: options.method });
+      return results[flowCalls.length - 1] as { provider: string; method: LoginMethod };
+    },
+    verify: async (provider: string) => {
+      verifyCalls.push(provider);
+      return verdicts[verifyCalls.length - 1] as "ok" | "rejected" | "unknown";
+    },
+  };
+}
+
+describe("loginWithKeyCheck (the rejected-key retry loop)", () => {
+  it("rejected → re-asks ONLY the key (provider+method pinned), exits on ok", async () => {
+    const f = fakes(
+      [
+        { provider: "deepseek", method: "api_key" },
+        { provider: "deepseek", method: "api_key" },
+      ],
+      ["rejected", "ok"],
+    );
+    const result = await loginWithKeyCheck(undefined, "/tmp/auth.json", "deepseek/chat", f);
+    expect(result).toEqual({ provider: "deepseek", method: "api_key" });
+    // First pass: nothing pinned (user picks provider/method); retry pins BOTH so only the key is re-asked.
+    expect(f.flowCalls).toEqual([
+      { provider: undefined, method: undefined },
+      { provider: "deepseek", method: "api_key" },
+    ]);
+    expect(f.verifyCalls).toEqual(["deepseek", "deepseek"]);
+  });
+
+  it("unknown keeps the key and exits (no retry); OAuth skips verification entirely", async () => {
+    const unknown = fakes([{ provider: "p", method: "api_key" }], ["unknown"]);
+    await loginWithKeyCheck("p", "/tmp/auth.json", undefined, unknown);
+    expect(unknown.flowCalls).toHaveLength(1); // no re-prompt on unverifiable
+
+    const oauth = fakes([{ provider: "openai-codex", method: "oauth" }], []);
+    await loginWithKeyCheck(undefined, "/tmp/auth.json", undefined, oauth);
+    expect(oauth.verifyCalls).toEqual([]); // completing the flow already proved the credential
+  });
+
+  it("cancel inside the retry propagates (caller's cancel policy decides)", async () => {
+    const f = fakes([{ provider: "p", method: "api_key" }], ["rejected"]);
+    const flow = async (io: unknown, options: { provider?: string; method?: LoginMethod }) => {
+      if (options.method === "api_key") throw new LoginCancelled("cancelled"); // the re-prompt round
+      return f.flow(io, options);
+    };
+    await expect(
+      loginWithKeyCheck(undefined, "/tmp/auth.json", undefined, { flow, verify: f.verify }),
+    ).rejects.toBeInstanceOf(LoginCancelled);
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -404,7 +404,14 @@ describe("rewriteConfigModel (first-run picker write-back)", async () => {
     expect(rewriteConfigModel(src, "new/two")).toBe('export default {\n  model: "new/two",\n};\n');
   });
 
-  it("returns null when there is no model line to touch (hand-shaped / zero-config)", () => {
-    expect(rewriteConfigModel("export default { http: { port: 8787 } };\n", "x/y")).toBeNull();
+  it("re-inserts the model line into a scaffold-shaped config whose line was hand-deleted", () => {
+    // Deleting the model line is the natural "reset" gesture — the next pick must persist again.
+    const src = "export default {\n  http: { port: 8787 },\n};\n";
+    expect(rewriteConfigModel(src, "x/y")).toBe('export default {\n  model: "x/y",\n  http: { port: 8787 },\n};\n');
+  });
+
+  it("returns null for a hand-shaped config (no model line, no scaffold block shape)", () => {
+    expect(rewriteConfigModel("export default { http: { port: 8787 } };\n", "x/y")).toBeNull(); // one-liner
+    expect(rewriteConfigModel("export default defineConfig({\n});\n", "x/y")).toBeNull(); // wrapper call
   });
 });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from "node:net";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, type FauxResponseStep } from "@earendil-works/pi-ai";
 import { createInvokeHandler, nodeListener, inMemorySessionStore, type Agent, type AgentEvent } from "../src/index.ts";
+import { INVOKE_EXAMPLE_BODY } from "../src/channels/http.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
@@ -50,6 +51,15 @@ describe("invoke handler (Fetch/SSE)", () => {
       .join("");
     expect(text).toBe("hello over http");
     expect(events.at(-1)).toEqual({ type: "completed" });
+  });
+
+  it("INVOKE_EXAMPLE_BODY (the CLI's \"try it\" hint) satisfies the handler's shape check", async () => {
+    // The constant's contract: it lives next to the shape check and must keep passing it — this test
+    // is what actually prevents the curl hint from drifting when the protocol changes.
+    const handler = createInvokeHandler(makeAgent([fauxAssistantMessage("ok")]));
+    const res = await handler(new Request("http://app/invoke", { method: "POST", body: INVOKE_EXAMPLE_BODY }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
   });
 
   it("same-session concurrency: one stream completes, the other receives failed 'session busy'", async () => {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,48 +1,50 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { Models } from "@earendil-works/pi-ai";
-import { log } from "../src/log.ts";
-import { configuredModelSpecs } from "../src/engines/pi/models.ts";
+import { providerAuthStatuses } from "../src/engines/pi/models.ts";
 
-type FakeProvider = { id: string; models: string[]; auth: "ok" | "none" | "reject" };
+type FakeProvider = {
+  id: string;
+  models: string[];
+  auth: "ok" | "none" | "reject";
+  oauth?: boolean;
+  apiKeyLogin?: boolean;
+};
 
-/** A minimal Models stub exposing only what configuredModelSpecs touches: getProviders + getAuth. */
+/** A minimal Models stub exposing only what providerAuthStatuses touches: getProviders + getAuth. */
 function fakeModels(providers: FakeProvider[]): Models {
   return {
     getProviders: () =>
       providers.map((p) => ({
         id: p.id,
+        // hasInteractiveLogin probes BOTH disjuncts: OAuth, and an interactive api-key entry flow.
+        auth: { oauth: p.oauth ? {} : undefined, apiKey: p.apiKeyLogin ? { login: () => {} } : undefined },
         getModels: () => p.models.map((id) => ({ id, provider: p.id })),
       })),
     getAuth: async (model: { provider: string }) => {
       const p = providers.find((x) => x.id === model.provider);
       if (!p || p.auth === "reject") throw new Error("expired");
-      return p.auth === "ok" ? { source: "test" } : undefined;
+      return p.auth === "ok" ? { source: "TEST_KEY" } : undefined;
     },
   } as unknown as Models;
 }
 
-describe("configuredModelSpecs", () => {
-  it("lists only models of providers with usable auth, sorted", async () => {
-    const models = fakeModels([
-      { id: "anthropic", models: ["claude-b", "claude-a"], auth: "ok" },
-      { id: "openai", models: ["gpt-x"], auth: "none" }, // unconfigured → omitted
-    ]);
-    expect(await configuredModelSpecs(models)).toEqual(["anthropic/claude-a", "anthropic/claude-b"]);
-  });
-
-  it("omits a provider whose auth rejects (configured-but-expired) and warns — not a silent drop", async () => {
-    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
-    const models = fakeModels([
-      { id: "openai", models: ["gpt-x"], auth: "reject" }, // expired → not offered, but visible
-      { id: "empty", models: [], auth: "ok" }, // no models → skipped
-      { id: "codex", models: ["gpt-5.5"], auth: "ok" },
-    ]);
-    expect(await configuredModelSpecs(models)).toEqual(["codex/gpt-5.5"]);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('provider "openai": auth check failed'));
-    warn.mockRestore();
-  });
-
-  it("returns empty when nothing is configured", async () => {
-    expect(await configuredModelSpecs(fakeModels([{ id: "openai", models: ["gpt-x"], auth: "none" }]))).toEqual([]);
+describe("providerAuthStatuses", () => {
+  it("maps usable → ready (with source), unconfigured, and rejecting → broken (with the message)", async () => {
+    const statuses = await providerAuthStatuses(
+      fakeModels([
+        { id: "anthropic", models: ["claude-a"], auth: "ok" },
+        { id: "openai", models: ["gpt-x"], auth: "none", oauth: true },
+        { id: "envonly", models: ["m1"], auth: "none" }, // no interactive login → the picker says "set the env var"
+        { id: "keylogin", models: ["m2"], auth: "none", apiKeyLogin: true }, // api-key ENTRY flow counts as login
+        { id: "codex", models: ["gpt-5.5"], auth: "reject", oauth: true }, // configured-but-broken → data, not a silent drop
+        { id: "empty", models: [], auth: "ok" }, // no models → nothing to pick → omitted
+      ]),
+    );
+    expect(statuses.get("anthropic")).toEqual({ state: "ready", source: "TEST_KEY" });
+    expect(statuses.get("openai")).toEqual({ state: "unconfigured", interactiveLogin: true });
+    expect(statuses.get("envonly")).toEqual({ state: "unconfigured", interactiveLogin: false });
+    expect(statuses.get("keylogin")).toEqual({ state: "unconfigured", interactiveLogin: true });
+    expect(statuses.get("codex")).toEqual({ state: "broken", message: "expired", interactiveLogin: true });
+    expect(statuses.has("empty")).toBe(false);
   });
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -16,7 +16,7 @@ function fakeModels(providers: FakeProvider[]): Models {
     getProviders: () =>
       providers.map((p) => ({
         id: p.id,
-        // hasInteractiveLogin probes BOTH disjuncts: OAuth, and an interactive api-key entry flow.
+        // interactiveLoginKind probes both surfaces: OAuth, and an interactive api-key entry flow.
         auth: { oauth: p.oauth ? {} : undefined, apiKey: p.apiKeyLogin ? { login: () => {} } : undefined },
         getModels: () => p.models.map((id) => ({ id, provider: p.id })),
       })),
@@ -35,16 +35,18 @@ describe("providerAuthStatuses", () => {
         { id: "anthropic", models: ["claude-a"], auth: "ok" },
         { id: "openai", models: ["gpt-x"], auth: "none", oauth: true },
         { id: "envonly", models: ["m1"], auth: "none" }, // no interactive login → the picker says "set the env var"
-        { id: "keylogin", models: ["m2"], auth: "none", apiKeyLogin: true }, // api-key ENTRY flow counts as login
+        { id: "keylogin", models: ["m2"], auth: "none", apiKeyLogin: true }, // key ENTRY flow → "api_key"
+        { id: "both", models: ["m3"], auth: "none", oauth: true, apiKeyLogin: true }, // OAuth wins when both exist
         { id: "codex", models: ["gpt-5.5"], auth: "reject", oauth: true }, // configured-but-broken → data, not a silent drop
         { id: "empty", models: [], auth: "ok" }, // no models → nothing to pick → omitted
       ]),
     );
     expect(statuses.get("anthropic")).toEqual({ state: "ready", source: "TEST_KEY" });
-    expect(statuses.get("openai")).toEqual({ state: "unconfigured", interactiveLogin: true });
-    expect(statuses.get("envonly")).toEqual({ state: "unconfigured", interactiveLogin: false });
-    expect(statuses.get("keylogin")).toEqual({ state: "unconfigured", interactiveLogin: true });
-    expect(statuses.get("codex")).toEqual({ state: "broken", message: "expired", interactiveLogin: true });
+    expect(statuses.get("openai")).toEqual({ state: "unconfigured", login: "oauth" });
+    expect(statuses.get("envonly")).toEqual({ state: "unconfigured", login: "none" });
+    expect(statuses.get("keylogin")).toEqual({ state: "unconfigured", login: "api_key" });
+    expect(statuses.get("both")).toEqual({ state: "unconfigured", login: "oauth" });
+    expect(statuses.get("codex")).toEqual({ state: "broken", message: "expired", login: "oauth" });
     expect(statuses.has("empty")).toBe(false);
   });
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { Models } from "@earendil-works/pi-ai";
-import { providerAuthStatuses } from "../src/engines/pi/models.ts";
+import type { Api, Model, Models } from "@earendil-works/pi-ai";
+import { probeApiKey, providerAuthStatuses } from "../src/engines/pi/models.ts";
 
 type FakeProvider = {
   id: string;
@@ -48,5 +48,49 @@ describe("providerAuthStatuses", () => {
     expect(statuses.get("both")).toEqual({ state: "unconfigured", login: "oauth" });
     expect(statuses.get("codex")).toEqual({ state: "broken", message: "expired", login: "oauth" });
     expect(statuses.has("empty")).toBe(false);
+  });
+});
+
+describe("probeApiKey (the post-login quick-fail check)", () => {
+  const model = { id: "m", provider: "p" } as unknown as Model<Api>;
+  /** A Models stub exposing only `complete`; `status` drives the onResponse callback. */
+  const stub = (reply: { stopReason: string; errorMessage?: string } | "throw", status?: number): Models =>
+    ({
+      complete: async (_m: unknown, _ctx: unknown, opts?: { onResponse?: (r: { status: number }) => void }) => {
+        if (status !== undefined) opts?.onResponse?.({ status });
+        if (reply === "throw") throw new Error("store unreadable");
+        return reply;
+      },
+    }) as unknown as Models;
+
+  it("a normal reply → ok (stop or length both count)", async () => {
+    expect(await probeApiKey(stub({ stopReason: "length" }, 200), model)).toEqual({ state: "ok" });
+  });
+
+  it("HTTP 401 → rejected — the only DEFINITIVE verdict (callers may delete state on it)", async () => {
+    expect(await probeApiKey(stub({ stopReason: "error", errorMessage: "invalid x-api-key" }, 401), model)).toEqual({
+      state: "rejected",
+      message: "invalid x-api-key",
+    });
+  });
+
+  it("no captured status falls back to a conservative 401 match in the error text", async () => {
+    expect(await probeApiKey(stub({ stopReason: "error", errorMessage: "401 Unauthorized" }), model)).toEqual({
+      state: "rejected",
+      message: "401 Unauthorized",
+    });
+    // "4011"/"1401" must NOT match — the fallback is a word-ish boundary, not a substring
+    expect(await probeApiKey(stub({ stopReason: "error", errorMessage: "code 14011" }), model)).toEqual({
+      state: "unknown",
+      message: "code 14011",
+    });
+  });
+
+  it("403 / network-ish failures → unknown (a valid key can 403; transport says nothing) — kept", async () => {
+    expect(await probeApiKey(stub({ stopReason: "error", errorMessage: "forbidden" }, 403), model)).toEqual({
+      state: "unknown",
+      message: "forbidden",
+    });
+    expect(await probeApiKey(stub("throw"), model)).toEqual({ state: "unknown", message: "store unreadable" });
   });
 });


### PR DESCRIPTION
## What

`fastagent dev` / `start` / `invoke` with no model set used to show only models of providers that already had credentials — on a fresh machine that meant a warn + exit + "run `fastagent login`, then come back". The first-run funnel is now one command with no dead ends:

- **Full catalog, annotated.** The picker lists every registered model; ready providers lead, each annotated with its credential source (`ready — OPENAI_API_KEY`), the rest with their remedy (`login required`, or `API key required — set the provider's env var` when the provider has no interactive login flow). A broken stored credential is annotated, not silently dropped.
- **Inline login.** Picking a model whose provider needs auth runs `loginFlow` right there (with `runLogin`'s state-root leak guard), then continues to serving. Cancel is a decision, not a failure (`LoginCancelled`) — silent fall-through to the existing `missing model` error; `fastagent login` cancel now reports "login cancelled" instead of a failure.
- **Env-key-only providers keep the choice.** Model validity is independent of credentials: the pick is persisted, the remedy is named, the startup auth report warns until the env var is set.
- **Proof of life.** Serving ends with a copy-paste `try it:` curl; its body is `INVOKE_EXAMPLE_BODY`, exported by the http channel next to the shape check and pinned by a test so the hint cannot drift from the protocol.

## Deleted

- `configuredModelSpecs` (the filtered-menu primitive; sole caller was the picker) → replaced by `providerAuthStatuses` (3-state data: `ready`/`unconfigured`/`broken`, plus `interactiveLogin`).
- The `no authenticated provider — run fastagent login` dead-end branch.
- The picker's `select`-vs-`autocomplete` size switch: **the picker is now always `autocomplete`** (the full catalog is always large) — small-list users see the filterable UI too; deliberate.

## Also

- `providerOf(spec)` centralized in `config.ts` (spec-domain home); `reportAuth`'s inline `slice(0, indexOf("/"))` (mangles a spec without `/`) routed through it.
- Docs updated: cli.md, quickstart.md, configuration.md, troubleshooting.md.
- Named trade-off: the post-pick branch policy (keep-and-warn vs inline-login vs cancel) stays in `cli.ts` untested — it is three lines of side-effect sequencing around `loginFlow`; extracting a pure action-enum function was judged ceremony. The pure surfaces (`providerAuthStatuses`, `buildModelPickerOptions`, `INVOKE_EXAMPLE_BODY`) are unit-tested.

## Verification

`npm run lint && npm run typecheck && npm test` green (753 tests); `rv.sh local` run three times, all findings fixed or explicitly declined above.

## Rebuild (2026-07-17)

Rebuilt on top of the commander CLI restructure (#243) + pi 0.80.10 compat (#249): the cli.ts changes now live in `src/cli/shared.ts` (picker + `reportAuth` + `terminalLoginIO`, now shared with the login command), `src/cli/serve.ts` (`routesFor` provenance + try-it hint), and `src/cli/commands/login.ts` (`LoginCancelled` handling). Two policy refinements from the post-rebuild `rv` pass:

- A **failed** inline login now keeps the model choice (same policy as the env-key-only branch: model validity is independent of credentials) — the pick persists, the startup auth report names the remedy, and a later `fastagent login` fixes auth without re-picking. Cancel still discards, deliberately.
- An unknown-provider spec (unreachable when specs/statuses share one `Models`) hints neutral `auth required` instead of promising a login flow.
