### PR TITLE
feat: extend the first-run funnel to chat and deploy

### DIFF
--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -40,7 +40,7 @@ All three paths continue with the same steps below: inspect, authenticate, initi
 
 You are non-interactive, so do not rely on prompts you cannot answer.
 
-- A model must be explicit. Without one, `dev`, `start`, and `invoke` open an interactive picker and fail in a non-TTY with `missing model`.
+- A model must be explicit. Without one, `dev`, `start`, `invoke`, `fire`, and `chat` open a picker on a TTY and fail in a non-TTY with `missing model`. `deploy` also opens the picker on a TTY, but non-interactively it does NOT say `missing model`: plan mode warns, and `--run` stops at the model-travel gate ("no model in fastagent.config.ts").
 - `fastagent login` is also interactive. Ask the user to run it in a terminal inside the workspace; it writes project-level `.fastagent/auth.json`, and credentials written in another directory are not visible here.
 - Alternatively, ask the user for a provider API key and put it in `.env` only with permission.
 - List available specifications with `fastagent models`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -115,8 +115,8 @@ live next turn, no restart); a supervisor restarts the worker on edits to the co
 With no model set and a terminal attached, `dev` first shows the full model catalog — models whose
 provider already has credentials are listed first and annotated with the source (e.g. `ready —
 OPENAI_API_KEY`); picking one that needs auth runs the login flow inline — then writes the choice
-back to the config (same for `start` / `invoke` / `fire` / `deploy`; `chat` prompts too, without the
-credential dimension — see its section). Pass `--model` or set `FASTAGENT_MODEL` to skip the prompt.
+back to the config (same for `start` / `invoke` / `fire` / `chat` / `deploy`). Pass `--model` or set
+`FASTAGENT_MODEL` to skip the prompt.
 
 Options:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -291,7 +291,7 @@ Recurring per-command options (same meaning everywhere they appear):
 
 | Option | Commands | Meaning |
 |---|---|---|
-| `--no-input` | `dev`, `start`, `invoke`, `fire`, `login`, `deploy` | Never prompt; missing information becomes an error with the flag to pass. |
+| `--no-input` | `dev`, `start`, `invoke`, `fire`, `login`, `deploy` | Never prompt; missing information becomes an error with the flag to pass (`deploy` plan mode only warns on a missing model — `--run` gates). |
 | `--model <provider/modelId>` | assembly commands | Model override (`--model > FASTAGENT_MODEL > config`). |
 | `--auth-path <file>` | assembly commands, `login` | Credentials file override. |
 | `--json` | `info`, `schedule history`, `schedule list` | Machine-readable output. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -115,8 +115,8 @@ live next turn, no restart); a supervisor restarts the worker on edits to the co
 With no model set and a terminal attached, `dev` first shows the full model catalog — models whose
 provider already has credentials are listed first and annotated with the source (e.g. `ready —
 OPENAI_API_KEY`); picking one that needs auth runs the login flow inline — then writes the choice
-back to the config (same for `start` / `invoke`). Pass `--model` or set `FASTAGENT_MODEL` to skip
-the prompt.
+back to the config (same for `start` / `invoke` / `fire` / `deploy`; `chat` prompts too, without the
+credential dimension — see its section). Pass `--model` or set `FASTAGENT_MODEL` to skip the prompt.
 
 Options:
 
@@ -145,7 +145,8 @@ Opens the same assembled workspace in pi's interactive TUI. This is useful for t
 
 Auth is fastagent's, same as every other command: `--auth-path` > `FASTAGENT_AUTH_PATH` > the
 workspace `auth.json`. Log in with `fastagent login` (or pi's `/login` inside the TUI, which writes
-to the same file).
+to the same file). With no model set, `chat` runs the same first-run picker as the serving commands
+(credential-annotated catalog, inline login) and writes the choice back to the config.
 
 ## `fastagent invoke`
 
@@ -290,7 +291,7 @@ Recurring per-command options (same meaning everywhere they appear):
 
 | Option | Commands | Meaning |
 |---|---|---|
