### PR TITLE
refactor(channels): shared turn-view reducer + side-task tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ src/
 │   ├── http.ts              # HTTP/SSE channel (consumes only the Agent contract)
 │   ├── control.ts           # session-control transport: bearer-token /control/* routes (dispatch + SSE events with wire envelope + /control/invoke)
 │   ├── body.ts, respond.ts  # channel-authoring kit (body cap, responses)
-│   ├── preview-kit.ts       # SHARED preview policies: ChannelFailure + customer-facing default error + tool-arg summary
+│   ├── preview-kit.ts       # SHARED turn-view reducer (event → view state + line renderers) + preview policies (ChannelFailure, wording)
+│   ├── tasks.ts             # SHARED fire-and-forget side-task tracking — channels drain it in turnsIdle
 │   ├── text.ts              # SHARED Unicode-safe code-point slicing (cards, preview kit)
 │   ├── turn-queue.ts        # SHARED: in-memory per-session serial turns (FIFO; telegram + slack + feishu)
 │   ├── turn-store.ts        # SHARED: generic durable turn intent (L1) — record shape/validator/order injected per channel

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4,7 +4,7 @@ description: "Agent Handler protocol v0.1: one invoke function and a small set o
 type: spec
 status: locked
 version: 0.1
-updated: 2026-06-09
+updated: 2026-07-18
 ---
 
 # Agent Handler — Protocol Specification v0.1 (locked)
@@ -67,6 +67,7 @@ type AgentEvent =
   | { type: "thinking";     delta: string }                      // Model reasoning (process, not the answer)
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended";   id: string; isError: boolean; content: Json }
+  | { type: "retrying";     attempt: number; maxAttempts: number; delayMs: number; reason: string } // Advisory: internal retry backoff
   | { type: "completed";    data?: Json }                        // Terminal: success
   | { type: "failed";       details: string; retryable: boolean; code?: string }; // Terminal: failure (code = §8 subdivision)
 
@@ -76,6 +77,10 @@ type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
 - All textual output is emitted as `text` deltas; `completed` is only a terminal success signal and does not repeat the full text.
 - `thinking` deltas carry the model's reasoning when the engine and model expose it (optional — many models emit none). It is process, not output: a consumer MUST NOT fold `thinking` into the final answer (`collect` ignores it). Surface it for live/observability UIs only.
 - `completed.data` is present only when the engine produces structured data.
+- `retrying` is advisory and non-terminal; engines MAY emit it when a transient internal failure
+  (e.g. a provider error during context summarization) schedules a retry with backoff. It exists so a
+  live consumer can explain an otherwise-quiet gap; it is deliberately unclosed — the next event is
+  its closure. Terminal consumers ignore it per MUST 4; `reason` is human-facing prose.
 - Every event MUST be JSON-serializable.
 
 ## 6. Conformance

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,6 +40,7 @@ type AgentEvent =
   | { type: "thinking"; delta: string }
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended"; id: string; isError: boolean; content: Json }
+  | { type: "retrying"; attempt: number; maxAttempts: number; delayMs: number; reason: string } // advisory backoff
   | { type: "completed"; data?: Json }
   | { type: "failed"; details: string; retryable: boolean; code?: string };
 ```

--- a/docs/channel-development.md
+++ b/docs/channel-development.md
@@ -43,6 +43,11 @@ const channel: ChannelModule = ({ agent, stateRoot }) => ({
 export default channel;
 ```
 
+The mount context also carries `control?: SessionControl` when the serve runs with
+`sessionControl: true` — the session-control hub, for dispatch-style channel features (the built-in
+channels map a user "stop" onto `dispatch(session, { type: "abort" })`). It is absent otherwise;
+degrade visibly, never silently.
+
 `fastagent dev` and `fastagent start` discover every `channels/*.ts|*.js|*.mjs`. A function export is called synchronously with the assembled agent and must return a non-empty `Routes` object; an object export must implement `{ name, connect(ctx, signal) }` and return `{ ready, closed }`. `ready` settles once the first usable connection is up; when the signal aborts before that, it must still settle (resolution then means cancellation — the server skips ready-side effects once the signal is aborted — and it must never hang). `closed` resolves after abort-driven shutdown and rejects on terminal transport failure. Long-connection adapters own reconnects and translate the framework's `AbortSignal` into their transport's close operation. Any enabled channel that fails to load fails serving. Rename a file to `<name>.ts.disabled` when it should remain present but disabled.
 
 Deployment preflight also imports every enabled channel to inspect this function/object shape, but it does not call a route module or open a connection. Module top-level code must therefore be import-safe when runtime secrets are absent: capture options in the adapter factory, then validate credentials when the route module is activated or `connect()` runs. An import failure remains fatal because the same enabled channel would fail after deployment.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -254,8 +254,8 @@ window can run a delivery twice. Exactly-once execution needs a different backen
 ### Slack
 
 Slack is a first-party HTTP Events API sibling under `src/channels/slack/`. It keeps the neutral
-`Agent.invoke` boundary and reuses shared `turn-queue`, generic `turn-store`, `state`, `seen`, and preview
-policies. Platform-specific modules own signature verification/event acceptance, message subtype policy,
+`Agent.invoke` boundary and reuses shared `turn-queue`, generic `turn-store`, `state`, `seen`, and the
+shared turn-view reducer + preview policies (`preview-kit`). Platform-specific modules own signature verification/event acceptance, message subtype policy,
 managed roots/context, private-file resolution, Slack Web API transport, and dual native-stream /
 rate-limited edited-message rendering.
 

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -418,6 +418,14 @@ for message-boundary delivery (enabling an opt-in follow_up/steer policy for mid
 once interactions exist, an interaction responder (e.g. Telegram inline keyboards). The extension
 unlocks those options; it does not mandate them.
 
+Shipped from that list — **the user-facing stop command**: `ChannelContext.control?` hands channels
+the hub for DISPATCH only (observation stays on the data plane — the `retrying` event precedent),
+and the chat channels map an explicit user stop (Telegram `/stop`; a bare "stop"/"cancel" summon on
+Slack/Feishu/Lark) onto `abort`. Decisions: the hub stays gated by `config.sessionControl` (no
+hub → a visible "not enabled" notice, never a silent ignore); the stop message is a control action,
+never a turn (it must not queue behind the run it stops); only the ACTIVE run is aborted — queued
+durable turns are independent asks and keep their at-least-once floor.
+
 ## 16. Invariants
 
 Implementation review should reject changes that violate these:

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -28,6 +28,7 @@ type AgentEvent =
   | { type: "thinking"; delta: string }
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended"; id: string; isError: boolean; content: Json }
+  | { type: "retrying"; attempt: number; maxAttempts: number; delayMs: number; reason: string } // advisory: internal retry backoff
   | { type: "completed"; data?: Json }    // terminal: success
   | { type: "failed"; details: string; retryable: boolean; code?: string };  // terminal: failure
 ```

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -309,6 +309,10 @@ Two audiences, like the Telegram channel:
 - **Operator log**: always receives the full diagnostic details.
 - **Chat user**: every answered turn receives `onError(failed)` if provided, otherwise a neutral default keyed on `retryable`.
 
+When the serve runs with `sessionControl: true`, a summon whose whole message is "stop" or "cancel"
+aborts the session's active turn instead of becoming a turn (queued asks keep running; without
+session control it answers with a visible "not enabled" notice).
+
 ## Files and images
 
 Message payloads are resolved by the channel before the agent turn runs — all as **primary** inputs (a load failure becomes a `failed` event, never a silent drop):

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -251,6 +251,13 @@ files.getUploadURLExternal
 at-least-once: if Slack commits completion but the network response is lost, an explicit retry may post a
 duplicate. The tool does not hide that uncertainty with an automatic final-step retry.
 
+## Stopping a running turn
+
+When the serve runs with `sessionControl: true` (fastagent.config), a DM or @mention whose whole
+message is "stop" or "cancel" aborts that conversation's active turn instead of becoming a turn.
+Queued asks are independent and keep running — stop the next one when it starts. Without session
+control the command answers with a visible "not enabled" notice.
+
 ## Durability and state
 
 Slack state lives under:

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -166,6 +166,13 @@ Failures have two audiences:
 
 For development bots, surfacing `failed.details` is useful. For public bots, prefer a neutral user-facing message.
 
+## Stopping a running turn
+
+When the serve runs with `sessionControl: true` (fastagent.config), `/stop` aborts the chat's active
+turn (queued asks are independent and keep running — send `/stop` again when one starts). Without
+session control the command answers with a visible "not enabled" notice. `/stop@<bot>` addressed to
+another bot is ignored.
+
 ## Files and images
 
 Telegram media are handled by the channel before the agent turn runs.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -29,6 +29,11 @@ export type AgentEvent =
   | { type: "thinking"; delta: string }
   | { type: "tool_started"; id: string; name: string; args: Json }
   | { type: "tool_ended"; id: string; isError: boolean; content: Json }
+  /** Advisory, non-terminal (engines MAY emit it): a transient internal failure scheduled a retry
+   *  with backoff — the turn is still alive. Explains a quiet gap that would otherwise read as a
+   *  hang; deliberately unclosed — the next event is its closure. Terminal consumers ignore it
+   *  (SPEC MUST 4). */
+  | { type: "retrying"; attempt: number; maxAttempts: number; delayMs: number; reason: string }
   /** Terminal: success. `data` is attached only when the engine produces a structured result. */
   | { type: "completed"; data?: Json }
   /** Terminal: failure. `retryable` means it is worth re-sending with the same session. `code` is the

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -274,6 +274,7 @@ function createFeishuRuntimeFactory(
       order: (a, b) => a.seq - b.seq,
     });
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
+    const stops = new Set<Promise<void>>();
     const toStored = (r: PendingFeishuTurn): StoredFeishuTurn => {
       const { preview: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
       return { ...intent, attempts: 0 };
@@ -521,9 +522,13 @@ function createFeishuRuntimeFactory(
       // message id so a platform re-push doesn't double-abort or double-notify.
       if (isStopText(normalized.content.text.replace(/@\S+/g, " "))) {
         seen.add(m.message_id);
-        void dispatchStop(control, session, label)
-          .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback))
-          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`));
+        const stop: Promise<void> = dispatchStop(control, session, label)
+          .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback).then(() => undefined))
+          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`))
+          .finally(() => {
+            stops.delete(stop);
+          });
+        stops.add(stop);
         return;
       }
       const resources = normalized.content.resources;
@@ -558,7 +563,9 @@ function createFeishuRuntimeFactory(
       );
     };
 
-    return { acceptEvent, turnsIdle: () => queue.idle() };
+    // Stop feedback is fire-and-forget for the ingress path but must be drained on shutdown —
+    // otherwise a stop's "⏹ Stopped." reply can be dropped when the process exits right after it.
+    return { acceptEvent, turnsIdle: () => Promise.all([queue.idle(), ...stops]).then(() => undefined) };
   };
 }
 

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -15,6 +15,7 @@ import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../seen.ts";
 import { ensureStateHome } from "../state.ts";
+import { dispatchStop, isStopText } from "../stop-command.ts";
 import { createTurnQueue } from "../turn-queue.ts";
 import { createTurnStore } from "../turn-store.ts";
 import { FEISHU_CLOUD, type FeishuCloudProfile } from "./cloud.ts";
@@ -216,7 +217,7 @@ function createFeishuRuntimeFactory(
   const baseUrl = opts.apiBaseUrl ?? opts.baseUrl ?? profile.apiBase;
   const { kind } = profile;
   const label = `[${kind}]`;
-  return ({ agent, stateRoot }) => {
+  return ({ agent, stateRoot, control }) => {
     // Credential checks run when serving starts, not while the authored module is imported: deployment
     // can inspect the module shape before secrets exist, while serving still fails before ready.
     if (!appId || !appSecret) {
@@ -515,6 +516,16 @@ function createFeishuRuntimeFactory(
       const replyInThread =
         replyTo !== undefined && (threadedConversation || m.thread_id !== undefined) ? true : undefined;
       const queueReplyTo = sameTarget ? m.message_id : undefined;
+      // Explicit user stop: a control action, never a turn — it must not queue behind the run it
+      // stops. Mentions arrive as @name tokens; strip them before matching the bare word. Record the
+      // message id so a platform re-push doesn't double-abort or double-notify.
+      if (isStopText(normalized.content.text.replace(/@\S+/g, " "))) {
+        seen.add(m.message_id);
+        void dispatchStop(control, session, label)
+          .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback))
+          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`));
+        return;
+      }
       const resources = normalized.content.resources;
       const images = resources
         .filter((resource) => resource.kind === "image")

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -14,6 +14,7 @@ import { log } from "../../log.ts";
 import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../seen.ts";
+import { createTaskTracker } from "../tasks.ts";
 import { ensureStateHome } from "../state.ts";
 import { dispatchStop, isStopText } from "../stop-command.ts";
 import { createTurnQueue } from "../turn-queue.ts";
@@ -274,7 +275,8 @@ function createFeishuRuntimeFactory(
       order: (a, b) => a.seq - b.seq,
     });
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
-    const stops = new Set<Promise<void>>();
+    // Side tasks (stop feedback) run off the ingress path but drain in turnsIdle.
+    const sideTasks = createTaskTracker();
     const toStored = (r: PendingFeishuTurn): StoredFeishuTurn => {
       const { preview: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
       return { ...intent, attempts: 0 };
@@ -522,13 +524,11 @@ function createFeishuRuntimeFactory(
       // message id so a platform re-push doesn't double-abort or double-notify.
       if (isStopText(normalized.content.text.replace(/@\S+/g, " "))) {
         seen.add(m.message_id);
-        const stop: Promise<void> = dispatchStop(control, session, label)
-          .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback).then(() => undefined))
-          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`))
-          .finally(() => {
-            stops.delete(stop);
-          });
-        stops.add(stop);
+        sideTasks.track(
+          dispatchStop(control, session, label)
+            .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback).then(() => undefined))
+            .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`)),
+        );
         return;
       }
       const resources = normalized.content.resources;
