### PR TITLE
fix(slack)!: stream inline tool traces in native streaming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ src/
 │   │   ├── telegram-api.ts  # the single Bot API pipeline + HTML-aware split
 │   │   ├── register-webhook.ts # --tunnel setWebhook registration
 │   │   └── scaffold/        # `add telegram` bundle (channel.ts + send tool)
-│   ├── slack/               # Slack Agent: native streams/tasks, rotating bot auth, signed Events API ingress, durable threads/context, files + onboarding/scaffold
+│   ├── slack/               # Slack Agent: native streams + inline tool traces, rotating bot auth, signed Events API ingress, durable threads/context, files + onboarding/scaffold
 │   ├── feishu/              # CANONICAL Feishu channel engine — see docs/design/core.md
 │   │   ├── feishu.ts        # ingress + per-turn lifecycle + composition; Lark binds this engine via a profile
 │   │   ├── cloud.ts         # explicit Feishu-reference / Lark-compatibility capability profiles

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -156,7 +156,7 @@ export default slackChannel({
     ? Number(process.env.SLACK_BOT_TOKEN_EXPIRES_AT)
     : undefined,
   groupBehavior: "context", // default; choose "mentions" only for explicit least privilege
-  rendering: "native", // Slack Agent streams/tasks; "classic" for compatibility
+  rendering: "native", // Slack Agent stream with inline tool traces; "classic" for compatibility
   // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
   // Direct/group asks default to independent sessions + Slack threads; opt out independently:
   // directMessageSession: "continuous",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -246,7 +246,7 @@ are the enable/disable source of truth.
 Slack scaffolds `channels/slack.ts` plus `tools/slack-send.ts`; `--group-behavior context|mentions`
 selects both runtime policy and manifest scopes/events, defaulting to context-aware `context`; choose
 `mentions` explicitly for least privilege. By default it opens Slack's App Configuration Token page,
-creates a new internal app with `agent_view`, native streams/tasks, and suggested prompts through
+creates a new internal app with `agent_view`, native Agent streaming, and suggested prompts through
 `apps.manifest.create`, installs it
 through OAuth, and writes rotating bot credentials + the Signing Secret to the gitignored `.env`. The configuration refresh token stays owner-readable
 under `<state root>/channels/slack/` and is used locally by `dev --tunnel` / `deploy --run` to update the

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -277,8 +277,9 @@ upload three-step protocol and remains at-least-once across an ambiguous complet
 
 Newly onboarded apps use Slack's `agent_view`, `assistant:write`, token rotation, suggested prompts, Agent
 status/title, and `chat.startStream` → `chat.appendStream` → `chat.stopStream`. Standard Markdown text events append to
-the stream; engine-neutral tool lifecycle events become dense `task_update` chunks. Raw model thinking and
-generic tool arguments stay private. The compatibility renderer retains one edited message with a strict
+the stream; engine-neutral tool lifecycle events become `task_update` chunks with a compact argument
+summary and, on failure, a bounded result summary. Raw model thinking and successful tool output stay
+private. The compatibility renderer retains one edited message with a strict
 three-second mutation interval; explicit continuous/custom top-level routes select it because native
 streams require a parent user message. HTTP Events API remains the production transport; Socket Mode is a
 separate future boundary rather than entering `ChannelModule` indirectly.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -278,9 +278,8 @@ upload three-step protocol and remains at-least-once across an ambiguous complet
 Newly onboarded apps use Slack's `agent_view`, `assistant:write`, token rotation, suggested prompts, Agent
 status/title, and `chat.startStream` → `chat.appendStream` → `chat.stopStream`. Standard Markdown text events append to
 the stream; engine-neutral tool lifecycle events become `task_update` chunks with a compact argument
-summary and, on failure, a bounded result summary. Timeline is the default because Slack's compact
-plan/dense blocks persist only task title/status; those modes fold the argument summary into the title.
-Raw model thinking and successful tool output stay private. The compatibility renderer retains one edited message with a strict
+summary and, on failure, a bounded result summary. Raw model thinking and successful tool output stay
+private. The compatibility renderer retains one edited message with a strict
 three-second mutation interval; explicit continuous/custom top-level routes select it because native
 streams require a parent user message. HTTP Events API remains the production transport; Socket Mode is a
 separate future boundary rather than entering `ChannelModule` indirectly.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -278,8 +278,9 @@ upload three-step protocol and remains at-least-once across an ambiguous complet
 Newly onboarded apps use Slack's `agent_view`, `assistant:write`, token rotation, suggested prompts, Agent
 status/title, and `chat.startStream` → `chat.appendStream` → `chat.stopStream`. Standard Markdown text events append to
 the stream; engine-neutral tool lifecycle events become `task_update` chunks with a compact argument
-summary and, on failure, a bounded result summary. Raw model thinking and successful tool output stay
-private. The compatibility renderer retains one edited message with a strict
+summary and, on failure, a bounded result summary. Timeline is the default because Slack's compact
+plan/dense blocks persist only task title/status; those modes fold the argument summary into the title.
+Raw model thinking and successful tool output stay private. The compatibility renderer retains one edited message with a strict
 three-second mutation interval; explicit continuous/custom top-level routes select it because native
 streams require a parent user message. HTTP Events API remains the production transport; Socket Mode is a
 separate future boundary rather than entering `ChannelModule` indirectly.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -277,9 +277,8 @@ upload three-step protocol and remains at-least-once across an ambiguous complet
 
 Newly onboarded apps use Slack's `agent_view`, `assistant:write`, token rotation, suggested prompts, Agent
 status/title, and `chat.startStream` → `chat.appendStream` → `chat.stopStream`. Standard Markdown text events append to
-the stream; engine-neutral tool lifecycle events become `task_update` chunks with a compact argument
-summary and, on failure, a bounded result summary. Raw model thinking and successful tool output stay
-private. The compatibility renderer retains one edited message with a strict
+the stream; each engine-neutral tool start appends a compact factual Markdown trace, while a failed tool
+end appends a bounded result summary. Raw model thinking and successful tool output stay private. The compatibility renderer retains one edited message with a strict
 three-second mutation interval; explicit continuous/custom top-level routes select it because native
 streams require a parent user message. HTTP Events API remains the production transport; Socket Mode is a
 separate future boundary rather than entering `ChannelModule` indirectly.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -277,8 +277,10 @@ upload three-step protocol and remains at-least-once across an ambiguous complet
 
 Newly onboarded apps use Slack's `agent_view`, `assistant:write`, token rotation, suggested prompts, Agent
 status/title, and `chat.startStream` → `chat.appendStream` → `chat.stopStream`. Standard Markdown text events append to
-the stream; each engine-neutral tool start appends a compact factual Markdown trace, while a failed tool
-end appends a bounded result summary. Raw model thinking and successful tool output stay private. The compatibility renderer retains one edited message with a strict
+the stream; each engine-neutral tool start appends a compact factual Markdown trace, and a failed tool end
+appends one line naming the call. Raw model thinking and tool output stay private — reading output would
+mean guessing the engine's result shape. An append-only stream is also the one renderer whose persisted
+message keeps the process beside the answer; the others settle into the answer alone. The compatibility renderer retains one edited message with a strict
 three-second mutation interval; explicit continuous/custom top-level routes select it because native
 streams require a parent user message. HTTP Events API remains the production transport; Socket Mode is a
 separate future boundary rather than entering `ChannelModule` indirectly.

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -114,7 +114,7 @@ export default slackChannel({
     : undefined,
   groupBehavior: "context", // default; choose "mentions" only for explicit least privilege
   rendering: "native", // native Agent streams/tasks; "classic" is the compatibility renderer
-  // taskDisplay: "plan", // native task-card layout: "plan" (default) | "timeline" | "dense"
+  // taskDisplay: "timeline", // native task-card layout (default); alternatives: "plan" | "dense"
   // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: generic)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)
@@ -221,8 +221,8 @@ usable only when Slack exposes authenticated downloadable bytes.
 4. maps `tool_started` / `tool_ended` to `task_update` chunks, humanizing each tool's identifier into a
    plain-language label (`mcp__github__create_issue` → `Github: create issue`) and putting a short,
    single-line argument summary (normally the command, path, or query) in `details`; failed tasks also put
-   a short error/result summary in `output`. The layout follows `taskDisplay` — `plan` (default) groups
-   steps under one collapsible heading, `timeline` lists each step, `dense` collapses consecutive tool calls;
+   a short error/result summary in `output`. The layout follows `taskDisplay` — `timeline` (default) lists
+   each step sequentially, `plan` groups steps under one collapsible heading, `dense` collapses consecutive tool calls;
 5. closes the stream with `chat.stopStream`.
 
 Raw model `thinking` and successful tool output are not customer-facing. The former is represented by

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -219,13 +219,15 @@ usable only when Slack exposes authenticated downloadable bytes.
 2. starts a native stream with `chat.startStream`;
 3. appends standard Markdown with `chat.appendStream`;
 4. maps `tool_started` / `tool_ended` to `task_update` chunks, humanizing each tool's identifier into a
-   plain-language label (`mcp__github__create_issue` → `Github: create issue`) without exposing arguments;
-   the layout follows `taskDisplay` — `plan` (default) groups steps under one collapsible heading,
-   `timeline` lists each step, `dense` collapses consecutive tool calls;
+   plain-language label (`mcp__github__create_issue` → `Github: create issue`) and putting a short,
+   single-line argument summary (normally the command, path, or query) in `details`; failed tasks also put
+   a short error/result summary in `output`. The layout follows `taskDisplay` — `plan` (default) groups
+   steps under one collapsible heading, `timeline` lists each step, `dense` collapses consecutive tool calls;
 5. closes the stream with `chat.stopStream`.
 
-Raw model `thinking` and generic tool arguments are never customer-facing. The former is represented by
-Slack's loading state; task cards carry only the tool name and completion state. Agent replies also
+Raw model `thinking` and successful tool output are not customer-facing. The former is represented by
+Slack's loading state; task-card details and failed output are whitespace-collapsed, Unicode-safe truncated,
+notification-control sanitized, and kept within Slack's 256-character task budget. Agent replies also
 neutralize Slack notification controls such as `<!channel>`; deliberate outbound mentions belong in the
 explicit `slack-send` tool. Successful replies omit repetitive disclaimers by default; configure an
 `aiDisclaimer` string only when workspace policy requires a per-message footer. Native channel streams carry the triggering user/team recipient IDs required by Slack. DM `app_context` entities are included in

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -114,7 +114,7 @@ export default slackChannel({
     : undefined,
   groupBehavior: "context", // default; choose "mentions" only for explicit least privilege
   rendering: "native", // native Agent streams/tasks; "classic" is the compatibility renderer
-  // taskDisplay: "plan", // native task-card layout: "plan" (default) | "timeline" | "dense"
+  // taskDisplay: "timeline", // default; shows details/output. "plan" | "dense" are compact title-only layouts
   // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: generic)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)
@@ -221,8 +221,9 @@ usable only when Slack exposes authenticated downloadable bytes.
 4. maps `tool_started` / `tool_ended` to `task_update` chunks, humanizing each tool's identifier into a
    plain-language label (`mcp__github__create_issue` → `Github: create issue`) and putting a short,
    single-line argument summary (normally the command, path, or query) in `details`; failed tasks also put
-   a short error/result summary in `output`. The layout follows `taskDisplay` — `plan` (default) groups
-   steps under one collapsible heading, `timeline` lists each step, `dense` collapses consecutive tool calls;
+   a short error/result summary in `output`. The default `timeline` layout renders those fields for each
+   step. Slack's compact `plan` and `dense` layouts persist only title/status, so FastAgent folds the argument
+   summary into their title instead;
 5. closes the stream with `chat.stopStream`.
 
 Raw model `thinking` and successful tool output are not customer-facing. The former is represented by

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -114,7 +114,7 @@ export default slackChannel({
     : undefined,
   groupBehavior: "context", // default; choose "mentions" only for explicit least privilege
   rendering: "native", // native Agent streams/tasks; "classic" is the compatibility renderer
-  // taskDisplay: "timeline", // default; shows details/output. "plan" | "dense" are compact title-only layouts
+  // taskDisplay: "plan", // native task-card layout: "plan" (default) | "timeline" | "dense"
   // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: generic)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)
@@ -221,9 +221,8 @@ usable only when Slack exposes authenticated downloadable bytes.
 4. maps `tool_started` / `tool_ended` to `task_update` chunks, humanizing each tool's identifier into a
    plain-language label (`mcp__github__create_issue` → `Github: create issue`) and putting a short,
    single-line argument summary (normally the command, path, or query) in `details`; failed tasks also put
-   a short error/result summary in `output`. The default `timeline` layout renders those fields for each
-   step. Slack's compact `plan` and `dense` layouts persist only title/status, so FastAgent folds the argument
-   summary into their title instead;
+   a short error/result summary in `output`. The layout follows `taskDisplay` — `plan` (default) groups
+   steps under one collapsible heading, `timeline` lists each step, `dense` collapses consecutive tool calls;
 5. closes the stream with `chat.stopStream`.
 
 Raw model `thinking` and successful tool output are not customer-facing. The former is represented by

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -1,6 +1,6 @@
 ---
 title: Slack channel
-description: "Serve an agent as a Slack-native Agent with signed Events API ingress, durable threads/context, native streams/tasks, and file IO."
+description: "Serve an agent as a Slack-native Agent with signed Events API ingress, durable threads/context, native streams with inline tool traces, and file IO."
 status: current
 ---
 
@@ -50,7 +50,7 @@ The command then:
 
 1. starts a temporary Cloudflare Quick Tunnel (`cloudflared` is required);
 2. creates the internal app from a mode-specific manifest;
-3. enables Slack's irreversible `agent_view`, native Agent streams/tasks, suggested prompts, the writable Messages tab, scopes, and Events API subscriptions;
+3. enables Slack's irreversible `agent_view`, native Agent streaming, suggested prompts, the writable Messages tab, scopes, and Events API subscriptions;
 4. opens [Slack OAuth v2](https://docs.slack.dev/authentication/installing-with-oauth/), validates its `state`, exchanges the code, and installs into one workspace;
 5. writes the Signing Secret plus the rotating bot access/refresh token, expiry, OAuth client ID, and
    client secret to the gitignored run-root `.env`.
@@ -113,8 +113,7 @@ export default slackChannel({
     ? Number(process.env.SLACK_BOT_TOKEN_EXPIRES_AT)
     : undefined,
   groupBehavior: "context", // default; choose "mentions" only for explicit least privilege
-  rendering: "native", // native Agent streams/tasks; "classic" is the compatibility renderer
-  // taskDisplay: "timeline", // native task-card layout (default); alternatives: "plan" | "dense"
+  rendering: "native", // native Agent stream with inline tool traces; "classic" is the compatibility renderer
   // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: generic)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)
@@ -218,16 +217,14 @@ usable only when Slack exposes authenticated downloadable bytes.
 1. sets the Slack Agent loading status (and a title for a new DM thread);
 2. starts a native stream with `chat.startStream`;
 3. appends standard Markdown with `chat.appendStream`;
-4. maps `tool_started` / `tool_ended` to `task_update` chunks, humanizing each tool's identifier into a
-   plain-language label (`mcp__github__create_issue` → `Github: create issue`) and putting a short,
-   single-line argument summary (normally the command, path, or query) in `details`; failed tasks also put
-   a short error/result summary in `output`. The layout follows `taskDisplay` — `timeline` (default) lists
-   each step sequentially, `plan` groups steps under one collapsible heading, `dense` collapses consecutive tool calls;
+4. maps each `tool_started` to a compact inline Markdown trace containing the humanized tool identifier
+   (`mcp__github__create_issue` → `Github: create issue`) and a bounded single-line argument summary
+   (normally the command, path, or query); an errored `tool_ended` appends one bounded failure line;
 5. closes the stream with `chat.stopStream`.
 
 Raw model `thinking` and successful tool output are not customer-facing. The former is represented by
-Slack's loading state; task-card details and failed output are whitespace-collapsed, Unicode-safe truncated,
-notification-control sanitized, and kept within Slack's 256-character task budget. Agent replies also
+Slack's loading state; tool arguments and failed output are whitespace-collapsed, Unicode-safe truncated,
+and notification-control sanitized. Agent replies also
 neutralize Slack notification controls such as `<!channel>`; deliberate outbound mentions belong in the
 explicit `slack-send` tool. Successful replies omit repetitive disclaimers by default; configure an
 `aiDisclaimer` string only when workspace policy requires a per-message footer. Native channel streams carry the triggering user/team recipient IDs required by Slack. DM `app_context` entities are included in

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -236,10 +236,6 @@ explicit `slack-send` tool. Successful replies omit repetitive disclaimers by de
 `aiDisclaimer` string only when workspace policy requires a per-message footer. Native channel streams carry the triggering user/team recipient IDs required by Slack. DM `app_context` entities are included in
 the Agent prompt when Slack supplies them.
 
-**Removed in 0.16:** `taskDisplay`. It laid out Slack Task Cards, which the native renderer no longer
-emits; tool activity is inline Markdown in the same stream and has no layout knob. Delete the option —
-`slackChannel` refuses a supplied value rather than ignoring it.
-
 Standard Markdown—not Slack-specific `mrkdwn`—is the output contract. Each API write stays below Slack's
 12,000-character Markdown limit. Link unfurls remain disabled. Very long answers continue in additional
 Markdown messages.

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -220,7 +220,8 @@ usable only when Slack exposes authenticated downloadable bytes.
 4. maps each `tool_started` to a compact inline Markdown trace containing the humanized tool identifier
    (`mcp__github__create_issue` → `Github: create issue`) and a bounded single-line argument summary
    (normally the command, path, or query); an errored `tool_ended` appends one line naming the failed
-   call, never its output;
+   call, never its output, while a successful one appends nothing — an emitted line cannot be flipped
+   to a checkmark, so the next trace (or the answer) is the completion signal;
 5. closes the stream with `chat.stopStream`.
 
 Raw model `thinking` and tool output are not customer-facing. The former is represented by Slack's

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -219,12 +219,16 @@ usable only when Slack exposes authenticated downloadable bytes.
 3. appends standard Markdown with `chat.appendStream`;
 4. maps each `tool_started` to a compact inline Markdown trace containing the humanized tool identifier
    (`mcp__github__create_issue` → `Github: create issue`) and a bounded single-line argument summary
-   (normally the command, path, or query); an errored `tool_ended` appends one bounded failure line;
+   (normally the command, path, or query); an errored `tool_ended` appends one line naming the failed
+   call, never its output;
 5. closes the stream with `chat.stopStream`.
 
-Raw model `thinking` and successful tool output are not customer-facing. The former is represented by
-Slack's loading state; tool arguments and failed output are whitespace-collapsed, Unicode-safe truncated,
-and notification-control sanitized. Agent replies also
+Raw model `thinking` and tool output are not customer-facing. The former is represented by Slack's
+loading state; argument summaries are whitespace-collapsed, Unicode-safe truncated, and
+notification-control sanitized. A native stream cannot be retracted, so unlike every other renderer
+these traces stay in the delivered message next to the answer — including that argument summary, which
+is the tool call's first string field and may name whatever the agent passed there. Choose
+`rendering: "classic"` for a message that settles into the answer alone. Agent replies also
 neutralize Slack notification controls such as `<!channel>`; deliberate outbound mentions belong in the
 explicit `slack-send` tool. Successful replies omit repetitive disclaimers by default; configure an
 `aiDisclaimer` string only when workspace policy requires a per-message footer. Native channel streams carry the triggering user/team recipient IDs required by Slack. DM `app_context` entities are included in

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -236,6 +236,10 @@ explicit `slack-send` tool. Successful replies omit repetitive disclaimers by de
 `aiDisclaimer` string only when workspace policy requires a per-message footer. Native channel streams carry the triggering user/team recipient IDs required by Slack. DM `app_context` entities are included in
 the Agent prompt when Slack supplies them.
 
+**Removed in 0.16:** `taskDisplay`. It laid out Slack Task Cards, which the native renderer no longer
+emits; tool activity is inline Markdown in the same stream and has no layout knob. Delete the option —
+`slackChannel` refuses a supplied value rather than ignoring it.
+
 Standard Markdown—not Slack-specific `mrkdwn`—is the output contract. Each API write stays below Slack's
 12,000-character Markdown limit. Link unfurls remain disabled. Very long answers continue in additional
 Markdown messages.

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -227,8 +227,9 @@ Raw model `thinking` and tool output are not customer-facing. The former is repr
 loading state; argument summaries are whitespace-collapsed, Unicode-safe truncated, and
 notification-control sanitized. A native stream cannot be retracted, so unlike every other renderer
 these traces stay in the delivered message next to the answer — including that argument summary, which
-is the tool call's first string field and may name whatever the agent passed there. Choose
-`rendering: "classic"` for a message that settles into the answer alone. Agent replies also
+is the tool call's first string field and may name whatever the agent passed there. There is no
+answer-only native stream: `rendering: "classic"` does settle into the answer alone, but it also gives
+up native streaming — process visibility and transport are one choice here, not two. Agent replies also
 neutralize Slack notification controls such as `<!channel>`; deliberate outbound mentions belong in the
 explicit `slack-send` tool. Successful replies omit repetitive disclaimers by default; configure an
 `aiDisclaimer` string only when workspace policy requires a per-message footer. Native channel streams carry the triggering user/team recipient IDs required by Slack. DM `app_context` entities are included in

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/yangshi/coding/fastagent-sh/fastagent/node_modules

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -80,9 +80,8 @@ interface StoredFeishuTurn {
   seq: number;
   session: string;
   baseText: string;
-  /** Context-buffer bucket to fold at dequeue (main chat, or this message's thread root). Optional only
-   *  for recovery compatibility with turn records written before context buffering existed. */
-  bufferKey?: string;
+  /** Context-buffer bucket to fold at dequeue (main chat, or this message's thread root). */
+  bufferKey: string;
   chatId: string;
   replyTo?: string;
   /** Source message to quote when queue feedback mounts. Unlike `replyTo`, this is also set for a p2p
@@ -108,7 +107,7 @@ function isStoredFeishuTurn(t: unknown): t is StoredFeishuTurn {
     typeof r.seq === "number" &&
     typeof r.session === "string" &&
     typeof r.baseText === "string" &&
-    (r.bufferKey === undefined || typeof r.bufferKey === "string") &&
+    typeof r.bufferKey === "string" &&
     typeof r.chatId === "string" &&
     (r.replyTo === undefined || typeof r.replyTo === "string") &&
     (r.queueReplyTo === undefined || typeof r.queueReplyTo === "string") &&
@@ -122,8 +121,7 @@ function isStoredFeishuTurn(t: unknown): t is StoredFeishuTurn {
 
 /** One accepted turn: the persisted intent plus live-only fields. The mounted queue card/text is not
  *  persisted; a replayed turn mounts a fresh preview because an old card may have expired. */
-interface PendingFeishuTurn extends Omit<StoredFeishuTurn, "attempts" | "bufferKey"> {
-  bufferKey: string;
+interface PendingFeishuTurn extends Omit<StoredFeishuTurn, "attempts"> {
   /** The queue-status card/text, when its delayed mount fired. The turn's preview takes it over. */
   preview?: MountedFeishuPreview;
 }
@@ -153,8 +151,6 @@ interface FeishuChannelBaseOptions {
    *  `https://open.feishu.cn`; Lark factories default to `https://open.larksuite.com`. Named to match
    *  the other channels (telegram/slack). */
   apiBaseUrl?: string;
-  /** @deprecated Alias of {@link apiBaseUrl}; kept for existing feishu/lark channel files. */
-  baseUrl?: string;
   /** How long (ms) a turn waits before its reply-quoted "⏳ Queued" card mounts. Defaults to 0
    *  (immediate); the same card is later taken over by the live preview/final answer. */
   queueNoticeDelayMs?: number;
@@ -215,7 +211,7 @@ function createFeishuRuntimeFactory(
     onError,
     queueNoticeDelayMs = QUEUE_NOTICE_DELAY_MS,
   } = opts;
-  const baseUrl = opts.apiBaseUrl ?? opts.baseUrl ?? profile.apiBase;
+  const baseUrl = opts.apiBaseUrl ?? profile.apiBase;
   const { kind } = profile;
   const label = `[${kind}]`;
   return ({ agent, stateRoot, control }) => {
@@ -435,12 +431,7 @@ function createFeishuRuntimeFactory(
     const recovered = store.recover();
     if (recovered.length > 0) log.info(`${label} recovering ${recovered.length} unfinished turn(s) from a prior run`);
     let seqCounter = recovered.reduce((max, r) => Math.max(max, r.seq), 0);
-    for (const { attempts: _a, ...intent } of recovered) {
-      // A pre-buffer-version record has no trustworthy place identity. Give it an empty private bucket
-      // rather than risk consuming new main-chat context that arrived after this restart.
-      const bufferKey = intent.bufferKey ?? `${intent.chatId}:legacy-turn:${intent.id}`;
-      submit({ ...intent, bufferKey, preview: undefined }, false);
-    }
+    for (const { attempts: _a, ...intent } of recovered) submit({ ...intent, preview: undefined }, false);
 
     // Transport-neutral acceptance boundary. It performs only the fast pre-ACK work: normalize,
     // route, persist intent/context, and enqueue. The minutes-long Agent turn remains fire-and-forget.
@@ -684,7 +675,7 @@ export function buildFeishuWebSocketChannel(
           kind: profile.kind,
           appId: opts.appId,
           appSecret: opts.appSecret,
-          domain: opts.apiBaseUrl ?? opts.baseUrl ?? profile.apiBase,
+          domain: opts.apiBaseUrl ?? profile.apiBase,
           onEvent: runtime.acceptEvent,
         },
         signal,

--- a/src/channels/feishu/parse.ts
+++ b/src/channels/feishu/parse.ts
@@ -10,8 +10,8 @@ import { decodeFeishuContent } from "./normalize.ts";
 
 export type { FeishuMention, FeishuMessage, FeishuMessageEvent, FeishuRoute, FeishuSender };
 
-/** Legacy compatibility shape returned by {@link parseContent}. New internal code consumes normalized
- * resource refs, which retain resource kind + carrying message id. */
+/** A resource reduced to what a caller needs to fetch and name it — the kind and carrying message id
+ * that {@link decodeFeishuContent} attaches are supplied by the caller's own context. */
 interface FeishuAttachmentRef {
   key: string;
   name?: string;
@@ -24,8 +24,9 @@ export interface ParsedFeishuContent {
 }
 
 /**
- * Compatibility decoder for existing helpers/tests and parent-message resolution. The canonical
- * decoder now emits typed resources; this wrapper projects them onto the historical parallel arrays.
+ * The decoder projected onto flat per-kind arrays, for callers that resolve a message on their own
+ * (the prompt envelope, and the quoted parent whose resources are carried by the PARENT message id).
+ * `decodeFeishuContent` stays canonical: this only reshapes what it returns.
  */
 export function parseContent(
   message: Pick<FeishuMessage, "message_type" | "content" | "mentions">,

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -228,7 +228,7 @@ function clip(s: string): string {
  * rather than just `🔧 read`. Generic (a channel knows no tool schemas): show the salient value — the
  * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
  */
-function summarizeToolArgs(args: Json): string {
+export function summarizeToolArgs(args: Json): string {
   if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));
   const values = Object.values(args);
   const primary = values.find((v) => typeof v === "string" || typeof v === "number");

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -218,22 +218,23 @@ const TOOL_NAME_MAX = 80;
 
 /** One-line, truncated at code-point boundaries: collapse whitespace so a multi-line command/arg
  *  stays on one line, and never tear a surrogate pair mid-emoji. */
-function clip(s: string): string {
+function clip(s: string, maxPoints: number): string {
   const one = s.replace(/\s+/g, " ").trim();
-  return truncateCodePointPrefix(one, TOOL_ARG_MAX);
+  return truncateCodePointPrefix(one, maxPoints);
 }
 
 /**
  * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
  * rather than just `🔧 read`. Generic (a channel knows no tool schemas): show the salient value — the
  * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
+ * Messaging previews use the compact default; a transport with more room may pass a larger bound.
  */
-export function summarizeToolArgs(args: Json): string {
-  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));
+export function summarizeToolArgs(args: Json, maxPoints = TOOL_ARG_MAX): string {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args), maxPoints);
   const values = Object.values(args);
   const primary = values.find((v) => typeof v === "string" || typeof v === "number");
-  if (primary !== undefined) return clip(String(primary));
-  return values.length > 0 ? clip(JSON.stringify(args)) : "";
+  if (primary !== undefined) return clip(String(primary), maxPoints);
+  return values.length > 0 ? clip(JSON.stringify(args), maxPoints) : "";
 }
 
 /**

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -218,23 +218,22 @@ const TOOL_NAME_MAX = 80;
 
 /** One-line, truncated at code-point boundaries: collapse whitespace so a multi-line command/arg
  *  stays on one line, and never tear a surrogate pair mid-emoji. */
-function clip(s: string, maxPoints: number): string {
+function clip(s: string): string {
   const one = s.replace(/\s+/g, " ").trim();
-  return truncateCodePointPrefix(one, maxPoints);
+  return truncateCodePointPrefix(one, TOOL_ARG_MAX);
 }
 
 /**
  * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
  * rather than just `🔧 read`. Generic (a channel knows no tool schemas): show the salient value — the
  * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
- * Messaging previews use the compact default; a transport with more room may pass a larger bound.
  */
-export function summarizeToolArgs(args: Json, maxPoints = TOOL_ARG_MAX): string {
-  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args), maxPoints);
+export function summarizeToolArgs(args: Json): string {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));
   const values = Object.values(args);
   const primary = values.find((v) => typeof v === "string" || typeof v === "number");
-  if (primary !== undefined) return clip(String(primary), maxPoints);
-  return values.length > 0 ? clip(JSON.stringify(args), maxPoints) : "";
+  if (primary !== undefined) return clip(String(primary));
+  return values.length > 0 ? clip(JSON.stringify(args)) : "";
 }
 
 /**

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -210,7 +210,9 @@ export function createPreviewPump(opts: {
   };
 }
 
-/** Max length (code points) of a tool's arg preview in the live view. */
+/** Max length (code points) of a tool's arg preview. A disclosure bound, not only a layout one: most
+ *  renderers show it in a live view that settles into the answer, but Slack's native stream cannot be
+ *  retracted, so the same summary persists in the delivered message. */
 const TOOL_ARG_MAX = 48;
 
 /** Max length (code points) of a humanized tool label. */
@@ -227,6 +229,8 @@ function clip(s: string): string {
  * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
  * rather than just `🔧 read`. Generic (a channel knows no tool schemas): show the salient value — the
  * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
+ * Knowing no schemas cuts both ways: the salient value is whatever the caller put first, so this is a
+ * disclosure decision every renderer inherits (see TOOL_ARG_MAX).
  */
 export function summarizeToolArgs(args: Json): string {
   if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -210,9 +210,8 @@ export function createPreviewPump(opts: {
   };
 }
 
-/** Max length (code points) of a tool's arg preview. A disclosure bound, not only a layout one: most
- *  renderers show it in a live view that settles into the answer, but Slack's native stream cannot be
- *  retracted, so the same summary persists in the delivered message. */
+/** Max length (code points) of a tool's arg preview. Slack's native stream cannot be retracted, so
+ *  this is a disclosure bound, not only a layout one. */
 const TOOL_ARG_MAX = 48;
 
 /** Max length (code points) of a humanized tool label. */
@@ -229,8 +228,6 @@ function clip(s: string): string {
  * A compact, human-readable preview of a tool call's args so the live view reads `🔧 read AGENTS.md`
  * rather than just `🔧 read`. Generic (a channel knows no tool schemas): show the salient value — the
  * first primitive field, conventionally the subject (path / command / query / url) — else compact JSON.
- * Knowing no schemas cuts both ways: the salient value is whatever the caller put first, so this is a
- * disclosure decision every renderer inherits (see TOOL_ARG_MAX).
  */
 export function summarizeToolArgs(args: Json): string {
   if (args === null || typeof args !== "object" || Array.isArray(args)) return clip(String(args));

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -472,7 +472,7 @@ export async function streamSlackReply(
     initialPreviewTs,
     threadTitle,
     disclaimer,
-    taskDisplay = "plan",
+    taskDisplay = "timeline",
     label = "[slack]",
   } = options;
   if (rendering === "native" && target.threadTs) {

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -1,5 +1,5 @@
 /** Slack reply rendering: native Agent streams first, rate-safe edited-message compatibility second. */
-import type { AgentEvent } from "../../agent.ts";
+import type { AgentEvent, Json } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   RETRY_NOTICE,
@@ -11,8 +11,10 @@ import {
   defaultErrorMessage,
   humanizeToolName,
   revealedAnswer,
+  summarizeToolArgs,
   toolLines,
 } from "../preview-kit.ts";
+import { truncateCodePointPrefix } from "../text.ts";
 import {
   type SlackApi,
   type SlackStreamChunk,
@@ -31,6 +33,8 @@ const CLASSIC_UPDATE_INTERVAL_MS = 3_000;
 const NATIVE_APPEND_INTERVAL_MS = 750;
 const WORKING_STATUS = "is working on your request…";
 const GENERIC_FAILURE = "⚠️ The response stream stopped unexpectedly. Please try again.";
+/** Slack documents one 256-character budget across a task_update's human-readable text. */
+const NATIVE_TASK_TEXT_MAX = 256;
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -42,6 +46,49 @@ const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(
  * (real Slack controls never contain a `<`). */
 export function sanitizeSlackMarkdown(markdown: string): string {
   return markdown.replace(/<[@!][^<>]*>/g, (control) => `&lt;${control.slice(1)}`);
+}
+
+interface NativeTask {
+  title: string;
+  details?: string;
+}
+
+/** Prefer pi's AgentToolResult text blocks, then common custom-tool error fields, then compact JSON. */
+function toolResultText(value: Json): string {
+  if (typeof value === "string") return value;
+  if (value === null) return "";
+  if (typeof value !== "object" || Array.isArray(value)) return JSON.stringify(value);
+
+  const blocks = value.content;
+  if (Array.isArray(blocks)) {
+    const text = blocks
+      .map((block) =>
+        block && typeof block === "object" && !Array.isArray(block) && typeof block.text === "string" ? block.text : "",
+      )
+      .filter(Boolean)
+      .join("\n");
+    if (text) return text;
+  }
+  for (const key of ["error", "message", "result"] as const) {
+    const field = value[key];
+    if (typeof field === "string" && field.trim()) return field;
+  }
+  return JSON.stringify(value);
+}
+
+function nativeTaskDetails(args: Json): string | undefined {
+  const details = sanitizeSlackMarkdown(summarizeToolArgs(args));
+  return details || undefined;
+}
+
+/** Failed output is the only result content made customer-facing: one line, sanitized, and fitted
+ * into Slack's task text budget after the title and operation details. */
+function nativeTaskErrorOutput(content: Json, task: NativeTask): string | undefined {
+  const used = Array.from(task.title).length + Array.from(task.details ?? "").length;
+  const available = NATIVE_TASK_TEXT_MAX - used;
+  if (available <= 0) return undefined;
+  const raw = toolResultText(content).replace(/\s+/g, " ").trim() || "Tool failed without an error message.";
+  return truncateCodePointPrefix(sanitizeSlackMarkdown(raw), available);
 }
 
 function withDisclaimer(markdown: string, disclaimer: string | false | undefined): string {
@@ -253,7 +300,7 @@ async function streamNativeSlackReply(
         .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
     );
   };
-  const toolNames = new Map<string, string>();
+  const toolTasks = new Map<string, NativeTask>();
   let pendingText = "";
   let fullAnswer = "";
   let textTimer: ReturnType<typeof setTimeout> | undefined;
@@ -354,15 +401,21 @@ async function streamNativeSlackReply(
           setStatus("hit a temporary problem — retrying…");
         }
       } else if (event.type === "tool_started") {
-        const title = humanizeToolName(event.name);
-        toolNames.set(event.id, title);
-        sendTask({ type: "task_update", id: event.id, title, status: "in_progress" });
+        const task: NativeTask = {
+          title: humanizeToolName(event.name),
+          details: nativeTaskDetails(event.args),
+        };
+        toolTasks.set(event.id, task);
+        sendTask({ type: "task_update", id: event.id, ...task, status: "in_progress" });
       } else if (event.type === "tool_ended") {
+        const task = toolTasks.get(event.id) ?? { title: "Tool" };
+        const output = event.isError ? nativeTaskErrorOutput(event.content, task) : undefined;
         sendTask({
           type: "task_update",
           id: event.id,
-          title: toolNames.get(event.id) ?? "Tool",
+          ...task,
           status: event.isError ? "error" : "complete",
+          ...(output ? { output } : {}),
         });
       } else if (event.type === "completed") {
         finalized = true;

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -76,14 +76,9 @@ function toolResultText(value: Json): string {
   return JSON.stringify(value);
 }
 
-function nativeTask(name: string, args: Json, displayMode: SlackTaskDisplayMode): NativeTask {
-  const title = humanizeToolName(name);
-  const details = sanitizeSlackMarkdown(summarizeToolArgs(args)) || undefined;
-  // Slack's plan/dense blocks persist only task title + status; details/output are timeline-only in
-  // the rendered message. Keep compact modes useful by folding the operation into their title.
-  return displayMode === "timeline"
-    ? { title, details }
-    : { title: truncateCodePointPrefix([title, details].filter(Boolean).join(" "), NATIVE_TASK_TEXT_MAX) };
+function nativeTaskDetails(args: Json): string | undefined {
+  const details = sanitizeSlackMarkdown(summarizeToolArgs(args));
+  return details || undefined;
 }
 
 /** Failed output is the only result content made customer-facing: one line, sanitized, and fitted
@@ -406,7 +401,10 @@ async function streamNativeSlackReply(
           setStatus("hit a temporary problem — retrying…");
         }
       } else if (event.type === "tool_started") {
-        const task = nativeTask(event.name, event.args, taskDisplayMode);
+        const task: NativeTask = {
+          title: humanizeToolName(event.name),
+          details: nativeTaskDetails(event.args),
+        };
         toolTasks.set(event.id, task);
         sendTask({ type: "task_update", id: event.id, ...task, status: "in_progress" });
       } else if (event.type === "tool_ended") {
@@ -474,7 +472,7 @@ export async function streamSlackReply(
     initialPreviewTs,
     threadTitle,
     disclaimer,
-    taskDisplay = "timeline",
+    taskDisplay = "plan",
     label = "[slack]",
   } = options;
   if (rendering === "native" && target.threadTs) {

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -76,9 +76,14 @@ function toolResultText(value: Json): string {
   return JSON.stringify(value);
 }
 
-function nativeTaskDetails(args: Json): string | undefined {
-  const details = sanitizeSlackMarkdown(summarizeToolArgs(args));
-  return details || undefined;
+function nativeTask(name: string, args: Json, displayMode: SlackTaskDisplayMode): NativeTask {
+  const title = humanizeToolName(name);
+  const details = sanitizeSlackMarkdown(summarizeToolArgs(args)) || undefined;
+  // Slack's plan/dense blocks persist only task title + status; details/output are timeline-only in
+  // the rendered message. Keep compact modes useful by folding the operation into their title.
+  return displayMode === "timeline"
+    ? { title, details }
+    : { title: truncateCodePointPrefix([title, details].filter(Boolean).join(" "), NATIVE_TASK_TEXT_MAX) };
 }
 
 /** Failed output is the only result content made customer-facing: one line, sanitized, and fitted
@@ -401,10 +406,7 @@ async function streamNativeSlackReply(
           setStatus("hit a temporary problem — retrying…");
         }
       } else if (event.type === "tool_started") {
-        const task: NativeTask = {
-          title: humanizeToolName(event.name),
-          details: nativeTaskDetails(event.args),
-        };
+        const task = nativeTask(event.name, event.args, taskDisplayMode);
         toolTasks.set(event.id, task);
         sendTask({ type: "task_update", id: event.id, ...task, status: "in_progress" });
       } else if (event.type === "tool_ended") {
@@ -472,7 +474,7 @@ export async function streamSlackReply(
     initialPreviewTs,
     threadTitle,
     disclaimer,
-    taskDisplay = "plan",
+    taskDisplay = "timeline",
     label = "[slack]",
   } = options;
   if (rendering === "native" && target.threadTs) {

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -17,9 +17,7 @@ import {
 import { truncateCodePointPrefix } from "../text.ts";
 import {
   type SlackApi,
-  type SlackStreamChunk,
   type SlackTarget,
-  type SlackTaskDisplayMode,
   chunkSlackMarkdown,
   chunkSlackText,
   isSlackNativeUnavailable,
@@ -33,8 +31,9 @@ const CLASSIC_UPDATE_INTERVAL_MS = 3_000;
 const NATIVE_APPEND_INTERVAL_MS = 750;
 const WORKING_STATUS = "is working on your request…";
 const GENERIC_FAILURE = "⚠️ The response stream stopped unexpectedly. Please try again.";
-/** Slack documents one 256-character budget across a task_update's human-readable text. */
-const NATIVE_TASK_TEXT_MAX = 256;
+/** Keep factual tool traces compact while leaving enough room for useful commands and paths. */
+const TOOL_TRACE_ARG_MAX = 96;
+const TOOL_TRACE_ERROR_MAX = 256;
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -48,9 +47,34 @@ export function sanitizeSlackMarkdown(markdown: string): string {
   return markdown.replace(/<[@!][^<>]*>/g, (control) => `&lt;${control.slice(1)}`);
 }
 
-interface NativeTask {
-  title: string;
-  details?: string;
+interface NativeToolTrace {
+  label: string;
+  operation?: string;
+}
+
+/** Render untrusted tool names/arguments as one standard-Markdown code span. A fence longer than any
+ * backtick run in the value keeps the span balanced without changing the factual text. */
+function inlineCode(value: string): string {
+  const longest = Math.max(0, ...(value.match(/`+/g) ?? []).map((run) => run.length));
+  const fence = "`".repeat(longest + 1);
+  const content = value.startsWith("`") || value.endsWith("`") ? ` ${value} ` : value;
+  return `${fence}${content}${fence}`;
+}
+
+function nativeToolTrace(name: string, args: Json): NativeToolTrace {
+  const operation = sanitizeSlackMarkdown(summarizeToolArgs(args, TOOL_TRACE_ARG_MAX));
+  return {
+    label: sanitizeSlackMarkdown(humanizeToolName(name)),
+    ...(operation ? { operation } : {}),
+  };
+}
+
+function boldText(value: string): string {
+  return `**${value.replace(/[\\*]/g, "\\$&")}**`;
+}
+
+function nativeToolInvocation(trace: NativeToolTrace): string {
+  return `${boldText(trace.label)}${trace.operation ? ` — ${inlineCode(trace.operation)}` : ""}`;
 }
 
 /** Prefer pi's AgentToolResult text blocks, then common custom-tool error fields, then compact JSON. */
@@ -76,19 +100,11 @@ function toolResultText(value: Json): string {
   return JSON.stringify(value);
 }
 
-function nativeTaskDetails(args: Json): string | undefined {
-  const details = sanitizeSlackMarkdown(summarizeToolArgs(args));
-  return details || undefined;
-}
-
-/** Failed output is the only result content made customer-facing: one line, sanitized, and fitted
- * into Slack's task text budget after the title and operation details. */
-function nativeTaskErrorOutput(content: Json, task: NativeTask): string | undefined {
-  const used = Array.from(task.title).length + Array.from(task.details ?? "").length;
-  const available = NATIVE_TASK_TEXT_MAX - used;
-  if (available <= 0) return undefined;
+/** Successful tool output stays private. A failed call gets one bounded, sanitized factual line. */
+function nativeToolFailure(content: Json, trace: NativeToolTrace): string {
   const raw = toolResultText(content).replace(/\s+/g, " ").trim() || "Tool failed without an error message.";
-  return truncateCodePointPrefix(sanitizeSlackMarkdown(raw), available);
+  const error = truncateCodePointPrefix(sanitizeSlackMarkdown(raw), TOOL_TRACE_ERROR_MAX);
+  return `${boldText(trace.label)} failed — ${inlineCode(error)}`;
 }
 
 function withDisclaimer(markdown: string, disclaimer: string | false | undefined): string {
@@ -265,7 +281,6 @@ async function streamNativeSlackReply(
   threadTitle: string | undefined,
   disclaimer: string | false | undefined,
   label: string,
-  taskDisplayMode: SlackTaskDisplayMode,
 ): Promise<void> {
   if (initialPreviewTs) {
     await api
@@ -300,7 +315,7 @@ async function streamNativeSlackReply(
         .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
     );
   };
-  const toolTasks = new Map<string, NativeTask>();
+  const toolTraces = new Map<string, NativeToolTrace>();
   let pendingText = "";
   let fullAnswer = "";
   let textTimer: ReturnType<typeof setTimeout> | undefined;
@@ -308,6 +323,8 @@ async function streamNativeSlackReply(
   let operation = Promise.resolve();
   let renderError: unknown;
   let finalized = false;
+  let streamHasContent = false;
+  let streamEndsWithBlankLine = false;
 
   const enqueue = (work: () => Promise<void>): void => {
     operation = operation.then(async () => {
@@ -319,12 +336,18 @@ async function streamNativeSlackReply(
       }
     });
   };
-  const sendContent = async (content: { markdownText?: string; chunks?: SlackStreamChunk[] }): Promise<void> => {
+  const sendContent = async (content: { markdownText?: string }): Promise<void> => {
     if (streamTs) {
       await api.appendStream(target.channelId, streamTs, content);
     } else {
-      streamTs = await api.startStream(target, content, taskDisplayMode);
+      streamTs = await api.startStream(target, content);
     }
+  };
+  const queueMarkdown = (markdownText: string): void => {
+    if (!markdownText) return;
+    streamHasContent = true;
+    streamEndsWithBlankLine = markdownText.endsWith("\n\n");
+    enqueue(() => sendContent({ markdownText }));
   };
   const flushText = (final = false): void => {
     if (textTimer) {
@@ -344,9 +367,7 @@ async function streamNativeSlackReply(
     }
     if (!value) return;
     lastTextFlushAt = Date.now();
-    for (const chunk of chunkSlackText(sanitizeSlackMarkdown(value))) {
-      enqueue(() => sendContent({ markdownText: chunk }));
-    }
+    for (const chunk of chunkSlackText(sanitizeSlackMarkdown(value))) queueMarkdown(chunk);
   };
   const scheduleText = (): void => {
     if (textTimer) return;
@@ -356,9 +377,10 @@ async function streamNativeSlackReply(
       flushText();
     }, delay);
   };
-  const sendTask = (chunk: SlackStreamChunk): void => {
+  const sendToolTrace = (line: string): void => {
     flushText();
-    enqueue(() => sendContent({ chunks: [chunk] }));
+    const separator = streamHasContent && !streamEndsWithBlankLine ? "\n\n" : "";
+    queueMarkdown(`${separator}${line}\n\n`);
   };
   const settleNative = async (terminalMarkdown: string): Promise<void> => {
     flushText(true);
@@ -375,7 +397,7 @@ async function streamNativeSlackReply(
       }
       throw renderError;
     }
-    if (!streamTs) streamTs = await api.startStream(target, { markdownText: safeTerminal }, taskDisplayMode);
+    if (!streamTs) streamTs = await api.startStream(target, { markdownText: safeTerminal });
     await api.stopStream(target.channelId, streamTs);
   };
 
@@ -401,22 +423,13 @@ async function streamNativeSlackReply(
           setStatus("hit a temporary problem — retrying…");
         }
       } else if (event.type === "tool_started") {
-        const task: NativeTask = {
-          title: humanizeToolName(event.name),
-          details: nativeTaskDetails(event.args),
-        };
-        toolTasks.set(event.id, task);
-        sendTask({ type: "task_update", id: event.id, ...task, status: "in_progress" });
+        const trace = nativeToolTrace(event.name, event.args);
+        toolTraces.set(event.id, trace);
+        sendToolTrace(nativeToolInvocation(trace));
       } else if (event.type === "tool_ended") {
-        const task = toolTasks.get(event.id) ?? { title: "Tool" };
-        const output = event.isError ? nativeTaskErrorOutput(event.content, task) : undefined;
-        sendTask({
-          type: "task_update",
-          id: event.id,
-          ...task,
-          status: event.isError ? "error" : "complete",
-          ...(output ? { output } : {}),
-        });
+        const trace = toolTraces.get(event.id) ?? { label: "Tool" };
+        toolTraces.delete(event.id);
+        if (event.isError) sendToolTrace(nativeToolFailure(event.content, trace));
       } else if (event.type === "completed") {
         finalized = true;
         const finalAnswer = withDisclaimer(fullAnswer, disclaimer);
@@ -463,30 +476,12 @@ export async function streamSlackReply(
     initialPreviewTs?: string;
     threadTitle?: string;
     disclaimer?: string | false;
-    taskDisplay?: SlackTaskDisplayMode;
     label?: string;
   } = {},
 ): Promise<void> {
-  const {
-    rendering = "native",
-    initialPreviewTs,
-    threadTitle,
-    disclaimer,
-    taskDisplay = "timeline",
-    label = "[slack]",
-  } = options;
+  const { rendering = "native", initialPreviewTs, threadTitle, disclaimer, label = "[slack]" } = options;
   if (rendering === "native" && target.threadTs) {
-    return streamNativeSlackReply(
-      events,
-      api,
-      target,
-      formatError,
-      initialPreviewTs,
-      threadTitle,
-      disclaimer,
-      label,
-      taskDisplay,
-    );
+    return streamNativeSlackReply(events, api, target, formatError, initialPreviewTs, threadTitle, disclaimer, label);
   }
   if (rendering === "native") {
     log.info(`${label} native streaming needs a thread target — using the classic renderer for this turn`);

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -65,21 +65,24 @@ function nativeToolTrace(name: string, args: Json): NativeToolTrace {
   };
 }
 
-/** Bold a factual label. The escape set is `\` and `*` only because `humanizeToolName` already
- * normalizes `_`/`-`/`.` separators to spaces, so no underscore emphasis can reach here. */
+/** Bold a factual label. `humanizeToolName` normalizes `_` away for every ordinary identifier, but it
+ * falls back to the raw name when normalization empties it (a tool literally named `_`), so emphasis
+ * characters are escaped rather than assumed absent. */
 function boldText(value: string): string {
-  return `**${value.replace(/[\\*]/g, "\\$&")}**`;
+  return `**${value.replace(/[\\*_]/g, "\\$&")}**`;
 }
 
-function nativeToolInvocation(trace: NativeToolTrace): string {
-  return `${boldText(trace.label)}${trace.operation ? ` — ${inlineCode(trace.operation)}` : ""}`;
-}
-
-/** Tool OUTPUT never leaves the process, failed or not: the channel would have to guess the engine's
+/**
+ * One trace line: the tool, what it was called on, and — on the failure line — that it failed.
+ *
+ * Tool OUTPUT never leaves the process, failed or not: the channel would have to guess the engine's
  * result shape to read it, and the agent already explains a failure it recovered from in its answer.
- * The trace states the fact only — which call failed. Operators get the detail from the logs. */
-function nativeToolFailure(trace: NativeToolTrace): string {
-  return `${boldText(trace.label)} failed`;
+ * The failure line therefore repeats the operation instead of adding one: it states WHICH call failed
+ * (six `Bash` calls in a turn are otherwise indistinguishable) without exposing anything the start
+ * line did not already show. Operators get the detail from the logs.
+ */
+function nativeToolLine(trace: NativeToolTrace, outcome = ""): string {
+  return `${boldText(trace.label)}${outcome}${trace.operation ? ` — ${inlineCode(trace.operation)}` : ""}`;
 }
 
 function withDisclaimer(markdown: string, disclaimer: string | false | undefined): string {
@@ -352,6 +355,10 @@ async function streamNativeSlackReply(
       flushText();
     }, delay);
   };
+  // ponytail: a trace appended while the answer has an unclosed ``` fence lands inside it, and the
+  // trace's own backticks can close it early. Tracking fence parity across chunk boundaries (the job
+  // chunkSlackMarkdown does for the classic renderer) is the fix if a model is ever seen calling a
+  // tool mid-fence; the trace's blank-line framing keeps every other case well-formed.
   const sendToolTrace = (line: string): void => {
     flushText();
     const separator = streamHasContent && !streamEndsWithBlankLine ? "\n\n" : "";
@@ -400,11 +407,11 @@ async function streamNativeSlackReply(
       } else if (event.type === "tool_started") {
         const trace = nativeToolTrace(event.name, event.args);
         toolTraces.set(event.id, trace);
-        sendToolTrace(nativeToolInvocation(trace));
+        sendToolTrace(nativeToolLine(trace));
       } else if (event.type === "tool_ended") {
         const trace = toolTraces.get(event.id) ?? { label: "Tool" };
         toolTraces.delete(event.id);
-        if (event.isError) sendToolTrace(nativeToolFailure(trace));
+        if (event.isError) sendToolTrace(nativeToolLine(trace, " failed"));
       } else if (event.type === "completed") {
         finalized = true;
         const finalAnswer = withDisclaimer(fullAnswer, disclaimer);

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -314,18 +314,18 @@ async function streamNativeSlackReply(
       }
     });
   };
-  const sendContent = async (content: { markdownText?: string }): Promise<void> => {
+  const sendContent = async (markdown: string): Promise<void> => {
     if (streamTs) {
-      await api.appendStream(target.channelId, streamTs, content);
+      await api.appendStream(target.channelId, streamTs, markdown);
     } else {
-      streamTs = await api.startStream(target, content);
+      streamTs = await api.startStream(target, markdown);
     }
   };
-  const queueMarkdown = (markdownText: string): void => {
-    if (!markdownText) return;
+  const queueMarkdown = (markdown: string): void => {
+    if (!markdown) return;
     streamHasContent = true;
-    streamEndsWithBlankLine = markdownText.endsWith("\n\n");
-    enqueue(() => sendContent({ markdownText }));
+    streamEndsWithBlankLine = markdown.endsWith("\n\n");
+    enqueue(() => sendContent(markdown));
   };
   const flushText = (final = false): void => {
     if (textTimer) {
@@ -375,11 +375,11 @@ async function streamNativeSlackReply(
         return;
       }
       if (streamTs) {
-        await api.stopStream(target.channelId, streamTs, { markdownText: `\n\n${GENERIC_FAILURE}` }).catch(() => {});
+        await api.stopStream(target.channelId, streamTs, `\n\n${GENERIC_FAILURE}`).catch(() => {});
       }
       throw renderError;
     }
-    if (!streamTs) streamTs = await api.startStream(target, { markdownText: safeTerminal });
+    if (!streamTs) streamTs = await api.startStream(target, safeTerminal);
     await api.stopStream(target.channelId, streamTs);
   };
 

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -14,7 +14,6 @@ import {
   summarizeToolArgs,
   toolLines,
 } from "../preview-kit.ts";
-import { truncateCodePointPrefix } from "../text.ts";
 import {
   type SlackApi,
   type SlackTarget,
@@ -31,9 +30,6 @@ const CLASSIC_UPDATE_INTERVAL_MS = 3_000;
 const NATIVE_APPEND_INTERVAL_MS = 750;
 const WORKING_STATUS = "is working on your request…";
 const GENERIC_FAILURE = "⚠️ The response stream stopped unexpectedly. Please try again.";
-/** Keep factual tool traces compact while leaving enough room for useful commands and paths. */
-const TOOL_TRACE_ARG_MAX = 96;
-const TOOL_TRACE_ERROR_MAX = 256;
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -62,13 +58,15 @@ function inlineCode(value: string): string {
 }
 
 function nativeToolTrace(name: string, args: Json): NativeToolTrace {
-  const operation = sanitizeSlackMarkdown(summarizeToolArgs(args, TOOL_TRACE_ARG_MAX));
+  const operation = sanitizeSlackMarkdown(summarizeToolArgs(args));
   return {
     label: sanitizeSlackMarkdown(humanizeToolName(name)),
     ...(operation ? { operation } : {}),
   };
 }
 
+/** Bold a factual label. The escape set is `\` and `*` only because `humanizeToolName` already
+ * normalizes `_`/`-`/`.` separators to spaces, so no underscore emphasis can reach here. */
 function boldText(value: string): string {
   return `**${value.replace(/[\\*]/g, "\\$&")}**`;
 }
@@ -77,34 +75,11 @@ function nativeToolInvocation(trace: NativeToolTrace): string {
   return `${boldText(trace.label)}${trace.operation ? ` — ${inlineCode(trace.operation)}` : ""}`;
 }
 
-/** Prefer pi's AgentToolResult text blocks, then common custom-tool error fields, then compact JSON. */
-function toolResultText(value: Json): string {
-  if (typeof value === "string") return value;
-  if (value === null) return "";
-  if (typeof value !== "object" || Array.isArray(value)) return JSON.stringify(value);
-
-  const blocks = value.content;
-  if (Array.isArray(blocks)) {
-    const text = blocks
-      .map((block) =>
-        block && typeof block === "object" && !Array.isArray(block) && typeof block.text === "string" ? block.text : "",
-      )
-      .filter(Boolean)
-      .join("\n");
-    if (text) return text;
-  }
-  for (const key of ["error", "message", "result"] as const) {
-    const field = value[key];
-    if (typeof field === "string" && field.trim()) return field;
-  }
-  return JSON.stringify(value);
-}
-
-/** Successful tool output stays private. A failed call gets one bounded, sanitized factual line. */
-function nativeToolFailure(content: Json, trace: NativeToolTrace): string {
-  const raw = toolResultText(content).replace(/\s+/g, " ").trim() || "Tool failed without an error message.";
-  const error = truncateCodePointPrefix(sanitizeSlackMarkdown(raw), TOOL_TRACE_ERROR_MAX);
-  return `${boldText(trace.label)} failed — ${inlineCode(error)}`;
+/** Tool OUTPUT never leaves the process, failed or not: the channel would have to guess the engine's
+ * result shape to read it, and the agent already explains a failure it recovered from in its answer.
+ * The trace states the fact only — which call failed. Operators get the detail from the logs. */
+function nativeToolFailure(trace: NativeToolTrace): string {
+  return `${boldText(trace.label)} failed`;
 }
 
 function withDisclaimer(markdown: string, disclaimer: string | false | undefined): string {
@@ -429,7 +404,7 @@ async function streamNativeSlackReply(
       } else if (event.type === "tool_ended") {
         const trace = toolTraces.get(event.id) ?? { label: "Tool" };
         toolTraces.delete(event.id);
-        if (event.isError) sendToolTrace(nativeToolFailure(event.content, trace));
+        if (event.isError) sendToolTrace(nativeToolFailure(trace));
       } else if (event.type === "completed") {
         finalized = true;
         const finalAnswer = withDisclaimer(fullAnswer, disclaimer);

--- a/src/channels/slack/scaffold/channel.ts
+++ b/src/channels/slack/scaffold/channel.ts
@@ -21,7 +21,7 @@ export default slackChannel({
     : undefined,
   groupBehavior: "context", // default; use "mentions" only for an explicit least-privilege setup
   rendering: "native", // Slack Agent streams + task timeline; use "classic" only for compatibility
-  // taskDisplay: "plan", // native task-card layout: "plan" (default) | "timeline" | "dense"
+  // taskDisplay: "timeline", // native task-card layout (default); alternatives: "plan" | "dense"
   // Optional per-reply footer, if your policy requires one: aiDisclaimer: "AI-generated; verify important information.",
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: a generic greeting)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)

--- a/src/channels/slack/scaffold/channel.ts
+++ b/src/channels/slack/scaffold/channel.ts
@@ -21,7 +21,7 @@ export default slackChannel({
     : undefined,
   groupBehavior: "context", // default; use "mentions" only for an explicit least-privilege setup
   rendering: "native", // Slack Agent streams + task timeline; use "classic" only for compatibility
-  // taskDisplay: "timeline", // default; shows details/output. "plan" | "dense" are compact title-only layouts
+  // taskDisplay: "plan", // native task-card layout: "plan" (default) | "timeline" | "dense"
   // Optional per-reply footer, if your policy requires one: aiDisclaimer: "AI-generated; verify important information.",
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: a generic greeting)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)

--- a/src/channels/slack/scaffold/channel.ts
+++ b/src/channels/slack/scaffold/channel.ts
@@ -20,8 +20,7 @@ export default slackChannel({
     ? Number(process.env.SLACK_BOT_TOKEN_EXPIRES_AT)
     : undefined,
   groupBehavior: "context", // default; use "mentions" only for an explicit least-privilege setup
-  rendering: "native", // Slack Agent streams + task timeline; use "classic" only for compatibility
-  // taskDisplay: "timeline", // native task-card layout (default); alternatives: "plan" | "dense"
+  rendering: "native", // Slack Agent stream with inline tool traces; use "classic" only for compatibility
   // Optional per-reply footer, if your policy requires one: aiDisclaimer: "AI-generated; verify important information.",
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: a generic greeting)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)

--- a/src/channels/slack/scaffold/channel.ts
+++ b/src/channels/slack/scaffold/channel.ts
@@ -21,7 +21,7 @@ export default slackChannel({
     : undefined,
   groupBehavior: "context", // default; use "mentions" only for an explicit least-privilege setup
   rendering: "native", // Slack Agent streams + task timeline; use "classic" only for compatibility
-  // taskDisplay: "plan", // native task-card layout: "plan" (default) | "timeline" | "dense"
+  // taskDisplay: "timeline", // default; shows details/output. "plan" | "dense" are compact title-only layouts
   // Optional per-reply footer, if your policy requires one: aiDisclaimer: "AI-generated; verify important information.",
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: a generic greeting)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)

--- a/src/channels/slack/scaffold/channel.ts
+++ b/src/channels/slack/scaffold/channel.ts
@@ -20,7 +20,9 @@ export default slackChannel({
     ? Number(process.env.SLACK_BOT_TOKEN_EXPIRES_AT)
     : undefined,
   groupBehavior: "context", // default; use "mentions" only for an explicit least-privilege setup
-  rendering: "native", // Slack Agent stream with inline tool traces; use "classic" only for compatibility
+  // Slack Agent stream; its inline tool traces show each call's first argument and stay in the
+  // delivered message. "classic" settles into the answer alone (and gives up native streaming).
+  rendering: "native",
   // Optional per-reply footer, if your policy requires one: aiDisclaimer: "AI-generated; verify important information.",
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: a generic greeting)
   // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -33,6 +33,10 @@ interface SlackTaskUpdateChunk {
   id: string;
   title: string;
   status: "pending" | "in_progress" | "complete" | "error";
+  /** Concise operation summary (for example a command or path). Slack caps task text at 256 chars. */
+  details?: string;
+  /** Concise result summary. The renderer currently sends this only for failed tools. */
+  output?: string;
 }
 
 export type SlackStreamChunk = SlackMarkdownTextChunk | SlackTaskUpdateChunk;

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -395,7 +395,7 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
       }
       return first;
     },
-    async startStream(target, content = {}, taskDisplayMode = "plan") {
+    async startStream(target, content = {}, taskDisplayMode = "timeline") {
       if (!target.threadTs) throw new Error("Slack native streams require a parent thread timestamp");
       const channelRecipient = target.channelId.startsWith("D")
         ? {}

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -23,33 +23,9 @@ export interface SlackTarget {
   recipientTeamId?: string;
 }
 
-interface SlackMarkdownTextChunk {
-  type: "markdown_text";
-  text: string;
-}
-
-interface SlackTaskUpdateChunk {
-  type: "task_update";
-  id: string;
-  title: string;
-  status: "pending" | "in_progress" | "complete" | "error";
-  /** Concise operation summary (for example a command or path). Slack caps task text at 256 chars. */
-  details?: string;
-  /** Concise result summary. The renderer currently sends this only for failed tools. */
-  output?: string;
-}
-
-export type SlackStreamChunk = SlackMarkdownTextChunk | SlackTaskUpdateChunk;
-
 interface SlackStreamContent {
   markdownText?: string;
-  chunks?: SlackStreamChunk[];
 }
-
-/** How Slack lays out task cards in a native stream (chat.startStream `task_display_mode`): `timeline`
- *  lists steps sequentially, `plan` groups them under one heading, `dense` collapses consecutive tool
- *  calls into one summarized card. */
-export type SlackTaskDisplayMode = "timeline" | "plan" | "dense";
 
 export interface DownloadedSlackFile {
   path: string;
@@ -113,11 +89,7 @@ export interface SlackApi {
   updateMarkdown(channelId: string, ts: string, markdown: string): Promise<void>;
   deleteMessage(channelId: string, ts: string): Promise<void>;
   sendMarkdown(target: SlackTarget, markdown: string): Promise<string | undefined>;
-  startStream(
-    target: SlackTarget,
-    content?: SlackStreamContent,
-    taskDisplayMode?: SlackTaskDisplayMode,
-  ): Promise<string>;
+  startStream(target: SlackTarget, content?: SlackStreamContent): Promise<string>;
   appendStream(channelId: string, ts: string, content: SlackStreamContent): Promise<void>;
   stopStream(channelId: string, ts: string, content?: SlackStreamContent): Promise<void>;
   setThreadStatus(target: SlackTarget, status: string): Promise<void>;
@@ -180,15 +152,6 @@ export function chunkSlackMarkdown(markdown: string, maxPoints = SLACK_MAX_MARKD
     output.push(`${prefix}${raw}${suffix}`);
   }
   return output;
-}
-
-/** Slack locks a stream to top-level `markdown_text` or `chunks` mode on its first write. Tasks need
- * chunks, so encode text as markdown chunks too; mixing the two modes yields `streaming_mode_mismatch`. */
-function streamChunks(content: SlackStreamContent): SlackStreamChunk[] {
-  return [
-    ...(content.markdownText ? ([{ type: "markdown_text", text: content.markdownText }] as const) : []),
-    ...(content.chunks ?? []),
-  ];
 }
 
 function safeFileName(file: SlackFile): string {
@@ -395,7 +358,7 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
       }
       return first;
     },
-    async startStream(target, content = {}, taskDisplayMode = "timeline") {
+    async startStream(target, content = {}) {
       if (!target.threadTs) throw new Error("Slack native streams require a parent thread timestamp");
       const channelRecipient = target.channelId.startsWith("D")
         ? {}
@@ -406,31 +369,27 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
       if (!target.channelId.startsWith("D") && (!target.recipientUserId || !target.recipientTeamId)) {
         throw new Error("Slack native channel streams require recipient user and team IDs");
       }
-      const chunks = streamChunks(content);
       const data = await call<SlackBody & { ts?: string }>("chat.startStream", {
         channel: target.channelId,
         thread_ts: target.threadTs,
-        task_display_mode: taskDisplayMode,
         ...channelRecipient,
-        ...(chunks.length ? { chunks } : {}),
+        ...(content.markdownText ? { markdown_text: content.markdownText } : {}),
       });
       if (!data.ts) throw new SlackApiError("chat.startStream", 200, "response carried no ts");
       return data.ts;
     },
     async appendStream(channelId, ts, content) {
-      const chunks = streamChunks(content);
       await call("chat.appendStream", {
         channel: channelId,
         ts,
-        ...(chunks.length ? { chunks } : {}),
+        ...(content.markdownText ? { markdown_text: content.markdownText } : {}),
       });
     },
     async stopStream(channelId, ts, content = {}) {
-      const chunks = streamChunks(content);
       await call("chat.stopStream", {
         channel: channelId,
         ts,
-        ...(chunks.length ? { chunks } : {}),
+        ...(content.markdownText ? { markdown_text: content.markdownText } : {}),
       });
     },
     async setThreadStatus(target, status) {

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -395,7 +395,7 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
       }
       return first;
     },
-    async startStream(target, content = {}, taskDisplayMode = "timeline") {
+    async startStream(target, content = {}, taskDisplayMode = "plan") {
       if (!target.threadTs) throw new Error("Slack native streams require a parent thread timestamp");
       const channelRecipient = target.channelId.startsWith("D")
         ? {}

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -23,10 +23,6 @@ export interface SlackTarget {
   recipientTeamId?: string;
 }
 
-interface SlackStreamContent {
-  markdownText?: string;
-}
-
 export interface DownloadedSlackFile {
   path: string;
   name: string;
@@ -89,9 +85,9 @@ export interface SlackApi {
   updateMarkdown(channelId: string, ts: string, markdown: string): Promise<void>;
   deleteMessage(channelId: string, ts: string): Promise<void>;
   sendMarkdown(target: SlackTarget, markdown: string): Promise<string | undefined>;
-  startStream(target: SlackTarget, content?: SlackStreamContent): Promise<string>;
-  appendStream(channelId: string, ts: string, content: SlackStreamContent): Promise<void>;
-  stopStream(channelId: string, ts: string, content?: SlackStreamContent): Promise<void>;
+  startStream(target: SlackTarget, markdown?: string): Promise<string>;
+  appendStream(channelId: string, ts: string, markdown: string): Promise<void>;
+  stopStream(channelId: string, ts: string, markdown?: string): Promise<void>;
   setThreadStatus(target: SlackTarget, status: string): Promise<void>;
   setThreadTitle(target: SlackTarget, title: string): Promise<void>;
   addReaction(channelId: string, timestamp: string, emoji: string): Promise<void>;
@@ -358,7 +354,7 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
       }
       return first;
     },
-    async startStream(target, content = {}) {
+    async startStream(target, markdown) {
       if (!target.threadTs) throw new Error("Slack native streams require a parent thread timestamp");
       const channelRecipient = target.channelId.startsWith("D")
         ? {}
@@ -373,23 +369,19 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
         channel: target.channelId,
         thread_ts: target.threadTs,
         ...channelRecipient,
-        ...(content.markdownText ? { markdown_text: content.markdownText } : {}),
+        ...(markdown ? { markdown_text: markdown } : {}),
       });
       if (!data.ts) throw new SlackApiError("chat.startStream", 200, "response carried no ts");
       return data.ts;
     },
-    async appendStream(channelId, ts, content) {
-      await call("chat.appendStream", {
-        channel: channelId,
-        ts,
-        ...(content.markdownText ? { markdown_text: content.markdownText } : {}),
-      });
+    async appendStream(channelId, ts, markdown) {
+      await call("chat.appendStream", { channel: channelId, ts, markdown_text: markdown });
     },
-    async stopStream(channelId, ts, content = {}) {
+    async stopStream(channelId, ts, markdown) {
       await call("chat.stopStream", {
         channel: channelId,
         ts,
-        ...(content.markdownText ? { markdown_text: content.markdownText } : {}),
+        ...(markdown ? { markdown_text: markdown } : {}),
       });
     },
     async setThreadStatus(target, status) {

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -118,8 +118,8 @@ export interface SlackChannelOptions {
    * explicit continuous/custom policy necessarily uses the classic renderer because Slack streams
    * require a parent user message. */
   rendering?: SlackRendering;
-  /** Native task-card layout (`chat.startStream` `task_display_mode`): `plan` (default) groups steps
-   * under a single collapsible heading, `timeline` lists each step sequentially, `dense` collapses
+  /** Native task-card layout (`chat.startStream` `task_display_mode`): `timeline` (default) lists each
+   * step sequentially, `plan` groups steps under a single collapsible heading, and `dense` collapses
    * consecutive tool calls into one summarized card. Applies to the native renderer only. */
   taskDisplay?: SlackTaskDisplayMode;
   /** Optional footer for successful Agent replies. Omitted or `false` sends no repetitive disclaimer. */
@@ -176,7 +176,7 @@ export function slackChannel({
   groupMessageSession = "threaded",
   groupBehavior = "context",
   rendering = "native",
-  taskDisplay = "plan",
+  taskDisplay = "timeline",
   aiDisclaimer,
   welcome = DEFAULT_WELCOME,
   reactionAck = {},

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -118,9 +118,9 @@ export interface SlackChannelOptions {
    * explicit continuous/custom policy necessarily uses the classic renderer because Slack streams
    * require a parent user message. */
   rendering?: SlackRendering;
-  /** Native task-card layout (`chat.startStream` `task_display_mode`): `timeline` (default) shows
-   * each tool's details/output, `plan` groups title-only steps under one heading, and `dense` collapses
-   * consecutive title-only calls. Applies to the native renderer only. */
+  /** Native task-card layout (`chat.startStream` `task_display_mode`): `plan` (default) groups steps
+   * under a single collapsible heading, `timeline` lists each step sequentially, `dense` collapses
+   * consecutive tool calls into one summarized card. Applies to the native renderer only. */
   taskDisplay?: SlackTaskDisplayMode;
   /** Optional footer for successful Agent replies. Omitted or `false` sends no repetitive disclaimer. */
   aiDisclaimer?: string | false;
@@ -176,7 +176,7 @@ export function slackChannel({
   groupMessageSession = "threaded",
   groupBehavior = "context",
   rendering = "native",
-  taskDisplay = "timeline",
+  taskDisplay = "plan",
   aiDisclaimer,
   welcome = DEFAULT_WELCOME,
   reactionAck = {},

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -41,7 +41,7 @@ import {
   streamSlackReply,
 } from "./preview.ts";
 import { resolveReactionEmojis, startSlackReaction } from "./reaction.ts";
-import { type SlackTarget, type SlackTaskDisplayMode, createSlackApi } from "./slack-api.ts";
+import { type SlackTarget, createSlackApi } from "./slack-api.ts";
 import { createWelcomedUsers } from "./welcomed.ts";
 
 export { defaultSlackRoute, slackEnvelope };
@@ -113,15 +113,11 @@ export interface SlackChannelOptions {
   /** `context` (default) admits bare replies in managed group threads and buffers unsummoned group
    * discussion. `mentions` answers only app_mention plus DMs for an explicit least-privilege setup. */
   groupBehavior?: "context" | "mentions";
-  /** `native` (default) uses Slack Agent streams/tasks for threaded replies. `classic` retains the
+  /** `native` (default) uses Slack Agent streams for threaded replies. `classic` retains the
    * compatibility renderer based on one rate-limited edited message. A top-level target selected by an
    * explicit continuous/custom policy necessarily uses the classic renderer because Slack streams
    * require a parent user message. */
   rendering?: SlackRendering;
-  /** Native task-card layout (`chat.startStream` `task_display_mode`): `timeline` (default) lists each
-   * step sequentially, `plan` groups steps under a single collapsible heading, and `dense` collapses
-   * consecutive tool calls into one summarized card. Applies to the native renderer only. */
-  taskDisplay?: SlackTaskDisplayMode;
   /** Optional footer for successful Agent replies. Omitted or `false` sends no repetitive disclaimer. */
   aiDisclaimer?: string | false;
   /** First-run direct-message welcome, sent once when a user first opens the DM (`app_home_opened`,
@@ -176,7 +172,6 @@ export function slackChannel({
   groupMessageSession = "threaded",
   groupBehavior = "context",
   rendering = "native",
-  taskDisplay = "timeline",
   aiDisclaimer,
   welcome = DEFAULT_WELCOME,
   reactionAck = {},
@@ -195,9 +190,6 @@ export function slackChannel({
   }
   if (!(["native", "classic"] as const).includes(rendering)) {
     throw new Error('slackChannel rendering must be "native" or "classic"');
-  }
-  if (!(["timeline", "plan", "dense"] as const).includes(taskDisplay)) {
-    throw new Error('slackChannel taskDisplay must be "timeline", "plan", or "dense"');
   }
   if (welcome !== false && typeof welcome !== "string") {
     throw new Error("slackChannel welcome must be a string or false");
@@ -370,7 +362,6 @@ export function slackChannel({
               initialPreviewTs: turn.previewTs,
               threadTitle: turn.threadTitle,
               disclaimer: aiDisclaimer,
-              taskDisplay,
               label,
             },
           );

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -118,9 +118,9 @@ export interface SlackChannelOptions {
    * explicit continuous/custom policy necessarily uses the classic renderer because Slack streams
    * require a parent user message. */
   rendering?: SlackRendering;
-  /** Native task-card layout (`chat.startStream` `task_display_mode`): `plan` (default) groups steps
-   * under a single collapsible heading, `timeline` lists each step sequentially, `dense` collapses
-   * consecutive tool calls into one summarized card. Applies to the native renderer only. */
+  /** Native task-card layout (`chat.startStream` `task_display_mode`): `timeline` (default) shows
+   * each tool's details/output, `plan` groups title-only steps under one heading, and `dense` collapses
+   * consecutive title-only calls. Applies to the native renderer only. */
   taskDisplay?: SlackTaskDisplayMode;
   /** Optional footer for successful Agent replies. Omitted or `false` sends no repetitive disclaimer. */
   aiDisclaimer?: string | false;
@@ -176,7 +176,7 @@ export function slackChannel({
   groupMessageSession = "threaded",
   groupBehavior = "context",
   rendering = "native",
-  taskDisplay = "plan",
+  taskDisplay = "timeline",
   aiDisclaimer,
   welcome = DEFAULT_WELCOME,
   reactionAck = {},

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -161,24 +161,35 @@ function messageRefOf(turnId: string): { channelId: string; ts: string } | undef
   return parts.length === 3 && parts[1] && parts[2] ? { channelId: parts[1], ts: parts[2] } : undefined;
 }
 
-export function slackChannel({
-  botToken,
-  signingSecret,
-  botRefreshToken,
-  clientId,
-  clientSecret,
-  botTokenExpiresAt,
-  directMessageSession = "threaded",
-  groupMessageSession = "threaded",
-  groupBehavior = "context",
-  rendering = "native",
-  aiDisclaimer,
-  welcome = DEFAULT_WELCOME,
-  reactionAck = {},
-  route,
-  onError,
-  apiBaseUrl = "https://slack.com/api",
-}: SlackChannelOptions): ChannelModule {
+export function slackChannel(options: SlackChannelOptions): ChannelModule {
+  const {
+    botToken,
+    signingSecret,
+    botRefreshToken,
+    clientId,
+    clientSecret,
+    botTokenExpiresAt,
+    directMessageSession = "threaded",
+    groupMessageSession = "threaded",
+    groupBehavior = "context",
+    rendering = "native",
+    aiDisclaimer,
+    welcome = DEFAULT_WELCOME,
+    reactionAck = {},
+    route,
+    onError,
+    apiBaseUrl = "https://slack.com/api",
+  } = options;
+
+  // `taskDisplay` was a published 0.15.0 option that only laid out Slack Task Cards. Silently
+  // ignoring it would turn a rejected illegal value into an accepted no-op for any config TS does not
+  // check (plain JS, an older scaffold copy).
+  if ("taskDisplay" in options) {
+    throw new Error(
+      "slackChannel no longer accepts taskDisplay: tool activity streams as inline Markdown traces, " +
+        "not Slack Task Cards — remove the option",
+    );
+  }
   if (!(["continuous", "threaded"] as const).includes(directMessageSession)) {
     throw new Error('slackChannel directMessageSession must be "continuous" or "threaded"');
   }

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -113,9 +113,11 @@ export interface SlackChannelOptions {
   /** `context` (default) admits bare replies in managed group threads and buffers unsummoned group
    * discussion. `mentions` answers only app_mention plus DMs for an explicit least-privilege setup. */
   groupBehavior?: "context" | "mentions";
-  /** `native` (default) uses Slack Agent streams for threaded replies. `classic` retains the
-   * compatibility renderer based on one rate-limited edited message. A top-level target selected by an
-   * explicit continuous/custom policy necessarily uses the classic renderer because Slack streams
+  /** `native` (default) uses Slack Agent streams for threaded replies. Its inline tool traces carry a
+   * bounded summary of each call's first argument and cannot be retracted, so they stay in the
+   * delivered message beside the answer. `classic` retains the compatibility renderer based on one
+   * rate-limited edited message, which settles into the answer alone. A top-level target selected by
+   * an explicit continuous/custom policy necessarily uses the classic renderer because Slack streams
    * require a parent user message. */
   rendering?: SlackRendering;
   /** Optional footer for successful Agent replies. Omitted or `false` sends no repetitive disclaimer. */

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -163,35 +163,24 @@ function messageRefOf(turnId: string): { channelId: string; ts: string } | undef
   return parts.length === 3 && parts[1] && parts[2] ? { channelId: parts[1], ts: parts[2] } : undefined;
 }
 
-export function slackChannel(options: SlackChannelOptions): ChannelModule {
-  const {
-    botToken,
-    signingSecret,
-    botRefreshToken,
-    clientId,
-    clientSecret,
-    botTokenExpiresAt,
-    directMessageSession = "threaded",
-    groupMessageSession = "threaded",
-    groupBehavior = "context",
-    rendering = "native",
-    aiDisclaimer,
-    welcome = DEFAULT_WELCOME,
-    reactionAck = {},
-    route,
-    onError,
-    apiBaseUrl = "https://slack.com/api",
-  } = options;
-
-  // `taskDisplay` was a published 0.15.0 option that only laid out Slack Task Cards. Silently
-  // ignoring it would turn a rejected illegal value into an accepted no-op for any config TS does not
-  // check (plain JS, an older scaffold copy).
-  if ((options as unknown as Record<string, unknown>).taskDisplay !== undefined) {
-    throw new Error(
-      "slackChannel no longer accepts taskDisplay: tool activity streams as inline Markdown traces, " +
-        "not Slack Task Cards — remove the option",
-    );
-  }
+export function slackChannel({
+  botToken,
+  signingSecret,
+  botRefreshToken,
+  clientId,
+  clientSecret,
+  botTokenExpiresAt,
+  directMessageSession = "threaded",
+  groupMessageSession = "threaded",
+  groupBehavior = "context",
+  rendering = "native",
+  aiDisclaimer,
+  welcome = DEFAULT_WELCOME,
+  reactionAck = {},
+  route,
+  onError,
+  apiBaseUrl = "https://slack.com/api",
+}: SlackChannelOptions): ChannelModule {
   if (!(["continuous", "threaded"] as const).includes(directMessageSession)) {
     throw new Error('slackChannel directMessageSession must be "continuous" or "threaded"');
   }

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -184,7 +184,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
   // `taskDisplay` was a published 0.15.0 option that only laid out Slack Task Cards. Silently
   // ignoring it would turn a rejected illegal value into an accepted no-op for any config TS does not
   // check (plain JS, an older scaffold copy).
-  if ("taskDisplay" in options) {
+  if ((options as unknown as Record<string, unknown>).taskDisplay !== undefined) {
     throw new Error(
       "slackChannel no longer accepts taskDisplay: tool activity streams as inline Markdown traces, " +
         "not Slack Task Cards — remove the option",

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -111,7 +111,7 @@ function buildChannel(
     appId: "app",
     appSecret: "secret",
     verificationToken: TOKEN,
-    baseUrl: BASE,
+    apiBaseUrl: BASE,
     ...channelOpts,
   })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control });
   const handler = routes["POST /feishu"];
@@ -372,7 +372,7 @@ describe("turn flow", () => {
       appId: "app",
       appSecret: "secret",
       verificationToken: TOKEN,
-      baseUrl: BASE,
+      apiBaseUrl: BASE,
     })({ agent: restarted.agent, stateRoot: first.root });
     const again = routes["POST /feishu"];
     if (!again) throw new Error("expected POST /feishu");
@@ -1443,6 +1443,7 @@ describe("turn flow", () => {
           seq: 1,
           session: "oc_9",
           baseText: "what a prior run never finished",
+          bufferKey: "oc_9",
           chatId: "oc_9",
           images: [],
           files: [],
@@ -1451,7 +1452,7 @@ describe("turn flow", () => {
       }),
     );
     const { agent, calls } = replyingAgent("recovered");
-    const handler = buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: TOKEN, baseUrl: BASE })({
+    const handler = buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: TOKEN, apiBaseUrl: BASE })({
       agent,
       stateRoot: root,
     })["POST /feishu"];
@@ -1562,7 +1563,7 @@ describe("the Lark compatibility profile", () => {
       appId: "app",
       appSecret: "secret",
       verificationToken: TOKEN,
-      baseUrl: BASE,
+      apiBaseUrl: BASE,
     })({ agent, stateRoot: root });
     expect(routes["POST /feishu"]).toBeUndefined();
     const handler = routes["POST /lark"];

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -96,7 +96,7 @@ describe("Slack Web API transport", () => {
         thread_ts: "9.0",
         recipient_user_id: "U1",
         recipient_team_id: "T1",
-        task_display_mode: "plan",
+        task_display_mode: "timeline",
       },
     });
     expect(calls[2]?.body).toMatchObject({

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -66,7 +66,16 @@ describe("Slack Web API transport", () => {
     await expect(api.postMarkdown(target, "**bold**")).resolves.toBe("1.0");
     const streamTs = await api.startStream(target, { markdownText: "# Answer" });
     await api.appendStream("C1", streamTs, {
-      chunks: [{ type: "task_update", id: "tool-1", title: "search", status: "in_progress" }],
+      chunks: [
+        {
+          type: "task_update",
+          id: "tool-1",
+          title: "search",
+          status: "in_progress",
+          details: "public docs",
+          output: "found 3 results",
+        },
+      ],
     });
     await api.stopStream("C1", streamTs);
     await api.setThreadStatus(target, "is working…");
@@ -91,7 +100,16 @@ describe("Slack Web API transport", () => {
       },
     });
     expect(calls[2]?.body).toMatchObject({
-      chunks: [{ type: "task_update", id: "tool-1", title: "search", status: "in_progress" }],
+      chunks: [
+        {
+          type: "task_update",
+          id: "tool-1",
+          title: "search",
+          status: "in_progress",
+          details: "public docs",
+          output: "found 3 results",
+        },
+      ],
     });
     expect(calls.map((call) => call.method)).toEqual([
       "chat.postMessage",

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -65,18 +65,7 @@ describe("Slack Web API transport", () => {
 
     await expect(api.postMarkdown(target, "**bold**")).resolves.toBe("1.0");
     const streamTs = await api.startStream(target, { markdownText: "# Answer" });
-    await api.appendStream("C1", streamTs, {
-      chunks: [
-        {
-          type: "task_update",
-          id: "tool-1",
-          title: "search",
-          status: "in_progress",
-          details: "public docs",
-          output: "found 3 results",
-        },
-      ],
-    });
+    await api.appendStream("C1", streamTs, { markdownText: "**Search** — `public docs`" });
     await api.stopStream("C1", streamTs);
     await api.setThreadStatus(target, "is working…");
     await api.setThreadTitle(target, "A useful title");
@@ -92,25 +81,13 @@ describe("Slack Web API transport", () => {
     expect(calls[1]).toMatchObject({
       method: "chat.startStream",
       body: {
-        chunks: [{ type: "markdown_text", text: "# Answer" }],
+        markdown_text: "# Answer",
         thread_ts: "9.0",
         recipient_user_id: "U1",
         recipient_team_id: "T1",
-        task_display_mode: "timeline",
       },
     });
-    expect(calls[2]?.body).toMatchObject({
-      chunks: [
-        {
-          type: "task_update",
-          id: "tool-1",
-          title: "search",
-          status: "in_progress",
-          details: "public docs",
-          output: "found 3 results",
-        },
-      ],
-    });
+    expect(calls[2]?.body).toMatchObject({ markdown_text: "**Search** — `public docs`" });
     expect(calls.map((call) => call.method)).toEqual([
       "chat.postMessage",
       "chat.startStream",

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -96,7 +96,7 @@ describe("Slack Web API transport", () => {
         thread_ts: "9.0",
         recipient_user_id: "U1",
         recipient_team_id: "T1",
-        task_display_mode: "timeline",
+        task_display_mode: "plan",
       },
     });
     expect(calls[2]?.body).toMatchObject({

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -64,8 +64,8 @@ describe("Slack Web API transport", () => {
     };
 
     await expect(api.postMarkdown(target, "**bold**")).resolves.toBe("1.0");
-    const streamTs = await api.startStream(target, { markdownText: "# Answer" });
-    await api.appendStream("C1", streamTs, { markdownText: "**Search** — `public docs`" });
+    const streamTs = await api.startStream(target, "# Answer");
+    await api.appendStream("C1", streamTs, "**Search** — `public docs`");
     await api.stopStream("C1", streamTs);
     await api.setThreadStatus(target, "is working…");
     await api.setThreadTitle(target, "A useful title");

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -86,6 +86,63 @@ describe("Slack reply rendering", () => {
   });
 });
 
+describe("native Slack tool tasks", () => {
+  it("shows the operation and a bounded failed result in the native task card", async () => {
+    const api = fakeApi();
+    const events = (async function* (): AsyncIterable<AgentEvent> {
+      yield {
+        type: "tool_started",
+        id: "tool-1",
+        name: "bash",
+        args: { command: `npm test <!channel> ${"🐍".repeat(80)}` },
+      };
+      yield {
+        type: "tool_ended",
+        id: "tool-1",
+        isError: true,
+        content: {
+          content: [{ type: "text", text: `permission denied <!here> ${"💥".repeat(300)}` }],
+        },
+      };
+      yield { type: "text", delta: "Recovered." };
+      yield { type: "completed" };
+    })();
+
+    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+      rendering: "native",
+      disclaimer: false,
+    });
+
+    const started = vi.mocked(api.startStream).mock.calls[0]?.[1]?.chunks?.[0];
+    expect(started).toMatchObject({
+      type: "task_update",
+      id: "tool-1",
+      title: "Bash",
+      status: "in_progress",
+    });
+    if (started?.type !== "task_update") throw new Error("missing started task update");
+    expect(started.details).toContain("npm test &lt;!channel>");
+    expect(started.details).not.toContain("<!channel>");
+
+    const ended = vi
+      .mocked(api.appendStream)
+      .mock.calls.flatMap(([, , content]) => content.chunks ?? [])
+      .find((chunk) => chunk.type === "task_update" && chunk.status === "error");
+    expect(ended).toMatchObject({
+      type: "task_update",
+      id: "tool-1",
+      title: "Bash",
+      details: started.details,
+      status: "error",
+    });
+    if (ended?.type !== "task_update") throw new Error("missing ended task update");
+    expect(ended.output).toContain("permission denied &lt;!here>");
+    expect(ended.output).not.toContain("<!here>");
+    expect(Array.from(`${ended.title}${ended.details ?? ""}${ended.output ?? ""}`)).toHaveLength(256);
+    expect(ended.output?.endsWith("…")).toBe(true);
+  });
+});
+
 describe("native DM Agent status around a retry backoff", () => {
   function eventSource() {
     const queue: AgentEvent[] = [];

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -140,6 +140,42 @@ describe("native Slack tool tasks", () => {
     expect(ended.output).not.toContain("<!here>");
     expect(Array.from(`${ended.title}${ended.details ?? ""}${ended.output ?? ""}`)).toHaveLength(256);
     expect(ended.output?.endsWith("…")).toBe(true);
+    expect(vi.mocked(api.startStream).mock.calls[0]?.[2]).toBe("timeline");
+  });
+
+  it("folds operation details into the title for Slack's compact layouts", async () => {
+    const api = fakeApi();
+    const events = (async function* (): AsyncIterable<AgentEvent> {
+      yield { type: "tool_started", id: "tool-1", name: "bash", args: { command: "find src -type f" } };
+      yield { type: "tool_ended", id: "tool-1", isError: false, content: null };
+      yield { type: "completed" };
+    })();
+
+    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+      rendering: "native",
+      taskDisplay: "plan",
+      disclaimer: false,
+    });
+
+    const started = vi.mocked(api.startStream).mock.calls[0]?.[1]?.chunks?.[0];
+    expect(started).toEqual({
+      type: "task_update",
+      id: "tool-1",
+      title: "Bash find src -type f",
+      status: "in_progress",
+    });
+    expect(vi.mocked(api.startStream).mock.calls[0]?.[2]).toBe("plan");
+
+    const ended = vi
+      .mocked(api.appendStream)
+      .mock.calls.flatMap(([, , content]) => content.chunks ?? [])
+      .find((chunk) => chunk.type === "task_update" && chunk.status === "complete");
+    expect(ended).toEqual({
+      type: "task_update",
+      id: "tool-1",
+      title: "Bash find src -type f",
+      status: "complete",
+    });
   });
 });
 

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -86,8 +86,8 @@ describe("Slack reply rendering", () => {
   });
 });
 
-describe("native Slack tool tasks", () => {
-  it("shows the operation and a bounded failed result in the native task card", async () => {
+describe("native Slack tool traces", () => {
+  it("shows the invoked operation and a bounded failed result as inline Markdown", async () => {
     const api = fakeApi();
     const events = (async function* (): AsyncIterable<AgentEvent> {
       yield {
@@ -113,33 +113,17 @@ describe("native Slack tool tasks", () => {
       disclaimer: false,
     });
 
-    const started = vi.mocked(api.startStream).mock.calls[0]?.[1]?.chunks?.[0];
-    expect(started).toMatchObject({
-      type: "task_update",
-      id: "tool-1",
-      title: "Bash",
-      status: "in_progress",
-    });
-    if (started?.type !== "task_update") throw new Error("missing started task update");
-    expect(started.details).toContain("npm test &lt;!channel>");
-    expect(started.details).not.toContain("<!channel>");
+    const invocation = vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText ?? "";
+    expect(invocation).toContain("**Bash** — `npm test &lt;!channel>");
+    expect(invocation).not.toContain("<!channel>");
 
-    const ended = vi
-      .mocked(api.appendStream)
-      .mock.calls.flatMap(([, , content]) => content.chunks ?? [])
-      .find((chunk) => chunk.type === "task_update" && chunk.status === "error");
-    expect(ended).toMatchObject({
-      type: "task_update",
-      id: "tool-1",
-      title: "Bash",
-      details: started.details,
-      status: "error",
-    });
-    if (ended?.type !== "task_update") throw new Error("missing ended task update");
-    expect(ended.output).toContain("permission denied &lt;!here>");
-    expect(ended.output).not.toContain("<!here>");
-    expect(Array.from(`${ended.title}${ended.details ?? ""}${ended.output ?? ""}`)).toHaveLength(256);
-    expect(ended.output?.endsWith("…")).toBe(true);
+    const appended = vi.mocked(api.appendStream).mock.calls.map(([, , content]) => content.markdownText ?? "");
+    const failure = appended.find((text) => text.includes("failed")) ?? "";
+    expect(failure).toContain("**Bash** failed — `permission denied &lt;!here>");
+    expect(failure).not.toContain("<!here>");
+    expect(failure).toContain("…");
+    expect(Array.from(failure).length).toBeLessThanOrEqual(300);
+    expect(appended.join("\n")).toContain("Recovered.");
   });
 });
 

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -140,42 +140,6 @@ describe("native Slack tool tasks", () => {
     expect(ended.output).not.toContain("<!here>");
     expect(Array.from(`${ended.title}${ended.details ?? ""}${ended.output ?? ""}`)).toHaveLength(256);
     expect(ended.output?.endsWith("…")).toBe(true);
-    expect(vi.mocked(api.startStream).mock.calls[0]?.[2]).toBe("timeline");
-  });
-
-  it("folds operation details into the title for Slack's compact layouts", async () => {
-    const api = fakeApi();
-    const events = (async function* (): AsyncIterable<AgentEvent> {
-      yield { type: "tool_started", id: "tool-1", name: "bash", args: { command: "find src -type f" } };
-      yield { type: "tool_ended", id: "tool-1", isError: false, content: null };
-      yield { type: "completed" };
-    })();
-
-    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
-      rendering: "native",
-      taskDisplay: "plan",
-      disclaimer: false,
-    });
-
-    const started = vi.mocked(api.startStream).mock.calls[0]?.[1]?.chunks?.[0];
-    expect(started).toEqual({
-      type: "task_update",
-      id: "tool-1",
-      title: "Bash find src -type f",
-      status: "in_progress",
-    });
-    expect(vi.mocked(api.startStream).mock.calls[0]?.[2]).toBe("plan");
-
-    const ended = vi
-      .mocked(api.appendStream)
-      .mock.calls.flatMap(([, , content]) => content.chunks ?? [])
-      .find((chunk) => chunk.type === "task_update" && chunk.status === "complete");
-    expect(ended).toEqual({
-      type: "task_update",
-      id: "tool-1",
-      title: "Bash find src -type f",
-      status: "complete",
-    });
   });
 });
 

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -87,7 +87,7 @@ describe("Slack reply rendering", () => {
 });
 
 describe("native Slack tool traces", () => {
-  it("shows the invoked operation and a bounded failed result as inline Markdown", async () => {
+  it("shows the bounded invoked operation and states a failure without its output", async () => {
     const api = fakeApi();
     const events = (async function* (): AsyncIterable<AgentEvent> {
       yield {
@@ -100,9 +100,7 @@ describe("native Slack tool traces", () => {
         type: "tool_ended",
         id: "tool-1",
         isError: true,
-        content: {
-          content: [{ type: "text", text: `permission denied <!here> ${"💥".repeat(300)}` }],
-        },
+        content: { content: [{ type: "text", text: "permission denied: /etc/shadow" }] },
       };
       yield { type: "text", delta: "Recovered." };
       yield { type: "completed" };
@@ -116,13 +114,12 @@ describe("native Slack tool traces", () => {
     const invocation = vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText ?? "";
     expect(invocation).toContain("**Bash** — `npm test &lt;!channel>");
     expect(invocation).not.toContain("<!channel>");
+    expect(invocation).toContain("…"); // the shared 48-code-point argument bound
 
     const appended = vi.mocked(api.appendStream).mock.calls.map(([, , content]) => content.markdownText ?? "");
     const failure = appended.find((text) => text.includes("failed")) ?? "";
-    expect(failure).toContain("**Bash** failed — `permission denied &lt;!here>");
-    expect(failure).not.toContain("<!here>");
-    expect(failure).toContain("…");
-    expect(Array.from(failure).length).toBeLessThanOrEqual(300);
+    expect(failure).toContain("**Bash** failed");
+    expect(appended.join("\n")).not.toContain("/etc/shadow");
     expect(appended.join("\n")).toContain("Recovered.");
   });
 });

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -146,6 +146,29 @@ describe("native Slack tool traces", () => {
     expect(written).toBe("Checking.\n\n**Read** — `AGENTS.md`\n\nDone.");
   });
 
+  it("keeps an untrusted name or argument from breaking the surrounding Markdown", async () => {
+    const api = fakeApi();
+    const events = (async function* (): AsyncIterable<AgentEvent> {
+      yield { type: "tool_started", id: "tool-1", name: "_", args: { command: "echo **b** _c_" } };
+      yield { type: "tool_started", id: "tool-2", name: "bash", args: { command: "`x`" } };
+      yield { type: "completed" };
+    })();
+
+    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+      rendering: "native",
+      disclaimer: false,
+    });
+
+    const written = [
+      vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText ?? "",
+      ...vi.mocked(api.appendStream).mock.calls.map(([, , content]) => content.markdownText ?? ""),
+    ].join("");
+    // Emphasis in the label is escaped, and a code span is fenced longer than any backtick run inside
+    // it (padded when the value's own edges are backticks) — the literal text is never rewritten.
+    expect(written).toContain("**\\_** — `echo **b** _c_`");
+    expect(written).toContain("**Bash** — `` `x` ``");
+  });
+
   it("shows the first primitive argument whatever it holds — the disclosed boundary, not a filter", async () => {
     const api = fakeApi();
     // A channel knows no tool schemas, so the summary cannot tell a query from a credential. This is

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -111,12 +111,12 @@ describe("native Slack tool traces", () => {
       disclaimer: false,
     });
 
-    const invocation = vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText ?? "";
+    const invocation = vi.mocked(api.startStream).mock.calls[0]?.[1] ?? "";
     expect(invocation).toContain("**Bash** — `npm test &lt;!channel>");
     expect(invocation).not.toContain("<!channel>");
     expect(invocation).toContain("…"); // the shared 48-code-point argument bound
 
-    const appended = vi.mocked(api.appendStream).mock.calls.map(([, , content]) => content.markdownText ?? "");
+    const appended = vi.mocked(api.appendStream).mock.calls.map(([, , markdown]) => markdown);
     const failure = appended.find((text) => text.includes("failed")) ?? "";
     expect(failure).toContain("**Bash** failed — `npm test"); // the operation, so repeated calls stay apart
     expect(appended.join("\n")).not.toContain("/etc/shadow");
@@ -139,8 +139,8 @@ describe("native Slack tool traces", () => {
     });
 
     const written = [
-      vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText ?? "",
-      ...vi.mocked(api.appendStream).mock.calls.map(([, , content]) => content.markdownText ?? ""),
+      vi.mocked(api.startStream).mock.calls[0]?.[1] ?? "",
+      ...vi.mocked(api.appendStream).mock.calls.map(([, , markdown]) => markdown),
     ].join("");
     // A trace after text opens its own block, and the text resuming after it is not glued to the trace.
     expect(written).toBe("Checking.\n\n**Read** — `AGENTS.md`\n\nDone.");
@@ -160,8 +160,8 @@ describe("native Slack tool traces", () => {
     });
 
     const written = [
-      vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText ?? "",
-      ...vi.mocked(api.appendStream).mock.calls.map(([, , content]) => content.markdownText ?? ""),
+      vi.mocked(api.startStream).mock.calls[0]?.[1] ?? "",
+      ...vi.mocked(api.appendStream).mock.calls.map(([, , markdown]) => markdown),
     ].join("");
     // Emphasis in the label is escaped, and a code span is fenced longer than any backtick run inside
     // it (padded when the value's own edges are backticks) — the literal text is never rewritten.
@@ -183,7 +183,7 @@ describe("native Slack tool traces", () => {
       disclaimer: false,
     });
 
-    expect(vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText).toContain("**Deploy** — `sk-live-secret`");
+    expect(vi.mocked(api.startStream).mock.calls[0]?.[1]).toContain("**Deploy** — `sk-live-secret`");
   });
 });
 

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -118,9 +118,49 @@ describe("native Slack tool traces", () => {
 
     const appended = vi.mocked(api.appendStream).mock.calls.map(([, , content]) => content.markdownText ?? "");
     const failure = appended.find((text) => text.includes("failed")) ?? "";
-    expect(failure).toContain("**Bash** failed");
+    expect(failure).toContain("**Bash** failed — `npm test"); // the operation, so repeated calls stay apart
     expect(appended.join("\n")).not.toContain("/etc/shadow");
     expect(appended.join("\n")).toContain("Recovered.");
+  });
+
+  it("separates a trace from the text around it without splitting the answer", async () => {
+    const api = fakeApi();
+    const events = (async function* (): AsyncIterable<AgentEvent> {
+      yield { type: "text", delta: "Checking." };
+      yield { type: "tool_started", id: "tool-1", name: "read", args: { path: "AGENTS.md" } };
+      yield { type: "tool_ended", id: "tool-1", isError: false, content: "ok" };
+      yield { type: "text", delta: "Done." };
+      yield { type: "completed" };
+    })();
+
+    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+      rendering: "native",
+      disclaimer: false,
+    });
+
+    const written = [
+      vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText ?? "",
+      ...vi.mocked(api.appendStream).mock.calls.map(([, , content]) => content.markdownText ?? ""),
+    ].join("");
+    // A trace after text opens its own block, and the text resuming after it is not glued to the trace.
+    expect(written).toBe("Checking.\n\n**Read** — `AGENTS.md`\n\nDone.");
+  });
+
+  it("shows the first primitive argument whatever it holds — the disclosed boundary, not a filter", async () => {
+    const api = fakeApi();
+    // A channel knows no tool schemas, so the summary cannot tell a query from a credential. This is
+    // the boundary docs/slack.md discloses; changing WHICH field is picked has to break a test.
+    const events = (async function* (): AsyncIterable<AgentEvent> {
+      yield { type: "tool_started", id: "tool-1", name: "deploy", args: { token: "sk-live-secret", env: "prod" } };
+      yield { type: "completed" };
+    })();
+
+    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+      rendering: "native",
+      disclaimer: false,
+    });
+
+    expect(vi.mocked(api.startStream).mock.calls[0]?.[1]?.markdownText).toContain("**Deploy** — `sk-live-secret`");
   });
 });
 

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -354,7 +354,7 @@ describe("Slack sessions, context, and managed threads", () => {
       channel: "D1",
       thread_ts: "1.0",
       chunks: [{ type: "markdown_text", text: expect.stringContaining("hello back") }],
-      task_display_mode: "plan",
+      task_display_mode: "timeline",
     });
     expect(JSON.stringify(JSON.parse(String(start?.[1]?.body)))).not.toContain("AI-generated content");
   });
@@ -363,11 +363,11 @@ describe("Slack sessions, context, and managed threads", () => {
     const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("hello back");
-    const { handler } = mount(agent, { taskDisplay: "timeline" });
+    const { handler } = mount(agent, { taskDisplay: "plan" });
     await handler(signedRequest(message("1.0", { channel: "D1", channel_type: "im", text: "hi" })));
     await settle();
 
-    expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({ task_display_mode: "timeline" });
+    expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({ task_display_mode: "plan" });
   });
 
   it("renders concise native task details without exposing reasoning or successful tool output", async () => {

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -370,7 +370,7 @@ describe("Slack sessions, context, and managed threads", () => {
     expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({ task_display_mode: "timeline" });
   });
 
-  it("renders safe native task updates without exposing reasoning or tool arguments", async () => {
+  it("renders concise native task details without exposing reasoning or successful tool output", async () => {
     const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     let prompt: Prompt | undefined;
@@ -378,8 +378,8 @@ describe("Slack sessions, context, and managed threads", () => {
       async *invoke(_scope, value): AsyncIterable<AgentEvent> {
         prompt = value;
         yield { type: "thinking", delta: "private chain of thought: launch-code" };
-        yield { type: "tool_started", id: "t1", name: "search", args: { token: "tool-secret" } };
-        yield { type: "tool_ended", id: "t1", isError: false, content: { result: "internal" } };
+        yield { type: "tool_started", id: "t1", name: "search", args: { query: "public docs" } };
+        yield { type: "tool_ended", id: "t1", isError: false, content: { result: "internal result" } };
         yield { type: "text", delta: "# Safe answer\n\n**Done.** Do not ping <!channel>." };
         yield { type: "completed" };
       },
@@ -404,17 +404,18 @@ describe("Slack sessions, context, and managed threads", () => {
       .map(([, init]) => String(init?.body))
       .join("\n");
     expect(outbound).not.toContain("launch-code");
-    expect(outbound).not.toContain("tool-secret");
+    expect(outbound).toContain("public docs");
+    expect(outbound).not.toContain("internal result");
     expect(outbound).not.toContain("<!channel>");
     expect(outbound).toContain("&lt;!channel>");
     expect(outbound).toContain("Custom policy footer.");
     expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({
-      chunks: [{ type: "task_update", id: "t1", title: "Search", status: "in_progress" }],
+      chunks: [{ type: "task_update", id: "t1", title: "Search", details: "public docs", status: "in_progress" }],
     });
     expect(slackBodies(fetchMock, "chat.appendStream")).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          chunks: [{ type: "task_update", id: "t1", title: "Search", status: "complete" }],
+          chunks: [{ type: "task_update", id: "t1", title: "Search", details: "public docs", status: "complete" }],
         }),
         expect.objectContaining({
           chunks: [{ type: "markdown_text", text: expect.stringContaining("# Safe answer") }],

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -354,20 +354,20 @@ describe("Slack sessions, context, and managed threads", () => {
       channel: "D1",
       thread_ts: "1.0",
       chunks: [{ type: "markdown_text", text: expect.stringContaining("hello back") }],
-      task_display_mode: "plan",
+      task_display_mode: "timeline",
     });
     expect(JSON.stringify(JSON.parse(String(start?.[1]?.body)))).not.toContain("AI-generated content");
   });
 
-  it("routes the configured taskDisplay into the native stream's task_display_mode", async () => {
+  it("routes a configured compact taskDisplay into the native stream", async () => {
     const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("hello back");
-    const { handler } = mount(agent, { taskDisplay: "timeline" });
+    const { handler } = mount(agent, { taskDisplay: "plan" });
     await handler(signedRequest(message("1.0", { channel: "D1", channel_type: "im", text: "hi" })));
     await settle();
 
-    expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({ task_display_mode: "timeline" });
+    expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({ task_display_mode: "plan" });
   });
 
   it("renders concise native task details without exposing reasoning or successful tool output", async () => {

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -354,20 +354,20 @@ describe("Slack sessions, context, and managed threads", () => {
       channel: "D1",
       thread_ts: "1.0",
       chunks: [{ type: "markdown_text", text: expect.stringContaining("hello back") }],
-      task_display_mode: "timeline",
+      task_display_mode: "plan",
     });
     expect(JSON.stringify(JSON.parse(String(start?.[1]?.body)))).not.toContain("AI-generated content");
   });
 
-  it("routes a configured compact taskDisplay into the native stream", async () => {
+  it("routes the configured taskDisplay into the native stream's task_display_mode", async () => {
     const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent } = replyingAgent("hello back");
-    const { handler } = mount(agent, { taskDisplay: "plan" });
+    const { handler } = mount(agent, { taskDisplay: "timeline" });
     await handler(signedRequest(message("1.0", { channel: "D1", channel_type: "im", text: "hi" })));
     await settle();
 
-    expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({ task_display_mode: "plan" });
+    expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({ task_display_mode: "timeline" });
   });
 
   it("renders concise native task details without exposing reasoning or successful tool output", async () => {

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -278,7 +278,7 @@ describe("Slack signed ingress", () => {
     expect(verifySlackSignature(SECRET, timestamp, signature, body, 1_700_001_000_000)).toBe(false);
   });
 
-  it("rejects invalid session, rendering, task-display, and reaction policies at construction", () => {
+  it("rejects invalid session, rendering, and reaction policies at construction", () => {
     expect(() =>
       slackChannel({
         botToken: "xoxb-test",
@@ -293,13 +293,6 @@ describe("Slack signed ingress", () => {
         rendering: "invalid" as "native",
       }),
     ).toThrow(/rendering/);
-    expect(() =>
-      slackChannel({
-        botToken: "xoxb-test",
-        signingSecret: SECRET,
-        taskDisplay: "invalid" as "dense",
-      }),
-    ).toThrow(/taskDisplay/);
     expect(() =>
       slackChannel({
         botToken: "xoxb-test",
@@ -353,24 +346,12 @@ describe("Slack sessions, context, and managed threads", () => {
     expect(JSON.parse(String(start?.[1]?.body))).toMatchObject({
       channel: "D1",
       thread_ts: "1.0",
-      chunks: [{ type: "markdown_text", text: expect.stringContaining("hello back") }],
-      task_display_mode: "timeline",
+      markdown_text: expect.stringContaining("hello back"),
     });
     expect(JSON.stringify(JSON.parse(String(start?.[1]?.body)))).not.toContain("AI-generated content");
   });
 
-  it("routes the configured taskDisplay into the native stream's task_display_mode", async () => {
-    const fetchMock = okFetch();
-    vi.stubGlobal("fetch", fetchMock);
-    const { agent } = replyingAgent("hello back");
-    const { handler } = mount(agent, { taskDisplay: "plan" });
-    await handler(signedRequest(message("1.0", { channel: "D1", channel_type: "im", text: "hi" })));
-    await settle();
-
-    expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({ task_display_mode: "plan" });
-  });
-
-  it("renders concise native task details without exposing reasoning or successful tool output", async () => {
+  it("renders concise native tool traces without exposing reasoning or successful tool output", async () => {
     const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     let prompt: Prompt | undefined;
@@ -410,17 +391,10 @@ describe("Slack sessions, context, and managed threads", () => {
     expect(outbound).toContain("&lt;!channel>");
     expect(outbound).toContain("Custom policy footer.");
     expect(slackBodies(fetchMock, "chat.startStream")[0]).toMatchObject({
-      chunks: [{ type: "task_update", id: "t1", title: "Search", details: "public docs", status: "in_progress" }],
+      markdown_text: expect.stringContaining("**Search** — `public docs`"),
     });
     expect(slackBodies(fetchMock, "chat.appendStream")).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          chunks: [{ type: "task_update", id: "t1", title: "Search", details: "public docs", status: "complete" }],
-        }),
-        expect.objectContaining({
-          chunks: [{ type: "markdown_text", text: expect.stringContaining("# Safe answer") }],
-        }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ markdown_text: expect.stringContaining("# Safe answer") })]),
     );
   });
 

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -293,6 +293,10 @@ describe("Slack signed ingress", () => {
         rendering: "invalid" as "native",
       }),
     ).toThrow(/rendering/);
+    // A published option that is gone: an accepted no-op would be a worse migration than a loud stop.
+    expect(() =>
+      slackChannel({ botToken: "xoxb-test", signingSecret: SECRET, taskDisplay: "timeline" } as SlackChannelOptions),
+    ).toThrow(/taskDisplay/);
     expect(() =>
       slackChannel({
         botToken: "xoxb-test",

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -293,10 +293,6 @@ describe("Slack signed ingress", () => {
         rendering: "invalid" as "native",
       }),
     ).toThrow(/rendering/);
-    // A published option that is gone: an accepted no-op would be a worse migration than a loud stop.
-    expect(() =>
-      slackChannel({ botToken: "xoxb-test", signingSecret: SECRET, taskDisplay: "timeline" } as SlackChannelOptions),
-    ).toThrow(/taskDisplay/);
     expect(() =>
       slackChannel({
         botToken: "xoxb-test",


### PR DESCRIPTION
## Summary

Slack's native streaming previously hid all tool activity, so multi-tool turns (e.g. six consecutive
`bash` calls) looked like the agent was silent or stuck. An earlier iteration of this PR mapped tool
calls to native `task_update` cards; that approach is reverted here because tool calls are execution
facts, not user-level tasks — mapping them to Task Cards misrepresents semantics and locks rendering
into Slack's fixed Task Card UI.

Final approach: stream compact, factual inline tool traces as plain `markdown_text`.

- render each tool call as a bold tool name with a code-formatted argument summary, no emoji:

  ```
  **Bash** — `npm test`
  **Bash** failed — `npm test`
  ```

- **a policy reversal, stated plainly**: native rendering previously showed no tool arguments at all
  (a Task Card had nowhere to put them). It now shows the call's first primitive argument, and a
  native stream cannot be retracted, so that value persists in the delivered message. The channel
  knows no tool schemas, so it cannot tell a query from a credential — `docs/slack.md` discloses this
  and a test pins it. The other renderers show the same summary, but only in a live preview that
  settles into the answer alone
- reuse the shared 48-code-point argument bound (`summarizeToolArgs`) that telegram, feishu, and the
  Slack compatibility renderer already use, so every channel exposes exactly the same thing
- tool OUTPUT never leaves the process, failed or not: the failure line repeats the operation so the
  call is identifiable, and says nothing about what it printed. Reading that would mean guessing the
  engine's result shape inside `src/channels`
- a successful call is not separately confirmed: an append-only stream cannot flip an already-sent
  line to ✓, and the next trace — or the answer itself — is the progress signal
- preserve ordinary assistant `text` in event order; raw `thinking` stays hidden
- drop the `taskDisplay` config and the `timeline | plan | dense` modes introduced mid-PR, along with
  the whole `chunks` mode of the Slack stream API (no longer applicable without Task Cards)
- record the one real exception in `docs/design/core.md` and `docs/slack.md`: a native stream cannot
  be retracted, so its traces persist beside the answer, while every other renderer settles into the
  answer alone. `rendering: "classic"` remains the answer-alone option

## Breaking change

`taskDisplay` was published in 0.15.0 and only laid out Slack Task Cards, which no longer exist here.
The option is removed outright — no runtime guard, no deprecation window: TypeScript rejects it, and a
stale JavaScript config ignores it.

```diff
 export default slackChannel({
   rendering: "native",
-  taskDisplay: "plan",
 });
```

Tool activity is inline Markdown in the same stream; there is no layout knob to replace it.

Explicit high-level task/plan events (Slack Plan UI) are intentionally out of scope: they require task
data the Agent contract does not yet emit, and must not be inferred from `tool_started`/`tool_ended`.


## Also in this branch

Two backward-compatibility carriers in the Feishu channel, removed under the same rule as
`taskDisplay` — this project does not carry compatibility for published options or for state written
by an older release:

- the `baseUrl` channel option, an `@deprecated` alias kept alive for channel files scaffolded before
  the rename to `apiBaseUrl`;
- `bufferKey`'s optionality on a stored turn. It existed so a record written before context buffering
  could still be recovered, at the cost of an invented `:legacy-turn:` bucket on every restart. The
  field is required now, so a pre-buffer record degrades like any wrong-shape state file: the store
  warns and starts empty, once, visibly.

`parse.ts`'s `parseContent` is *described* as a compatibility shim "for existing helpers/tests" but
sits on the live path (the prompt envelope, and quoted-parent resolution). Only its companion text was
wrong; the projection itself is real and stays.

## Testing

- `npm test` (1003 tests / 89 files)
- `npm run typecheck`
- `npm run lint` (only the pre-existing warning)
- `npm run build`




