### PR TITLE
feat(channels): user-facing stop command over the session-control hub

### DIFF
--- a/docs/channel-development.md
+++ b/docs/channel-development.md
@@ -43,6 +43,11 @@ const channel: ChannelModule = ({ agent, stateRoot }) => ({
 export default channel;
 ```
 
+The mount context also carries `control?: SessionControl` when the serve runs with
+`sessionControl: true` — the session-control hub, for dispatch-style channel features (the built-in
+channels map a user "stop" onto `dispatch(session, { type: "abort" })`). It is absent otherwise;
+degrade visibly, never silently.
+
 `fastagent dev` and `fastagent start` discover every `channels/*.ts|*.js|*.mjs`. A function export is called synchronously with the assembled agent and must return a non-empty `Routes` object; an object export must implement `{ name, connect(ctx, signal) }` and return `{ ready, closed }`. `ready` settles once the first usable connection is up; when the signal aborts before that, it must still settle (resolution then means cancellation — the server skips ready-side effects once the signal is aborted — and it must never hang). `closed` resolves after abort-driven shutdown and rejects on terminal transport failure. Long-connection adapters own reconnects and translate the framework's `AbortSignal` into their transport's close operation. Any enabled channel that fails to load fails serving. Rename a file to `<name>.ts.disabled` when it should remain present but disabled.
 
 Deployment preflight also imports every enabled channel to inspect this function/object shape, but it does not call a route module or open a connection. Module top-level code must therefore be import-safe when runtime secrets are absent: capture options in the adapter factory, then validate credentials when the route module is activated or `connect()` runs. An import failure remains fatal because the same enabled channel would fail after deployment.

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -426,6 +426,14 @@ channels' design center. Any future adoption must first give steered messages th
 treatment (which is exactly the opt-in policy sketched above — an events consumer at message
 boundaries — not a replacement of the queue).
 
+Shipped from that list — **the user-facing stop command**: `ChannelContext.control?` hands channels
+the hub for DISPATCH only (observation stays on the data plane — the `retrying` event precedent),
+and the chat channels map an explicit user stop (Telegram `/stop`; a bare "stop"/"cancel" summon on
+Slack/Feishu/Lark) onto `abort`. Decisions: the hub stays gated by `config.sessionControl` (no
+hub → a visible "not enabled" notice, never a silent ignore); the stop message is a control action,
+never a turn (it must not queue behind the run it stops); only the ACTIVE run is aborted — queued
+durable turns are independent asks and keep their at-least-once floor.
+
 ## 16. Invariants
 
 Implementation review should reject changes that violate these:

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -309,6 +309,10 @@ Two audiences, like the Telegram channel:
 - **Operator log**: always receives the full diagnostic details.
 - **Chat user**: every answered turn receives `onError(failed)` if provided, otherwise a neutral default keyed on `retryable`.
 
+When the serve runs with `sessionControl: true`, a summon whose whole message is "stop" or "cancel"
+aborts the session's active turn instead of becoming a turn (queued asks keep running; without
+session control it answers with a visible "not enabled" notice).
+
 ## Files and images
 
 Message payloads are resolved by the channel before the agent turn runs — all as **primary** inputs (a load failure becomes a `failed` event, never a silent drop):

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -253,6 +253,13 @@ files.getUploadURLExternal
 at-least-once: if Slack commits completion but the network response is lost, an explicit retry may post a
 duplicate. The tool does not hide that uncertainty with an automatic final-step retry.
 
+## Stopping a running turn
+
+When the serve runs with `sessionControl: true` (fastagent.config), a DM or @mention whose whole
+message is "stop" or "cancel" aborts that conversation's active turn instead of becoming a turn.
+Queued asks are independent and keep running — stop the next one when it starts. Without session
+control the command answers with a visible "not enabled" notice.
+
 ## Durability and state
 
 Slack state lives under:

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -166,6 +166,13 @@ Failures have two audiences:
 
 For development bots, surfacing `failed.details` is useful. For public bots, prefer a neutral user-facing message.
 
+## Stopping a running turn
+
+When the serve runs with `sessionControl: true` (fastagent.config), `/stop` aborts the chat's active
+turn (queued asks are independent and keep running — send `/stop` again when one starts). Without
+session control the command answers with a visible "not enabled" notice. `/stop@<bot>` addressed to
+another bot is ignored.
+
 ## Files and images
 
 Telegram media are handled by the channel before the agent turn runs.

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -274,6 +274,7 @@ function createFeishuRuntimeFactory(
       order: (a, b) => a.seq - b.seq,
     });
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
+    const stops = new Set<Promise<void>>();
     const toStored = (r: PendingFeishuTurn): StoredFeishuTurn => {
       const { preview: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
       return { ...intent, attempts: 0 };
@@ -521,9 +522,13 @@ function createFeishuRuntimeFactory(
       // message id so a platform re-push doesn't double-abort or double-notify.
       if (isStopText(normalized.content.text.replace(/@\S+/g, " "))) {
         seen.add(m.message_id);
-        void dispatchStop(control, session, label)
-          .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback))
-          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`));
+        const stop: Promise<void> = dispatchStop(control, session, label)
+          .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback).then(() => undefined))
+          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`))
+          .finally(() => {
+            stops.delete(stop);
+          });
+        stops.add(stop);
         return;
       }
       const resources = normalized.content.resources;
@@ -558,7 +563,9 @@ function createFeishuRuntimeFactory(
       );
     };
 
-    return { acceptEvent, turnsIdle: () => queue.idle() };
+    // Stop feedback is fire-and-forget for the ingress path but must be drained on shutdown —
+    // otherwise a stop's "⏹ Stopped." reply can be dropped when the process exits right after it.
+    return { acceptEvent, turnsIdle: () => Promise.all([queue.idle(), ...stops]).then(() => undefined) };
   };
 }
 

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -15,6 +15,7 @@ import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../seen.ts";
 import { ensureStateHome } from "../state.ts";
+import { dispatchStop, isStopText } from "../stop-command.ts";
 import { createTurnQueue } from "../turn-queue.ts";
 import { createTurnStore } from "../turn-store.ts";
 import { FEISHU_CLOUD, type FeishuCloudProfile } from "./cloud.ts";
@@ -216,7 +217,7 @@ function createFeishuRuntimeFactory(
   const baseUrl = opts.apiBaseUrl ?? opts.baseUrl ?? profile.apiBase;
   const { kind } = profile;
   const label = `[${kind}]`;
-  return ({ agent, stateRoot }) => {
+  return ({ agent, stateRoot, control }) => {
     // Credential checks run when serving starts, not while the authored module is imported: deployment
     // can inspect the module shape before secrets exist, while serving still fails before ready.
     if (!appId || !appSecret) {
@@ -515,6 +516,16 @@ function createFeishuRuntimeFactory(
       const replyInThread =
         replyTo !== undefined && (threadedConversation || m.thread_id !== undefined) ? true : undefined;
       const queueReplyTo = sameTarget ? m.message_id : undefined;
+      // Explicit user stop: a control action, never a turn — it must not queue behind the run it
+      // stops. Mentions arrive as @name tokens; strip them before matching the bare word. Record the
+      // message id so a platform re-push doesn't double-abort or double-notify.
+      if (isStopText(normalized.content.text.replace(/@\S+/g, " "))) {
+        seen.add(m.message_id);
+        void dispatchStop(control, session, label)
+          .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback))
+          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`));
+        return;
+      }
       const resources = normalized.content.resources;
       const images = resources
         .filter((resource) => resource.kind === "image")

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -7,6 +7,7 @@ import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../seen.ts";
 import { ensureStateHome } from "../state.ts";
+import { dispatchStop, isStopText } from "../stop-command.ts";
 import { codePointPrefix } from "../text.ts";
 import { createTurnQueue } from "../turn-queue.ts";
 import { createTurnStore } from "../turn-store.ts";
@@ -202,7 +203,7 @@ export function slackChannel({
   }
   const reactionEmojis = resolveReactionEmojis(reactionAck);
 
-  return ({ agent, stateRoot }) => {
+  return ({ agent, stateRoot, control }) => {
     if (!botToken) throw new Error("slackChannel requires a non-empty botToken (Bot User OAuth Token)");
     if (!signingSecret)
       throw new Error("slackChannel requires a non-empty signingSecret (Basic Information → App Credentials)");
@@ -477,6 +478,21 @@ export function slackChannel({
         : groupMessageSession === "continuous" && continuousTopLevel
           ? `slack:${teamId}:${event.channel}`
           : `slack:${teamId}:${event.channel}:${rootTs}`;
+      // Explicit user stop: a control action, never a turn — it must not queue behind the run it
+      // stops. Match the bare word after stripping the bot mention; record the logical id so a Slack
+      // redelivery doesn't double-abort or double-notify.
+      if (isStopText((event.text ?? "").replace(/<@[A-Z0-9]+>/gi, " "))) {
+        seen.add(logicalId);
+        const target: SlackTarget = { channelId: event.channel, threadTs: event.thread_ts };
+        const stop: Promise<void> = dispatchStop(control, routed.session ?? defaultSession, label)
+          .then((feedback) => api.postMessage(target, feedback).then(() => undefined))
+          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`))
+          .finally(() => {
+            stops.delete(stop);
+          });
+        stops.add(stop);
+        return;
+      }
       const fileIds = slackFileIds(event);
       const baseText = routed.text ?? slackEnvelope(envelope);
       if (!baseText.trim() && fileIds.length === 0) return;
@@ -520,6 +536,8 @@ export function slackChannel({
         true,
       );
     };
+
+    const stops = new Set<Promise<void>>();
 
     // First-run DM welcome: app_home_opened(tab="messages") signals a DM open. Post once per user.
     const welcomeInFlight = new Set<string>();
@@ -590,7 +608,7 @@ export function slackChannel({
       return new Response(null, { status: 200 });
     };
     (handler as typeof handler & { turnsIdle?: () => Promise<void> }).turnsIdle = () =>
-      Promise.all([queue.idle(), ...welcomes]).then(() => undefined);
+      Promise.all([queue.idle(), ...welcomes, ...stops]).then(() => undefined);
     return { "POST /slack": handler };
   };
 }

--- a/src/channels/stop-command.ts
+++ b/src/channels/stop-command.ts
@@ -1,0 +1,40 @@
+/**
+ * SHARED user-facing stop command: the chat channels (telegram, feishu/lark, slack) map an explicit
+ * "stop" ask onto the session control plane's `abort`. Policy decisions (design session-control.md
+ * §15): the stop message is a CONTROL ACTION, never a turn (it must not queue behind the run it
+ * stops); only the ACTIVE run is aborted — queued durable turns are independent asks and keep their
+ * at-least-once floor; and the hub stays gated by `config.sessionControl`, so without it the command
+ * degrades to a visible "not enabled" notice, never a silent ignore.
+ */
+import { log } from "../log.ts";
+import { NO_ACTIVE_RUN_CODE, type SessionControl } from "../session.ts";
+
+/** Bare stop word for summon-body matching (Slack/Feishu); Telegram uses its native `/stop` command. */
+export function isStopText(text: string): boolean {
+  return /^(stop|cancel)[.!]?$/i.test(text.trim());
+}
+
+export const STOPPED_NOTICE = "⏹ Stopped.";
+export const NOTHING_RUNNING_NOTICE = "Nothing is running.";
+export const STOP_UNAVAILABLE_NOTICE =
+  "⚠️ Stop isn't enabled on this deployment (set sessionControl: true in fastagent.config).";
+
+/** Dispatch `abort` for the session and map the outcome to the customer-facing line. Never throws;
+ *  full details go to the operator log. */
+export async function dispatchStop(
+  control: SessionControl | undefined,
+  session: string,
+  label: string,
+): Promise<string> {
+  if (!control) return STOP_UNAVAILABLE_NOTICE;
+  try {
+    const result = await control.dispatch(session, { type: "abort" });
+    if (result.ok) return STOPPED_NOTICE;
+    if (result.error.code === NO_ACTIVE_RUN_CODE) return NOTHING_RUNNING_NOTICE;
+    log.warn(`${label} stop dispatch rejected for ${session}: ${result.error.code} — ${result.error.message}`);
+    return `⚠️ Could not stop (${result.error.code}).`;
+  } catch (error) {
+    log.warn(`${label} stop dispatch failed for ${session}: ${String(error)}`);
+    return "⚠️ Could not stop — see the server logs.";
+  }
+}

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -47,6 +47,7 @@ import {
 } from "./parse.ts";
 import { type TelegramFailure, defaultErrorMessage, streamReply } from "./preview.ts";
 import { ensureStateHome } from "../state.ts";
+import { dispatchStop } from "../stop-command.ts";
 import { type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 import { createTurnQueue } from "../turn-queue.ts";
 import { type StoredTurn, createTurnStore } from "./turn-store.ts";
@@ -124,7 +125,7 @@ export function telegramChannel({
   botUsername,
   apiBaseUrl = "https://api.telegram.org",
 }: TelegramChannelOptions): ChannelModule {
-  return ({ agent, stateRoot }) => {
+  return ({ agent, stateRoot, control }) => {
     // Validate at activation so deploy may inspect the module shape before secrets are provisioned.
     if (!secretToken) {
       throw new Error(
@@ -407,6 +408,22 @@ export function telegramChannel({
         // that explicitly returns the same chat/thread still quotes.
         const threadId = r.threadId ?? m.message_thread_id;
         const sameTarget = String(chatId) === String(m.chat.id) && threadId === m.message_thread_id;
+        // Explicit user stop (`/stop`): a control action, never a turn — it must not queue behind the
+        // run it stops. `/stop@otherbot` is not ours; a bare `/stop` always is. Awaited before the ACK:
+        // dispatch + one sendMessage is fast, and a delivery failure logs instead of failing the webhook.
+        const stopMatch = /^\/stop(?:@([A-Za-z0-9_]+))?$/i.exec(messageText(m).trim());
+        if (stopMatch && (!stopMatch[1] || stopMatch[1].toLowerCase() === mentionName?.toLowerCase())) {
+          const feedback = await dispatchStop(control, session, "[telegram]");
+          const target: Target = {
+            chatId,
+            threadId,
+            replyTo: m.chat.type !== "private" && sameTarget ? m.message_id : undefined,
+          };
+          await sendMessage(apiBaseUrl, botToken, target, feedback, { html: false }).catch((e) =>
+            log.warn(`[telegram] stop feedback failed: ${String(e)}`),
+          );
+          return new Response(null, { status: 200 });
+        }
         const baseText = r.text ?? telegramEnvelope(m);
         const imageFileIds = extractImages(m);
         const fileIds = extractFiles(m);

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -69,7 +69,7 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const traced = logAgentLoop(a.agent);
-  const routed = await routesFor(a.agentDir, traced, a.stateRoot).catch(failStartup);
+  const routed = await routesFor(a.agentDir, traced, a.stateRoot, a.sessionControl).catch(failStartup);
   const withControl = mountSessionControl(routed.routes, a.sessionControl, a.stateRoot, {
     tunnel: opts.tunnel ?? false,
     agent: traced, // the remote data plane (POST /control/invoke) drives the SAME traced agent

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -94,7 +94,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
 
   // Same debug turn trace as dev; gated out here by the info level (see dev.ts serveOnce).
   const traced = logAgentLoop(agent);
-  const routed = await routesFor(agentDir, traced, stateRoot).catch(failStartup);
+  const routed = await routesFor(agentDir, traced, stateRoot, sessionControl).catch(failStartup);
   const withControl = mountSessionControl(routed.routes, sessionControl, stateRoot, {
     tunnel: opts.tunnel ?? false,
     agent: traced,

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -33,10 +33,16 @@ export interface ServingSurface {
  * The surface this deployment serves: default `GET /health` plus discovered channels, or the default
  * POST `/invoke` only when neither a route nor a long-connection channel was declared.
  */
-export async function routesFor(workspaceDir: string, agent: Agent, stateRoot: string): Promise<ServingSurface> {
+export async function routesFor(
+  workspaceDir: string,
+  agent: Agent,
+  stateRoot: string,
+  control?: SessionControl,
+): Promise<ServingSurface> {
   const { routes, longConnections, routeChannels, collisions, failures } = await loadChannels(workspaceDir, {
     agent,
     stateRoot,
+    control,
   });
   for (const c of collisions) {
     console.error(

--- a/src/host/node.ts
+++ b/src/host/node.ts
@@ -6,6 +6,7 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Agent } from "../agent.ts";
+import type { SessionControl } from "../session.ts";
 import { nodeListener } from "../channels/http.ts";
 import { text } from "../channels/respond.ts";
 
@@ -25,6 +26,9 @@ export type Routes = Record<string, ChannelHandler>;
 export interface ChannelContext {
   agent: Agent;
   stateRoot: string;
+  /** The serving session-control hub, when the serve wires one (`config.sessionControl`). Channels
+   *  use it for DISPATCH only (the user-facing stop command); observation stays on the data plane. */
+  control?: SessionControl;
 }
 
 /** A `channels/<name>.ts` route channel: receives mount context and returns its HTTP routes. */

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCipheriv, createHash, randomBytes } from "node:crypto";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
+import type { SessionCommand, SessionControl } from "../src/session.ts";
 import { type FeishuChannelOptions, feishuChannel as buildFeishuChannel } from "../src/feishu.ts";
 import { larkChannel } from "../src/lark.ts";
 import { eventSignature } from "../src/channels/feishu/crypto.ts";
@@ -98,7 +99,11 @@ function feishuFetch(overrides: Partial<Record<string, (url: string, init: Reque
 }
 
 /** Build a channel on a temp state root; returns the handler + the recorded agent + the state home. */
-function buildChannel(opts: Partial<FeishuChannelOptions> = {}, agentReply = "the answer") {
+function buildChannel(
+  opts: Partial<FeishuChannelOptions> & { control?: SessionControl } = {},
+  agentReply = "the answer",
+) {
+  const { control, ...channelOpts } = opts;
   const root = mkdtempSync(join(tmpdir(), "feishu-state-"));
   tempRoots.push(root);
   const { agent, calls } = replyingAgent(agentReply);
@@ -107,8 +112,8 @@ function buildChannel(opts: Partial<FeishuChannelOptions> = {}, agentReply = "th
     appSecret: "secret",
     verificationToken: TOKEN,
     baseUrl: BASE,
-    ...opts,
-  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root });
+    ...channelOpts,
+  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control });
   const handler = routes["POST /feishu"];
   if (!handler) throw new Error("expected POST /feishu");
   const maybeIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
@@ -1603,5 +1608,44 @@ describe("cardSummary: the settled card's chat-list/notification preview", () =>
     expect(emojiBoundary).toContain("😀");
     expect(Buffer.from(emojiBoundary, "utf8").toString("utf8")).toBe(emojiBoundary);
     expect(cardSummary("   \n  ")).toBe("");
+  });
+});
+
+describe("feishu stop command", () => {
+  const fakeControl = (result: { ok: true } | { code: string }) => {
+    const dispatched: { session: string; command: SessionCommand }[] = [];
+    const control = {
+      dispatch: async (session: string, command: SessionCommand) => {
+        dispatched.push({ session, command });
+        return "ok" in result
+          ? { ok: true as const }
+          : { ok: false as const, error: { code: result.code, message: "no run", retryable: false } };
+      },
+    } as unknown as SessionControl;
+    return { control, dispatched };
+  };
+
+  it("aborts the session, replies, and never submits a turn (mention-stripped match)", async () => {
+    feishuFetch();
+    const { control, dispatched } = fakeControl({ ok: true });
+    const { handler, calls, idle } = buildChannel({ control });
+    const evt = messageEvent({ id: "om_stop", text: "Stop." });
+    expect((await handler(feishuRequest(evt))).status).toBe(200);
+    await flush();
+    await idle();
+    expect(dispatched).toEqual([{ session: "feishu:om_stop", command: { type: "abort" } }]);
+    expect(calls).toHaveLength(0); // a control action, never a turn
+  });
+
+  it("no hub degrades to the visible not-enabled notice; 'stop it' stays a normal turn", async () => {
+    const net = feishuFetch();
+    const { handler, calls, idle } = buildChannel();
+    expect((await handler(feishuRequest(messageEvent({ id: "om_s1", text: "stop" })))).status).toBe(200);
+    expect((await handler(feishuRequest(messageEvent({ id: "om_s2", text: "stop it" })))).status).toBe(200);
+    await flush();
+    await idle();
+    expect(calls).toHaveLength(1); // only "stop it" became a turn
+    const bodies = net.calls("/im/v1/messages", "POST").map((c) => JSON.stringify(c.body));
+    expect(bodies.some((b) => b.includes("Stop isn't enabled"))).toBe(true);
   });
 });

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/agent.ts";
+import { NO_ACTIVE_RUN_CODE, type SessionCommand, type SessionControl } from "../src/session.ts";
 import { type SlackChannelOptions, type SlackEventEnvelope, slackChannel, verifySlackSignature } from "../src/slack.ts";
 
 const SECRET = "slack-signing-secret";
@@ -103,13 +104,13 @@ function storedTurn(id: string, seq: number, extra: Record<string, unknown> = {}
   };
 }
 
-function mount(agent: Agent, options: Partial<SlackChannelOptions> = {}, stateRoot = root()) {
+function mount(agent: Agent, options: Partial<SlackChannelOptions> = {}, stateRoot = root(), control?: SessionControl) {
   const handler = slackChannel({
     botToken: "xoxb-test",
     signingSecret: SECRET,
     apiBaseUrl: API,
     ...options,
-  })({ agent, stateRoot })["POST /slack"]!;
+  })({ agent, stateRoot, control })["POST /slack"]!;
   const turnsIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle ?? (async () => {});
   idles.add(turnsIdle);
   return { handler, stateRoot, turnsIdle };
@@ -687,5 +688,58 @@ describe("Slack sessions, context, and managed threads", () => {
       .map((body) => String(body.text))
       .join("\n");
     expect(customerText).not.toContain("complete an earlier request");
+  });
+});
+
+describe("Slack stop command", () => {
+  const fakeControl = (result: { ok: true } | { code: string }) => {
+    const dispatched: { session: string; command: SessionCommand }[] = [];
+    const control = {
+      dispatch: async (session: string, command: SessionCommand) => {
+        dispatched.push({ session, command });
+        return "ok" in result
+          ? { ok: true as const }
+          : { ok: false as const, error: { code: result.code, message: "no run", retryable: false } };
+      },
+    } as unknown as SessionControl;
+    return { control, dispatched };
+  };
+  const invoked: string[] = [];
+  const agent: Agent = {
+    async *invoke(_scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
+      invoked.push(prompt.text);
+      yield { type: "completed" };
+    },
+  };
+
+  it("aborts the routed session, notifies, and never submits a turn", async () => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control, dispatched } = fakeControl({ ok: true });
+    const { handler, turnsIdle } = mount(agent, {}, root(), control);
+    const res = await handler(signedRequest(message("10.0", { channel: "D1", channel_type: "im", text: "Stop!" })));
+    expect(res.status).toBe(200);
+    await turnsIdle();
+    expect(dispatched).toEqual([{ session: "slack:T1:D1:10.0", command: { type: "abort" } }]);
+    expect(invoked).toEqual([]); // a control action, never a turn
+    expect(slackBodies(fetchMock, "chat.postMessage").map((b) => b.text)).toEqual(["⏹ Stopped."]);
+  });
+
+  it("maps no_active_run to the idle notice and degrades visibly without a control hub", async () => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control } = fakeControl({ code: NO_ACTIVE_RUN_CODE });
+    const withHub = mount(agent, {}, root(), control);
+    await withHub.handler(signedRequest(message("11.0", { channel: "D1", channel_type: "im", text: "cancel" })));
+    await withHub.turnsIdle();
+    const noHub = mount(agent, {}, root());
+    await noHub.handler(signedRequest(message("12.0", { channel: "D1", channel_type: "im", text: "stop" })));
+    await noHub.turnsIdle();
+    expect(invoked).toEqual([]);
+    const texts = slackBodies(fetchMock, "chat.postMessage").map((b) => String(b.text));
+    expect(texts[0]).toBe("Nothing is running.");
+    expect(texts[1]).toContain("Stop isn't enabled");
   });
 });

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -10,6 +10,7 @@ import {
   telegramEnvelope,
 } from "../src/telegram.ts";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
+import { NO_ACTIVE_RUN_CODE, type SessionCommand, type SessionControl } from "../src/session.ts";
 
 /** A faux Agent that records each invocation's prompt and replies with `reply`. */
 function replyingAgent(reply = "") {
@@ -110,11 +111,14 @@ const freshStateDir = (): string => {
  *  keeps every call site terse. The test-only `stateDir` field is the channel HOME from
  *  {@link freshStateDir} (mapped back to its root for ctx), so persistence tests share one home across
  *  "restarts" and read files at the same paths. */
-const telegramChannel = (agent: Agent, { stateDir, ...opts }: TelegramChannelOptions & { stateDir?: string }) => {
+const telegramChannel = (
+  agent: Agent,
+  { stateDir, control, ...opts }: TelegramChannelOptions & { stateDir?: string; control?: SessionControl },
+) => {
   const home = stateDir ?? freshStateDir();
   const root = rootOfHome.get(home);
   if (!root) throw new Error("test stateDir must come from freshStateDir()");
-  const handler = buildTelegramChannel(opts)({ agent, stateRoot: root })["POST /telegram"]!;
+  const handler = buildTelegramChannel(opts)({ agent, stateRoot: root, control })["POST /telegram"]!;
   // Register the turn-queue idle so flush() awaits this channel's fire-and-forget turns deterministically.
   const idle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
   if (idle) channelIdles.add(idle);
@@ -1751,5 +1755,69 @@ describe("telegram channel", () => {
     const edits = callsTo(fetchMock, "editMessageText").map((c) => bodyOf(c).text as string);
     expect(edits.some((t) => /something went wrong/i.test(t))).toBe(true);
     expect(callsTo(fetchMock, "deleteMessage")).toHaveLength(0);
+  });
+});
+
+describe("telegram /stop command", () => {
+  const okFetch = () =>
+    vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { message_id: 9 } }), { status: 200 }));
+  const fakeControl = (result: { ok: true } | { code: string }) => {
+    const dispatched: { session: string; command: SessionCommand }[] = [];
+    const control = {
+      dispatch: async (session: string, command: SessionCommand) => {
+        dispatched.push({ session, command });
+        return "ok" in result
+          ? { ok: true as const }
+          : { ok: false as const, error: { code: result.code, message: "no run", retryable: false } };
+      },
+    } as unknown as SessionControl;
+    return { control, dispatched };
+  };
+  const stopUpdate = (text: string): TelegramUpdate => ({
+    update_id: 77,
+    message: { message_id: 3, text, chat: { id: 42, type: "private" } },
+  });
+  const invoked: string[] = [];
+  const agent: Agent = {
+    async *invoke(_scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
+      invoked.push(prompt.text);
+      yield { type: "completed" };
+    },
+  };
+
+  it("/stop aborts the session, replies, and never becomes a turn", async () => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control, dispatched } = fakeControl({ ok: true });
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", control });
+    expect((await ch(tgRequest(stopUpdate("/stop")))).status).toBe(200);
+    expect(dispatched).toEqual([{ session: "42", command: { type: "abort" } }]);
+    expect(invoked).toEqual([]);
+    const sent = (fetchMock.mock.calls as unknown as [string, RequestInit][]).map(
+      ([, init]) => JSON.parse(String(init.body)) as { text?: string },
+    );
+    expect(sent.some((b) => b.text === "⏹ Stopped.")).toBe(true);
+  });
+
+  it("/stop@otherbot is not ours; idle and hub-less outcomes stay visible", async () => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control, dispatched } = fakeControl({ code: NO_ACTIVE_RUN_CODE });
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", botUsername: "mybot", control });
+    await ch(tgRequest(stopUpdate("/stop@otherbot"))); // routed as a normal turn, not a stop
+    await flush();
+    expect(dispatched).toEqual([]);
+    expect(invoked).toHaveLength(1);
+    await ch(tgRequest(stopUpdate("/stop@mybot")));
+    expect(dispatched).toEqual([{ session: "42", command: { type: "abort" } }]);
+    const noHub = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT" });
+    await noHub(tgRequest(stopUpdate("/stop")));
+    const sent = (fetchMock.mock.calls as unknown as [string, RequestInit][]).map(
+      ([, init]) => JSON.parse(String(init.body)) as { text?: string },
+    );
+    expect(sent.some((b) => b.text === "Nothing is running.")).toBe(true);
+    expect(sent.some((b) => String(b.text).includes("Stop isn't enabled"))).toBe(true);
   });
 });


### PR DESCRIPTION
**Stacked on #264 — merge after it lands.** This PR's own change is the last commit. Note: touches the same §15 area of `docs/design/session-control.md` as #269 — whichever merges second needs a trivial rebase.

## Summary

Implements the reviewed G1 design (decisions as confirmed: hub stays gated by `config.sessionControl`; English stop words; queued turns are not flushed):

- **`ChannelContext.control?: SessionControl`** (host surface, not SPEC): channels get the session-control hub for **dispatch only** — observation stays on the data plane (the `retrying` precedent). `dev`/`start` pass the hub through `routesFor`; embedders that mount routes directly simply omit it.
- **Per-channel trigger**: Telegram `/stop` (a `/stop@otherbot` is not ours); Slack and Feishu/Lark a summon whose whole message is "stop"/"cancel" (mention-stripped). Lark inherits via the shared Feishu engine.
- **Semantics**: the stop message is a control action, never a turn (it must not queue behind the run it stops). Only the ACTIVE run aborts — queued durable turns are independent asks and keep the L1 at-least-once floor. Outcomes are shared wording (`channels/stop-command.ts`): ⏹ Stopped / Nothing is running / a visible "not enabled" notice when the hub is absent — never a silent ignore.
- **Dedup**: Slack/Feishu record the stop message id, so a platform redelivery doesn't double-abort or double-notify.
- docs: channel-development (contract), telegram/slack/feishu user docs, session-control §15 (shipped + decisions).

## Validation

- [x] `npm run lint` (existing suppression warning only)
- [x] `npm run typecheck`
- [x] `npm test` — 987 tests (6 new: per-channel abort/no-turn/feedback, idle + hub-less outcomes, non-command text stays a turn)
