### PR TITLE
refactor(channels): shared turn-view reducer + side-task tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ src/
 │   ├── http.ts              # HTTP/SSE channel (consumes only the Agent contract)
 │   ├── control.ts           # session-control transport: bearer-token /control/* routes (dispatch + SSE events with wire envelope + /control/invoke)
 │   ├── body.ts, respond.ts  # channel-authoring kit (body cap, responses)
-│   ├── preview-kit.ts       # SHARED preview policies: ChannelFailure + customer-facing default error + tool-arg summary
+│   ├── preview-kit.ts       # SHARED turn-view reducer (event → view state + line renderers) + preview policies (ChannelFailure, wording)
+│   ├── tasks.ts             # SHARED fire-and-forget side-task tracking — channels drain it in turnsIdle
 │   ├── text.ts              # SHARED Unicode-safe code-point slicing (cards, preview kit)
 │   ├── turn-queue.ts        # SHARED: in-memory per-session serial turns (FIFO; telegram + slack + feishu)
 │   ├── turn-store.ts        # SHARED: generic durable turn intent (L1) — record shape/validator/order injected per channel

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -254,8 +254,8 @@ window can run a delivery twice. Exactly-once execution needs a different backen
 ### Slack
 
 Slack is a first-party HTTP Events API sibling under `src/channels/slack/`. It keeps the neutral
-`Agent.invoke` boundary and reuses shared `turn-queue`, generic `turn-store`, `state`, `seen`, and preview
-policies. Platform-specific modules own signature verification/event acceptance, message subtype policy,
+`Agent.invoke` boundary and reuses shared `turn-queue`, generic `turn-store`, `state`, `seen`, and the
+shared turn-view reducer + preview policies (`preview-kit`). Platform-specific modules own signature verification/event acceptance, message subtype policy,
 managed roots/context, private-file resolution, Slack Web API transport, and dual native-stream /
 rate-limited edited-message rendering.
 

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -14,6 +14,7 @@ import { log } from "../../log.ts";
 import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../seen.ts";
+import { createTaskTracker } from "../tasks.ts";
 import { ensureStateHome } from "../state.ts";
 import { dispatchStop, isStopText } from "../stop-command.ts";
 import { createTurnQueue } from "../turn-queue.ts";
@@ -274,7 +275,8 @@ function createFeishuRuntimeFactory(
       order: (a, b) => a.seq - b.seq,
     });
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
-    const stops = new Set<Promise<void>>();
+    // Side tasks (stop feedback) run off the ingress path but drain in turnsIdle.
+    const sideTasks = createTaskTracker();
     const toStored = (r: PendingFeishuTurn): StoredFeishuTurn => {
       const { preview: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
       return { ...intent, attempts: 0 };
@@ -522,13 +524,11 @@ function createFeishuRuntimeFactory(
       // message id so a platform re-push doesn't double-abort or double-notify.
       if (isStopText(normalized.content.text.replace(/@\S+/g, " "))) {
         seen.add(m.message_id);
-        const stop: Promise<void> = dispatchStop(control, session, label)
-          .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback).then(() => undefined))
-          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`))
-          .finally(() => {
-            stops.delete(stop);
-          });
-        stops.add(stop);
+        sideTasks.track(
+          dispatchStop(control, session, label)
+            .then((feedback) => api.sendText({ chatId, replyTo, replyInThread }, feedback).then(() => undefined))
+            .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`)),
+        );
         return;
       }
       const resources = normalized.content.resources;
@@ -563,9 +563,7 @@ function createFeishuRuntimeFactory(
       );
     };
 
-    // Stop feedback is fire-and-forget for the ingress path but must be drained on shutdown —
-    // otherwise a stop's "⏹ Stopped." reply can be dropped when the process exits right after it.
-    return { acceptEvent, turnsIdle: () => Promise.all([queue.idle(), ...stops]).then(() => undefined) };
+    return { acceptEvent, turnsIdle: () => Promise.all([queue.idle(), sideTasks.drain()]).then(() => undefined) };
   };
 }
 

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -36,6 +36,7 @@ import {
   type ChannelFailure,
   applyTurnEvent,
   composeTurnBody,
+  createPreviewPump,
   createTurnView,
   defaultErrorMessage,
   revealedAnswer,
@@ -253,65 +254,15 @@ export async function streamFeishuReply(
     }
   };
 
-  // ── Live-preview pump: a SINGLE serialized writer. ──────────────────────────────────────────
-  // Events mutate state (thinking / tools / answer) and mark the preview dirty; the pump pushes the
-  // LATEST view() with at most ONE update in flight, paced by a throttle. One-in-flight also guarantees
-  // the card's strictly-increasing `sequence` lands in order (no concurrent frames).
-  let dirty = false;
-  let pumping = false;
-  let stopped = false;
-  let previewErrLogged = false;
-  let pumpDone: Promise<void> | undefined;
-  let wakeThrottle: (() => void) | undefined; // set while the pump is mid-throttle; finish() cuts it short
-
-  const runPump = async (): Promise<void> => {
-    pumping = true;
-    try {
-      while (dirty && !stopped) {
-        dirty = false;
-        try {
-          await flushPreview();
-        } catch (e) {
-          // Best-effort preview (the final write is authoritative), but a failing update must be visible —
-          // log once per turn so a never-rendering preview is diagnosable, not silent.
-          if (!previewErrLogged) {
-            previewErrLogged = true;
-            log.warn(`${label} live preview failed (final reply still sends): ${String(e)}`);
-          }
-        }
-        if (dirty && !stopped) {
-          // Pace + coalesce a burst into one snapshot. Interruptible: finish() cuts this short so the
-          // final write is not delayed by up to STREAM_THROTTLE_MS after the turn completes.
-          await new Promise<void>((resolve) => {
-            const t = setTimeout(resolve, STREAM_THROTTLE_MS);
-            wakeThrottle = () => {
-              clearTimeout(t);
-              resolve();
-            };
-          });
-          wakeThrottle = undefined;
-        }
-      }
-    } finally {
-      pumping = false;
-    }
-  };
-  // Mark the preview dirty and ensure the single writer is running (an update already in flight picks
-  // up the new state on its next loop). Synchronous — callers never await a network write.
-  const touch = (): void => {
-    dirty = true;
-    if (!pumping) pumpDone = runPump();
-  };
+  // The shared single-writer pump (preview-kit) serializes snapshots to the one preview — which also
+  // guarantees the card's strictly-increasing `sequence` lands in order (no concurrent frames).
+  const { touch, finish } = createPreviewPump({
+    flush: flushPreview,
+    throttleMs: STREAM_THROTTLE_MS,
+    onError: (e) => log.warn(`${label} live preview failed (final reply still sends): ${String(e)}`),
+  });
 
   touch(); // mount the "💭 Thinking…" preview immediately
