### PR TITLE
feat(slack): add `add slack --replace-config` and point registrar fallbacks at it

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -251,6 +251,10 @@ creates a new internal app with `agent_view`, native streams/tasks, and suggeste
 through OAuth, and writes rotating bot credentials + the Signing Secret to the gitignored `.env`. The configuration refresh token stays owner-readable
 under `<state root>/channels/slack/` and is used locally by `dev --tunnel` / `deploy --run` to update the
 Events API URL; it never travels to the host. `--no-onboard` preserves the manual scaffold-only path.
+`--replace-config` skips the menu and directly replaces the local App Configuration token pair — the
+repair when automatic Request URL updates fail because the tokens expired or were revoked. It works only
+on the machine that onboarded the app (the pair lives in its local state); other machines set the Request
+URL manually in the Slack console.
 
 See:
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -94,7 +94,9 @@ a manually configured classic-only app may omit those two Agent capabilities. Su
 `message.channels`, `message.groups`, and `message.mpim`. Set `https://<host>/slack` under Event
 Subscriptions while FastAgent is running,
 then put the Bot Token and Signing Secret in `.env`. Without local onboarding state, tunnel/deploy commands
-print this manual Request URL instead of claiming registration succeeded.
+print this manual Request URL instead of claiming registration succeeded. On the machine that onboarded the
+app, `fastagent add slack --replace-config` replaces an expired or revoked App Configuration token pair
+without touching the installed app or its runtime credentials.
 
 ## Scaffolded channel
 

--- a/src/channels/slack/register-webhook.ts
+++ b/src/channels/slack/register-webhook.ts
@@ -28,7 +28,9 @@ export async function registerSlackWebhook(
   }
   if (!state?.appId || !state.installedAt) {
     note(
-      `[fastagent] slack: no completed local onboarding state — set Event Subscriptions → Request URL = ${publicBaseUrl}/slack manually, or re-run \`fastagent add slack\` interactively`,
+      `[fastagent] slack: no completed local onboarding state on this machine — the config credential lives only where \`fastagent add slack\` ran. ` +
+        `Set Event Subscriptions → Request URL = ${publicBaseUrl}/slack manually in the Slack console, or re-run this command from the onboarding machine ` +
+        `(repair its expired/revoked tokens with \`fastagent add slack --replace-config\`)`,
     );
     return "manual";
   }
@@ -60,7 +62,7 @@ export async function registerSlackWebhook(
   } catch (error) {
     note(
       `[fastagent] slack: automatic Request URL registration failed: ${String(error)} — ` +
-        `re-run \`fastagent add slack\` to repair onboarding, or set ${publicBaseUrl}/slack in the Slack console`,
+        `re-run \`fastagent add slack --replace-config\` to repair the configuration tokens, or set ${publicBaseUrl}/slack in the Slack console`,
     );
     return "failed";
   }

