### PR TITLE
feat(session): Phase 2a — run modulation (steer / follow_up / abort)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -31,7 +31,12 @@ interface Agent {
 }
 ```
 
-One turn = one `invoke`. The result is one async event stream; buffered consumption is a degeneration of that stream (§7).
+One turn = one `invoke`; a turn is the ACTIVITY WINDOW of one invoke. Without mid-run intervention
+that window is a single prompt→response exchange. With the optional session control plane
+([design](design/session-control.md)), steering and queued follow-ups may extend it — the stream
+then terminates when the run settles. Consumers that never dispatch mid-run see identical behavior
+either way. The result is one async event stream; buffered consumption is a degeneration of that
+stream (§7).
 
 The return type MUST be `AsyncIterable`; `async function*`, `ReadableStream`, and equivalent implementations are all valid.
 
@@ -137,7 +142,7 @@ The core stays small. The following extensions attach through additional `scope`
 | Identity / multi-tenancy | `scope.principal`, e.g. `{ type, issuer, subject }` |
 | Source / trace | `scope.source` and other identifying fields |
 | Execution constraints such as deadline / budget | Middleware; for example, `budget_exceeded` becomes a `failed` event produced by Middleware |
-| Mid-turn steering | **Extension, not part of the v0.1 core signature**: add an optional third parameter `input?: AsyncIterable<Prompt>` to `invoke` and feed input into the in-flight turn, corresponding to pi `steer` / `followUp` / `nextTurn`. If the desired behavior is “discard the current turn and go another way”, use cancel + a new `invoke` with the same `session`; no steering extension is required. |
+| Mid-turn steering | **Extension, not part of the v0.1 core signature** — provided by the [session control plane](design/session-control.md): `dispatch(session, { type: "steer" \| "follow_up" \| "abort", … })` modulates the run an invoke is driving, beside the invoke rather than through its signature. (An earlier sketch — an optional third `input?: AsyncIterable<Prompt>` parameter — was rejected in favor of the control plane.) If the desired behavior is “discard the current turn and go another way”, cancel + a new `invoke` with the same `session` still works without any extension. |
 | Thinking / citations / artifact streaming | Add new non-terminal `AgentEvent` types |
 | Structured / typed result | Per-invoke output-schema negotiation; the validated result rides on `completed.data`. Demand-driven (task-style embed features); not in v0.1 core, and MUST NOT change the frozen terminal set. |
 | Failure subdivision | `failed.code?` — **adopted**: an optional machine-readable code alongside `details` (e.g. the reference engine sets `session_busy` for a same-session-busy reject). |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -423,7 +423,10 @@ await control.dispatch("s1", { type: "abort" }); // invoke ends failed{code:"abo
 
 With steering/follow-ups the invoke stream terminates at the run's SETTLE (all queued continuations
 drained) — for consumers that never dispatch, a run equals a single turn, byte-identical behavior.
-Run commands on an idle session reject with `no_active_run` before acceptance. Boundary mutations
+Run commands on an idle session reject with `no_active_run` before acceptance; a command that
+reached a run but could not take effect (the run raced to settlement) rejects with
+`run_command_failed`, retryable. An accepted `abort` can still settle `completed` when the run
+finishes inside the race window — acceptance is not outcome; the settlement is the truth. Boundary mutations
 (`compact`/`set_model`/`set_thinking`) are not shipped yet: `capabilities()` reports them off and
 they reject with `unsupported_capability`.
 For workspace assembly the store lives inside the opener, so ask the opener to wire the hub:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -426,8 +426,10 @@ drained) — for consumers that never dispatch, a run equals a single turn, byte
 Run commands on an idle session reject with `no_active_run` before acceptance; a command that
 reached a run but could not take effect (the run raced to settlement) rejects with
 `run_command_failed`. Both are `retryable: false` — the same command as-is fails again; consult
-`state()` before re-dispatching. An accepted `abort` can still settle `completed` when the run
-finishes inside the race window — acceptance is not outcome; the settlement is the truth. Boundary mutations
+`state()` before re-dispatching. The race window applies to all three commands symmetrically: an
+accepted `abort` can still settle `completed`, and an accepted `steer`/`follow_up` can settle
+without its prompt being consumed, when the run finishes inside the window — acceptance is not
+outcome; the settlement is the truth. Boundary mutations
 (`compact`/`set_model`/`set_thinking`) are not shipped yet: `capabilities()` reports them off and
 they reject with `unsupported_capability`.
 For workspace assembly the store lives inside the opener, so ask the opener to wire the hub:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -425,7 +425,8 @@ With steering/follow-ups the invoke stream terminates at the run's SETTLE (all q
 drained) — for consumers that never dispatch, a run equals a single turn, byte-identical behavior.
 Run commands on an idle session reject with `no_active_run` before acceptance; a command that
 reached a run but could not take effect (the run raced to settlement) rejects with
-`run_command_failed`, retryable. An accepted `abort` can still settle `completed` when the run
+`run_command_failed`. Both are `retryable: false` — the same command as-is fails again; consult
+`state()` before re-dispatching. An accepted `abort` can still settle `completed` when the run
 finishes inside the race window — acceptance is not outcome; the settlement is the truth. Boundary mutations
 (`compact`/`set_model`/`set_thinking`) are not shipped yet: `capabilities()` reports them off and
 they reject with `unsupported_capability`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -412,8 +412,20 @@ const state = await control.state("s1"); // { status, activeRunId?, leafEntryId?
 ```
 
 `invoke` stays the only way to start work; the `AgentEvent` stream is a projection of the rich
