### PR TITLE
feat: pi 0.81.1 summarization retries — opt-in policy wired + retry_scheduled session event

### DIFF
--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -299,7 +299,7 @@ compare. The vocabulary, grouped by the client maturity level that needs it:
 | L1 | `queue_changed { steering, followUp }` | Normalized queue depths. |
 | L2 | `turn_started`, `turn_finished` | Group tool activity under one assistant turn. |
 | L2 | `compaction_started/finished` | Manual compaction bounds: between runs, no `runId`; every started is closed (`summary`, `error`, or `aborted` — a deliberate stop is not a failure). Automatic overflow compaction stays inside its run and does not emit these. |
-| L2 | `retry_scheduled/finished` | Explain why a run is alive with no tokens flowing (future vocabulary — not yet emitted). |
+| L2 | `retry_scheduled { operation, attempt, maxAttempts, delayMs, error }` | A transient provider failure scheduled a summarization retry backoff — explains a quiet gap that would otherwise read as a hang. Inside a run (auto-compaction / branch summary, `runId`) or during manual compaction (no `runId`). No closing event: the next event is the closure. |
 | L2 | `state_changed { model?, thinkingLevel? }` | Material state changes. |
 
 Consumers MUST forward or ignore unknown event types; the vocabulary is additive. The contract

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",
-        "@earendil-works/pi-agent-core": "^0.81.0",
-        "@earendil-works/pi-ai": "^0.81.0",
-        "@earendil-works/pi-coding-agent": "^0.81.0",
+        "@earendil-works/pi-agent-core": "^0.81.1",
+        "@earendil-works/pi-ai": "^0.81.1",
+        "@earendil-works/pi-coding-agent": "^0.81.1",
         "@larksuiteoapi/node-sdk": "^1.71.1",
         "@octokit/webhooks-methods": "^6.0.0",
         "@octokit/webhooks-types": "^7.6.1",

