### PR TITLE
chore: ignore node_modules/dist/.fastagent as names, not only as directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-node_modules/
-dist/
-.fastagent/
+node_modules
+dist
+.fastagent
 .env
 .env.*
 !.env.example


### PR DESCRIPTION
## Why

A trailing-slash `.gitignore` pattern matches only a path that lstat reports as a **directory**. A
*symlink* named `node_modules` — the ordinary way to share one install across git worktrees — is not a
directory, so it was untracked rather than ignored, and `git add -A` swept it into a commit.

That is not hypothetical: a `node_modules` symlink pointing at one machine's absolute path rode into
`main` in #279 (`2b73db5`) and was removed again in #282 (`e368a3d`). No release fell inside that
window and nothing else was affected — but the same trap is still armed for `dist` and `.fastagent`.

## Reproduction

```console
$ git init t && cd t
$ printf 'node_modules/\n' > .gitignore && ln -s /tmp node_modules
$ git status --short
?? .gitignore
?? node_modules          # <- swept up by `git add -A`

$ printf 'node_modules\n' > .gitignore
$ git status --short
?? .gitignore            # node_modules is ignored
```

## What changes

`node_modules/` becomes `node_modules`, and the same for `dist` and `.fastagent`. A bare name matches
the entry however it is realized — directory, file, or symlink — which is what these three entries
mean. The remaining patterns (`.env`, `*.log`, ...) were already names.
