### PR TITLE
refactor(preview): humanize tool labels in Telegram/Feishu live previews

### DIFF
--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -30,7 +30,7 @@ import {
   streamingCardJson,
 } from "./card.ts";
 import { type FeishuApi, type FeishuTarget, chunkFeishuText, isCardStreamingClosed } from "./feishu-api.ts";
-import { type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
+import { type ChannelFailure, defaultErrorMessage, humanizeToolName, summarizeToolArgs } from "../preview-kit.ts";
 import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
 
 /** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
@@ -340,7 +340,8 @@ export async function streamFeishuReply(
       } else if (e.type === "tool_started") {
         const arg = summarizeToolArgs(e.args);
         toolIndexById.set(e.id, tools.length);
-        tools.push({ label: arg ? `${e.name} ${arg}` : e.name, status: "running" });
+        const name = humanizeToolName(e.name);
+        tools.push({ label: arg ? `${name} ${arg}` : name, status: "running" });
         touch();
       } else if (e.type === "tool_ended") {
         const i = toolIndexById.get(e.id);

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -1,8 +1,8 @@
 /**
  * Channel-neutral live-preview pieces shared by every messaging channel's preview renderer
  * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the terminal-failure shape a channel hands to its
- * `onError`, the customer-facing default message for it, and the compact tool-arg summary for the
- * live view. The preview LIFECYCLES stay per-platform (message edits vs streaming cards) — only
+ * `onError`, the customer-facing default message for it, and the compact tool-arg summary and
+ * humanized tool label for the live view. The preview LIFECYCLES stay per-platform (message edits vs streaming cards) — only
  * these platform-independent policies live here, so the customer-facing wording cannot drift
  * between channels.
  */

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -6,7 +6,7 @@
  * message, works in groups and private (unlike sendMessageDraft, which is private/forum-topic only).
  */
 import type { AgentEvent } from "../../agent.ts";
-import { type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
+import { type ChannelFailure, defaultErrorMessage, humanizeToolName, summarizeToolArgs } from "../preview-kit.ts";
 import { log } from "../../log.ts";
 import { TELEGRAM_MAX_TEXT, type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 
@@ -212,7 +212,8 @@ export async function streamReply(
       } else if (e.type === "tool_started") {
         const arg = summarizeToolArgs(e.args);
         toolIndexById.set(e.id, tools.length);
-        tools.push({ label: arg ? `${e.name} ${arg}` : e.name, status: "running" });
+        const name = humanizeToolName(e.name);
+        tools.push({ label: arg ? `${name} ${arg}` : name, status: "running" });
         touch();
       } else if (e.type === "tool_ended") {
         const i = toolIndexById.get(e.id);

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -193,7 +193,7 @@ describe("streamReply answer preview (direct)", () => {
     await vi.advanceTimersByTimeAsync(0);
     src.push({ type: "tool_started", id: "t1", name: "read", args: { path: "AGENTS.md" } });
     await vi.advanceTimersByTimeAsync(0);
-    expect(edits).toEqual(["🔧 read AGENTS.md …"]);
+    expect(edits).toEqual(["🔧 Read AGENTS.md …"]);
     src.push({ type: "completed" });
     src.end();
     await turn;

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1054,7 +1054,7 @@ describe("telegram channel", () => {
     const edits = callsTo(fetchMock, "editMessageText").map((c) => bodyOf(c).text as string);
     // a mid-turn frame shows the reasoning + tool activity (process), edited into the one preview message
     expect(
-      edits.some((t) => /💭/.test(t) && /weighing options/.test(t) && /word-count the quick brown fox/.test(t)),
+      edits.some((t) => /💭/.test(t) && /weighing options/.test(t) && /Word count the quick brown fox/.test(t)),
     ).toBe(true);
     expect(edits.at(-1)).toBe("4 words"); // …but the final message is the answer alone, no thinking/tool noise
     expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1); // one preview message, not per-step spam


### PR DESCRIPTION
**Stacked on #264 — merge after it lands.** The diff vs main includes #264's commits until then; this PR's own change is the last commit (`fc40397`).

## Summary

- wire `humanizeToolName` (added to the shared `preview-kit` by #264) into the Telegram and Feishu live-preview renderers, so all three channels show the same plain-language tool labels (`read` → "Read", `mcp__github__create_issue` → "Github: create issue") instead of raw identifiers
- update the preview-kit header comment to list the humanized tool label among the shared pieces

This closes the "single consumer in a shared module" gap: the shared placement of `humanizeToolName` is now real, and tool-label wording cannot drift between channels.

## Validation

- [x] `npm run lint` (existing suppression warning only)
- [x] `npm run typecheck`
- [x] `npm test` — 981 tests
- [x] Updated the two preview assertions that pinned raw tool names