### PR TITLE
chore: release 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, in Telegram, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Bump the package version to 0.14.0.

Minor, not patch: since v0.13.0 main carries four features and one breaking CLI change alongside the urgent pi-compatibility fix — the published 0.13.0 is broken on fresh installs (`^0.80.7` resolves to pi 0.80.10, which removed `FileAuthStorageBackend`), so this release is what makes `npm i @fastagent-sh/fastagent` work again.

## Changes since v0.13.0

**Fix (the reason this release is urgent)**
- #249 — restore compatibility with pi 0.80.10 by owning the auth file lock (fresh installs of 0.13.0 fail at import time)
- #234 — restore the session's active-tool set when reopening (stateless invoke)

**Features**
- #237 — `thinkingLevel` config: the serving-side counterpart of pi's thinking selector
- #241 — deferred tools: dynamic tool loading on the serving path
- #230 — `deploy docker`: local Docker Compose target
- #242 — Feishu managed threaded conversations

**Breaking (CLI)**
- #243 — CLI rebuilt on commander following clig.dev:
  - flags belong to their command and come **after** it (`fastagent info --json`, not `fastagent --json info`)
  - usage errors now exit 2 consistently (0 success, 1 runtime, 2 usage)
  - per-command help (`-h`/`--help`/`help <cmd>`), examples, did-you-mean suggestions, `--no-input` on `dev`/`start`/`invoke`/`fire`/`login`
  - `fastagent --help` ~0.8s → ~0.08s (lazy per-command imports)

**Chores**
- #244 #245 #251 — dependency/workflow bumps; dependabot now groups github-actions bumps

## Release flow

After merge: tag `v0.14.0` on the squash commit, create the GitHub Release (notes above), and `publish.yml` publishes to npm via OIDC.