-
-  // Stop the pump and await any in-flight update, so the final write below is strictly the LAST one to
-  // the preview (no stale frame landing after the answer).
-  const finish = async (): Promise<void> => {
-    stopped = true;
-    wakeThrottle?.(); // cut an in-flight throttle so the final write is not delayed up to STREAM_THROTTLE_MS
-    await pumpDone?.catch(() => {});
-  };
 
   /** Terminal write, whatever tier the preview reached. */
   const settle = async (text: string): Promise<void> => {

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -32,12 +32,16 @@ import {
 import { type FeishuApi, type FeishuTarget, chunkFeishuText, isCardStreamingClosed } from "./feishu-api.ts";
 import {
   RETRY_NOTICE,
+  THINKING_PLACEHOLDER,
   type ChannelFailure,
+  applyTurnEvent,
+  composeTurnBody,
+  createTurnView,
   defaultErrorMessage,
-  humanizeToolName,
-  summarizeToolArgs,
+  thinkingLine,
+  toolLines,
 } from "../preview-kit.ts";
-import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
+import { truncateUtf8 } from "../text.ts";
 
 /** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
 export type FeishuFailure = ChannelFailure;
@@ -51,9 +55,6 @@ const STREAM_THROTTLE_MS = 1000;
 
 /** How much of the (growing) reasoning to peek at in the live view — the most recent tail. */
 const THINKING_PREVIEW = 280;
-
-/** The placeholder shown before any reasoning/tool/text arrives. */
-const THINKING_PLACEHOLDER = "💭 Thinking…";
 
 /** Cap a live view to the card budget, PREFIX-STABLE: the streaming client animates only when the old
  *  text is a prefix of the new, so an over-budget view freezes at its head rather than sliding a tail
@@ -201,35 +202,24 @@ export async function streamFeishuReply(
   initialPreview?: MountedFeishuPreview,
   label = "[feishu]",
 ): Promise<void> {
-  const tools: { label: string; status: "running" | "ok" | "error" }[] = [];
-  const toolIndexById = new Map<string, number>();
-  let thinking = "";
-  let answer = "";
-  let answerPreviewSince: number | undefined;
-  let retryNotice = false;
-
-  const mark = { running: "…", ok: "✓", error: "✗" } as const;
-  const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
-  // Reasoning is process, not the answer: shown (capped to its tail) in the live preview only, never
-  // in the settled final card (which is `answer` alone).
-  const thinkingView = (): string => {
-    const t = thinking.replace(/\s+/g, " ").trim();
-    if (t === "") return "";
-    return `💭 ${truncateCodePointSuffix(t, THINKING_PREVIEW)}`;
-  };
+  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
+  // policy, the card-budget cap, and delivery below.
+  const turn = createTurnView();
   // The answer is hidden until its first delta has aged one STREAM_THROTTLE_MS: the pump's leading-edge
   // flush would otherwise turn the very first content delta (often a lone character) into its own frame
-  // — the short-reply flicker. Aging is anchored at delta ARRIVAL (set in the event loop, not here) so
+  // — the short-reply flicker. Aging is anchored at delta ARRIVAL (answerSince, set by the reducer) so
   // an in-flight update can't skew the clock; a turn completing within the window settles directly.
   const answerView = (): string => {
-    if (answer.trim() === "" || answerPreviewSince === undefined) return "";
-    return Date.now() - answerPreviewSince >= STREAM_THROTTLE_MS ? answer : "";
+    if (turn.answer.trim() === "" || turn.answerSince === undefined) return "";
+    return Date.now() - turn.answerSince >= STREAM_THROTTLE_MS ? turn.answer : "";
   };
   const view = (): string => {
-    const v = [thinkingView(), toolView(), retryNotice ? RETRY_NOTICE : "", answerView()]
-      .filter((s) => s.trim() !== "")
-      .join("\n\n")
-      .trim();
+    const v = composeTurnBody([
+      thinkingLine(turn, THINKING_PREVIEW),
+      toolLines(turn),
+      turn.retrying ? RETRY_NOTICE : "",
+      answerView(),
+    ]);
     return capBytes(v === "" ? THINKING_PLACEHOLDER : v, CARD_MARKDOWN_MAX_BYTES);
   };
 
@@ -337,39 +327,17 @@ export async function streamFeishuReply(
 
   try {
     for await (const e of events) {
-      if (e.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
-      if (e.type === "text") {
-        answer += e.delta;
-        if (answerPreviewSince === undefined && answer.trim() !== "") answerPreviewSince = Date.now();
-        touch();
-      } else if (e.type === "thinking") {
-        thinking += e.delta;
-        touch();
-      } else if (e.type === "tool_started") {
-        const arg = summarizeToolArgs(e.args);
-        toolIndexById.set(e.id, tools.length);
-        const name = humanizeToolName(e.name);
-        tools.push({ label: arg ? `${name} ${arg}` : name, status: "running" });
-        touch();
-      } else if (e.type === "tool_ended") {
-        const i = toolIndexById.get(e.id);
-        const t = i === undefined ? undefined : tools[i];
-        if (t) t.status = e.isError ? "error" : "ok";
-        touch();
-      } else if (e.type === "retrying") {
-        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
-        retryNotice = true;
-        touch();
-      } else if (e.type === "completed") {
+      if (e.type === "completed") {
         await finish();
         // Settle the preview into the final answer; the persisted card is the answer alone — the
         // process (thinking/tools) was preview-only. Mark finalized BEFORE delivering: the terminal was
         // reached, so a delivery failure here is a plain failure, not an "abnormal exit" (which would
         // wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
         finalized = true;
-        await settle(answer.trim() !== "" ? answer : "(no reply)");
+        await settle(turn.answer.trim() !== "" ? turn.answer : "(no reply)");
         return;
-      } else if (e.type === "failed") {
+      }
+      if (e.type === "failed") {
         await finish();
         // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
         // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
@@ -388,6 +356,7 @@ export async function streamFeishuReply(
         }
         throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
       }
+      if (applyTurnEvent(turn, e)) touch();
     }
     throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
   } finally {

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -38,6 +38,7 @@ import {
   composeTurnBody,
   createTurnView,
   defaultErrorMessage,
+  revealedAnswer,
   thinkingLine,
   toolLines,
 } from "../preview-kit.ts";
@@ -205,20 +206,12 @@ export async function streamFeishuReply(
   // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
   // policy, the card-budget cap, and delivery below.
   const turn = createTurnView();
-  // The answer is hidden until its first delta has aged one STREAM_THROTTLE_MS: the pump's leading-edge
-  // flush would otherwise turn the very first content delta (often a lone character) into its own frame
-  // — the short-reply flicker. Aging is anchored at delta ARRIVAL (answerSince, set by the reducer) so
-  // an in-flight update can't skew the clock; a turn completing within the window settles directly.
-  const answerView = (): string => {
-    if (turn.answer.trim() === "" || turn.answerSince === undefined) return "";
-    return Date.now() - turn.answerSince >= STREAM_THROTTLE_MS ? turn.answer : "";
-  };
   const view = (): string => {
     const v = composeTurnBody([
       thinkingLine(turn, THINKING_PREVIEW),
       toolLines(turn),
       turn.retrying ? RETRY_NOTICE : "",
-      answerView(),
+      revealedAnswer(turn, STREAM_THROTTLE_MS),
     ]);
     return capBytes(v === "" ? THINKING_PLACEHOLDER : v, CARD_MARKDOWN_MAX_BYTES);
   };

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -1,13 +1,14 @@
 /**
  * Channel-neutral live-preview pieces shared by every messaging channel's preview renderer
- * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the terminal-failure shape a channel hands to its
- * `onError`, the customer-facing default message for it, and the compact tool-arg summary and
- * humanized tool label for the live view. The preview LIFECYCLES stay per-platform (message edits vs streaming cards) — only
- * these platform-independent policies live here, so the customer-facing wording cannot drift
- * between channels.
+ * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the turn-view REDUCER (the one
+ * event → view-state machine every renderer consumes), its line renderers, the terminal-failure
+ * shape a channel hands to its `onError`, and the customer-facing wording for it. The preview
+ * LIFECYCLES stay per-platform — pumps, throttles, and delivery (message edits vs streaming cards
+ * vs chat.update) are real platform differences — but everything platform-independent lives here,
+ * so a new event type or a wording change lands in ONE place instead of one hunk per channel.
  */
-import type { Json } from "../agent.ts";
-import { truncateCodePointPrefix } from "./text.ts";
+import type { AgentEvent, Json } from "../agent.ts";
+import { truncateCodePointPrefix, truncateCodePointSuffix } from "./text.ts";
 
 /** A terminal failure, as a channel hands it to its `onError`. */
 export interface ChannelFailure {
@@ -28,6 +29,97 @@ export function defaultErrorMessage(failed: ChannelFailure): string {
 /** Customer-facing live-preview line for an engine-internal retry backoff (the advisory `retrying`
  *  event): neutral, no leaked internals — the reason stays in operator logs. */
 export const RETRY_NOTICE = "⏳ Temporary problem — retrying…";
+
+/** The placeholder shown before any reasoning/tool/text arrives. */
+export const THINKING_PLACEHOLDER = "💭 Thinking…";
+
+/** One tool call's line in the live view. */
+export interface ToolLine {
+  label: string;
+  status: "running" | "ok" | "error";
+}
+
+/**
+ * The channel-neutral view STATE of one in-flight turn. Renderers own everything after this state:
+ * when to reveal the young answer (age vs timer), how to format (HTML / card markdown / mrkdwn),
+ * and how to deliver frames. Terminal events are deliberately NOT view state — completed/failed
+ * resolve the preview into a final write, which is each platform's terminal-write policy.
+ */
+export interface TurnView {
+  thinking: string;
+  tools: ToolLine[];
+  /** tool-call id → its line, for `tool_ended` status flips (bookkeeping; renderers read `tools`). */
+  toolById: Map<string, ToolLine>;
+  answer: string;
+  /** Arrival time of the first non-empty answer delta; age-based reveal policies read it. */
+  answerSince?: number;
+  /** An advisory retry backoff is in progress (closed again by any subsequent progress event). */
+  retrying: boolean;
+}
+
+export function createTurnView(): TurnView {
+  return { thinking: "", tools: [], toolById: new Map(), answer: "", retrying: false };
+}
+
+/**
+ * Apply one event to the view state. Returns true when the view changed (the caller repaints).
+ * This is the ONE place the shared view rules live: tool labels are humanized with a compact arg
+ * summary, and any progress event closes an open retry notice (a stale "retrying" line must never
+ * outlive actual progress). Terminal events only close the notice — they are the caller's business.
+ */
+export function applyTurnEvent(view: TurnView, e: AgentEvent): boolean {
+  const closedRetry = view.retrying && e.type !== "retrying";
+  if (closedRetry) view.retrying = false;
+  switch (e.type) {
+    case "text":
+      view.answer += e.delta;
+      if (view.answerSince === undefined && view.answer.trim() !== "") view.answerSince = Date.now();
+      return true;
+    case "thinking":
+      view.thinking += e.delta;
+      return true;
+    case "tool_started": {
+      const arg = summarizeToolArgs(e.args);
+      const name = humanizeToolName(e.name);
+      const line: ToolLine = { label: arg ? `${name} ${arg}` : name, status: "running" };
+      view.tools.push(line);
+      view.toolById.set(e.id, line);
+      return true;
+    }
+    case "tool_ended": {
+      const line = view.toolById.get(e.id);
+      if (line) line.status = e.isError ? "error" : "ok";
+      return true;
+    }
+    case "retrying":
+      view.retrying = true;
+      return true;
+    default:
+      return closedRetry;
+  }
+}
+
+const TOOL_MARK = { running: "…", ok: "✓", error: "✗" } as const;
+
+/** The tool-activity block: one `🔧 label …/✓/✗` line per call, in call order. */
+export function toolLines(view: TurnView): string {
+  return view.tools.map((t) => `🔧 ${t.label} ${TOOL_MARK[t.status]}`).join("\n");
+}
+
+/** The reasoning peek: the most recent tail of the (growing) reasoning, one line, code-point safe.
+ *  Process, not the answer — renderers show it live only, never in the persisted final message. */
+export function thinkingLine(view: TurnView, maxTail: number): string {
+  const t = view.thinking.replace(/\s+/g, " ").trim();
+  return t === "" ? "" : `💭 ${truncateCodePointSuffix(t, maxTail)}`;
+}
+
+/** Compose body parts (thinking/tools/retry/answer) into one frame: skip empties, blank-line joins. */
+export function composeTurnBody(parts: readonly string[]): string {
+  return parts
+    .filter((s) => s.trim() !== "")
+    .join("\n\n")
+    .trim();
+}
 
 /** Max length (code points) of a tool's arg preview in the live view. */
 const TOOL_ARG_MAX = 48;

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -2,10 +2,11 @@
  * Channel-neutral live-preview pieces shared by every messaging channel's preview renderer
  * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the turn-view REDUCER (the one
  * event → view-state machine every renderer consumes), its line renderers, the terminal-failure
- * shape a channel hands to its `onError`, and the customer-facing wording for it. The preview
- * LIFECYCLES stay per-platform — pumps, throttles, and delivery (message edits vs streaming cards
- * vs chat.update) are real platform differences — but everything platform-independent lives here,
- * so a new event type or a wording change lands in ONE place instead of one hunk per channel.
+ * shape a channel hands to its `onError`, the customer-facing wording for it, and the serialized
+ * single-writer pump. DELIVERY stays per-platform — message edits vs streaming cards vs chat.update,
+ * pacing constants, reveal timing, and terminal-write policies are real platform differences — but
+ * everything platform-independent lives here, so a new event type or a wording change lands in ONE
+ * place instead of one hunk per channel.
  */
 import type { AgentEvent, Json } from "../agent.ts";
 import { truncateCodePointPrefix, truncateCodePointSuffix } from "./text.ts";
@@ -133,6 +134,80 @@ export function composeTurnBody(parts: readonly string[]): string {
     .filter((s) => s.trim() !== "")
     .join("\n\n")
     .trim();
+}
+
+/**
+ * The serialized live-preview writer shared by the edit/snapshot renderers (telegram, feishu).
+ * Events mark the view dirty; the pump repaints to the LATEST view with at most ONE write in
+ * flight, paced by `throttleMs`. One-in-flight is the whole point: concurrent writes can land out
+ * of order — an older frame over a newer one is the "shows 3-4 steps, blanks, re-fills" flicker —
+ * so a single writer keeps frames monotonic (and makes feishu's strictly-increasing card `sequence`
+ * correct by construction). NOT used by slack-classic: its pacing lives inside the flush (the 3s
+ * chat.update rate slot), not at the frame boundary.
+ */
+export interface PreviewPump {
+  /** Mark the view dirty and ensure the single writer runs (an in-flight write picks the new state
+   *  up on its next loop). Synchronous — callers never await a network write. */
+  touch(): void;
+  /** Stop the pump, cut an in-flight throttle short, and await any in-flight write — so the
+   *  caller's terminal write is strictly the LAST one (no stale frame landing after the answer). */
+  finish(): Promise<void>;
+}
+
+export function createPreviewPump(opts: {
+  /** Write the LATEST view. Best-effort — the terminal write is authoritative. */
+  flush: () => Promise<void>;
+  /** Pace + coalesce a burst into one write; finish() interrupts a throttle in progress. */
+  throttleMs: number;
+  /** Called for the FIRST failing flush only (the pump keeps running): a never-rendering preview
+   *  must be diagnosable, not silent — and not a log flood. */
+  onError: (error: unknown) => void;
+}): PreviewPump {
+  let dirty = false;
+  let pumping = false;
+  let stopped = false;
+  let errored = false;
+  let pumpDone: Promise<void> | undefined;
+  let wakeThrottle: (() => void) | undefined; // set while mid-throttle; finish() cuts it short
+  const runPump = async (): Promise<void> => {
+    pumping = true;
+    try {
+      while (dirty && !stopped) {
+        dirty = false;
+        try {
+          await opts.flush();
+        } catch (error) {
+          if (!errored) {
+            errored = true;
+            opts.onError(error);
+          }
+        }
+        if (dirty && !stopped) {
+          await new Promise<void>((resolve) => {
+            const t = setTimeout(resolve, opts.throttleMs);
+            wakeThrottle = () => {
+              clearTimeout(t);
+              resolve();
+            };
+          });
+          wakeThrottle = undefined;
+        }
+      }
+    } finally {
+      pumping = false;
+    }
+  };
+  return {
+    touch() {
+      dirty = true;
+      if (!pumping) pumpDone = runPump();
+    },
+    async finish() {
+      stopped = true;
+      wakeThrottle?.();
+      await pumpDone?.catch(() => {});
+    },
+  };
 }
 
 /** Max length (code points) of a tool's arg preview in the live view. */

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -113,6 +113,20 @@ export function thinkingLine(view: TurnView, maxTail: number): string {
   return t === "" ? "" : `💭 ${truncateCodePointSuffix(t, maxTail)}`;
 }
 
+/**
+ * The shared answer-reveal policy: the answer stays hidden until its first delta has aged one
+ * throttle window (`ageMs` — each platform passes its own pacing constant). The pump's leading-edge
+ * flush would otherwise turn the very first content delta (often a lone character or unbalanced
+ * markup) into its own frame — the short-reply flicker (placeholder → "O" → "OK."). Aging is
+ * anchored at delta ARRIVAL (`answerSince`, set by the reducer) so an in-flight write can't skew the
+ * clock, and there is deliberately NO timer at the boundary: a young answer surfaces on the next
+ * content-driven pass, so a turn completing within the window delivers the final answer only.
+ */
+export function revealedAnswer(view: TurnView, ageMs: number): string {
+  if (view.answer.trim() === "" || view.answerSince === undefined) return "";
+  return Date.now() - view.answerSince >= ageMs ? view.answer : "";
+}
+
 /** Compose body parts (thinking/tools/retry/answer) into one frame: skip empties, blank-line joins. */
 export function composeTurnBody(parts: readonly string[]): string {
   return parts

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -10,6 +10,7 @@ import {
   createTurnView,
   defaultErrorMessage,
   humanizeToolName,
+  revealedAnswer,
   toolLines,
 } from "../preview-kit.ts";
 import {
@@ -99,13 +100,10 @@ async function streamClassicSlackReply(
   disclaimer: string | false | undefined,
   label: string,
 ): Promise<void> {
-  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
-  // policy (timer-based — chat.update has no per-frame pacing beyond the 3s interval), mrkdwn
-  // sanitizing, and delivery. Reasoning stays a static "Thinking…" here: raw chain-of-thought is not
+  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns mrkdwn
+  // sanitizing and delivery. Reasoning stays a static "Thinking…" here: raw chain-of-thought is not
   // customer-facing on Slack, so the reducer accumulates it but this view never reads it.
   const turn = createTurnView();
-  let answerVisible = false;
-  let answerTimer: ReturnType<typeof setTimeout> | undefined;
   let previewTs = initialPreviewTs;
   let previewAttempted = previewTs !== undefined;
   let finalized = false;
@@ -122,7 +120,7 @@ async function streamClassicSlackReply(
       THINKING_PLACEHOLDER,
       toolLines(turn),
       turn.retrying ? RETRY_NOTICE : "",
-      answerVisible ? sanitizeSlackMarkdown(turn.answer) : "",
+      sanitizeSlackMarkdown(revealedAnswer(turn, CLASSIC_UPDATE_INTERVAL_MS)),
     ]);
   const waitForMutationSlot = async (): Promise<void> => {
     const remaining = lastMutationAt + CLASSIC_UPDATE_INTERVAL_MS - Date.now();
@@ -170,7 +168,6 @@ async function streamClassicSlackReply(
   };
   const finishPump = async (): Promise<void> => {
     stopped = true;
-    if (answerTimer) clearTimeout(answerTimer);
     await pumpDone?.catch(() => {});
   };
   const finalize = async (markdown: string): Promise<void> => {
@@ -195,19 +192,10 @@ async function streamClassicSlackReply(
         throw new Error(`agent failed: ${event.details} (retryable=${event.retryable})`);
       }
       const changed = applyTurnEvent(turn, event);
-      if (event.type === "text" && !answerVisible) {
-        // Reveal-on-timer: the first delta arms a one-shot that flips the answer visible and repaints;
-        // hidden deltas need no repaint of their own.
-        if (answerTimer === undefined) {
-          answerTimer = setTimeout(() => {
-            answerVisible = true;
-            answerTimer = undefined;
-            touch();
-          }, CLASSIC_UPDATE_INTERVAL_MS);
-        }
-      } else if (changed) {
-        touch();
-      }
+      // A young (hidden) answer must not trigger the first frame: unlike telegram/feishu, classic
+      // rendering never posts an upfront placeholder, so a text-only fast turn delivers ONE final
+      // post instead of placeholder → 3s-rate-limited edit. Thinking/tool activity still paints.
+      if (changed && (event.type !== "text" || revealedAnswer(turn, CLASSIC_UPDATE_INTERVAL_MS) !== "")) touch();
     }
     throw new Error("stream ended without a terminal event");
   } finally {

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -1,7 +1,17 @@
 /** Slack reply rendering: native Agent streams first, rate-safe edited-message compatibility second. */
 import type { AgentEvent } from "../../agent.ts";
 import { log } from "../../log.ts";
-import { RETRY_NOTICE, type ChannelFailure, defaultErrorMessage, humanizeToolName } from "../preview-kit.ts";
+import {
+  RETRY_NOTICE,
+  THINKING_PLACEHOLDER,
+  type ChannelFailure,
+  applyTurnEvent,
+  composeTurnBody,
+  createTurnView,
+  defaultErrorMessage,
+  humanizeToolName,
+  toolLines,
+} from "../preview-kit.ts";
 import {
   type SlackApi,
   type SlackStreamChunk,
@@ -89,10 +99,11 @@ async function streamClassicSlackReply(
   disclaimer: string | false | undefined,
   label: string,
 ): Promise<void> {
-  const tools: { name: string; status: "running" | "ok" | "error" }[] = [];
-  const toolIndex = new Map<string, number>();
-  let answer = "";
-  let retryNotice = false;
+  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
+  // policy (timer-based — chat.update has no per-frame pacing beyond the 3s interval), mrkdwn
+  // sanitizing, and delivery. Reasoning stays a static "Thinking…" here: raw chain-of-thought is not
+  // customer-facing on Slack, so the reducer accumulates it but this view never reads it.
+  const turn = createTurnView();
   let answerVisible = false;
   let answerTimer: ReturnType<typeof setTimeout> | undefined;
   let previewTs = initialPreviewTs;
@@ -106,13 +117,13 @@ async function streamClassicSlackReply(
   let pumpDone: Promise<void> | undefined;
   let previewErrorLogged = false;
 
-  const toolView = (): string =>
-    tools.map((tool) => `🔧 ${tool.name} ${{ running: "…", ok: "✓", error: "✗" }[tool.status]}`).join("\n");
   const view = (): string =>
-    ["💭 Thinking…", toolView(), retryNotice ? RETRY_NOTICE : "", answerVisible ? sanitizeSlackMarkdown(answer) : ""]
-      .filter((value) => value.trim())
-      .join("\n\n")
-      .trim();
+    composeTurnBody([
+      THINKING_PLACEHOLDER,
+      toolLines(turn),
+      turn.retrying ? RETRY_NOTICE : "",
+      answerVisible ? sanitizeSlackMarkdown(turn.answer) : "",
+    ]);
   const waitForMutationSlot = async (): Promise<void> => {
     const remaining = lastMutationAt + CLASSIC_UPDATE_INTERVAL_MS - Date.now();
     if (remaining > 0) await wait(remaining);
@@ -123,7 +134,7 @@ async function streamClassicSlackReply(
     lastMutationAt = Date.now();
   };
   const flushPreview = async (): Promise<void> => {
-    const markdown = chunkSlackText(view())[0] ?? "💭 Thinking…";
+    const markdown = chunkSlackText(view())[0] ?? THINKING_PLACEHOLDER;
     if (markdown === lastSent) return;
     if (previewTs) {
       await updateRateSafe(previewTs, markdown);
@@ -168,40 +179,13 @@ async function streamClassicSlackReply(
 
   try {
     for await (const event of events) {
-      if (event.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
-      if (event.type === "text") {
-        answer += event.delta;
-        if (!answerVisible && answerTimer === undefined) {
-          answerTimer = setTimeout(() => {
-            answerVisible = true;
-            answerTimer = undefined;
-            touch();
-          }, CLASSIC_UPDATE_INTERVAL_MS);
-        } else if (answerVisible) {
-          touch();
-        }
-      } else if (event.type === "thinking") {
-        // Raw model reasoning is not customer-facing. A static loading state communicates progress
-        // without leaking chain-of-thought or prompt data.
-        touch();
-      } else if (event.type === "tool_started") {
-        toolIndex.set(event.id, tools.length);
-        tools.push({ name: humanizeToolName(event.name), status: "running" });
-        touch();
-      } else if (event.type === "tool_ended") {
-        const index = toolIndex.get(event.id);
-        if (index !== undefined && tools[index]) tools[index].status = event.isError ? "error" : "ok";
-        touch();
-      } else if (event.type === "retrying") {
-        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
-        retryNotice = true;
-        touch();
-      } else if (event.type === "completed") {
+      if (event.type === "completed") {
         await finishPump();
         finalized = true;
-        await finalize(withDisclaimer(answer, disclaimer));
+        await finalize(withDisclaimer(turn.answer, disclaimer));
         return;
-      } else if (event.type === "failed") {
+      }
+      if (event.type === "failed") {
         await finishPump();
         finalized = true;
         const notice = formatError({ details: event.details, retryable: event.retryable }) ?? "";
@@ -209,6 +193,20 @@ async function streamClassicSlackReply(
           log.error(`${label} failed to deliver the agent-failure notice: ${String(error)}`),
         );
         throw new Error(`agent failed: ${event.details} (retryable=${event.retryable})`);
+      }
+      const changed = applyTurnEvent(turn, event);
+      if (event.type === "text" && !answerVisible) {
+        // Reveal-on-timer: the first delta arms a one-shot that flips the answer visible and repaints;
+        // hidden deltas need no repaint of their own.
+        if (answerTimer === undefined) {
+          answerTimer = setTimeout(() => {
+            answerVisible = true;
+            answerTimer = undefined;
+            touch();
+          }, CLASSIC_UPDATE_INTERVAL_MS);
+        }
+      } else if (changed) {
+        touch();
       }
     }
     throw new Error("stream ended without a terminal event");

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -6,6 +6,7 @@ import { log } from "../../log.ts";
 import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../seen.ts";
+import { createTaskTracker } from "../tasks.ts";
 import { ensureStateHome } from "../state.ts";
 import { dispatchStop, isStopText } from "../stop-command.ts";
 import { codePointPrefix } from "../text.ts";
@@ -484,13 +485,11 @@ export function slackChannel({
       if (isStopText((event.text ?? "").replace(/<@[A-Z0-9]+>/gi, " "))) {
         seen.add(logicalId);
         const target: SlackTarget = { channelId: event.channel, threadTs: event.thread_ts };
-        const stop: Promise<void> = dispatchStop(control, routed.session ?? defaultSession, label)
-          .then((feedback) => api.postMessage(target, feedback).then(() => undefined))
-          .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`))
-          .finally(() => {
-            stops.delete(stop);
-          });
-        stops.add(stop);
+        sideTasks.track(
+          dispatchStop(control, routed.session ?? defaultSession, label)
+            .then((feedback) => api.postMessage(target, feedback).then(() => undefined))
+            .catch((error) => log.warn(`${label} stop feedback failed: ${String(error)}`)),
+        );
         return;
       }
       const fileIds = slackFileIds(event);
@@ -537,11 +536,11 @@ export function slackChannel({
       );
     };
 
-    const stops = new Set<Promise<void>>();
+    // Side tasks (stop feedback, DM welcomes) run off the ACK path but drain in turnsIdle.
+    const sideTasks = createTaskTracker();
 
     // First-run DM welcome: app_home_opened(tab="messages") signals a DM open. Post once per user.
     const welcomeInFlight = new Set<string>();
-    const welcomes = new Set<Promise<void>>();
     const maybeWelcome = (envelope: SlackEventEnvelope): void => {
       if (welcome === false) return;
       const body = welcome.trim();
@@ -559,20 +558,20 @@ export function slackChannel({
       // Reserve in-memory so rapid re-opens don't double-post; persist to the durable set only on a
       // successful post, so a failed post simply retries on the next open.
       welcomeInFlight.add(id);
-      const promise = api
-        .postMarkdown({ channelId }, body)
-        .then(() => {
-          welcomed.add(teamId, userId);
-          log.info(`${label} sent first-run welcome to ${id}`);
-        })
-        .catch((error) =>
-          log.warn(`${label} could not send first-run welcome (retries on next open): ${String(error)}`),
-        )
-        .finally(() => {
-          welcomeInFlight.delete(id);
-          welcomes.delete(promise);
-        });
-      welcomes.add(promise);
+      sideTasks.track(
+        api
+          .postMarkdown({ channelId }, body)
+          .then(() => {
+            welcomed.add(teamId, userId);
+            log.info(`${label} sent first-run welcome to ${id}`);
+          })
+          .catch((error) =>
+            log.warn(`${label} could not send first-run welcome (retries on next open): ${String(error)}`),
+          )
+          .finally(() => {
+            welcomeInFlight.delete(id);
+          }),
+      );
     };
 
     const handler = async (request: Request): Promise<Response> => {
@@ -608,7 +607,7 @@ export function slackChannel({
       return new Response(null, { status: 200 });
     };
     (handler as typeof handler & { turnsIdle?: () => Promise<void> }).turnsIdle = () =>
-      Promise.all([queue.idle(), ...welcomes, ...stops]).then(() => undefined);
+      Promise.all([queue.idle(), sideTasks.drain()]).then(() => undefined);
     return { "POST /slack": handler };
   };
 }

--- a/src/channels/tasks.ts
+++ b/src/channels/tasks.ts
@@ -1,0 +1,23 @@
+/**
+ * SHARED fire-and-forget side-task tracking. Channels launch work off the request path (stop
+ * feedback, DM welcomes) that must not block the transport ACK but MUST be drained on shutdown
+ * (`turnsIdle`) — otherwise a reply in flight when the process exits is silently dropped. Error
+ * handling stays with the caller: track() only guarantees the drain sees the task settle.
+ */
+export interface TaskTracker {
+  /** Track one task. The caller keeps its own `.catch` — rejections must already be handled. */
+  track(task: Promise<unknown>): void;
+  /** Resolves when every currently-tracked task has settled. */
+  drain(): Promise<void>;
+}
+
+export function createTaskTracker(): TaskTracker {
+  const tasks = new Set<Promise<unknown>>();
+  return {
+    track(task) {
+      tasks.add(task);
+      void task.finally(() => tasks.delete(task)).catch(() => {}); // the caller's chain owns the error
+    },
+    drain: () => Promise.all(tasks).then(() => undefined),
+  };
+}

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -14,6 +14,7 @@ import {
   composeTurnBody,
   createTurnView,
   defaultErrorMessage,
+  revealedAnswer,
   thinkingLine,
   toolLines,
 } from "../preview-kit.ts";
@@ -91,22 +92,12 @@ export async function streamReply(
   // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
   // policy, formatting, and delivery below.
   const turn = createTurnView();
-  // The answer is hidden until its first delta has aged one EDIT_THROTTLE_MS: the pump's leading-edge
-  // flush would otherwise turn the very first content delta (often a lone character or unbalanced markup)
-  // into its own Telegram edit — the short-reply flicker (placeholder → "O" → "OK."). Aging is anchored
-  // at delta ARRIVAL (answerSince, set by the reducer) so an in-flight edit can't skew the clock, and
-  // there is deliberately NO timer at the boundary: a young answer surfaces on the next content-driven
-  // preview pass, so a turn completing within the window sends the final answer edit only.
-  const answerView = (): string => {
-    if (turn.answer.trim() === "" || turn.answerSince === undefined) return "";
-    return Date.now() - turn.answerSince >= EDIT_THROTTLE_MS ? turn.answer : "";
-  };
   const view = (): string => {
     const v = composeTurnBody([
       thinkingLine(turn, THINKING_PREVIEW),
       toolLines(turn),
       turn.retrying ? RETRY_NOTICE : "",
-      answerView(),
+      revealedAnswer(turn, EDIT_THROTTLE_MS),
     ]);
     // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
     return v === "" ? THINKING_PLACEHOLDER : v;

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -8,10 +8,14 @@
 import type { AgentEvent } from "../../agent.ts";
 import {
   RETRY_NOTICE,
+  THINKING_PLACEHOLDER,
   type ChannelFailure,
+  applyTurnEvent,
+  composeTurnBody,
+  createTurnView,
   defaultErrorMessage,
-  humanizeToolName,
-  summarizeToolArgs,
+  thinkingLine,
+  toolLines,
 } from "../preview-kit.ts";
 import { log } from "../../log.ts";
 import { TELEGRAM_MAX_TEXT, type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
@@ -84,39 +88,28 @@ export async function streamReply(
   formatError: (failed: TelegramFailure) => string | undefined,
   previewId?: number,
 ): Promise<void> {
-  const tools: { label: string; status: "running" | "ok" | "error" }[] = [];
-  const toolIndexById = new Map<string, number>();
-  let thinking = "";
-  let answer = "";
-  let answerPreviewSince: number | undefined;
-  let retryNotice = false;
-
-  const mark = { running: "…", ok: "✓", error: "✗" } as const;
-  const toolView = (): string => tools.map((t) => `🔧 ${t.label} ${mark[t.status]}`).join("\n");
-  // Reasoning is process, not the answer: shown (capped to its tail) in the live preview only, never
-  // in the persisted final message (which is `answer` alone).
-  const thinkingView = (): string => {
-    const t = thinking.replace(/\s+/g, " ").trim();
-    if (t === "") return "";
-    return `💭 ${t.length > THINKING_PREVIEW ? `…${t.slice(t.length - THINKING_PREVIEW + 1)}` : t}`;
-  };
+  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
+  // policy, formatting, and delivery below.
+  const turn = createTurnView();
   // The answer is hidden until its first delta has aged one EDIT_THROTTLE_MS: the pump's leading-edge
   // flush would otherwise turn the very first content delta (often a lone character or unbalanced markup)
   // into its own Telegram edit — the short-reply flicker (placeholder → "O" → "OK."). Aging is anchored
-  // at delta ARRIVAL (set in the event loop, not here) so an in-flight edit can't skew the clock, and
+  // at delta ARRIVAL (answerSince, set by the reducer) so an in-flight edit can't skew the clock, and
   // there is deliberately NO timer at the boundary: a young answer surfaces on the next content-driven
   // preview pass, so a turn completing within the window sends the final answer edit only.
   const answerView = (): string => {
-    if (answer.trim() === "" || answerPreviewSince === undefined) return "";
-    return Date.now() - answerPreviewSince >= EDIT_THROTTLE_MS ? answer : "";
+    if (turn.answer.trim() === "" || turn.answerSince === undefined) return "";
+    return Date.now() - turn.answerSince >= EDIT_THROTTLE_MS ? turn.answer : "";
   };
   const view = (): string => {
-    const v = [thinkingView(), toolView(), retryNotice ? RETRY_NOTICE : "", answerView()]
-      .filter((s) => s.trim() !== "")
-      .join("\n\n")
-      .trim();
+    const v = composeTurnBody([
+      thinkingLine(turn, THINKING_PREVIEW),
+      toolLines(turn),
+      turn.retrying ? RETRY_NOTICE : "",
+      answerView(),
+    ]);
     // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
-    return v === "" ? "💭 Thinking…" : v;
+    return v === "" ? THINKING_PLACEHOLDER : v;
   };
 
   // The live preview is ONE real message: sent once (capturing its id + threading under the asker),
@@ -209,39 +202,17 @@ export async function streamReply(
 
   try {
     for await (const e of events) {
-      if (e.type !== "retrying") retryNotice = false; // any progress closes the advisory backoff notice
-      if (e.type === "text") {
-        answer += e.delta;
-        if (answerPreviewSince === undefined && answer.trim() !== "") answerPreviewSince = Date.now();
-        touch();
-      } else if (e.type === "thinking") {
-        thinking += e.delta;
-        touch();
-      } else if (e.type === "tool_started") {
-        const arg = summarizeToolArgs(e.args);
-        toolIndexById.set(e.id, tools.length);
-        const name = humanizeToolName(e.name);
-        tools.push({ label: arg ? `${name} ${arg}` : name, status: "running" });
-        touch();
-      } else if (e.type === "tool_ended") {
-        const i = toolIndexById.get(e.id);
-        const t = i === undefined ? undefined : tools[i];
-        if (t) t.status = e.isError ? "error" : "ok";
-        touch();
-      } else if (e.type === "retrying") {
-        // Summarization retry backoff — up to ~14s of quiet that would otherwise read as a hang.
-        retryNotice = true;
-        touch();
-      } else if (e.type === "completed") {
+      if (e.type === "completed") {
         await finish();
         // Edit the preview into the final answer (HTML, plain fallback); the persisted message is the
         // answer alone — the process (thinking/tools) was preview-only. Mark finalized BEFORE delivering:
         // the terminal was reached, so a delivery failure here is a plain failure, not an "abnormal exit"
         // (which would wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
         finalized = true;
-        await finalize(api, botToken, target, messageId, answer.trim() !== "" ? answer : "(no reply)");
+        await finalize(api, botToken, target, messageId, turn.answer.trim() !== "" ? turn.answer : "(no reply)");
         return;
-      } else if (e.type === "failed") {
+      }
+      if (e.type === "failed") {
         await finish();
         // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
         // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
@@ -256,6 +227,7 @@ export async function streamReply(
         }
         throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
       }
+      if (applyTurnEvent(turn, e)) touch();
     }
     throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
   } finally {

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -12,6 +12,7 @@ import {
   type ChannelFailure,
   applyTurnEvent,
   composeTurnBody,
+  createPreviewPump,
   createTurnView,
   defaultErrorMessage,
   revealedAnswer,
@@ -129,67 +130,15 @@ export async function streamReply(
       throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
   };
 
-  // ── Live-preview pump: a SINGLE serialized writer. ──────────────────────────────────────────
-  // Events mutate state (thinking / tools / answer) and mark the preview dirty; the pump edits the
-  // message to the LATEST view() with at most ONE edit in flight, paced by a throttle. One-in-flight is
-  // the whole point: concurrent edits can reach Telegram out of order — an older frame landing over a
-  // newer one is the "shows 3-4 steps, blanks, re-fills" flicker. Serializing keeps frames monotonic.
-  // (No keepalive: a real message does not expire, unlike a Bot API `sendMessageDraft` (30s window).)
-  let dirty = false;
-  let pumping = false;
-  let stopped = false;
-  let previewErrLogged = false;
-  let pumpDone: Promise<void> | undefined;
-  let wakeThrottle: (() => void) | undefined; // set while the pump is mid-throttle; finish() cuts it short
-
-  const runPump = async (): Promise<void> => {
-    pumping = true;
-    try {
-      while (dirty && !stopped) {
-        dirty = false;
-        try {
-          await flushPreview();
-        } catch (e) {
-          // Best-effort preview (the final write is authoritative), but a failing edit must be visible —
-          // log once per turn so a never-rendering preview is diagnosable, not silent.
-          if (!previewErrLogged) {
-            previewErrLogged = true;
-            log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`);
-          }
-        }
-        if (dirty && !stopped) {
-          // Pace + coalesce a burst into one edit. Interruptible: finish() cuts this short so the final
-          // write is not delayed by up to EDIT_THROTTLE_MS after the turn completes.
-          await new Promise<void>((resolve) => {
-            const t = setTimeout(resolve, EDIT_THROTTLE_MS);
-            wakeThrottle = () => {
-              clearTimeout(t);
-              resolve();
-            };
-          });
-          wakeThrottle = undefined;
-        }
-      }
-    } finally {
-      pumping = false;
-    }
-  };
-  // Mark the preview dirty and ensure the single writer is running (an edit already in flight picks up
-  // the new state on its next loop). Synchronous — callers never await a network write.
-  const touch = (): void => {
-    dirty = true;
-    if (!pumping) pumpDone = runPump();
-  };
+  // The shared single-writer pump (preview-kit) serializes edits to the one preview message. (No
+  // keepalive: a real message does not expire, unlike a Bot API `sendMessageDraft` (30s window).)
+  const { touch, finish } = createPreviewPump({
+    flush: flushPreview,
+    throttleMs: EDIT_THROTTLE_MS,
+    onError: (e) => log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`),
+  });
 
   touch(); // send the "💭 Thinking…" placeholder immediately
-
-  // Stop the pump and await any in-flight edit, so the final write below is strictly the LAST one to the
-  // preview message (no stale frame landing after the answer).
-  const finish = async (): Promise<void> => {
-    stopped = true;
-    wakeThrottle?.(); // cut an in-flight throttle so the final write is not delayed up to EDIT_THROTTLE_MS
-    await pumpDone?.catch(() => {});
-  };
 
   try {
     for await (const e of events) {

--- a/test/preview-kit.test.ts
+++ b/test/preview-kit.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { defaultErrorMessage, humanizeToolName } from "../src/channels/preview-kit.ts";
+import type { AgentEvent } from "../src/agent.ts";
+import {
+  applyTurnEvent,
+  composeTurnBody,
+  createTurnView,
+  defaultErrorMessage,
+  humanizeToolName,
+  thinkingLine,
+  toolLines,
+} from "../src/channels/preview-kit.ts";
 
 describe("humanizeToolName", () => {
   it("splits an mcp identifier into server: tool", () => {
@@ -42,5 +51,54 @@ describe("defaultErrorMessage", () => {
     // The shared "something went wrong" phrase is preserved verbatim (cross-channel wording contract).
     expect(message).toMatch(/something went wrong/i);
     expect(message).toMatch(/rephrasing|access/i);
+  });
+});
+
+describe("turn-view reducer", () => {
+  const apply = (events: AgentEvent[]) => {
+    const view = createTurnView();
+    const changes = events.map((e) => applyTurnEvent(view, e));
+    return { view, changes };
+  };
+
+  it("reduces a full turn: humanized+arg'd tool lines, status flips, answer accumulation", () => {
+    const { view } = apply([
+      { type: "thinking", delta: "hm " },
+      { type: "tool_started", id: "t1", name: "read", args: { path: "AGENTS.md" } },
+      { type: "tool_started", id: "t2", name: "mcp__github__create_issue", args: {} },
+      { type: "tool_ended", id: "t1", isError: false, content: null },
+      { type: "tool_ended", id: "t2", isError: true, content: null },
+      { type: "text", delta: "ok" },
+    ]);
+    expect(toolLines(view)).toBe("🔧 Read AGENTS.md ✓\n🔧 Github: create issue ✗");
+    expect(view.answer).toBe("ok");
+    expect(view.answerSince).toBeDefined();
+    expect(view.thinking).toBe("hm ");
+  });
+
+  it("opens the retry notice and closes it on ANY subsequent event, including terminals", () => {
+    const retrying = { type: "retrying", attempt: 1, maxAttempts: 4, delayMs: 1000, reason: "503" } as const;
+    const { view, changes } = apply([retrying, { type: "completed" }]);
+    expect(changes).toEqual([true, true]); // the close is a view change even on a terminal
+    expect(view.retrying).toBe(false);
+    const open = apply([retrying]);
+    expect(open.view.retrying).toBe(true);
+  });
+
+  it("a terminal without an open notice is not a view change", () => {
+    const { changes } = apply([{ type: "completed" }]);
+    expect(changes).toEqual([false]);
+  });
+
+  it("thinkingLine takes a code-point-safe tail and collapses whitespace", () => {
+    const view = createTurnView();
+    applyTurnEvent(view, { type: "thinking", delta: `a\nb  ${"🐍".repeat(10)}` });
+    expect(thinkingLine(view, 6)).toBe("💭 …🐍🐍🐍🐍🐍"); // marker + 5 points, no torn surrogate
+    expect(thinkingLine(createTurnView(), 6)).toBe("");
+  });
+
+  it("composeTurnBody skips empty parts and joins with blank lines", () => {
+    expect(composeTurnBody(["a", "", "  ", "b"])).toBe("a\n\nb");
+    expect(composeTurnBody(["", " "])).toBe("");
   });
 });

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createTaskTracker } from "../src/channels/tasks.ts";
+
+describe("createTaskTracker", () => {
+  it("drain waits for tracked tasks; settled tasks drop out", async () => {
+    const tracker = createTaskTracker();
+    let done = false;
+    let release!: () => void;
+    tracker.track(
+      new Promise<void>((resolve) => {
+        release = resolve;
+      }).then(() => {
+        done = true;
+      }),
+    );
+    const drain = tracker.drain();
+    release();
+    await drain;
+    expect(done).toBe(true);
+    await tracker.drain(); // empty after settle — drains immediately
+  });
+
+  it("a rejected (caller-handled) task still settles the drain", async () => {
+    const tracker = createTaskTracker();
+    tracker.track(Promise.reject(new Error("boom")).catch(() => "handled"));
+    await expect(tracker.drain()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

#267 and #270 were the evidence: every preview-semantics change (humanized tool labels, the retry notice) landed as one structurally identical hunk per channel — telegram, feishu, and slack-classic each hand-wrote the same event → view-state machine. This PR moves that machine into `preview-kit` so the next event type or wording rule lands in ONE place.

## What

- **`preview-kit`: turn-view reducer.** `createTurnView`/`applyTurnEvent` own the shared view rules (tool-line labeling with humanize + arg summary, retry-notice open/close-on-progress, answer/thinking accumulation, `answerSince` for age-based reveal). `toolLines`/`thinkingLine`/`composeTurnBody` render the shared line formats, and `revealedAnswer` is the one answer-reveal policy (age-based; each platform passes its pacing constant). `createPreviewPump` is the one implementation of the single-writer pump (telegram's and feishu's were line-for-line copies of subtle one-in-flight concurrency). Delivery, pacing constants, formatting (HTML / card markdown / mrkdwn), and terminal-write policies stay per-platform — those are real platform differences, deliberately not abstracted. slack-classic keeps its own loop (pacing lives inside the flush, not at the frame boundary). Slack-native keeps its hand-written status-line renderer (no composed text view).
- **`channels/tasks.ts`: side-task tracker.** `createTaskTracker().track/drain` replaces the bespoke promise-Set bookkeeping slack (stops + welcomes) and feishu (stops) each hand-rolled for turnsIdle drain.

## Deliberate alignments (behavior changes)

- slack-classic tool lines now include the compact arg summary (`🔧 Read AGENTS.md …`) — it was the only renderer without it; the shared placement makes wording drift impossible.
- telegram's thinking tail now truncates code-point-safe (its `slice` could tear a surrogate pair mid-emoji).
- slack-classic's answer reveal moves from a 3s timer to the shared age-based policy (deleting its `answerVisible`/`answerTimer` machinery). Its one real difference stays explicit: no upfront placeholder — a text-only fast turn still delivers ONE final post. Named trade-off: a stream stalling right after its first delta reveals on the next event rather than at exactly 3s (the semantics telegram/feishu already had).

## Stacked on

#267, #270, #271 (branch contains merge commits of all three; the real diff is the last commit). Rebase + un-draft after they land.



---
_Superseding #272 (its head SHA was stuck on GitHub after rebase; branch content identical)._