-| `--no-input` | `dev`, `start`, `invoke`, `fire`, `login` | Never prompt; missing information becomes an error with the flag to pass. |
+| `--no-input` | `dev`, `start`, `invoke`, `fire`, `login`, `deploy` | Never prompt; missing information becomes an error with the flag to pass. |
 | `--model <provider/modelId>` | assembly commands | Model override (`--model > FASTAGENT_MODEL > config`). |
 | `--auth-path <file>` | assembly commands, `login` | Credentials file override. |
 | `--json` | `info`, `schedule history`, `schedule list` | Machine-readable output. |

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -3,11 +3,16 @@ import { resolve } from "node:path";
 import { loadDotEnv } from "../../env.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { failStartup } from "../fail.ts";
+import { resolveFirstRunModel } from "../shared.ts";
 
 export async function runChat(dirArg: string, opts: { model?: string; authPath?: string }): Promise<void> {
   const dir = resolve(dirArg);
   loadDotEnv(dir);
   installProxyFetch(); // model calls (and the login dialog) must go through the proxy too
+  // First-run funnel, CHOICE ONLY (pickOnly): chat authenticates through pi's own ~/.pi store (see
+  // engines/pi/chat.ts AUTH note), so the picker shows a plain catalog — credential annotations or an
+  // inline login judged against fastagent's store would lie here. pi's TUI handles login natively.
+  await resolveFirstRunModel(dir, { model: opts.model, pickOnly: true });
   // Run the chat process IN the workspace: pi resolves a session's cwd as `header.cwd ?? process.cwd()`,
   // so aligning process.cwd() with the workspace keeps a cwd-less session on the workspace. `dir` is absolute.
   process.chdir(dir);

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -9,10 +9,10 @@ export async function runChat(dirArg: string, opts: { model?: string; authPath?:
   const dir = resolve(dirArg);
   loadDotEnv(dir);
   installProxyFetch(); // model calls (and the login dialog) must go through the proxy too
-  // First-run funnel, CHOICE ONLY (pickOnly): chat authenticates through pi's own ~/.pi store (see
-  // engines/pi/chat.ts AUTH note), so the picker shows a plain catalog — credential annotations or an
-  // inline login judged against fastagent's store would lie here. pi's TUI handles login natively.
-  await resolveFirstRunModel(dir, { model: opts.model, pickOnly: true });
+  // First-run funnel, FULL picker: chat authenticates through fastagent's credential store like every
+  // other command (the shared session builder injects it — see engines/pi/session-builder.ts), so the
+  // credential-annotated catalog and inline login apply here too.
+  await resolveFirstRunModel(dir, { model: opts.model, authPath: opts.authPath });
   // Run the chat process IN the workspace: pi resolves a session's cwd as `header.cwd ?? process.cwd()`,
   // so aligning process.cwd() with the workspace keeps a cwd-less session on the workspace. `dir` is absolute.
   process.chdir(dir);

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -41,6 +41,7 @@ import { exists } from "../../scaffold/init.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
 import { announceWebhooks } from "../../tunnel.ts";
 import { failStartup, failUsage } from "../fail.ts";
+import { resolveFirstRunModel } from "../shared.ts";
 
 export type DeployHost = "docker" | "fly" | "railway";
 
@@ -54,6 +55,8 @@ export interface DeployOptions {
   intoLinked?: boolean;
   model?: string;
   authPath?: string;
+  /** false ⇔ `--no-input`. */
+  input?: boolean;
 }
 
 export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOptions): Promise<void> {
@@ -64,6 +67,11 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
   }
   loadDotEnv(target); // a custom provider/tool may read a key at config load
   installProxyFetch(); // post-deploy channel API calls must honor HTTP(S)_PROXY under Node
+  // First-run funnel, FULL picker: the write-back lands the model in fastagent.config.* — exactly what
+  // the model-travel gate below requires (--model/env don't reach the deployed box) — and an inline
+  // login stores the credential `--run` then carries. Runs BEFORE loadConfig; the read-back sees the
+  // rewritten file because loadConfig cache-busts on mtime (a failed write-back still gates, correctly).
+  await resolveFirstRunModel(target, { model: opts.model, authPath: opts.authPath, input: opts.input });
   const { config } = await loadConfig(target).catch(failStartup);
   const agentDir = resolveAgentDir(target, config);
   const modelSpec = resolveModelSpec(opts.model, config);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -377,6 +377,7 @@ const deploy: CommandSpec = {
     },
     MODEL,
     AUTH_PATH,
+    NO_INPUT,
   ],
   examples: [
     { cmd: "fastagent deploy fly --run", note: "provision + deploy + webhooks" },
@@ -397,6 +398,7 @@ const deploy: CommandSpec = {
       intoLinked: f.intoLinked === true,
       model: f.model as string | undefined,
       authPath: f.authPath as string | undefined,
+      input: f.input !== false,
     }),
 };
 

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -6,6 +6,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { relative } from "node:path";
 import { autocomplete, isCancel, log as clackLog, password, select, text as clackText } from "@clack/prompts";
