### PR TITLE
feat(spec): add the advisory `retrying` event and surface retry backoff in live previews

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4,7 +4,7 @@ description: "Agent Handler protocol v0.1: one invoke function and a small set o
 type: spec
 status: locked
 version: 0.1
-updated: 2026-06-09
+updated: 2026-07-18
 ---
 
 # Agent Handler — Protocol Specification v0.1 (locked)
@@ -67,6 +67,7 @@ type AgentEvent =
   | { type: "thinking";     delta: string }                      // Model reasoning (process, not the answer)
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended";   id: string; isError: boolean; content: Json }
+  | { type: "retrying";     attempt: number; maxAttempts: number; delayMs: number; reason: string } // Advisory: internal retry backoff
   | { type: "completed";    data?: Json }                        // Terminal: success
   | { type: "failed";       details: string; retryable: boolean; code?: string }; // Terminal: failure (code = §8 subdivision)
 
@@ -76,6 +77,10 @@ type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
 - All textual output is emitted as `text` deltas; `completed` is only a terminal success signal and does not repeat the full text.
 - `thinking` deltas carry the model's reasoning when the engine and model expose it (optional — many models emit none). It is process, not output: a consumer MUST NOT fold `thinking` into the final answer (`collect` ignores it). Surface it for live/observability UIs only.
 - `completed.data` is present only when the engine produces structured data.
