### PR TITLE
refactor(channels): shared preview kit — one failure shape, one wording, one arg summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ src/
 │   ├── http.ts              # HTTP/SSE channel (consumes only the Agent contract)
 │   ├── control.ts           # session-control transport: bearer-token /control/* routes (dispatch + SSE events with wire envelope + /control/invoke)
 │   ├── body.ts, respond.ts  # channel-authoring kit (body cap, responses)
+│   ├── preview-kit.ts       # SHARED preview policies: ChannelFailure + customer-facing default error + tool-arg summary
+│   ├── text.ts              # SHARED Unicode-safe code-point slicing (cards, preview kit)
 │   ├── turn-queue.ts        # SHARED: in-memory per-session serial turns (FIFO; telegram + feishu)
 │   ├── turn-store.ts        # SHARED: generic durable turn intent (L1) — record shape/validator/order injected per channel
 │   ├── state.ts             # SHARED: atomic state files under <stateRoot>/channels/<kind>/
@@ -68,7 +70,6 @@ src/
 │   │   ├── invoke-turn.ts, preview.ts, seen.ts # turn IO, streaming-card delivery, delivery dedup
 │   │   ├── owned-threads.ts # durable index of Agent-created group threads (admits bare continuations)
 │   │   ├── context-buffer.ts# unsummoned group/thread discussion (durable, commit-on-completed)
-│   │   ├── text.ts          # Unicode-safe code-point slicing for card/text rendering
 │   │   ├── feishu-api.ts    # canonical Open API pipeline (token cache, retry, cardkit)
 │   │   ├── register-app.ts  # `add feishu`: scan-to-create device flow
 │   │   ├── register-webhook.ts, bootstrap-token.ts # event URL + token automation

--- a/src/channels/feishu/card.ts
+++ b/src/channels/feishu/card.ts
@@ -12,7 +12,7 @@
  * well under it; longer answers overflow into follow-up messages (preview.ts owns that policy).
  */
 
-import { truncateCodePointPrefix } from "./text.ts";
+import { truncateCodePointPrefix } from "../text.ts";
 
 /** The one streamed element's id — shared by create (card.ts) and update (preview.ts). */
 export const ANSWER_ELEMENT_ID = "answer";

--- a/src/channels/feishu/feishu-api.ts
+++ b/src/channels/feishu/feishu-api.ts
@@ -23,7 +23,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ImageRef } from "../../agent.ts";
 import type { FeishuCloudKind } from "./cloud.ts";
-import { utf8Prefix } from "./text.ts";
+import { utf8Prefix } from "../text.ts";
 
 /** Per-attempt timeout for a JSON API call — small JSON round-trips, so 30s is generous. */
 const API_TIMEOUT_MS = 30_000;

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -16,7 +16,7 @@ import { log } from "../../log.ts";
 import type { FeishuBufferedRef } from "./context-buffer.ts";
 import type { DownloadedFile, FeishuApi } from "./feishu-api.ts";
 import { type FeishuMention, parseContent } from "./parse.ts";
-import { codePointPrefix } from "./text.ts";
+import { codePointPrefix } from "../text.ts";
 
 /** Appended to the prompt (not the system prompt): the channel renders the reply in a card, and the
  *  card's markdown element is the natural fit for LLM output — steer away from HTML/plain. */

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -20,7 +20,7 @@
  * settle/delete+send/suppress).
  */
 import { setTimeout as sleep } from "node:timers/promises";
-import type { AgentEvent, Json } from "../../agent.ts";
+import type { AgentEvent } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   ANSWER_ELEMENT_ID,
@@ -30,18 +30,12 @@ import {
   streamingCardJson,
 } from "./card.ts";
 import { type FeishuApi, type FeishuTarget, chunkFeishuText, isCardStreamingClosed } from "./feishu-api.ts";