--- a/package.json
+++ b/package.json
@@ -92,9 +92,9 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.6.0",
-    "@earendil-works/pi-agent-core": "^0.81.0",
-    "@earendil-works/pi-ai": "^0.81.0",
-    "@earendil-works/pi-coding-agent": "^0.81.0",
+    "@earendil-works/pi-agent-core": "^0.81.1",
+    "@earendil-works/pi-ai": "^0.81.1",
+    "@earendil-works/pi-coding-agent": "^0.81.1",
     "@larksuiteoapi/node-sdk": "^1.71.1",
     "@octokit/webhooks-methods": "^6.0.0",
     "@octokit/webhooks-types": "^7.6.1",

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -87,6 +87,14 @@ export interface PiHarnessFactoryOptions {
 const PROVIDER_MAX_RETRIES = 2;
 
 /**
+ * Retry policy for generated compaction/branch-summary model calls (pi ≥0.81.1, #6901). OPT-IN
+ * upstream — an undefined policy means no retries — so both compaction paths pass it explicitly:
+ * the harness config (auto-compaction inside a run) and the manual `compact()` dispatch in
+ * session-control. Values mirror pi's own app defaults (maxRetries 3, base 2s exponential).
+ */
+export const SUMMARIZATION_RETRY_POLICY = { enabled: true, maxRetries: 3, baseDelayMs: 2000 } as const;
+
+/**
  * The serving default for reasoning effort, pinned to what pi's TUI defaults to (its
  * DEFAULT_THINKING_LEVEL) — NOT inherited from the bare harness, whose own fallback is "off": an
  * author vibes at "medium" in pi and must get "medium" when served (fidelity), and pinning the value
@@ -275,6 +283,7 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
       systemPrompt: prompt,
       resources: skills ? { skills } : undefined,
       streamOptions: { maxRetries: PROVIDER_MAX_RETRIES },
+      retry: SUMMARIZATION_RETRY_POLICY,
     });
     harnessSessions.set(harness, session);
     return harness;

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -24,7 +24,7 @@ import {
   SESSION_BUSY_CODE,
 } from "../../agent.ts";
 import { abortFirstIterator } from "../../collect.ts";
-import type { RunSettledEvent, SessionEvent } from "../../session.ts";
+import type { RetryScheduledEvent, RunSettledEvent, SessionEvent } from "../../session.ts";
 import { log } from "../../log.ts";
 import { TOOL_ACTIVATION_ENTRY, harnessSession, type PiHarnessFactory } from "./harness.ts";
 import { type ReadonlySessionManager, type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
@@ -143,7 +143,7 @@ function messageSignal(message: AssistantMessage): { status?: number; code?: unk
  * translation plus one projection, never two parallel translations). pi events with no session
  * vocabulary yet (turn_start, agent_start, …) are dropped.
  */
-function toSessionEvent(pe: AgentHarnessEvent, runId: string): SessionEvent | null {
+export function toSessionEvent(pe: AgentHarnessEvent, runId: string): SessionEvent | null {
   const at = Date.now();
   switch (pe.type) {
     case "queue_update":
@@ -191,6 +191,26 @@ function toSessionEvent(pe: AgentHarnessEvent, runId: string): SessionEvent | nu
         runId,
         data: { id: pe.toolCallId, isError: pe.isError, content: pe.result as Json },
       };
+    case "retry_scheduled": {
+      // Summarization retry backoff (auto-compaction / branch summary, pi ≥0.81.1) — without it,
+      // up to ~14s of backoff at the turn's tail reads as a hang. `retry_attempt_start`/
+      // `retry_finished` stay dropped: they carry no outcome, and the next event is the closure.
+      // Typed against the vocabulary (as is the second construction site, session-control's
+      // manual-compact callback) so a payload change breaks both at compile time.
+      const event: RetryScheduledEvent = {
+        type: "retry_scheduled",
+        timestamp: at,
+        runId,
+        data: {
+          operation: pe.operation,
+          attempt: pe.attempt,
+          maxAttempts: pe.maxAttempts,
+          delayMs: pe.delayMs,
+          error: pe.errorMessage,
+        },
+      };
+      return event;
+    }
     default:
       return null;
   }
@@ -583,8 +603,8 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       }
       const queue = new EventQueue<AgentEvent>();
       const unsub = harness.subscribe((pe) => {
-        // Summarization retries (auto-compaction / branch summaries, pi ≥0.81.1) have no SPEC
-        // projection — without this, up to ~14s of backoff at the turn's tail reads as a hang.
+        // Summarization retries also warn to server logs: the session `retry_scheduled` event only
+        // reaches attached observers, and an operator tailing logs must see the backoff too.
         if (pe.type === "retry_scheduled") {
           log.warn(
             `[fastagent] ${pe.operation} retry ${pe.attempt}/${pe.maxAttempts} in ${pe.delayMs}ms (session ${scope.session}): ${pe.errorMessage}`,

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -583,6 +583,13 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       }
       const queue = new EventQueue<AgentEvent>();
       const unsub = harness.subscribe((pe) => {
+        // Summarization retries (auto-compaction / branch summaries, pi ≥0.81.1) have no SPEC
+        // projection — without this, up to ~14s of backoff at the turn's tail reads as a hang.
+        if (pe.type === "retry_scheduled") {
+          log.warn(
+            `[fastagent] ${pe.operation} retry ${pe.attempt}/${pe.maxAttempts} in ${pe.delayMs}ms (session ${scope.session}): ${pe.errorMessage}`,
+          );
+        }
         const rich = toSessionEvent(pe, runId);
         if (!rich) return;
         observe(rich);

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -35,7 +35,13 @@ import {
 } from "../../session.ts";
 import { listModels } from "./config.ts";
 import type { Lease, RunControls, SessionObserver } from "./invoke.ts";
-import { type PiHarnessFactory, THINKING_LEVELS, harnessSession, lastOverrideEntries } from "./harness.ts";
+import {
+  SUMMARIZATION_RETRY_POLICY,
+  type PiHarnessFactory,
+  THINKING_LEVELS,
+  harnessSession,
+  lastOverrideEntries,
+} from "./harness.ts";
 import { log } from "../../log.ts";
 import type { PiSessionReader } from "./sessions.ts";
 
@@ -568,6 +574,15 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
                   command.instructions,
                   door.signal,
                   harness.getThinkingLevel(),
+                  SUMMARIZATION_RETRY_POLICY,
+                  {
+                    // Retries are otherwise invisible between compaction_started and _finished —
+                    // surface each backoff so a long gap is diagnosable (not confusable with a hang).
+                    onRetryScheduled: (attempt, maxAttempts, delayMs, errorMessage) =>
+                      log.warn(
+                        `[fastagent] compaction retry ${attempt}/${maxAttempts} in ${delayMs}ms (session ${session}): ${errorMessage}`,
+                      ),
+                  },
                 );
                 if (!done.ok) throw done.error;
                 await record.appendCompaction(

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -23,6 +23,7 @@ import {
   NOTHING_TO_COMPACT_CODE,
   NO_SUCH_SESSION_CODE,
   RUN_COMMAND_FAILED_CODE,
+  type RetryScheduledEvent,
   type SessionCapabilities,
   type SessionCommand,
   type SessionControl,
@@ -577,11 +578,18 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
                   SUMMARIZATION_RETRY_POLICY,
                   {
                     // Retries are otherwise invisible between compaction_started and _finished —
-                    // surface each backoff so a long gap is diagnosable (not confusable with a hang).
-                    onRetryScheduled: (attempt, maxAttempts, delayMs, errorMessage) =>
+                    // surface each backoff so a long gap is diagnosable (not confusable with a
+                    // hang): as a session event for attached observers, as a warn for server logs.
+                    onRetryScheduled: (attempt, maxAttempts, delayMs, errorMessage) => {
                       log.warn(
                         `[fastagent] compaction retry ${attempt}/${maxAttempts} in ${delayMs}ms (session ${session}): ${errorMessage}`,
-                      ),
+                      );
+                      emitOwn(session, {
+                        type: "retry_scheduled",
+                        timestamp: Date.now(),
+                        data: { operation: "compaction", attempt, maxAttempts, delayMs, error: errorMessage },
+                      } satisfies RetryScheduledEvent);
+                    },
                   },
                 );
                 if (!done.ok) throw done.error;

--- a/src/session.ts
+++ b/src/session.ts
@@ -208,6 +208,16 @@ export type CompactionFinishedEvent = SessionEvent<
   { summary?: string; error?: string; aborted?: boolean }
 >;
 
+/** A transient provider failure scheduled a summarization retry backoff (auto-compaction /
+ *  branch summaries inside a run — `runId` present — or a manual `compact` at a boundary — no
+ *  `runId`). Explains a quiet gap that would otherwise read as a hang. Deliberately unclosed:
+ *  the next event (message_*, `run_settled`, `compaction_finished`) is the closure, and the
+ *  engine's `retry_finished` carries no outcome to forward. */
+export type RetryScheduledEvent = SessionEvent<
+  "retry_scheduled",
+  { operation: "compaction" | "branch_summary"; attempt: number; maxAttempts: number; delayMs: number; error: string }
+>;
+
 /**
  * The serving process failed outside a normal run outcome (fail visibly). Emitted by TRANSPORT
  * adapters (design §13) when they lose the backend before ending a remote stream — an in-process
@@ -217,8 +227,8 @@ export type CompactionFinishedEvent = SessionEvent<
 export type ServingErrorEvent = SessionEvent<"serving_error", { message: string }>;
 
 /** Every event the in-process observation plane emits today: L0, L1 `queue_changed`, and the L2
- *  boundary-mutation events (`state_changed`, `compaction_*`). Remaining L2 events (turn_*,
- *  retry_*) are future vocabulary; {@link ServingErrorEvent} arrives with the transport adapter. */
+ *  events (`state_changed`, `compaction_*`, `retry_scheduled`). Remaining L2 events (turn_*) are
+ *  future vocabulary; {@link ServingErrorEvent} arrives with the transport adapter. */
 export type KnownSessionEvent =
   | RunStartedEvent
   | RunSettledEvent
@@ -231,4 +241,5 @@ export type KnownSessionEvent =
   | QueueChangedEvent
   | StateChangedEvent
   | CompactionStartedEvent
-  | CompactionFinishedEvent;
+  | CompactionFinishedEvent
+  | RetryScheduledEvent;

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -10,7 +10,13 @@ import { fauxAssistantMessage, fauxThinking, fauxToolCall, Type, type FauxRespon
 import type { AssistantMessage, StopReason, Usage } from "@earendil-works/pi-ai";
 import { defineTool, inMemorySessionStore, inProcessLease, type AgentEvent, z } from "../src/index.ts";
 import { SESSION_BUSY_CODE } from "../src/agent.ts";
-import { classifyRetryable, createPiAgentFromHarness, errorToTerminal, toTerminal } from "../src/engines/pi/invoke.ts";
+import {
+  classifyRetryable,
+  createPiAgentFromHarness,
+  errorToTerminal,
+  toSessionEvent,
+  toTerminal,
+} from "../src/engines/pi/invoke.ts";
 import { type PiHarnessFactory, piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 
@@ -534,6 +540,33 @@ describe("invoke: auto-compaction", () => {
     expect(events.at(-1)).toEqual({ type: "completed" }); // turn still completed
     expect(compact).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/auto-compaction failed/));
+  });
+});
+
+describe("toSessionEvent retry projection", () => {
+  it("projects harness retry_scheduled into the session vocabulary (errorMessage → error)", () => {
+    const se = toSessionEvent(
+      {
+        type: "retry_scheduled",
+        operation: "compaction",
+        attempt: 2,
+        maxAttempts: 4,
+        delayMs: 4000,
+        errorMessage: "503 upstream",
+      },
+      "run-1",
+    );
+    expect(se).toEqual({
+      type: "retry_scheduled",
+      timestamp: expect.any(Number),
+      runId: "run-1",
+      data: { operation: "compaction", attempt: 2, maxAttempts: 4, delayMs: 4000, error: "503 upstream" },
+    });
+  });
+
+  it("drops retry_attempt_start and retry_finished (no outcome to forward)", () => {
+    expect(toSessionEvent({ type: "retry_attempt_start", operation: "compaction" }, "run-1")).toBeNull();
+    expect(toSessionEvent({ type: "retry_finished", operation: "branch_summary" }, "run-1")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Why

pi 0.81.1 (#6901 upstream) makes compaction/branch-summary model calls retry transient provider failures — but the policy is **opt-in**: `retryAssistantCall` with an undefined policy is equivalent to a direct call. Without this PR, neither of fastagent's compaction paths gets the fix. And since the upstream event source now exists, the reserved `retry_*` slot in the session-event vocabulary graduates from "future vocabulary" to an emitted event — deferring it to "when a consumer appears" would mean re-deriving today's context later.

## What

**Enable retries (commit 1)**
- `SUMMARIZATION_RETRY_POLICY` (`{ enabled: true, maxRetries: 3, baseDelayMs: 2000 }` — mirrors pi's own app defaults) wired into:
  - the `AgentHarness` config (`retry` option) → auto-compaction and branch summaries inside a run
  - the manual `compact()` dispatch in session-control (new 7th parameter); the abort door's signal still cuts through backoff sleeps
- Dependency floor → `^0.81.1`: on 0.81.0 the `retry` option, the `retry_scheduled` event, and the extra `compact()` arguments would all be silently ignored.

**Surface retries (commit 2)**
- `RetryScheduledEvent { operation, attempt, maxAttempts, delayMs, error }` joins `KnownSessionEvent` — explains a quiet gap (up to ~14s of backoff) that would otherwise read as a hang. Deliberately unclosed (the next event is the closure) and scheduled-only: the engine's `retry_finished` carries no outcome to forward, `retry_attempt_start` adds nothing over `delayMs`.
- Two provenances, both emitting: in-run (harness event → `toSessionEvent`, `runId` present) and manual compaction (`RetryCallbacks` → `emitOwn`, no `runId`). Both construction sites are typed against `RetryScheduledEvent` so a payload change breaks both at compile time.
- `log.warn` at both sites stays: events reach attached observers, warns reach operators tailing logs.
- `docs/design/session-control.md` L2 table updated; `session.ts` future-vocabulary note now lists only `turn_*`.

## Non-changes (checked, deliberately skipped)

- `classifyRetryable` stays: upstream's newly-exported `isRetryableAssistantError` is prose-only on `errorMessage`; ours is structured-signal-first (diagnostics code / HTTP status / thrown errors) and serves SPEC `failed.retryable`.
- SPEC `AgentEvent` untouched — `projectAgentEvent` drops `retry_scheduled` (the SPEC vocabulary is locked; SPEC consumers see the outcome, not the mechanics).
- 0.81.1's release-archive, extension stream-fallback, and Kimi K3 items need no code (the K3 metadata fix flows in via pi builtins).

## Verification

- `npm run lint && npm run typecheck && npm test` — 896/896 green on 0.81.1
- Upstream signatures cross-checked against installed d.ts: `AgentHarnessConfig.retry`, `compact(…, retry?, callbacks?)`, `RetryPolicy`/`RetryCallbacks`, `RetryScheduledEvent` payload (`errorMessage` → `error` rename consistent at both sites)
- `rv.sh local` run to clean across both commits; all findings addressed (silent retries, naming, version floor, dual-construction drift risk)