@@ -563,9 +563,7 @@ function createFeishuRuntimeFactory(
       );
     };
 
-    // Stop feedback is fire-and-forget for the ingress path but must be drained on shutdown —
-    // otherwise a stop's "⏹ Stopped." reply can be dropped when the process exits right after it.
-    return { acceptEvent, turnsIdle: () => Promise.all([queue.idle(), ...stops]).then(() => undefined) };
+    return { acceptEvent, turnsIdle: () => Promise.all([queue.idle(), sideTasks.drain()]).then(() => undefined) };
   };
 }
 

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -36,6 +36,7 @@ import {
   type ChannelFailure,
   applyTurnEvent,
   composeTurnBody,
+  createPreviewPump,
   createTurnView,
   defaultErrorMessage,
   revealedAnswer,
@@ -253,65 +254,15 @@ export async function streamFeishuReply(
     }
   };
 
-  // ── Live-preview pump: a SINGLE serialized writer. ──────────────────────────────────────────
-  // Events mutate state (thinking / tools / answer) and mark the preview dirty; the pump pushes the
-  // LATEST view() with at most ONE update in flight, paced by a throttle. One-in-flight also guarantees
-  // the card's strictly-increasing `sequence` lands in order (no concurrent frames).
-  let dirty = false;
-  let pumping = false;
-  let stopped = false;
-  let previewErrLogged = false;
-  let pumpDone: Promise<void> | undefined;
-  let wakeThrottle: (() => void) | undefined; // set while the pump is mid-throttle; finish() cuts it short
-
-  const runPump = async (): Promise<void> => {
-    pumping = true;
-    try {
-      while (dirty && !stopped) {
-        dirty = false;
-        try {
-          await flushPreview();
-        } catch (e) {
-          // Best-effort preview (the final write is authoritative), but a failing update must be visible —
-          // log once per turn so a never-rendering preview is diagnosable, not silent.
-          if (!previewErrLogged) {
-            previewErrLogged = true;
-            log.warn(`${label} live preview failed (final reply still sends): ${String(e)}`);
-          }
-        }
-        if (dirty && !stopped) {
-          // Pace + coalesce a burst into one snapshot. Interruptible: finish() cuts this short so the
-          // final write is not delayed by up to STREAM_THROTTLE_MS after the turn completes.
-          await new Promise<void>((resolve) => {
-            const t = setTimeout(resolve, STREAM_THROTTLE_MS);
-            wakeThrottle = () => {
-              clearTimeout(t);
-              resolve();
-            };
-          });
-          wakeThrottle = undefined;
-        }
-      }
-    } finally {
-      pumping = false;
-    }
-  };
-  // Mark the preview dirty and ensure the single writer is running (an update already in flight picks
-  // up the new state on its next loop). Synchronous — callers never await a network write.
-  const touch = (): void => {
-    dirty = true;
-    if (!pumping) pumpDone = runPump();
-  };
+  // The shared single-writer pump (preview-kit) serializes snapshots to the one preview — which also
+  // guarantees the card's strictly-increasing `sequence` lands in order (no concurrent frames).
+  const { touch, finish } = createPreviewPump({
+    flush: flushPreview,
+    throttleMs: STREAM_THROTTLE_MS,
+    onError: (e) => log.warn(`${label} live preview failed (final reply still sends): ${String(e)}`),
+  });
 
   touch(); // mount the "💭 Thinking…" preview immediately
