### PR TITLE
feat(session): Phase 2b — boundary mutations (compact / set_model / set_thinking)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -443,9 +443,9 @@ await control.dispatch("s1", { type: "compact", instructions: "keep the decision
 Overrides persist in the session record and every later turn's fresh harness applies them — on any
 serving path, channels included. Invalid payloads reject `invalid_command` before acceptance;
 `capabilities()` lists `allowedModels`/`allowedLevels`. Boundary commands require the wiring the
-workspace opener provides (`sessionControl: true`); an observation-only hub reports them off. Boundary mutations
-(`compact`/`set_model`/`set_thinking`) are not shipped yet: `capabilities()` reports them off and
-they reject with `unsupported_capability`.
+workspace opener provides (`sessionControl: true`); a hub without it reports them off and rejects
+with `unsupported_capability`.
+
 For workspace assembly the store lives inside the opener, so ask the opener to wire the hub:
 
 ```ts

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -441,7 +441,9 @@ await control.dispatch("s1", { type: "compact", instructions: "keep the decision
 ```
 
 Overrides persist in the session record and every later turn's fresh harness applies them — on any
-serving path, channels included. Invalid payloads reject `invalid_command` before acceptance;
+serving path, channels included. Boundary mutations require an EXISTING session (`no_such_session`
+otherwise): sessions are created by `invoke`, never by the control plane. Invalid payloads reject
+`invalid_command` before acceptance;
 `capabilities()` lists `allowedModels`/`allowedLevels`. Boundary commands require the wiring the
 workspace opener provides (`sessionControl: true`); a hub without it reports them off and rejects
 with `unsupported_capability`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -429,7 +429,21 @@ reached a run but could not take effect (the run raced to settlement) rejects wi
 `state()` before re-dispatching. The race window applies to all three commands symmetrically: an
 accepted `abort` can still settle `completed`, and an accepted `steer`/`follow_up` can settle
 without its prompt being consumed, when the run finishes inside the window — acceptance is not
-outcome; the settlement is the truth. Boundary mutations
+outcome; the settlement is the truth.
+
+Boundary mutations run between runs, under the SAME lease (`session_busy` while a run is active,
+retryable at idle):
+
+```ts
+await control.dispatch("s1", { type: "set_model", model: "anthropic/claude-sonnet-4-5" }); // durable per-session override
+await control.dispatch("s1", { type: "set_thinking", level: "high" });
+await control.dispatch("s1", { type: "compact", instructions: "keep the decisions" }); // compaction_started/finished
+```
+
+Overrides persist in the session record and every later turn's fresh harness applies them — on any
+serving path, channels included. Invalid payloads reject `invalid_command` before acceptance;
+`capabilities()` lists `allowedModels`/`allowedLevels`. Boundary commands require the wiring the
+workspace opener provides (`sessionControl: true`); an observation-only hub reports them off. Boundary mutations
 (`compact`/`set_model`/`set_thinking`) are not shipped yet: `capabilities()` reports them off and
 they reject with `unsupported_capability`.
 For workspace assembly the store lives inside the opener, so ask the opener to wire the hub:

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -8,8 +8,8 @@ updated: 2026-07-19
 
 # Session control plane
 
-This document is the serving-extension design for FastAgent. Phases 0–2a (§15) are implemented;
-Phases 2b–3 remain proposed. It is a companion to, not a replacement
+This document is the serving-extension design for FastAgent. Phases 0–2 (§15) are implemented;
+Phase 3 (transport) remains proposed. It is a companion to, not a replacement
 for, the locked [Agent Handler SPEC v0.1](../SPEC.md).
 
 The whole design reduces to one sentence: **`invoke` is the only data plane; the session control
@@ -397,7 +397,7 @@ safe for untrusted users; `ExecutionEnv` is still not a complete sandbox boundar
 | 0 | **Done.** The definition-aware session builder is extracted (`session-builder.ts`); the TUI-only `~/.pi` auth divergence is eliminated in place; `runPiChat` is one consumer. | Chat assembly semantics unchanged; auth source and `thinkingLevel` deliberately converged to serving; builder independently instantiable. |
 | 1 | **Done.** Observation plane: pi events translate ONCE to `SessionEvent` inside the invoke path (`toSessionEvent`), `AgentEvent` is its projection (`projectAgentEvent`); the `session` subpath types + pi `createPiSessionControl` (`state`/`entries`/`events` over a read-only `PiSessionReader`); conformance tests for projection fidelity, run boundaries (incl. cancellation → exactly-one `run_settled{aborted}`), reconnect, and single-writer. | An L0 client can watch and reconnect to any invoke-driven run. |
 | 2a | **Done.** Run modulation: `dispatch` routes `steer`/`follow_up`/`abort` to the live run via {@link RunControls} registered with `run_started`; the settle window spans steered/queued continuations inside one invoke (pi's agent loop drains both queues within one `prompt()`); `queue_changed` + live `pending` in state; a control-plane abort terminates as `failed{code: "aborted"}` / `run_settled{aborted}`; idle-session run commands reject `no_active_run` before acceptance. | L1 clients. |
-| 2b | Boundary mutations (`compact`, `set_model`, `set_thinking`) under the lease, with `state_changed`/`compaction_*` events. Requires per-session model-override persistence in the fresh-harness architecture (harness.ts resolve semantics — see §3 of core.md for the active-tools precedent). | L2 clients. |
+| 2b | **Done.** Boundary mutations under the lease: `set_model`/`set_thinking` append durable session overrides (validated against the registry / pi's thinking scale; `invalid_command` before acceptance) and the fresh-harness resolve (`resolveHarnessOverrides`, the active-tools precedent) applies them on every later turn — a registry change across deploys falls back to the default with a deduped warn instead of bricking the session. `compact` builds the session's harness and summarizes, bounded by `compaction_started/finished`; failures reject `boundary_command_failed` with nothing durable landed. Mutations contend on the SAME lease as runs (`session_busy` when busy); capabilities report `allowedModels`/`allowedLevels` from the live wiring (`PiBoundaryWiring`, a lazy thunk — the hub exists before the assembly that produces the parts). | L2 clients. |
 | 3 | Transport codec and a remote/subprocess adapter (the envelope is born here); product runners add authentication, idempotency, event persistence, and routing. | Remote `SessionControl` is isomorphic to local. |
 
 Phase 1 modifies the existing invoke pipeline incrementally (translation + projection); it does not

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -298,7 +298,8 @@ compare. The vocabulary, grouped by the client maturity level that needs it:
 | transport | `serving_error` | A transport adapter lost the serving process outside a normal run outcome (fail visibly). Not emittable in-process — a dead process has no one left to emit. |
 | L1 | `queue_changed { steering, followUp }` | Normalized queue depths. |
 | L2 | `turn_started`, `turn_finished` | Group tool activity under one assistant turn. |
-| L2 | `compaction_started/finished`, `retry_scheduled/finished` | Explain why a run is alive with no tokens flowing. |
+| L2 | `compaction_started/finished` | Manual compaction bounds: between runs, no `runId`; every started is closed (`summary` or `error`). Automatic overflow compaction stays inside its run and does not emit these. |
+| L2 | `retry_scheduled/finished` | Explain why a run is alive with no tokens flowing (future vocabulary — not yet emitted). |
 | L2 | `state_changed { model?, thinkingLevel? }` | Material state changes. |
 
 Consumers MUST forward or ignore unknown event types; the vocabulary is additive. The contract

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -14,7 +14,7 @@ import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
 import type { AgentTool, ExecutionEnv, Skill, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { createCodingTools } from "@earendil-works/pi-coding-agent";
-import type { Provider } from "@earendil-works/pi-ai";
+import type { Models, Provider } from "@earendil-works/pi-ai";
 import type { Agent } from "../../agent.ts";
 import { type FastagentConfig, defaultAuthPath, resolveModel, resolveStateRoot } from "./config.ts";
 import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
@@ -32,7 +32,7 @@ import {
   mergeDiscoveredTools,
 } from "./tool.ts";
 import { withSearchTool } from "./search-tools.ts";
-import { type Lease, type SessionObserver, createPiAgentFromHarness } from "./invoke.ts";
+import { type Lease, type SessionObserver, createPiAgentFromHarness, inProcessLease } from "./invoke.ts";
 
 // ── §1 tools ─────────────────────────────────────────────────────────────────
 //
@@ -204,24 +204,38 @@ function buildPiAgent(opts: {
   env?: ExecutionEnv;
   lease?: Lease;
   observer?: SessionObserver;
+  onAssembly?: OnAssembly;
 }): Agent {
   const models = createPiModels({ providers: opts.providers, authPath: opts.authPath });
-  return createPiAgentFromHarness({
-    lease: opts.lease,
-    observer: opts.observer,
-    harnessFactory: piHarnessFactory({
-      sessions: opts.sessions ?? inMemorySessionStore(),
-      env: opts.env ?? new NodeExecutionEnv({ cwd: process.cwd() }),
-      models,
-      model: resolveModel(models, opts.model),
-      thinkingLevel: opts.thinkingLevel,
-      systemPrompt: opts.systemPrompt,
-      tools: opts.tools,
-      skills: opts.skills,
-      live: opts.live,
-    }),
+  // Materialized here (not defaulted inside createPiAgentFromHarness) so the exposed parts carry
+  // the SAME lease instance the agent runs under — boundary mutations must contend on it.
+  const lease = opts.lease ?? inProcessLease();
+  const harnessFactory = piHarnessFactory({
+    sessions: opts.sessions ?? inMemorySessionStore(),
+    env: opts.env ?? new NodeExecutionEnv({ cwd: process.cwd() }),
+    models,
+    model: resolveModel(models, opts.model),
+    thinkingLevel: opts.thinkingLevel,
+    systemPrompt: opts.systemPrompt,
+    tools: opts.tools,
+    skills: opts.skills,
+    live: opts.live,
   });
+  opts.onAssembly?.({ models, harnessFactory, lease });
+  return createPiAgentFromHarness({ lease, observer: opts.observer, harnessFactory });
 }
+
+/**
+ * INTERNAL seam (workspace ↔ assembly): hands the hub-wiring consumer the assembly's live parts —
+ * the SAME models collection, harness factory, and lease the agent runs with — so boundary
+ * mutations (session-control.ts) contend on the real lease and validate against the real registry.
+ * Called synchronously, exactly once, before the agent is returned. Not part of the public surface.
+ */
+export type OnAssembly = (parts: {
+  models: Models;
+  harnessFactory: ReturnType<typeof piHarnessFactory>;
+  lease: Lease;
+}) => void;
 
 /**
  * L1 system prompt: `instructions` ARE the prompt (no engine base, no wrapping); the skills listing
@@ -336,6 +350,8 @@ export interface CreatePiAgentFromDefinitionOptions {
   lease?: Lease;
   /** Observation-plane tap; see {@link CreatePiAgentOptions.observer}. */
   observer?: SessionObserver;
+  /** INTERNAL seam for hub wiring; see {@link OnAssembly}. */
+  onAssembly?: OnAssembly;
 }
 
 /** Stable identity of a definition's non-fatal findings, for change-detection in `live` (dedup only). */
@@ -409,6 +425,7 @@ export async function createPiAgentFromDefinition(
     env,
     lease: options.lease,
     observer: options.observer,
+    onAssembly: options.onAssembly,
   });
   return { agent, definition };
 }

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -118,6 +118,60 @@ const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
  * (like L2's findings memo), not session state — the resolve stays derived from the session.
  */
 const warnedRestores = new Set<string>();
+
+/** pi's ThinkingLevel union as a checkable set — a session entry stores a plain string. */
+const THINKING_LEVELS = new Set<ThinkingLevel>(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+
+/**
+ * Resolve the session's model/thinking OVERRIDES for a fresh harness — same shape as the
+ * active-tools resolve above: pi writes `model_change`/`thinking_level_change` entries on explicit
+ * setModel/setThinkingLevel (the control plane's `set_model`/`set_thinking` append them directly)
+ * but a fresh harness never reads them back. The LAST entry of each kind wins; absent → the
+ * assembly default. A recorded model no longer in this deployment's registry falls back to the
+ * default with a deduped warn (fail visibly without bricking the session — the conversation must
+ * survive a registry change across deploys); an unknown thinking level likewise.
+ */
+export function resolveHarnessOverrides(
+  entries: { type: string; provider?: string; modelId?: string; thinkingLevel?: string }[],
+  models: Models,
+  defaults: { model: AnyModel; thinkingLevel: ThinkingLevel },
+  sessionId: string,
+): { model: AnyModel; thinkingLevel: ThinkingLevel } {
+  let model = defaults.model;
+  let thinkingLevel = defaults.thinkingLevel;
+  const warnOnce = (key: string, message: string) => {
+    const emit = warnedRestores.has(key) ? log.debug : log.warn;
+    warnedRestores.add(key);
+    emit(message);
+  };
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i];
+    if (e?.type !== "model_change") continue;
+    const recorded = e.provider !== undefined && e.modelId !== undefined && models.getModel(e.provider, e.modelId);
+    if (recorded) model = recorded as AnyModel;
+    else {
+      warnOnce(
+        `${sessionId}\u0000model\u0000${e.provider}/${e.modelId}`,
+        `[fastagent] session ${sessionId}: recorded model override ${e.provider}/${e.modelId} is not in this deployment's registry — using the configured default`,
+      );
+    }
+    break;
+  }
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i];
+    if (e?.type !== "thinking_level_change") continue;
+    if (e.thinkingLevel !== undefined && THINKING_LEVELS.has(e.thinkingLevel as ThinkingLevel)) {
+      thinkingLevel = e.thinkingLevel as ThinkingLevel;
+    } else {
+      warnOnce(
+        `${sessionId}\u0000thinking\u0000${e.thinkingLevel}`,
+        `[fastagent] session ${sessionId}: recorded thinking level "${e.thinkingLevel}" is unknown — using the configured default`,
+      );
+    }
+    break;
+  }
+  return { model, thinkingLevel };
+}
 export function resolveHarnessActiveToolNames(
   recorded: string[] | null,
   tools: AgentTool[],
@@ -154,12 +208,19 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
     const { systemPrompt } = options;
     const prompt = fresh ? fresh.systemPrompt : typeof systemPrompt === "function" ? systemPrompt() : systemPrompt;
     const skills = fresh ? fresh.skills : options.skills;
+    // Session overrides (set_model / set_thinking) win over the assembly defaults — same entry walk.
+    const overrides = resolveHarnessOverrides(
+      entries as Parameters<typeof resolveHarnessOverrides>[0],
+      options.models,
+      { model: options.model, thinkingLevel: options.thinkingLevel ?? DEFAULT_THINKING_LEVEL },
+      sessionId,
+    );
     const harness = new AgentHarness({
       env: options.env,
       session,
       models: options.models,
-      model: options.model,
-      thinkingLevel: options.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
+      model: overrides.model,
+      thinkingLevel: overrides.thinkingLevel,
       tools: options.tools,
       activeToolNames: resolveHarnessActiveToolNames(
         activated.length > 0 ? activated : null,

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -119,8 +119,18 @@ const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
  */
 const warnedRestores = new Set<string>();
 
-/** pi's ThinkingLevel union as a checkable set — a session entry stores a plain string. */
-const THINKING_LEVELS = new Set<ThinkingLevel>(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+/** pi's ThinkingLevel scale as a checkable set — THE single source (session entries store plain
+ *  strings; session-control's dispatch validation and capabilities derive from this too, so a new
+ *  pi level added here cannot leave the two sides disagreeing). */
+export const THINKING_LEVELS: ReadonlySet<ThinkingLevel> = new Set<ThinkingLevel>([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
 
 /**
  * Resolve the session's model/thinking OVERRIDES for a fresh harness — same shape as the

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -135,17 +135,54 @@ const ALL_THINKING_LEVELS = {
 } satisfies Record<ThinkingLevel, true>;
 export const THINKING_LEVELS: ReadonlySet<ThinkingLevel> = new Set(Object.keys(ALL_THINKING_LEVELS) as ThinkingLevel[]);
 
+/** The shape both override consumers walk — a session entry, structurally. */
+export interface OverrideEntryLike {
+  type: string;
+  provider?: string;
+  modelId?: string;
+  thinkingLevel?: string;
+}
+
+/**
+ * The session's durable override FACTS — the ONE walk both surfaces consume (`state()` reports the
+ * recorded truth; `resolveHarnessOverrides` below applies registry/scale fallbacks on top). The
+ * LAST entry of each kind wins, and a malformed record reads as ABSENT for that kind — never
+ * skipped over to an earlier record: the reporting surface and the execution surface must agree on
+ * which record is "the" override.
+ */
+export function lastOverrideEntries(entries: OverrideEntryLike[]): {
+  model?: { provider: string; modelId: string };
+  thinkingLevel?: string;
+} {
+  let model: { provider: string; modelId: string } | undefined;
+  let modelSeen = false;
+  let thinkingLevel: string | undefined;
+  let thinkingSeen = false;
+  for (let i = entries.length - 1; i >= 0 && !(modelSeen && thinkingSeen); i--) {
+    const e = entries[i];
+    if (!modelSeen && e?.type === "model_change") {
+      modelSeen = true;
+      if (e.provider !== undefined && e.modelId !== undefined) model = { provider: e.provider, modelId: e.modelId };
+    }
+    if (!thinkingSeen && e?.type === "thinking_level_change") {
+      thinkingSeen = true;
+      if (e.thinkingLevel !== undefined) thinkingLevel = e.thinkingLevel;
+    }
+  }
+  return { model, thinkingLevel };
+}
+
 /**
  * Resolve the session's model/thinking OVERRIDES for a fresh harness — same shape as the
  * active-tools resolve above: pi writes `model_change`/`thinking_level_change` entries on explicit
  * setModel/setThinkingLevel (the control plane's `set_model`/`set_thinking` append them directly)
- * but a fresh harness never reads them back. The LAST entry of each kind wins; absent → the
- * assembly default. A recorded model no longer in this deployment's registry falls back to the
- * default with a deduped warn (fail visibly without bricking the session — the conversation must
- * survive a registry change across deploys); an unknown thinking level likewise.
+ * but a fresh harness never reads them back. Override facts come from {@link lastOverrideEntries};
+ * this adds the EXECUTION fallbacks: a recorded model no longer in this deployment's registry falls
+ * back to the default with a deduped warn (fail visibly without bricking the session — the
+ * conversation must survive a registry change across deploys); an unknown thinking level likewise.
  */
 export function resolveHarnessOverrides(
-  entries: { type: string; provider?: string; modelId?: string; thinkingLevel?: string }[],
+  entries: OverrideEntryLike[],
   models: Models,
   defaults: { model: AnyModel; thinkingLevel: ThinkingLevel },
   sessionId: string,
@@ -157,31 +194,26 @@ export function resolveHarnessOverrides(
     warnedRestores.add(key);
     emit(message);
   };
-  for (let i = entries.length - 1; i >= 0; i--) {
-    const e = entries[i];
-    if (e?.type !== "model_change") continue;
-    const recorded = e.provider !== undefined && e.modelId !== undefined && models.getModel(e.provider, e.modelId);
-    if (recorded) model = recorded as AnyModel;
+  const recorded = lastOverrideEntries(entries);
+  if (recorded.model) {
+    const found = models.getModel(recorded.model.provider, recorded.model.modelId);
+    if (found) model = found as AnyModel;
     else {
       warnOnce(
-        `${sessionId}\u0000model\u0000${e.provider}/${e.modelId}`,
-        `[fastagent] session ${sessionId}: recorded model override ${e.provider}/${e.modelId} is not in this deployment's registry — using the configured default`,
+        `${sessionId}\u0000model\u0000${recorded.model.provider}/${recorded.model.modelId}`,
+        `[fastagent] session ${sessionId}: recorded model override ${recorded.model.provider}/${recorded.model.modelId} is not in this deployment's registry — using the configured default`,
       );
     }
-    break;
   }
-  for (let i = entries.length - 1; i >= 0; i--) {
-    const e = entries[i];
-    if (e?.type !== "thinking_level_change") continue;
-    if (e.thinkingLevel !== undefined && THINKING_LEVELS.has(e.thinkingLevel as ThinkingLevel)) {
-      thinkingLevel = e.thinkingLevel as ThinkingLevel;
+  if (recorded.thinkingLevel !== undefined) {
+    if (THINKING_LEVELS.has(recorded.thinkingLevel as ThinkingLevel)) {
+      thinkingLevel = recorded.thinkingLevel as ThinkingLevel;
     } else {
       warnOnce(
-        `${sessionId}\u0000thinking\u0000${e.thinkingLevel}`,
-        `[fastagent] session ${sessionId}: recorded thinking level "${e.thinkingLevel}" is unknown — using the configured default`,
+        `${sessionId}\u0000thinking\u0000${recorded.thinkingLevel}`,
+        `[fastagent] session ${sessionId}: recorded thinking level "${recorded.thinkingLevel}" is unknown — using the configured default`,
       );
     }
-    break;
   }
   return { model, thinkingLevel };
 }

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -119,18 +119,21 @@ const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
  */
 const warnedRestores = new Set<string>();
 
-/** pi's ThinkingLevel scale as a checkable set — THE single source (session entries store plain
- *  strings; session-control's dispatch validation and capabilities derive from this too, so a new
- *  pi level added here cannot leave the two sides disagreeing). */
-export const THINKING_LEVELS: ReadonlySet<ThinkingLevel> = new Set<ThinkingLevel>([
-  "off",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-]);
+/** pi's ThinkingLevel scale as a checkable set — THE single source for fastagent (session entries
+ *  store plain strings; session-control's dispatch validation and capabilities derive from this).
+ *  The `satisfies Record<ThinkingLevel, …>` anchor makes it EXHAUSTIVE against pi's union: pi
+ *  adding a level turns this into a type error instead of a silent drift where `set_thinking`
+ *  rejects a value pi supports. */
+const ALL_THINKING_LEVELS = {
+  off: true,
+  minimal: true,
+  low: true,
+  medium: true,
+  high: true,
+  xhigh: true,
+  max: true,
+} satisfies Record<ThinkingLevel, true>;
+export const THINKING_LEVELS: ReadonlySet<ThinkingLevel> = new Set(Object.keys(ALL_THINKING_LEVELS) as ThinkingLevel[]);
 
 /**
  * Resolve the session's model/thinking OVERRIDES for a fresh harness — same shape as the

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -229,10 +229,12 @@ export interface RunControls {
   abort(): Promise<void>;
 }
 
-/** The observation-plane seam: every rich event of every run, pushed as it happens. `run` carries
- *  the live {@link RunControls}, attached to the `run_started` event only. A hub
+/** The DATA-plane observation seam: every rich event of every run, pushed as it happens. `run`
+ *  carries the live {@link RunControls}, attached to the `run_started` event only. A hub
  *  (session-control.ts) implements this to serve `events()`/`state()`/`dispatch`; absent = zero
- *  overhead. TRUST BOUNDARY: since Phase 2a this seam hands every wired observer the run's
+ *  overhead. Scope: RUN events only — the hub's own boundary-mutation events (`state_changed`,
+ *  `compaction_*`) originate in the hub and reach full-vocabulary taps via the hub's `tap` option,
+ *  not this seam. TRUST BOUNDARY: since Phase 2a this seam hands every wired observer the run's
  *  modulation handles — it is the trusted hub seam, not a public fan-out point. Do not wire
  *  untrusted taps here; give third parties the read-only `events()` stream instead. */
 export type SessionObserver = (session: string, event: SessionEvent, run?: RunControls) => void;

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -324,7 +324,8 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
             };
           }
           // Payload validation BEFORE the lease — an invalid value must not briefly block a run.
-          let apply: (session: import("@earendil-works/pi-agent-core").Session) => Promise<SessionEvent | undefined>;
+          /** The entry-append for set_model/set_thinking — undefined for compact (harness path). */
+          let apply: ((session: import("@earendil-works/pi-agent-core").Session) => Promise<SessionEvent>) | undefined;
           if (command.type === "set_model") {
             const slash = command.model.indexOf("/");
             const model =
@@ -360,13 +361,11 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
               await s.appendThinkingLevelChange(command.level);
               return { type: "state_changed", timestamp: Date.now(), data: { thinkingLevel: command.level } };
             };
-          } else {
-            apply = async () => undefined; // compact runs through the harness below, not an entry append
           }
           // Sessions are created by invoke, never here: a mutation on an unknown id is rejected,
-          // not minted into a ghost record. (Existence check before the lease — read-only.)
-          const existing = await sessions.openIfExists(session);
-          if (!existing) {
+          // not minted into a ghost record. (Existence check before the lease — read-only; the
+          // WRITE handle is re-opened under the lease below, this one is discarded.)
+          if (!(await sessions.openIfExists(session))) {
             return {
               ok: false,
               error: {
@@ -392,12 +391,14 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
           try {
             if (command.type === "compact") {
               compacting.add(session);
-              fanOut(session, { type: "compaction_started", timestamp: Date.now(), data: {} });
               // Compaction is a model call: build the session's full harness (the factory applies
-              // the session's own model/thinking overrides) and tear it down after. Every started
-              // is CLOSED: success → finished{summary}; failure → finished{error} (the bounds
-              // contract — an events-only watcher must never hang on an open compaction).
+              // the session's own model/thinking overrides) and tear it down after. `started` is
+              // emitted only once the harness EXISTS — a factory failure rejects with no started
+              // at all — and every started is then CLOSED: success → finished{summary}; failure →
+              // finished{error} (the bounds contract — an events-only watcher must never hang on
+              // an open compaction).
               const harness = await b.harnessFactory(session);
+              fanOut(session, { type: "compaction_started", timestamp: Date.now(), data: {} });
               try {
                 const result = await harness.compact(command.instructions);
                 fanOut(session, {
@@ -420,7 +421,13 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
                 }
               }
             } else {
-              const event = await apply(existing);
+              // The WRITE handle is opened UNDER the lease: a handle from before tryAcquire could
+              // be a stale snapshot of a run that completed in the window — appending to it would
+              // hang the override off an outdated leaf. `apply` is set by construction (only
+              // set_model/set_thinking reach this branch; compact took the branch above).
+              const fresh = await sessions.openIfExists(session);
+              if (!fresh || !apply) throw new Error("session disappeared between existence check and lease");
+              const event = await apply(fresh);
               if (event) fanOut(session, event);
             }
           } catch (error) {

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -207,8 +207,15 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
         const entries = await opened.getEntries();
         for (let i = entries.length - 1; i >= 0; i--) {
           const e = entries[i] as { type: string; provider?: string; modelId?: string; thinkingLevel?: string };
-          if (model === undefined && e.type === "model_change") model = `${e.provider}/${e.modelId}`;
-          if (thinkingLevel === undefined && e.type === "thinking_level_change") thinkingLevel = e.thinkingLevel;
+          // Same malformed-entry guard as resolveHarnessOverrides: a broken record reads as absent
+          // on BOTH surfaces — state() must not report "undefined/undefined" while the resolve
+          // falls back to the default.
+          if (model === undefined && e.type === "model_change" && e.provider !== undefined && e.modelId !== undefined) {
+            model = `${e.provider}/${e.modelId}`;
+          }
+          if (thinkingLevel === undefined && e.type === "thinking_level_change" && e.thinkingLevel !== undefined) {
+            thinkingLevel = e.thinkingLevel;
+          }
           if (model !== undefined && thinkingLevel !== undefined) break;
         }
       }

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -420,12 +420,24 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
             } else {
               // The WRITE handle is opened UNDER the lease: a handle from before tryAcquire could
               // be a stale snapshot of a run that completed in the window — appending to it would
-              // hang the override off an outdated leaf. `apply` is set by construction (only
-              // set_model/set_thinking reach this branch; compact took the branch above).
+              // hang the override off an outdated leaf.
               const fresh = await sessions.openIfExists(session);
-              if (!fresh || !apply) throw new Error("session disappeared between existence check and lease");
-              const event = await apply(fresh);
-              if (event) fanOut(session, event);
+              if (!fresh) {
+                // Same real condition as the pre-lease check (the session vanished in the window):
+                // same code, same disposition — not a retryable internal error.
+                return {
+                  ok: false,
+                  error: {
+                    code: NO_SUCH_SESSION_CODE,
+                    message: `session "${session}" does not exist — sessions are created by invoke, not by boundary mutations`,
+                    retryable: false,
+                  },
+                };
+              }
+              // Unreachable by construction: only set_model/set_thinking reach this branch, and
+              // both assign `apply` in validation. Throw rather than silently skip (fail visibly).
+              if (!apply) throw new Error("apply unset outside the compact branch (dispatch invariant broken)");
+              fanOut(session, await apply(fresh));
             }
           } catch (error) {
             // Admitted but nothing durable landed (pi appends the compaction entry only at the

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -12,8 +12,11 @@
  * with `unsupported_capability` — a client gating on `capabilities()` never sends them.
  */
 import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
-import type { Json } from "../../agent.ts";
+import type { Models } from "@earendil-works/pi-ai";
+import { type Json, SESSION_BUSY_CODE } from "../../agent.ts";
 import {
+  BOUNDARY_COMMAND_FAILED_CODE,
+  INVALID_COMMAND_CODE,
   NO_ACTIVE_RUN_CODE,
   RUN_COMMAND_FAILED_CODE,
   type SessionCapabilities,
@@ -26,8 +29,14 @@ import {
   type SessionState,
   UNSUPPORTED_CAPABILITY_CODE,
 } from "../../session.ts";
-import type { RunControls, SessionObserver } from "./invoke.ts";
-import type { PiSessionReader } from "./sessions.ts";
+import { listModels } from "./config.ts";
+import type { Lease, RunControls, SessionObserver } from "./invoke.ts";
+import type { PiHarnessFactory } from "./harness.ts";
+import { log } from "../../log.ts";
+import type { PiSessionReader, PiSessionStore } from "./sessions.ts";
+
+/** pi's thinking scale, mirrored for capability reporting (pi clamps unsupported levels per model). */
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
 // ── Entry normalization (durable plane) ──────────────────────────────────────
 
@@ -109,9 +118,24 @@ class Subscriber {
 
 // ── The hub ──────────────────────────────────────────────────────────────────
 
+/** What boundary mutations (compact / set_model / set_thinking) need — the SAME instances the
+ *  agent assembly uses: the lease (mutations must not race a run), the write store, the model
+ *  registry (validation + allowedModels), and the harness factory (compaction is a model call). */
+export interface PiBoundaryWiring {
+  store: PiSessionStore;
+  lease: Lease;
+  models: Models;
+  harnessFactory: PiHarnessFactory;
+}
+
 export interface CreatePiSessionControlOptions {
   /** Read-only access to the durable session repository (the same root the agent writes). */
   sessions: PiSessionReader;
+  /** Boundary-mutation wiring, as a LAZY thunk: the hub's observer must exist before the agent
+   *  assembly that produces these parts, so the hub asks for them at dispatch time instead
+   *  (assembly completes before any dispatch can arrive). Absent / undefined → boundary commands
+   *  are gated off in `capabilities()` and rejected `unsupported_capability`. */
+  boundary?: () => PiBoundaryWiring | undefined;
 }
 
 /**
@@ -126,7 +150,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
   control: SessionControl;
   observer: SessionObserver;
 } {
-  const { sessions } = options;
+  const { sessions, boundary } = options;
   /** Live run state per session — derived purely from run_started/run_settled and the controls
    *  registered with run_started. */
   const active = new Map<
@@ -134,6 +158,15 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
     { runId: string; controls?: RunControls; pending: { steering: number; followUp: number } }
   >();
   const subscribers = new Map<string, Set<Subscriber>>();
+  /** Sessions with a manual compaction in flight — reported as `status: "compacting"`. */
+  const compacting = new Set<string>();
+
+  /** Fan an event out to this session's subscribers — shared by the observer (run events) and the
+   *  boundary mutations (session-level events, no runId). */
+  const fanOut = (session: string, event: SessionEvent): void => {
+    const subs = subscribers.get(session);
+    if (subs) for (const sub of [...subs]) sub.push(event);
+  };
 
   const observer: SessionObserver = (session, event, run) => {
     if (event.type === "run_started" && event.runId) {
@@ -144,29 +177,29 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
       const entry = active.get(session);
       if (entry) entry.pending = event.data as { steering: number; followUp: number };
     }
-    const subs = subscribers.get(session);
-    if (subs) for (const sub of [...subs]) sub.push(event);
-  };
-
-  const capabilities: SessionCapabilities = {
-    steering: true,
-    followUp: true,
-    manualCompaction: false, // Phase 2b
-    modelSelection: false, // Phase 2b
-    thinkingLevel: false, // Phase 2b
-    toolProgress: true, // tool_progress IS delivered (replace-semantics snapshots)
-    usage: false,
+    fanOut(session, event);
   };
 
   const control: SessionControl = {
-    capabilities: () => capabilities,
+    capabilities: (): SessionCapabilities => {
+      const b = boundary?.();
+      return {
+        steering: true,
+        followUp: true,
+        manualCompaction: !!b,
+        modelSelection: b ? { allowedModels: listModels(b.models) } : false,
+        thinkingLevel: b ? { allowedLevels: [...THINKING_LEVELS] } : false,
+        toolProgress: true, // tool_progress IS delivered (replace-semantics snapshots)
+        usage: false,
+      };
+    },
 
     async state(session): Promise<SessionState> {
       const run = active.get(session);
       const opened = await sessions.openIfExists(session);
       const leafEntryId = opened ? ((await opened.getLeafId()) ?? undefined) : undefined;
       return {
-        status: run ? "running" : "idle",
+        status: run ? "running" : compacting.has(session) ? "compacting" : "idle",
         ...(run ? { activeRunId: run.runId } : {}),
         pending: run ? { ...run.pending } : { steering: 0, followUp: 0 },
         ...(leafEntryId ? { leafEntryId } : {}),
@@ -258,17 +291,112 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
           // Accepted: joined (or stopped) THIS run. The outcome arrives as run_settled.
           return { ok: true, runId: run.runId };
         }
-        default:
-          // Phase 2b (compact/set_model/set_thinking): rejected before acceptance; a
-          // capability-gating client never lands here.
-          return {
-            ok: false,
-            error: {
-              code: UNSUPPORTED_CAPABILITY_CODE,
-              message: `command "${command.type}" is not supported by this runtime yet`,
-              retryable: false,
-            },
-          };
+        case "compact":
+        case "set_model":
+        case "set_thinking": {
+          const b = boundary?.();
+          if (!b) {
+            // No boundary wiring: rejected before acceptance; a capability-gating client never
+            // lands here.
+            return {
+              ok: false,
+              error: {
+                code: UNSUPPORTED_CAPABILITY_CODE,
+                message: `command "${command.type}" is not supported by this runtime (no boundary wiring)`,
+                retryable: false,
+              },
+            };
+          }
+          // Payload validation BEFORE the lease — an invalid value must not briefly block a run.
+          let apply: (session: import("@earendil-works/pi-agent-core").Session) => Promise<SessionEvent | undefined>;
+          if (command.type === "set_model") {
+            const slash = command.model.indexOf("/");
+            const model =
+              slash > 0 ? b.models.getModel(command.model.slice(0, slash), command.model.slice(slash + 1)) : undefined;
+            if (!model) {
+              return {
+                ok: false,
+                error: {
+                  code: INVALID_COMMAND_CODE,
+                  message: `unknown model "${command.model}" — capabilities().modelSelection lists the allowed specs`,
+                  retryable: false,
+                },
+              };
+            }
+            apply = async (s) => {
+              await s.appendModelChange(model.provider, model.id);
+              return { type: "state_changed", timestamp: Date.now(), data: { model: command.model } };
+            };
+          } else if (command.type === "set_thinking") {
+            if (!THINKING_LEVELS.includes(command.level)) {
+              return {
+                ok: false,
+                error: {
+                  code: INVALID_COMMAND_CODE,
+                  message: `unknown thinking level "${command.level}" — capabilities().thinkingLevel lists the allowed values`,
+                  retryable: false,
+                },
+              };
+            }
+            apply = async (s) => {
+              await s.appendThinkingLevelChange(command.level);
+              return { type: "state_changed", timestamp: Date.now(), data: { thinkingLevel: command.level } };
+            };
+          } else {
+            apply = async () => undefined; // compact runs through the harness below, not an entry append
+          }
+          // Boundary mutations are the control plane's only writers: same lease as every run — a
+          // mutation must never race one (design §9).
+          const release = b.lease.tryAcquire(session);
+          if (!release) {
+            return {
+              ok: false,
+              error: {
+                code: SESSION_BUSY_CODE,
+                message: "session busy: a run (or another boundary mutation) is in flight — retry at idle",
+                retryable: true,
+              },
+            };
+          }
+          try {
+            if (command.type === "compact") {
+              compacting.add(session);
+              fanOut(session, { type: "compaction_started", timestamp: Date.now(), data: {} });
+              // Compaction is a model call: build the session's full harness (the factory applies
+              // the session's own model/thinking overrides) and tear it down after.
+              const harness = await b.harnessFactory(session);
+              try {
+                const result = await harness.compact(command.instructions);
+                fanOut(session, {
+                  type: "compaction_finished",
+                  timestamp: Date.now(),
+                  data: { summary: result.summary },
+                });
+              } finally {
+                try {
+                  await harness.abort(); // teardown — fresh-harness discipline (never throws past here)
+                } catch (error) {
+                  log.warn(`[fastagent] compaction harness teardown failed: ${String(error)}`);
+                }
+              }
+            } else {
+              const opened = await b.store.openOrCreate(session);
+              const event = await apply(opened);
+              if (event) fanOut(session, event);
+            }
+          } catch (error) {
+            // Admitted but nothing durable landed (pi appends the compaction entry only at the
+            // end): still "nothing took effect" — the same command may succeed on retry.
+            return {
+              ok: false,
+              error: { code: BOUNDARY_COMMAND_FAILED_CODE, message: String(error), retryable: true },
+            };
+          } finally {
+            compacting.delete(session);
+            release();
+          }
+          return { ok: true };
+        }
       }
     },
   };

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -135,6 +135,11 @@ export interface CreatePiSessionControlOptions {
    *  (assembly completes before any dispatch can arrive). Absent / undefined → boundary commands
    *  are gated off in `capabilities()` and rejected `unsupported_capability`. */
   boundary?: () => PiBoundaryWiring | undefined;
+  /** Tap for the events the HUB ITSELF generates (boundary mutations: `state_changed`,
+   *  `compaction_*`) — those never pass through the data plane's observer seam, so a consumer
+   *  composing a full-vocabulary tap wires the run events via the observer AND this. Called after
+   *  the hub's own subscribers. */
+  tap?: (session: string, event: SessionEvent) => void;
 }
 
 /**
@@ -165,6 +170,18 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
   const fanOut = (session: string, event: SessionEvent): void => {
     const subs = subscribers.get(session);
     if (subs) for (const sub of [...subs]) sub.push(event);
+  };
+
+  /** Emit a HUB-generated event: subscribers first, then the external tap — the boundary-event
+   *  half of a full-vocabulary tap (run events reach it through the observer composition). */
+  const emitOwn = (session: string, event: SessionEvent): void => {
+    fanOut(session, event);
+    try {
+      options.tap?.(session, event);
+    } catch (error) {
+      // Same discipline as the data plane's observer guard: a broken tap is its own problem.
+      log.warn(`[fastagent] session-control tap threw (event ${event.type}): ${String(error)}`);
+    }
   };
 
   const observer: SessionObserver = (session, event, run) => {
@@ -395,16 +412,16 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
               // finished{error} (the bounds contract — an events-only watcher must never hang on
               // an open compaction).
               const harness = await b.harnessFactory(session);
-              fanOut(session, { type: "compaction_started", timestamp: Date.now(), data: {} });
+              emitOwn(session, { type: "compaction_started", timestamp: Date.now(), data: {} });
               try {
                 const result = await harness.compact(command.instructions);
-                fanOut(session, {
+                emitOwn(session, {
                   type: "compaction_finished",
                   timestamp: Date.now(),
                   data: { summary: result.summary },
                 });
               } catch (error) {
-                fanOut(session, {
+                emitOwn(session, {
                   type: "compaction_finished",
                   timestamp: Date.now(),
                   data: { error: String(error) },
@@ -437,7 +454,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
               // Unreachable by construction: only set_model/set_thinking reach this branch, and
               // both assign `apply` in validation. Throw rather than silently skip (fail visibly).
               if (!apply) throw new Error("apply unset outside the compact branch (dispatch invariant broken)");
-              fanOut(session, await apply(fresh));
+              emitOwn(session, await apply(fresh));
             }
           } catch (error) {
             // Admitted but nothing durable landed (pi appends the compaction entry only at the

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -32,7 +32,7 @@ import {
 } from "../../session.ts";
 import { listModels } from "./config.ts";
 import type { Lease, RunControls, SessionObserver } from "./invoke.ts";
-import { type PiHarnessFactory, THINKING_LEVELS } from "./harness.ts";
+import { type PiHarnessFactory, THINKING_LEVELS, lastOverrideEntries } from "./harness.ts";
 import { log } from "../../log.ts";
 import type { PiSessionReader } from "./sessions.ts";
 
@@ -197,27 +197,17 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
       const run = active.get(session);
       const opened = await sessions.openIfExists(session);
       const leafEntryId = opened ? ((await opened.getLeafId()) ?? undefined) : undefined;
-      // The durable overrides (set_model / set_thinking): the LAST record of each kind — what a
-      // reconnecting client needs without scanning entries itself. Reported as recorded, even if
-      // the current registry lacks the model (state reports session truth; the harness resolve
-      // owns the execution fallback).
+      // The durable overrides (set_model / set_thinking), via the SAME walk the harness resolve
+      // uses (lastOverrideEntries) — one physical implementation, so the reporting surface and the
+      // execution surface can never disagree on which record is "the" override. Reported as
+      // recorded, even if the current registry lacks the model (state reports session truth; the
+      // harness resolve owns the execution fallback).
       let model: string | undefined;
       let thinkingLevel: string | undefined;
       if (opened) {
-        const entries = await opened.getEntries();
-        for (let i = entries.length - 1; i >= 0; i--) {
-          const e = entries[i] as { type: string; provider?: string; modelId?: string; thinkingLevel?: string };
-          // Same malformed-entry guard as resolveHarnessOverrides: a broken record reads as absent
-          // on BOTH surfaces — state() must not report "undefined/undefined" while the resolve
-          // falls back to the default.
-          if (model === undefined && e.type === "model_change" && e.provider !== undefined && e.modelId !== undefined) {
-            model = `${e.provider}/${e.modelId}`;
-          }
-          if (thinkingLevel === undefined && e.type === "thinking_level_change" && e.thinkingLevel !== undefined) {
-            thinkingLevel = e.thinkingLevel;
-          }
-          if (model !== undefined && thinkingLevel !== undefined) break;
-        }
+        const recorded = lastOverrideEntries((await opened.getEntries()) as Parameters<typeof lastOverrideEntries>[0]);
+        if (recorded.model) model = `${recorded.model.provider}/${recorded.model.modelId}`;
+        thinkingLevel = recorded.thinkingLevel;
       }
       return {
         status: run ? "running" : compacting.has(session) ? "compacting" : "idle",

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -31,12 +31,9 @@ import {
 } from "../../session.ts";
 import { listModels } from "./config.ts";
 import type { Lease, RunControls, SessionObserver } from "./invoke.ts";
-import type { PiHarnessFactory } from "./harness.ts";
+import { type PiHarnessFactory, THINKING_LEVELS } from "./harness.ts";
 import { log } from "../../log.ts";
 import type { PiSessionReader, PiSessionStore } from "./sessions.ts";
-
-/** pi's thinking scale, mirrored for capability reporting (pi clamps unsupported levels per model). */
-const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
 // ── Entry normalization (durable plane) ──────────────────────────────────────
 
@@ -188,7 +185,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
         followUp: true,
         manualCompaction: !!b,
         modelSelection: b ? { allowedModels: listModels(b.models) } : false,
-        thinkingLevel: b ? { allowedLevels: [...THINKING_LEVELS] } : false,
+        thinkingLevel: b ? { allowedLevels: [...THINKING_LEVELS] as string[] } : false,
         toolProgress: true, // tool_progress IS delivered (replace-semantics snapshots)
         usage: false,
       };
@@ -198,9 +195,26 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
       const run = active.get(session);
       const opened = await sessions.openIfExists(session);
       const leafEntryId = opened ? ((await opened.getLeafId()) ?? undefined) : undefined;
+      // The durable overrides (set_model / set_thinking): the LAST record of each kind — what a
+      // reconnecting client needs without scanning entries itself. Reported as recorded, even if
+      // the current registry lacks the model (state reports session truth; the harness resolve
+      // owns the execution fallback).
+      let model: string | undefined;
+      let thinkingLevel: string | undefined;
+      if (opened) {
+        const entries = await opened.getEntries();
+        for (let i = entries.length - 1; i >= 0; i--) {
+          const e = entries[i] as { type: string; provider?: string; modelId?: string; thinkingLevel?: string };
+          if (model === undefined && e.type === "model_change") model = `${e.provider}/${e.modelId}`;
+          if (thinkingLevel === undefined && e.type === "thinking_level_change") thinkingLevel = e.thinkingLevel;
+          if (model !== undefined && thinkingLevel !== undefined) break;
+        }
+      }
       return {
         status: run ? "running" : compacting.has(session) ? "compacting" : "idle",
         ...(run ? { activeRunId: run.runId } : {}),
+        ...(model !== undefined ? { model } : {}),
+        ...(thinkingLevel !== undefined ? { thinkingLevel } : {}),
         pending: run ? { ...run.pending } : { steering: 0, followUp: 0 },
         ...(leafEntryId ? { leafEntryId } : {}),
       };
@@ -328,7 +342,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
               return { type: "state_changed", timestamp: Date.now(), data: { model: command.model } };
             };
           } else if (command.type === "set_thinking") {
-            if (!THINKING_LEVELS.includes(command.level)) {
+            if (!(THINKING_LEVELS as ReadonlySet<string>).has(command.level)) {
               return {
                 ok: false,
                 error: {
@@ -363,7 +377,9 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
               compacting.add(session);
               fanOut(session, { type: "compaction_started", timestamp: Date.now(), data: {} });
               // Compaction is a model call: build the session's full harness (the factory applies
-              // the session's own model/thinking overrides) and tear it down after.
+              // the session's own model/thinking overrides) and tear it down after. Every started
+              // is CLOSED: success → finished{summary}; failure → finished{error} (the bounds
+              // contract — an events-only watcher must never hang on an open compaction).
               const harness = await b.harnessFactory(session);
               try {
                 const result = await harness.compact(command.instructions);
@@ -372,6 +388,13 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
                   timestamp: Date.now(),
                   data: { summary: result.summary },
                 });
+              } catch (error) {
+                fanOut(session, {
+                  type: "compaction_finished",
+                  timestamp: Date.now(),
+                  data: { error: String(error) },
+                });
+                throw error; // → the shared catch below returns boundary_command_failed
               } finally {
                 try {
                   await harness.abort(); // teardown — fresh-harness discipline (never throws past here)

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -18,6 +18,7 @@ import {
   BOUNDARY_COMMAND_FAILED_CODE,
   INVALID_COMMAND_CODE,
   NO_ACTIVE_RUN_CODE,
+  NO_SUCH_SESSION_CODE,
   RUN_COMMAND_FAILED_CODE,
   type SessionCapabilities,
   type SessionCommand,
@@ -33,7 +34,7 @@ import { listModels } from "./config.ts";
 import type { Lease, RunControls, SessionObserver } from "./invoke.ts";
 import { type PiHarnessFactory, THINKING_LEVELS } from "./harness.ts";
 import { log } from "../../log.ts";
-import type { PiSessionReader, PiSessionStore } from "./sessions.ts";
+import type { PiSessionReader } from "./sessions.ts";
 
 // ── Entry normalization (durable plane) ──────────────────────────────────────
 
@@ -116,10 +117,11 @@ class Subscriber {
 // ── The hub ──────────────────────────────────────────────────────────────────
 
 /** What boundary mutations (compact / set_model / set_thinking) need — the SAME instances the
- *  agent assembly uses: the lease (mutations must not race a run), the write store, the model
- *  registry (validation + allowedModels), and the harness factory (compaction is a model call). */
+ *  agent assembly uses: the lease (mutations must not race a run), the model registry (validation +
+ *  allowedModels), and the harness factory (compaction is a model call). Writes go through the
+ *  session the hub's reader opened — after an existence check, so the control plane never creates
+ *  a session (that is the data plane's monopoly). */
 export interface PiBoundaryWiring {
-  store: PiSessionStore;
   lease: Lease;
   models: Models;
   harnessFactory: PiHarnessFactory;
@@ -339,7 +341,9 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
             }
             apply = async (s) => {
               await s.appendModelChange(model.provider, model.id);
-              return { type: "state_changed", timestamp: Date.now(), data: { model: command.model } };
+              // The CANONICAL spec, same string the durable entry and state() report — the event
+              // must not echo a client alias the other two surfaces would disagree with.
+              return { type: "state_changed", timestamp: Date.now(), data: { model: `${model.provider}/${model.id}` } };
             };
           } else if (command.type === "set_thinking") {
             if (!(THINKING_LEVELS as ReadonlySet<string>).has(command.level)) {
@@ -358,6 +362,19 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
             };
           } else {
             apply = async () => undefined; // compact runs through the harness below, not an entry append
+          }
+          // Sessions are created by invoke, never here: a mutation on an unknown id is rejected,
+          // not minted into a ghost record. (Existence check before the lease — read-only.)
+          const existing = await sessions.openIfExists(session);
+          if (!existing) {
+            return {
+              ok: false,
+              error: {
+                code: NO_SUCH_SESSION_CODE,
+                message: `session "${session}" does not exist — sessions are created by invoke, not by boundary mutations`,
+                retryable: false,
+              },
+            };
           }
           // Boundary mutations are the control plane's only writers: same lease as every run — a
           // mutation must never race one (design §9).
@@ -403,8 +420,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
                 }
               }
             } else {
-              const opened = await b.store.openOrCreate(session);
-              const event = await apply(opened);
+              const event = await apply(existing);
               if (event) fanOut(session, event);
             }
           } catch (error) {

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -20,10 +20,16 @@ export interface PiSessionStore {
 }
 
 /**
- * READ-only sibling of {@link PiSessionStore}, for the observation plane (session-control.ts):
- * `state()`/`entries()` on an unknown session must answer "empty", never create one — the
- * observation plane is strictly read-only (design §16 invariant 4). Also skips the open-time
- * crash reconciliation (that appends repair entries — a write).
+ * OPEN-EXISTING sibling of {@link PiSessionStore} (session-control.ts): an unknown session answers
+ * `undefined`, never creates one — sessions are the data plane's monopoly. Two consumers:
+ * - the OBSERVATION plane (`state()`/`entries()`), strictly read-only (design §16 invariant 4);
+ * - the control plane's BOUNDARY writers (`set_model`/`set_thinking`), which append override
+ *   records to the returned handle after an existence check, under the run lease.
+ * `openIfExists` skips the open-time crash reconciliation (that appends repair entries — a write
+ * the observation plane must not perform). The boundary writers are safe WITHOUT it only because
+ * override records are not messages — they cannot create or interact with a dangling tool_use
+ * pair. Writing MESSAGE-class records through this handle would bypass that repair: use
+ * `openOrCreate` for anything that enters the transcript.
  */
 export interface PiSessionReader {
   openIfExists(sessionId: string): Promise<Session | undefined>;

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -24,7 +24,7 @@ import {
 import type { SessionControl } from "../../session.ts";
 import { createPiAgentFromDefinition, resolveWorkspaceTools } from "./create.ts";
 import type { SessionObserver } from "./invoke.ts";
-import { createPiSessionControl } from "./session-control.ts";
+import { type PiBoundaryWiring, createPiSessionControl } from "./session-control.ts";
 import type { PiSessionReader, PiSessionStore } from "./sessions.ts";
 import { withWakeTool } from "./wake-tool.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
@@ -193,14 +193,18 @@ export async function createPiAgentFromWorkspace(
   await mkdir(sessionsDir, { recursive: true });
   const sessions = jsonlSessionStore({ dir: sessionsDir, cwd: dir });
   // The hub is wired HERE because the store is created here: chicken-and-egg otherwise (the hub
-  // needs the store; the agent needs the hub's observer). An extra caller observer composes after it.
-  const hub = options.sessionControl ? createPiSessionControl({ sessions }) : undefined;
+  // needs the store; the agent needs the hub's observer). Boundary parts (models/factory/lease)
+  // only exist after the assembly below — the hub takes them as a lazy thunk, filled by the
+  // assembly's onAssembly callback (assembly completes before this function returns, so every
+  // dispatch sees them). An extra caller observer composes after the hub's (TRUSTED seam).
+  let boundaryParts: PiBoundaryWiring | undefined;
+  const hub = options.sessionControl ? createPiSessionControl({ sessions, boundary: () => boundaryParts }) : undefined;
   const caller = options.observer;
   const observer: SessionObserver | undefined = hub
     ? caller
-      ? (session, event) => {
-          hub.observer(session, event);
-          caller(session, event);
+      ? (session, event, run) => {
+          hub.observer(session, event, run);
+          caller(session, event, run);
         }
       : hub.observer
     : caller;
@@ -213,6 +217,16 @@ export async function createPiAgentFromWorkspace(
     // Skills are definition-only (the agent is its directory), so dev mirrors deployment exactly.
     sessions,
     observer,
+    onAssembly: hub
+      ? (parts) => {
+          boundaryParts = {
+            store: sessions,
+            lease: parts.lease,
+            models: parts.models,
+            harnessFactory: parts.harnessFactory,
+          };
+        }
+      : undefined,
   });
   return {
     agent,

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -57,9 +57,11 @@ export interface CreatePiAgentFromWorkspaceOptions {
    *  {@link sessionControl} — the store is created inside this opener, so the hub must be wired
    *  here too (an external `createPiSessionControl` cannot exist before the store does). */
   sessionControl?: boolean;
-  /** Additional raw tap, composed AFTER the {@link sessionControl} hub's observer. TRUSTED seam:
-   *  since Phase 2a an observer receives each run's live modulation handles (see
-   *  `SessionObserver`) — for read-only consumers use the hub's `events()` stream instead. */
+  /** Additional raw tap with the FULL vocabulary: run events composed after the
+   *  {@link sessionControl} hub's observer, plus the hub's own boundary-mutation events
+   *  (`state_changed`/`compaction_*`) via the hub's tap. TRUSTED seam: since Phase 2a an observer
+   *  receives each run's live modulation handles (see `SessionObserver`) — for read-only consumers
+   *  use the hub's `events()` stream instead. */
   observer?: SessionObserver;
 }
 
@@ -198,8 +200,17 @@ export async function createPiAgentFromWorkspace(
   // assembly's onAssembly callback (assembly completes before this function returns, so every
   // dispatch sees them). An extra caller observer composes after the hub's (TRUSTED seam).
   let boundaryParts: PiBoundaryWiring | undefined;
-  const hub = options.sessionControl ? createPiSessionControl({ sessions, boundary: () => boundaryParts }) : undefined;
   const caller = options.observer;
+  const hub = options.sessionControl
+    ? createPiSessionControl({
+        sessions,
+        boundary: () => boundaryParts,
+        // The caller tap's boundary-event half: state_changed/compaction_* originate in the hub
+        // and never cross the data plane's observer seam — without this, an audit tap wired here
+        // would miss exactly the mutations it most needs to see (set_model).
+        tap: caller ? (session, event) => caller(session, event) : undefined,
+      })
+    : undefined;
   const observer: SessionObserver | undefined = hub
     ? caller
       ? (session, event, run) => {

--- a/src/engines/pi/workspace.ts
+++ b/src/engines/pi/workspace.ts
@@ -220,7 +220,6 @@ export async function createPiAgentFromWorkspace(
     onAssembly: hub
       ? (parts) => {
           boundaryParts = {
-            store: sessions,
             lease: parts.lease,
             models: parts.models,
             harnessFactory: parts.harnessFactory,

--- a/src/session.ts
+++ b/src/session.ts
@@ -49,6 +49,16 @@ export const UNSUPPORTED_CAPABILITY_CODE = "unsupported_capability";
  *  fails again; re-dispatch only after `state()` shows an active run. */
 export const NO_ACTIVE_RUN_CODE = "no_active_run";
 
+/** Stable `SessionResult.error.code` for a command whose PAYLOAD is invalid for this runtime — an
+ *  unknown model spec, an unsupported thinking level. Permanent for that payload; a different value
+ *  may succeed. Rejected before acceptance. */
+export const INVALID_COMMAND_CODE = "invalid_command";
+
+/** Stable `SessionResult.error.code` for a boundary mutation (`compact`) that was admitted but
+ *  failed before any durable change landed (e.g. the summarization model call failed). Nothing took
+ *  effect; the same command may succeed on retry. */
+export const BOUNDARY_COMMAND_FAILED_CODE = "boundary_command_failed";
+
 /** Stable `SessionResult.error.code` for a run command that reached an active run but could not
  *  take effect because the run raced to settlement (or the engine refused it). Distinct from
  *  {@link NO_ACTIVE_RUN_CODE}: the run existed — and TRANSIENT: the session's next run can be
@@ -163,6 +173,15 @@ export type QueueChangedEvent = SessionEvent<"queue_changed", { steering: number
   runId: string;
 };
 
+/** A boundary mutation changed durable session state (L2; no runId — boundary mutations happen
+ *  between runs). */
+export type StateChangedEvent = SessionEvent<"state_changed", { model?: string; thinkingLevel?: string }>;
+
+/** Manual compaction bounds (L2). Automatic overflow compaction stays inside its run's activity
+ *  window and does not emit these. */
+export type CompactionStartedEvent = SessionEvent<"compaction_started", Record<never, never>>;
+export type CompactionFinishedEvent = SessionEvent<"compaction_finished", { summary: string }>;
+
 /**
  * The serving process failed outside a normal run outcome (fail visibly). Emitted by TRANSPORT
  * adapters (design §13) when they lose the backend before ending a remote stream — an in-process
@@ -171,9 +190,9 @@ export type QueueChangedEvent = SessionEvent<"queue_changed", { steering: number
  */
 export type ServingErrorEvent = SessionEvent<"serving_error", { message: string }>;
 
-/** Every event the in-process observation plane emits today: the L0 vocabulary plus L1
- *  `queue_changed`. L2 events (turn_*, compaction_*, retry_*, state_changed) arrive with boundary
- *  mutations; {@link ServingErrorEvent} arrives with the transport adapter. */
+/** Every event the in-process observation plane emits today: L0, L1 `queue_changed`, and the L2
+ *  boundary-mutation events (`state_changed`, `compaction_*`). Remaining L2 events (turn_*,
+ *  retry_*) are future vocabulary; {@link ServingErrorEvent} arrives with the transport adapter. */
 export type KnownSessionEvent =
   | RunStartedEvent
   | RunSettledEvent
@@ -183,4 +202,7 @@ export type KnownSessionEvent =
   | ToolStartedEvent
   | ToolProgressEvent
   | ToolFinishedEvent
-  | QueueChangedEvent;
+  | QueueChangedEvent
+  | StateChangedEvent
+  | CompactionStartedEvent
+  | CompactionFinishedEvent;

--- a/src/session.ts
+++ b/src/session.ts
@@ -100,6 +100,8 @@ export interface SessionState {
    *  compaction happens inside a run's activity window and reports as `running`. */
   status: "idle" | "running" | "compacting";
   activeRunId?: string;
+  /** The session's durable overrides (set_model / set_thinking), read from the record — so a
+   *  reconnecting client sees them without scanning entries. Absent = the assembly default. */
   model?: string;
   thinkingLevel?: string;
   pending: { steering: number; followUp: number };
@@ -177,10 +179,11 @@ export type QueueChangedEvent = SessionEvent<"queue_changed", { steering: number
  *  between runs). */
 export type StateChangedEvent = SessionEvent<"state_changed", { model?: string; thinkingLevel?: string }>;
 
-/** Manual compaction bounds (L2). Automatic overflow compaction stays inside its run's activity
- *  window and does not emit these. */
+/** Manual compaction bounds (L2): every `compaction_started` is closed by exactly one
+ *  `compaction_finished` — `summary` on success, `error` on failure (nothing durable landed).
+ *  Automatic overflow compaction stays inside its run's activity window and does not emit these. */
 export type CompactionStartedEvent = SessionEvent<"compaction_started", Record<never, never>>;
-export type CompactionFinishedEvent = SessionEvent<"compaction_finished", { summary: string }>;
+export type CompactionFinishedEvent = SessionEvent<"compaction_finished", { summary?: string; error?: string }>;
 
 /**
  * The serving process failed outside a normal run outcome (fail visibly). Emitted by TRANSPORT

--- a/src/session.ts
+++ b/src/session.ts
@@ -54,6 +54,12 @@ export const NO_ACTIVE_RUN_CODE = "no_active_run";
  *  may succeed. Rejected before acceptance. */
 export const INVALID_COMMAND_CODE = "invalid_command";
 
+/** Stable `SessionResult.error.code` for a boundary mutation on a session that does not exist.
+ *  Sessions are created by the DATA plane (`invoke`), never by the control plane — a mutation on an
+ *  unknown id (a typo, a not-yet-started conversation) must not mint a ghost record. Rejected
+ *  before acceptance; retry after the session's first turn exists. */
+export const NO_SUCH_SESSION_CODE = "no_such_session";
+
 /** Stable `SessionResult.error.code` for a boundary mutation (`compact`) that was admitted but
  *  failed before any durable change landed (e.g. the summarization model call failed). Nothing took
  *  effect; the same command may succeed on retry. */

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -746,6 +746,24 @@ describe("session control (Phase 2b): boundary mutations", () => {
     expect(bad.thinkingLevel).toBe("medium");
   });
 
+  it("a malformed override record reads as ABSENT on both surfaces — never skipped over", async () => {
+    const { faux, models } = makeFaux({ models: [{ id: "faux-a" }, { id: "faux-b" }] });
+    const fallback = {
+      model: faux.getModel("faux-a") as NonNullable<ReturnType<typeof faux.getModel>>,
+      thinkingLevel: "medium" as const,
+    };
+    const entries = [
+      { type: "model_change", provider: faux.provider.id, modelId: "faux-b" }, // an earlier, VALID override
+      { type: "model_change" }, // the LAST record is malformed
+    ];
+    // Execution surface: malformed = absent → the default, NOT the earlier valid record.
+    const resolved = resolveHarnessOverrides(entries, models, fallback, "sMal");
+    expect(resolved.model).toBe(fallback.model);
+    // Fact surface agrees: no override reported.
+    const { lastOverrideEntries } = await import("../src/engines/pi/harness.ts");
+    expect(lastOverrideEntries(entries).model).toBeUndefined();
+  });
+
   it("set_model rejects an unknown spec before acceptance (invalid_command)", async () => {
     const { control } = makeBoundary([]);
     const result = await control.dispatch("sB2", { type: "set_model", model: "ghost/model" });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -852,6 +852,40 @@ describe("session control (Phase 2b): boundary mutations", () => {
     expect(state.thinkingLevel).toBe("xhigh");
   });
 
+  it("the override rides the next turn end to end: set_model changes which model answers", async () => {
+    // Two faux models in ONE registry; the response FACTORY answers with the model that was asked —
+    // this pins the factory→resolveHarnessOverrides→AgentHarness wiring, not just the resolver.
+    const { faux, models } = makeFaux({ models: [{ id: "faux-a" }, { id: "faux-b" }] });
+    faux.setResponses([
+      (_ctx: unknown, _opts: unknown, _state: unknown, model: { id: string }) =>
+        fauxAssistantMessage(`answered by ${model.id}`),
+      (_ctx: unknown, _opts: unknown, _state: unknown, model: { id: string }) =>
+        fauxAssistantMessage(`answered by ${model.id}`),
+    ] as never);
+    const sessions = inMemorySessionStore();
+    const lease = inProcessLease();
+    const factory = piHarnessFactory({
+      sessions,
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel("faux-a") as NonNullable<ReturnType<typeof faux.getModel>>, // assembly default
+      tools: [],
+      systemPrompt: "test",
+    });
+    const boundary: PiBoundaryWiring = { lease, models, harnessFactory: factory };
+    const { control, observer } = createControl({ sessions, boundary: () => boundary });
+    const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
+
+    const first = await drain(agent.invoke({ session: "sE2E" }, { text: "hi" }));
+    expect(first.map((e) => (e.type === "text" ? (e as { delta: string }).delta : "")).join("")).toContain("faux-a");
+
+    expect(await control.dispatch("sE2E", { type: "set_model", model: `${faux.provider.id}/faux-b` })).toEqual({
+      ok: true,
+    });
+    const second = await drain(agent.invoke({ session: "sE2E" }, { text: "again" }));
+    expect(second.map((e) => (e.type === "text" ? (e as { delta: string }).delta : "")).join("")).toContain("faux-b");
+  });
+
   it("boundary mutations never mint sessions: unknown id rejects no_such_session", async () => {
     const { control, sessions, spec } = makeBoundary([]);
     const result = await control.dispatch("ghost", { type: "set_model", model: spec });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -24,7 +24,7 @@ import {
   type SessionEvent,
 } from "../src/session.ts";
 import { SESSION_BUSY_CODE } from "../src/agent.ts";
-import { type PiBoundaryWiring, createPiSessionControl as createControl } from "../src/engines/pi/session-control.ts";
+import type { PiBoundaryWiring } from "../src/engines/pi/session-control.ts";
 import { inProcessLease } from "../src/engines/pi/invoke.ts";
 import { resolveHarnessOverrides } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
@@ -660,7 +660,7 @@ function makeBoundary(responses: FauxResponseStep[]) {
     systemPrompt: "test",
   });
   const boundary: PiBoundaryWiring = { lease, models, harnessFactory: factory };
-  const { control, observer } = createControl({ sessions, boundary: () => boundary });
+  const { control, observer } = createPiSessionControl({ sessions, boundary: () => boundary });
   const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
   const spec = `${faux.getModel().provider}/${faux.getModel().id}`;
   return { agent, control, sessions, spec, models };
@@ -789,7 +789,7 @@ describe("session control (Phase 2b): boundary mutations", () => {
       systemPrompt: "test",
     });
     const boundary: PiBoundaryWiring = { lease, models, harnessFactory: factory };
-    const { control, observer } = createControl({ sessions, boundary: () => boundary });
+    const { control, observer } = createPiSessionControl({ sessions, boundary: () => boundary });
     const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
     const spec = `${faux.getModel().provider}/${faux.getModel().id}`;
 
@@ -891,7 +891,7 @@ describe("session control (Phase 2b): boundary mutations", () => {
       systemPrompt: "test",
     });
     const boundary: PiBoundaryWiring = { lease, models, harnessFactory: factory };
-    const { control, observer } = createControl({ sessions, boundary: () => boundary });
+    const { control, observer } = createPiSessionControl({ sessions, boundary: () => boundary });
     const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
 
     const first = await drain(agent.invoke({ session: "sE2E" }, { text: "hi" }));

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -15,11 +15,16 @@ import { createPiSessionControl } from "../src/engines/pi/session-control.ts";
 import { inMemorySessionStore } from "../src/engines/pi/sessions.ts";
 import { createPiAgentFromWorkspace } from "../src/engines/pi/workspace.ts";
 import {
+  INVALID_COMMAND_CODE,
   NO_ACTIVE_RUN_CODE,
   RUN_COMMAND_FAILED_CODE,
   UNSUPPORTED_CAPABILITY_CODE,
   type SessionEvent,
 } from "../src/session.ts";
+import { SESSION_BUSY_CODE } from "../src/agent.ts";
+import { type PiBoundaryWiring, createPiSessionControl as createControl } from "../src/engines/pi/session-control.ts";
+import { inProcessLease } from "../src/engines/pi/invoke.ts";
+import { resolveHarnessOverrides } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 
 const echoTool: AgentTool = {
@@ -635,5 +640,166 @@ describe("session control (Phase 2a): run modulation", () => {
     expect(settledData.error?.message).toBeTruthy();
     // The session is reusable: back to idle, not poisoned.
     expect((await control.state("s2c")).status).toBe("idle");
+  });
+});
+
+/** Agent + control with full boundary wiring — the workspace shape, assembled by hand. */
+function makeBoundary(responses: FauxResponseStep[]) {
+  const { faux, models } = makeFaux();
+  faux.setResponses(responses);
+  const sessions = inMemorySessionStore();
+  const lease = inProcessLease();
+  const factory = piHarnessFactory({
+    sessions,
+    env: new NodeExecutionEnv({ cwd: process.cwd() }),
+    models,
+    model: faux.getModel(),
+    tools: [],
+    systemPrompt: "test",
+  });
+  const boundary: PiBoundaryWiring = { store: sessions, lease, models, harnessFactory: factory };
+  const { control, observer } = createControl({ sessions, boundary: () => boundary });
+  const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
+  const spec = `${faux.getModel().provider}/${faux.getModel().id}`;
+  return { agent, control, sessions, spec, models };
+}
+
+describe("session control (Phase 2b): boundary mutations", () => {
+  it("capabilities reflect the boundary wiring: allowed models and thinking levels", async () => {
+    const { control, spec } = makeBoundary([]);
+    const caps = control.capabilities();
+    expect(caps.manualCompaction).toBe(true);
+    expect(caps.modelSelection ? caps.modelSelection.allowedModels : []).toContain(spec);
+    expect(caps.thinkingLevel ? caps.thinkingLevel.allowedLevels : []).toContain("high");
+  });
+
+  it("set_model / set_thinking append durable overrides and emit state_changed", async () => {
+    const { agent, control, sessions, spec } = makeBoundary([fauxAssistantMessage("ok")]);
+    await drain(agent.invoke({ session: "sB1" }, { text: "hi" })); // session exists
+    const seen: SessionEvent[] = [];
+    const watching = (async () => {
+      for await (const ev of control.events("sB1")) {
+        seen.push(ev);
+        if (seen.filter((e) => e.type === "state_changed").length === 2) break;
+      }
+    })();
+    expect(await control.dispatch("sB1", { type: "set_model", model: spec })).toEqual({ ok: true });
+    expect(await control.dispatch("sB1", { type: "set_thinking", level: "high" })).toEqual({ ok: true });
+    await watching;
+    expect(seen.map((e) => e.data)).toEqual([{ model: spec }, { thinkingLevel: "high" }]);
+    // Durable: the overrides live in the session record (open-set kinds on the entries plane).
+    const kinds = (await control.entries("sB1")).entries.map((e) => e.kind);
+    expect(kinds).toContain("model_change");
+    expect(kinds).toContain("thinking_level_change");
+    // And the fresh-harness resolve applies them: the recorded thinking level rides the next turn.
+    const opened = await sessions.openIfExists("sB1");
+    const resolved = resolveHarnessOverrides(
+      ((await opened?.getEntries()) ?? []) as Parameters<typeof resolveHarnessOverrides>[0],
+      makeFaux().models,
+      { model: makeFaux().faux.getModel(), thinkingLevel: "medium" },
+      "sB1",
+    );
+    expect(resolved.thinkingLevel).toBe("high");
+  });
+
+  it("resolveHarnessOverrides: last entry wins; unknown recorded model falls back with the default", () => {
+    const { faux, models } = makeFaux();
+    const fallback = { model: faux.getModel(), thinkingLevel: "medium" as const };
+    // Unknown model → fallback (deployment registry changed); known thinking level applies.
+    const out = resolveHarnessOverrides(
+      [
+        { type: "model_change", provider: "gone", modelId: "nope" },
+        { type: "thinking_level_change", thinkingLevel: "low" },
+      ],
+      models,
+      fallback,
+      "sR",
+    );
+    expect(out.model).toBe(fallback.model);
+    expect(out.thinkingLevel).toBe("low");
+    // Unknown thinking level → fallback.
+    const bad = resolveHarnessOverrides(
+      [{ type: "thinking_level_change", thinkingLevel: "ultra" }],
+      models,
+      fallback,
+      "sR2",
+    );
+    expect(bad.thinkingLevel).toBe("medium");
+  });
+
+  it("set_model rejects an unknown spec before acceptance (invalid_command)", async () => {
+    const { control } = makeBoundary([]);
+    const result = await control.dispatch("sB2", { type: "set_model", model: "ghost/model" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe(INVALID_COMMAND_CODE);
+    const bad = await control.dispatch("sB2", { type: "set_thinking", level: "ultra" });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.error.code).toBe(INVALID_COMMAND_CODE);
+  });
+
+  it("boundary mutations are rejected session_busy while a run holds the lease", async () => {
+    const { faux, models } = makeFaux();
+    faux.setResponses([fauxAssistantMessage(fauxToolCall("gate", {}, { id: "g1" }))]);
+    const sessions = inMemorySessionStore();
+    const lease = inProcessLease();
+    const gate = makeGate();
+    const factory = piHarnessFactory({
+      sessions,
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      models,
+      model: faux.getModel(),
+      tools: [gate.tool],
+      systemPrompt: "test",
+    });
+    const boundary: PiBoundaryWiring = { store: sessions, lease, models, harnessFactory: factory };
+    const { control, observer } = createControl({ sessions, boundary: () => boundary });
+    const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
+    const spec = `${faux.getModel().provider}/${faux.getModel().id}`;
+
+    const invoked = drive(agent, "sB3");
+    await waitForRunning(control, "sB3");
+    const busy = await control.dispatch("sB3", { type: "set_model", model: spec });
+    expect(busy.ok).toBe(false);
+    if (!busy.ok) {
+      expect(busy.error.code).toBe(SESSION_BUSY_CODE);
+      expect(busy.error.retryable).toBe(true); // retry AT IDLE succeeds as-is
+    }
+    gate.release();
+    await invoked;
+    expect(await control.dispatch("sB3", { type: "set_model", model: spec })).toEqual({ ok: true });
+  });
+
+  it("compact summarizes under the lease: compaction events, durable compaction entry, ok:true", async () => {
+    const { agent, control } = makeBoundary([
+      fauxAssistantMessage("a long answer worth compacting"),
+      fauxAssistantMessage("summary of the conversation"), // consumed by harness.compact()
+    ]);
+    await drain(agent.invoke({ session: "sB4" }, { text: "tell me things" }));
+    const seen: SessionEvent[] = [];
+    const watching = (async () => {
+      for await (const ev of control.events("sB4")) {
+        seen.push(ev);
+        if (ev.type === "compaction_finished") break;
+      }
+    })();
+    const result = await control.dispatch("sB4", { type: "compact" });
+    expect(result).toEqual({ ok: true });
+    await watching;
+    expect(seen.map((e) => e.type)).toEqual(["compaction_started", "compaction_finished"]);
+    const finished = seen.at(-1)?.data as { summary: string };
+    expect(finished.summary).toBeTruthy();
+    const kinds = (await control.entries("sB4")).entries.map((e) => e.kind);
+    expect(kinds).toContain("compaction");
+    expect((await control.state("sB4")).status).toBe("idle"); // lease released, not stuck compacting
+  });
+
+  it("without boundary wiring the commands stay gated off and rejected", async () => {
+    const { control } = makeObserved([]); // observation + run modulation only
+    const caps = control.capabilities();
+    expect(caps.manualCompaction).toBe(false);
+    expect(caps.modelSelection).toBe(false);
+    const result = await control.dispatch("sB5", { type: "set_model", model: "any/thing" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe(UNSUPPORTED_CAPABILITY_CODE);
   });
 });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -18,6 +18,7 @@ import {
   BOUNDARY_COMMAND_FAILED_CODE,
   INVALID_COMMAND_CODE,
   NO_ACTIVE_RUN_CODE,
+  NO_SUCH_SESSION_CODE,
   RUN_COMMAND_FAILED_CODE,
   UNSUPPORTED_CAPABILITY_CODE,
   type SessionEvent,
@@ -658,7 +659,7 @@ function makeBoundary(responses: FauxResponseStep[]) {
     tools: [],
     systemPrompt: "test",
   });
-  const boundary: PiBoundaryWiring = { store: sessions, lease, models, harnessFactory: factory };
+  const boundary: PiBoundaryWiring = { lease, models, harnessFactory: factory };
   const { control, observer } = createControl({ sessions, boundary: () => boundary });
   const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
   const spec = `${faux.getModel().provider}/${faux.getModel().id}`;
@@ -701,6 +702,23 @@ describe("session control (Phase 2b): boundary mutations", () => {
       "sB1",
     );
     expect(resolved.thinkingLevel).toBe("high");
+  });
+
+  it("resolveHarnessOverrides: a known recorded model override wins over the default", () => {
+    const { faux, models } = makeFaux({ models: [{ id: "faux-a" }, { id: "faux-b" }] });
+    const fallback = {
+      model: faux.getModel("faux-a") as NonNullable<ReturnType<typeof faux.getModel>>,
+      thinkingLevel: "medium" as const,
+    };
+    const recorded = faux.getModel("faux-b") as NonNullable<ReturnType<typeof faux.getModel>>;
+    const out = resolveHarnessOverrides(
+      [{ type: "model_change", provider: recorded.provider, modelId: recorded.id }],
+      models,
+      fallback,
+      "sRK",
+    );
+    expect(out.model).toBe(recorded); // the session override rides the fresh harness
+    expect(out.model).not.toBe(fallback.model);
   });
 
   it("resolveHarnessOverrides: last entry wins; unknown recorded model falls back with the default", () => {
@@ -752,7 +770,7 @@ describe("session control (Phase 2b): boundary mutations", () => {
       tools: [gate.tool],
       systemPrompt: "test",
     });
-    const boundary: PiBoundaryWiring = { store: sessions, lease, models, harnessFactory: factory };
+    const boundary: PiBoundaryWiring = { lease, models, harnessFactory: factory };
     const { control, observer } = createControl({ sessions, boundary: () => boundary });
     const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
     const spec = `${faux.getModel().provider}/${faux.getModel().id}`;
@@ -832,6 +850,17 @@ describe("session control (Phase 2b): boundary mutations", () => {
     const state = await control.state("sB7");
     expect(state.model).toBe(spec);
     expect(state.thinkingLevel).toBe("xhigh");
+  });
+
+  it("boundary mutations never mint sessions: unknown id rejects no_such_session", async () => {
+    const { control, sessions, spec } = makeBoundary([]);
+    const result = await control.dispatch("ghost", { type: "set_model", model: spec });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe(NO_SUCH_SESSION_CODE);
+    expect(await sessions.openIfExists("ghost")).toBeUndefined(); // no ghost record landed
+    const compact = await control.dispatch("ghost", { type: "compact" });
+    expect(compact.ok).toBe(false);
+    if (!compact.ok) expect(compact.error.code).toBe(NO_SUCH_SESSION_CODE);
   });
 
   it("without boundary wiring the commands stay gated off and rejected", async () => {

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -15,6 +15,7 @@ import { createPiSessionControl } from "../src/engines/pi/session-control.ts";
 import { inMemorySessionStore } from "../src/engines/pi/sessions.ts";
 import { createPiAgentFromWorkspace } from "../src/engines/pi/workspace.ts";
 import {
+  BOUNDARY_COMMAND_FAILED_CODE,
   INVALID_COMMAND_CODE,
   NO_ACTIVE_RUN_CODE,
   RUN_COMMAND_FAILED_CODE,
@@ -791,6 +792,46 @@ describe("session control (Phase 2b): boundary mutations", () => {
     const kinds = (await control.entries("sB4")).entries.map((e) => e.kind);
     expect(kinds).toContain("compaction");
     expect((await control.state("sB4")).status).toBe("idle"); // lease released, not stuck compacting
+  });
+
+  it("a failing compaction is closed and non-durable: boundary_command_failed, finished{error}, clean state", async () => {
+    // ONE response seeds the conversation; the compaction's summarization call then finds the faux
+    // queue empty and throws — the deterministic model-call failure.
+    const { agent, control } = makeBoundary([fauxAssistantMessage("seed")]);
+    await drain(agent.invoke({ session: "sB6" }, { text: "hi" }));
+    const seen: SessionEvent[] = [];
+    const watching = (async () => {
+      for await (const ev of control.events("sB6")) {
+        seen.push(ev);
+        if (ev.type === "compaction_finished") break; // bounds contract: failure must still close
+      }
+    })();
+    const result = await control.dispatch("sB6", { type: "compact" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(BOUNDARY_COMMAND_FAILED_CODE);
+      expect(result.error.retryable).toBe(true);
+    }
+    await watching;
+    expect(seen.map((e) => e.type)).toEqual(["compaction_started", "compaction_finished"]);
+    expect((seen.at(-1)?.data as { error?: string }).error).toBeTruthy();
+    // Nothing durable landed, and neither the lease nor the compacting flag is stuck.
+    const kinds = (await control.entries("sB6")).entries.map((e) => e.kind);
+    expect(kinds).not.toContain("compaction");
+    expect((await control.state("sB6")).status).toBe("idle");
+    const retry = await control.dispatch("sB6", { type: "set_thinking", level: "low" });
+    expect(retry.ok).toBe(true); // the lease was released
+  });
+
+  it("state() reports the durable overrides for a reconnecting client", async () => {
+    const { agent, control, spec } = makeBoundary([fauxAssistantMessage("ok")]);
+    await drain(agent.invoke({ session: "sB7" }, { text: "hi" }));
+    expect((await control.state("sB7")).model).toBeUndefined(); // no override → assembly default
+    await control.dispatch("sB7", { type: "set_model", model: spec });
+    await control.dispatch("sB7", { type: "set_thinking", level: "xhigh" });
+    const state = await control.state("sB7");
+    expect(state.model).toBe(spec);
+    expect(state.thinkingLevel).toBe("xhigh");
   });
 
   it("without boundary wiring the commands stay gated off and rejected", async () => {

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -905,6 +905,32 @@ describe("session control (Phase 2b): boundary mutations", () => {
     expect(second.map((e) => (e.type === "text" ? (e as { delta: string }).delta : "")).join("")).toContain("faux-b");
   });
 
+  it("a workspace caller observer receives the full vocabulary, boundary events included", async () => {
+    const { mkdtemp, rm, writeFile } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "fa-sc-tap-"));
+    try {
+      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      const seen: string[] = [];
+      const opened = await createPiAgentFromWorkspace(dir, {
+        sessionControl: true,
+        observer: (_s, event) => {
+          seen.push(event.type);
+        },
+      });
+      const control = opened.sessionControl as NonNullable<typeof opened.sessionControl>;
+      // Seed a session WITHOUT a model call: boundary mutations need an existing session, and the
+      // observer tap must then see the hub-generated state_changed — the audit-tap guarantee.
+      await opened.sessions.openOrCreate("sTap");
+      const result = await control.dispatch("sTap", { type: "set_thinking", level: "low" });
+      expect(result.ok).toBe(true);
+      expect(seen).toContain("state_changed");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("boundary mutations never mint sessions: unknown id rejects no_such_session", async () => {
     const { control, sessions, spec } = makeBoundary([]);
     const result = await control.dispatch("ghost", { type: "set_model", model: spec });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -850,7 +850,8 @@ describe("session control (Phase 2b): boundary mutations", () => {
     }
     await watching;
     expect(seen.map((e) => e.type)).toEqual(["compaction_started", "compaction_finished"]);
-    expect((seen.at(-1)?.data as { error?: string }).error).toBeTruthy();
+    const closed = seen.at(-1)?.data as { error?: string };
+    expect(closed.error).toBeTruthy();
     // Nothing durable landed, and neither the lease nor the compacting flag is stuck.
     const kinds = (await control.entries("sB6")).entries.map((e) => e.kind);
     expect(kinds).not.toContain("compaction");


### PR DESCRIPTION
## What

The control plane's boundary-mutation half, per [design §15 Phase 2b](https://github.com/fastagent-sh/fastagent/blob/main/docs/design/session-control.md): durable per-session overrides + manual compaction, completing Phase 2.

### Mechanism

- **`set_model` / `set_thinking`** append the records pi itself writes on explicit changes (`model_change` / `thinking_level_change`), validated before acceptance (`invalid_command`; `capabilities()` lists `allowedModels`/`allowedLevels`). The fresh-harness factory resolves the LAST override on every later turn (`resolveHarnessOverrides`, following the active-tools precedent) — **on any serving path, channels included**. A recorded model missing from the deployment registry falls back to the default with a deduped warn: the conversation survives a registry change.
- **One physical override walk** (`lastOverrideEntries`): the reporting surface (`state()` now returns the durable `model`/`thinkingLevel`) and the execution surface consume the same function — last record of each kind wins, malformed reads as absent, never skipped over.
- **`compact`** builds the session's full harness (applying its own overrides), summarizes, tears down. Bounds contract: `compaction_started` only once the harness exists, and every started is closed — `finished{summary}` or `finished{error}` + `boundary_command_failed` with nothing durable landed.
- **Same lease as runs**: `session_busy` while a run is active (retryable at idle); the write handle is re-opened UNDER the lease (a pre-lease handle could be a stale snapshot). `status: "compacting"` during manual compaction.
- **The control plane never mints sessions**: an unknown id rejects `no_such_session` — sessions are created by `invoke` only.
- **Wiring**: the assembly exposes its live parts (models/harnessFactory/lease) through an internal `onAssembly` seam; the workspace opener fills the hub's lazy `boundary` thunk. `THINKING_LEVELS` is anchored with `satisfies Record<ThinkingLevel, …>` — pi adding a level is a type error, not a drift.
- **Note (drive-by fix)**: the workspace's composed caller observer now forwards the `run` parameter (previously silently dropped) — external observers wired at the workspace receive run handles, per the documented trusted-seam semantics.

## Verification

- lint / typecheck / test: **834/834** (14 new: capabilities wiring, durable overrides + state_changed canonical spec, end-to-end 'set_model changes which model answers', known/unknown/malformed override resolve, failing compaction closed + non-durable + lease released, session_busy under a live run, no-mint, observation-only gating).
- `rv.sh local`: **5 review rounds, 14 findings, all addressed** (ghost-session minting, stale write handle, compaction bounds through factory failure, duplicated override walk already drifting, exhaustive thinking-scale anchor…). Final round: 3 cosmetic findings, fixed.