-`SessionEvent` stream. `dispatch` (steer/follow_up/abort/…) arrives with the control plane — until
-then `capabilities()` reports it off and commands are rejected with `unsupported_capability`.
+`SessionEvent` stream. `dispatch` modulates the run an invoke is driving — acceptance is not
+outcome (`ok: true` = admitted; the result arrives as `run_settled`):
+
+```ts
+await control.dispatch("s1", { type: "steer", prompt: { text: "use bun, not npm" } }); // joins the run
+await control.dispatch("s1", { type: "follow_up", prompt: { text: "then summarize" } }); // FIFO queue
+await control.dispatch("s1", { type: "abort" }); // invoke ends failed{code:"aborted"}, run_settled{aborted}
+```
+
+With steering/follow-ups the invoke stream terminates at the run's SETTLE (all queued continuations
+drained) — for consumers that never dispatch, a run equals a single turn, byte-identical behavior.
+Run commands on an idle session reject with `no_active_run` before acceptance. Boundary mutations
+(`compact`/`set_model`/`set_thinking`) are not shipped yet: `capabilities()` reports them off and
+they reject with `unsupported_capability`.
 For workspace assembly the store lives inside the opener, so ask the opener to wire the hub:
 
 ```ts

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -8,8 +8,8 @@ updated: 2026-07-19
 
 # Session control plane
 
-This document is the serving-extension design for FastAgent. Phases 0–1 (§15) are implemented;
-Phases 2–3 remain proposed. It is a companion to, not a replacement
+This document is the serving-extension design for FastAgent. Phases 0–2a (§15) are implemented;
+Phases 2b–3 remain proposed. It is a companion to, not a replacement
 for, the locked [Agent Handler SPEC v0.1](../SPEC.md).
 
 The whole design reduces to one sentence: **`invoke` is the only data plane; the session control
@@ -396,7 +396,8 @@ safe for untrusted users; `ExecutionEnv` is still not a complete sandbox boundar
 |---|---|---|
 | 0 | **Done.** The definition-aware session builder is extracted (`session-builder.ts`); the TUI-only `~/.pi` auth divergence is eliminated in place; `runPiChat` is one consumer. | Chat assembly semantics unchanged; auth source and `thinkingLevel` deliberately converged to serving; builder independently instantiable. |
 | 1 | **Done.** Observation plane: pi events translate ONCE to `SessionEvent` inside the invoke path (`toSessionEvent`), `AgentEvent` is its projection (`projectAgentEvent`); the `session` subpath types + pi `createPiSessionControl` (`state`/`entries`/`events` over a read-only `PiSessionReader`); conformance tests for projection fidelity, run boundaries (incl. cancellation → exactly-one `run_settled{aborted}`), reconnect, and single-writer. | An L0 client can watch and reconnect to any invoke-driven run. |
-| 2 | Control plane: `steer`/`follow_up`/`abort` with settle-window invoke semantics and `queue_changed`; boundary mutations (`compact`, `set_model`, `set_thinking`) under the lease. | L1–L2 clients. |
+| 2a | **Done.** Run modulation: `dispatch` routes `steer`/`follow_up`/`abort` to the live run via {@link RunControls} registered with `run_started`; the settle window spans steered/queued continuations inside one invoke (pi's agent loop drains both queues within one `prompt()`); `queue_changed` + live `pending` in state; a control-plane abort terminates as `failed{code: "aborted"}` / `run_settled{aborted}`; idle-session run commands reject `no_active_run` before acceptance. | L1 clients. |
+| 2b | Boundary mutations (`compact`, `set_model`, `set_thinking`) under the lease, with `state_changed`/`compaction_*` events. Requires per-session model-override persistence in the fresh-harness architecture (harness.ts resolve semantics — see §3 of core.md for the active-tools precedent). | L2 clients. |
 | 3 | Transport codec and a remote/subprocess adapter (the envelope is born here); product runners add authentication, idempotency, event persistence, and routing. | Remote `SessionControl` is isomorphic to local. |
 
 Phase 1 modifies the existing invoke pipeline incrementally (translation + projection); it does not

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -412,7 +412,9 @@ unlocks those options; it does not mandate them.
 
 Implementation review should reject changes that violate these:
 
-1. Agent Handler v0.1 and `src/agent.ts` stay unchanged.
+1. Agent Handler v0.1 semantics and the frozen terminal set stay unchanged; additive advisory
+   `failed.code` constants in `src/agent.ts` are allowed (the `SESSION_BUSY_CODE` precedent —
+   `ABORTED_CODE` followed it).
 2. `invoke` holds no state between calls.
 3. No run exists without an invoke; the control plane modulates, never initiates.
 4. The observation plane is strictly read-only.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -47,6 +47,15 @@ export type AgentEvent =
 export const SESSION_BUSY_CODE = "session_busy";
 
 /**
+ * The `failed.code` set when a run was deliberately stopped (a control-plane abort) rather than
+ * failing on its own. Channels can render cancellation distinctly from an error, and MUST treat it
+ * as a settled outcome — durable turn-intent cleanup included — so an operator's abort is never
+ * replayed as a fresh turn on restart. Exported as a constant for the same reason as
+ * {@link SESSION_BUSY_CODE}: a consumer that must branch on it should not string-match.
+ */
+export const ABORTED_CODE = "aborted";
+
+/**
  * One turn = one invoke, returning a single async event stream. The stream MUST terminate with
  * exactly one of completed / failed, or be cancelled by the caller (no terminal event). Any
  * AsyncIterable producer that implements this conforms (interface, not base class).

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -47,11 +47,12 @@ export type AgentEvent =
 export const SESSION_BUSY_CODE = "session_busy";
 
 /**
- * The `failed.code` set when a run was deliberately stopped (a control-plane abort) rather than
- * failing on its own. Channels can render cancellation distinctly from an error, and MUST treat it
- * as a settled outcome — durable turn-intent cleanup included — so an operator's abort is never
- * replayed as a fresh turn on restart. Exported as a constant for the same reason as
- * {@link SESSION_BUSY_CODE}: a consumer that must branch on it should not string-match.
+ * The `failed.code` set when a run was DELIBERATELY stopped — a control-plane abort, or any
+ * harness-level abort the engine attributes (`stopReason: "aborted"`) — rather than failing on its
+ * own. Channels can render cancellation distinctly from an error, and MUST treat it as a settled
+ * outcome — durable turn-intent cleanup included — so a deliberate stop is never replayed as a
+ * fresh turn on restart. Exported as a constant for the same reason as {@link SESSION_BUSY_CODE}:
+ * a consumer that must branch on it should not string-match.
  */
 export const ABORTED_CODE = "aborted";
 

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -436,15 +436,27 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
     // terminal deterministically either way. Set optimistically and ROLLED BACK if abort() itself
     // fails: a rejected abort must not reclassify this run's real error as a deliberate stop.
     let abortRequested = false;
+    // Stale-controls guard: after settlement pi's steer()/followUp()/abort() would still resolve
+    // (they queue / no-op on the to-be-discarded harness) — a silent acceptance of a command that
+    // can never take effect. The flag flips in the outer finally BEFORE run_settled is observed, so
+    // a post-settle call throws and the dispatcher maps it to `run_command_failed`.
+    let runSettled = false;
+    const requireLive = async () => {
+      const harness = await harnessGate;
+      if (runSettled) throw new Error("run already settled; the command cannot take effect");
+      return harness;
+    };
     const controls: RunControls = {
       async steer(p: Prompt) {
-        await (await harnessGate).steer(p.text, await toPiPromptOptions(p));
+        const opts = await toPiPromptOptions(p);
+        await (await requireLive()).steer(p.text, opts);
       },
       async followUp(p: Prompt) {
-        await (await harnessGate).followUp(p.text, await toPiPromptOptions(p));
+        const opts = await toPiPromptOptions(p);
+        await (await requireLive()).followUp(p.text, opts);
       },
       async abort() {
-        const harness = await harnessGate;
+        const harness = await requireLive();
         abortRequested = true;
         try {
           await harness.abort();
@@ -541,7 +553,9 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       }
     } finally {
       // Exactly-one settlement, after ALL run work (incl. auto-compaction) and immediately before
-      // the lease releases — see the outcome note above.
+      // the lease releases — see the outcome note above. The stale-controls flag flips FIRST so a
+      // dispatch racing this settlement is rejected instead of silently accepted.
+      runSettled = true;
       observe({ type: "run_settled", timestamp: Date.now(), runId, data: outcome ?? { status: "aborted" } });
       release(); // after cleanup, so the next invoke for this session can enter
     }

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -137,6 +137,13 @@ function messageSignal(message: AssistantMessage): { status?: number; code?: unk
 function toSessionEvent(pe: AgentHarnessEvent, runId: string): SessionEvent | null {
   const at = Date.now();
   switch (pe.type) {
+    case "queue_update":
+      return {
+        type: "queue_changed",
+        timestamp: at,
+        runId,
+        data: { steering: pe.steer.length, followUp: pe.followUp.length },
+      };
     case "message_start":
       // Assistant streaming only — a user/toolResult message is not a live message boundary.
       if (pe.message.role !== "assistant") return null;
@@ -202,9 +209,20 @@ export function projectAgentEvent(se: SessionEvent): AgentEvent | null {
   }
 }
 
-/** The observation-plane seam: every rich event of every run, pushed as it happens. A hub
- *  (session-control.ts) implements this to serve `events()`/`state()`; absent = zero overhead. */
-export type SessionObserver = (session: string, event: SessionEvent) => void;
+/** Live modulation handles for one active run — what the control plane's `dispatch` routes to.
+ *  Built inside the invoke closure (it owns the harness); registered with the observer at
+ *  run_started, gone after run_settled. */
+export interface RunControls {
+  steer(prompt: Prompt): Promise<void>;
+  followUp(prompt: Prompt): Promise<void>;
+  abort(): Promise<void>;
+}
+
+/** The observation-plane seam: every rich event of every run, pushed as it happens. `run` carries
+ *  the live {@link RunControls}, attached to the `run_started` event only. A hub
+ *  (session-control.ts) implements this to serve `events()`/`state()`/`dispatch`; absent = zero
+ *  overhead. */
+export type SessionObserver = (session: string, event: SessionEvent, run?: RunControls) => void;
 
 /**
  * Terminal mapping, decided by the resolved message's stopReason: pi's prompt() resolves a message
@@ -212,7 +230,14 @@ export type SessionObserver = (session: string, event: SessionEvent) => void;
  * entire failure class (violating SPEC MUST 1).
  */
 export function toTerminal(message: AssistantMessage): AgentEvent {
-  if (message.stopReason === "error" || message.stopReason === "aborted") {
+  if (message.stopReason === "aborted") {
+    // A deliberate stop (control-plane abort / harness abort), not an error: `code: "aborted"` lets
+    // a channel render cancellation distinctly, and channels MUST treat it as a settled outcome
+    // (durable turn-intent cleanup included) so an operator's abort is never replayed (design §6).
+    const details = message.errorMessage ?? "run aborted";
+    return { type: "failed", details, retryable: false, code: "aborted" };
+  }
+  if (message.stopReason === "error") {
     const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
     return { type: "failed", details, retryable: classifyRetryable(details, messageSignal(message)) };
   }
@@ -383,16 +408,41 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
     // was cancelled by the caller (SPEC: cancellation has no terminal event) → aborted.
     const runId = crypto.randomUUID();
     let outcome: RunSettledEvent["data"] | undefined;
-    const observe = (event: SessionEvent | null): void => {
+    const observe = (event: SessionEvent | null, run?: RunControls): void => {
       if (!event || !observer) return;
       try {
-        observer(scope.session, event);
+        observer(scope.session, event, run);
       } catch (error) {
         // The observation plane must never break the data plane; a broken hub is its own problem.
         log.warn(`[fastagent] session observer threw (event ${event.type}): ${String(error)}`);
       }
     };
-    observe({ type: "run_started", timestamp: Date.now(), runId, data: {} });
+    // The controls close over the harness REFERENCE (assigned below): run_started must be observed
+    // before the (awaited) harness build so no early event outruns registration, and a dispatch
+    // that races the build simply finds the queue on the freshly built harness.
+    let liveHarness: Awaited<ReturnType<PiHarnessFactory>> | undefined;
+    const requireHarness = () => {
+      if (!liveHarness) throw new Error("run is still assembling; retry the command");
+      return liveHarness;
+    };
+    // A control-plane abort may surface from pi as a THROWN harness error or as a resolved
+    // stopReason:"aborted" message depending on where the run was cut — the flag classifies the
+    // terminal deterministically either way.
+    let abortRequested = false;
+    const controls: RunControls = {
+      async steer(p: Prompt) {
+        await requireHarness().steer(p.text, await toPiPromptOptions(p));
+      },
+      async followUp(p: Prompt) {
+        await requireHarness().followUp(p.text, await toPiPromptOptions(p));
+      },
+      async abort() {
+        const harness = requireHarness();
+        abortRequested = true;
+        await harness.abort();
+      },
+    };
+    observe({ type: "run_started", timestamp: Date.now(), runId, data: {} }, controls);
     try {
       let harness: Awaited<ReturnType<PiHarnessFactory>>;
       try {
@@ -405,6 +455,7 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         return; // → outer finally emits the settlement
       }
 
+      liveHarness = harness;
       const queue = new EventQueue<AgentEvent>();
       const unsub = harness.subscribe((pe) => {
         const rich = toSessionEvent(pe, runId);
@@ -431,12 +482,18 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         } catch (error) {
           terminal = errorToTerminal(error);
         }
+        if (abortRequested && terminal.type === "failed") {
+          terminal = { type: "failed", details: terminal.details, retryable: false, code: "aborted" };
+        }
         if (terminal.type === "completed") outcome = { status: "completed" };
         else if (terminal.type === "failed") {
-          outcome = {
-            status: "failed",
-            error: { code: terminal.code, message: terminal.details, retryable: terminal.retryable },
-          };
+          outcome =
+            terminal.code === "aborted"
+              ? { status: "aborted" }
+              : {
+                  status: "failed",
+                  error: { code: terminal.code, message: terminal.details, retryable: terminal.retryable },
+                };
         }
         yield terminal;
       } finally {

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -232,7 +232,9 @@ export interface RunControls {
 /** The observation-plane seam: every rich event of every run, pushed as it happens. `run` carries
  *  the live {@link RunControls}, attached to the `run_started` event only. A hub
  *  (session-control.ts) implements this to serve `events()`/`state()`/`dispatch`; absent = zero
- *  overhead. */
+ *  overhead. TRUST BOUNDARY: since Phase 2a this seam hands every wired observer the run's
+ *  modulation handles — it is the trusted hub seam, not a public fan-out point. Do not wire
+ *  untrusted taps here; give third parties the read-only `events()` stream instead. */
 export type SessionObserver = (session: string, event: SessionEvent, run?: RunControls) => void;
 
 /**

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -211,7 +211,9 @@ export function projectAgentEvent(se: SessionEvent): AgentEvent | null {
 
 /** Live modulation handles for one active run — what the control plane's `dispatch` routes to.
  *  Built inside the invoke closure (it owns the harness); registered with the observer at
- *  run_started, gone after run_settled. */
+ *  run_started, gone after run_settled. RACE WINDOW: an accepted `abort` can still settle
+ *  `completed` — the run may finish between acceptance and the cut; acceptance is not outcome,
+ *  the settlement is the truth. */
 export interface RunControls {
   steer(prompt: Prompt): Promise<void>;
   followUp(prompt: Prompt): Promise<void>;
@@ -417,29 +419,39 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         log.warn(`[fastagent] session observer threw (event ${event.type}): ${String(error)}`);
       }
     };
-    // The controls close over the harness REFERENCE (assigned below): run_started must be observed
-    // before the (awaited) harness build so no early event outruns registration, and a dispatch
-    // that races the build simply finds the queue on the freshly built harness.
-    let liveHarness: Awaited<ReturnType<PiHarnessFactory>> | undefined;
-    const requireHarness = () => {
-      if (!liveHarness) throw new Error("run is still assembling; retry the command");
-      return liveHarness;
-    };
+    // run_started must be observed before the (awaited) harness build so no early event outruns
+    // registration — so the controls AWAIT the build instead of erroring on the assembling window:
+    // a dispatch that races the build simply queues on the freshly built harness. A setup failure
+    // rejects the gate (and the run settles failed); the guard keeps an undispatched rejection from
+    // becoming an unhandled-rejection crash.
+    let harnessReady!: (h: Awaited<ReturnType<PiHarnessFactory>>) => void;
+    let harnessFailed!: (e: unknown) => void;
+    const harnessGate = new Promise<Awaited<ReturnType<PiHarnessFactory>>>((resolve, reject) => {
+      harnessReady = resolve;
+      harnessFailed = reject;
+    });
+    harnessGate.catch(() => {}); // observed via controls only when a dispatch actually happens
     // A control-plane abort may surface from pi as a THROWN harness error or as a resolved
     // stopReason:"aborted" message depending on where the run was cut — the flag classifies the
-    // terminal deterministically either way.
+    // terminal deterministically either way. Set optimistically and ROLLED BACK if abort() itself
+    // fails: a rejected abort must not reclassify this run's real error as a deliberate stop.
     let abortRequested = false;
     const controls: RunControls = {
       async steer(p: Prompt) {
-        await requireHarness().steer(p.text, await toPiPromptOptions(p));
+        await (await harnessGate).steer(p.text, await toPiPromptOptions(p));
       },
       async followUp(p: Prompt) {
-        await requireHarness().followUp(p.text, await toPiPromptOptions(p));
+        await (await harnessGate).followUp(p.text, await toPiPromptOptions(p));
       },
       async abort() {
-        const harness = requireHarness();
+        const harness = await harnessGate;
         abortRequested = true;
-        await harness.abort();
+        try {
+          await harness.abort();
+        } catch (error) {
+          abortRequested = false;
+          throw error;
+        }
       },
     };
     observe({ type: "run_started", timestamp: Date.now(), runId, data: {} }, controls);
@@ -449,13 +461,14 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         harness = await harnessFactory(scope.session);
       } catch (error) {
         // Setup failures (session open / auth / …) MUST surface as a failed event, never a throw.
+        harnessFailed(error); // a pending dispatch learns the run cannot take commands
         const terminal = errorToTerminal(error);
         outcome = { status: "failed", error: { message: terminal.details, retryable: terminal.retryable } };
         yield terminal;
         return; // → outer finally emits the settlement
       }
 
-      liveHarness = harness;
+      harnessReady(harness);
       const queue = new EventQueue<AgentEvent>();
       const unsub = harness.subscribe((pe) => {
         const rich = toSessionEvent(pe, runId);

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -461,11 +461,14 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       async abort() {
         const harness = await harnessGate;
         if (runSettled) throw settledError();
+        // Rollback is scoped to THIS call: a failed second abort must not undo a first, successful
+        // abort's classification — only the caller that flipped the flag may flip it back.
+        const mine = !abortRequested;
         abortRequested = true;
         try {
           await harness.abort();
         } catch (error) {
-          abortRequested = false;
+          if (mine) abortRequested = false;
           throw error;
         }
       },
@@ -480,6 +483,7 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         harnessFailed(error); // a pending dispatch learns the run cannot take commands
         const terminal = errorToTerminal(error);
         outcome = { status: "failed", error: { message: terminal.details, retryable: terminal.retryable } };
+        runSettled = true; // commands can no longer take effect — reject stale controls from here on
         yield terminal;
         return; // → outer finally emits the settlement
       }
@@ -524,6 +528,11 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
                   error: { code: terminal.code, message: terminal.details, retryable: terminal.retryable },
                 };
         }
+        // Commands become ineffective the moment the run resolved — NOT at the outer finally, which
+        // sits behind `yield terminal` (a consumer-paced suspension) and auto-compaction. Flipping
+        // here closes the silent-drop window for steer/follow_up dispatched in that gap; the
+        // outer-finally flip remains as the backstop for caller cancellation.
+        runSettled = true;
         yield terminal;
       } finally {
         // After a successful turn, keep the session under the model's context window (a long shared group

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -439,15 +439,17 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       harnessFailed = reject;
     });
     harnessGate.catch(() => {}); // observed via controls only when a dispatch actually happens
-    // A control-plane abort may surface from pi as a THROWN harness error or as a resolved
-    // stopReason:"aborted" message, and providers do not uniformly attribute an aborted stream —
-    // so classification is by INTENT (this flag), not by error source. Set optimistically (the
-    // harness error can land before abort() resolves) and rolled back only when no abort call
-    // succeeded. GUARANTEE BOUNDARY: if abort() ultimately rejects but the run resolved with an
-    // independent real error before the rollback landed, that error is classified `aborted` — a
-    // narrow window, and non-lossy: the settlement carries `error.message` either way.
-    let abortRequested = false;
-    let abortSucceeded = false; // any ONE successful abort() pins the aborted classification
+    // Aborted classification has two attribution sources, either suffices: pi's own
+    // stopReason:"aborted" (toTerminal), and control-plane INTENT — needed because providers do
+    // not uniformly attribute an aborted stream (verified empirically: the faux path surfaces a
+    // plain error). Intent = "an abort() succeeded, OR one was still in flight when the terminal
+    // arrived" (the harness error often lands before abort() resolves). A rejected abort that
+    // RETURNED before the terminal counts as nothing — no rollback dance, no interleaving hazard.
+    // GUARANTEE BOUNDARY: an abort still in flight that ultimately rejects can classify a
+    // concurrent real error as aborted — narrow, and non-lossy: the settlement carries
+    // `error.message` either way.
+    let abortsInFlight = 0;
+    let abortSucceeded = false;
     // Stale-controls guard: after settlement pi's steer()/followUp()/abort() would still resolve
     // (they queue / no-op on the to-be-discarded harness) — a silent acceptance of a command that
     // can never take effect. The flag flips at THREE points, earliest wins: (1) the moment the
@@ -476,18 +478,12 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       async abort() {
         const harness = await harnessGate;
         if (runSettled) throw settledError();
-        // The optimistic flag covers the window where the harness error lands before abort()
-        // resolves. Rollback only when NO abort call has succeeded: the flag means "an abort took
-        // effect", so a failed first call must not undo a concurrent second call's success (nor
-        // vice versa) — ownership alone would roll back the wrong direction.
-        const mine = !abortRequested;
-        abortRequested = true;
+        abortsInFlight++;
         try {
           await harness.abort();
           abortSucceeded = true;
-        } catch (error) {
-          if (mine && !abortSucceeded) abortRequested = false;
-          throw error;
+        } finally {
+          abortsInFlight--;
         }
       },
     };
@@ -533,7 +529,7 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         } catch (error) {
           terminal = errorToTerminal(error);
         }
-        if (abortRequested && terminal.type === "failed") {
+        if ((abortSucceeded || abortsInFlight > 0) && terminal.type === "failed") {
           terminal = { type: "failed", details: terminal.details, retryable: false, code: ABORTED_CODE };
         }
         if (terminal.type === "completed") outcome = { status: "completed" };

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -441,22 +441,26 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
     // can never take effect. The flag flips in the outer finally BEFORE run_settled is observed, so
     // a post-settle call throws and the dispatcher maps it to `run_command_failed`.
     let runSettled = false;
-    const requireLive = async () => {
-      const harness = await harnessGate;
-      if (runSettled) throw new Error("run already settled; the command cannot take effect");
-      return harness;
-    };
+    const settledError = () => new Error("run already settled; the command cannot take effect");
+    // The settled check and the harness call MUST share one synchronous block (no await between):
+    // pi enqueues/aborts synchronously at method entry, so check-then-call in the same tick truly
+    // closes the race — a check behind its own await boundary would only shrink it.
     const controls: RunControls = {
       async steer(p: Prompt) {
         const opts = await toPiPromptOptions(p);
-        await (await requireLive()).steer(p.text, opts);
+        const harness = await harnessGate;
+        if (runSettled) throw settledError();
+        await harness.steer(p.text, opts);
       },
       async followUp(p: Prompt) {
         const opts = await toPiPromptOptions(p);
-        await (await requireLive()).followUp(p.text, opts);
+        const harness = await harnessGate;
+        if (runSettled) throw settledError();
+        await harness.followUp(p.text, opts);
       },
       async abort() {
-        const harness = await requireLive();
+        const harness = await harnessGate;
+        if (runSettled) throw settledError();
         abortRequested = true;
         try {
           await harness.abort();

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -219,9 +219,10 @@ export function projectAgentEvent(se: SessionEvent): AgentEvent | null {
 
 /** Live modulation handles for one active run — what the control plane's `dispatch` routes to.
  *  Built inside the invoke closure (it owns the harness); registered with the observer at
- *  run_started, gone after run_settled. RACE WINDOW: an accepted `abort` can still settle
- *  `completed` — the run may finish between acceptance and the cut; acceptance is not outcome,
- *  the settlement is the truth. */
+ *  run_started, gone after run_settled. RACE WINDOW (all three commands, symmetric): the run may
+ *  resolve between the settled-check and the engine call landing — an accepted `abort` can still
+ *  settle `completed`, and an accepted `steer`/`followUp` can settle without the prompt ever being
+ *  consumed. Acceptance is not outcome; the settlement is the truth. */
 export interface RunControls {
   steer(prompt: Prompt): Promise<void>;
   followUp(prompt: Prompt): Promise<void>;

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -14,7 +14,15 @@
 import type { AgentHarnessEvent } from "@earendil-works/pi-agent-core";
 import { DEFAULT_COMPACTION_SETTINGS, calculateContextTokens, shouldCompact } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
-import { type Agent, type AgentEvent, type Json, type Prompt, type Scope, SESSION_BUSY_CODE } from "../../agent.ts";
+import {
+  ABORTED_CODE,
+  type Agent,
+  type AgentEvent,
+  type Json,
+  type Prompt,
+  type Scope,
+  SESSION_BUSY_CODE,
+} from "../../agent.ts";
 import type { RunSettledEvent, SessionEvent } from "../../session.ts";
 import { log } from "../../log.ts";
 import { TOOL_ACTIVATION_ENTRY, harnessSession, type PiHarnessFactory } from "./harness.ts";
@@ -233,11 +241,10 @@ export type SessionObserver = (session: string, event: SessionEvent, run?: RunCo
  */
 export function toTerminal(message: AssistantMessage): AgentEvent {
   if (message.stopReason === "aborted") {
-    // A deliberate stop (control-plane abort / harness abort), not an error: `code: "aborted"` lets
-    // a channel render cancellation distinctly, and channels MUST treat it as a settled outcome
-    // (durable turn-intent cleanup included) so an operator's abort is never replayed (design §6).
+    // A deliberate stop (control-plane abort / harness abort), not an error — see {@link ABORTED_CODE}
+    // for the consumer contract (design §6).
     const details = message.errorMessage ?? "run aborted";
-    return { type: "failed", details, retryable: false, code: "aborted" };
+    return { type: "failed", details, retryable: false, code: ABORTED_CODE };
   }
   if (message.stopReason === "error") {
     const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
@@ -432,15 +439,21 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
     });
     harnessGate.catch(() => {}); // observed via controls only when a dispatch actually happens
     // A control-plane abort may surface from pi as a THROWN harness error or as a resolved
-    // stopReason:"aborted" message depending on where the run was cut — the flag classifies the
-    // terminal deterministically either way. Set optimistically and ROLLED BACK if abort() itself
-    // fails: a rejected abort must not reclassify this run's real error as a deliberate stop.
+    // stopReason:"aborted" message, and providers do not uniformly attribute an aborted stream —
+    // so classification is by INTENT (this flag), not by error source. Set optimistically (the
+    // harness error can land before abort() resolves) and rolled back only when no abort call
+    // succeeded. GUARANTEE BOUNDARY: if abort() ultimately rejects but the run resolved with an
+    // independent real error before the rollback landed, that error is classified `aborted` — a
+    // narrow window, and non-lossy: the settlement carries `error.message` either way.
     let abortRequested = false;
     let abortSucceeded = false; // any ONE successful abort() pins the aborted classification
     // Stale-controls guard: after settlement pi's steer()/followUp()/abort() would still resolve
     // (they queue / no-op on the to-be-discarded harness) — a silent acceptance of a command that
-    // can never take effect. The flag flips in the outer finally BEFORE run_settled is observed, so
-    // a post-settle call throws and the dispatcher maps it to `run_command_failed`.
+    // can never take effect. The flag flips at THREE points, earliest wins: (1) the moment the
+    // run's terminal is determined (the main window — before the consumer-paced `yield terminal`
+    // and auto-compaction), (2) the setup-failure path, (3) the outer finally as the backstop for
+    // caller cancellation. A post-settle call throws and the dispatcher maps it to
+    // `run_command_failed`.
     let runSettled = false;
     const settledError = () => new Error("run already settled; the command cannot take effect");
     // The settled check and the harness call MUST share one synchronous block (no await between):
@@ -520,12 +533,12 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
           terminal = errorToTerminal(error);
         }
         if (abortRequested && terminal.type === "failed") {
-          terminal = { type: "failed", details: terminal.details, retryable: false, code: "aborted" };
+          terminal = { type: "failed", details: terminal.details, retryable: false, code: ABORTED_CODE };
         }
         if (terminal.type === "completed") outcome = { status: "completed" };
         else if (terminal.type === "failed") {
           outcome =
-            terminal.code === "aborted"
+            terminal.code === ABORTED_CODE
               ? // Carry the detail: an independent real error that raced an accepted abort must stay
                 // diagnosable in the settlement (audit consumers read run_settled, not the invoke
                 // stream) — aborted classifies the run, the message preserves what actually stopped it.

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -436,6 +436,7 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
     // terminal deterministically either way. Set optimistically and ROLLED BACK if abort() itself
     // fails: a rejected abort must not reclassify this run's real error as a deliberate stop.
     let abortRequested = false;
+    let abortSucceeded = false; // any ONE successful abort() pins the aborted classification
     // Stale-controls guard: after settlement pi's steer()/followUp()/abort() would still resolve
     // (they queue / no-op on the to-be-discarded harness) — a silent acceptance of a command that
     // can never take effect. The flag flips in the outer finally BEFORE run_settled is observed, so
@@ -461,14 +462,17 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       async abort() {
         const harness = await harnessGate;
         if (runSettled) throw settledError();
-        // Rollback is scoped to THIS call: a failed second abort must not undo a first, successful
-        // abort's classification — only the caller that flipped the flag may flip it back.
+        // The optimistic flag covers the window where the harness error lands before abort()
+        // resolves. Rollback only when NO abort call has succeeded: the flag means "an abort took
+        // effect", so a failed first call must not undo a concurrent second call's success (nor
+        // vice versa) — ownership alone would roll back the wrong direction.
         const mine = !abortRequested;
         abortRequested = true;
         try {
           await harness.abort();
+          abortSucceeded = true;
         } catch (error) {
-          if (mine) abortRequested = false;
+          if (mine && !abortSucceeded) abortRequested = false;
           throw error;
         }
       },
@@ -522,7 +526,10 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
         else if (terminal.type === "failed") {
           outcome =
             terminal.code === "aborted"
-              ? { status: "aborted" }
+              ? // Carry the detail: an independent real error that raced an accepted abort must stay
+                // diagnosable in the settlement (audit consumers read run_settled, not the invoke
+                // stream) — aborted classifies the run, the message preserves what actually stopped it.
+                { status: "aborted", error: { message: terminal.details, retryable: false } }
               : {
                   status: "failed",
                   error: { code: terminal.code, message: terminal.details, retryable: terminal.retryable },

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -15,6 +15,7 @@ import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import type { Json } from "../../agent.ts";
 import {
   NO_ACTIVE_RUN_CODE,
+  RUN_COMMAND_FAILED_CODE,
   type SessionCapabilities,
   type SessionCommand,
   type SessionControl,
@@ -232,11 +233,12 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
             else if (command.type === "follow_up") await run.controls.followUp(command.prompt);
             else await run.controls.abort();
           } catch (error) {
-            // The run raced us to settlement (or the engine refused): still pre-acceptance — the
-            // queue/abort call did not take effect.
+            // The run raced us to settlement, failed setup, or the engine refused: still
+            // pre-acceptance (nothing was queued), distinct from "no run existed" — and safe to
+            // retry against the session's next state.
             return {
               ok: false,
-              error: { code: NO_ACTIVE_RUN_CODE, message: String(error), retryable: false },
+              error: { code: RUN_COMMAND_FAILED_CODE, message: String(error), retryable: true },
             };
           }
           // Accepted: joined (or stopped) THIS run. The outcome arrives as run_settled.

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -230,14 +230,14 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
           }
           if (!run.controls) {
             // A run EXISTS (state() rightly reports running) but was registered observation-only
-            // (the observer seam allows run_started without controls) — a different failure than
-            // "no run": the no_active_run guidance ("re-dispatch once state() shows a run") would
-            // loop forever here.
+            // (the observer seam allows run_started without controls). That is a CAPABILITY
+            // problem, not a run problem — permanent for this wiring, so neither no_active_run
+            // (would poll forever) nor run_command_failed (transient) fits.
             return {
               ok: false,
               error: {
-                code: RUN_COMMAND_FAILED_CODE,
-                message: `the active run registered without controls (observation-only) — ${command.type} cannot reach it`,
+                code: UNSUPPORTED_CAPABILITY_CODE,
+                message: `the active run registered without modulation controls (observation-only) — ${command.type} cannot reach it`,
                 retryable: false,
               },
             };

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -1,18 +1,20 @@
 /**
- * The pi implementation of the session control plane's OBSERVATION half (design Phase 1):
- * `state`/`entries`/`events` over invoke-driven runs. `createPiSessionControl` returns the neutral
- * `SessionControl` plus the {@link SessionObserver} to plug into the invoke pipeline
- * (`createPiAgentFromHarness({ observer })`) — the hub derives everything from the rich event
- * stream, holds no durable state of its own, and never writes: durable truth stays in the session
- * repository (read via {@link PiSessionReader}), live truth in the events the data plane emits.
+ * The pi implementation of the session control plane: observation (`state`/`entries`/`events`,
+ * design Phase 1) and run modulation (`dispatch`: steer/follow_up/abort, Phase 2a) over
+ * invoke-driven runs. `createPiSessionControl` returns the neutral `SessionControl` plus the
+ * {@link SessionObserver} to plug into the invoke pipeline (`createPiAgentFromHarness({ observer })`)
+ * — the hub derives everything from the rich event stream (plus the {@link RunControls} the
+ * run_started event carries), holds no durable state of its own, and never writes: durable truth
+ * stays in the session repository (read via {@link PiSessionReader}), live truth in the events the
+ * data plane emits, modulation in the controls the data plane registers.
  *
- * Phase 2 (steer/follow_up/abort/compact/set_model/set_thinking) lands in `dispatch`; until then
- * every command is rejected before acceptance with `unsupported_capability` — a client gating on
- * `capabilities()` never sends them.
+ * Phase 2b (boundary mutations: compact/set_model/set_thinking) is still rejected before acceptance
+ * with `unsupported_capability` — a client gating on `capabilities()` never sends them.
  */
 import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import type { Json } from "../../agent.ts";
 import {
+  NO_ACTIVE_RUN_CODE,
   type SessionCapabilities,
   type SessionCommand,
   type SessionControl,
@@ -23,7 +25,7 @@ import {
   type SessionState,
   UNSUPPORTED_CAPABILITY_CODE,
 } from "../../session.ts";
-import type { SessionObserver } from "./invoke.ts";
+import type { RunControls, SessionObserver } from "./invoke.ts";
 import type { PiSessionReader } from "./sessions.ts";
 
 // ── Entry normalization (durable plane) ──────────────────────────────────────
@@ -124,23 +126,33 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
   observer: SessionObserver;
 } {
   const { sessions } = options;
-  /** Live run state per session — derived purely from run_started/run_settled. */
-  const active = new Map<string, string>(); // session → activeRunId
+  /** Live run state per session — derived purely from run_started/run_settled and the controls
+   *  registered with run_started. */
+  const active = new Map<
+    string,
+    { runId: string; controls?: RunControls; pending: { steering: number; followUp: number } }
+  >();
   const subscribers = new Map<string, Set<Subscriber>>();
 
-  const observer: SessionObserver = (session, event) => {
-    if (event.type === "run_started" && event.runId) active.set(session, event.runId);
-    else if (event.type === "run_settled") active.delete(session);
+  const observer: SessionObserver = (session, event, run) => {
+    if (event.type === "run_started" && event.runId) {
+      active.set(session, { runId: event.runId, controls: run, pending: { steering: 0, followUp: 0 } });
+    } else if (event.type === "run_settled") {
+      active.delete(session);
+    } else if (event.type === "queue_changed") {
+      const entry = active.get(session);
+      if (entry) entry.pending = event.data as { steering: number; followUp: number };
+    }
     const subs = subscribers.get(session);
     if (subs) for (const sub of [...subs]) sub.push(event);
   };
 
   const capabilities: SessionCapabilities = {
-    steering: false,
-    followUp: false,
-    manualCompaction: false,
-    modelSelection: false,
-    thinkingLevel: false,
+    steering: true,
+    followUp: true,
+    manualCompaction: false, // Phase 2b
+    modelSelection: false, // Phase 2b
+    thinkingLevel: false, // Phase 2b
     toolProgress: true, // tool_progress IS delivered (replace-semantics snapshots)
     usage: false,
   };
@@ -149,13 +161,13 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
     capabilities: () => capabilities,
 
     async state(session): Promise<SessionState> {
-      const activeRunId = active.get(session);
+      const run = active.get(session);
       const opened = await sessions.openIfExists(session);
       const leafEntryId = opened ? ((await opened.getLeafId()) ?? undefined) : undefined;
       return {
-        status: activeRunId ? "running" : "idle",
-        ...(activeRunId ? { activeRunId } : {}),
-        pending: { steering: 0, followUp: 0 },
+        status: run ? "running" : "idle",
+        ...(run ? { activeRunId: run.runId } : {}),
+        pending: run ? { ...run.pending } : { steering: 0, followUp: 0 },
         ...(leafEntryId ? { leafEntryId } : {}),
       };
     },
@@ -197,17 +209,51 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
       })();
     },
 
-    async dispatch(_session, command: SessionCommand): Promise<SessionResult> {
-      // Phase 1 is the observation plane only. Rejected BEFORE acceptance (safe to retry after
-      // upgrading); a capability-gating client never lands here.
-      return {
-        ok: false,
-        error: {
-          code: UNSUPPORTED_CAPABILITY_CODE,
-          message: `command "${command.type}" is not supported by this runtime (observation plane only)`,
-          retryable: false,
-        },
-      };
+    async dispatch(session, command: SessionCommand): Promise<SessionResult> {
+      switch (command.type) {
+        case "steer":
+        case "follow_up":
+        case "abort": {
+          const run = active.get(session);
+          if (!run?.controls) {
+            // Rejected BEFORE acceptance: no run exists (or its controls are gone), nothing
+            // happened, safe to retry once a run is active.
+            return {
+              ok: false,
+              error: {
+                code: NO_ACTIVE_RUN_CODE,
+                message: `no active run for this session — ${command.type} modulates a run an invoke is driving`,
+                retryable: false,
+              },
+            };
+          }
+          try {
+            if (command.type === "steer") await run.controls.steer(command.prompt);
+            else if (command.type === "follow_up") await run.controls.followUp(command.prompt);
+            else await run.controls.abort();
+          } catch (error) {
+            // The run raced us to settlement (or the engine refused): still pre-acceptance — the
+            // queue/abort call did not take effect.
+            return {
+              ok: false,
+              error: { code: NO_ACTIVE_RUN_CODE, message: String(error), retryable: false },
+            };
+          }
+          // Accepted: joined (or stopped) THIS run. The outcome arrives as run_settled.
+          return { ok: true, runId: run.runId };
+        }
+        default:
+          // Phase 2b (compact/set_model/set_thinking): rejected before acceptance; a
+          // capability-gating client never lands here.
+          return {
+            ok: false,
+            error: {
+              code: UNSUPPORTED_CAPABILITY_CODE,
+              message: `command "${command.type}" is not supported by this runtime yet`,
+              retryable: false,
+            },
+          };
+      }
     },
   };
 

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -218,7 +218,8 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
           const run = active.get(session);
           if (!run?.controls) {
             // Rejected BEFORE acceptance: no run exists (or its controls are gone), nothing
-            // happened, safe to retry once a run is active.
+            // happened. retryable: false — as-is retry fails again; re-dispatch after state()
+            // shows an active run.
             return {
               ok: false,
               error: {
@@ -234,11 +235,11 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
             else await run.controls.abort();
           } catch (error) {
             // The run raced us to settlement, failed setup, or the engine refused: still
-            // pre-acceptance (nothing was queued), distinct from "no run existed" — and safe to
-            // retry against the session's next state.
+            // pre-acceptance (nothing was queued), distinct from "no run existed". retryable:
+            // false for the same reason — the run is gone; consult state() before re-dispatching.
             return {
               ok: false,
-              error: { code: RUN_COMMAND_FAILED_CODE, message: String(error), retryable: true },
+              error: { code: RUN_COMMAND_FAILED_CODE, message: String(error), retryable: false },
             };
           }
           // Accepted: joined (or stopped) THIS run. The outcome arrives as run_settled.

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -216,15 +216,28 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
         case "follow_up":
         case "abort": {
           const run = active.get(session);
-          if (!run?.controls) {
-            // Rejected BEFORE acceptance: no run exists (or its controls are gone), nothing
-            // happened. retryable: false — as-is retry fails again; re-dispatch after state()
-            // shows an active run.
+          if (!run) {
+            // Rejected BEFORE acceptance: no run exists, nothing happened. retryable: false —
+            // as-is retry fails again; re-dispatch after state() shows an active run.
             return {
               ok: false,
               error: {
                 code: NO_ACTIVE_RUN_CODE,
                 message: `no active run for this session — ${command.type} modulates a run an invoke is driving`,
+                retryable: false,
+              },
+            };
+          }
+          if (!run.controls) {
+            // A run EXISTS (state() rightly reports running) but was registered observation-only
+            // (the observer seam allows run_started without controls) — a different failure than
+            // "no run": the no_active_run guidance ("re-dispatch once state() shows a run") would
+            // loop forever here.
+            return {
+              ok: false,
+              error: {
+                code: RUN_COMMAND_FAILED_CODE,
+                message: `the active run registered without controls (observation-only) — ${command.type} cannot reach it`,
                 retryable: false,
               },
             };

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -57,8 +57,9 @@ export interface CreatePiAgentFromWorkspaceOptions {
    *  {@link sessionControl} — the store is created inside this opener, so the hub must be wired
    *  here too (an external `createPiSessionControl` cannot exist before the store does). */
   sessionControl?: boolean;
-  /** Additional raw observation tap, composed AFTER the {@link sessionControl} hub's observer.
-   *  Advanced: most consumers want {@link sessionControl} instead. */
+  /** Additional raw tap, composed AFTER the {@link sessionControl} hub's observer. TRUSTED seam:
+   *  since Phase 2a an observer receives each run's live modulation handles (see
+   *  `SessionObserver`) — for read-only consumers use the hub's `events()` stream instead. */
   observer?: SessionObserver;
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -49,6 +49,12 @@ export const UNSUPPORTED_CAPABILITY_CODE = "unsupported_capability";
  *  once a run exists. */
 export const NO_ACTIVE_RUN_CODE = "no_active_run";
 
+/** Stable `SessionResult.error.code` for a run command that reached an active run but could not
+ *  take effect (the run raced to settlement, or the engine refused it). Distinct from
+ *  {@link NO_ACTIVE_RUN_CODE}: the run existed. Still pre-acceptance — nothing was queued — and
+ *  safe to retry against the session's next state. */
+export const RUN_COMMAND_FAILED_CODE = "run_command_failed";
+
 // ── Commands (control plane) ─────────────────────────────────────────────────
 
 /** Six commands; deliberately NO `prompt` — starting work is the data plane's definition. */

--- a/src/session.ts
+++ b/src/session.ts
@@ -49,11 +49,12 @@ export const UNSUPPORTED_CAPABILITY_CODE = "unsupported_capability";
  *  fails again; re-dispatch only after `state()` shows an active run. */
 export const NO_ACTIVE_RUN_CODE = "no_active_run";
 
-/** Stable `SessionResult.error.code` for a run command that reached an active run but could not
- *  take effect (the run raced to settlement, or the engine refused it). Distinct from
- *  {@link NO_ACTIVE_RUN_CODE}: the run existed. Still pre-acceptance — nothing was queued — and
- *  `retryable: false` for the same reason: the run is gone, so the same command as-is fails again;
- *  consult `state()` before re-dispatching. */
+/** Stable `SessionResult.error.code` for a run command that reached a run but could not take
+ *  effect. Distinct from {@link NO_ACTIVE_RUN_CODE}: the run existed. Two situations share it —
+ *  the run raced to settlement (gone by now), or the runtime registered the run without
+ *  modulation controls (observation-only; still running). `state()` alone cannot disambiguate;
+ *  inspect `error.message`. Still pre-acceptance — nothing was queued — and `retryable: false`:
+ *  the same command as-is fails again. */
 export const RUN_COMMAND_FAILED_CODE = "run_command_failed";
 
 // ── Commands (control plane) ─────────────────────────────────────────────────

--- a/src/session.ts
+++ b/src/session.ts
@@ -44,6 +44,11 @@ export interface SessionCapabilities {
 /** Stable `SessionResult.error.code` for a command the implementation does not support. */
 export const UNSUPPORTED_CAPABILITY_CODE = "unsupported_capability";
 
+/** Stable `SessionResult.error.code` for a run-modulating command (`steer`/`follow_up`/`abort`)
+ *  dispatched while the session has no active run — rejected before acceptance, safe to retry
+ *  once a run exists. */
+export const NO_ACTIVE_RUN_CODE = "no_active_run";
+
 // ── Commands (control plane) ─────────────────────────────────────────────────
 
 /** Six commands; deliberately NO `prompt` — starting work is the data plane's definition. */
@@ -139,6 +144,11 @@ export type ToolProgressEvent = SessionEvent<"tool_progress", { id: string; name
 export type ToolFinishedEvent = SessionEvent<"tool_finished", { id: string; isError: boolean; content: Json }> & {
   runId: string;
 };
+/** Normalized live queue depths for the active run (L1). */
+export type QueueChangedEvent = SessionEvent<"queue_changed", { steering: number; followUp: number }> & {
+  runId: string;
+};
+
 /**
  * The serving process failed outside a normal run outcome (fail visibly). Emitted by TRANSPORT
  * adapters (design §13) when they lose the backend before ending a remote stream — an in-process
@@ -147,9 +157,9 @@ export type ToolFinishedEvent = SessionEvent<"tool_finished", { id: string; isEr
  */
 export type ServingErrorEvent = SessionEvent<"serving_error", { message: string }>;
 
-/** The Phase 1 (L0) vocabulary — every event the in-process observation plane emits today. L1–L2
- *  events (queue_changed, turn_*, compaction_*, retry_*, state_changed) arrive with the control
- *  plane; {@link ServingErrorEvent} arrives with the transport adapter. */
+/** Every event the in-process observation plane emits today: the L0 vocabulary plus L1
+ *  `queue_changed`. L2 events (turn_*, compaction_*, retry_*, state_changed) arrive with boundary
+ *  mutations; {@link ServingErrorEvent} arrives with the transport adapter. */
 export type KnownSessionEvent =
   | RunStartedEvent
   | RunSettledEvent
@@ -158,4 +168,5 @@ export type KnownSessionEvent =
   | MessageFinishedEvent
   | ToolStartedEvent
   | ToolProgressEvent
-  | ToolFinishedEvent;
+  | ToolFinishedEvent
+  | QueueChangedEvent;

--- a/src/session.ts
+++ b/src/session.ts
@@ -45,14 +45,15 @@ export interface SessionCapabilities {
 export const UNSUPPORTED_CAPABILITY_CODE = "unsupported_capability";
 
 /** Stable `SessionResult.error.code` for a run-modulating command (`steer`/`follow_up`/`abort`)
- *  dispatched while the session has no active run — rejected before acceptance, safe to retry
- *  once a run exists. */
+ *  dispatched while the session has no active run. `retryable: false` — re-dispatching as-is
+ *  fails again; re-dispatch only after `state()` shows an active run. */
 export const NO_ACTIVE_RUN_CODE = "no_active_run";
 
 /** Stable `SessionResult.error.code` for a run command that reached an active run but could not
  *  take effect (the run raced to settlement, or the engine refused it). Distinct from
  *  {@link NO_ACTIVE_RUN_CODE}: the run existed. Still pre-acceptance — nothing was queued — and
- *  safe to retry against the session's next state. */
+ *  `retryable: false` for the same reason: the run is gone, so the same command as-is fails again;
+ *  consult `state()` before re-dispatching. */
 export const RUN_COMMAND_FAILED_CODE = "run_command_failed";
 
 // ── Commands (control plane) ─────────────────────────────────────────────────
@@ -69,7 +70,10 @@ export type SessionCommand =
 /**
  * Acceptance is not outcome: `ok: true` means admitted or applied, never that the run ultimately
  * succeeded (outcomes are `run_settled` events / the invoke terminal). `ok: false` is guaranteed to
- * mean rejection BEFORE acceptance — the only case that is safe to blindly retry.
+ * mean rejection BEFORE acceptance — nothing took effect. `error.retryable` means "re-dispatching
+ * the SAME command as-is may succeed"; a `false` with a state-dependent code (e.g.
+ * {@link NO_ACTIVE_RUN_CODE}) invites a re-dispatch only after `state()` shows the condition
+ * changed.
  */
 export type SessionResult =
   | { ok: true; runId?: string }

--- a/src/session.ts
+++ b/src/session.ts
@@ -49,12 +49,12 @@ export const UNSUPPORTED_CAPABILITY_CODE = "unsupported_capability";
  *  fails again; re-dispatch only after `state()` shows an active run. */
 export const NO_ACTIVE_RUN_CODE = "no_active_run";
 
-/** Stable `SessionResult.error.code` for a run command that reached a run but could not take
- *  effect. Distinct from {@link NO_ACTIVE_RUN_CODE}: the run existed. Two situations share it —
- *  the run raced to settlement (gone by now), or the runtime registered the run without
- *  modulation controls (observation-only; still running). `state()` alone cannot disambiguate;
- *  inspect `error.message`. Still pre-acceptance — nothing was queued — and `retryable: false`:
- *  the same command as-is fails again. */
+/** Stable `SessionResult.error.code` for a run command that reached an active run but could not
+ *  take effect because the run raced to settlement (or the engine refused it). Distinct from
+ *  {@link NO_ACTIVE_RUN_CODE}: the run existed — and TRANSIENT: the session's next run can be
+ *  dispatched to. Still pre-acceptance — nothing was queued — and `retryable: false`: the same
+ *  command as-is fails again. (A run registered without modulation controls is a capability
+ *  problem, not a run problem, and rejects with {@link UNSUPPORTED_CAPABILITY_CODE}.) */
 export const RUN_COMMAND_FAILED_CODE = "run_command_failed";
 
 // ── Commands (control plane) ─────────────────────────────────────────────────
@@ -71,8 +71,11 @@ export type SessionCommand =
 /**
  * Acceptance is not outcome: `ok: true` means admitted or applied, never that the run ultimately
  * succeeded (outcomes are `run_settled` events / the invoke terminal). `ok: false` is guaranteed to
- * mean rejection BEFORE acceptance — nothing took effect. `error.retryable` means "re-dispatching
- * the SAME command as-is may succeed"; a `false` with a state-dependent code (e.g.
+ * mean rejection BEFORE acceptance — nothing was queued or applied. ONE exception to "nothing took
+ * effect": a rejected `abort` may still have attributed a concurrently-settling run as `aborted`
+ * (the intent was live while the run resolved — see the guarantee boundary in the pi
+ * implementation); the settlement is the truth. `error.retryable` means "re-dispatching the SAME
+ * command as-is may succeed"; a `false` with a state-dependent code (e.g.
  * {@link NO_ACTIVE_RUN_CODE}) invites a re-dispatch only after `state()` shows the condition
  * changed.
  */

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -519,7 +519,7 @@ describe("session control (Phase 2a): run modulation", () => {
     await expect((captured as NonNullable<typeof captured>).abort()).rejects.toThrow(/already settled/);
   });
 
-  it("dispatch maps a refused run command to run_command_failed (retryable)", async () => {
+  it("dispatch maps a refused run command to run_command_failed", async () => {
     const sessions = inMemorySessionStore();
     const { control, observer } = createPiSessionControl({ sessions });
     // Register a live run whose controls refuse — the observer seam is the public wiring point.
@@ -538,7 +538,7 @@ describe("session control (Phase 2a): run modulation", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.code).toBe(RUN_COMMAND_FAILED_CODE);
-      expect(result.error.retryable).toBe(true);
+      expect(result.error.retryable).toBe(false); // as-is retry fails again — consult state() first
     }
   });
 

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -495,6 +495,27 @@ describe("session control (Phase 2a): run modulation", () => {
     expect(seen.filter((e) => e.type === "run_settled")).toHaveLength(1); // still exactly one
   });
 
+  it("toTerminal attributes pi's own stopReason 'aborted' without any control-plane intent", async () => {
+    const { toTerminal } = await import("../src/engines/pi/invoke.ts");
+    const terminal = toTerminal({
+      role: "assistant",
+      content: [],
+      api: "openai-completions",
+      provider: "faux",
+      model: "faux",
+      stopReason: "aborted",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      timestamp: 0,
+    } as never);
+    expect(terminal).toMatchObject({ type: "failed", code: ABORTED_CODE, retryable: false });
+  });
+
   it("stale controls are rejected after settlement — never a silent acceptance", async () => {
     const { faux, models } = makeFaux();
     faux.setResponses([fauxAssistantMessage("done")]);
@@ -592,7 +613,10 @@ describe("session control (Phase 2a): run modulation", () => {
     const terminal = events.at(-1);
     expect(terminal).toMatchObject({ type: "failed", code: ABORTED_CODE, retryable: false });
     const settled = seen.find((e) => e.type === "run_settled");
-    expect(settled?.data).toMatchObject({ status: "aborted" }); // error.message carries the stop detail
+    // Intent-attributed (the faux provider surfaces a plain error, not stopReason "aborted" — the
+    // in-flight abort classifies it), and NON-LOSSY: what actually stopped the run stays readable.
+    expect(settled?.data).toMatchObject({ status: "aborted" });
+    expect((settled?.data as { error?: { message: string } }).error?.message).toBeTruthy();
     // The session is reusable: back to idle, not poisoned.
     expect((await control.state("s2c")).status).toBe("idle");
   });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -14,7 +14,12 @@ import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { createPiSessionControl } from "../src/engines/pi/session-control.ts";
 import { inMemorySessionStore } from "../src/engines/pi/sessions.ts";
 import { createPiAgentFromWorkspace } from "../src/engines/pi/workspace.ts";
-import { NO_ACTIVE_RUN_CODE, UNSUPPORTED_CAPABILITY_CODE, type SessionEvent } from "../src/session.ts";
+import {
+  NO_ACTIVE_RUN_CODE,
+  RUN_COMMAND_FAILED_CODE,
+  UNSUPPORTED_CAPABILITY_CODE,
+  type SessionEvent,
+} from "../src/session.ts";
 import { makeFaux } from "./faux.ts";
 
 const echoTool: AgentTool = {
@@ -488,6 +493,53 @@ describe("session control (Phase 2a): run modulation", () => {
     expect(text).toContain("follow-up answer"); // the settle window spanned the continuation
     expect(seen.some((e) => e.type === "queue_changed")).toBe(true);
     expect(seen.filter((e) => e.type === "run_settled")).toHaveLength(1); // still exactly one
+  });
+
+  it("stale controls are rejected after settlement — never a silent acceptance", async () => {
+    const { faux, models } = makeFaux();
+    faux.setResponses([fauxAssistantMessage("done")]);
+    let captured: import("../src/engines/pi/invoke.ts").RunControls | undefined;
+    const agent = createPiAgentFromHarness({
+      observer: (_s, ev, run) => {
+        if (ev.type === "run_started") captured = run;
+      },
+      harnessFactory: piHarnessFactory({
+        sessions: inMemorySessionStore(),
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
+        models,
+        model: faux.getModel(),
+        systemPrompt: "test",
+      }),
+    });
+    await drain(agent.invoke({ session: "sStale" }, { text: "hi" })); // run fully settled
+    expect(captured).toBeDefined();
+    // A dispatch that grabbed the controls before settlement and calls after it must THROW —
+    // pi's queue/abort calls would otherwise resolve silently against a discarded harness.
+    await expect((captured as NonNullable<typeof captured>).steer({ text: "late" })).rejects.toThrow(/already settled/);
+    await expect((captured as NonNullable<typeof captured>).abort()).rejects.toThrow(/already settled/);
+  });
+
+  it("dispatch maps a refused run command to run_command_failed (retryable)", async () => {
+    const sessions = inMemorySessionStore();
+    const { control, observer } = createPiSessionControl({ sessions });
+    // Register a live run whose controls refuse — the observer seam is the public wiring point.
+    observer(
+      "sRefuse",
+      { type: "run_started", timestamp: Date.now(), runId: "r1", data: {} },
+      {
+        steer: async () => {
+          throw new Error("run already settled; the command cannot take effect");
+        },
+        followUp: async () => {},
+        abort: async () => {},
+      },
+    );
+    const result = await control.dispatch("sRefuse", { type: "steer", prompt: { text: "x" } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(RUN_COMMAND_FAILED_CODE);
+      expect(result.error.retryable).toBe(true);
+    }
   });
 
   it("abort stops the run: accepted, invoke terminal failed{code: aborted}, run_settled{aborted}", async () => {

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -519,6 +519,34 @@ describe("session control (Phase 2a): run modulation", () => {
     await expect((captured as NonNullable<typeof captured>).abort()).rejects.toThrow(/already settled/);
   });
 
+  it("a dispatch racing a failing harness build gets run_command_failed with the setup error", async () => {
+    const sessions = inMemorySessionStore();
+    const { control, observer } = createPiSessionControl({ sessions });
+    let releaseFactory: () => void = () => {};
+    const factoryGate = new Promise<void>((r) => {
+      releaseFactory = r;
+    });
+    const agent = createPiAgentFromHarness({
+      observer,
+      harnessFactory: async () => {
+        await factoryGate;
+        throw new Error("boom: setup exploded");
+      },
+    });
+    const invoked = drive(agent, "sSetup");
+    await waitForRunning(control, "sSetup"); // run_started observed; harness still assembling
+    const pending = control.dispatch("sSetup", { type: "steer", prompt: { text: "late" } });
+    releaseFactory(); // → factory throws → gate rejects → the pending dispatch learns it
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(RUN_COMMAND_FAILED_CODE);
+      expect(result.error.message).toContain("boom");
+    }
+    const events = await invoked;
+    expect(events.at(-1)).toMatchObject({ type: "failed" }); // the data plane failed visibly too
+  });
+
   it("dispatch maps a refused run command to run_command_failed", async () => {
     const sessions = inMemorySessionStore();
     const { control, observer } = createPiSessionControl({ sessions });
@@ -564,7 +592,7 @@ describe("session control (Phase 2a): run modulation", () => {
     const terminal = events.at(-1);
     expect(terminal).toMatchObject({ type: "failed", code: "aborted", retryable: false });
     const settled = seen.find((e) => e.type === "run_settled");
-    expect(settled?.data).toEqual({ status: "aborted" });
+    expect(settled?.data).toMatchObject({ status: "aborted" }); // error.message carries the stop detail
     // The session is reusable: back to idle, not poisoned.
     expect((await control.state("s2c")).status).toBe("idle");
   });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -8,7 +8,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { Type, type FauxResponseStep, fauxAssistantMessage, fauxThinking, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import type { AgentEvent } from "../src/agent.ts";
+import { ABORTED_CODE, type AgentEvent } from "../src/agent.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { createPiSessionControl } from "../src/engines/pi/session-control.ts";
@@ -590,7 +590,7 @@ describe("session control (Phase 2a): run modulation", () => {
     await watching;
 
     const terminal = events.at(-1);
-    expect(terminal).toMatchObject({ type: "failed", code: "aborted", retryable: false });
+    expect(terminal).toMatchObject({ type: "failed", code: ABORTED_CODE, retryable: false });
     const settled = seen.find((e) => e.type === "run_settled");
     expect(settled?.data).toMatchObject({ status: "aborted" }); // error.message carries the stop detail
     // The session is reusable: back to idle, not poisoned.

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -434,7 +434,11 @@ describe("session control (Phase 2a): run modulation", () => {
 
     const result = await control.dispatch("s2a", { type: "steer", prompt: { text: "actually, do it differently" } });
     expect(result).toEqual({ ok: true, runId });
-    // Queue visibility while the steer is pending (the gate still holds the run).
+    // Queue visibility while the steer is pending (the gate still holds the run). Poll: the
+    // contract says "queued", not "queue_update delivered synchronously before dispatch resolves".
+    for (let i = 0; i < 200 && (await control.state("s2a")).pending.steering !== 1; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
     expect((await control.state("s2a")).pending.steering).toBe(1);
 
     gate.release();

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -568,6 +568,21 @@ describe("session control (Phase 2a): run modulation", () => {
     expect(events.at(-1)).toMatchObject({ type: "failed" }); // the data plane failed visibly too
   });
 
+  it("an observation-only run (no controls) rejects with unsupported_capability, not a run code", async () => {
+    const sessions = inMemorySessionStore();
+    const { control, observer } = createPiSessionControl({ sessions });
+    // run_started without controls — the observer seam permits observation-only registration.
+    observer("sObs", { type: "run_started", timestamp: Date.now(), runId: "r1", data: {} });
+    expect((await control.state("sObs")).status).toBe("running"); // state truthfully reports the run
+    const result = await control.dispatch("sObs", { type: "steer", prompt: { text: "x" } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Capability problem (permanent for this wiring) — NOT no_active_run (would poll forever)
+      // and NOT run_command_failed (transient).
+      expect(result.error.code).toBe(UNSUPPORTED_CAPABILITY_CODE);
+    }
+  });
+
   it("dispatch maps a refused run command to run_command_failed", async () => {
     const sessions = inMemorySessionStore();
     const { control, observer } = createPiSessionControl({ sessions });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -14,7 +14,7 @@ import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { createPiSessionControl } from "../src/engines/pi/session-control.ts";
 import { inMemorySessionStore } from "../src/engines/pi/sessions.ts";
 import { createPiAgentFromWorkspace } from "../src/engines/pi/workspace.ts";
-import { UNSUPPORTED_CAPABILITY_CODE, type SessionEvent } from "../src/session.ts";
+import { NO_ACTIVE_RUN_CODE, UNSUPPORTED_CAPABILITY_CODE, type SessionEvent } from "../src/session.ts";
 import { makeFaux } from "./faux.ts";
 
 const echoTool: AgentTool = {
@@ -324,18 +324,192 @@ describe("session control (Phase 1): observation plane", () => {
     }
   });
 
-  it("dispatch(): Phase 1 rejects every command before acceptance with the stable code", async () => {
+  it("dispatch(): boundary mutations still reject with unsupported_capability; run commands on idle reject with no_active_run", async () => {
     const { control } = makeObserved([]);
-    const result = await control.dispatch("sD", { type: "abort" });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.code).toBe(UNSUPPORTED_CAPABILITY_CODE);
-      expect(result.error.retryable).toBe(false);
+    const compact = await control.dispatch("sD", { type: "compact" });
+    expect(compact.ok).toBe(false);
+    if (!compact.ok) expect(compact.error.code).toBe(UNSUPPORTED_CAPABILITY_CODE);
+    // steer/follow_up/abort on an idle session: rejected BEFORE acceptance with the stable code.
+    for (const cmd of [
+      { type: "steer", prompt: { text: "x" } },
+      { type: "follow_up", prompt: { text: "x" } },
+      { type: "abort" },
+    ] as const) {
+      const r = await control.dispatch("sD", cmd);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.code).toBe(NO_ACTIVE_RUN_CODE);
     }
-    // And capabilities honestly gate them off.
     const caps = control.capabilities();
-    expect(caps.steering).toBe(false);
-    expect(caps.followUp).toBe(false);
-    expect(caps.toolProgress).toBe(true);
+    expect(caps.steering).toBe(true);
+    expect(caps.followUp).toBe(true);
+    expect(caps.manualCompaction).toBe(false);
+  });
+});
+
+/** A tool whose execution blocks until the test releases it — the deterministic mid-run window. */
+function makeGate() {
+  let release: () => void = () => {};
+  const opened = new Promise<void>((r) => {
+    release = r;
+  });
+  const tool: AgentTool = {
+    name: "gate",
+    label: "Gate",
+    description: "Blocks until released",
+    parameters: Type.Object({}),
+    async execute(_id, _params, signal) {
+      await Promise.race([
+        opened,
+        new Promise<never>((_, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        }),
+      ]);
+      return { content: [{ type: "text", text: "gate opened" }], details: {} };
+    },
+  };
+  return { tool, release };
+}
+
+/** Agent + control with the gate tool mounted — for mid-run dispatch tests. */
+function makeGated(responses: FauxResponseStep[]) {
+  const { faux, models } = makeFaux();
+  faux.setResponses(responses);
+  const sessions = inMemorySessionStore();
+  const { control, observer } = createPiSessionControl({ sessions });
+  const gate = makeGate();
+  const agent = createPiAgentFromHarness({
+    observer,
+    harnessFactory: piHarnessFactory({
+      sessions,
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      tools: [gate.tool],
+      systemPrompt: "test",
+    }),
+  });
+  return { agent, control, gate };
+}
+
+/** Drive invoke in the background; resolve with all events once settled. */
+function drive(
+  agent: { invoke: (s: { session: string }, p: { text: string }) => AsyncIterable<AgentEvent> },
+  session: string,
+) {
+  return (async () => {
+    const out: AgentEvent[] = [];
+    for await (const e of agent.invoke({ session }, { text: "go" })) out.push(e);
+    return out;
+  })();
+}
+
+/** Wait until the control plane reports an active run for the session. */
+async function waitForRunning(control: ReturnType<typeof makeGated>["control"], session: string) {
+  for (let i = 0; i < 200; i++) {
+    const s = await control.state(session);
+    if (s.status === "running" && s.activeRunId) return s.activeRunId;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error("run never became active");
+}
+
+/** Wait until the given tool is executing (its started event was observed). */
+async function waitForToolStarted(control: ReturnType<typeof makeGated>["control"], session: string) {
+  for await (const ev of control.events(session)) {
+    if (ev.type === "tool_started") return;
+    if (ev.type === "run_settled") throw new Error("run settled before the tool started");
+  }
+}
+
+describe("session control (Phase 2a): run modulation", () => {
+  it("steer joins the active run: accepted with its runId, delivered before the next model call, settle window spans it", async () => {
+    const { agent, control, gate } = makeGated([
+      fauxAssistantMessage(fauxToolCall("gate", {}, { id: "g1" })),
+      fauxAssistantMessage("steered answer"),
+    ]);
+    const invoked = drive(agent, "s2a");
+    const toolRunning = waitForToolStarted(control, "s2a");
+    const runId = await waitForRunning(control, "s2a");
+    await toolRunning;
+
+    const result = await control.dispatch("s2a", { type: "steer", prompt: { text: "actually, do it differently" } });
+    expect(result).toEqual({ ok: true, runId });
+    // Queue visibility while the steer is pending (the gate still holds the run).
+    expect((await control.state("s2a")).pending.steering).toBe(1);
+
+    gate.release();
+    const events = await invoked;
+    // Settle window: the steered continuation's text arrives in the SAME invoke stream.
+    const text = events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as { delta: string }).delta)
+      .join("");
+    expect(text).toContain("steered answer");
+    expect(events.at(-1)).toEqual({ type: "completed" });
+    // After settle the queue state is gone with the run.
+    const after = await control.state("s2a");
+    expect(after.status).toBe("idle");
+    expect(after.pending).toEqual({ steering: 0, followUp: 0 });
+  });
+
+  it("follow_up continues the run after it would otherwise stop; queue_changed is observable", async () => {
+    const { agent, control, gate } = makeGated([
+      fauxAssistantMessage(fauxToolCall("gate", {}, { id: "g1" })),
+      fauxAssistantMessage("first answer"),
+      fauxAssistantMessage("follow-up answer"),
+    ]);
+    const seen: SessionEvent[] = [];
+    const watching = (async () => {
+      for await (const ev of control.events("s2b")) {
+        seen.push(ev);
+        if (ev.type === "run_settled") break;
+      }
+    })();
+    const invoked = drive(agent, "s2b");
+    await waitForRunning(control, "s2b");
+    // Wait for the tool to be executing before queueing the follow-up.
+    while (!seen.some((e) => e.type === "tool_started")) await new Promise((r) => setTimeout(r, 5));
+
+    const result = await control.dispatch("s2b", { type: "follow_up", prompt: { text: "and then summarize" } });
+    expect(result.ok).toBe(true);
+    gate.release();
+    const events = await invoked;
+    await watching;
+
+    const text = events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as { delta: string }).delta)
+      .join("");
+    expect(text).toContain("first answer");
+    expect(text).toContain("follow-up answer"); // the settle window spanned the continuation
+    expect(seen.some((e) => e.type === "queue_changed")).toBe(true);
+    expect(seen.filter((e) => e.type === "run_settled")).toHaveLength(1); // still exactly one
+  });
+
+  it("abort stops the run: accepted, invoke terminal failed{code: aborted}, run_settled{aborted}", async () => {
+    const { agent, control, gate } = makeGated([fauxAssistantMessage(fauxToolCall("gate", {}, { id: "g1" }))]);
+    const seen: SessionEvent[] = [];
+    const watching = (async () => {
+      for await (const ev of control.events("s2c")) {
+        seen.push(ev);
+        if (ev.type === "run_settled") break;
+      }
+    })();
+    const invoked = drive(agent, "s2c");
+    await waitForRunning(control, "s2c");
+    while (!seen.some((e) => e.type === "tool_started")) await new Promise((r) => setTimeout(r, 5));
+
+    const result = await control.dispatch("s2c", { type: "abort" });
+    expect(result.ok).toBe(true);
+    void gate; // never released — abort must cut through the blocked tool
+    const events = await invoked;
+    await watching;
+
+    const terminal = events.at(-1);
+    expect(terminal).toMatchObject({ type: "failed", code: "aborted", retryable: false });
+    const settled = seen.find((e) => e.type === "run_settled");
+    expect(settled?.data).toEqual({ status: "aborted" });
+    // The session is reusable: back to idle, not poisoned.
+    expect((await control.state("s2c")).status).toBe("idle");
   });
 });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -615,8 +615,9 @@ describe("session control (Phase 2a): run modulation", () => {
     const settled = seen.find((e) => e.type === "run_settled");
     // Intent-attributed (the faux provider surfaces a plain error, not stopReason "aborted" — the
     // in-flight abort classifies it), and NON-LOSSY: what actually stopped the run stays readable.
-    expect(settled?.data).toMatchObject({ status: "aborted" });
-    expect((settled?.data as { error?: { message: string } }).error?.message).toBeTruthy();
+    const settledData = settled?.data as { status: string; error?: { message: string } };
+    expect(settledData).toMatchObject({ status: "aborted" });
+    expect(settledData.error?.message).toBeTruthy();
     // The session is reusable: back to idle, not poisoned.
     expect((await control.state("s2c")).status).toBe("idle");
   });


### PR DESCRIPTION
## What

The control plane's run-modulation half, per [design §15 Phase 2a](https://github.com/fastagent-sh/fastagent/blob/main/docs/design/session-control.md): `dispatch` routes `steer`/`follow_up`/`abort` to the live run.

### Mechanism

- **`RunControls`**: built inside the invoke closure (it owns the harness), registered with the observer on `run_started`, gone after `run_settled`. The settled check and the pi enqueue/abort call share one synchronous block; stale controls throw and map to `run_command_failed`.
- **Settle window needs no new flow control**: pi's agent loop already drains the steering queue between turns and the follow-up queue when the run would otherwise stop — all inside one `prompt()`. Consumers that never dispatch keep byte-identical single-turn behavior.
- **`queue_changed` (L1)** from pi's `queue_update`, feeding live `state().pending`.
- **Abort classification** by two attribution sources (either suffices): pi's `stopReason: "aborted"`, and control-plane intent as **in-flight counting** — 'an abort succeeded OR one was still in flight at the terminal'. No optimistic flag, no rollback, no interleaving hazard; the residual window is documented and non-lossy (settlements carry `error.message`). Terminal: `failed{code: ABORTED_CODE}` (new constant beside `SESSION_BUSY_CODE`) / `run_settled{aborted}`.
- **Stable rejection codes**: `no_active_run` (idle session), `run_command_failed` (run raced to settlement / observation-only registration) — both pre-acceptance, both `retryable: false` with the retry condition documented at `SessionResult`.
- Capabilities: `steering`/`followUp` on; `compact`/`set_model`/`set_thinking` (Phase 2b) still gated off.

## Verification

- lint / typecheck / test: **819/819** (11 new conformance tests: steer joins + settle window, follow_up continuation, abort classification incl. the intent branch and `toTerminal` attribution, stale-controls rejection, setup-failure race, refused-command mapping, queue visibility).
- `rv.sh local`: **7 review rounds, 12 findings, all addressed**; the abort-classification logic was re-derived from first principles after hitting the rule-11 stop sign (three revisions → in-flight counting). Final round: one doc finding, fixed.