--- a/src/cli/add-slack.ts
+++ b/src/cli/add-slack.ts
@@ -28,6 +28,8 @@ export async function onboardSlackInternalApp(input: {
   stateRoot: string;
   envIgnored: boolean;
   groupBehavior: GroupBehaviorChoice;
+  /** `--replace-config`: go straight to replacing the local App Configuration token pair. */
+  replaceConfig?: boolean;
 }): Promise<void> {
   installProxyFetch();
   if (!input.envIgnored) {
@@ -46,6 +48,12 @@ export async function onboardSlackInternalApp(input: {
   await ensureStateRootSelfIgnored(input.target, input.stateRoot);
   let state = await readSlackOnboardingState(input.stateRoot);
   const resumed = state !== undefined;
+  if (input.replaceConfig && !state) {
+    throw new Error(
+      "--replace-config found no local Slack onboarding state on this machine — nothing to replace. " +
+        "Run `fastagent add slack` to onboard, or update the Request URL manually in the Slack console",
+    );
+  }
   if (state?.installedAt) {
     const env = await readFile(join(input.target, ".env"), "utf8")
       .then(parseEnvContent)
@@ -73,19 +81,23 @@ export async function onboardSlackInternalApp(input: {
           "OAuth scopes is a migration. Keep the existing choice, or remove the app + Slack onboarding state and create a new app",
       );
     }
-    const action = await select<"keep" | "replace-config">({
-      message: `Slack app ${state.appId ?? "(unknown)"} is already installed${state.teamName ? ` in ${state.teamName}` : ""}`,
-      initialValue: "keep",
-      options: [
-        { value: "keep", label: "Keep the installed app" },
-        {
-          value: "replace-config",
-          label: "Replace App Configuration tokens",
-          hint: "repair automatic dev/deploy Request URL updates",
-        },
-      ],
-    });
-    if (isCancel(action)) throw new Error("Slack onboarding cancelled");
+    let action: "keep" | "replace-config" = "replace-config";
+    if (!input.replaceConfig) {
+      const answer = await select<"keep" | "replace-config">({
+        message: `Slack app ${state.appId ?? "(unknown)"} is already installed${state.teamName ? ` in ${state.teamName}` : ""}`,
+        initialValue: "keep",
+        options: [
+          { value: "keep", label: "Keep the installed app" },
+          {
+            value: "replace-config",
+            label: "Replace App Configuration tokens",
+            hint: "repair automatic dev/deploy Request URL updates",
+          },
+        ],
+      });
+      if (isCancel(answer)) throw new Error("Slack onboarding cancelled");
+      action = answer;
+    }
     if (action === "replace-config") {
       console.error(`[fastagent] generate a fresh App Configuration Token pair at ${CONFIG_TOKEN_URL}`);
       openExternalUrl(CONFIG_TOKEN_URL);
@@ -138,16 +150,22 @@ export async function onboardSlackInternalApp(input: {
         `inspect ${CONFIG_TOKEN_URL}; delete any incomplete app and ${input.stateRoot}/channels/slack/onboarding.json before retrying`,
     );
   }
-  if (resumed && !state.appId) {
-    const action = await select<"keep" | "replace-config">({
-      message: "Resume Slack onboarding with which App Configuration tokens?",
-      initialValue: "keep",
-      options: [
-        { value: "keep", label: "Use the saved token pair" },
-        { value: "replace-config", label: "Paste a fresh token pair" },
-      ],
-    });
-    if (isCancel(action)) throw new Error("Slack onboarding cancelled");
+  // `--replace-config` also covers the created-but-not-installed state, where a revoked token would
+  // otherwise strand the resume (rotation fails and no menu offers replacement).
+  if (resumed && (!state.appId || input.replaceConfig)) {
+    let action: "keep" | "replace-config" = "replace-config";
+    if (!input.replaceConfig) {
+      const answer = await select<"keep" | "replace-config">({
+        message: "Resume Slack onboarding with which App Configuration tokens?",
+        initialValue: "keep",
+        options: [
+          { value: "keep", label: "Use the saved token pair" },
+          { value: "replace-config", label: "Paste a fresh token pair" },
+        ],
+      });
+      if (isCancel(answer)) throw new Error("Slack onboarding cancelled");
+      action = answer;
+    }
     if (action === "replace-config") {
       openExternalUrl(CONFIG_TOKEN_URL);
       state = {

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -31,9 +31,12 @@ import { failStartup, failUsage } from "../fail.ts";
 export async function runAddChannel(
   channelKind: ChannelKind,
   dirArg: string,
-  opts: { createApp?: boolean; ingress?: string; groupBehavior?: string; onboard?: boolean },
+  opts: { createApp?: boolean; ingress?: string; groupBehavior?: string; onboard?: boolean; replaceConfig?: boolean },
 ): Promise<void> {
   const target = resolve(dirArg);
+  if (opts.replaceConfig && opts.onboard === false) {
+    failUsage("--replace-config replaces onboarding credentials; it cannot be combined with --no-onboard");
+  }
   loadDotEnv(target); // onboarding state follows the same FASTAGENT_STATE_DIR as serving/deploy
   // App creation is not a flag — it is what `add feishu` IS (the scan-to-create flow is the default
   // and only path there). The retired --create-app spelling gets a pointer, not silence.
@@ -102,6 +105,7 @@ export async function runAddChannel(
       stateRoot: resolveStateRoot(target),
       envIgnored,
       groupBehavior,
+      replaceConfig: opts.replaceConfig,
     })
       .then(() => undefined)
       .catch(failStartup);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -281,6 +281,12 @@ const NO_ONBOARD: FlagSpec = {
   flags: "--no-onboard",
   description: "Slack: scaffold only; skip internal-app creation/OAuth",
 };
+const REPLACE_CONFIG: FlagSpec = {
+  flags: "--replace-config",
+  description:
+    "Slack: replace the local App Configuration token pair (repairs automatic dev/deploy Request URL " +
+    "updates after the tokens expire or are revoked; runs on the machine that onboarded the app)",
+};
 
 const channelSub = (
   kind: "github" | "telegram" | "slack" | "feishu" | "lark",
@@ -297,7 +303,7 @@ const channelSub = (
     ...(kind === "feishu" || kind === "lark"
       ? [INGRESS, GROUP_BEHAVIOR]
       : kind === "slack"
-        ? [GROUP_BEHAVIOR, NO_ONBOARD]
+        ? [GROUP_BEHAVIOR, NO_ONBOARD, REPLACE_CONFIG]
         : []),
   ],
   examples: [{ cmd: `fastagent add ${kind}` }],
@@ -308,6 +314,7 @@ const channelSub = (
       ingress: f.ingress as string | undefined,
       groupBehavior: f.groupBehavior as string | undefined,
       onboard: f.onboard !== false,
+      replaceConfig: f.replaceConfig === true,
     }),
 });
 

--- a/test/add-slack-replace-config.test.ts
+++ b/test/add-slack-replace-config.test.ts
@@ -1,0 +1,147 @@
+/**
+ * `add slack --replace-config`: the non-interactive repair path. The flag must skip the menus
+ * (select is never shown), replace ONLY the local App Configuration token pair, and fail visibly
+ * when there is no local onboarding state to repair.
+ */
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const prompts = vi.hoisted(() => ({
+  passwordAnswers: [] as string[],
+  select: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  isCancel: () => false,
+  log: { info: vi.fn() },
+  password: vi.fn(async () => {
+    const next = prompts.passwordAnswers.shift();
+    if (next === undefined) throw new Error("test: unexpected password prompt");
+    return next;
+  }),
+  select: prompts.select,
+  text: vi.fn(async () => {
+    throw new Error("test: unexpected text prompt");
+  }),
+}));
+vi.mock("../src/open-url.ts", () => ({ openExternalUrl: vi.fn() }));
+vi.mock("../src/proxy.ts", () => ({ installProxyFetch: vi.fn() }));
+// The resume path continues into app installation after replacing tokens; stop it at the setup
+// server with a sentinel so the test proves both "tokens persisted" and "resume continued".
+vi.mock("../src/channels/slack/setup-server.ts", () => ({
+  startSlackSetupServer: vi.fn(async () => {
+    throw new Error("SENTINEL: setup server reached");
+  }),
+}));
+
+import { onboardSlackInternalApp } from "../src/cli/add-slack.ts";
+import { writeSlackOnboardingState } from "../src/channels/slack/onboarding-state.ts";
+
+const RUNTIME_ENV = [
+  "SLACK_BOT_TOKEN=xoxe.xoxb-runtime",
+  "SLACK_BOT_REFRESH_TOKEN=xoxe-runtime-refresh",
+  "SLACK_BOT_TOKEN_EXPIRES_AT=2000000000000",
+  "SLACK_CLIENT_ID=client",
+  "SLACK_CLIENT_SECRET=secret",
+  "SLACK_SIGNING_SECRET=signing",
+].join("\n");
+
+describe("add slack --replace-config", () => {
+  let target: string;
+  let stateRoot: string;
+
+  beforeEach(async () => {
+    target = await mkdtemp(join(tmpdir(), "fa-slack-rc-"));
+    stateRoot = join(target, ".fastagent");
+    prompts.passwordAnswers.length = 0;
+    prompts.select.mockClear();
+    // isTTY is a plain data property (undefined under vitest) — assign, restore in afterEach.
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+  });
+
+  afterEach(async () => {
+    process.stdin.isTTY = undefined as unknown as boolean;
+    process.stdout.isTTY = undefined as unknown as boolean;
+    vi.restoreAllMocks();
+    await rm(target, { recursive: true, force: true });
+  });
+
+  const run = () =>
+    onboardSlackInternalApp({
+      target,
+      stateRoot,
+      envIgnored: true,
+      groupBehavior: { behavior: "context", explicit: false },
+      replaceConfig: true,
+    });
+
+  const readState = async (): Promise<Record<string, unknown>> =>
+    JSON.parse(await readFile(join(stateRoot, "channels", "slack", "onboarding.json"), "utf8"));
+
+  it("fails visibly when there is no local onboarding state to replace", async () => {
+    await expect(run()).rejects.toThrow(/--replace-config found no local Slack onboarding state/);
+    expect(prompts.select).not.toHaveBeenCalled();
+  });
+
+  it("installed app: skips the menu, replaces only the config token pair, leaves runtime credentials alone", async () => {
+    await writeFile(join(target, ".env"), RUNTIME_ENV);
+    await writeSlackOnboardingState(stateRoot, {
+      version: 1,
+      appName: "App",
+      groupBehavior: "context",
+      appId: "A1",
+      configToken: "xoxe.xoxp-old",
+      configRefreshToken: "xoxe-old",
+      configTokenExpiresAt: 1,
+      teamId: "T1",
+      installedAt: "2026-01-01T00:00:00.000Z",
+    });
+    prompts.passwordAnswers.push("xoxe.xoxp-new", "xoxe-new");
+    await run();
+    expect(prompts.select).not.toHaveBeenCalled();
+    const state = await readState();
+    expect(state.configToken).toBe("xoxe.xoxp-new");
+    expect(state.configRefreshToken).toBe("xoxe-new");
+    expect(state.appId).toBe("A1");
+    expect(state.installedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(await readFile(join(target, ".env"), "utf8")).toBe(RUNTIME_ENV); // untouched
+  });
+
+  it("installed app: rejects a token pair with the wrong prefixes", async () => {
+    await writeFile(join(target, ".env"), RUNTIME_ENV);
+    await writeSlackOnboardingState(stateRoot, {
+      version: 1,
+      appName: "App",
+      groupBehavior: "context",
+      appId: "A1",
+      configToken: "xoxe.xoxp-old",
+      configRefreshToken: "xoxe-old",
+      configTokenExpiresAt: 1,
+      installedAt: "2026-01-01T00:00:00.000Z",
+    });
+    prompts.passwordAnswers.push("wrong-prefix", "also-wrong");
+    await expect(run()).rejects.toThrow(/invalid Slack configuration token prefix/);
+    expect((await readState()).configToken).toBe("xoxe.xoxp-old"); // nothing persisted
+  });
+
+  it("created-but-not-installed app: replaces tokens without a menu, then resumes installation", async () => {
+    await writeSlackOnboardingState(stateRoot, {
+      version: 1,
+      appName: "App",
+      groupBehavior: "context",
+      appId: "A1", // created, never installed — the state a revoked token would otherwise strand
+      configToken: "xoxe.xoxp-old",
+      configRefreshToken: "xoxe-old",
+      configTokenExpiresAt: 1,
+    });
+    prompts.passwordAnswers.push("xoxe.xoxp-new", "xoxe-new");
+    await expect(run()).rejects.toThrow(/SENTINEL: setup server reached/);
+    expect(prompts.select).not.toHaveBeenCalled();
+    const state = await readState();
+    expect(state.configToken).toBe("xoxe.xoxp-new");
+    expect(state.configRefreshToken).toBe("xoxe-new");
+  });
+});


### PR DESCRIPTION
**Stacked on #264 — merge after it lands.** The diff vs main includes #264's commits until then; this PR's own change is the last commit.

## Summary

- `fastagent add slack --replace-config`: a direct, discoverable spelling for replacing the local App Configuration token pair (previously buried in the interactive menu). It skips the menu on the installed path, also covers the created-but-not-installed resume state (where a revoked token would otherwise strand the resume — rotation fails and no menu offered replacement), errors clearly when combined with `--no-onboard` or when no local onboarding state exists, and never touches the installed app or runtime credentials.
- `registerSlackWebhook` fallback messages now name the real remediation split: without local onboarding state → set the Request URL manually in the console or re-run from the onboarding machine; on a registration failure → `add slack --replace-config` repairs the tokens.
- docs: `cli.md` + `slack.md` document the flag and the machine-locality of the config credential.

Deliberately **not** included: an "adopt existing app on a new machine" flow (reconstructing onboarding state from appId + fresh tokens). The Request URL is one-time per stable host (Fly/Railway), so the second-machine gap is narrow; the manual console path remains its documented answer.

## Validation

- [x] `npm run lint` (existing suppression warning only)
- [x] `npm run typecheck`
- [x] `npm test` — 981 tests