-
-  // Stop the pump and await any in-flight update, so the final write below is strictly the LAST one to
-  // the preview (no stale frame landing after the answer).
-  const finish = async (): Promise<void> => {
-    stopped = true;
-    wakeThrottle?.(); // cut an in-flight throttle so the final write is not delayed up to STREAM_THROTTLE_MS
-    await pumpDone?.catch(() => {});
-  };
 
   /** Terminal write, whatever tier the preview reached. */
   const settle = async (text: string): Promise<void> => {

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -32,12 +32,16 @@ import {
 import { type FeishuApi, type FeishuTarget, chunkFeishuText, isCardStreamingClosed } from "./feishu-api.ts";
 import {
   RETRY_NOTICE,
+  THINKING_PLACEHOLDER,
   type ChannelFailure,
+  applyTurnEvent,
+  composeTurnBody,
+  createTurnView,
   defaultErrorMessage,
-  humanizeToolName,
-  summarizeToolArgs,
+  thinkingLine,
+  toolLines,
 } from "../preview-kit.ts";
-import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
+import { truncateUtf8 } from "../text.ts";
 
 /** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
 export type FeishuFailure = ChannelFailure;
@@ -51,9 +55,6 @@ const STREAM_THROTTLE_MS = 1000;
 
 /** How much of the (growing) reasoning to peek at in the live view — the most recent tail. */
 const THINKING_PREVIEW = 280;
-
-/** The placeholder shown before any reasoning/tool/text arrives. */
-const THINKING_PLACEHOLDER = "💭 Thinking…";
 
 /** Cap a live view to the card budget, PREFIX-STABLE: the streaming client animates only when the old
  *  text is a prefix of the new, so an over-budget view freezes at its head rather than sliding a tail
@@ -201,35 +202,24 @@ export async function streamFeishuReply(
   initialPreview?: MountedFeishuPreview,
   label = "[feishu]",
 ): Promise<void> {
-  const tools: { label: string; status: "running" | "ok" | "error" }[] = [];
-  const toolIndexById = new Map<string, number>();
-  let thinking = "";
-  let answer = "";
-  let answerPreviewSince: number | undefined;
-  let retryNotice = false;
-
-  const mark = { running: "…", ok: "✓", error: "✗" } as const;
-  const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
-  // Reasoning is process, not the answer: shown (capped to its tail) in the live preview only, never
-  // in the settled final card (which is `answer` alone).
-  const thinkingView = (): string => {
-    const t = thinking.replace(/\s+/g, " ").trim();
-    if (t === "") return "";
-    return `💭 ${truncateCodePointSuffix(t, THINKING_PREVIEW)}`;
-  };
+  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
+  // policy, the card-budget cap, and delivery below.
+  const turn = createTurnView();
   // The answer is hidden until its first delta has aged one STREAM_THROTTLE_MS: the pump's leading-edge
   // flush would otherwise turn the very first content delta (often a lone character) into its own frame
-  // — the short-reply flicker. Aging is anchored at delta ARRIVAL (set in the event loop, not here) so
+  // — the short-reply flicker. Aging is anchored at delta ARRIVAL (answerSince, set by the reducer) so
   // an in-flight update can't skew the clock; a turn completing within the window settles directly.
   const answerView = (): string => {
-    if (answer.trim() === "" || answerPreviewSince === undefined) return "";
-    return Date.now() - answerPreviewSince >= STREAM_THROTTLE_MS ? answer : "";
+    if (turn.answer.trim() === "" || turn.answerSince === undefined) return "";
+    return Date.now() - turn.answerSince >= STREAM_THROTTLE_MS ? turn.answer : "";
   };
   const view = (): string => {
-    const v = [thinkingView(), toolView(), retryNotice ? RETRY_NOTICE : "", answerView()]
-      .filter((s) => s.trim() !== "")
-      .join("\n\n")
-      .trim();
+    const v = composeTurnBody([
+      thinkingLine(turn, THINKING_PREVIEW),
+      toolLines(turn),
+      turn.retrying ? RETRY_NOTICE : "",
+      answerView(),
+    ]);
     return capBytes(v === "" ? THINKING_PLACEHOLDER : v, CARD_MARKDOWN_MAX_BYTES);
   };
 
@@ -337,39 +327,17 @@ export async function streamFeishuReply(
 
   try {
     for await (const e of events) {
-      if (e.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
-      if (e.type === "text") {
-        answer += e.delta;
-        if (answerPreviewSince === undefined && answer.trim() !== "") answerPreviewSince = Date.now();
-        touch();
-      } else if (e.type === "thinking") {
-        thinking += e.delta;
-        touch();
-      } else if (e.type === "tool_started") {
-        const arg = summarizeToolArgs(e.args);
-        toolIndexById.set(e.id, tools.length);
-        const name = humanizeToolName(e.name);
-        tools.push({ label: arg ? `${name} ${arg}` : name, status: "running" });
-        touch();
-      } else if (e.type === "tool_ended") {
-        const i = toolIndexById.get(e.id);
-        const t = i === undefined ? undefined : tools[i];
-        if (t) t.status = e.isError ? "error" : "ok";
-        touch();
-      } else if (e.type === "retrying") {
-        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
-        retryNotice = true;
-        touch();
-      } else if (e.type === "completed") {
+      if (e.type === "completed") {
         await finish();
         // Settle the preview into the final answer; the persisted card is the answer alone — the
         // process (thinking/tools) was preview-only. Mark finalized BEFORE delivering: the terminal was
         // reached, so a delivery failure here is a plain failure, not an "abnormal exit" (which would
         // wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
         finalized = true;
-        await settle(answer.trim() !== "" ? answer : "(no reply)");
+        await settle(turn.answer.trim() !== "" ? turn.answer : "(no reply)");
         return;
-      } else if (e.type === "failed") {
+      }
+      if (e.type === "failed") {
         await finish();
         // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
         // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
@@ -388,6 +356,7 @@ export async function streamFeishuReply(
         }
         throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
       }
+      if (applyTurnEvent(turn, e)) touch();
     }
     throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
   } finally {

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -30,7 +30,7 @@ import {
   streamingCardJson,
 } from "./card.ts";
 import { type FeishuApi, type FeishuTarget, chunkFeishuText, isCardStreamingClosed } from "./feishu-api.ts";
-import { type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
+import { type ChannelFailure, defaultErrorMessage, humanizeToolName, summarizeToolArgs } from "../preview-kit.ts";
 import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
 
 /** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
@@ -340,7 +340,8 @@ export async function streamFeishuReply(
       } else if (e.type === "tool_started") {
         const arg = summarizeToolArgs(e.args);
         toolIndexById.set(e.id, tools.length);
-        tools.push({ label: arg ? `${e.name} ${arg}` : e.name, status: "running" });
+        const name = humanizeToolName(e.name);
+        tools.push({ label: arg ? `${name} ${arg}` : name, status: "running" });
         touch();
       } else if (e.type === "tool_ended") {
         const i = toolIndexById.get(e.id);

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -38,6 +38,7 @@ import {
   composeTurnBody,
   createTurnView,
   defaultErrorMessage,
+  revealedAnswer,
   thinkingLine,
   toolLines,
 } from "../preview-kit.ts";
@@ -205,20 +206,12 @@ export async function streamFeishuReply(
   // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
   // policy, the card-budget cap, and delivery below.
   const turn = createTurnView();
-  // The answer is hidden until its first delta has aged one STREAM_THROTTLE_MS: the pump's leading-edge
-  // flush would otherwise turn the very first content delta (often a lone character) into its own frame
-  // — the short-reply flicker. Aging is anchored at delta ARRIVAL (answerSince, set by the reducer) so
-  // an in-flight update can't skew the clock; a turn completing within the window settles directly.
-  const answerView = (): string => {
-    if (turn.answer.trim() === "" || turn.answerSince === undefined) return "";
-    return Date.now() - turn.answerSince >= STREAM_THROTTLE_MS ? turn.answer : "";
-  };
   const view = (): string => {
     const v = composeTurnBody([
       thinkingLine(turn, THINKING_PREVIEW),
       toolLines(turn),
       turn.retrying ? RETRY_NOTICE : "",
-      answerView(),
+      revealedAnswer(turn, STREAM_THROTTLE_MS),
     ]);
     return capBytes(v === "" ? THINKING_PLACEHOLDER : v, CARD_MARKDOWN_MAX_BYTES);
   };

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -30,7 +30,7 @@ import {
   streamingCardJson,
 } from "./card.ts";
 import { type FeishuApi, type FeishuTarget, chunkFeishuText, isCardStreamingClosed } from "./feishu-api.ts";
-import { type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
+import { RETRY_NOTICE, type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
 import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
 
 /** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
@@ -200,6 +200,7 @@ export async function streamFeishuReply(
   let thinking = "";
   let answer = "";
   let answerPreviewSince: number | undefined;
+  let retryNotice = false;
 
   const mark = { running: "…", ok: "✓", error: "✗" } as const;
   const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
@@ -219,7 +220,7 @@ export async function streamFeishuReply(
     return Date.now() - answerPreviewSince >= STREAM_THROTTLE_MS ? answer : "";
   };
   const view = (): string => {
-    const v = [thinkingView(), toolView(), answerView()]
+    const v = [thinkingView(), toolView(), retryNotice ? RETRY_NOTICE : "", answerView()]
       .filter((s) => s.trim() !== "")
       .join("\n\n")
       .trim();
@@ -330,6 +331,7 @@ export async function streamFeishuReply(
 
   try {
     for await (const e of events) {
+      if (e.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
       if (e.type === "text") {
         answer += e.delta;
         if (answerPreviewSince === undefined && answer.trim() !== "") answerPreviewSince = Date.now();
@@ -346,6 +348,10 @@ export async function streamFeishuReply(
         const i = toolIndexById.get(e.id);
         const t = i === undefined ? undefined : tools[i];
         if (t) t.status = e.isError ? "error" : "ok";
+        touch();
+      } else if (e.type === "retrying") {
+        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
+        retryNotice = true;
         touch();
       } else if (e.type === "completed") {
         await finish();

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -1,8 +1,8 @@
 /**
  * Channel-neutral live-preview pieces shared by every messaging channel's preview renderer
  * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the terminal-failure shape a channel hands to its
- * `onError`, the customer-facing default message for it, and the compact tool-arg summary for the
- * live view. The preview LIFECYCLES stay per-platform (message edits vs streaming cards) — only
+ * `onError`, the customer-facing default message for it, and the compact tool-arg summary and
+ * humanized tool label for the live view. The preview LIFECYCLES stay per-platform (message edits vs streaming cards) — only
  * these platform-independent policies live here, so the customer-facing wording cannot drift
  * between channels.
  */

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -1,13 +1,14 @@
 /**
  * Channel-neutral live-preview pieces shared by every messaging channel's preview renderer
- * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the terminal-failure shape a channel hands to its
- * `onError`, the customer-facing default message for it, and the compact tool-arg summary and
- * humanized tool label for the live view. The preview LIFECYCLES stay per-platform (message edits vs streaming cards) — only
- * these platform-independent policies live here, so the customer-facing wording cannot drift
- * between channels.
+ * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the turn-view REDUCER (the one
+ * event → view-state machine every renderer consumes), its line renderers, the terminal-failure
+ * shape a channel hands to its `onError`, and the customer-facing wording for it. The preview
+ * LIFECYCLES stay per-platform — pumps, throttles, and delivery (message edits vs streaming cards
+ * vs chat.update) are real platform differences — but everything platform-independent lives here,
+ * so a new event type or a wording change lands in ONE place instead of one hunk per channel.
  */
-import type { Json } from "../agent.ts";
-import { truncateCodePointPrefix } from "./text.ts";
+import type { AgentEvent, Json } from "../agent.ts";
+import { truncateCodePointPrefix, truncateCodePointSuffix } from "./text.ts";
 
 /** A terminal failure, as a channel hands it to its `onError`. */
 export interface ChannelFailure {
@@ -28,6 +29,97 @@ export function defaultErrorMessage(failed: ChannelFailure): string {
 /** Customer-facing live-preview line for an engine-internal retry backoff (the advisory `retrying`
  *  event): neutral, no leaked internals — the reason stays in operator logs. */
 export const RETRY_NOTICE = "⏳ Temporary problem — retrying…";
+
+/** The placeholder shown before any reasoning/tool/text arrives. */
+export const THINKING_PLACEHOLDER = "💭 Thinking…";
+
+/** One tool call's line in the live view. */
+export interface ToolLine {
+  label: string;
+  status: "running" | "ok" | "error";
+}
+
+/**
+ * The channel-neutral view STATE of one in-flight turn. Renderers own everything after this state:
+ * when to reveal the young answer (age vs timer), how to format (HTML / card markdown / mrkdwn),
+ * and how to deliver frames. Terminal events are deliberately NOT view state — completed/failed
+ * resolve the preview into a final write, which is each platform's terminal-write policy.
+ */
+export interface TurnView {
+  thinking: string;
+  tools: ToolLine[];
+  /** tool-call id → its line, for `tool_ended` status flips (bookkeeping; renderers read `tools`). */
+  toolById: Map<string, ToolLine>;
+  answer: string;
+  /** Arrival time of the first non-empty answer delta; age-based reveal policies read it. */
+  answerSince?: number;
+  /** An advisory retry backoff is in progress (closed again by any subsequent progress event). */
+  retrying: boolean;
+}
+
+export function createTurnView(): TurnView {
+  return { thinking: "", tools: [], toolById: new Map(), answer: "", retrying: false };
+}
+
+/**
+ * Apply one event to the view state. Returns true when the view changed (the caller repaints).
+ * This is the ONE place the shared view rules live: tool labels are humanized with a compact arg
+ * summary, and any progress event closes an open retry notice (a stale "retrying" line must never
+ * outlive actual progress). Terminal events only close the notice — they are the caller's business.
+ */
+export function applyTurnEvent(view: TurnView, e: AgentEvent): boolean {
+  const closedRetry = view.retrying && e.type !== "retrying";
+  if (closedRetry) view.retrying = false;
+  switch (e.type) {
+    case "text":
+      view.answer += e.delta;
+      if (view.answerSince === undefined && view.answer.trim() !== "") view.answerSince = Date.now();
+      return true;
+    case "thinking":
+      view.thinking += e.delta;
+      return true;
+    case "tool_started": {
+      const arg = summarizeToolArgs(e.args);
+      const name = humanizeToolName(e.name);
+      const line: ToolLine = { label: arg ? `${name} ${arg}` : name, status: "running" };
+      view.tools.push(line);
+      view.toolById.set(e.id, line);
+      return true;
+    }
+    case "tool_ended": {
+      const line = view.toolById.get(e.id);
+      if (line) line.status = e.isError ? "error" : "ok";
+      return true;
+    }
+    case "retrying":
+      view.retrying = true;
+      return true;
+    default:
+      return closedRetry;
+  }
+}
+
+const TOOL_MARK = { running: "…", ok: "✓", error: "✗" } as const;
+
+/** The tool-activity block: one `🔧 label …/✓/✗` line per call, in call order. */
+export function toolLines(view: TurnView): string {
+  return view.tools.map((t) => `🔧 ${t.label} ${TOOL_MARK[t.status]}`).join("\n");
+}
+
+/** The reasoning peek: the most recent tail of the (growing) reasoning, one line, code-point safe.
+ *  Process, not the answer — renderers show it live only, never in the persisted final message. */
+export function thinkingLine(view: TurnView, maxTail: number): string {
+  const t = view.thinking.replace(/\s+/g, " ").trim();
+  return t === "" ? "" : `💭 ${truncateCodePointSuffix(t, maxTail)}`;
+}
+
+/** Compose body parts (thinking/tools/retry/answer) into one frame: skip empties, blank-line joins. */
+export function composeTurnBody(parts: readonly string[]): string {
+  return parts
+    .filter((s) => s.trim() !== "")
+    .join("\n\n")
+    .trim();
+}
 
 /** Max length (code points) of a tool's arg preview in the live view. */
 const TOOL_ARG_MAX = 48;

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -2,10 +2,11 @@
  * Channel-neutral live-preview pieces shared by every messaging channel's preview renderer
  * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the turn-view REDUCER (the one
  * event → view-state machine every renderer consumes), its line renderers, the terminal-failure
- * shape a channel hands to its `onError`, and the customer-facing wording for it. The preview
- * LIFECYCLES stay per-platform — pumps, throttles, and delivery (message edits vs streaming cards
- * vs chat.update) are real platform differences — but everything platform-independent lives here,
- * so a new event type or a wording change lands in ONE place instead of one hunk per channel.
+ * shape a channel hands to its `onError`, the customer-facing wording for it, and the serialized
+ * single-writer pump. DELIVERY stays per-platform — message edits vs streaming cards vs chat.update,
+ * pacing constants, reveal timing, and terminal-write policies are real platform differences — but
+ * everything platform-independent lives here, so a new event type or a wording change lands in ONE
+ * place instead of one hunk per channel.
  */
 import type { AgentEvent, Json } from "../agent.ts";
 import { truncateCodePointPrefix, truncateCodePointSuffix } from "./text.ts";
@@ -133,6 +134,80 @@ export function composeTurnBody(parts: readonly string[]): string {
     .filter((s) => s.trim() !== "")
     .join("\n\n")
     .trim();
+}
+
+/**
+ * The serialized live-preview writer shared by the edit/snapshot renderers (telegram, feishu).
+ * Events mark the view dirty; the pump repaints to the LATEST view with at most ONE write in
+ * flight, paced by `throttleMs`. One-in-flight is the whole point: concurrent writes can land out
+ * of order — an older frame over a newer one is the "shows 3-4 steps, blanks, re-fills" flicker —
+ * so a single writer keeps frames monotonic (and makes feishu's strictly-increasing card `sequence`
+ * correct by construction). NOT used by slack-classic: its pacing lives inside the flush (the 3s
+ * chat.update rate slot), not at the frame boundary.
+ */
+export interface PreviewPump {
+  /** Mark the view dirty and ensure the single writer runs (an in-flight write picks the new state
+   *  up on its next loop). Synchronous — callers never await a network write. */
+  touch(): void;
+  /** Stop the pump, cut an in-flight throttle short, and await any in-flight write — so the
+   *  caller's terminal write is strictly the LAST one (no stale frame landing after the answer). */
+  finish(): Promise<void>;
+}
+
+export function createPreviewPump(opts: {
+  /** Write the LATEST view. Best-effort — the terminal write is authoritative. */
+  flush: () => Promise<void>;
+  /** Pace + coalesce a burst into one write; finish() interrupts a throttle in progress. */
+  throttleMs: number;
+  /** Called for the FIRST failing flush only (the pump keeps running): a never-rendering preview
+   *  must be diagnosable, not silent — and not a log flood. */
+  onError: (error: unknown) => void;
+}): PreviewPump {
+  let dirty = false;
+  let pumping = false;
+  let stopped = false;
+  let errored = false;
+  let pumpDone: Promise<void> | undefined;
+  let wakeThrottle: (() => void) | undefined; // set while mid-throttle; finish() cuts it short
+  const runPump = async (): Promise<void> => {
+    pumping = true;
+    try {
+      while (dirty && !stopped) {
+        dirty = false;
+        try {
+          await opts.flush();
+        } catch (error) {
+          if (!errored) {
+            errored = true;
+            opts.onError(error);
+          }
+        }
+        if (dirty && !stopped) {
+          await new Promise<void>((resolve) => {
+            const t = setTimeout(resolve, opts.throttleMs);
+            wakeThrottle = () => {
+              clearTimeout(t);
+              resolve();
+            };
+          });
+          wakeThrottle = undefined;
+        }
+      }
+    } finally {
+      pumping = false;
+    }
+  };
+  return {
+    touch() {
+      dirty = true;
+      if (!pumping) pumpDone = runPump();
+    },
+    async finish() {
+      stopped = true;
+      wakeThrottle?.();
+      await pumpDone?.catch(() => {});
+    },
+  };
 }
 
 /** Max length (code points) of a tool's arg preview in the live view. */

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -25,6 +25,10 @@ export function defaultErrorMessage(failed: ChannelFailure): string {
     : "⚠️ Sorry, something went wrong. Try rephrasing, or check I have access to what you need.";
 }
 
+/** Customer-facing live-preview line for an engine-internal retry backoff (the advisory `retrying`
+ *  event): neutral, no leaked internals — the reason stays in operator logs. */
+export const RETRY_NOTICE = "⏳ Temporary problem — retrying…";
+
 /** Max length (code points) of a tool's arg preview in the live view. */
 const TOOL_ARG_MAX = 48;
 

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -113,6 +113,20 @@ export function thinkingLine(view: TurnView, maxTail: number): string {
   return t === "" ? "" : `💭 ${truncateCodePointSuffix(t, maxTail)}`;
 }
 
+/**
+ * The shared answer-reveal policy: the answer stays hidden until its first delta has aged one
+ * throttle window (`ageMs` — each platform passes its own pacing constant). The pump's leading-edge
+ * flush would otherwise turn the very first content delta (often a lone character or unbalanced
+ * markup) into its own frame — the short-reply flicker (placeholder → "O" → "OK."). Aging is
+ * anchored at delta ARRIVAL (`answerSince`, set by the reducer) so an in-flight write can't skew the
+ * clock, and there is deliberately NO timer at the boundary: a young answer surfaces on the next
+ * content-driven pass, so a turn completing within the window delivers the final answer only.
+ */
+export function revealedAnswer(view: TurnView, ageMs: number): string {
+  if (view.answer.trim() === "" || view.answerSince === undefined) return "";
+  return Date.now() - view.answerSince >= ageMs ? view.answer : "";
+}
+
 /** Compose body parts (thinking/tools/retry/answer) into one frame: skip empties, blank-line joins. */
 export function composeTurnBody(parts: readonly string[]): string {
   return parts

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -256,6 +256,17 @@ async function streamNativeSlackReply(
 
   let streamTs: string | undefined;
   let retryStatusShown = false;
+  // DM Agent-status writes are fire-and-forget for the render loop, but must reach Slack in order:
+  // an out-of-order pair would leave a stale "retrying" line after progress (or after the final
+  // clear). One promise chain serializes them; each link swallows its own delivery error.
+  let statusChain = Promise.resolve();
+  const setStatus = (status: string): void => {
+    statusChain = statusChain.then(() =>
+      api
+        .setThreadStatus(target, status)
+        .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
+    );
+  };
   const toolNames = new Map<string, string>();
   let pendingText = "";
   let fullAnswer = "";
@@ -341,9 +352,7 @@ async function streamNativeSlackReply(
         // Progress after a retry notice: restore the normal working status so the stale line doesn't
         // contradict a visibly streaming answer.
         retryStatusShown = false;
-        void api
-          .setThreadStatus(target, WORKING_STATUS)
-          .catch((error) => log.warn(`${label} could not restore the working status: ${String(error)}`));
+        setStatus(WORKING_STATUS);
       }
       if (event.type === "text") {
         pendingText += event.delta;
@@ -356,9 +365,7 @@ async function streamNativeSlackReply(
         // status surface in native mode; DMs get the explicit Agent status line, restored on progress.
         if (target.channelId.startsWith("D")) {
           retryStatusShown = true;
-          void api
-            .setThreadStatus(target, "hit a temporary problem — retrying…")
-            .catch((error) => log.warn(`${label} could not set the retry status: ${String(error)}`));
+          setStatus("hit a temporary problem — retrying…");
         }
       } else if (event.type === "tool_started") {
         const title = humanizeToolName(event.name);
@@ -401,9 +408,8 @@ async function streamNativeSlackReply(
       );
     }
     if (target.channelId.startsWith("D")) {
-      await api
-        .setThreadStatus(target, "")
-        .catch((error) => log.warn(`${label} could not clear Slack Agent status: ${String(error)}`));
+      setStatus("");
+      await statusChain;
     }
   }
 }

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -10,6 +10,7 @@ import {
   createTurnView,
   defaultErrorMessage,
   humanizeToolName,
+  revealedAnswer,
   toolLines,
 } from "../preview-kit.ts";
 import {
@@ -99,13 +100,10 @@ async function streamClassicSlackReply(
   disclaimer: string | false | undefined,
   label: string,
 ): Promise<void> {
-  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
-  // policy (timer-based — chat.update has no per-frame pacing beyond the 3s interval), mrkdwn
-  // sanitizing, and delivery. Reasoning stays a static "Thinking…" here: raw chain-of-thought is not
+  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns mrkdwn
+  // sanitizing and delivery. Reasoning stays a static "Thinking…" here: raw chain-of-thought is not
   // customer-facing on Slack, so the reducer accumulates it but this view never reads it.
   const turn = createTurnView();
-  let answerVisible = false;
-  let answerTimer: ReturnType<typeof setTimeout> | undefined;
   let previewTs = initialPreviewTs;
   let previewAttempted = previewTs !== undefined;
   let finalized = false;
@@ -122,7 +120,7 @@ async function streamClassicSlackReply(
       THINKING_PLACEHOLDER,
       toolLines(turn),
       turn.retrying ? RETRY_NOTICE : "",
-      answerVisible ? sanitizeSlackMarkdown(turn.answer) : "",
+      sanitizeSlackMarkdown(revealedAnswer(turn, CLASSIC_UPDATE_INTERVAL_MS)),
     ]);
   const waitForMutationSlot = async (): Promise<void> => {
     const remaining = lastMutationAt + CLASSIC_UPDATE_INTERVAL_MS - Date.now();
@@ -170,7 +168,6 @@ async function streamClassicSlackReply(
   };
   const finishPump = async (): Promise<void> => {
     stopped = true;
-    if (answerTimer) clearTimeout(answerTimer);
     await pumpDone?.catch(() => {});
   };
   const finalize = async (markdown: string): Promise<void> => {
@@ -195,19 +192,10 @@ async function streamClassicSlackReply(
         throw new Error(`agent failed: ${event.details} (retryable=${event.retryable})`);
       }
       const changed = applyTurnEvent(turn, event);
-      if (event.type === "text" && !answerVisible) {
-        // Reveal-on-timer: the first delta arms a one-shot that flips the answer visible and repaints;
-        // hidden deltas need no repaint of their own.
-        if (answerTimer === undefined) {
-          answerTimer = setTimeout(() => {
-            answerVisible = true;
-            answerTimer = undefined;
-            touch();
-          }, CLASSIC_UPDATE_INTERVAL_MS);
-        }
-      } else if (changed) {
-        touch();
-      }
+      // A young (hidden) answer must not trigger the first frame: unlike telegram/feishu, classic
+      // rendering never posts an upfront placeholder, so a text-only fast turn delivers ONE final
+      // post instead of placeholder → 3s-rate-limited edit. Thinking/tool activity still paints.
+      if (changed && (event.type !== "text" || revealedAnswer(turn, CLASSIC_UPDATE_INTERVAL_MS) !== "")) touch();
     }
     throw new Error("stream ended without a terminal event");
   } finally {

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -1,7 +1,7 @@
 /** Slack reply rendering: native Agent streams first, rate-safe edited-message compatibility second. */
 import type { AgentEvent } from "../../agent.ts";
 import { log } from "../../log.ts";
-import { type ChannelFailure, defaultErrorMessage, humanizeToolName } from "../preview-kit.ts";
+import { RETRY_NOTICE, type ChannelFailure, defaultErrorMessage, humanizeToolName } from "../preview-kit.ts";
 import {
   type SlackApi,
   type SlackStreamChunk,
@@ -18,6 +18,7 @@ export { defaultErrorMessage };
 
 const CLASSIC_UPDATE_INTERVAL_MS = 3_000;
 const NATIVE_APPEND_INTERVAL_MS = 750;
+const WORKING_STATUS = "is working on your request…";
 const GENERIC_FAILURE = "⚠️ The response stream stopped unexpectedly. Please try again.";
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -91,6 +92,7 @@ async function streamClassicSlackReply(
   const tools: { name: string; status: "running" | "ok" | "error" }[] = [];
   const toolIndex = new Map<string, number>();
   let answer = "";
+  let retryNotice = false;
   let answerVisible = false;
   let answerTimer: ReturnType<typeof setTimeout> | undefined;
   let previewTs = initialPreviewTs;
@@ -107,7 +109,7 @@ async function streamClassicSlackReply(
   const toolView = (): string =>
     tools.map((tool) => `🔧 ${tool.name} ${{ running: "…", ok: "✓", error: "✗" }[tool.status]}`).join("\n");
   const view = (): string =>
-    ["💭 Thinking…", toolView(), answerVisible ? sanitizeSlackMarkdown(answer) : ""]
+    ["💭 Thinking…", toolView(), retryNotice ? RETRY_NOTICE : "", answerVisible ? sanitizeSlackMarkdown(answer) : ""]
       .filter((value) => value.trim())
       .join("\n\n")
       .trim();
@@ -166,6 +168,7 @@ async function streamClassicSlackReply(
 
   try {
     for await (const event of events) {
+      if (event.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
       if (event.type === "text") {
         answer += event.delta;
         if (!answerVisible && answerTimer === undefined) {
@@ -188,6 +191,10 @@ async function streamClassicSlackReply(
       } else if (event.type === "tool_ended") {
         const index = toolIndex.get(event.id);
         if (index !== undefined && tools[index]) tools[index].status = event.isError ? "error" : "ok";
+        touch();
+      } else if (event.type === "retrying") {
+        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
+        retryNotice = true;
         touch();
       } else if (event.type === "completed") {
         await finishPump();
@@ -237,7 +244,7 @@ async function streamNativeSlackReply(
   if (target.channelId.startsWith("D")) {
     await Promise.all([
       api
-        .setThreadStatus(target, "is working on your request…")
+        .setThreadStatus(target, WORKING_STATUS)
         .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
       threadTitle
         ? api
@@ -248,6 +255,7 @@ async function streamNativeSlackReply(
   }
 
   let streamTs: string | undefined;
+  let retryStatusShown = false;
   const toolNames = new Map<string, string>();
   let pendingText = "";
   let fullAnswer = "";
@@ -329,12 +337,29 @@ async function streamNativeSlackReply(
 
   try {
     for await (const event of events) {
+      if (event.type !== "retrying" && retryStatusShown) {
+        // Progress after a retry notice: restore the normal working status so the stale line doesn't
+        // contradict a visibly streaming answer.
+        retryStatusShown = false;
+        void api
+          .setThreadStatus(target, WORKING_STATUS)
+          .catch((error) => log.warn(`${label} could not restore the working status: ${String(error)}`));
+      }
       if (event.type === "text") {
         pendingText += event.delta;
         fullAnswer += event.delta;
         scheduleText();
       } else if (event.type === "thinking") {
         // Slack's native loading status represents private reasoning without exposing it.
+      } else if (event.type === "retrying") {
+        // A summarization retry backoff pauses the stream (~14s worst case). Channels have no per-run
+        // status surface in native mode; DMs get the explicit Agent status line, restored on progress.
+        if (target.channelId.startsWith("D")) {
+          retryStatusShown = true;
+          void api
+            .setThreadStatus(target, "hit a temporary problem — retrying…")
+            .catch((error) => log.warn(`${label} could not set the retry status: ${String(error)}`));
+        }
       } else if (event.type === "tool_started") {
         const title = humanizeToolName(event.name);
         toolNames.set(event.id, title);

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -1,7 +1,17 @@
 /** Slack reply rendering: native Agent streams first, rate-safe edited-message compatibility second. */
 import type { AgentEvent } from "../../agent.ts";
 import { log } from "../../log.ts";
-import { RETRY_NOTICE, type ChannelFailure, defaultErrorMessage, humanizeToolName } from "../preview-kit.ts";
+import {
+  RETRY_NOTICE,
+  THINKING_PLACEHOLDER,
+  type ChannelFailure,
+  applyTurnEvent,
+  composeTurnBody,
+  createTurnView,
+  defaultErrorMessage,
+  humanizeToolName,
+  toolLines,
+} from "../preview-kit.ts";
 import {
   type SlackApi,
   type SlackStreamChunk,
@@ -89,10 +99,11 @@ async function streamClassicSlackReply(
   disclaimer: string | false | undefined,
   label: string,
 ): Promise<void> {
-  const tools: { name: string; status: "running" | "ok" | "error" }[] = [];
-  const toolIndex = new Map<string, number>();
-  let answer = "";
-  let retryNotice = false;
+  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
+  // policy (timer-based — chat.update has no per-frame pacing beyond the 3s interval), mrkdwn
+  // sanitizing, and delivery. Reasoning stays a static "Thinking…" here: raw chain-of-thought is not
+  // customer-facing on Slack, so the reducer accumulates it but this view never reads it.
+  const turn = createTurnView();
   let answerVisible = false;
   let answerTimer: ReturnType<typeof setTimeout> | undefined;
   let previewTs = initialPreviewTs;
@@ -106,13 +117,13 @@ async function streamClassicSlackReply(
   let pumpDone: Promise<void> | undefined;
   let previewErrorLogged = false;
 
-  const toolView = (): string =>
-    tools.map((tool) => `🔧 ${tool.name} ${{ running: "…", ok: "✓", error: "✗" }[tool.status]}`).join("\n");
   const view = (): string =>
-    ["💭 Thinking…", toolView(), retryNotice ? RETRY_NOTICE : "", answerVisible ? sanitizeSlackMarkdown(answer) : ""]
-      .filter((value) => value.trim())
-      .join("\n\n")
-      .trim();
+    composeTurnBody([
+      THINKING_PLACEHOLDER,
+      toolLines(turn),
+      turn.retrying ? RETRY_NOTICE : "",
+      answerVisible ? sanitizeSlackMarkdown(turn.answer) : "",
+    ]);
   const waitForMutationSlot = async (): Promise<void> => {
     const remaining = lastMutationAt + CLASSIC_UPDATE_INTERVAL_MS - Date.now();
     if (remaining > 0) await wait(remaining);
@@ -123,7 +134,7 @@ async function streamClassicSlackReply(
     lastMutationAt = Date.now();
   };
   const flushPreview = async (): Promise<void> => {
-    const markdown = chunkSlackText(view())[0] ?? "💭 Thinking…";
+    const markdown = chunkSlackText(view())[0] ?? THINKING_PLACEHOLDER;
     if (markdown === lastSent) return;
     if (previewTs) {
       await updateRateSafe(previewTs, markdown);
@@ -168,40 +179,13 @@ async function streamClassicSlackReply(
 
   try {
     for await (const event of events) {
-      if (event.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
-      if (event.type === "text") {
-        answer += event.delta;
-        if (!answerVisible && answerTimer === undefined) {
-          answerTimer = setTimeout(() => {
-            answerVisible = true;
-            answerTimer = undefined;
-            touch();
-          }, CLASSIC_UPDATE_INTERVAL_MS);
-        } else if (answerVisible) {
-          touch();
-        }
-      } else if (event.type === "thinking") {
-        // Raw model reasoning is not customer-facing. A static loading state communicates progress
-        // without leaking chain-of-thought or prompt data.
-        touch();
-      } else if (event.type === "tool_started") {
-        toolIndex.set(event.id, tools.length);
-        tools.push({ name: humanizeToolName(event.name), status: "running" });
-        touch();
-      } else if (event.type === "tool_ended") {
-        const index = toolIndex.get(event.id);
-        if (index !== undefined && tools[index]) tools[index].status = event.isError ? "error" : "ok";
-        touch();
-      } else if (event.type === "retrying") {
-        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
-        retryNotice = true;
-        touch();
-      } else if (event.type === "completed") {
+      if (event.type === "completed") {
         await finishPump();
         finalized = true;
-        await finalize(withDisclaimer(answer, disclaimer));
+        await finalize(withDisclaimer(turn.answer, disclaimer));
         return;
-      } else if (event.type === "failed") {
+      }
+      if (event.type === "failed") {
         await finishPump();
         finalized = true;
         const notice = formatError({ details: event.details, retryable: event.retryable }) ?? "";
@@ -209,6 +193,20 @@ async function streamClassicSlackReply(
           log.error(`${label} failed to deliver the agent-failure notice: ${String(error)}`),
         );
         throw new Error(`agent failed: ${event.details} (retryable=${event.retryable})`);
+      }
+      const changed = applyTurnEvent(turn, event);
+      if (event.type === "text" && !answerVisible) {
+        // Reveal-on-timer: the first delta arms a one-shot that flips the answer visible and repaints;
+        // hidden deltas need no repaint of their own.
+        if (answerTimer === undefined) {
+          answerTimer = setTimeout(() => {
+            answerVisible = true;
+            answerTimer = undefined;
+            touch();
+          }, CLASSIC_UPDATE_INTERVAL_MS);
+        }
+      } else if (changed) {
+        touch();
       }
     }
     throw new Error("stream ended without a terminal event");

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -6,6 +6,7 @@ import { log } from "../../log.ts";
 import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../seen.ts";
+import { createTaskTracker } from "../tasks.ts";
 import { ensureStateHome } from "../state.ts";
 import { dispatchStop, isStopText } from "../stop-command.ts";
 import { codePointPrefix } from "../text.ts";
@@ -484,13 +485,11 @@ export function slackChannel({
       if (isStopText((event.text ?? "").replace(/<@[A-Z0-9]+>/gi, " "))) {
         seen.add(logicalId);
         const target: SlackTarget = { channelId: event.channel, threadTs: event.thread_ts };
-        const stop: Promise<void> = dispatchStop(control, routed.session ?? defaultSession, label)
-          .then((feedback) => api.postMessage(target, feedback).then(() => undefined))
-          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`))
-          .finally(() => {
-            stops.delete(stop);
-          });
-        stops.add(stop);
+        sideTasks.track(
+          dispatchStop(control, routed.session ?? defaultSession, label)
+            .then((feedback) => api.postMessage(target, feedback).then(() => undefined))
+            .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`)),
+        );
         return;
       }
       const fileIds = slackFileIds(event);
@@ -537,11 +536,11 @@ export function slackChannel({
       );
     };
 
-    const stops = new Set<Promise<void>>();
+    // Side tasks (stop feedback, DM welcomes) run off the ACK path but drain in turnsIdle.
+    const sideTasks = createTaskTracker();
 
     // First-run DM welcome: app_home_opened(tab="messages") signals a DM open. Post once per user.
     const welcomeInFlight = new Set<string>();
-    const welcomes = new Set<Promise<void>>();
     const maybeWelcome = (envelope: SlackEventEnvelope): void => {
       if (welcome === false) return;
       const body = welcome.trim();
@@ -559,20 +558,20 @@ export function slackChannel({
       // Reserve in-memory so rapid re-opens don't double-post; persist to the durable set only on a
       // successful post, so a failed post simply retries on the next open.
       welcomeInFlight.add(id);
-      const promise = api
-        .postMarkdown({ channelId }, body)
-        .then(() => {
-          welcomed.add(teamId, userId);
-          log.info(`${label} sent first-run welcome to ${id}`);
-        })
-        .catch((error) =>
-          log.warn(`${label} could not send first-run welcome (retries on next open): ${String(error)}`),
-        )
-        .finally(() => {
-          welcomeInFlight.delete(id);
-          welcomes.delete(promise);
-        });
-      welcomes.add(promise);
+      sideTasks.track(
+        api
+          .postMarkdown({ channelId }, body)
+          .then(() => {
+            welcomed.add(teamId, userId);
+            log.info(`${label} sent first-run welcome to ${id}`);
+          })
+          .catch((error) =>
+            log.warn(`${label} could not send first-run welcome (retries on next open): ${String(error)}`),
+          )
+          .finally(() => {
+            welcomeInFlight.delete(id);
+          }),
+      );
     };
 
     const handler = async (request: Request): Promise<Response> => {
@@ -608,7 +607,7 @@ export function slackChannel({
       return new Response(null, { status: 200 });
     };
     (handler as typeof handler & { turnsIdle?: () => Promise<void> }).turnsIdle = () =>
-      Promise.all([queue.idle(), ...welcomes, ...stops]).then(() => undefined);
+      Promise.all([queue.idle(), sideTasks.drain()]).then(() => undefined);
     return { "POST /slack": handler };
   };
 }

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -7,6 +7,7 @@ import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../seen.ts";
 import { ensureStateHome } from "../state.ts";
+import { dispatchStop, isStopText } from "../stop-command.ts";
 import { codePointPrefix } from "../text.ts";
 import { createTurnQueue } from "../turn-queue.ts";
 import { createTurnStore } from "../turn-store.ts";
@@ -202,7 +203,7 @@ export function slackChannel({
   }
   const reactionEmojis = resolveReactionEmojis(reactionAck);
 
-  return ({ agent, stateRoot }) => {
+  return ({ agent, stateRoot, control }) => {
     if (!botToken) throw new Error("slackChannel requires a non-empty botToken (Bot User OAuth Token)");
     if (!signingSecret)
       throw new Error("slackChannel requires a non-empty signingSecret (Basic Information → App Credentials)");
@@ -477,6 +478,21 @@ export function slackChannel({
         : groupMessageSession === "continuous" && continuousTopLevel
           ? `slack:${teamId}:${event.channel}`
           : `slack:${teamId}:${event.channel}:${rootTs}`;
+      // Explicit user stop: a control action, never a turn — it must not queue behind the run it
+      // stops. Match the bare word after stripping the bot mention; record the logical id so a Slack
+      // redelivery doesn't double-abort or double-notify.
+      if (isStopText((event.text ?? "").replace(/<@[A-Z0-9]+>/gi, " "))) {
+        seen.add(logicalId);
+        const target: SlackTarget = { channelId: event.channel, threadTs: event.thread_ts };
+        const stop: Promise<void> = dispatchStop(control, routed.session ?? defaultSession, label)
+          .then((feedback) => api.postMessage(target, feedback).then(() => undefined))
+          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`))
+          .finally(() => {
+            stops.delete(stop);
+          });
+        stops.add(stop);
+        return;
+      }
       const fileIds = slackFileIds(event);
       const baseText = routed.text ?? slackEnvelope(envelope);
       if (!baseText.trim() && fileIds.length === 0) return;
@@ -520,6 +536,8 @@ export function slackChannel({
         true,
       );
     };
+
+    const stops = new Set<Promise<void>>();
 
     // First-run DM welcome: app_home_opened(tab="messages") signals a DM open. Post once per user.
     const welcomeInFlight = new Set<string>();
@@ -590,7 +608,7 @@ export function slackChannel({
       return new Response(null, { status: 200 });
     };
     (handler as typeof handler & { turnsIdle?: () => Promise<void> }).turnsIdle = () =>
-      Promise.all([queue.idle(), ...welcomes]).then(() => undefined);
+      Promise.all([queue.idle(), ...welcomes, ...stops]).then(() => undefined);
     return { "POST /slack": handler };
   };
 }

--- a/src/channels/stop-command.ts
+++ b/src/channels/stop-command.ts
@@ -1,0 +1,40 @@
+/**
+ * SHARED user-facing stop command: the chat channels (telegram, feishu/lark, slack) map an explicit
+ * "stop" ask onto the session control plane's `abort`. Policy decisions (design session-control.md
+ * §15): the stop message is a CONTROL ACTION, never a turn (it must not queue behind the run it
+ * stops); only the ACTIVE run is aborted — queued durable turns are independent asks and keep their
+ * at-least-once floor; and the hub stays gated by `config.sessionControl`, so without it the command
+ * degrades to a visible "not enabled" notice, never a silent ignore.
+ */
+import { log } from "../log.ts";
+import { NO_ACTIVE_RUN_CODE, type SessionControl } from "../session.ts";
+
+/** Bare stop word for summon-body matching (Slack/Feishu); Telegram uses its native `/stop` command. */
+export function isStopText(text: string): boolean {
+  return /^(stop|cancel)[.!]?$/i.test(text.trim());
+}
+
+export const STOPPED_NOTICE = "⏹ Stopped.";
+export const NOTHING_RUNNING_NOTICE = "Nothing is running.";
+export const STOP_UNAVAILABLE_NOTICE =
+  "⚠️ Stop isn't enabled on this deployment (set sessionControl: true in fastagent.config).";
+
+/** Dispatch `abort` for the session and map the outcome to the customer-facing line. Never throws;
+ *  full details go to the operator log. */
+export async function dispatchStop(
+  control: SessionControl | undefined,
+  session: string,
+  label: string,
+): Promise<string> {
+  if (!control) return STOP_UNAVAILABLE_NOTICE;
+  try {
+    const result = await control.dispatch(session, { type: "abort" });
+    if (result.ok) return STOPPED_NOTICE;
+    if (result.error.code === NO_ACTIVE_RUN_CODE) return NOTHING_RUNNING_NOTICE;
+    log.warn(`${label} stop dispatch rejected for ${session}: ${result.error.code} — ${result.error.message}`);
+    return `⚠️ Could not stop (${result.error.code}).`;
+  } catch (error) {
+    log.warn(`${label} stop dispatch failed for ${session}: ${String(error)}`);
+    return "⚠️ Could not stop — see the server logs.";
+  }
+}

--- a/src/channels/tasks.ts
+++ b/src/channels/tasks.ts
@@ -1,0 +1,23 @@
+/**
+ * SHARED fire-and-forget side-task tracking. Channels launch work off the request path (stop
+ * feedback, DM welcomes) that must not block the transport ACK but MUST be drained on shutdown
+ * (`turnsIdle`) — otherwise a reply in flight when the process exits is silently dropped. Error
+ * handling stays with the caller: track() only guarantees the drain sees the task settle.
+ */
+export interface TaskTracker {
+  /** Track one task. The caller keeps its own `.catch` — rejections must already be handled. */
+  track(task: Promise<unknown>): void;
+  /** Resolves when every currently-tracked task has settled. */
+  drain(): Promise<void>;
+}
+
+export function createTaskTracker(): TaskTracker {
+  const tasks = new Set<Promise<unknown>>();
+  return {
+    track(task) {
+      tasks.add(task);
+      void task.finally(() => tasks.delete(task)).catch(() => {}); // the caller's chain owns the error
+    },
+    drain: () => Promise.all(tasks).then(() => undefined),
+  };
+}

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -14,6 +14,7 @@ import {
   composeTurnBody,
   createTurnView,
   defaultErrorMessage,
+  revealedAnswer,
   thinkingLine,
   toolLines,
 } from "../preview-kit.ts";
@@ -91,22 +92,12 @@ export async function streamReply(
   // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
   // policy, formatting, and delivery below.
   const turn = createTurnView();
-  // The answer is hidden until its first delta has aged one EDIT_THROTTLE_MS: the pump's leading-edge
-  // flush would otherwise turn the very first content delta (often a lone character or unbalanced markup)
-  // into its own Telegram edit — the short-reply flicker (placeholder → "O" → "OK."). Aging is anchored
-  // at delta ARRIVAL (answerSince, set by the reducer) so an in-flight edit can't skew the clock, and
-  // there is deliberately NO timer at the boundary: a young answer surfaces on the next content-driven
-  // preview pass, so a turn completing within the window sends the final answer edit only.
-  const answerView = (): string => {
-    if (turn.answer.trim() === "" || turn.answerSince === undefined) return "";
-    return Date.now() - turn.answerSince >= EDIT_THROTTLE_MS ? turn.answer : "";
-  };
   const view = (): string => {
     const v = composeTurnBody([
       thinkingLine(turn, THINKING_PREVIEW),
       toolLines(turn),
       turn.retrying ? RETRY_NOTICE : "",
-      answerView(),
+      revealedAnswer(turn, EDIT_THROTTLE_MS),
     ]);
     // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
     return v === "" ? THINKING_PLACEHOLDER : v;

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -6,7 +6,7 @@
  * message, works in groups and private (unlike sendMessageDraft, which is private/forum-topic only).
  */
 import type { AgentEvent } from "../../agent.ts";
-import { type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
+import { RETRY_NOTICE, type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
 import { log } from "../../log.ts";
 import { TELEGRAM_MAX_TEXT, type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 
@@ -83,6 +83,7 @@ export async function streamReply(
   let thinking = "";
   let answer = "";
   let answerPreviewSince: number | undefined;
+  let retryNotice = false;
 
   const mark = { running: "…", ok: "✓", error: "✗" } as const;
   const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
@@ -104,7 +105,7 @@ export async function streamReply(
     return Date.now() - answerPreviewSince >= EDIT_THROTTLE_MS ? answer : "";
   };
   const view = (): string => {
-    const v = [thinkingView(), toolView(), answerView()]
+    const v = [thinkingView(), toolView(), retryNotice ? RETRY_NOTICE : "", answerView()]
       .filter((s) => s.trim() !== "")
       .join("\n\n")
       .trim();
@@ -202,6 +203,7 @@ export async function streamReply(
 
   try {
     for await (const e of events) {
+      if (e.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
       if (e.type === "text") {
         answer += e.delta;
         if (answerPreviewSince === undefined && answer.trim() !== "") answerPreviewSince = Date.now();
@@ -218,6 +220,10 @@ export async function streamReply(
         const i = toolIndexById.get(e.id);
         const t = i === undefined ? undefined : tools[i];
         if (t) t.status = e.isError ? "error" : "ok";
+        touch();
+      } else if (e.type === "retrying") {
+        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
+        retryNotice = true;
         touch();
       } else if (e.type === "completed") {
         await finish();

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -6,7 +6,7 @@
  * message, works in groups and private (unlike sendMessageDraft, which is private/forum-topic only).
  */
 import type { AgentEvent } from "../../agent.ts";
-import { type ChannelFailure, defaultErrorMessage, summarizeToolArgs } from "../preview-kit.ts";
+import { type ChannelFailure, defaultErrorMessage, humanizeToolName, summarizeToolArgs } from "../preview-kit.ts";
 import { log } from "../../log.ts";
 import { TELEGRAM_MAX_TEXT, type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 
@@ -212,7 +212,8 @@ export async function streamReply(
       } else if (e.type === "tool_started") {
         const arg = summarizeToolArgs(e.args);
         toolIndexById.set(e.id, tools.length);
-        tools.push({ label: arg ? `${e.name} ${arg}` : e.name, status: "running" });
+        const name = humanizeToolName(e.name);
+        tools.push({ label: arg ? `${name} ${arg}` : name, status: "running" });
         touch();
       } else if (e.type === "tool_ended") {
         const i = toolIndexById.get(e.id);

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -8,10 +8,14 @@
 import type { AgentEvent } from "../../agent.ts";
 import {
   RETRY_NOTICE,
+  THINKING_PLACEHOLDER,
   type ChannelFailure,
+  applyTurnEvent,
+  composeTurnBody,
+  createTurnView,
   defaultErrorMessage,
-  humanizeToolName,
-  summarizeToolArgs,
+  thinkingLine,
+  toolLines,
 } from "../preview-kit.ts";
 import { log } from "../../log.ts";
 import { TELEGRAM_MAX_TEXT, type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
@@ -84,39 +88,28 @@ export async function streamReply(
   formatError: (failed: TelegramFailure) => string | undefined,
   previewId?: number,
 ): Promise<void> {
-  const tools: { label: string; status: "running" | "ok" | "error" }[] = [];
-  const toolIndexById = new Map<string, number>();
-  let thinking = "";
-  let answer = "";
-  let answerPreviewSince: number | undefined;
-  let retryNotice = false;
-
-  const mark = { running: "…", ok: "✓", error: "✗" } as const;
-  const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
-  // Reasoning is process, not the answer: shown (capped to its tail) in the live preview only, never
-  // in the persisted final message (which is `answer` alone).
-  const thinkingView = (): string => {
-    const t = thinking.replace(/\s+/g, " ").trim();
-    if (t === "") return "";
-    return `💭 ${t.length > THINKING_PREVIEW ? `…${t.slice(t.length - THINKING_PREVIEW + 1)}` : t}`;
-  };
+  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
+  // policy, formatting, and delivery below.
+  const turn = createTurnView();
   // The answer is hidden until its first delta has aged one EDIT_THROTTLE_MS: the pump's leading-edge
   // flush would otherwise turn the very first content delta (often a lone character or unbalanced markup)
   // into its own Telegram edit — the short-reply flicker (placeholder → "O" → "OK."). Aging is anchored
-  // at delta ARRIVAL (set in the event loop, not here) so an in-flight edit can't skew the clock, and
+  // at delta ARRIVAL (answerSince, set by the reducer) so an in-flight edit can't skew the clock, and
   // there is deliberately NO timer at the boundary: a young answer surfaces on the next content-driven
   // preview pass, so a turn completing within the window sends the final answer edit only.
   const answerView = (): string => {
-    if (answer.trim() === "" || answerPreviewSince === undefined) return "";
-    return Date.now() - answerPreviewSince >= EDIT_THROTTLE_MS ? answer : "";
+    if (turn.answer.trim() === "" || turn.answerSince === undefined) return "";
+    return Date.now() - turn.answerSince >= EDIT_THROTTLE_MS ? turn.answer : "";
   };
   const view = (): string => {
-    const v = [thinkingView(), toolView(), retryNotice ? RETRY_NOTICE : "", answerView()]
-      .filter((s) => s.trim() !== "")
-      .join("\n\n")
-      .trim();
+    const v = composeTurnBody([
+      thinkingLine(turn, THINKING_PREVIEW),
+      toolLines(turn),
+      turn.retrying ? RETRY_NOTICE : "",
+      answerView(),
+    ]);
     // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
-    return v === "" ? "💭 Thinking…" : v;
+    return v === "" ? THINKING_PLACEHOLDER : v;
   };
 
   // The live preview is ONE real message: sent once (capturing its id + threading under the asker),
@@ -209,39 +202,17 @@ export async function streamReply(
 
   try {
     for await (const e of events) {
-      if (e.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
-      if (e.type === "text") {
-        answer += e.delta;
-        if (answerPreviewSince === undefined && answer.trim() !== "") answerPreviewSince = Date.now();
-        touch();
-      } else if (e.type === "thinking") {
-        thinking += e.delta;
-        touch();
-      } else if (e.type === "tool_started") {
-        const arg = summarizeToolArgs(e.args);
-        toolIndexById.set(e.id, tools.length);
-        const name = humanizeToolName(e.name);
-        tools.push({ label: arg ? `${name} ${arg}` : name, status: "running" });
-        touch();
-      } else if (e.type === "tool_ended") {
-        const i = toolIndexById.get(e.id);
-        const t = i === undefined ? undefined : tools[i];
-        if (t) t.status = e.isError ? "error" : "ok";
-        touch();
-      } else if (e.type === "retrying") {
-        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
-        retryNotice = true;
-        touch();
-      } else if (e.type === "completed") {
+      if (e.type === "completed") {
         await finish();
         // Edit the preview into the final answer (HTML, plain fallback); the persisted message is the
         // answer alone — the process (thinking/tools) was preview-only. Mark finalized BEFORE delivering:
         // the terminal was reached, so a delivery failure here is a plain failure, not an "abnormal exit"
         // (which would wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
         finalized = true;
-        await finalize(api, botToken, target, messageId, answer.trim() !== "" ? answer : "(no reply)");
+        await finalize(api, botToken, target, messageId, turn.answer.trim() !== "" ? turn.answer : "(no reply)");
         return;
-      } else if (e.type === "failed") {
+      }
+      if (e.type === "failed") {
         await finish();
         // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
         // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
@@ -256,6 +227,7 @@ export async function streamReply(
         }
         throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
       }
+      if (applyTurnEvent(turn, e)) touch();
     }
     throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
   } finally {

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -12,6 +12,7 @@ import {
   type ChannelFailure,
   applyTurnEvent,
   composeTurnBody,
+  createPreviewPump,
   createTurnView,
   defaultErrorMessage,
   revealedAnswer,
@@ -129,67 +130,15 @@ export async function streamReply(
       throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
   };
 
-  // ── Live-preview pump: a SINGLE serialized writer. ──────────────────────────────────────────
-  // Events mutate state (thinking / tools / answer) and mark the preview dirty; the pump edits the
-  // message to the LATEST view() with at most ONE edit in flight, paced by a throttle. One-in-flight is
-  // the whole point: concurrent edits can reach Telegram out of order — an older frame landing over a
-  // newer one is the "shows 3-4 steps, blanks, re-fills" flicker. Serializing keeps frames monotonic.
-  // (No keepalive: a real message does not expire, unlike a Bot API `sendMessageDraft` (30s window).)
-  let dirty = false;
-  let pumping = false;
-  let stopped = false;
-  let previewErrLogged = false;
-  let pumpDone: Promise<void> | undefined;
-  let wakeThrottle: (() => void) | undefined; // set while the pump is mid-throttle; finish() cuts it short
-
-  const runPump = async (): Promise<void> => {
-    pumping = true;
-    try {
-      while (dirty && !stopped) {
-        dirty = false;
-        try {
-          await flushPreview();
-        } catch (e) {
-          // Best-effort preview (the final write is authoritative), but a failing edit must be visible —
-          // log once per turn so a never-rendering preview is diagnosable, not silent.
-          if (!previewErrLogged) {
-            previewErrLogged = true;
-            log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`);
-          }
-        }
-        if (dirty && !stopped) {
-          // Pace + coalesce a burst into one edit. Interruptible: finish() cuts this short so the final
-          // write is not delayed by up to EDIT_THROTTLE_MS after the turn completes.
-          await new Promise<void>((resolve) => {
-            const t = setTimeout(resolve, EDIT_THROTTLE_MS);
-            wakeThrottle = () => {
-              clearTimeout(t);
-              resolve();
-            };
-          });
-          wakeThrottle = undefined;
-        }
-      }
-    } finally {
-      pumping = false;
-    }
-  };
-  // Mark the preview dirty and ensure the single writer is running (an edit already in flight picks up
-  // the new state on its next loop). Synchronous — callers never await a network write.
-  const touch = (): void => {
-    dirty = true;
-    if (!pumping) pumpDone = runPump();
-  };
+  // The shared single-writer pump (preview-kit) serializes edits to the one preview message. (No
+  // keepalive: a real message does not expire, unlike a Bot API `sendMessageDraft` (30s window).)
+  const { touch, finish } = createPreviewPump({
+    flush: flushPreview,
+    throttleMs: EDIT_THROTTLE_MS,
+    onError: (e) => log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`),
+  });
 
   touch(); // send the "💭 Thinking…" placeholder immediately
-
-  // Stop the pump and await any in-flight edit, so the final write below is strictly the LAST one to the
-  // preview message (no stale frame landing after the answer).
-  const finish = async (): Promise<void> => {
-    stopped = true;
-    wakeThrottle?.(); // cut an in-flight throttle so the final write is not delayed up to EDIT_THROTTLE_MS
-    await pumpDone?.catch(() => {});
-  };
 
   try {
     for await (const e of events) {

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -47,6 +47,7 @@ import {
 } from "./parse.ts";
 import { type TelegramFailure, defaultErrorMessage, streamReply } from "./preview.ts";
 import { ensureStateHome } from "../state.ts";
+import { dispatchStop } from "../stop-command.ts";
 import { type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 import { createTurnQueue } from "../turn-queue.ts";
 import { type StoredTurn, createTurnStore } from "./turn-store.ts";
@@ -124,7 +125,7 @@ export function telegramChannel({
   botUsername,
   apiBaseUrl = "https://api.telegram.org",
 }: TelegramChannelOptions): ChannelModule {
-  return ({ agent, stateRoot }) => {
+  return ({ agent, stateRoot, control }) => {
     // Validate at activation so deploy may inspect the module shape before secrets are provisioned.
     if (!secretToken) {
       throw new Error(
@@ -407,6 +408,22 @@ export function telegramChannel({
         // that explicitly returns the same chat/thread still quotes.
         const threadId = r.threadId ?? m.message_thread_id;
         const sameTarget = String(chatId) === String(m.chat.id) && threadId === m.message_thread_id;
+        // Explicit user stop (`/stop`): a control action, never a turn — it must not queue behind the
+        // run it stops. `/stop@otherbot` is not ours; a bare `/stop` always is. Awaited before the ACK:
+        // dispatch + one sendMessage is fast, and a delivery failure logs instead of failing the webhook.
+        const stopMatch = /^\/stop(?:@([A-Za-z0-9_]+))?$/i.exec(messageText(m).trim());
+        if (stopMatch && (!stopMatch[1] || stopMatch[1].toLowerCase() === mentionName?.toLowerCase())) {
+          const feedback = await dispatchStop(control, session, "[telegram]");
+          const target: Target = {
+            chatId,
+            threadId,
+            replyTo: m.chat.type !== "private" && sameTarget ? m.message_id : undefined,
+          };
+          await sendMessage(apiBaseUrl, botToken, target, feedback, { html: false }).catch((e) =>
+            log.warn(`[telegram] stop feedback failed: ${String(e)}`),
+          );
+          return new Response(null, { status: 200 });
+        }
         const baseText = r.text ?? telegramEnvelope(m);
         const imageFileIds = extractImages(m);
         const fileIds = extractFiles(m);

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -69,7 +69,7 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const traced = logAgentLoop(a.agent);
-  const routed = await routesFor(a.agentDir, traced, a.stateRoot).catch(failStartup);
+  const routed = await routesFor(a.agentDir, traced, a.stateRoot, a.sessionControl).catch(failStartup);
   const withControl = mountSessionControl(routed.routes, a.sessionControl, a.stateRoot, {
     tunnel: opts.tunnel ?? false,
     agent: traced, // the remote data plane (POST /control/invoke) drives the SAME traced agent

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -94,7 +94,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
 
   // Same debug turn trace as dev; gated out here by the info level (see dev.ts serveOnce).
   const traced = logAgentLoop(agent);
-  const routed = await routesFor(agentDir, traced, stateRoot).catch(failStartup);
+  const routed = await routesFor(agentDir, traced, stateRoot, sessionControl).catch(failStartup);
   const withControl = mountSessionControl(routed.routes, sessionControl, stateRoot, {
     tunnel: opts.tunnel ?? false,
     agent: traced,

--- a/src/cli/invoke-stream.ts
+++ b/src/cli/invoke-stream.ts
@@ -27,6 +27,12 @@ export async function runInvokeStream(
       case "tool_ended":
         if (event.isError) err(`[tool] ${toolName.get(event.id) ?? event.id} failed`);
         break;
+      case "retrying":
+        // Operator-facing: include the reason (channels show a neutral customer line instead).
+        err(
+          `[fastagent] transient failure — retrying (${event.attempt}/${event.maxAttempts} in ${event.delayMs}ms): ${event.reason}`,
+        );
+        break;
       case "failed":
         err(`[fastagent] failed: ${event.details}${event.retryable ? " (retryable)" : ""}`);
         exitCode = 1;

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -33,10 +33,16 @@ export interface ServingSurface {
  * The surface this deployment serves: default `GET /health` plus discovered channels, or the default
  * POST `/invoke` only when neither a route nor a long-connection channel was declared.
  */
-export async function routesFor(workspaceDir: string, agent: Agent, stateRoot: string): Promise<ServingSurface> {
+export async function routesFor(
+  workspaceDir: string,
+  agent: Agent,
+  stateRoot: string,
+  control?: SessionControl,
+): Promise<ServingSurface> {
   const { routes, longConnections, routeChannels, collisions, failures } = await loadChannels(workspaceDir, {
     agent,
     stateRoot,
+    control,
   });
   for (const c of collisions) {
     console.error(

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -233,6 +233,12 @@ export function projectAgentEvent(se: SessionEvent): AgentEvent | null {
       const d = se.data as { id: string; isError: boolean; content: Json };
       return { type: "tool_ended", id: d.id, isError: d.isError, content: d.content };
     }
+    case "retry_scheduled": {
+      // `operation` (compaction | branch_summary) stays session-plane vocabulary — a turn renderer
+      // only needs "transient failure, retrying"; the engine detail lives in the control plane.
+      const d = se.data as { attempt: number; maxAttempts: number; delayMs: number; error: string };
+      return { type: "retrying", attempt: d.attempt, maxAttempts: d.maxAttempts, delayMs: d.delayMs, reason: d.error };
+    }
     default:
       return null;
   }

--- a/src/host/node.ts
+++ b/src/host/node.ts
@@ -6,6 +6,7 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Agent } from "../agent.ts";
+import type { SessionControl } from "../session.ts";
 import { nodeListener } from "../channels/http.ts";
 import { text } from "../channels/respond.ts";
 
@@ -25,6 +26,9 @@ export type Routes = Record<string, ChannelHandler>;
 export interface ChannelContext {
   agent: Agent;
   stateRoot: string;
+  /** The serving session-control hub, when the serve wires one (`config.sessionControl`). Channels
+   *  use it for DISPATCH only (the user-facing stop command); observation stays on the data plane. */
+  control?: SessionControl;
 }
 
 /** A `channels/<name>.ts` route channel: receives mount context and returns its HTTP routes. */

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -39,6 +39,8 @@ export function logAgentLoop(agent: Agent, sink: (line: string) => void = (line)
           sink(`[agent]   tool → ${e.name}(${preview(e.args)})`);
         } else if (e.type === "tool_ended") {
           sink(`[agent]   tool ${e.isError ? "✗" : "✓"} ${toolName.get(e.id) ?? e.id} → ${preview(e.content)}`);
+        } else if (e.type === "retrying") {
+          sink(`[agent]   retrying (${e.attempt}/${e.maxAttempts} in ${e.delayMs}ms): ${oneLine(e.reason)}`);
         } else if (e.type === "completed") {
           if (thinking.trim() !== "") sink(`[agent]   thinking: ${oneLine(thinking)}`);
           sink(`[agent]   reply: ${oneLine(reply) || "(empty)"}`);

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCipheriv, createHash, randomBytes } from "node:crypto";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
+import type { SessionCommand, SessionControl } from "../src/session.ts";
 import { type FeishuChannelOptions, feishuChannel as buildFeishuChannel } from "../src/feishu.ts";
 import { larkChannel } from "../src/lark.ts";
 import { eventSignature } from "../src/channels/feishu/crypto.ts";
@@ -98,7 +99,11 @@ function feishuFetch(overrides: Partial<Record<string, (url: string, init: Reque
 }
 
 /** Build a channel on a temp state root; returns the handler + the recorded agent + the state home. */
-function buildChannel(opts: Partial<FeishuChannelOptions> = {}, agentReply = "the answer") {
+function buildChannel(
+  opts: Partial<FeishuChannelOptions> & { control?: SessionControl } = {},
+  agentReply = "the answer",
+) {
+  const { control, ...channelOpts } = opts;
   const root = mkdtempSync(join(tmpdir(), "feishu-state-"));
   tempRoots.push(root);
   const { agent, calls } = replyingAgent(agentReply);
@@ -107,8 +112,8 @@ function buildChannel(opts: Partial<FeishuChannelOptions> = {}, agentReply = "th
     appSecret: "secret",
     verificationToken: TOKEN,
     baseUrl: BASE,
-    ...opts,
-  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root });
+    ...channelOpts,
+  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control });
   const handler = routes["POST /feishu"];
   if (!handler) throw new Error("expected POST /feishu");
   const maybeIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
@@ -1603,5 +1608,44 @@ describe("cardSummary: the settled card's chat-list/notification preview", () =>
     expect(emojiBoundary).toContain("😀");
     expect(Buffer.from(emojiBoundary, "utf8").toString("utf8")).toBe(emojiBoundary);
     expect(cardSummary("   \n  ")).toBe("");
+  });
+});
+
+describe("feishu stop command", () => {
+  const fakeControl = (result: { ok: true } | { code: string }) => {
+    const dispatched: { session: string; command: SessionCommand }[] = [];
+    const control = {
+      dispatch: async (session: string, command: SessionCommand) => {
+        dispatched.push({ session, command });
+        return "ok" in result
+          ? { ok: true as const }
+          : { ok: false as const, error: { code: result.code, message: "no run", retryable: false } };
+      },
+    } as unknown as SessionControl;
+    return { control, dispatched };
+  };
+
+  it("aborts the session, replies, and never submits a turn (mention-stripped match)", async () => {
+    feishuFetch();
+    const { control, dispatched } = fakeControl({ ok: true });
+    const { handler, calls, idle } = buildChannel({ control });
+    const evt = messageEvent({ id: "om_stop", text: "Stop." });
+    expect((await handler(feishuRequest(evt))).status).toBe(200);
+    await flush();
+    await idle();
+    expect(dispatched).toEqual([{ session: "feishu:om_stop", command: { type: "abort" } }]);
+    expect(calls).toHaveLength(0); // a control action, never a turn
+  });
+
+  it("no hub degrades to the visible not-enabled notice; 'stop it' stays a normal turn", async () => {
+    const net = feishuFetch();
+    const { handler, calls, idle } = buildChannel();
+    expect((await handler(feishuRequest(messageEvent({ id: "om_s1", text: "stop" })))).status).toBe(200);
+    expect((await handler(feishuRequest(messageEvent({ id: "om_s2", text: "stop it" })))).status).toBe(200);
+    await flush();
+    await idle();
+    expect(calls).toHaveLength(1); // only "stop it" became a turn
+    const bodies = net.calls("/im/v1/messages", "POST").map((c) => JSON.stringify(c.body));
+    expect(bodies.some((b) => b.includes("Stop isn't enabled"))).toBe(true);
   });
 });

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -14,6 +14,7 @@ import {
   classifyRetryable,
   createPiAgentFromHarness,
   errorToTerminal,
+  projectAgentEvent,
   toSessionEvent,
   toTerminal,
 } from "../src/engines/pi/invoke.ts";
@@ -567,6 +568,16 @@ describe("toSessionEvent retry projection", () => {
   it("drops retry_attempt_start and retry_finished (no outcome to forward)", () => {
     expect(toSessionEvent({ type: "retry_attempt_start", operation: "compaction" }, "run-1")).toBeNull();
     expect(toSessionEvent({ type: "retry_finished", operation: "branch_summary" }, "run-1")).toBeNull();
+  });
+
+  it("projects retry_scheduled into the SPEC `retrying` event (operation stays session-plane)", () => {
+    const projected = projectAgentEvent({
+      type: "retry_scheduled",
+      timestamp: 1,
+      runId: "run-1",
+      data: { operation: "compaction", attempt: 2, maxAttempts: 4, delayMs: 4000, error: "503 upstream" },
+    });
+    expect(projected).toEqual({ type: "retrying", attempt: 2, maxAttempts: 4, delayMs: 4000, reason: "503 upstream" });
   });
 });
 

--- a/test/preview-kit.test.ts
+++ b/test/preview-kit.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { defaultErrorMessage, humanizeToolName } from "../src/channels/preview-kit.ts";
+import type { AgentEvent } from "../src/agent.ts";
+import {
+  applyTurnEvent,
+  composeTurnBody,
+  createTurnView,
+  defaultErrorMessage,
+  humanizeToolName,
+  thinkingLine,
+  toolLines,
+} from "../src/channels/preview-kit.ts";
 
 describe("humanizeToolName", () => {
   it("splits an mcp identifier into server: tool", () => {
@@ -42,5 +51,54 @@ describe("defaultErrorMessage", () => {
     // The shared "something went wrong" phrase is preserved verbatim (cross-channel wording contract).
     expect(message).toMatch(/something went wrong/i);
     expect(message).toMatch(/rephrasing|access/i);
+  });
+});
+
+describe("turn-view reducer", () => {
+  const apply = (events: AgentEvent[]) => {
+    const view = createTurnView();
+    const changes = events.map((e) => applyTurnEvent(view, e));
+    return { view, changes };
+  };
+
+  it("reduces a full turn: humanized+arg'd tool lines, status flips, answer accumulation", () => {
+    const { view } = apply([
+      { type: "thinking", delta: "hm " },
+      { type: "tool_started", id: "t1", name: "read", args: { path: "AGENTS.md" } },
+      { type: "tool_started", id: "t2", name: "mcp__github__create_issue", args: {} },
+      { type: "tool_ended", id: "t1", isError: false, content: null },
+      { type: "tool_ended", id: "t2", isError: true, content: null },
+      { type: "text", delta: "ok" },
+    ]);
+    expect(toolLines(view)).toBe("🔧 Read AGENTS.md ✓\n🔧 Github: create issue ✗");
+    expect(view.answer).toBe("ok");
+    expect(view.answerSince).toBeDefined();
+    expect(view.thinking).toBe("hm ");
+  });
+
+  it("opens the retry notice and closes it on ANY subsequent event, including terminals", () => {
+    const retrying = { type: "retrying", attempt: 1, maxAttempts: 4, delayMs: 1000, reason: "503" } as const;
+    const { view, changes } = apply([retrying, { type: "completed" }]);
+    expect(changes).toEqual([true, true]); // the close is a view change even on a terminal
+    expect(view.retrying).toBe(false);
+    const open = apply([retrying]);
+    expect(open.view.retrying).toBe(true);
+  });
+
+  it("a terminal without an open notice is not a view change", () => {
+    const { changes } = apply([{ type: "completed" }]);
+    expect(changes).toEqual([false]);
+  });
+
+  it("thinkingLine takes a code-point-safe tail and collapses whitespace", () => {
+    const view = createTurnView();
+    applyTurnEvent(view, { type: "thinking", delta: `a\nb  ${"🐍".repeat(10)}` });
+    expect(thinkingLine(view, 6)).toBe("💭 …🐍🐍🐍🐍🐍"); // marker + 5 points, no torn surrogate
+    expect(thinkingLine(createTurnView(), 6)).toBe("");
+  });
+
+  it("composeTurnBody skips empty parts and joins with blank lines", () => {
+    expect(composeTurnBody(["a", "", "  ", "b"])).toBe("a\n\nb");
+    expect(composeTurnBody(["", " "])).toBe("");
   });
 });

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -194,7 +194,7 @@ describe("streamReply answer preview (direct)", () => {
     expect(edits).toEqual(["⏳ Temporary problem — retrying…"]);
     src.push({ type: "tool_started", id: "t1", name: "read", args: {} });
     await vi.advanceTimersByTimeAsync(0);
-    expect(edits.at(-1)).toBe("🔧 read …"); // notice closed by progress, no stale retry line
+    expect(edits.at(-1)).toBe("🔧 Read …"); // notice closed by progress, no stale retry line
     src.push({ type: "completed" });
     src.end();
     await turn;

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -193,7 +193,7 @@ describe("streamReply answer preview (direct)", () => {
     await vi.advanceTimersByTimeAsync(0);
     src.push({ type: "tool_started", id: "t1", name: "read", args: { path: "AGENTS.md" } });
     await vi.advanceTimersByTimeAsync(0);
-    expect(edits).toEqual(["🔧 read AGENTS.md …"]);
+    expect(edits).toEqual(["🔧 Read AGENTS.md …"]);
     src.push({ type: "completed" });
     src.end();
     await turn;

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -183,6 +183,23 @@ describe("streamReply answer preview (direct)", () => {
     expect(edits.at(-1)).toBe("answer");
   });
 
+  it("a retrying event shows the backoff notice; the next progress event clears it", async () => {
+    vi.useFakeTimers();
+    const { edits } = recordingFetch();
+    const src = eventSource();
+    const turn = streamReply(src.iterable, API, "BOT", { chatId: 1 }, neutral);
+    await vi.advanceTimersByTimeAsync(0); // placeholder sent
+    src.push({ type: "retrying", attempt: 1, maxAttempts: 3, delayMs: 2000, reason: "503 upstream" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(edits).toEqual(["⏳ Temporary problem — retrying…"]);
+    src.push({ type: "tool_started", id: "t1", name: "read", args: {} });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(edits.at(-1)).toBe("🔧 read …"); // notice closed by progress, no stale retry line
+    src.push({ type: "completed" });
+    src.end();
+    await turn;
+  });
+
   it("tool previews do not leak pending short answer text", async () => {
     vi.useFakeTimers();
     const { edits } = recordingFetch();

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -86,6 +86,75 @@ describe("Slack reply rendering", () => {
   });
 });
 
+describe("native DM Agent status around a retry backoff", () => {
+  function eventSource() {
+    const queue: AgentEvent[] = [];
+    let notify: (() => void) | undefined;
+    let done = false;
+    return {
+      push(e: AgentEvent) {
+        queue.push(e);
+        notify?.();
+      },
+      end() {
+        done = true;
+        notify?.();
+      },
+      iterable: (async function* (): AsyncIterable<AgentEvent> {
+        while (true) {
+          const next = queue.shift();
+          if (next) {
+            yield next;
+            continue;
+          }
+          if (done) return;
+          await new Promise<void>((resolve) => (notify = resolve));
+        }
+      })(),
+    };
+  }
+  const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+  it("serializes status writes so a slow retry status cannot land after its restore", async () => {
+    const api = fakeApi();
+    const gates: Array<() => void> = [];
+    vi.mocked(api.setThreadStatus).mockImplementation(() => new Promise<void>((resolve) => gates.push(resolve)));
+    const statuses = () => vi.mocked(api.setThreadStatus).mock.calls.map((c) => c[1]);
+
+    const src = eventSource();
+    const turn = streamSlackReply(src.iterable, api, { channelId: "D1", threadTs: "1.0" }, () => undefined, {
+      rendering: "native",
+      disclaimer: false,
+    });
+    await flush();
+    gates.shift()?.(); // initial "is working…" status (awaited before the loop)
+    await flush();
+
+    src.push({ type: "text", delta: "a" });
+    src.push({ type: "retrying", attempt: 1, maxAttempts: 4, delayMs: 2_000, reason: "503" });
+    await flush();
+    expect(statuses().at(-1)).toContain("retrying");
+
+    // Progress while the retry-status write is still in flight: the restore must QUEUE behind it,
+    // not race it — otherwise the stale "retrying" line could land last.
+    src.push({ type: "text", delta: "b" });
+    await flush();
+    expect(statuses()).toHaveLength(2);
+    gates.shift()?.(); // retry status delivered
+    await flush();
+    expect(statuses()).toHaveLength(3);
+    expect(statuses().at(-1)).toBe("is working on your request…");
+
+    src.push({ type: "completed" });
+    src.end();
+    gates.shift()?.(); // restore delivered
+    await flush();
+    gates.shift()?.(); // final clear delivered
+    await turn;
+    expect(statuses().at(-1)).toBe(""); // the clear is last, after every queued write
+  });
+});
+
 describe("sanitizeSlackMarkdown", () => {
   it("neutralizes Slack control mentions and preserves ordinary autolinks", () => {
     expect(sanitizeSlackMarkdown("ping <!channel> now")).toBe("ping &lt;!channel> now");

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/agent.ts";
+import { NO_ACTIVE_RUN_CODE, type SessionCommand, type SessionControl } from "../src/session.ts";
 import { type SlackChannelOptions, type SlackEventEnvelope, slackChannel, verifySlackSignature } from "../src/slack.ts";
 
 const SECRET = "slack-signing-secret";
@@ -103,13 +104,13 @@ function storedTurn(id: string, seq: number, extra: Record<string, unknown> = {}
   };
 }
 
-function mount(agent: Agent, options: Partial<SlackChannelOptions> = {}, stateRoot = root()) {
+function mount(agent: Agent, options: Partial<SlackChannelOptions> = {}, stateRoot = root(), control?: SessionControl) {
   const handler = slackChannel({
     botToken: "xoxb-test",
     signingSecret: SECRET,
     apiBaseUrl: API,
     ...options,
-  })({ agent, stateRoot })["POST /slack"]!;
+  })({ agent, stateRoot, control })["POST /slack"]!;
   const turnsIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle ?? (async () => {});
   idles.add(turnsIdle);
   return { handler, stateRoot, turnsIdle };
@@ -687,5 +688,58 @@ describe("Slack sessions, context, and managed threads", () => {
       .map((body) => String(body.text))
       .join("\n");
     expect(customerText).not.toContain("complete an earlier request");
+  });
+});
+
+describe("Slack stop command", () => {
+  const fakeControl = (result: { ok: true } | { code: string }) => {
+    const dispatched: { session: string; command: SessionCommand }[] = [];
+    const control = {
+      dispatch: async (session: string, command: SessionCommand) => {
+        dispatched.push({ session, command });
+        return "ok" in result
+          ? { ok: true as const }
+          : { ok: false as const, error: { code: result.code, message: "no run", retryable: false } };
+      },
+    } as unknown as SessionControl;
+    return { control, dispatched };
+  };
+  const invoked: string[] = [];
+  const agent: Agent = {
+    async *invoke(_scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
+      invoked.push(prompt.text);
+      yield { type: "completed" };
+    },
+  };
+
+  it("aborts the routed session, notifies, and never submits a turn", async () => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control, dispatched } = fakeControl({ ok: true });
+    const { handler, turnsIdle } = mount(agent, {}, root(), control);
+    const res = await handler(signedRequest(message("10.0", { channel: "D1", channel_type: "im", text: "Stop!" })));
+    expect(res.status).toBe(200);
+    await turnsIdle();
+    expect(dispatched).toEqual([{ session: "slack:T1:D1:10.0", command: { type: "abort" } }]);
+    expect(invoked).toEqual([]); // a control action, never a turn
+    expect(slackBodies(fetchMock, "chat.postMessage").map((b) => b.text)).toEqual(["⏹ Stopped."]);
+  });
+
+  it("maps no_active_run to the idle notice and degrades visibly without a control hub", async () => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control } = fakeControl({ code: NO_ACTIVE_RUN_CODE });
+    const withHub = mount(agent, {}, root(), control);
+    await withHub.handler(signedRequest(message("11.0", { channel: "D1", channel_type: "im", text: "cancel" })));
+    await withHub.turnsIdle();
+    const noHub = mount(agent, {}, root());
+    await noHub.handler(signedRequest(message("12.0", { channel: "D1", channel_type: "im", text: "stop" })));
+    await noHub.turnsIdle();
+    expect(invoked).toEqual([]);
+    const texts = slackBodies(fetchMock, "chat.postMessage").map((b) => String(b.text));
+    expect(texts[0]).toBe("Nothing is running.");
+    expect(texts[1]).toContain("Stop isn't enabled");
   });
 });

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createTaskTracker } from "../src/channels/tasks.ts";
+
+describe("createTaskTracker", () => {
+  it("drain waits for tracked tasks; settled tasks drop out", async () => {
+    const tracker = createTaskTracker();
+    let done = false;
+    let release!: () => void;
+    tracker.track(
+      new Promise<void>((resolve) => {
+        release = resolve;
+      }).then(() => {
+        done = true;
+      }),
+    );
+    const drain = tracker.drain();
+    release();
+    await drain;
+    expect(done).toBe(true);
+    await tracker.drain(); // empty after settle — drains immediately
+  });
+
+  it("a rejected (caller-handled) task still settles the drain", async () => {
+    const tracker = createTaskTracker();
+    tracker.track(Promise.reject(new Error("boom")).catch(() => "handled"));
+    await expect(tracker.drain()).resolves.toBeUndefined();
+  });
+});

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1054,7 +1054,7 @@ describe("telegram channel", () => {
     const edits = callsTo(fetchMock, "editMessageText").map((c) => bodyOf(c).text as string);
     // a mid-turn frame shows the reasoning + tool activity (process), edited into the one preview message
     expect(
-      edits.some((t) => /💭/.test(t) && /weighing options/.test(t) && /word-count the quick brown fox/.test(t)),
+      edits.some((t) => /💭/.test(t) && /weighing options/.test(t) && /Word count the quick brown fox/.test(t)),
     ).toBe(true);
     expect(edits.at(-1)).toBe("4 words"); // …but the final message is the answer alone, no thinking/tool noise
     expect(callsTo(fetchMock, "sendMessage")).toHaveLength(1); // one preview message, not per-step spam

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -10,6 +10,7 @@ import {
   telegramEnvelope,
 } from "../src/telegram.ts";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
+import { NO_ACTIVE_RUN_CODE, type SessionCommand, type SessionControl } from "../src/session.ts";
 
 /** A faux Agent that records each invocation's prompt and replies with `reply`. */
 function replyingAgent(reply = "") {
@@ -110,11 +111,14 @@ const freshStateDir = (): string => {
  *  keeps every call site terse. The test-only `stateDir` field is the channel HOME from
  *  {@link freshStateDir} (mapped back to its root for ctx), so persistence tests share one home across
  *  "restarts" and read files at the same paths. */
-const telegramChannel = (agent: Agent, { stateDir, ...opts }: TelegramChannelOptions & { stateDir?: string }) => {
+const telegramChannel = (
+  agent: Agent,
+  { stateDir, control, ...opts }: TelegramChannelOptions & { stateDir?: string; control?: SessionControl },
+) => {
   const home = stateDir ?? freshStateDir();
   const root = rootOfHome.get(home);
   if (!root) throw new Error("test stateDir must come from freshStateDir()");
-  const handler = buildTelegramChannel(opts)({ agent, stateRoot: root })["POST /telegram"]!;
+  const handler = buildTelegramChannel(opts)({ agent, stateRoot: root, control })["POST /telegram"]!;
   // Register the turn-queue idle so flush() awaits this channel's fire-and-forget turns deterministically.
   const idle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
   if (idle) channelIdles.add(idle);
@@ -1751,5 +1755,69 @@ describe("telegram channel", () => {
     const edits = callsTo(fetchMock, "editMessageText").map((c) => bodyOf(c).text as string);
     expect(edits.some((t) => /something went wrong/i.test(t))).toBe(true);
     expect(callsTo(fetchMock, "deleteMessage")).toHaveLength(0);
+  });
+});
+
+describe("telegram /stop command", () => {
+  const okFetch = () =>
+    vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { message_id: 9 } }), { status: 200 }));
+  const fakeControl = (result: { ok: true } | { code: string }) => {
+    const dispatched: { session: string; command: SessionCommand }[] = [];
+    const control = {
+      dispatch: async (session: string, command: SessionCommand) => {
+        dispatched.push({ session, command });
+        return "ok" in result
+          ? { ok: true as const }
+          : { ok: false as const, error: { code: result.code, message: "no run", retryable: false } };
+      },
+    } as unknown as SessionControl;
+    return { control, dispatched };
+  };
+  const stopUpdate = (text: string): TelegramUpdate => ({
+    update_id: 77,
+    message: { message_id: 3, text, chat: { id: 42, type: "private" } },
+  });
+  const invoked: string[] = [];
+  const agent: Agent = {
+    async *invoke(_scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
+      invoked.push(prompt.text);
+      yield { type: "completed" };
+    },
+  };
+
+  it("/stop aborts the session, replies, and never becomes a turn", async () => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control, dispatched } = fakeControl({ ok: true });
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", control });
+    expect((await ch(tgRequest(stopUpdate("/stop")))).status).toBe(200);
+    expect(dispatched).toEqual([{ session: "42", command: { type: "abort" } }]);
+    expect(invoked).toEqual([]);
+    const sent = (fetchMock.mock.calls as unknown as [string, RequestInit][]).map(
+      ([, init]) => JSON.parse(String(init.body)) as { text?: string },
+    );
+    expect(sent.some((b) => b.text === "⏹ Stopped.")).toBe(true);
+  });
+
+  it("/stop@otherbot is not ours; idle and hub-less outcomes stay visible", async () => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control, dispatched } = fakeControl({ code: NO_ACTIVE_RUN_CODE });
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", botUsername: "mybot", control });
+    await ch(tgRequest(stopUpdate("/stop@otherbot"))); // routed as a normal turn, not a stop
+    await flush();
+    expect(dispatched).toEqual([]);
+    expect(invoked).toHaveLength(1);
+    await ch(tgRequest(stopUpdate("/stop@mybot")));
+    expect(dispatched).toEqual([{ session: "42", command: { type: "abort" } }]);
+    const noHub = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT" });
+    await noHub(tgRequest(stopUpdate("/stop")));
+    const sent = (fetchMock.mock.calls as unknown as [string, RequestInit][]).map(
+      ([, init]) => JSON.parse(String(init.body)) as { text?: string },
+    );
+    expect(sent.some((b) => b.text === "Nothing is running.")).toBe(true);
+    expect(sent.some((b) => String(b.text).includes("Stop isn't enabled"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

#267 and #270 were the evidence: every preview-semantics change (humanized tool labels, the retry notice) landed as one structurally identical hunk per channel — telegram, feishu, and slack-classic each hand-wrote the same event → view-state machine. This PR moves that machine into `preview-kit` so the next event type or wording rule lands in ONE place.

## What

- **`preview-kit`: turn-view reducer.** `createTurnView`/`applyTurnEvent` own the shared view rules (tool-line labeling with humanize + arg summary, retry-notice open/close-on-progress, answer/thinking accumulation, `answerSince` for age-based reveal). `toolLines`/`thinkingLine`/`composeTurnBody` render the shared line formats, and `revealedAnswer` is the one answer-reveal policy (age-based; each platform passes its pacing constant). `createPreviewPump` is the one implementation of the single-writer pump (telegram's and feishu's were line-for-line copies of subtle one-in-flight concurrency). Delivery, pacing constants, formatting (HTML / card markdown / mrkdwn), and terminal-write policies stay per-platform — those are real platform differences, deliberately not abstracted. slack-classic keeps its own loop (pacing lives inside the flush, not at the frame boundary). Slack-native keeps its hand-written status-line renderer (no composed text view).
- **`channels/tasks.ts`: side-task tracker.** `createTaskTracker().track/drain` replaces the bespoke promise-Set bookkeeping slack (stops + welcomes) and feishu (stops) each hand-rolled for turnsIdle drain.

## Deliberate alignments (behavior changes)

- slack-classic tool lines now include the compact arg summary (`🔧 Read AGENTS.md …`) — it was the only renderer without it; the shared placement makes wording drift impossible.
- telegram's thinking tail now truncates code-point-safe (its `slice` could tear a surrogate pair mid-emoji).
- slack-classic's answer reveal moves from a 3s timer to the shared age-based policy (deleting its `answerVisible`/`answerTimer` machinery). Its one real difference stays explicit: no upfront placeholder — a text-only fast turn still delivers ONE final post. Named trade-off: a stream stalling right after its first delta reveals on the next event rather than at exactly 3s (the semantics telegram/feishu already had).

## Stacked on

#267, #270, #271 (branch contains merge commits of all three; the real diff is the last commit). Rebase + un-draft after they land.