-import { truncateCodePointPrefix, truncateCodePointSuffix, truncateUtf8 } from "./text.ts";
+import { type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
+import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
 
-/** A terminal failure, as the channel hands it to `onError`. */
-export interface FeishuFailure {
-  details: string;
-  retryable: boolean;
-}
-
-/** The customer-facing default: neutral, no leaked internals; differentiate only on whether to retry. */
-export function defaultErrorMessage(failed: FeishuFailure): string {
-  return failed.retryable ? "⚠️ Temporary problem — please try again." : "⚠️ Sorry, something went wrong.";
-}
+/** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
+export type FeishuFailure = ChannelFailure;
+export { defaultErrorMessage };
 
 /** How often (ms) to push a live-preview snapshot; tool events still flush on the next loop. Cardkit
  *  allows 10 QPS per card entity (50 per app), but one snapshot a second reads smoothly (the client
@@ -49,33 +43,11 @@ export function defaultErrorMessage(failed: FeishuFailure): string {
  *  Doubles as the answer-preview aging window (see answerView). */
 const STREAM_THROTTLE_MS = 1000;
 
-/** Max length of a tool's arg preview in the live view. */
-const TOOL_ARG_MAX = 48;
-
 /** How much of the (growing) reasoning to peek at in the live view — the most recent tail. */
 const THINKING_PREVIEW = 280;
 
 /** The placeholder shown before any reasoning/tool/text arrives. */
 const THINKING_PLACEHOLDER = "💭 Thinking…";
-
-/** One-line, truncated: collapse whitespace so a multi-line command/arg stays on one line. */
-function clip(s: string): string {
-  const one = s.replace(/\s+/g, " ").trim();
-  return truncateCodePointPrefix(one, TOOL_ARG_MAX);
-}
-
-/**
- * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
- * rather than just `🔧 read`. Generic (the channel knows no tool schemas): show the salient value — the
- * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
- */
-function summarizeArgs(args: Json): string {
-  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));
-  const values = Object.values(args);
-  const primary = values.find((v) => typeof v === "string" || typeof v === "number");
-  if (primary !== undefined) return clip(String(primary));
-  return values.length > 0 ? clip(JSON.stringify(args)) : "";
-}
 
 /** Cap a live view to the card budget, PREFIX-STABLE: the streaming client animates only when the old
  *  text is a prefix of the new, so an over-budget view freezes at its head rather than sliding a tail
@@ -366,7 +338,7 @@ export async function streamFeishuReply(
         thinking += e.delta;
         touch();
       } else if (e.type === "tool_started") {
-        const arg = summarizeArgs(e.args);
+        const arg = summarizeToolArgs(e.args);
         toolIndexById.set(e.id, tools.length);
         tools.push({ label: arg ? `${e.name} ${arg}` : e.name, status: "running" });
         touch();

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -1,0 +1,44 @@
+/**
+ * Channel-neutral live-preview pieces shared by every messaging channel's preview renderer
+ * (telegram/preview.ts, feishu/preview.ts): the terminal-failure shape a channel hands to its
+ * `onError`, the customer-facing default message for it, and the compact tool-arg summary for the
+ * live view. The preview LIFECYCLES stay per-platform (message edits vs streaming cards) — only
+ * these platform-independent policies live here, so the customer-facing wording cannot drift
+ * between channels.
+ */
+import type { Json } from "../agent.ts";
+import { truncateCodePointPrefix } from "./text.ts";
+
+/** A terminal failure, as a channel hands it to its `onError`. */
+export interface ChannelFailure {
+  details: string;
+  retryable: boolean;
+}
+
+/** The customer-facing default: neutral, no leaked internals; differentiate only on whether to retry. */
+export function defaultErrorMessage(failed: ChannelFailure): string {
+  return failed.retryable ? "⚠️ Temporary problem — please try again." : "⚠️ Sorry, something went wrong.";
+}
+
+/** Max length (code points) of a tool's arg preview in the live view. */
+const TOOL_ARG_MAX = 48;
+
+/** One-line, truncated at code-point boundaries: collapse whitespace so a multi-line command/arg
+ *  stays on one line, and never tear a surrogate pair mid-emoji. */
+function clip(s: string): string {
+  const one = s.replace(/\s+/g, " ").trim();
+  return truncateCodePointPrefix(one, TOOL_ARG_MAX);
+}
+
+/**
+ * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
+ * rather than just `🔧 read`. Generic (a channel knows no tool schemas): show the salient value — the
+ * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
+ */
+export function summarizeToolArgs(args: Json): string {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));
+  const values = Object.values(args);
+  const primary = values.find((v) => typeof v === "string" || typeof v === "number");
+  if (primary !== undefined) return clip(String(primary));
+  return values.length > 0 ? clip(JSON.stringify(args)) : "";
+}

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -5,20 +5,14 @@
  * carry unbalanced HTML); on completion the same message is edited into the final answer as HTML. One
  * message, works in groups and private (unlike sendMessageDraft, which is private/forum-topic only).
  */
