### PR TITLE
feat(pi): add session-aware tool context

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -191,11 +191,28 @@ export default defineTool({
 
 `tools/<name>.ts` files are discovered with `loadTools(dir)`, and the filename becomes the tool name.
 
-The second `execute` argument is a `ToolContext`: `{ signal?, session?, tools? }`. `session` is the id of
-the current turn's conversation (undefined outside a turn, e.g. a bare `fastagent tool` run) — a per-turn
-value carried via `AsyncLocalStorage`, not a closure (a tool is built once and reused across sessions).
-The built-in **`wake`** tool uses it to self-schedule: `wake({ in, prompt })` records a one-shot wake-up
-that the scheduler fires back into THIS session after the delay (see [Schedule authoring](#schedule-authoring)).
+The second `execute` argument is a `ToolContext`:
+
+```ts
+interface ToolContext {
+  cwd: string;
+  signal?: AbortSignal;
+  sessionManager?: ReadonlySessionManager;
+  tools?: ToolActivation;
+}
+
+interface ReadonlySessionManager {
+  getSessionId(): string;
+  getHeader(): Promise<{ id: string; timestamp: string }>;
+  getBranch(): Promise<SessionTreeEntry[]>;
+}
+```
+
+During serving and `fastagent chat`, `sessionManager` is FastAgent's read-only adapter over the current
+conversation. It is undefined in a sessionless direct call such as `fastagent tool`. Current bindings
+ride `AsyncLocalStorage`, not definition closures, because a tool is built once and reused across turns.
+The built-in **`wake`** tool uses `sessionManager.getSessionId()` to schedule a follow-up in the same
+conversation.
 
 ### Deferred tools
 
@@ -337,7 +354,7 @@ one-shot `invoke`/`fire`) mounts a built-in **`wake`** tool so the agent can sch
 records a one-shot wake-up — or `wake({ cron: "0 9 * * *", tz?, prompt })` a RECURRING one — persisted under
 `<stateRoot>/schedule/`, polled by the scheduler and fired back into the SAME session, so the agent resumes
 the conversation — the woken turn's prompt is enveloped with the wake-up's id and origin ("YOUR
-self-scheduled turn, not a user message"), so the model can tell its own alarm from the user speaking. It reads the current session from `ToolContext.session`; guardrails cap the minimum delay,
+self-scheduled turn, not a user message"), so the model can tell its own alarm from the user speaking. It reads the current session through `ToolContext.sessionManager`; guardrails cap the minimum delay,
 the recurring frequency (≥10 min between fires), and the per-session pending count. The agent cancels its own
 with `unwake({ id })` (session-scoped); the operator with `fastagent schedule cancel <id>` (`schedule list`
 shows ids).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -218,7 +218,8 @@ session-scoped).
 fastagent tool <name> '<json-args>' [dir]
 ```
 
-Runs one discovered or configured tool directly, without a model or server.
+Runs one discovered or configured tool directly, without a model or server. The call receives its
+workspace cwd but no session manager; a session-dependent tool reports that requirement itself.
 
 Example:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,7 +150,20 @@ There are two ways to add tools:
 tools/lookup-order.ts  ->  lookup-order
 ```
 
-`config.tools` are appended after the default pi tools. Discovered `tools/` are appended after those. Name collisions are surfaced as warnings; existing tools win.
+`config.tools` are appended after the default pi tools. Discovered `tools/` are appended after those.
+Name collisions are surfaced as warnings; existing tools win. Reusable packages do not need a separate
+plugin contract: export ordinary `FastagentTool[]` and mount them explicitly:
+
+```ts
+import { integrationTools } from "@acme/fastagent-tools";
+
+export default defineConfig({
+  tools: integrationTools({ apiKey: process.env.ACME_API_KEY! }),
+});
+```
+
+Package tools receive the same `ToolContext` as definition-local `defineTool` tools, including the
+optional read-only `sessionManager` during serving/chat turns.
 
 ### When the repo already owns `tools/` or `channels/`
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -140,6 +140,13 @@ Workspace tools are merged in this order:
 3. discovered `tools/*.ts|js|mjs`.
 
 Earlier names win and collisions are reported. Broken discovered tools are reported and skipped.
+Reusable integrations export ordinary `FastagentTool[]` for explicit `config.tools` mounting; package
+origin does not create a second tool runtime.
+
+Every `defineTool` execution receives the same generic runtime context. Serving adapts its fresh
+pi-agent-core `Session`; chat adapts pi coding agent's resident `SessionManager`; both expose the
+FastAgent-owned read-only port (`getSessionId`, `getHeader`, `getBranch`). Sessionless direct execution
+provides cwd but no manager.
 
 **Deferred tools** (`defineTool({ deferred: true })`) are registered but not initially active: their
 schemas stay out of the request — and the model's sight — until the built-in `search_tools` loader

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -4,6 +4,7 @@ import { loadDotEnv } from "../../env.ts";
 import { loadConfig, resolveAgentDir } from "../../engines/pi/config.ts";
 import { resolveWorkspaceTools } from "../../engines/pi/create.ts";
 import { reportModuleLoadFailures } from "../../engines/pi/report.ts";
+import { turnContext } from "../../engines/pi/tool-context.ts";
 import { failStartup, failUsage } from "../fail.ts";
 
 export async function runTool(name: string, argsJson: string, dirArg: string): Promise<void> {
@@ -33,7 +34,7 @@ export async function runTool(name: string, argsJson: string, dirArg: string): P
   } catch {
     failUsage(`invalid JSON args: ${argsJson}`); // malformed input syntax = usage error, exit 2
   }
-  const result = await tool.execute(`cli-${name}`, args).catch(failStartup);
+  const result = await turnContext.run({ cwd: toolDir }, () => tool.execute(`cli-${name}`, args)).catch(failStartup);
   const out =
     result?.details !== undefined
       ? result.details

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -207,12 +207,13 @@ function buildPiAgent(opts: {
   onAssembly?: OnAssembly;
 }): Agent {
   const models = createPiModels({ providers: opts.providers, authPath: opts.authPath });
+  const env = opts.env ?? new NodeExecutionEnv({ cwd: process.cwd() });
   // Materialized here (not defaulted inside createPiAgentFromHarness) so the exposed parts carry
   // the SAME lease instance the agent runs under — boundary mutations must contend on it.
   const lease = opts.lease ?? inProcessLease();
   const harnessFactory = piHarnessFactory({
     sessions: opts.sessions ?? inMemorySessionStore(),
-    env: opts.env ?? new NodeExecutionEnv({ cwd: process.cwd() }),
+    env,
     models,
     model: resolveModel(models, opts.model),
     thinkingLevel: opts.thinkingLevel,
@@ -222,7 +223,7 @@ function buildPiAgent(opts: {
     live: opts.live,
   });
   opts.onAssembly?.({ models, harnessFactory, lease });
-  return createPiAgentFromHarness({ lease, observer: opts.observer, harnessFactory });
+  return createPiAgentFromHarness({ lease, observer: opts.observer, cwd: env.cwd, harnessFactory });
 }
 
 /**

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -27,7 +27,7 @@ import { abortFirstIterator } from "../../collect.ts";
 import type { RunSettledEvent, SessionEvent } from "../../session.ts";
 import { log } from "../../log.ts";
 import { TOOL_ACTIVATION_ENTRY, harnessSession, type PiHarnessFactory } from "./harness.ts";
-import { type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
+import { type ReadonlySessionManager, type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
 
 // ── §1 Lease: single-writer concurrency floor ───────────────────────────────
 //
@@ -266,6 +266,20 @@ export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "fa
 
 type PiHarness = Awaited<ReturnType<PiHarnessFactory>>;
 
+/** Bind the concrete pi-agent-core Session behind FastAgent's tool-runtime manager port. */
+function toolSessionManager(sessionId: string, harness: PiHarness): ReadonlySessionManager | undefined {
+  const session = harnessSession(harness);
+  if (!session) return undefined;
+  return {
+    getSessionId: () => sessionId,
+    async getHeader() {
+      const metadata = await session.getMetadata();
+      return { id: sessionId, timestamp: metadata.createdAt };
+    },
+    getBranch: () => session.getBranch(),
+  };
+}
+
 /**
  * The turn's {@link ToolActivation} over the live harness. `activate` is additive and filters to the
  * registered names first — pi's `setActiveTools` THROWS on unknown names, and a loader must get a
@@ -397,6 +411,8 @@ export interface CreatePiAgentFromHarnessOptions {
   /** Observation-plane tap (see {@link SessionObserver}). Optional; invoke behavior is identical
    *  with or without it — the SPEC stream is a projection of what the observer sees. */
   observer?: SessionObserver;
+  /** Working directory exposed to FastAgent-defined tools. Defaults to process.cwd(). */
+  cwd?: string;
 }
 
 /** "From a harness factory": engine wired by the caller; adds only the concurrency/stream shell. */
@@ -575,12 +591,15 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       });
       let completed: AssistantMessage | undefined; // the assistant message of a cleanly completed turn
       try {
-        // Run the turn inside the session context so a tool's `execute` can read which session it is in
-        // (turnContext / ToolContext.session). prompt() starts the async work synchronously here, so the
-        // store propagates to the tool calls awaited within it.
+        // Bind current cwd/session/activation capabilities for every FastAgent-defined tool.
         const opts = await toPiPromptOptions(prompt);
-        const run = turnContext.run({ session: scope.session, tools: toolActivation(harness) }, () =>
-          harness.prompt(prompt.text, opts),
+        const run = turnContext.run(
+          {
+            cwd: options.cwd ?? process.cwd(),
+            sessionManager: toolSessionManager(scope.session, harness),
+            tools: toolActivation(harness),
+          },
+          () => harness.prompt(prompt.text, opts),
         );
         yield* queue.drainUntil(run);
         let terminal: AgentEvent;

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -27,6 +27,7 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   type AgentSession,
@@ -44,9 +45,24 @@ import { assembleSystemPrompt, piBasePrompt, piDefaultTools } from "./create.ts"
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
 import { createPiModelRuntime, probeAuthSource } from "./models.ts";
 import { log } from "../../log.ts";
-import { type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
+import { type ReadonlySessionManager, type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
 import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 import { resolveWorkspaceAssembly } from "./workspace.ts";
+
+/** Adapt coding-agent's resident SessionManager to FastAgent's shared tool-runtime manager port. */
+function toolChatSessionManager(session: AgentSession): ReadonlySessionManager {
+  return {
+    getSessionId: () => session.sessionManager.getSessionId(),
+    async getHeader() {
+      const header = session.sessionManager.getHeader();
+      if (!header) throw new Error("chat session has no metadata header");
+      return { id: header.id, timestamp: header.timestamp };
+    },
+    async getBranch() {
+      return session.sessionManager.getBranch() as SessionTreeEntry[];
+    },
+  };
+}
 
 export interface BuildSessionRuntimeOptions {
   /** Model spec override (the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -155,7 +171,7 @@ export async function buildWorkspaceSessionRuntime(
         // session-lifecycle invariant as a normal out-of-turn call (fail visibly).
         if (!bound) throw new Error("tool executed before its session was built (lifecycle invariant broken)");
         return turnContext.run(
-          { session: bound.session.sessionId, tools: bound.activation },
+          { cwd, sessionManager: bound.sessionManager, tools: bound.activation },
           () => t.execute(id, params, signal) as Promise<unknown>,
         );
       },
@@ -194,7 +210,9 @@ export async function buildWorkspaceSessionRuntime(
   // parallel batches: pi wraps SDK customTools in its own before/after active-set diff, so an
   // activating tool must carry `executionMode: "sequential"` (the builtin loader does) — pi then runs
   // the whole batch serially and the outer diff sees correct snapshots.
-  const sessionRef: { current?: { session: AgentSession; activation: ToolActivation } } = {};
+  const sessionRef: {
+    current?: { session: AgentSession; sessionManager: ReadonlySessionManager; activation: ToolActivation };
+  } = {};
   let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
   const assemblyFor = (cwd: string) => {
     // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
@@ -264,7 +282,11 @@ export async function buildWorkspaceSessionRuntime(
       tools: [...defaultNames, ...customTools.map((t) => t.name)],
       customTools: customToolDefs,
     });
-    sessionRef.current = { session: result.session, activation: sessionToolActivation(result.session) };
+    sessionRef.current = {
+      session: result.session,
+      sessionManager: toolChatSessionManager(result.session),
+      activation: sessionToolActivation(result.session),
+    };
     // Deferral emulation: pi's session starts with everything active — narrow it by SUBTRACTING
     // the deferred names from whatever is active (robust to pi mounting tools of its own; an
     // exact-set-equality gate would silently stop narrowing the day pi adds one). Applied on EVERY

--- a/src/engines/pi/tool-context.ts
+++ b/src/engines/pi/tool-context.ts
@@ -1,15 +1,18 @@
 /**
- * The per-turn context a tool's `execute` can read (beyond its abort signal): the SESSION the current
- * turn runs in. A `defineTool` tool is built ONCE and reused across sessions, so the session can't be a
- * closure — it rides an AsyncLocalStorage set around the harness turn (invoke.ts) and read inside
- * `execute` (tool.ts). Undefined outside a turn (e.g. `fastagent tool`, which runs a tool with no
- * session). This is what lets a tool know which conversation it is in — the mechanism the agent's
- * self-scheduling `wake` tool needs to fire a later turn back into the SAME session.
- *
- * Only `session` lives here (a per-turn runtime value). Deploy-time ambients a tool closes over at
- * build time (e.g. a stateRoot) do NOT belong here — pass them via the tool's own closure.
+ * Per-turn capabilities shared by every FastAgent-defined tool. A tool is built once and reused across
+ * turns, so current cwd/session/activation bindings ride AsyncLocalStorage rather than definition
+ * closures. Deploy-time ambients a tool closes over at build time do NOT belong here.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
+
+/** FastAgent's read-only port over the current conversation manager. Serving and chat adapt their
+ * different concrete session implementations to this one tool-runtime contract. */
+export interface ReadonlySessionManager {
+  getSessionId(): string;
+  getHeader(): Promise<{ id: string; timestamp: string }>;
+  getBranch(): Promise<SessionTreeEntry[]>;
+}
 
 /**
  * The turn's tool-activation bridge — narrow closures over the CURRENT harness (invoke.ts builds it
@@ -30,8 +33,10 @@ export interface ToolActivation {
 }
 
 export interface TurnContext {
-  /** The session id of the current turn. */
-  session: string;
+  /** Working directory for this execution. Falls back to process.cwd() only for an unbound direct call. */
+  cwd?: string;
+  /** Current conversation manager. Absent outside a FastAgent-managed agent turn. */
+  sessionManager?: ReadonlySessionManager;
   /** Tool activation for the current turn. Two producers, one consumer surface: invoke.ts bridges the
    *  serving harness; chat.ts bridges pi's AgentSession (chat emulates deferral — same loader, same
    *  semantics). Absent only outside any turn (a bare `fastagent tool` run). */

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -14,17 +14,15 @@ import { join } from "node:path";
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { z } from "zod";
 import { type ModuleLoadFailure, loadModuleDir } from "../../loader.ts";
-import { type ToolActivation, turnContext } from "./tool-context.ts";
+import { type ReadonlySessionManager, type ToolActivation, turnContext } from "./tool-context.ts";
 
 export interface ToolContext {
+  /** Working directory for this execution. */
+  cwd: string;
   /** Abort signal for the current turn — honor it to cancel in-flight work on cancellation. */
   signal?: AbortSignal;
-  /** The session id of the current turn — which conversation this tool is running in. A general tool
-   *  capability: partition per-conversation data, tag logs, scope state. Undefined outside a turn (a bare
-   *  `fastagent tool` run, or any call with no session). (The built-in `wake` tool is one consumer — it
-   *  fires a later turn back into this same session.) In a `fastagent chat` turn this is pi's LOCAL
-   *  chat session id, not a served session — serving-coupled consumers like wake are not mounted there. */
-  session?: string;
+  /** Current conversation manager. Present during serving/chat; absent for sessionless direct calls. */
+  sessionManager?: ReadonlySessionManager;
   /** Tool activation for the current turn (a loader tool activates {@link DefineToolOptions.deferred}
    *  tools with it — the built-in `search_tools` is one consumer). Provided by both the serving path
    *  (invoke.ts, over the harness) and chat (over pi's AgentSession); undefined only outside any turn
@@ -55,7 +53,9 @@ export interface DefineToolOptions<I extends z.ZodType> {
 /** An AgentTool with fastagent's deferral marker — the type for raw tools handed to fastagent
  *  (`config.tools`, L1/L2 `tools`): plain `AgentTool` has no `deferred`, so an object literal with the
  *  marker would fail excess-property checking against upstream's type. `defineTool` produces it. */
-export type FastagentTool = AgentTool & { deferred?: boolean };
+export type FastagentTool = AgentTool & {
+  deferred?: boolean;
+};
 
 /** Read the {@link DefineToolOptions.deferred} marker off a mounted tool (extra property on the
  *  AgentTool object — pi ignores it). */
@@ -80,7 +80,7 @@ function wrapResult(value: unknown): AgentToolResult<unknown> {
   return { content: [{ type: "text", text }], details: value };
 }
 
-export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): AgentTool {
+export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): FastagentTool {
   const { $schema: _drop, ...parameters } = z.toJSONSchema(options.input) as Record<string, unknown>;
   const tool = {
     name: options.name ?? "",
@@ -114,7 +114,14 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
             },
           }
         : undefined;
-      const result = wrapResult(await options.execute(parsed.data, { signal, session: store?.session, tools }));
+      const result = wrapResult(
+        await options.execute(parsed.data, {
+          cwd: store?.cwd ?? process.cwd(),
+          signal,
+          sessionManager: store?.sessionManager,
+          tools,
+        }),
+      );
       if (added.length > 0) {
         // A copy, not a mutation: wrapResult passes a full AgentToolResult through by REFERENCE, and an
         // author may legally return a shared/frozen result object — stamping in place would corrupt it
@@ -124,7 +131,7 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
       return result;
     },
   };
-  return tool as unknown as AgentTool;
+  return tool as unknown as FastagentTool;
 }
 
 /** A discarded same-name tool (within `tools/`, or against an existing tool). Surfaced, never silent. */

--- a/src/engines/pi/wake-tool.ts
+++ b/src/engines/pi/wake-tool.ts
@@ -2,7 +2,7 @@
  * The built-in `wake` tool: the agent's self-scheduling surface. Calling it records a one-shot wake-up
  * (wakeups.ts); the scheduler fires it back into the SAME session, so the agent resumes THIS
  * conversation after a delay ("check the deploy in 10 minutes"). The session comes from the turn
- * context (ToolContext.session, set around the harness turn); the state root is closed over at build
+ * context (ToolContext.sessionManager, set around the harness turn); the state root is closed over at build
  * time (where it is known — the workspace opener), never read from the turn.
  *
  * Mounted by the opener ONLY when `config.selfSchedule` is on AND on the serving path (`dev`/`start`, where
@@ -68,17 +68,14 @@ export function makeWakeTool(stateRoot: string, now: () => Date = () => new Date
       prompt: z.string().min(1).describe("the instruction for the woken turn (runs in this same conversation)"),
     }),
     execute(input, ctx) {
-      if (!ctx.session) return "wake is only available inside a conversation (there is no session to resume).";
+      const session = ctx.sessionManager?.getSessionId();
+      if (!session) return "wake is only available inside a conversation (there is no session to resume).";
       if ((input.in === undefined) === (input.cron === undefined)) {
         return "pass exactly one of `in` (one-shot) or `cron` (recurring).";
       }
       if (input.cron !== undefined) {
         // addWakeup validates the cron and DERIVES the first instant itself — one computation, one truth.
-        const r = addWakeup(
-          stateRoot,
-          { session: ctx.session, prompt: input.prompt, cron: input.cron, tz: input.tz },
-          now(),
-        );
+        const r = addWakeup(stateRoot, { session, prompt: input.prompt, cron: input.cron, tz: input.tz }, now());
         if (!r.ok) return r.error; // guardrail message the model can act on
         return `OK — recurring wake ${r.id} (cron "${input.cron}"${input.tz ? ` ${input.tz}` : ""}), first at ${r.fireAt}: ${input.prompt}. Use unwake({ id: "${r.id}" }) to stop it.`;
       }
@@ -87,7 +84,7 @@ export function makeWakeTool(stateRoot: string, now: () => Date = () => new Date
         return `couldn't parse "in" (${JSON.stringify(input.in)}) — use a unit like "30m" / "2h" / "1d", or a number of seconds (a bare number as text like "120" is rejected).`;
       }
       const at = new Date(now().getTime() + ms);
-      const r = addWakeup(stateRoot, { session: ctx.session, prompt: input.prompt, fireAt: at }, now());
+      const r = addWakeup(stateRoot, { session, prompt: input.prompt, fireAt: at }, now());
       if (!r.ok) return r.error; // guardrail message the model can act on
       return `OK — I'll wake up at ${r.fireAt} (id ${r.id}) to: ${input.prompt}. Use unwake({ id: "${r.id}" }) if it becomes unnecessary.`;
     },
@@ -104,8 +101,9 @@ export function makeUnwakeTool(stateRoot: string): AgentTool {
       "a scheduled follow-up is no longer needed — especially to stop a recurring wake once its job is done.",
     input: z.object({ id: z.string().min(1).describe("the wake-up id (returned by `wake`)") }),
     execute(input, ctx) {
-      if (!ctx.session) return "unwake is only available inside a conversation.";
-      return removeWakeup(stateRoot, input.id, ctx.session)
+      const session = ctx.sessionManager?.getSessionId();
+      if (!session) return "unwake is only available inside a conversation.";
+      return removeWakeup(stateRoot, input.id, session)
         ? `OK — wake-up ${input.id} cancelled.`
         : `no pending wake-up ${input.id} in this conversation (already fired, or not yours).`;
     },

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -14,9 +14,16 @@ export {
   type ToolCollision,
   type ToolContext,
 } from "./engines/pi/tool.ts";
-export type { ToolActivation } from "./engines/pi/tool-context.ts";
+export type { ReadonlySessionManager, ToolActivation } from "./engines/pi/tool-context.ts";
 export { z } from "zod";
-export type { AgentTool, ExecutionEnv, Session, Skill, SkillDiagnostic } from "@earendil-works/pi-agent-core";
+export type {
+  AgentTool,
+  ExecutionEnv,
+  Session,
+  SessionTreeEntry,
+  Skill,
+  SkillDiagnostic,
+} from "@earendil-works/pi-agent-core";
 
 export { loadChannels, type ChannelCollision } from "./engines/pi/channel.ts";
 export {

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { AgentHarness, InMemorySessionRepo, type AgentTool } from "@earendil-works/pi-agent-core";
+import {
+  AgentHarness,
+  InMemorySessionRepo,
+  type AgentTool,
+  type SessionTreeEntry,
+} from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { fauxAssistantMessage, fauxThinking, fauxToolCall, Type, type FauxResponseStep } from "@earendil-works/pi-ai";
 import type { AssistantMessage, StopReason, Usage } from "@earendil-works/pi-ai";
-import { inMemorySessionStore, inProcessLease, type AgentEvent } from "../src/index.ts";
+import { defineTool, inMemorySessionStore, inProcessLease, type AgentEvent, z } from "../src/index.ts";
 import { SESSION_BUSY_CODE } from "../src/agent.ts";
 import { classifyRetryable, createPiAgentFromHarness, errorToTerminal, toTerminal } from "../src/engines/pi/invoke.ts";
 import { type PiHarnessFactory, piHarnessFactory } from "../src/engines/pi/harness.ts";
@@ -80,6 +85,45 @@ describe("invoke fan-in", () => {
 
     expect(thinking).toContain("let me think");
     expect(text).toBe("the answer"); // reasoning is not folded into the answer
+  });
+
+  it("binds the current read-only session manager to ordinary defineTool tools", async () => {
+    let observed: { id: string; branch: SessionTreeEntry[] } | undefined;
+    const inspectSession = defineTool({
+      name: "inspect_session",
+      description: "Inspect the current session.",
+      input: z.object({}),
+      async execute(_input, ctx) {
+        if (!ctx.sessionManager) throw new Error("missing current session manager");
+        observed = {
+          id: ctx.sessionManager.getSessionId(),
+          branch: await ctx.sessionManager.getBranch(),
+        };
+        return "inspected";
+      },
+    });
+    const { faux, models } = makeFaux();
+    faux.setResponses([
+      fauxAssistantMessage(fauxToolCall("inspect_session", {}, { id: "inspect-1" })),
+      fauxAssistantMessage("done"),
+    ]);
+    const agent = createPiAgentFromHarness({
+      cwd: process.cwd(),
+      harnessFactory: piHarnessFactory({
+        sessions: inMemorySessionStore(),
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
+        models,
+        model: faux.getModel(),
+        tools: [inspectSession],
+        systemPrompt: "test",
+      }),
+    });
+
+    await drain(agent.invoke({ session: "history-session" }, { text: "inspect this conversation" }));
+
+    expect(observed?.id).toBe("history-session");
+    expect(JSON.stringify(observed?.branch)).toContain("inspect this conversation");
+    expect(JSON.stringify(observed?.branch)).toContain("inspect_session");
   });
 
   it("preserves text → tool → completed order", async () => {

--- a/test/session-builder.test.ts
+++ b/test/session-builder.test.ts
@@ -11,6 +11,55 @@ import { buildWorkspaceSessionRuntime } from "../src/engines/pi/session-builder.
 // TTY. In-memory sessions keep the test from writing to the machine's pi session store. A raw
 // AgentTool via `config.tools` lets the custom-tool path be tested without installing the package.
 describe("session builder: buildWorkspaceSessionRuntime injects fastagent's assembled agent into pi's session", () => {
+  it("binds the chat session manager to ordinary configured defineTool tools", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-chat-session-tool-"));
+    const observedKey = "__fastagent_chat_tool_session_test__";
+    const piUrl = new URL("../src/pi.ts", import.meta.url).href;
+    try {
+      await writeFile(
+        join(dir, "fastagent.config.mjs"),
+        `import { defineTool, z } from ${JSON.stringify(piUrl)};
+         export default {
+           model: "openai-codex/gpt-5.5",
+           tools: [defineTool({
+             name: "inspect_session",
+             description: "Inspect this session.",
+             input: z.object({}),
+             execute: async (_input, ctx) => {
+               globalThis[${JSON.stringify(observedKey)}] = {
+                 sessionId: ctx.sessionManager.getSessionId(),
+                 header: await ctx.sessionManager.getHeader(),
+                 branch: await ctx.sessionManager.getBranch(),
+               };
+               return "ok";
+             },
+           })],
+         };\n`,
+      );
+      const rt = await buildWorkspaceSessionRuntime(dir, {}, SessionManager.inMemory());
+      try {
+        rt.session.sessionManager.appendMessage({ role: "user", content: "history marker", timestamp: Date.now() });
+        const tool = rt.session.agent.state.tools.find((candidate) => candidate.name === "inspect_session");
+        expect(tool).toBeDefined();
+        await tool!.execute("inspect-1", {});
+        const observed = (globalThis as Record<string, unknown>)[observedKey] as {
+          sessionId: string;
+          header: { id: string; timestamp: string };
+          branch: unknown[];
+        };
+        expect(observed.sessionId).toBe(rt.session.sessionId);
+        expect(observed.header.id).toBe(rt.session.sessionId);
+        expect(observed.header.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(JSON.stringify(observed.branch)).toContain("history marker");
+      } finally {
+        delete (globalThis as Record<string, unknown>)[observedKey];
+        await rt.dispose();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("emulates deferral: deferred tools start inactive, search_tools mounts and activates via pi's session", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-chat-defer-"));
     try {

--- a/test/tool-context.test.ts
+++ b/test/tool-context.test.ts
@@ -9,27 +9,27 @@ import { defineTool } from "../src/engines/pi/tool.ts";
 import { inMemorySessionStore } from "../src/index.ts";
 import { makeFaux } from "./faux.ts";
 
-/** Call a built tool's execute directly (the `fastagent tool` path — no turn, no ALS). */
+/** Call a built tool's execute directly (the `fastagent tool` path — no session binding). */
 type RawExecute = (id: string, params: unknown, signal?: AbortSignal) => Promise<unknown>;
 
-describe("tool ctx.session (turn context via AsyncLocalStorage)", () => {
-  it("a tool's execute reads the CURRENT turn's session (ALS propagates through pi's tool call)", async () => {
-    // The load-bearing feasibility check for self-scheduling: a defineTool tool is built once and reused
-    // across sessions, so it can't close over the session — it must read the turn's session at call time.
-    // If ALS did not propagate through pi's tool execution, `seen` would stay unset and this fails.
+describe("shared ToolContext session manager", () => {
+  it("a defineTool tool reads the CURRENT turn's manager through the shared runtime context", async () => {
+    // A tool is built once and reused across sessions, so its manager cannot be a definition closure.
+    // If turn-context propagation through pi's tool execution breaks, `seen` stays unset.
     let seen: string | undefined = "UNSET";
     const probe = defineTool({
       name: "probe",
       description: "records the session it ran in",
       input: z.object({}),
       execute(_input, ctx) {
-        seen = ctx.session;
+        seen = ctx.sessionManager?.getSessionId();
         return "ok";
       },
     });
     const { faux, models } = makeFaux();
     faux.setResponses([fauxAssistantMessage(fauxToolCall("probe", {}, { id: "c1" })), fauxAssistantMessage("done")]);
     const agent = createPiAgentFromHarness({
+      cwd: process.cwd(),
       harnessFactory: piHarnessFactory({
         sessions: inMemorySessionStore(),
         env: new NodeExecutionEnv({ cwd: process.cwd() }),
@@ -41,23 +41,23 @@ describe("tool ctx.session (turn context via AsyncLocalStorage)", () => {
     });
 
     const events: AgentEvent[] = [];
-    for await (const e of agent.invoke({ session: "sess-42" }, { text: "go" })) events.push(e);
+    for await (const event of agent.invoke({ session: "sess-42" }, { text: "go" })) events.push(event);
 
     expect(events.at(-1)?.type).toBe("completed");
-    expect(seen).toBe("sess-42"); // the tool saw the turn's session
+    expect(seen).toBe("sess-42");
   });
 
-  it("ctx.session is undefined outside a turn (a bare `fastagent tool` run, no ALS)", async () => {
-    let seen: string | undefined = "UNSET";
+  it("sessionManager is undefined outside an agent turn", async () => {
+    let seen = true;
     const probe = defineTool({
-      description: "records session",
+      description: "records session availability",
       input: z.object({}),
-      execute(_i, ctx) {
-        seen = ctx.session;
+      execute(_input, ctx) {
+        seen = ctx.sessionManager !== undefined;
         return "ok";
       },
     });
     await (probe as unknown as { execute: RawExecute }).execute("cli", {});
-    expect(seen).toBeUndefined();
+    expect(seen).toBe(false);
   });
 });

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -31,6 +31,23 @@ describe("defineTool", () => {
     expect(JSON.stringify(bad)).toMatch(/Invalid arguments|expected number/);
   });
 
+  it("uses the unified ToolContext without a duplicate session id", async () => {
+    let context: Record<string, unknown> | undefined;
+    const tool = defineTool({
+      name: "ordinary",
+      description: "ordinary",
+      input: z.object({}),
+      execute(_input, ctx) {
+        context = ctx as unknown as Record<string, unknown>;
+        return "ok";
+      },
+    });
+    await tool.execute("c", {});
+    expect(context?.cwd).toBe(process.cwd());
+    expect(context?.sessionManager).toBeUndefined();
+    expect(context).not.toHaveProperty("session");
+  });
+
   it("passes a full {content,details} result through unchanged", async () => {
     const tool = defineTool({
       name: "raw",

--- a/test/wakeups.test.ts
+++ b/test/wakeups.test.ts
@@ -20,6 +20,14 @@ import { turnContext } from "../src/engines/pi/tool-context.ts";
 const root = (): Promise<string> => mkdtemp(join(tmpdir(), "fa-wake-"));
 const NOW = new Date("2026-07-07T12:00:00Z");
 const at = (ms: number): Date => new Date(NOW.getTime() + ms);
+const contextFor = (session: string) => ({
+  cwd: process.cwd(),
+  sessionManager: {
+    getSessionId: () => session,
+    getHeader: async () => ({ id: session, timestamp: NOW.toISOString() }),
+    getBranch: async () => [],
+  },
+});
 
 type RawExecute = (id: string, params: unknown, signal?: AbortSignal) => Promise<unknown>;
 const exec = (tool: { execute?: unknown }, params: unknown): Promise<unknown> =>
@@ -160,7 +168,7 @@ describe("schedule/wake-tool", () => {
   it("the wake tool records a wake-up into the CURRENT session", async () => {
     const r = await root();
     const tool = makeWakeTool(r, () => NOW);
-    await turnContext.run({ session: "conv-1" }, () => exec(tool, { in: "30m", prompt: "resume the check" }));
+    await turnContext.run(contextFor("conv-1"), () => exec(tool, { in: "30m", prompt: "resume the check" }));
     expect(listWakeups(r)).toHaveLength(1);
     expect(listWakeups(r)[0]).toMatchObject({ session: "conv-1", prompt: "resume the check" });
   });
@@ -177,7 +185,7 @@ describe("schedule/wake-tool", () => {
   it("a below-minimum delay is a guardrail message, records nothing", async () => {
     const r = await root();
     const tool = makeWakeTool(r, () => NOW);
-    await turnContext.run({ session: "s" }, () => exec(tool, { in: "1s", prompt: "x" }));
+    await turnContext.run(contextFor("s"), () => exec(tool, { in: "1s", prompt: "x" }));
     expect(listWakeups(r)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- replace the duplicated `ToolContext.session` string with a FastAgent-owned read-only session manager exposing session identity, header, and branch history
- adapt both the stateless serving session and the resident chat session manager to the same tool-runtime contract
- bind execution cwd for serving, chat, and sessionless `fastagent tool` calls, and migrate `wake`/`unwake` to the shared session identity
- document reusable package tools as ordinary `config.tools` integrations; no extension or package-specific runtime is introduced

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Added or updated the smallest relevant tests
- [x] `npm run build`

`npm run lint` retains the existing unused-suppression warning in `test/control-http.test.ts:650`; it reports no errors.

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added (`*_PLAN.md`, `HANDOFF.md`, session notes, etc.)
- [x] Docs were updated when behavior or public APIs changed
