### PR TITLE
refactor(pi): THINKING_LEVELS has one definition — the one with the drift guard

### DIFF
--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -13,20 +13,11 @@ import { pathToFileURL } from "node:url";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { FastagentTool } from "./tool.ts";
 import type { Models } from "@earendil-works/pi-ai";
-import type { AnyModel } from "./harness.ts";
+import { THINKING_LEVELS, type AnyModel } from "./harness.ts";
 import { moduleLoadHint } from "../../loader.ts";
 
-/** pi's thinking levels (types.d.ts `ThinkingLevel`), as a runtime list for config validation — pi
- *  exports only the type. A level the selected model does not support is clamped by pi per model. */
-export const THINKING_LEVELS = [
-  "off",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-] as const satisfies readonly ThinkingLevel[];
+// pi's thinking levels as a runtime value live in harness.ts (THE single source, with the
+// exhaustiveness anchor against pi's union) — config validation consumes it, never redefines it.
 
 export interface FastagentConfig {
   /** "provider/modelId". Precedence: CLI --model > FASTAGENT_MODEL > config. */
@@ -161,8 +152,8 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   if (c.sessionControl !== undefined && typeof c.sessionControl !== "boolean") {
     throw new Error(`${path}: "sessionControl" must be a boolean`);
   }
-  if (c.thinkingLevel !== undefined && !(THINKING_LEVELS as readonly string[]).includes(c.thinkingLevel as string)) {
-    throw new Error(`${path}: "thinkingLevel" must be one of ${THINKING_LEVELS.join(", ")}`);
+  if (c.thinkingLevel !== undefined && !(THINKING_LEVELS as ReadonlySet<string>).has(c.thinkingLevel as string)) {
+    throw new Error(`${path}: "thinkingLevel" must be one of ${[...THINKING_LEVELS].join(", ")}`);
   }
   if (c.agentDir !== undefined && typeof c.agentDir !== "string") {
     throw new Error(`${path}: "agentDir" must be a string (a subdirectory relative to the config file)`);


### PR DESCRIPTION
config.ts and harness.ts each defined pi's runtime thinking-level list, and each claimed to be the single source. Only harness.ts's Set carries the exhaustiveness anchor (`satisfies Record<ThinkingLevel, true>`): pi adding a level breaks the build instead of config validation silently falling behind. It wins; config validation imports it, following the existing config→harness type-import direction (AnyModel).

- No behavior change: Set insertion order keeps the error message's level order identical.
- Verified: typecheck / lint / 835 tests green; `rv.sh local`: no findings.