-import type { AgentEvent, Json } from "../../agent.ts";
+import type { AgentEvent } from "../../agent.ts";
+import { type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
 import { log } from "../../log.ts";
 import { TELEGRAM_MAX_TEXT, type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 
-/** A terminal failure, as the channel hands it to `onError`. */
-export interface TelegramFailure {
-  details: string;
-  retryable: boolean;
-}
-
-/** The customer-facing default: neutral, no leaked internals; differentiate only on whether to retry. */
-export function defaultErrorMessage(failed: TelegramFailure): string {
-  return failed.retryable ? "⚠️ Temporary problem — please try again." : "⚠️ Sorry, something went wrong.";
-}
+/** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
+export type TelegramFailure = ChannelFailure;
+export { defaultErrorMessage };
 
 /** How often (ms) to edit the live-preview message; tool events still flush on the next loop. Edits to
  *  one message are rate-limited tighter than sends, so pace them ~1.5s (vs every token). Doubles as the
@@ -26,30 +20,8 @@ export function defaultErrorMessage(failed: TelegramFailure): string {
  *  this long — one knob, same order of magnitude. */
 const EDIT_THROTTLE_MS = 1500;
 
-/** Max length of a tool's arg preview in the live view. */
-const TOOL_ARG_MAX = 48;
-
 /** How much of the (growing) reasoning to peek at in the live view — the most recent tail. */
 const THINKING_PREVIEW = 280;
-
-/** One-line, truncated: collapse whitespace so a multi-line command/arg stays on one line. */
-function clip(s: string): string {
-  const one = s.replace(/\s+/g, " ").trim();
-  return one.length > TOOL_ARG_MAX ? `${one.slice(0, TOOL_ARG_MAX - 1)}…` : one;
-}
-
-/**
- * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
- * rather than just `🔧 read`. Generic (the channel knows no tool schemas): show the salient value — the
- * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
- */
-function summarizeArgs(args: Json): string {
-  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));
-  const values = Object.values(args);
-  const primary = values.find((v) => typeof v === "string" || typeof v === "number");
-  if (primary !== undefined) return clip(String(primary));
-  return values.length > 0 ? clip(JSON.stringify(args)) : "";
-}
 
 /**
  * The terminal-write POLICY: resolve the single preview message into `text`. streamReply owns the
@@ -238,7 +210,7 @@ export async function streamReply(
         thinking += e.delta;
         touch();
       } else if (e.type === "tool_started") {
-        const arg = summarizeArgs(e.args);
+        const arg = summarizeToolArgs(e.args);
         toolIndexById.set(e.id, tools.length);
         tools.push({ label: arg ? `${e.name} ${arg}` : e.name, status: "running" });
         touch();

--- a/src/channels/text.ts
+++ b/src/channels/text.ts
@@ -1,4 +1,4 @@
-/** Pure Unicode-safe text slicing helpers shared by Feishu/Lark rendering paths. JavaScript string
+/** Pure Unicode-safe text slicing helpers shared by channel rendering paths (Feishu/Lark cards, the preview kit). JavaScript string
  * indexes are UTF-16 code units, so direct `slice()` can tear a surrogate pair and send replacement
  * characters after JSON/UTF-8 encoding. These helpers only cut at Unicode code-point boundaries. */
 

--- a/test/channels-text.test.ts
+++ b/test/channels-text.test.ts
@@ -9,7 +9,7 @@ import {
 
 const isWellFormed = (text: string): boolean => Buffer.from(text, "utf8").toString("utf8") === text;
 
-describe("Feishu Unicode-safe text truncation", () => {
+describe("channel Unicode-safe text truncation", () => {
   it("takes and ellipsizes by code point rather than UTF-16 code unit", () => {
     expect(codePointPrefix("a😀b", 2)).toBe("a😀");
     expect(truncateCodePointPrefix(`${"a".repeat(46)}😀xy`, 48)).toBe(`${"a".repeat(46)}😀…`);

--- a/test/feishu-text.test.ts
+++ b/test/feishu-text.test.ts
@@ -5,7 +5,7 @@ import {
   truncateCodePointSuffix,
   truncateUtf8,
   utf8Prefix,
-} from "../src/channels/feishu/text.ts";
+} from "../src/channels/text.ts";
 
 const isWellFormed = (text: string): boolean => Buffer.from(text, "utf8").toString("utf8") === text;
 


### PR DESCRIPTION
TelegramFailure/FeishuFailure, defaultErrorMessage and summarizeArgs were verbatim (or near-verbatim) copies across the two channel previews — the customer-facing wording could drift channel by channel. Extracted to `channels/preview-kit.ts` (ChannelFailure + defaultErrorMessage + summarizeToolArgs); the platform-branded Failure types stay as public aliases (the LarkFailure precedent). Preview lifecycles stay per-platform (message edits vs streaming cards).

**One deliberate behavior change**: the kit's clip takes Feishu's code-point-safe truncation, so **Telegram's tool-arg preview no longer tears a surrogate pair mid-emoji** (its old naive UTF-16 slice could) — a bug fix riding the merge, not an equivalent transform. Enabler: `feishu/text.ts` → `channels/text.ts` (it was platform-neutral all along); its test renamed to channels-text.test.ts.

Verified: typecheck / lint / 835 tests green; `rv.sh local`: two findings (test name, changelog honesty), both addressed.