+- `retrying` is advisory and non-terminal; engines MAY emit it when a transient internal failure
+  (e.g. a provider error during context summarization) schedules a retry with backoff. It exists so a
+  live consumer can explain an otherwise-quiet gap; it is deliberately unclosed — the next event is
+  its closure. Terminal consumers ignore it per MUST 4; `reason` is human-facing prose.
 - Every event MUST be JSON-serializable.
 
 ## 6. Conformance

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,6 +40,7 @@ type AgentEvent =
   | { type: "thinking"; delta: string }
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended"; id: string; isError: boolean; content: Json }
+  | { type: "retrying"; attempt: number; maxAttempts: number; delayMs: number; reason: string } // advisory backoff
   | { type: "completed"; data?: Json }
   | { type: "failed"; details: string; retryable: boolean; code?: string };
 ```

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -28,6 +28,7 @@ type AgentEvent =
   | { type: "thinking"; delta: string }
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended"; id: string; isError: boolean; content: Json }
+  | { type: "retrying"; attempt: number; maxAttempts: number; delayMs: number; reason: string } // advisory: internal retry backoff
   | { type: "completed"; data?: Json }    // terminal: success
   | { type: "failed"; details: string; retryable: boolean; code?: string };  // terminal: failure
 ```

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -29,6 +29,11 @@ export type AgentEvent =
   | { type: "thinking"; delta: string }
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended"; id: string; isError: boolean; content: Json }
+  /** Advisory, non-terminal (engines MAY emit it): a transient internal failure scheduled a retry
+   *  with backoff — the turn is still alive. Explains a quiet gap that would otherwise read as a
+   *  hang; deliberately unclosed — the next event is its closure. Terminal consumers ignore it
+   *  (SPEC MUST 4). */
+  | { type: "retrying"; attempt: number; maxAttempts: number; delayMs: number; reason: string }
   /** Terminal: success. `data` is attached only when the engine produces a structured result. */
   | { type: "completed"; data?: Json }
   /** Terminal: failure. `retryable` means it is worth re-sending with the same session. `code` is the

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -30,7 +30,13 @@ import {
   streamingCardJson,
 } from "./card.ts";
 import { type FeishuApi, type FeishuTarget, chunkFeishuText, isCardStreamingClosed } from "./feishu-api.ts";
-import { type ChannelFailure, defaultErrorMessage, humanizeToolName, summarizeToolArgs } from "../preview-kit.ts";
+import {
+  RETRY_NOTICE,
+  type ChannelFailure,
+  defaultErrorMessage,
+  humanizeToolName,
+  summarizeToolArgs,
+} from "../preview-kit.ts";
 import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
 
 /** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
@@ -200,6 +206,7 @@ export async function streamFeishuReply(
   let thinking = "";
   let answer = "";
   let answerPreviewSince: number | undefined;
+  let retryNotice = false;
 
   const mark = { running: "…", ok: "✓", error: "✗" } as const;
   const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
@@ -219,7 +226,7 @@ export async function streamFeishuReply(
     return Date.now() - answerPreviewSince >= STREAM_THROTTLE_MS ? answer : "";
   };
   const view = (): string => {
-    const v = [thinkingView(), toolView(), answerView()]
+    const v = [thinkingView(), toolView(), retryNotice ? RETRY_NOTICE : "", answerView()]
       .filter((s) => s.trim() !== "")
       .join("\n\n")
       .trim();
@@ -330,6 +337,7 @@ export async function streamFeishuReply(
 
   try {
     for await (const e of events) {
+      if (e.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
       if (e.type === "text") {
         answer += e.delta;
         if (answerPreviewSince === undefined && answer.trim() !== "") answerPreviewSince = Date.now();
@@ -347,6 +355,10 @@ export async function streamFeishuReply(
         const i = toolIndexById.get(e.id);
         const t = i === undefined ? undefined : tools[i];
         if (t) t.status = e.isError ? "error" : "ok";
+        touch();
+      } else if (e.type === "retrying") {
+        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
+        retryNotice = true;
         touch();
       } else if (e.type === "completed") {
         await finish();

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -25,6 +25,10 @@ export function defaultErrorMessage(failed: ChannelFailure): string {
     : "⚠️ Sorry, something went wrong. Try rephrasing, or check I have access to what you need.";
 }
 
+/** Customer-facing live-preview line for an engine-internal retry backoff (the advisory `retrying`
+ *  event): neutral, no leaked internals — the reason stays in operator logs. */
+export const RETRY_NOTICE = "⏳ Temporary problem — retrying…";
+
 /** Max length (code points) of a tool's arg preview in the live view. */
 const TOOL_ARG_MAX = 48;
 

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -256,6 +256,17 @@ async function streamNativeSlackReply(
 
   let streamTs: string | undefined;
   let retryStatusShown = false;
+  // DM Agent-status writes are fire-and-forget for the render loop, but must reach Slack in order:
+  // an out-of-order pair would leave a stale "retrying" line after progress (or after the final
+  // clear). One promise chain serializes them; each link swallows its own delivery error.
+  let statusChain = Promise.resolve();
+  const setStatus = (status: string): void => {
+    statusChain = statusChain.then(() =>
+      api
+        .setThreadStatus(target, status)
+        .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
+    );
+  };
   const toolNames = new Map<string, string>();
   let pendingText = "";
   let fullAnswer = "";
@@ -341,9 +352,7 @@ async function streamNativeSlackReply(
         // Progress after a retry notice: restore the normal working status so the stale line doesn't
         // contradict a visibly streaming answer.
         retryStatusShown = false;
-        void api
-          .setThreadStatus(target, WORKING_STATUS)
-          .catch((error) => log.warn(`${label} could not restore the working status: ${String(error)}`));
+        setStatus(WORKING_STATUS);
       }
       if (event.type === "text") {
         pendingText += event.delta;
@@ -356,9 +365,7 @@ async function streamNativeSlackReply(
         // status surface in native mode; DMs get the explicit Agent status line, restored on progress.
         if (target.channelId.startsWith("D")) {
           retryStatusShown = true;
-          void api
-            .setThreadStatus(target, "hit a temporary problem — retrying…")
-            .catch((error) => log.warn(`${label} could not set the retry status: ${String(error)}`));
+          setStatus("hit a temporary problem — retrying…");
         }
       } else if (event.type === "tool_started") {
         const title = humanizeToolName(event.name);
@@ -401,9 +408,8 @@ async function streamNativeSlackReply(
       );
     }
     if (target.channelId.startsWith("D")) {
-      await api
-        .setThreadStatus(target, "")
-        .catch((error) => log.warn(`${label} could not clear Slack Agent status: ${String(error)}`));
+      setStatus("");
+      await statusChain;
     }
   }
 }

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -1,7 +1,7 @@
 /** Slack reply rendering: native Agent streams first, rate-safe edited-message compatibility second. */
 import type { AgentEvent } from "../../agent.ts";
 import { log } from "../../log.ts";
