### PR TITLE
docs(session-control): record the steer-vs-durability rejection; true up the builder header

### DIFF
--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -418,6 +418,14 @@ for message-boundary delivery (enabling an opt-in follow_up/steer policy for mid
 once interactions exist, an interaction responder (e.g. Telegram inline keyboards). The extension
 unlocks those options; it does not mandate them.
 
+Considered and rejected — **replacing the chat channels' queued-turn path with `steer`/`follow_up`**:
+the stateful channels persist each accepted turn intent BEFORE the transport ACK (L1, at-least-once,
+crash replay); a message folded into a live run as a steer exists only in that run's in-memory queue,
+so a process crash silently loses it. Trading the durability floor for lower latency inverts the
+channels' design center. Any future adoption must first give steered messages the same durable-intent
+treatment (which is exactly the opt-in policy sketched above — an events consumer at message
+boundaries — not a replacement of the queue).
+
 ## 16. Invariants
 
 Implementation review should reject changes that violate these:

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -1,8 +1,10 @@
 /**
  * The shared definition-aware session builder: open a workspace's assembled agent as a resident pi
- * `AgentSessionRuntime`. Extracted from chat.ts (session-control Phase 0) so the TUI is ONE consumer
- * of it and the future serving session-control plane is another — both must run the SAME agent that
- * `dev`/`start` serve.
+ * `AgentSessionRuntime`. Extracted from chat.ts (session-control Phase 0) as the proof of the
+ * assembly seam — independently instantiable, running the SAME agent that `dev`/`start` serve. The
+ * TUI (chat.ts) is its one consumer: the session control plane (Phases 1–3) was built on the invoke
+ * pipeline instead of this resident runtime, so control-plane observation covers invoke-driven runs
+ * and deliberately not chat sessions (design §10/§15).
  *
  * FIDELITY: pi's vanilla discovery (AGENTS.md walk to repo root, machine-global skills/extensions)
  * is suppressed; fastagent's assembly is INJECTED into pi's session:


### PR DESCRIPTION
## Summary

Two truth fixes from a review of session-control consumers:

- **session-control.md §15**: record *considered and rejected* — replacing the chat channels' queued-turn path with `steer`/`follow_up`. The stateful channels persist turn intents pre-ACK (L1 at-least-once); a steered message lives only in the run's in-memory queue, so adopting steer would trade the durability floor for latency. The existing demand-driven "opt-in follow_up/steer policy" sketch remains the only sanctioned path.
- **session-builder.ts header**: it still promised the serving control plane as a second consumer; Phases 1–3 were built on the invoke pipeline instead. The header now states the reality: chat TUI is the one consumer, the builder is the independently instantiable assembly-seam proof, and control-plane observation deliberately covers invoke-driven runs, not chat sessions.

Comment/docs only; no behavior change.

## Validation

- [x] `npm run typecheck`
- [x] `npm run lint`