+import type { Models } from "@earendil-works/pi-ai";
 import { buildModelPickerOptions } from "../cli-models.ts";
 import { fastagentCredentialStore } from "../engines/pi/auth.ts";
 import {
@@ -68,14 +69,15 @@ export async function reportAuth(modelSpec: string, authPath: string): Promise<v
 }
 
 /**
- * First-run model resolution for the serving commands: ONE funnel, no dead ends. When no model is set
- * (flag/env/config) and we're on a TTY, show the FULL catalog annotated per provider — ready (with the
- * credential source, so which account pays is visible at the decision point) or login-required — and,
- * when the choice needs auth, run the login flow INLINE instead of exiting with "run `fastagent login`
- * and come back". A no-op when a model is already set; on a non-TTY (CI/deploy), with `--no-input`, on
- * cancel, or on a failed login it stays quiet and lets the opener raise its clear "missing model"
- * error. The pick is exported to FASTAGENT_MODEL so a spawned `dev` worker inherits it, and
- * best-effort written back to the config so the next run is quiet.
+ * First-run model resolution for every assembly command (dev/start/invoke/fire/chat/deploy): ONE
+ * funnel, no dead ends. When no model is set (flag/env/config) and we're on a TTY, show the FULL
+ * catalog annotated per provider — ready (with the credential source, so which account pays is
+ * visible at the decision point) or login-required — and, when the choice needs auth, run the login
+ * flow INLINE instead of exiting with "run `fastagent login` and come back". A no-op when a model is
+ * already set; on a non-TTY (CI, a piped stdin), with `--no-input`, on cancel, or on a failed login
+ * it stays quiet and lets the caller raise its own clear error (`missing model`, or deploy's
+ * model-travel gate). The pick is exported to FASTAGENT_MODEL so a spawned `dev` worker inherits it,
+ * and best-effort written back to the config so the next run is quiet.
  *
  * `pickOnly` drops the credential dimension entirely — a plain catalog, no ready/login annotations,
  * no inline login — for commands whose auth does NOT live in fastagent's credential file (`chat`
@@ -93,16 +95,33 @@ export async function resolveFirstRunModel(
 
   const authPath = resolveAuthPath(workspaceDir, options.authPath);
   const models = createPiModels({ authPath });
-  if (options.pickOnly) {
-    const r = await autocomplete({
-      message: "Choose a model for this agent",
-      options: listModels(models).map((s) => ({ value: s, label: s })),
-    });
-    if (isCancel(r)) return; // cancelled: the caller raises its clear missing-model error
-    process.env.FASTAGENT_MODEL = r as string;
-    await persistModelChoice(workspaceDir, configPath, r as string);
-    return;
-  }
+  const chosen = options.pickOnly
+    ? await promptModelChoice(listModels(models).map((s) => ({ value: s, label: s })))
+    : await pickWithCredentials(workspaceDir, models, authPath);
+  if (chosen === undefined) return; // cancelled (or auth probe failed): the caller raises its clear missing-model error
+  process.env.FASTAGENT_MODEL = chosen; // this process + any spawned dev worker inherits it
+  await persistModelChoice(workspaceDir, configPath, chosen);
+}
+
+/** The one picker prompt — both modes share the message and the cancel semantics (undefined). */
+async function promptModelChoice(
+  options: Array<{ value: string; label: string; hint?: string }>,
+): Promise<string | undefined> {
+  const r = await autocomplete({ message: "Choose a model for this agent", options });
+  return isCancel(r) ? undefined : (r as string);
+}
+
+/**
+ * The credential-aware pick: full catalog annotated per provider, then the post-pick auth policy —
+ * remedy warnings for providers no login flow can fix (the choice is KEPT: model validity is
+ * independent of credentials), or the inline login for the rest. Returns the chosen spec, or
+ * undefined when the pick should be discarded (picker cancel, login cancel, a failed auth probe).
+ */
+async function pickWithCredentials(
+  workspaceDir: string,
+  models: Models,
+  authPath: string,
+): Promise<string | undefined> {
   let statuses: Awaited<ReturnType<typeof providerAuthStatuses>>;
   try {
     statuses = await providerAuthStatuses(models);
@@ -111,21 +130,18 @@ export async function resolveFirstRunModel(
     // means the enumeration itself failed (getProviders / a provider with no probe-able surface) — a
     // system fault. Surface it; the opener then still raises the clear missing-model error.
     log.warn(`[fastagent] could not probe provider auth: ${(error as Error).message}`);
-    return;
+    return undefined;
   }
-  const r = await autocomplete({
-    message: "Choose a model for this agent",
-    options: buildModelPickerOptions(listModels(models), statuses),
-  });
-  if (isCancel(r)) return; // cancelled: let the opener report the missing model
-  const chosen = r as string;
+  const chosen = await promptModelChoice(buildModelPickerOptions(listModels(models), statuses));
+  if (chosen === undefined) return undefined;
   const provider = providerOf(chosen);
   const status = statuses.get(provider);
-  if (status && status.state !== "ready" && status.login === "none") {
-    // No login flow exists for this provider — the model choice is still valid (its validity is
-    // independent of credentials), so KEEP it and name the remedy. The remedy depends on WHY it is
-    // not ready: a BROKEN stored credential still owns the provider (env is consulted only when
-    // nothing is stored — createPiModels), so "set the env var" would not help there.
+  if (status?.state === "ready") return chosen; // usable now — nothing to fix
+
+  if (status && status.login === "none") {
+    // No login flow exists for this provider — KEEP the choice and name the remedy. The remedy depends
+    // on WHY it is not ready: a BROKEN stored credential still owns the provider (env is consulted
+    // only when nothing is stored — createPiModels), so "set the env var" would not help there.
     if (status.state === "broken") {
       log.warn(
         `[fastagent] stored auth for "${provider}" is unusable: ${status.message} — fix or remove it in ${authPath}; invokes fail until then`,
@@ -133,28 +149,27 @@ export async function resolveFirstRunModel(
     } else {
       log.warn(`[fastagent] "${provider}" has no interactive login — set its API key env var; invokes fail until then`);
     }
-  } else if (status?.state !== "ready") {
-    // Inline login. Same leak guard as `login`: self-ignore the state root BEFORE a credential
-    // can land in-tree, so the secret is never untracked-but-committable.
-    const stateRoot = resolveStateRoot(workspaceDir);
-    if (isUnderDir(authPath, stateRoot)) await ensureStateRootSelfIgnored(workspaceDir, stateRoot);
-    try {
-      // Verified against the CHOSEN model — the exact request the agent is about to make; a rejected
-      // key re-prompts inside the loop, so reaching here means a usable (or at worst unverifiable) key.
-      await loginWithKeyCheck(provider, authPath, chosen);
-      console.error(`[fastagent] logged in to ${provider} — saved to ${authPath}`);
-    } catch (error) {
-      if (error instanceof LoginCancelled) return; // user backed out — discard the choice, like a picker cancel
-      // A FAILED login keeps the choice (same policy as the env-only branch above: model validity is
-      // independent of credentials) — the pick persists, the startup auth report names the remedy,
-      // and a later `fastagent login` fixes auth without re-picking the model.
-      log.warn(
-        `[fastagent] login for "${provider}" failed: ${(error as Error).message} — model saved; run \`fastagent login\` to fix auth`,
-      );
-    }
+    return chosen;
   }
-  process.env.FASTAGENT_MODEL = chosen; // this process + any spawned dev worker inherits it
-  await persistModelChoice(workspaceDir, configPath, chosen);
+
+  // Inline login. Same leak guard as `login`: self-ignore the state root BEFORE a credential
+  // can land in-tree, so the secret is never untracked-but-committable.
+  const stateRoot = resolveStateRoot(workspaceDir);
+  if (isUnderDir(authPath, stateRoot)) await ensureStateRootSelfIgnored(workspaceDir, stateRoot);
+  try {
+    // Verified against the CHOSEN model — the exact request the agent is about to make; a rejected
+    // key re-prompts inside the loop, so reaching here means a usable (or at worst unverifiable) key.
+    await loginWithKeyCheck(provider, authPath, chosen);
+    console.error(`[fastagent] logged in to ${provider} — saved to ${authPath}`);
+  } catch (error) {
+    if (error instanceof LoginCancelled) return undefined; // user backed out — discard the choice, like a picker cancel
+    // A FAILED login keeps the choice: the pick persists, the startup auth report names the remedy,
+    // and a later `fastagent login` fixes auth without re-picking the model.
+    log.warn(
+      `[fastagent] login for "${provider}" failed: ${(error as Error).message} — model saved; run \`fastagent login\` to fix auth`,
+    );
+  }
+  return chosen;
 }
 
 /**

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -264,7 +264,8 @@ export function terminalLoginIO(): LoginIO {
 async function persistModelChoice(workspaceDir: string, configPath: string | undefined, spec: string): Promise<void> {
   const hint = (): void =>
     console.error(
-      `[fastagent] using ${spec} for this run; set \`model: ${JSON.stringify(spec)}\` in your config to persist`,
+      // No "using it for this run" promise: deploy's model-travel gate rightly ignores the un-persisted pick.
+      `[fastagent] picked ${spec} — set \`model: ${JSON.stringify(spec)}\` in your config to persist`,
     );
   if (!configPath) return hint();
   try {

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -78,15 +78,10 @@ export async function reportAuth(modelSpec: string, authPath: string): Promise<v
  * it stays quiet and lets the caller raise its own clear error (`missing model`, or deploy's
  * model-travel gate). The pick is exported to FASTAGENT_MODEL so a spawned `dev` worker inherits it,
  * and best-effort written back to the config so the next run is quiet.
- *
- * `pickOnly` drops the credential dimension entirely — a plain catalog, no ready/login annotations,
- * no inline login — for commands whose auth does NOT live in fastagent's credential file (`chat`
- * authenticates through pi's own `~/.pi` store): annotations judged against fastagent's store would
- * lie there, in both directions.
  */
 export async function resolveFirstRunModel(
   workspaceDir: string,
-  options: { model?: string; authPath?: string; input?: boolean; pickOnly?: boolean } = {},
+  options: { model?: string; authPath?: string; input?: boolean } = {},
 ): Promise<void> {
   const { config, path: configPath } = await loadConfig(workspaceDir).catch(failStartup);
   if (resolveModelSpec(options.model, config)) return; // already set (flag > FASTAGENT_MODEL > config)
@@ -95,20 +90,10 @@ export async function resolveFirstRunModel(
 
   const authPath = resolveAuthPath(workspaceDir, options.authPath);
   const models = createPiModels({ authPath });
-  const chosen = options.pickOnly
-    ? await promptModelChoice(listModels(models).map((s) => ({ value: s, label: s })))
-    : await pickWithCredentials(workspaceDir, models, authPath);
+  const chosen = await pickWithCredentials(workspaceDir, models, authPath);
   if (chosen === undefined) return; // cancelled (or auth probe failed): the caller raises its clear missing-model error
   process.env.FASTAGENT_MODEL = chosen; // this process + any spawned dev worker inherits it
   await persistModelChoice(workspaceDir, configPath, chosen);
-}
-
-/** The one picker prompt — both modes share the message and the cancel semantics (undefined). */
-async function promptModelChoice(
-  options: Array<{ value: string; label: string; hint?: string }>,
-): Promise<string | undefined> {
-  const r = await autocomplete({ message: "Choose a model for this agent", options });
-  return isCancel(r) ? undefined : (r as string);
 }
 
 /**
@@ -132,8 +117,12 @@ async function pickWithCredentials(
     log.warn(`[fastagent] could not probe provider auth: ${(error as Error).message}`);
     return undefined;
   }
-  const chosen = await promptModelChoice(buildModelPickerOptions(listModels(models), statuses));
-  if (chosen === undefined) return undefined;
+  const r = await autocomplete({
+    message: "Choose a model for this agent",
+    options: buildModelPickerOptions(listModels(models), statuses),
+  });
+  if (isCancel(r)) return undefined; // cancelled: the caller raises its clear missing-model error
+  const chosen = r as string;
   const provider = providerOf(chosen);
   const status = statuses.get(provider);
   if (status?.state === "ready") return chosen; // usable now — nothing to fix

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -76,10 +76,15 @@ export async function reportAuth(modelSpec: string, authPath: string): Promise<v
  * cancel, or on a failed login it stays quiet and lets the opener raise its clear "missing model"
  * error. The pick is exported to FASTAGENT_MODEL so a spawned `dev` worker inherits it, and
  * best-effort written back to the config so the next run is quiet.
+ *
+ * `pickOnly` drops the credential dimension entirely — a plain catalog, no ready/login annotations,
+ * no inline login — for commands whose auth does NOT live in fastagent's credential file (`chat`
+ * authenticates through pi's own `~/.pi` store): annotations judged against fastagent's store would
+ * lie there, in both directions.
  */
 export async function resolveFirstRunModel(
   workspaceDir: string,
-  options: { model?: string; authPath?: string; input?: boolean } = {},
+  options: { model?: string; authPath?: string; input?: boolean; pickOnly?: boolean } = {},
 ): Promise<void> {
   const { config, path: configPath } = await loadConfig(workspaceDir).catch(failStartup);
   if (resolveModelSpec(options.model, config)) return; // already set (flag > FASTAGENT_MODEL > config)
@@ -88,6 +93,16 @@ export async function resolveFirstRunModel(
 
   const authPath = resolveAuthPath(workspaceDir, options.authPath);
   const models = createPiModels({ authPath });
+  if (options.pickOnly) {
+    const r = await autocomplete({
+      message: "Choose a model for this agent",
+      options: listModels(models).map((s) => ({ value: s, label: s })),
+    });
+    if (isCancel(r)) return; // cancelled: the caller raises its clear missing-model error
+    process.env.FASTAGENT_MODEL = r as string;
+    await persistModelChoice(workspaceDir, configPath, r as string);
+    return;
+  }
   let statuses: Awaited<ReturnType<typeof providerAuthStatuses>>;
   try {
     statuses = await providerAuthStatuses(models);

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -6,7 +6,7 @@
  * live in persona.md + skills, with AGENTS.md as project context). Deleting the config still leaves a
  * zero-config agent runnable with a model supplied by --model / FASTAGENT_MODEL.
  */
-import { existsSync, lstatSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -112,7 +112,12 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   const path = found[0]!;
   let mod: { default?: unknown };
   try {
-    mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
+    // Cache-bust on file change: ESM `import()` caches by URL, so a config REWRITTEN in this process
+    // (the first-run picker's write-back) would otherwise read back stale — deploy's model-travel gate
+    // then contradicts the "saved model" line it just printed. mtime keeps unchanged files cached.
+    const url = pathToFileURL(path);
+    url.searchParams.set("v", String(statSync(path).mtimeMs));
+    mod = (await import(url.href)) as { default?: unknown };
   } catch (error) {
     throw new Error(`${path}: ${(error as Error).message}${moduleLoadHint(error as NodeJS.ErrnoException)}`);
   }

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -114,7 +114,9 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   try {
     // Cache-bust on file change: ESM `import()` caches by URL, so a config REWRITTEN in this process
     // (the first-run picker's write-back) would otherwise read back stale — deploy's model-travel gate
-    // then contradicts the "saved model" line it just printed. mtime keeps unchanged files cached.
+    // then contradicts the "saved model" line it just printed. mtime keeps unchanged files cached;
+    // its resolution is the ceiling — a rewrite within the same timestamp tick reads stale (fine for
+    // the write-back: sub-tick only on coarse-mtime filesystems, and the next process starts fresh).
     const url = pathToFileURL(path);
     url.searchParams.set("v", String(statSync(path).mtimeMs));
     mod = (await import(url.href)) as { default?: unknown };

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
@@ -41,6 +41,9 @@ describe("config: loadConfig rereads a config rewritten in-process (ESM cache-bu
     // cache-buster the second load returns the stale cached module and deploy's model-travel gate
     // contradicts the "saved model" line it just printed.
     await writeFile(path, 'export default {\n  model: "prov/m1",\n};\n');
+    // Push mtime past any fs timestamp granularity — the assertion targets the cache-bust, not the fs.
+    const t = new Date((await stat(path)).mtimeMs + 2000);
+    await utimes(path, t, t);
     expect((await loadConfig(dir)).config.model).toBe("prov/m1");
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -31,6 +31,20 @@ describe("config: resolveSessionsDirOverride (start's sessions precedence)", () 
   });
 });
 
+describe("config: loadConfig rereads a config rewritten in-process (ESM cache-bust)", () => {
+  it("a write-back (the first-run picker) is visible to the next loadConfig — not the cached module", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-config-fresh-"));
+    const path = join(dir, "fastagent.config.mjs");
+    await writeFile(path, "export default {\n};\n");
+    expect((await loadConfig(dir)).config.model).toBeUndefined();
+    // Simulate persistModelChoice: rewrite the file AFTER it was imported once. Without the mtime
+    // cache-buster the second load returns the stale cached module and deploy's model-travel gate
+    // contradicts the "saved model" line it just printed.
+    await writeFile(path, 'export default {\n  model: "prov/m1",\n};\n');
+    expect((await loadConfig(dir)).config.model).toBe("prov/m1");
+  });
+});
+
 describe("config: loadConfig agentDir validation", () => {
   it("accepts a subdirectory agentDir; rejects one that escapes the config dir (dev watch-scope guard)", async () => {
     const ok = await mkdtemp(join(tmpdir(), "fa-agentdir-ok-"));


### PR DESCRIPTION
## What

Follow-up to #250: the first-run funnel ("no model set + a TTY → pick, auth inline, persist, serve") covered `dev`/`start`/`invoke`/`fire` but left the two remaining interactive commands as dead ends. This PR closes both:

- **`chat` — full picker.** The vibe-first entry (`init` → `chat`) used to die with `missing model`. It now runs the same credential-annotated picker (inline login, `--auth-path`) as every other assembly command and persists the choice. (An earlier revision gave chat a plain `pickOnly` catalog because chat then authenticated through pi's own `~/.pi` store; #255 moved chat onto the shared session builder with fastagent's credential store, so that divergence — and `pickOnly` — is gone.)
- **`deploy` — full picker, before `loadConfig`.** The picker's write-back lands the model in `fastagent.config.*` — exactly what the model-travel gate requires (`--model`/env don't reach the deployed box) — and an inline login stores the credential that `--run` then carries. `deploy` gains `--no-input`, matching the other assembly commands (plan mode still only warns on a missing model; `--run` gates — documented).

## The bug this surfaced

`loadConfig` imports the config via ESM `import()`, which caches by URL — so a config **rewritten in the same process** (the picker's write-back) read back stale: deploy's travel gate would reject the model one line after printing `saved model "X"`. Fixed at the root: `loadConfig` cache-busts on file mtime (unchanged files stay cached; mtime resolution is the named ceiling). A failed write-back (zero-config / hand-shaped config) still gates, correctly — freshness, not a bypass. Pinned by a test (rewrite → second load sees the new value, mtime pushed past fs granularity).

## Named trade-offs

- The deploy `--no-input` wiring and the prompt path are interactive glue, untested (same declared boundary as #250); the testable regression class (config freshness) is what got the test.
- `chat` has no `--no-input`: the TUI is interactive by definition.

## Verification

`npm run lint && npm run typecheck && npm test` green (813 tests); `rv.sh local` after the #255 rebase → findings fixed (stale cross-reference in cli.md, over-promising persist hint, `--no-input` table exception, mtime-granularity test pin), rerun → No findings.