-import { type ChannelFailure, defaultErrorMessage, humanizeToolName } from "../preview-kit.ts";
+import { RETRY_NOTICE, type ChannelFailure, defaultErrorMessage, humanizeToolName } from "../preview-kit.ts";
 import {
   type SlackApi,
   type SlackStreamChunk,
@@ -18,6 +18,7 @@ export { defaultErrorMessage };
 
 const CLASSIC_UPDATE_INTERVAL_MS = 3_000;
 const NATIVE_APPEND_INTERVAL_MS = 750;
+const WORKING_STATUS = "is working on your request…";
 const GENERIC_FAILURE = "⚠️ The response stream stopped unexpectedly. Please try again.";
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -91,6 +92,7 @@ async function streamClassicSlackReply(
   const tools: { name: string; status: "running" | "ok" | "error" }[] = [];
   const toolIndex = new Map<string, number>();
   let answer = "";
+  let retryNotice = false;
   let answerVisible = false;
   let answerTimer: ReturnType<typeof setTimeout> | undefined;
   let previewTs = initialPreviewTs;
@@ -107,7 +109,7 @@ async function streamClassicSlackReply(
   const toolView = (): string =>
     tools.map((tool) => `🔧 ${tool.name} ${{ running: "…", ok: "✓", error: "✗" }[tool.status]}`).join("\n");
   const view = (): string =>
-    ["💭 Thinking…", toolView(), answerVisible ? sanitizeSlackMarkdown(answer) : ""]
+    ["💭 Thinking…", toolView(), retryNotice ? RETRY_NOTICE : "", answerVisible ? sanitizeSlackMarkdown(answer) : ""]
       .filter((value) => value.trim())
       .join("\n\n")
       .trim();
@@ -166,6 +168,7 @@ async function streamClassicSlackReply(
 
   try {
     for await (const event of events) {
+      if (event.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
       if (event.type === "text") {
         answer += event.delta;
         if (!answerVisible && answerTimer === undefined) {
@@ -188,6 +191,10 @@ async function streamClassicSlackReply(
       } else if (event.type === "tool_ended") {
         const index = toolIndex.get(event.id);
         if (index !== undefined && tools[index]) tools[index].status = event.isError ? "error" : "ok";
+        touch();
+      } else if (event.type === "retrying") {
+        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
+        retryNotice = true;
         touch();
       } else if (event.type === "completed") {
         await finishPump();
@@ -237,7 +244,7 @@ async function streamNativeSlackReply(
   if (target.channelId.startsWith("D")) {
     await Promise.all([
       api
-        .setThreadStatus(target, "is working on your request…")
+        .setThreadStatus(target, WORKING_STATUS)
         .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
       threadTitle
         ? api
@@ -248,6 +255,7 @@ async function streamNativeSlackReply(
   }
 
   let streamTs: string | undefined;
+  let retryStatusShown = false;
   const toolNames = new Map<string, string>();
   let pendingText = "";
   let fullAnswer = "";
@@ -329,12 +337,29 @@ async function streamNativeSlackReply(
 
   try {
     for await (const event of events) {
+      if (event.type !== "retrying" && retryStatusShown) {
+        // Progress after a retry notice: restore the normal working status so the stale line doesn't
+        // contradict a visibly streaming answer.
+        retryStatusShown = false;
+        void api
+          .setThreadStatus(target, WORKING_STATUS)
+          .catch((error) => log.warn(`${label} could not restore the working status: ${String(error)}`));
+      }
       if (event.type === "text") {
         pendingText += event.delta;
         fullAnswer += event.delta;
         scheduleText();
       } else if (event.type === "thinking") {
         // Slack's native loading status represents private reasoning without exposing it.
+      } else if (event.type === "retrying") {
+        // A summarization retry backoff pauses the stream (~14s worst case). Channels have no per-run
+        // status surface in native mode; DMs get the explicit Agent status line, restored on progress.
+        if (target.channelId.startsWith("D")) {
+          retryStatusShown = true;
+          void api
+            .setThreadStatus(target, "hit a temporary problem — retrying…")
+            .catch((error) => log.warn(`${label} could not set the retry status: ${String(error)}`));
+        }
       } else if (event.type === "tool_started") {
         const title = humanizeToolName(event.name);
         toolNames.set(event.id, title);

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -6,7 +6,13 @@
  * message, works in groups and private (unlike sendMessageDraft, which is private/forum-topic only).
  */
 import type { AgentEvent } from "../../agent.ts";
-import { type ChannelFailure, defaultErrorMessage, humanizeToolName, summarizeToolArgs } from "../preview-kit.ts";
+import {
+  RETRY_NOTICE,
+  type ChannelFailure,
+  defaultErrorMessage,
+  humanizeToolName,
+  summarizeToolArgs,
+} from "../preview-kit.ts";
 import { log } from "../../log.ts";
 import { TELEGRAM_MAX_TEXT, type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 
@@ -83,6 +89,7 @@ export async function streamReply(
   let thinking = "";
   let answer = "";
   let answerPreviewSince: number | undefined;
+  let retryNotice = false;
 
   const mark = { running: "…", ok: "✓", error: "✗" } as const;
   const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
@@ -104,7 +111,7 @@ export async function streamReply(
     return Date.now() - answerPreviewSince >= EDIT_THROTTLE_MS ? answer : "";
   };
   const view = (): string => {
-    const v = [thinkingView(), toolView(), answerView()]
+    const v = [thinkingView(), toolView(), retryNotice ? RETRY_NOTICE : "", answerView()]
       .filter((s) => s.trim() !== "")
       .join("\n\n")
       .trim();
@@ -202,6 +209,7 @@ export async function streamReply(
 
   try {
     for await (const e of events) {
+      if (e.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
       if (e.type === "text") {
         answer += e.delta;
         if (answerPreviewSince === undefined && answer.trim() !== "") answerPreviewSince = Date.now();
@@ -219,6 +227,10 @@ export async function streamReply(
         const i = toolIndexById.get(e.id);
         const t = i === undefined ? undefined : tools[i];
         if (t) t.status = e.isError ? "error" : "ok";
+        touch();
+      } else if (e.type === "retrying") {
+        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
+        retryNotice = true;
         touch();
       } else if (e.type === "completed") {
         await finish();

--- a/src/cli/invoke-stream.ts
+++ b/src/cli/invoke-stream.ts
@@ -27,6 +27,12 @@ export async function runInvokeStream(
       case "tool_ended":
         if (event.isError) err(`[tool] ${toolName.get(event.id) ?? event.id} failed`);
         break;
+      case "retrying":
+        // Operator-facing: include the reason (channels show a neutral customer line instead).
+        err(
+          `[fastagent] transient failure — retrying (${event.attempt}/${event.maxAttempts} in ${event.delayMs}ms): ${event.reason}`,
+        );
+        break;
       case "failed":
         err(`[fastagent] failed: ${event.details}${event.retryable ? " (retryable)" : ""}`);
         exitCode = 1;

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -233,6 +233,12 @@ export function projectAgentEvent(se: SessionEvent): AgentEvent | null {
       const d = se.data as { id: string; isError: boolean; content: Json };
       return { type: "tool_ended", id: d.id, isError: d.isError, content: d.content };
     }
+    case "retry_scheduled": {
+      // `operation` (compaction | branch_summary) stays session-plane vocabulary — a turn renderer
+      // only needs "transient failure, retrying"; the engine detail lives in the control plane.
+      const d = se.data as { attempt: number; maxAttempts: number; delayMs: number; error: string };
+      return { type: "retrying", attempt: d.attempt, maxAttempts: d.maxAttempts, delayMs: d.delayMs, reason: d.error };
+    }
     default:
       return null;
   }

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -39,6 +39,8 @@ export function logAgentLoop(agent: Agent, sink: (line: string) => void = (line)
           sink(`[agent]   tool → ${e.name}(${preview(e.args)})`);
         } else if (e.type === "tool_ended") {
           sink(`[agent]   tool ${e.isError ? "✗" : "✓"} ${toolName.get(e.id) ?? e.id} → ${preview(e.content)}`);
+        } else if (e.type === "retrying") {
+          sink(`[agent]   retrying (${e.attempt}/${e.maxAttempts} in ${e.delayMs}ms): ${oneLine(e.reason)}`);
         } else if (e.type === "completed") {
           if (thinking.trim() !== "") sink(`[agent]   thinking: ${oneLine(thinking)}`);
           sink(`[agent]   reply: ${oneLine(reply) || "(empty)"}`);

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -14,6 +14,7 @@ import {
   classifyRetryable,
   createPiAgentFromHarness,
   errorToTerminal,
+  projectAgentEvent,
   toSessionEvent,
   toTerminal,
 } from "../src/engines/pi/invoke.ts";
@@ -567,6 +568,16 @@ describe("toSessionEvent retry projection", () => {
   it("drops retry_attempt_start and retry_finished (no outcome to forward)", () => {
     expect(toSessionEvent({ type: "retry_attempt_start", operation: "compaction" }, "run-1")).toBeNull();
     expect(toSessionEvent({ type: "retry_finished", operation: "branch_summary" }, "run-1")).toBeNull();
+  });
+
+  it("projects retry_scheduled into the SPEC `retrying` event (operation stays session-plane)", () => {
+    const projected = projectAgentEvent({
+      type: "retry_scheduled",
+      timestamp: 1,
+      runId: "run-1",
+      data: { operation: "compaction", attempt: 2, maxAttempts: 4, delayMs: 4000, error: "503 upstream" },
+    });
+    expect(projected).toEqual({ type: "retrying", attempt: 2, maxAttempts: 4, delayMs: 4000, reason: "503 upstream" });
   });
 });
 

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -194,7 +194,7 @@ describe("streamReply answer preview (direct)", () => {
     expect(edits).toEqual(["⏳ Temporary problem — retrying…"]);
     src.push({ type: "tool_started", id: "t1", name: "read", args: {} });
     await vi.advanceTimersByTimeAsync(0);
-    expect(edits.at(-1)).toBe("🔧 read …"); // notice closed by progress, no stale retry line
+    expect(edits.at(-1)).toBe("🔧 Read …"); // notice closed by progress, no stale retry line
     src.push({ type: "completed" });
     src.end();
     await turn;

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -183,6 +183,23 @@ describe("streamReply answer preview (direct)", () => {
     expect(edits.at(-1)).toBe("answer");
   });
 
+  it("a retrying event shows the backoff notice; the next progress event clears it", async () => {
+    vi.useFakeTimers();
+    const { edits } = recordingFetch();
+    const src = eventSource();
+    const turn = streamReply(src.iterable, API, "BOT", { chatId: 1 }, neutral);
+    await vi.advanceTimersByTimeAsync(0); // placeholder sent
+    src.push({ type: "retrying", attempt: 1, maxAttempts: 3, delayMs: 2000, reason: "503 upstream" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(edits).toEqual(["⏳ Temporary problem — retrying…"]);
+    src.push({ type: "tool_started", id: "t1", name: "read", args: {} });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(edits.at(-1)).toBe("🔧 read …"); // notice closed by progress, no stale retry line
+    src.push({ type: "completed" });
+    src.end();
+    await turn;
+  });
+
   it("tool previews do not leak pending short answer text", async () => {
     vi.useFakeTimers();
     const { edits } = recordingFetch();

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -86,6 +86,75 @@ describe("Slack reply rendering", () => {
   });
 });
 
+describe("native DM Agent status around a retry backoff", () => {
+  function eventSource() {
+    const queue: AgentEvent[] = [];
+    let notify: (() => void) | undefined;
+    let done = false;
+    return {
+      push(e: AgentEvent) {
+        queue.push(e);
+        notify?.();
+      },
+      end() {
+        done = true;
+        notify?.();
+      },
+      iterable: (async function* (): AsyncIterable<AgentEvent> {
+        while (true) {
+          const next = queue.shift();
+          if (next) {
+            yield next;
+            continue;
+          }
+          if (done) return;
+          await new Promise<void>((resolve) => (notify = resolve));
+        }
+      })(),
+    };
+  }
+  const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+  it("serializes status writes so a slow retry status cannot land after its restore", async () => {
+    const api = fakeApi();
+    const gates: Array<() => void> = [];
+    vi.mocked(api.setThreadStatus).mockImplementation(() => new Promise<void>((resolve) => gates.push(resolve)));
+    const statuses = () => vi.mocked(api.setThreadStatus).mock.calls.map((c) => c[1]);
+
+    const src = eventSource();
+    const turn = streamSlackReply(src.iterable, api, { channelId: "D1", threadTs: "1.0" }, () => undefined, {
+      rendering: "native",
+      disclaimer: false,
+    });
+    await flush();
+    gates.shift()?.(); // initial "is working…" status (awaited before the loop)
+    await flush();
+
+    src.push({ type: "text", delta: "a" });
+    src.push({ type: "retrying", attempt: 1, maxAttempts: 4, delayMs: 2_000, reason: "503" });
+    await flush();
+    expect(statuses().at(-1)).toContain("retrying");
+
+    // Progress while the retry-status write is still in flight: the restore must QUEUE behind it,
+    // not race it — otherwise the stale "retrying" line could land last.
+    src.push({ type: "text", delta: "b" });
+    await flush();
+    expect(statuses()).toHaveLength(2);
+    gates.shift()?.(); // retry status delivered
+    await flush();
+    expect(statuses()).toHaveLength(3);
+    expect(statuses().at(-1)).toBe("is working on your request…");
+
+    src.push({ type: "completed" });
+    src.end();
+    gates.shift()?.(); // restore delivered
+    await flush();
+    gates.shift()?.(); // final clear delivered
+    await turn;
+    expect(statuses().at(-1)).toBe(""); // the clear is last, after every queued write
+  });
+});
+
 describe("sanitizeSlackMarkdown", () => {
   it("neutralizes Slack control mentions and preserves ordinary autolinks", () => {
     expect(sanitizeSlackMarkdown("ping <!channel> now")).toBe("ping &lt;!channel> now");


### PR DESCRIPTION
## Summary

pi 0.81.1's summarization retries (#266) reach the session plane as `retry_scheduled` but were dropped by the `AgentEvent` projection — up to ~14s of exponential backoff mid-turn read as a hang in every channel's live preview.

**Design decision**: the turn's own renderer must not depend on the opt-in control plane (`sessionControl` defaults off and is a remote-control surface — a layering inversion for preview completeness). The data plane carries it instead, via exactly the extension mechanism SPEC MUST 4/5 anticipates: a **non-terminal advisory event**. The terminal set stays frozen, existing terminal consumers ignore it, and relays pass it through. No existing terminal semantics change; SPEC stays v0.1 with the additive event recorded.

- **SPEC §5 + `agent.ts`**: `{ type: "retrying", attempt, maxAttempts, delayMs, reason }` — advisory, deliberately unclosed (the next event is its closure); `reason` is human-facing prose
- **projection** (`projectAgentEvent`): `retry_scheduled` → `retrying`; `operation` (`compaction | branch_summary`) stays session-plane vocabulary
- **telegram / feishu / slack-classic**: render a shared neutral notice (`preview-kit.RETRY_NOTICE`, no leaked internals), closed by the next progress event
- **slack-native**: DM and channel threads override Agent View's visible `loading_messages` during retry, restore Slack's default working state on progress, serialize status transitions through final clear, and keep DM-only thread titles
- **slack-classic rate safety**: re-render after the three-second mutation wait so a closed retry cannot publish a stale notice over newer progress
- **CLI `invoke-stream` + `observe`**: operator-facing retry lines including the reason
- **docs**: SPEC / API reference / embedding event enumerations and Slack rendering behavior updated

## Validation

- [x] `npm run lint` (existing unused-suppression warning only)
- [x] `npm run typecheck`
- [x] `npm test` — 87 files, 986 tests
- [x] `npm run build`
- [x] Real Slack Agent View smoke: default pending → `Temporary problem — retrying…` → default pending → streamed answer
