### PR TITLE
feat(serve): a bind address — containers keep all interfaces, a desktop gets loopback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,15 @@ src/
 ├── cli.ts                   # the THIN entry (import-free; lazy-loads cli/program.ts)
 ├── cli/                     # the CLI, built on clig.dev: kernel.ts (CommandSpec-as-data + the commander adapter — commander appears ONLY here; help/suggestions/exit-code policy: 0 ok, 1 runtime, 2 usage), program.ts (the spec registry — the CLI surface's single source of truth; lazy per-command imports), presenters (invoke-stream.ts `invoke` stream → exit code; models-view.ts/auth-view.ts `models`/auth-report output; add-feishu.ts `add feishu|lark` app onboarding), shared.ts/serve.ts (cross-command helpers incl. mountSessionControl — per-boot token + control.json discovery file; process side effects live in the command modules), fail.ts, commands/ (one module per command)
 ├── telegram.ts, github.ts   # subpath-export shims (@fastagent-sh/fastagent/telegram etc. — the supported surface)
-├── bind.ts                  # THE reading of a bind address: parse (isBindAddress), reach
-│                           # (classifyBind), localhost-dialability (answersLocalhost), URL form
-│                           # (clientHost). The flag, http.host validation, serveNode, the ready log
-│                           # and the deploy pre-flight all read one through it — two parsers of "is
-│                           # this LAN-reachable" would disagree, and the answer gates --tunnel.
+├── bind.ts                  # THE reading of a bind address, as the six DIFFERENT questions it is:
+│                           # bindable (isBindAddress) / an address not a name (bindAddress, applied
+│                           # where a value enters) / reach (classifyBind) / dialable by the NAME
+│                           # localhost (answersLocalhost — NOT the same as reach: 127.0.0.2 is
+│                           # loopback and --tunnel still cannot reach it) / how a message names it
+│                           # (bindLabel) / what a client dials (clientHost). The flag, http.host
+│                           # validation, serveNode, the ready lines, control.json and the deploy
+│                           # pre-flight all read one through this — conflating any two of those
+│                           # questions produces a silent failure, which is why they are separate.
 ├── log.ts                   # leveled logging singleton (dev=debug, start=info)
 ├── session.ts               # engine-neutral session-control contract (SessionControl: state/entries/events + dispatch, error codes)
 ├── session-remote.ts        # remote clients over /control/*: connectSessionControl (control plane) + connectAgent (data plane)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ src/
 ├── cli.ts                   # the THIN entry (import-free; lazy-loads cli/program.ts)
 ├── cli/                     # the CLI, built on clig.dev: kernel.ts (CommandSpec-as-data + the commander adapter — commander appears ONLY here; help/suggestions/exit-code policy: 0 ok, 1 runtime, 2 usage), program.ts (the spec registry — the CLI surface's single source of truth; lazy per-command imports), presenters (invoke-stream.ts `invoke` stream → exit code; models-view.ts/auth-view.ts `models`/auth-report output; add-feishu.ts `add feishu|lark` app onboarding), shared.ts/serve.ts (cross-command helpers incl. mountSessionControl — per-boot token + control.json discovery file; process side effects live in the command modules), fail.ts, commands/ (one module per command)
 ├── telegram.ts, github.ts   # subpath-export shims (@fastagent-sh/fastagent/telegram etc. — the supported surface)
+├── bind.ts                  # THE reading of a bind address: parse (isBindAddress), reach
+│                           # (classifyBind), localhost-dialability (answersLocalhost), URL form
+│                           # (clientHost). The flag, http.host validation, serveNode, the ready log
+│                           # and the deploy pre-flight all read one through it — two parsers of "is
+│                           # this LAN-reachable" would disagree, and the answer gates --tunnel.
 ├── log.ts                   # leveled logging singleton (dev=debug, start=info)
 ├── session.ts               # engine-neutral session-control contract (SessionControl: state/entries/events + dispatch, error codes)
 ├── session-remote.ts        # remote clients over /control/*: connectSessionControl (control plane) + connectAgent (data plane)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -86,7 +86,8 @@ JSON.
 ```ts
 function nodeListener(handler: (req: Request) => Promise<Response>): (req, res) => void;
 function router(routes: Routes): ChannelHandler;
-function serveNode(handler: ChannelHandler, options: { port: number }): {
+// `host` is the bind address; unset binds all interfaces (what containers need).
+function serveNode(handler: ChannelHandler, options: { port: number; host?: string }): {
   listening: Promise<number>;
   close(): Promise<void>;
   closeAllConnections(): void;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -112,7 +112,7 @@ prints the provider's message.
 ## `fastagent dev`
 
 ```bash
-fastagent dev [dir] [--port N] [--model provider/modelId] [--auth-path file] [--no-watch] [--tunnel] [--no-input]
+fastagent dev [dir] [--port N] [--bind addr] [--model provider/modelId] [--auth-path file] [--no-watch] [--tunnel] [--no-input]
 ```
 
 Assembles the agent and serves it locally. persona.md/AGENTS.md/`skills/` are re-read every turn (edits go
@@ -287,7 +287,7 @@ Use `--update` to overwrite an existing vendored skill. Review the result with `
 ## `fastagent start`
 
 ```bash
-fastagent start [dir] [--port N] [--model provider/modelId] [--sessions-dir dir] [--auth-path file] [--tunnel] [--no-input]
+fastagent start [dir] [--port N] [--bind addr] [--model provider/modelId] [--sessions-dir dir] [--auth-path file] [--tunnel] [--no-input]
 ```
 
 Runs the agent in production posture: no watch, same assembly as `dev`.
@@ -296,6 +296,12 @@ Port precedence:
 
 ```txt
 --port > PORT > fastagent.config.* http.port > 8787
+```
+
+Bind precedence (same for `dev`):
+
+```txt
+--bind > fastagent.config.* http.host > all interfaces
 ```
 
 Session directory precedence:
@@ -339,6 +345,7 @@ Recurring per-command options (same meaning everywhere they appear):
 
 | Option | Commands | Meaning |
 |---|---|---|
+| `--bind <addr>` | `dev`, `start` | Bind address. Default: all interfaces (containers need it); `127.0.0.1` keeps the port, `/control/*` included, off the LAN. Prefer this flag over `http.host` for a local-only bind — config travels into a deployed image, where `deploy` gates it. See [Bind address](configuration.md#bind-address). |
 | `--no-input` | `dev`, `start`, `invoke`, `fire`, `login`, `deploy` | Never prompt; missing information becomes an error with the flag to pass (`deploy` plan mode only warns on a missing model — `--run` gates). |
 | `--model <provider/modelId>` | assembly commands | Model override (`--model > FASTAGENT_MODEL > config`). |
 | `--auth-path <file>` | assembly commands, `login` | Credentials file override. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -345,7 +345,7 @@ Recurring per-command options (same meaning everywhere they appear):
 
 | Option | Commands | Meaning |
 |---|---|---|
-| `--bind <addr>` | `dev`, `start` | Bind address. Default: all interfaces (containers need it); `127.0.0.1` keeps the port, `/control/*` included, off the LAN. Prefer this flag over `http.host` for a local-only bind — config travels into a deployed image, where `deploy` gates it. See [Bind address](configuration.md#bind-address). |
+| `--bind <addr>` | `dev`, `start` | Bind address — an IP literal, or `localhost` (read as `127.0.0.1`). Default: all interfaces (containers need it); `127.0.0.1` keeps the port, `/control/*` included, off the LAN. Prefer this flag over `http.host` for a local-only bind — config travels into a deployed image, where `deploy` gates it. See [Bind address](configuration.md#bind-address). |
 | `--no-input` | `dev`, `start`, `invoke`, `fire`, `login`, `deploy` | Never prompt; missing information becomes an error with the flag to pass (`deploy` plan mode only warns on a missing model — `--run` gates). |
 | `--model <provider/modelId>` | assembly commands | Model override (`--model > FASTAGENT_MODEL > config`). |
 | `--auth-path <file>` | assembly commands, `login` | Credentials file override. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,8 +41,9 @@ Supported keys:
 | `thinkingLevel` | Reasoning effort for the model, on pi's scale: `off` \| `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max`. Default: `medium` — pinned by fastagent to match the pi TUI's default (authors vibe at `medium`, so serving must match; the pin also means an upstream default change cannot silently alter deployments). Levels a model doesn't support are clamped by the engine. |
 | `tools` | Extra programmatic tools appended after default pi tools. Most users should prefer `tools/` discovery. |
 | `http.port` | Default port for `dev` / `start`. |
+| `http.host` | Bind address for `dev` / `start`. Unset (or `0.0.0.0`) binds all interfaces — what containers need. `--bind` overrides it; prefer the flag for a local-only bind, since this value travels into a deployed image (see [Bind address](#bind-address)). |
 | `selfSchedule` | Mount the built-in `wake` tool so the agent can schedule its own follow-up turns (self-scheduling). Off by default — an autonomy capability, opt in when you want it; only active on the serving path (`dev`/`start`, where the scheduler poller runs). |
-| `sessionControl` | Serve the session control plane at `/control/*` (state/entries/live events + dispatch: steer/abort/compact/set_model…) for remote consumers — a Web panel, a desktop app, `fastagent attach`. Off by default (it is a remote-control surface). When on, `dev`/`start` mint a per-boot bearer token into `<stateRoot>/control.json`; the serve binds all interfaces, so the routes are LAN-reachable with the token as the only protection — firewall the port or wrap it. On a deployed box (`fastagent deploy`) the routes ride the public host URL with the token minted inside the container: read `<stateRoot>/control.json` on the box, or front the endpoint with real auth; `deploy` warns about this. |
+| `sessionControl` | Serve the session control plane at `/control/*` (state/entries/live events + dispatch: steer/abort/compact/set_model…) for remote consumers — a Web panel, a desktop app, `fastagent attach`. Off by default (it is a remote-control surface). When on, `dev`/`start` mint a per-boot bearer token into `<stateRoot>/control.json`; the serve binds all interfaces by default, so the routes are LAN-reachable with the token as the only protection — bind loopback (`--bind 127.0.0.1` — not `http.host`, which travels into a deployed image), firewall the port, or wrap it. On a deployed box (`fastagent deploy`) the routes ride the public host URL with the token minted inside the container: read `<stateRoot>/control.json` on the box, or front the endpoint with real auth; `deploy` warns about this. |
 | `deploy.secrets` | Extra secret env-var names the deployed agent needs (e.g. `["GH_TOKEN"]`). `deploy` lists them in the runbook and, under `--run`, carries each value from your local env to the host secret store; a missing value gates the run. |
 | `deploy.apt` | Extra apt packages baked into the generated image (`["git", "ripgrep"]` — Debian default repos). For a package needing a custom apt repo (e.g. `gh`) or a different base image, provide your own `Dockerfile` — `deploy` keeps an existing one (and warns that `deploy.apt` isn't applied to a hand-written Dockerfile). A `Dockerfile` fastagent generated that later drifts from the current config (a changed `deploy.apt`, a new lockfile) is kept but flagged stale; `--force` regenerates it. |
 
@@ -112,6 +113,22 @@ Port precedence for `start`:
 ```
 
 Use `PORT` in hosted environments that inject a port.
+
+## Bind address
+
+```txt
+--bind > fastagent.config.* http.host > all interfaces
+```
+
+All interfaces is the default because containers require it. A desktop app driving a local agent wants
+the opposite: `--bind 127.0.0.1` keeps the port — `/control/*` with it — unreachable from the LAN.
+`<stateRoot>/control.json` records the address a client should dial, so clients read it rather than
+assume one.
+
+Two edges: `--tunnel` reaches the serve by dialing `localhost`, so a bind that name never resolves to
+(`--bind 192.168.1.5`, or even `--bind 127.0.0.2`) is refused with it; and `http.host` travels into a deployed image, where any non-wildcard bind
+breaks the container (unreachable, or unable to bind at all) — `deploy` warns and gates `--run`, so keep
+the local-only choice on `--bind`.
 
 ## Machinery: `.state/` and `.secrets/`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,10 @@ Use `PORT` in hosted environments that inject a port.
 --bind > fastagent.config.* http.host > all interfaces
 ```
 
+`localhost` is accepted and resolved to `127.0.0.1` as it is read, so what binds, what the startup
+lines print and what `control.json` records are the same address — a name would leave that to
+`dns.lookup` on one side and to the client's resolver on the other, which can disagree.
+
 All interfaces is the default because containers require it. A desktop app driving a local agent wants
 the opposite: `--bind 127.0.0.1` keeps the port — `/control/*` with it — unreachable from the LAN.
 `<stateRoot>/control.json` records the address a client should dial, so clients read it rather than

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -14,11 +14,25 @@ function normalize(host: string): string {
     .replace(/^::ffff:/, "");
 }
 
-/** A bindable host: an IP literal (v4/v6, brackets optional) or "localhost". No DNS names — a bind
- *  address must be an address of THIS machine, and resolving one at parse time is not our job. */
+/** A bindable host: an IP literal (v4/v6, brackets optional) or "localhost". No other DNS name — a
+ *  bind address must be an address of THIS machine, and resolving one is not this module's job. */
 export function isBindAddress(host: string): boolean {
   const h = normalize(host);
   return h === "localhost" || isIP(h) !== 0;
+}
+
+/**
+ * The ADDRESS form of an accepted bind value: `localhost` becomes `127.0.0.1`, everything else is
+ * already an address. Applied where a value ENTERS (the flag, `http.host`), so nothing downstream ever
+ * holds a name — not deferring the resolution but removing it, which is the module's whole point.
+ *
+ * Two things go wrong otherwise, and both are silent. `server.listen` hands the name to `dns.lookup`,
+ * which picks ONE of 127.0.0.1/::1 by rules we do not control — so what got bound is unknown here. And
+ * `clientHost` would then write that NAME into control.json and the copyable curl, where a consumer
+ * resolves it again, possibly to the other one.
+ */
+export function bindAddress(host: string): string {
+  return normalize(host) === "localhost" ? "127.0.0.1" : host;
 }
 
 /**
@@ -44,6 +58,14 @@ export function answersLocalhost(host: string | undefined): boolean {
   if (classifyBind(host) === "wildcard") return true;
   const h = normalize(host as string);
   return h === "localhost" || h === "127.0.0.1" || h === "::1";
+}
+
+/** How to NAME a bind in a message: the wildcard is every interface, so calling it one address would
+ *  understate it; anything else is dialable as itself. THE renderer — the ready lines, the
+ *  already-in-use refusal and the generic bind failure all read a bind through this one, so a reader
+ *  never sees the same bind described two ways. */
+export function bindLabel(host: string | undefined, port: number): string {
+  return classifyBind(host) === "wildcard" ? `port ${port}` : `${clientHost(host)}:${port}`;
 }
 
 /** The address a local client should dial for a serve bound to `host` (control.json, the ready log). */

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -1,0 +1,54 @@
+/**
+ * The ONE reading of a bind address, shared by everything that parses, binds, warns about, or ships
+ * one (the CLI flag, `http.host` validation, the Node host, the deploy pre-flight). Engine- and
+ * host-neutral on purpose: a bind address is a plain value, and two parsers of it would disagree.
+ */
+import { isIP } from "node:net";
+
+/** Lowercase, unbracketed, IPv4-mapped IPv6 reduced to its IPv4 form — the form the checks below read.
+ *  Brackets come off only as a PAIR: a half-bracketed `[::1` must stay invalid, not become an address. */
+function normalize(host: string): string {
+  return host
+    .toLowerCase()
+    .replace(/^\[(.+)]$/, "$1")
+    .replace(/^::ffff:/, "");
+}
+
+/** A bindable host: an IP literal (v4/v6, brackets optional) or "localhost". No DNS names — a bind
+ *  address must be an address of THIS machine, and resolving one at parse time is not our job. */
+export function isBindAddress(host: string): boolean {
+  const h = normalize(host);
+  return h === "localhost" || isIP(h) !== 0;
+}
+
+/**
+ * How far a bind address reaches: `wildcard` (unset or all-interfaces) reaches every interface and
+ * answers on loopback too; `loopback` is this machine only; `specific` is one interface, reachable
+ * only as itself. Loopback covers the whole reserved range (127/8, ::1) — a `127.0.0.2` bind is no
+ * more LAN-reachable than `127.0.0.1`.
+ */
+export function classifyBind(host: string | undefined): "wildcard" | "loopback" | "specific" {
+  if (host === undefined) return "wildcard";
+  const h = normalize(host);
+  if (h === "0.0.0.0" || h === "::" || h === "::0") return "wildcard";
+  if (h === "localhost" || h === "::1" || /^127\.\d+\.\d+\.\d+$/.test(h)) return "loopback";
+  return "specific";
+}
+
+/**
+ * Does a serve bound to `host` answer a dial of the NAME `localhost`? Only the addresses that name
+ * resolves to (127.0.0.1 / ::1) and a wildcard bind do — `127.0.0.2` is loopback yet unreachable that
+ * way. cloudflared dials by name, so `--tunnel` needs this question, not `classifyBind`'s reach.
+ */
+export function answersLocalhost(host: string | undefined): boolean {
+  if (classifyBind(host) === "wildcard") return true;
+  const h = normalize(host as string);
+  return h === "localhost" || h === "127.0.0.1" || h === "::1";
+}
+
+/** The address a local client should dial for a serve bound to `host` (control.json, the ready log). */
+export function clientHost(host: string | undefined): string {
+  if (classifyBind(host) === "wildcard") return "127.0.0.1";
+  // biome-ignore lint/style/noNonNullAssertion: only a wildcard bind leaves host undefined
+  return host!.includes(":") && !host!.startsWith("[") ? `[${host}]` : host!;
+}

--- a/src/channels/control.ts
+++ b/src/channels/control.ts
@@ -12,8 +12,10 @@
  * beyond a shared secret (principals, per-permission split, audit) is the wrapping host's job
  * (design §14). The serving process generates a per-boot token and writes it to
  * `<stateRoot>/control.json` for local discovery — filesystem permissions guard the token, and
- * the token guards the routes: the serve binds ALL interfaces (containers require it), so the port
- * is LAN-reachable and the mount warns accordingly.
+ * the token guards the routes. How far those routes REACH is the bind address: all interfaces by
+ * default (containers require it), so the port is LAN-reachable and the mount warns accordingly —
+ * `--bind 127.0.0.1` (or `http.host`) closes exactly that reach, and the warning goes quiet because
+ * there is none left to state.
  */
 import type { ImageRef, Prompt } from "../agent.ts";
 import { INVALID_COMMAND_CODE, type SessionCommand, type SessionControl, type SessionEvent } from "../session.ts";

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -13,6 +13,7 @@ import { setLogLevel } from "../../log.ts";
 import { logAgentLoop } from "../../observe.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { workspaceHint } from "../../paths.ts";
+import { bindAddress } from "../../bind.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import { assertTunnelBindable, maybeTunnel, mountSessionControl, routesFor, serve, startSchedules } from "../serve.ts";
 import { parseBind, parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
@@ -77,7 +78,10 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const traced = logAgentLoop(a.agent);
   const routed = await routesFor(a.agentDir, traced, a.stateRoot, a.sessionControl).catch(failStartup);
-  const host = bindFlag ?? a.config.http?.host;
+  // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
+  // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
+  const configured = a.config.http?.host;
+  const host = bindFlag ?? (configured === undefined ? undefined : bindAddress(configured));
   assertTunnelBindable(host, opts.tunnel ?? false, bindFlag ? "flag" : "config");
   const withControl = mountSessionControl(routed.routes, a.sessionControl, a.stateRoot, {
     tunnel: opts.tunnel ?? false,

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -14,11 +14,12 @@ import { logAgentLoop } from "../../observe.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { workspaceHint } from "../../paths.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
-import { maybeTunnel, mountSessionControl, routesFor, serve, startSchedules } from "../serve.ts";
-import { parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
+import { assertTunnelBindable, maybeTunnel, mountSessionControl, routesFor, serve, startSchedules } from "../serve.ts";
+import { parseBind, parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
 
 export interface DevOptions {
   port?: string;
+  bind?: string;
   model?: string;
   authPath?: string;
   /** false ⇔ `--no-watch`. */
@@ -46,13 +47,17 @@ export async function runDev(dirArg: string, opts: DevOptions): Promise<void> {
     await serveOnce(dir, opts);
     return;
   }
-  parsePort(opts.port, "--port", "flag"); // flag-shape check before spawning
+  parsePort(opts.port, "--port", "flag"); // flag-shape checks before spawning
+  // The --bind/--tunnel conflict is decidable from flags alone: refuse it HERE, before a worker and a
+  // tunnel exist. The worker repeats the check because `http.host` can supply the address instead.
+  assertTunnelBindable(parseBind(opts.bind), opts.tunnel ?? false, "flag");
   await runDevSupervisor(placement, { tunnel: opts.tunnel ?? false });
 }
 
 /** Assemble the agent and serve it once (the dev worker; also the --no-watch path). */
 async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   const portFlag = parsePort(opts.port, "--port", "flag");
+  const bindFlag = parseBind(opts.bind);
   loadDotEnv(placementOrExit(dir).agentDir);
   installProxyFetch();
 
@@ -72,12 +77,15 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const traced = logAgentLoop(a.agent);
   const routed = await routesFor(a.agentDir, traced, a.stateRoot, a.sessionControl).catch(failStartup);
+  const host = bindFlag ?? a.config.http?.host;
+  assertTunnelBindable(host, opts.tunnel ?? false, bindFlag ? "flag" : "config");
   const withControl = mountSessionControl(routed.routes, a.sessionControl, a.stateRoot, {
     tunnel: opts.tunnel ?? false,
     agent: traced, // the remote data plane (POST /control/invoke) drives the SAME traced agent
+    host,
   });
   await startSchedules(a.agentDir, traced, a.stateRoot, a.config.selfSchedule ?? false);
-  serve({ ...routed, routes: withControl.routes }, portFlag ?? a.config.http?.port ?? 8787, (p) => {
+  serve({ ...routed, routes: withControl.routes }, { port: portFlag ?? a.config.http?.port ?? 8787, host }, (p) => {
     withControl.announce(p);
     maybeTunnel(a.agentDir, routed.routeChannels, p, opts.tunnel ?? false, a.stateRoot);
   });

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -17,6 +17,7 @@ import { setWakeupsSink } from "../../schedule/wakeups.ts";
 import { logAgentLoop } from "../../observe.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { exists } from "../../paths.ts";
+import { bindAddress } from "../../bind.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import {
   assertTunnelBindable,
@@ -45,8 +46,8 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   // Flag validation first: a bad --port is a USAGE error (exit 2), and reporting it must not depend on
   // the directory being an agent (which is a runtime/environment failure, exit 1).
   const portFlag = parsePort(opts.port, "--port", "flag");
-  const placement = placementOrExit(dir);
   const bindFlag = parseBind(opts.bind);
+  const placement = placementOrExit(dir);
   setLogLevel("info"); // production posture: info+, the debug turn trace (and its end-user content) gated out
   loadDotEnv(placement.agentDir);
   installProxyFetch();
@@ -132,7 +133,10 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   const routed = await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: !agentcore }).catch(
     failStartup,
   );
-  const host = bindFlag ?? config.http?.host;
+  // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
+  // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
+  const configured = config.http?.host;
+  const host = bindFlag ?? (configured === undefined ? undefined : bindAddress(configured));
   assertTunnelBindable(host, opts.tunnel ?? false, bindFlag ? "flag" : "config");
   const withControl = mountSessionControl(routed.routes, sessionControl, stateRoot, {
     tunnel: opts.tunnel ?? false,

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -18,11 +18,20 @@ import { logAgentLoop } from "../../observe.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { exists } from "../../paths.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
-import { maybeTunnel, mountAgentcore, mountSessionControl, routesFor, serve, startSchedules } from "../serve.ts";
-import { parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
+import {
+  assertTunnelBindable,
+  maybeTunnel,
+  mountAgentcore,
+  mountSessionControl,
+  routesFor,
+  serve,
+  startSchedules,
+} from "../serve.ts";
+import { parseBind, parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
 
 export interface StartOptions {
   port?: string;
+  bind?: string;
   model?: string;
   sessionsDir?: string;
   authPath?: string;
@@ -37,6 +46,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   // the directory being an agent (which is a runtime/environment failure, exit 1).
   const portFlag = parsePort(opts.port, "--port", "flag");
   const placement = placementOrExit(dir);
+  const bindFlag = parseBind(opts.bind);
   setLogLevel("info"); // production posture: info+, the debug turn trace (and its end-user content) gated out
   loadDotEnv(placement.agentDir);
   installProxyFetch();
@@ -122,9 +132,12 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   const routed = await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: !agentcore }).catch(
     failStartup,
   );
+  const host = bindFlag ?? config.http?.host;
+  assertTunnelBindable(host, opts.tunnel ?? false, bindFlag ? "flag" : "config");
   const withControl = mountSessionControl(routed.routes, sessionControl, stateRoot, {
     tunnel: opts.tunnel ?? false,
     agent: traced,
+    host,
   });
   // AgentCore + selfSchedule: register the wake-ALARM sink BEFORE the scheduler starts — the boot
   // wake pump may advance a recurring entry (a store save) and that save must already re-arm its
@@ -162,7 +175,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   }
   serve(
     { ...routed, routes },
-    portFlag ?? parsePort(process.env.PORT, "PORT env", "env") ?? config.http?.port ?? 8787,
+    { port: portFlag ?? parsePort(process.env.PORT, "PORT env", "env") ?? config.http?.port ?? 8787, host },
     (p) => {
       withControl.announce(p);
       maybeTunnel(agentDir, routed.routeChannels, p, opts.tunnel ?? false, stateRoot);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -29,6 +29,10 @@ const NO_INPUT: FlagSpec = {
   description: "never prompt (CI/scripts) — missing information becomes an error instead of a question",
 };
 const PORT: FlagSpec = { flags: "--port <n>", description: "HTTP port" };
+const BIND: FlagSpec = {
+  flags: "--bind <addr>",
+  description: "bind address (default: all interfaces; 127.0.0.1 keeps it off the LAN)",
+};
 const TUNNEL: FlagSpec = {
   flags: "--tunnel",
   description:
@@ -94,6 +98,7 @@ const dev: CommandSpec = {
   args: [DIR_ARG],
   flags: [
     PORT,
+    BIND,
     MODEL,
     AUTH_PATH,
     { flags: "--no-watch", description: "serve once, no file-watching" },
@@ -107,6 +112,7 @@ const dev: CommandSpec = {
   run: async (args, f) =>
     (await import("./commands/dev.ts")).runDev(args[0] as string, {
       port: f.port as string | undefined,
+      bind: f.bind as string | undefined,
       model: f.model as string | undefined,
       authPath: f.authPath as string | undefined,
       watch: f.watch !== false,
@@ -251,6 +257,7 @@ const start: CommandSpec = {
   args: [DIR_ARG],
   flags: [
     PORT,
+    BIND,
     MODEL,
     { flags: "--sessions-dir <dir>", description: "sessions directory override" },
     AUTH_PATH,
@@ -264,6 +271,7 @@ const start: CommandSpec = {
   notes:
     "Precedence chains:\n" +
     "  port:     --port > PORT env > fastagent.config.ts http.port > 8787\n" +
+    "  bind:     --bind > fastagent.config.ts http.host > all interfaces\n" +
     "  state:    FASTAGENT_STATE_DIR > <agent dir>/.state — mutable machine state\n" +
     "            (sessions, channel state, schedule state); point it at a mounted\n" +
     "            volume so a redeploy that replaces the directory never wipes it\n" +
@@ -275,6 +283,7 @@ const start: CommandSpec = {
   run: async (args, f) =>
     (await import("./commands/start.ts")).runStart(args[0] as string, {
       port: f.port as string | undefined,
+      bind: f.bind as string | undefined,
       model: f.model as string | undefined,
       sessionsDir: f.sessionsDir as string | undefined,
       authPath: f.authPath as string | undefined,

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -241,10 +241,32 @@ export function assertTunnelBindable(host: string | undefined, tunnel: boolean, 
   const fix =
     source === "flag"
       ? "bind 0.0.0.0 (or 127.0.0.1), or drop --tunnel"
-      : 'set http.host to 0.0.0.0 (or 127.0.0.1) in fastagent.config.*, override it with --bind, or drop --tunnel';
+      : "set http.host to 0.0.0.0 (or 127.0.0.1) in fastagent.config.*, override it with --bind, or drop --tunnel";
   const message = `--tunnel reaches the serve by dialing localhost, which the bind address ${host} does not answer — ${fix}`;
   if (source === "flag") failUsage(message);
   failStartup(new Error(message));
+}
+
+/**
+ * The startup lines that name WHERE the serve is: the bind report, and the curl the reader copies.
+ * ONE function because they are one message — they were two, and `--bind` updated the first while the
+ * second went on dialing `localhost`, which is precisely what a non-wildcard bind stops answering. Now
+ * neither can be changed without the other in view, and the address has a single derivation.
+ *
+ * A wildcard bind is every interface, and naming one address there would understate it — but the curl
+ * still needs one to dial, which is what `clientHost` gives (loopback for a wildcard, itself otherwise).
+ */
+export function readyAddressLines(host: string | undefined, boundPort: number, builtinInvoke: boolean): string[] {
+  const dial = `${clientHost(host)}:${boundPort}`;
+  const lines = [
+    `[fastagent] http host on ${classifyBind(host) === "wildcard" ? `:${boundPort} (all interfaces)` : dial}`,
+  ];
+  if (builtinInvoke) {
+    lines.push(
+      `[fastagent] try it: curl -s ${dial}/invoke -X POST -H 'content-type: application/json' -d '${INVOKE_EXAMPLE_BODY}'`,
+    );
+  }
+  return lines;
 }
 
 /**
@@ -318,23 +340,11 @@ export function serve(
           port: boundPort,
           routeChannels: surface.routeChannels,
         });
-        // Report the BIND: a wildcard bind is every interface, and naming one address there would
-        // understate it. For an explicit bind, address and dial target coincide — clientHost is used
-        // only for its URL form (IPv6 brackets).
-        log.info(
-          `[fastagent] http host on ${
-            classifyBind(host) === "wildcard" ? `:${boundPort} (all interfaces)` : `${clientHost(host)}:${boundPort}`
-          }`,
-        );
+        for (const line of readyAddressLines(host, boundPort, surface.builtinInvoke)) log.info(line);
         log.info(`[fastagent] routes: ${Object.keys(surface.routes).join(", ") || "(none)"}`);
         if (surface.longConnections.length > 0) {
           log.info(
             `[fastagent] long connections: ${surface.longConnections.map((connection) => connection.name).join(", ")}`,
-          );
-        }
-        if (surface.builtinInvoke) {
-          log.info(
-            `[fastagent] try it: curl -s localhost:${boundPort}/invoke -X POST -H 'content-type: application/json' -d '${INVOKE_EXAMPLE_BODY}'`,
           );
         }
         onListening?.(boundPort);
@@ -357,7 +367,10 @@ export function serve(
           ),
         );
       }
-      failStartup(new Error(`cannot bind http channel on ${host ?? ""}:${port}: ${error.message}`));
+      // Through the same renderer as the EADDRINUSE branch above: hand-concatenating gives `:::8787`
+      // for an IPv6 bind and a bare `:8787` for the wildcard, which reads as an explicit bind of nothing.
+      const where = classifyBind(host) === "wildcard" ? `port ${port}` : `${clientHost(host)}:${port}`;
+      failStartup(new Error(`cannot bind http channel on ${where}: ${error.message}`));
     },
   );
 }

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -13,6 +13,7 @@ import { INVOKE_EXAMPLE_BODY, createInvokeHandler } from "../channels/http.ts";
 import { text } from "../channels/respond.ts";
 import { type LoadedLongConnectionChannel, loadChannels } from "../engines/pi/channel.ts";
 import { reportModuleLoadFailures } from "../engines/pi/report.ts";
+import { answersLocalhost, classifyBind, clientHost } from "../bind.ts";
 import { type Routes, parseRouteKey, router, serveNode } from "../host/node.ts";
 import { log } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
@@ -21,7 +22,7 @@ import type { LoadedSchedule } from "../schedule/schedule.ts";
 import { createScheduler, fireScheduleOnce } from "../schedule/scheduler.ts";
 import type { SessionControl } from "../session.ts";
 import { announceWebhooks, startCloudflareTunnel } from "../tunnel.ts";
-import { failStartup } from "./fail.ts";
+import { failStartup, failUsage } from "./fail.ts";
 
 export interface ServingSurface {
   routes: Routes;
@@ -95,7 +96,7 @@ export function mountSessionControl(
   routes: Routes,
   control: SessionControl | undefined,
   stateRoot: string,
-  options: { tunnel?: boolean; agent?: Agent } = {},
+  options: { tunnel?: boolean; agent?: Agent; host?: string } = {},
 ): { routes: Routes; announce: (boundPort: number) => void } {
   if (!control) return { routes, announce: () => {} };
   const token = crypto.randomUUID();
@@ -122,17 +123,24 @@ export function mountSessionControl(
       // Atomic (tmp+rename, the state.ts pattern): attach re-reads this file exactly during the
       // restart window — a torn read would be misdiagnosed as "serve gone".
       const tmp = `${path}.tmp`;
-      writeFileSync(tmp, `${JSON.stringify({ url: `http://127.0.0.1:${boundPort}`, token })}\n`, { mode: 0o600 });
+      writeFileSync(tmp, `${JSON.stringify({ url: `http://${clientHost(options.host)}:${boundPort}`, token })}\n`, {
+        mode: 0o600,
+      });
       chmodSync(tmp, 0o600); // an existing file keeps its old mode on rewrite — pin it
       renameSync(tmp, path);
       log.info(`[fastagent] session control on /control/* (token in ${path})`);
-      // The serve binds ALL interfaces (containers require it), so /control/* is LAN-reachable
-      // with the bearer token as the only protection — the tunnel and deploy paths warn loudly,
-      // and the LAN path must not be the silent third way past the local trust story.
-      log.warn(
-        "[fastagent] the port binds all interfaces: /control/* is reachable on your LAN, protected only by " +
-          "the bearer token — firewall the port or wrap it for real exposure (docs: design §14)",
-      );
+      // The serve binds ALL interfaces by DEFAULT (containers require it), so /control/* is
+      // LAN-reachable with the bearer token as the only protection — the tunnel and deploy paths warn
+      // loudly, and the LAN path must not be the silent third way past the local trust story. A
+      // loopback bind closes exactly that reach, so it earns silence.
+      const bind = classifyBind(options.host);
+      if (bind !== "loopback") {
+        log.warn(
+          `[fastagent] the port binds ${bind === "wildcard" ? "all interfaces" : `${options.host} (off this machine)`}: ` +
+            "/control/* is reachable on your LAN, protected only by the bearer token — bind loopback " +
+            "(--bind 127.0.0.1), firewall the port, or wrap it for real exposure (docs: design §14)",
+        );
+      }
       if (options.tunnel) {
         // Local trust = the token + its file permissions; --tunnel takes the whole port PUBLIC
         // (beyond even the LAN reach the mount already warned about). The operator asked for the tunnel (webhooks), but must not DISCOVER the control
@@ -218,12 +226,39 @@ export function mountAgentcore(
 }
 
 /**
+ * Refuse `--tunnel` with a bind that cloudflared cannot reach: it dials the NAME `localhost:<port>`
+ * (the dev supervisor's tunnel too), so anything outside `127.0.0.1`/`::1`/wildcard — including a
+ * `127.0.0.2` bind, loopback though it is — would leave the tunnel up and 502ing every request.
+ * Checked BEFORE the bind (the flag alone pre-spawn in `dev`, again once config is loaded, since
+ * `http.host` can carry the address), so the failure is clean rather than a live-but-broken public URL.
+ * `source` decides the exit code, per fail.ts: a flag COMBINATION is a usage error (2), a value that
+ * came from config is broken runtime configuration (1).
+ */
+export function assertTunnelBindable(host: string | undefined, tunnel: boolean, source: "flag" | "config"): void {
+  if (!tunnel || answersLocalhost(host)) return;
+  // Name the source, not just the exit code: under `config` there is no `--bind` to change and no flag
+  // to drop, so flag-only wording would send the reader looking for something they never typed.
+  const fix =
+    source === "flag"
+      ? "bind 0.0.0.0 (or 127.0.0.1), or drop --tunnel"
+      : 'set http.host to 0.0.0.0 (or 127.0.0.1) in fastagent.config.*, override it with --bind, or drop --tunnel';
+  const message = `--tunnel reaches the serve by dialing localhost, which the bind address ${host} does not answer — ${fix}`;
+  if (source === "flag") failUsage(message);
+  failStartup(new Error(message));
+}
+
+/**
  * Bind HTTP, open long-connection channels, and report ready only when both forms are usable. Each
  * adapter owns reconnects; a terminal close rejects `closed` and fails the process visibly. Abort is
- * the sole clean-shutdown command.
+ * the sole clean-shutdown command. `host` unset binds all interfaces.
  */
-export function serve(surface: ServingSurface, port: number, onListening?: (boundPort: number) => void): void {
-  const hosted = serveNode(router(surface.routes), { port });
+export function serve(
+  surface: ServingSurface,
+  bind: { port: number; host?: string },
+  onListening?: (boundPort: number) => void,
+): void {
+  const { port, host } = bind;
+  const hosted = serveNode(router(surface.routes), { port, host });
   const abort = new AbortController();
   let stopping = false;
 
@@ -283,7 +318,14 @@ export function serve(surface: ServingSurface, port: number, onListening?: (boun
           port: boundPort,
           routeChannels: surface.routeChannels,
         });
-        log.info(`[fastagent] http host on :${boundPort}`);
+        // Report the BIND: a wildcard bind is every interface, and naming one address there would
+        // understate it. For an explicit bind, address and dial target coincide — clientHost is used
+        // only for its URL form (IPv6 brackets).
+        log.info(
+          `[fastagent] http host on ${
+            classifyBind(host) === "wildcard" ? `:${boundPort} (all interfaces)` : `${clientHost(host)}:${boundPort}`
+          }`,
+        );
         log.info(`[fastagent] routes: ${Object.keys(surface.routes).join(", ") || "(none)"}`);
         if (surface.longConnections.length > 0) {
           log.info(
@@ -305,9 +347,17 @@ export function serve(surface: ServingSurface, port: number, onListening?: (boun
       }
     },
     (error: NodeJS.ErrnoException) => {
-      if (error.code === "EADDRINUSE")
-        failStartup(new Error(`port ${port} is already in use; choose another with --port`));
-      failStartup(new Error(`cannot bind http channel on :${port}: ${error.message}`));
+      if (error.code === "EADDRINUSE") {
+        // With a bind address the port is only taken ON THAT interface, so moving the bind is as valid
+        // a fix as moving the port.
+        failStartup(
+          new Error(
+            `${classifyBind(host) === "wildcard" ? `port ${port}` : `${clientHost(host)}:${port}`} is already ` +
+              `in use; choose another with --port${classifyBind(host) === "wildcard" ? "" : " or --bind"}`,
+          ),
+        );
+      }
+      failStartup(new Error(`cannot bind http channel on ${host ?? ""}:${port}: ${error.message}`));
     },
   );
 }

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -13,7 +13,7 @@ import { INVOKE_EXAMPLE_BODY, createInvokeHandler } from "../channels/http.ts";
 import { text } from "../channels/respond.ts";
 import { type LoadedLongConnectionChannel, loadChannels } from "../engines/pi/channel.ts";
 import { reportModuleLoadFailures } from "../engines/pi/report.ts";
-import { answersLocalhost, classifyBind, clientHost } from "../bind.ts";
+import { answersLocalhost, bindLabel, classifyBind, clientHost } from "../bind.ts";
 import { type Routes, parseRouteKey, router, serveNode } from "../host/node.ts";
 import { log } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
@@ -259,7 +259,7 @@ export function assertTunnelBindable(host: string | undefined, tunnel: boolean, 
 export function readyAddressLines(host: string | undefined, boundPort: number, builtinInvoke: boolean): string[] {
   const dial = `${clientHost(host)}:${boundPort}`;
   const lines = [
-    `[fastagent] http host on ${classifyBind(host) === "wildcard" ? `:${boundPort} (all interfaces)` : dial}`,
+    `[fastagent] http host on ${classifyBind(host) === "wildcard" ? `:${boundPort} (all interfaces)` : bindLabel(host, boundPort)}`,
   ];
   if (builtinInvoke) {
     lines.push(
@@ -362,15 +362,14 @@ export function serve(
         // a fix as moving the port.
         failStartup(
           new Error(
-            `${classifyBind(host) === "wildcard" ? `port ${port}` : `${clientHost(host)}:${port}`} is already ` +
-              `in use; choose another with --port${classifyBind(host) === "wildcard" ? "" : " or --bind"}`,
+            `${bindLabel(host, port)} is already in use; choose another with ` +
+              `--port${classifyBind(host) === "wildcard" ? "" : " or --bind"}`,
           ),
         );
       }
-      // Through the same renderer as the EADDRINUSE branch above: hand-concatenating gives `:::8787`
+      // Through `bindLabel`, like every other message about a bind: hand-concatenating gives `:::8787`
       // for an IPv6 bind and a bare `:8787` for the wildcard, which reads as an explicit bind of nothing.
-      const where = classifyBind(host) === "wildcard" ? `port ${port}` : `${clientHost(host)}:${port}`;
-      failStartup(new Error(`cannot bind http channel on ${where}: ${error.message}`));
+      failStartup(new Error(`cannot bind http channel on ${bindLabel(host, port)}: ${error.message}`));
     },
   );
 }

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -24,7 +24,7 @@ import { createPiModels, probeApiKey, probeAuthSource, providerAuthStatuses } fr
 import { formatAuthReport } from "./auth-view.ts";
 import { log } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
-import { isBindAddress } from "../bind.ts";
+import { bindAddress, isBindAddress } from "../bind.ts";
 import { failStartup, failUsage } from "./fail.ts";
 
 /**
@@ -77,7 +77,7 @@ export function parseBind(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
   if (!isBindAddress(trimmed)) failUsage(`invalid --bind "${value}": must be an IP address or "localhost"`);
-  return trimmed;
+  return bindAddress(trimmed); // a name never travels past this point — see bind.ts
 }
 
 /** Report which source provides the model's credentials, surfacing a remediation hint at startup. Non-blocking. */

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -24,6 +24,7 @@ import { createPiModels, probeApiKey, probeAuthSource, providerAuthStatuses } fr
 import { formatAuthReport } from "./auth-view.ts";
 import { log } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
+import { isBindAddress } from "../bind.ts";
 import { failStartup, failUsage } from "./fail.ts";
 
 /**
@@ -65,6 +66,18 @@ export function parsePort(value: string | undefined, source: string, from: "flag
     failStartup(new Error(message));
   }
   return Number(trimmed);
+}
+
+/**
+ * Parse a `--bind` address: empty/whitespace is "not set" → undefined (the `??` chain falls through to
+ * config, then all interfaces). An unbindable string is a USAGE error (2) — caught here rather than as
+ * a node bind failure, or worse, as a "the interface you bound" diagnostic downstream.
+ */
+export function parseBind(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  if (!isBindAddress(trimmed)) failUsage(`invalid --bind "${value}": must be an IP address or "localhost"`);
+  return trimmed;
 }
 
 /** Report which source provides the model's credentials, surfacing a remediation hint at startup. Non-blocking. */

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -12,6 +12,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, sep } from "node:path";
 import ignore from "ignore";
+import { classifyBind } from "../bind.ts";
 import type { FastagentConfig } from "../engines/pi/config.ts";
 import { resolveAuthPath } from "../engines/pi/config.ts";
 import { type ResolvedPlacement, resolveSecretsDir, resolveStateRoot } from "../paths.ts";
@@ -416,6 +417,23 @@ export async function preflightDeploy(input: {
     shipsGit,
   };
   const port = config.http?.port ?? 8787;
+  // `http.host` travels in the artifact (config is what deploy ships), and any non-wildcard value that
+  // is right on a laptop is wrong in a container: the wildcard bind is what makes the published port,
+  // the health check and webhook ingress reachable at all. `--bind` is the local-only knob; config is not.
+  const configBind = classifyBind(config.http?.host);
+  if (configBind !== "wildcard") {
+    const issue =
+      `fastagent.config.ts sets http.host: "${config.http?.host}" — it travels into the image, where ` +
+      (configBind === "loopback"
+        ? `nothing outside the container can reach the serve (published port, health check, webhooks).`
+        : `that address does not exist, so the container fails to bind at start.`) +
+      ` Drop it and use \`--bind ${config.http?.host}\` locally instead.`;
+    // Same disposition as the model-travel issue: warn when producing artifacts (the operator may be
+    // deploying somewhere that fronts the port), gate `--run` — which would otherwise ship a box that
+    // answers nothing, or crash-loops on a bind that cannot resolve inside the container.
+    if (run) return { ok: false, gate: issue };
+    messages.push({ level: "warn", text: issue });
+  }
   // What the agent declared it needs on the box (fastagent.config deploy.secrets) — carried like channel
   // secrets: listed in the runbook, set from the local env under --run, gated if a value is missing.
   const extraSecrets = config.deploy?.secrets ?? [];

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -16,6 +16,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { FastagentTool } from "./tool.ts";
 import type { Models } from "@earendil-works/pi-ai";
 import { THINKING_LEVELS, type AnyModel } from "./harness.ts";
+import { isBindAddress } from "../../bind.ts";
 import { moduleLoadHint } from "../../loader.ts";
 import { AGENT_CONFIG_NAMES, resolveOverridePath, resolveSecretsDir } from "../../paths.ts";
 
@@ -32,7 +33,9 @@ export interface FastagentConfig {
   /** Extra custom tools, appended after pi defaults — never replaces them. `FastagentTool` = AgentTool
    *  plus the optional `deferred` marker (see defineTool). */
   tools?: FastagentTool[];
-  http?: { port?: number };
+  /** `host` is the bind address: unset (or `0.0.0.0`) binds all interfaces — what containers need;
+   *  `127.0.0.1` keeps the serve (including `/control/*`) off the LAN. Precedence: `--bind` > this. */
+  http?: { port?: number; host?: string };
   /** Mount the built-in `wake` tool so the agent can schedule its OWN follow-up turns (self-scheduling).
    *  Off by default — self-scheduling is an autonomy capability, opt in when you want it. Only takes
    *  effect on the serving path (`dev`/`start`, where the scheduler poller honors a wake-up). */
@@ -42,8 +45,9 @@ export interface FastagentConfig {
    * steer/abort/compact/set_model…) for remote consumers: a Web panel, a desktop app, `fastagent
    * attach`. Default off (it is a remote-control surface). When on, `dev`/`start` generate a
    * per-boot bearer token and write `<stateRoot>/control.json` for local discovery. The serve
-   * binds all interfaces, so the routes are LAN-reachable with the token as the only protection —
-   * firewall the port, or wrap it for real exposure (design §14).
+   * binds all interfaces by default, so the routes are LAN-reachable with the token as the only
+   * protection — bind loopback (`--bind 127.0.0.1`; not `http.host`, which travels into a deployed
+   * image), firewall the port, or wrap it for real exposure (design §14).
    */
   sessionControl?: boolean;
   /** Deploy-time declarations for what the agent needs on the box, so real agents don't hand-write a
@@ -165,12 +169,17 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     throw new Error(`${path}: "http" must be an object`);
   }
   for (const key of Object.keys(c.http ?? {})) {
-    if (key !== "port") {
-      throw new Error(`${path}: unknown key "http.${key}" (valid keys: port)`);
+    if (key !== "port" && key !== "host") {
+      throw new Error(`${path}: unknown key "http.${key}" (valid keys: port, host)`);
     }
   }
   if (c.http?.port !== undefined && (typeof c.http.port !== "number" || !isValidPort(c.http.port))) {
     throw new Error(`${path}: "http.port" must be an integer 0-65535`);
+  }
+  // Validated as strictly as http.port: an unbindable string ("banana") must fail HERE, not surface
+  // later as a topology diagnostic about "the interface you bound".
+  if (c.http?.host !== undefined && (typeof c.http.host !== "string" || !isBindAddress(c.http.host))) {
+    throw new Error(`${path}: "http.host" must be an IP address or "localhost" (e.g. "127.0.0.1", "0.0.0.0")`);
   }
   if (c.deploy !== undefined && (typeof c.deploy !== "object" || c.deploy === null)) {
     throw new Error(`${path}: "deploy" must be an object`);

--- a/src/host/node.ts
+++ b/src/host/node.ts
@@ -79,15 +79,16 @@ export function router(routes: Routes): ChannelHandler {
  * Serve `handler` on a Node HTTP server. Thin mechanism: bind, report the port, let the caller stop
  * accepting or force-close active connections — no logging/signals/exit (the CLI owns those).
  * `listening` resolves with the bound port (useful for port 0) or rejects on a bind error.
+ * `host` is the bind address; unset means all interfaces (what containers need).
  */
 export function serveNode(
   handler: ChannelHandler,
-  options: { port: number },
+  options: { port: number; host?: string },
 ): { listening: Promise<number>; close: () => Promise<void>; closeAllConnections: () => void } {
   const server = createServer(nodeListener(async (req) => handler(req)));
   const listening = new Promise<number>((resolve, reject) => {
     server.once("error", reject); // a bind failure surfaces here, before "listening"
-    server.listen(options.port, () => {
+    server.listen({ port: options.port, host: options.host }, () => {
       server.off("error", reject);
       resolve((server.address() as AddressInfo).port);
     });

--- a/test/bind.test.ts
+++ b/test/bind.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { answersLocalhost, classifyBind, clientHost, isBindAddress } from "../src/bind.ts";
+
+describe("bind: one reading of a bind address", () => {
+  it("accepts IP literals and localhost, rejects anything unbindable", () => {
+    for (const ok of ["0.0.0.0", "127.0.0.1", "192.168.1.5", "::", "[::]", "::1", "localhost", "LOCALHOST"]) {
+      expect(isBindAddress(ok), ok).toBe(true);
+    }
+    for (const bad of ["banana", "example.com", "", "127.0.0.1:8787", "[::1", "::1]", "0"]) {
+      expect(isBindAddress(bad), bad).toBe(false);
+    }
+  });
+
+  it("classifies every form of the same reach identically — the parser and the classifier agree", () => {
+    // Every spelling of "all interfaces": what isBindAddress accepts, classifyBind must read as wildcard
+    // (a bracketed [::] read as `specific` would refuse --tunnel and gate a deploy that is in fact fine).
+    for (const w of [undefined, "0.0.0.0", "::", "[::]", "::0"]) expect(classifyBind(w), String(w)).toBe("wildcard");
+    for (const l of ["127.0.0.1", "127.0.0.2", "localhost", "::1", "[::1]", "::ffff:127.0.0.1"]) {
+      expect(classifyBind(l), l).toBe("loopback");
+    }
+    for (const s of ["192.168.1.5", "fd00::1"]) expect(classifyBind(s), s).toBe("specific");
+  });
+
+  it("answersLocalhost: only the addresses the NAME localhost resolves to (plus wildcard)", () => {
+    for (const yes of [undefined, "0.0.0.0", "[::]", "127.0.0.1", "::1", "localhost"]) {
+      expect(answersLocalhost(yes), String(yes)).toBe(true);
+    }
+    // Loopback by reach, but a dial of `localhost` never lands there — the tunnel gate must refuse it.
+    for (const no of ["127.0.0.2", "127.0.1.1", "192.168.1.5"]) expect(answersLocalhost(no), no).toBe(false);
+  });
+
+  it("derives the address a client dials", () => {
+    expect(clientHost(undefined)).toBe("127.0.0.1"); // a wildcard bind answers on loopback
+    expect(clientHost("0.0.0.0")).toBe("127.0.0.1");
+    expect(clientHost("192.168.1.5")).toBe("192.168.1.5"); // a specific bind only answers as itself
+    expect(clientHost("::1")).toBe("[::1]"); // IPv6 needs brackets in a URL
+    expect(clientHost("[::1]")).toBe("[::1]"); // …and must not get a second pair
+  });
+});

--- a/test/bind.test.ts
+++ b/test/bind.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { answersLocalhost, classifyBind, clientHost, isBindAddress } from "../src/bind.ts";
+import { answersLocalhost, bindAddress, bindLabel, classifyBind, clientHost, isBindAddress } from "../src/bind.ts";
 
 describe("bind: one reading of a bind address", () => {
   it("accepts IP literals and localhost, rejects anything unbindable", () => {
@@ -27,6 +27,28 @@ describe("bind: one reading of a bind address", () => {
     }
     // Loopback by reach, but a dial of `localhost` never lands there — the tunnel gate must refuse it.
     for (const no of ["127.0.0.2", "127.0.1.1", "192.168.1.5"]) expect(answersLocalhost(no), no).toBe(false);
+  });
+
+  it("a NAME never leaves the parser: localhost resolves to an address at the boundary", () => {
+    // Accepting `localhost` and PASSING IT ON are different things. `server.listen` would hand the name
+    // to dns.lookup, which picks one of 127.0.0.1/::1 by rules this module does not control — so what
+    // got bound would be unknown here, while control.json and the copyable curl carried a name for the
+    // client to resolve again, possibly to the other one. Resolving at the boundary removes both.
+    expect(isBindAddress("localhost")).toBe(true); // still a legitimate thing to type
+    expect(bindAddress("localhost")).toBe("127.0.0.1");
+    expect(bindAddress("LOCALHOST")).toBe("127.0.0.1");
+    for (const already of ["127.0.0.1", "::1", "0.0.0.0", "192.168.1.5"]) {
+      expect(bindAddress(already), already).toBe(already); // an address is left exactly as written
+    }
+  });
+
+  it("renders one label for a bind, wherever a message names it", () => {
+    // The ready lines, the already-in-use refusal and the generic bind failure all read through this,
+    // so the same bind is never described two ways (a hand-built `${host}:${port}` gave `:::8787`).
+    expect(bindLabel(undefined, 8787)).toBe("port 8787"); // a wildcard IS every interface — do not name one
+    expect(bindLabel("0.0.0.0", 8787)).toBe("port 8787");
+    expect(bindLabel("127.0.0.1", 8787)).toBe("127.0.0.1:8787");
+    expect(bindLabel("::1", 8787)).toBe("[::1]:8787"); // URL form, brackets and all
   });
 
   it("derives the address a client dials", () => {

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -158,7 +158,12 @@ describe("cli: bind address policy", () => {
     // localhost — the very address that bind stops answering. They come from one function now; this
     // pins the property that made splitting them a bug.
     const { readyAddressLines } = await import("../src/cli/serve.ts");
-    for (const host of [undefined, "0.0.0.0", "127.0.0.1", "192.168.1.5", "::1"]) {
+    const { bindAddress } = await import("../src/bind.ts");
+    // `localhost` is IN the list on purpose: it is the only accepted input that could put a NAME in
+    // these lines, so leaving it out would make the `not.toContain("localhost")` below pass for the
+    // reason that it was never tried. It cannot get here — `parseBind`/`http.host` resolve it to an
+    // address first (bind.ts `bindAddress`) — and this is what says so.
+    for (const host of [undefined, "0.0.0.0", "127.0.0.1", "192.168.1.5", "::1", bindAddress("localhost")]) {
       const [bindLine, tryLine] = readyAddressLines(host, 8899, true);
       const dial = tryLine!.match(/curl -s (\S+?)\/invoke/)![1]!;
       expect(dial, String(host)).toContain(":8899");

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -85,6 +85,9 @@ describe("mountAgentcore", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ fired: true });
     process.env.FASTAGENT_INGRESS_SECRET = undefined;
+  });
+});
+
 describe("cli: bind address policy", () => {
   /** Both policies end in process.exit — trade it for a throw so the exit CODE is assertable. */
   const exits = (fn: () => void): number | undefined => {
@@ -122,5 +125,52 @@ describe("cli: bind address policy", () => {
     // Loopback yet NOT what `localhost` resolves to — the tunnel would 502, so it is refused.
     expect(exits(() => assertTunnelBindable("127.0.0.2", true, "flag"))).toBe(2); // a flag combination = usage
     expect(exits(() => assertTunnelBindable(undefined, true, "flag"))).toBeUndefined();
+  });
+
+  it("assertTunnelBindable names the SOURCE, not just the exit code", async () => {
+    const { assertTunnelBindable } = await import("../src/cli/serve.ts");
+    // Same refusal, two audiences: under `config` there is no --bind to change and no flag to drop, so
+    // flag-only wording sends the reader hunting for something they never typed.
+    const said = (source: "flag" | "config") => {
+      const seen: string[] = [];
+      const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("exit");
+      }) as never);
+      const err = vi.spyOn(console, "error").mockImplementation((m: unknown) => void seen.push(String(m)));
+      try {
+        assertTunnelBindable("192.168.1.5", true, source);
+      } catch {
+        /* the injected exit */
+      } finally {
+        err.mockRestore();
+        exit.mockRestore();
+      }
+      return seen.join("\n");
+    };
+    expect(said("flag")).toMatch(/drop --tunnel/);
+    expect(said("flag")).not.toMatch(/http\.host/);
+    expect(said("config")).toMatch(/http\.host/); // the file the value actually came from
+  });
+
+  it("the ready lines all name the SAME dialable address", async () => {
+    // They are one message: the first says where it bound, the second is the command a reader copies.
+    // Only the first was updated when --bind landed, so `--bind 192.168.1.5` printed a curl to
+    // localhost — the very address that bind stops answering. They come from one function now; this
+    // pins the property that made splitting them a bug.
+    const { readyAddressLines } = await import("../src/cli/serve.ts");
+    for (const host of [undefined, "0.0.0.0", "127.0.0.1", "192.168.1.5", "::1"]) {
+      const [bindLine, tryLine] = readyAddressLines(host, 8899, true);
+      const dial = tryLine!.match(/curl -s (\S+?)\/invoke/)![1]!;
+      expect(dial, String(host)).toContain(":8899");
+      expect(dial, String(host)).not.toContain("localhost"); // never a name the bind may not answer
+      // A wildcard bind IS every interface, so the report says so rather than understating it as one
+      // address — but the curl still has to dial something, and loopback is what a wildcard answers.
+      expect(bindLine, String(host)).toContain(
+        host === undefined || host === "0.0.0.0" ? ":8899 (all interfaces)" : dial,
+      );
+      if (host === "::1") expect(dial).toBe("[::1]:8899"); // URL form, brackets and all
+    }
+    // No builtin invoke route, no curl to offer — and still exactly one line about the bind.
+    expect(readyAddressLines("127.0.0.1", 1, false)).toHaveLength(1);
   });
 });

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Agent } from "../src/agent.ts";
 import { mountAgentcore, routesFor } from "../src/cli/serve.ts";
 import { text } from "../src/channels/respond.ts";
@@ -85,5 +85,42 @@ describe("mountAgentcore", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ fired: true });
     process.env.FASTAGENT_INGRESS_SECRET = undefined;
+describe("cli: bind address policy", () => {
+  /** Both policies end in process.exit — trade it for a throw so the exit CODE is assertable. */
+  const exits = (fn: () => void): number | undefined => {
+    const spy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      fn();
+      return undefined;
+    } catch (e) {
+      // Only the injected exit is an outcome; a real throw is a bug and must not read as "accepted".
+      if (spy.mock.calls.length === 0) throw e;
+      return spy.mock.calls[0]?.[0] as number | undefined;
+    } finally {
+      spy.mockRestore();
+      quiet.mockRestore();
+    }
+  };
+
+  it("parseBind: an unbindable value is a usage error (2), a valid one passes through", async () => {
+    const { parseBind } = await import("../src/cli/shared.ts");
+    expect(parseBind(undefined)).toBeUndefined();
+    expect(parseBind("  ")).toBeUndefined(); // "not set", so the config/default chain still applies
+    expect(parseBind("127.0.0.1")).toBe("127.0.0.1");
+    expect(exits(() => parseBind("banana"))).toBe(2);
+  });
+
+  it("assertTunnelBindable: --tunnel refuses a bind localhost cannot reach; the source picks the exit code", async () => {
+    const { assertTunnelBindable } = await import("../src/cli/serve.ts");
+    expect(exits(() => assertTunnelBindable("192.168.1.5", true, "config"))).toBe(1); // startup failure
+    expect(exits(() => assertTunnelBindable("192.168.1.5", false, "flag"))).toBeUndefined(); // no tunnel, no conflict
+    expect(exits(() => assertTunnelBindable("127.0.0.1", true, "flag"))).toBeUndefined();
+    expect(exits(() => assertTunnelBindable("::1", true, "flag"))).toBeUndefined(); // localhost resolves to it
+    // Loopback yet NOT what `localhost` resolves to — the tunnel would 502, so it is refused.
+    expect(exits(() => assertTunnelBindable("127.0.0.2", true, "flag"))).toBe(2); // a flag combination = usage
+    expect(exits(() => assertTunnelBindable(undefined, true, "flag"))).toBeUndefined();
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -206,6 +206,18 @@ describe("config: loadConfig", () => {
     await expect(loadConfig(dir)).rejects.toThrow(/"http\.port" must be an integer/);
   });
 
+  it("http.host: an IP literal loads, an unbindable string throws at load (not at listen time)", async () => {
+    const load = async (body: string) => {
+      const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
+      await writeFile(join(dir, "fastagent.config.mjs"), body);
+      return loadConfig(dir);
+    };
+    expect((await load(`export default { http: { host: "127.0.0.1" } };`)).config.http?.host).toBe("127.0.0.1");
+    await expect(load(`export default { http: { host: "banana" } };`)).rejects.toThrow(
+      /"http\.host" must be an IP address/,
+    );
+  });
+
   it("thinkingLevel: a valid pi level loads; an invalid value throws (fail visibly, not a silent default)", async () => {
     const load = async (body: string) => {
       const dir = await mkdtemp(join(tmpdir(), "fa-config-"));

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -529,7 +529,11 @@ describe("session control over HTTP (Phase 3)", () => {
       expect(warn).not.toHaveBeenCalled(); // loopback is not LAN-reachable — nothing to warn about
       // A specific non-wildcard bind is only reachable as itself: the client must dial that address.
       expect(await url("192.168.1.5", join(root, "b"))).toBe("http://192.168.1.5:9000");
+      // …and the warning NAMES that bind. Counting alone would stay green if the address rendered as
+      // `undefined`, which is the whole content of the claim "names the actual bind".
+      expect(warn.mock.calls.flat().join(" ")).toContain("192.168.1.5 (off this machine)");
       expect(await url(undefined, join(root, "c"))).toBe("http://127.0.0.1:9000"); // wildcard accepts loopback
+      expect(warn.mock.calls.flat().join(" ")).toContain("binds all interfaces");
       expect(warn).toHaveBeenCalledTimes(2);
       warn.mockRestore();
     } finally {

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -7,7 +7,7 @@
  */
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
 import { controlRoutes } from "../src/channels/control.ts";
 import { createPiAgentFromHarness, inProcessLease } from "../src/engines/pi/invoke.ts";
@@ -506,6 +506,32 @@ describe("session control over HTTP (Phase 3)", () => {
       // Without a hub: passthrough, no file side effects.
       const off = mountSessionControl(base, undefined, stateRoot);
       expect(off.routes).toBe(base);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a bind address lands in the discovery url and a loopback bind drops the LAN warning", async () => {
+    const { mkdtemp, rm, readFile } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { mountSessionControl } = await import("../src/cli/serve.ts");
+    const { log } = await import("../src/log.ts");
+    const root = await mkdtemp(join(tmpdir(), "fa-ctl-bind-"));
+    try {
+      const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+      const { control } = createPiSessionControl({ sessions: inMemorySessionStore() });
+      const url = (host: string | undefined, stateRoot: string) => {
+        mountSessionControl({}, control, stateRoot, { host }).announce(9000);
+        return readFile(join(stateRoot, "control.json"), "utf8").then((s) => (JSON.parse(s) as { url: string }).url);
+      };
+      expect(await url("127.0.0.1", join(root, "a"))).toBe("http://127.0.0.1:9000");
+      expect(warn).not.toHaveBeenCalled(); // loopback is not LAN-reachable — nothing to warn about
+      // A specific non-wildcard bind is only reachable as itself: the client must dial that address.
+      expect(await url("192.168.1.5", join(root, "b"))).toBe("http://192.168.1.5:9000");
+      expect(await url(undefined, join(root, "c"))).toBe("http://127.0.0.1:9000"); // wildcard accepts loopback
+      expect(warn).toHaveBeenCalledTimes(2);
+      warn.mockRestore();
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -65,6 +65,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     if (!gated.ok) expect(gated.gate).toMatch(/nothing outside the container can reach the serve/);
     // A one-interface address doesn't even exist in the container — different consequence, same gate.
     const gatedSpecific = await call(dir, cfg("192.168.1.5"), { run: true });
+    expect(gatedSpecific.ok).toBe(false); // unconditional: a gate that stops firing must fail this
     if (!gatedSpecific.ok) expect(gatedSpecific.gate).toMatch(/fails to bind at start/);
     // Plan mode only produces artifacts, so it warns and proceeds.
     const planned = await call(dir, cfg("127.0.0.1"));

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -47,6 +47,30 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
       "package.json": `{"type":"module","dependencies":{"@fastagent-sh/fastagent":"^1"}}`,
     });
     await mkdir(join(dirname(agentDir), ".git")); // the workspace is a git repo — the image gets the git binary
+  it("http.host travels into the image: gates --run, warns in plan mode, wildcard is silent", async () => {
+    const dir = await workspace();
+    const cfg = (host?: string): FastagentConfig => ({ model: "openai/gpt-4o-mini", http: host ? { host } : {} });
+    const gated = await call(dir, cfg("127.0.0.1"), { run: true });
+    expect(gated.ok).toBe(false);
+    if (!gated.ok) expect(gated.gate).toMatch(/nothing outside the container can reach the serve/);
+    // A one-interface address doesn't even exist in the container — different consequence, same gate.
+    const gatedSpecific = await call(dir, cfg("192.168.1.5"), { run: true });
+    if (!gatedSpecific.ok) expect(gatedSpecific.gate).toMatch(/fails to bind at start/);
+    // Plan mode only produces artifacts, so it warns and proceeds.
+    const planned = await call(dir, cfg("127.0.0.1"));
+    expect(planned.ok && planned.messages.some((m) => m.level === "warn" && /http\.host/.test(m.text))).toBe(true);
+    const wildcard = await call(dir, cfg("0.0.0.0"), { run: true });
+    expect(wildcard.ok && wildcard.messages.every((m) => !/http\.host/.test(m.text))).toBe(true);
+  });
+
+  it("agentDir layout: container facts come from the KIT, git is auto-baked, --run stays gated", async () => {
+    const dir = await workspace({ "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n` });
+    const agentDir = join(dir, "agent");
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(
+      join(agentDir, "package.json"),
+      `{"type":"module","dependencies":{"@fastagent-sh/fastagent":"^1"}}`,
+    );
 
     const ok = await call(agentDir, { model: "openai/gpt-4o-mini", deploy: { apt: ["ripgrep"] } }, { run: true });
     expect(ok.ok).toBe(true);

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -47,6 +47,16 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
       "package.json": `{"type":"module","dependencies":{"@fastagent-sh/fastagent":"^1"}}`,
     });
     await mkdir(join(dirname(agentDir), ".git")); // the workspace is a git repo — the image gets the git binary
+
+    const ok = await call(agentDir, { model: "openai/gpt-4o-mini", deploy: { apt: ["ripgrep"] } }, { run: true });
+    expect(ok.ok).toBe(true);
+    if (ok.ok) {
+      expect(ok.container.hasPackageJson).toBe(true); // the AGENT's manifest, not the workspace's
+      expect(ok.container.apt).toEqual(["git", "ripgrep"]); // git baked (workspace ships .git), deploy.apt kept, deduped
+      expect(JSON.stringify(ok.messages)).toMatch(/baked as the agent's workspace/); // the WYSIWYG note is stated
+    }
+  });
+
   it("http.host travels into the image: gates --run, warns in plan mode, wildcard is silent", async () => {
     const dir = await workspace();
     const cfg = (host?: string): FastagentConfig => ({ model: "openai/gpt-4o-mini", http: host ? { host } : {} });
@@ -61,24 +71,6 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     expect(planned.ok && planned.messages.some((m) => m.level === "warn" && /http\.host/.test(m.text))).toBe(true);
     const wildcard = await call(dir, cfg("0.0.0.0"), { run: true });
     expect(wildcard.ok && wildcard.messages.every((m) => !/http\.host/.test(m.text))).toBe(true);
-  });
-
-  it("agentDir layout: container facts come from the KIT, git is auto-baked, --run stays gated", async () => {
-    const dir = await workspace({ "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n` });
-    const agentDir = join(dir, "agent");
-    await mkdir(agentDir, { recursive: true });
-    await writeFile(
-      join(agentDir, "package.json"),
-      `{"type":"module","dependencies":{"@fastagent-sh/fastagent":"^1"}}`,
-    );
-
-    const ok = await call(agentDir, { model: "openai/gpt-4o-mini", deploy: { apt: ["ripgrep"] } }, { run: true });
-    expect(ok.ok).toBe(true);
-    if (ok.ok) {
-      expect(ok.container.hasPackageJson).toBe(true); // the AGENT's manifest, not the workspace's
-      expect(ok.container.apt).toEqual(["git", "ripgrep"]); // git baked (workspace ships .git), deploy.apt kept, deduped
-      expect(JSON.stringify(ok.messages)).toMatch(/baked as the agent's workspace/); // the WYSIWYG note is stated
-    }
   });
 
   it("git is baked iff the baked workspace ships a .git — a non-git dir gets no silent git layer", async () => {

--- a/test/host-node.test.ts
+++ b/test/host-node.test.ts
@@ -29,6 +29,19 @@ describe("host/node: serveNode", () => {
     await host.close(); // caller-owned shutdown — releases the listening socket
   });
 
+  it("binds only the given host, leaving every other interface unserved", async () => {
+    const { networkInterfaces } = await import("node:os");
+    const host = serveNode(() => new Response("ok"), { port: 0, host: "127.0.0.1" });
+    const port = await host.listening;
+    expect((await fetch(`http://127.0.0.1:${port}/`)).status).toBe(200);
+    const lan = Object.values(networkInterfaces())
+      .flat()
+      .find((i) => i?.family === "IPv4" && !i.internal)?.address;
+    // The bind is the point: a LAN address must NOT answer (skipped on a box with no LAN interface).
+    if (lan) await expect(fetch(`http://${lan}:${port}/`)).rejects.toThrow();
+    await host.close();
+  });
+
   it("can force-close an active request instead of waiting for the handler to drain", async () => {
     let entered!: () => void;
     const handling = new Promise<void>((resolve) => {

--- a/test/host-node.test.ts
+++ b/test/host-node.test.ts
@@ -29,16 +29,16 @@ describe("host/node: serveNode", () => {
     await host.close(); // caller-owned shutdown — releases the listening socket
   });
 
-  it("binds only the given host, leaving every other interface unserved", async () => {
-    const { networkInterfaces } = await import("node:os");
+  it("binds only the given host, leaving every other address unserved", async () => {
     const host = serveNode(() => new Response("ok"), { port: 0, host: "127.0.0.1" });
     const port = await host.listening;
     expect((await fetch(`http://127.0.0.1:${port}/`)).status).toBe(200);
-    const lan = Object.values(networkInterfaces())
-      .flat()
-      .find((i) => i?.family === "IPv4" && !i.internal)?.address;
-    // The bind is the point: a LAN address must NOT answer (skipped on a box with no LAN interface).
-    if (lan) await expect(fetch(`http://${lan}:${port}/`)).rejects.toThrow();
+    // The negative goes to a second LOOPBACK alias, not to a LAN address: `127.0.0.2` is the whole
+    // point of the bind (loopback by reach, still not the address bound), it needs no network, and it
+    // cannot pass for the wrong reason — a LAN probe picks up whatever interface is first, often a
+    // VPN/docker one where the refusal comes from routing, and a FILTERED interface would hang the
+    // fetch with no timeout until vitest killed the file.
+    await expect(fetch(`http://127.0.0.2:${port}/`, { signal: AbortSignal.timeout(2000) })).rejects.toThrow();
     await host.close();
   });
 


### PR DESCRIPTION
Closes #290.

## Why

The serve binds all interfaces because containers require it, which leaves `/control/*` (steer/abort/set_model, the transcript) LAN-reachable behind one bearer token — honest, and warned about, but wrong for a desktop app that started the process by opening a window. The two deployments want opposite things, so this adds an option rather than changing the default.

Unset behaves exactly as today.

```txt
--bind <addr>  >  fastagent.config.* http.host  >  all interfaces
```

## One reading of a bind address, as the six questions it actually is

`src/bind.ts` exists because "is this local?" is not one question, and conflating any two of them produces a silent failure:

| | asks | why it is its own question |
|---|---|---|
| `isBindAddress` | can this be bound? | an IP literal or `localhost` — no other DNS name, since a bind address must be an address of *this* machine |
| `bindAddress` | as an ADDRESS, not a name | `localhost` → `127.0.0.1`, applied where a value **enters** |
| `classifyBind` | how far does it reach? | `wildcard` / `loopback` / `specific`; all of `127/8` is loopback |
| `answersLocalhost` | does a dial of the **name** `localhost` land here? | **not** the same as reach — `127.0.0.2` is loopback and a tunnel still cannot reach it |
| `bindLabel` | how does a message name it? | one rendering, so a reader never meets the same bind described two ways |
| `clientHost` | what does a client dial? | wildcard → loopback, otherwise itself; IPv6 gets its brackets |

The flag, `http.host` validation, `serveNode`, the ready lines, `control.json` and the deploy pre-flight all read a bind through this one module.

**A name never travels past the boundary.** Accepting `localhost` and passing it on are different things: `server.listen` would hand the name to `dns.lookup`, which picks one of `127.0.0.1`/`::1` by rules this module does not control — so what got bound would be unknown downstream, while `control.json` and the copyable curl carried a name for the client to resolve *again*, possibly to the other one. Resolving it on the way in removes both.

## Two edges that would otherwise fail silently

- **`--tunnel` + a bind `localhost` does not resolve to** (`192.168.1.5`, or even `127.0.0.2`): cloudflared dials by name, so the tunnel would come up and 502 everything. Refused before anything binds — in `dev` from the flags alone before a worker exists, then again once config is loaded, since `http.host` can carry the address. Exit 2 for a flag combination, exit 1 when the value came from config, and the message names whichever source it was: under `config` there is no flag to drop.
- **A non-wildcard `http.host` travels into the deployed image**, where it makes the container unreachable (loopback) or unbindable (an address that does not exist there): `deploy` warns, `deploy --run` gates, and the docs point local-only binds at `--bind`.

## Discovery and the warning

`control.json` records the address a client should dial, so a consumer never assumes one. The LAN warning goes silent on a loopback bind — there is no LAN reach left to state — and names the actual bind otherwise.

## The startup lines are one message

The bind report and the `try it` curl are two halves of one thing — where it bound, and the command that proves it. They were two call sites that happened to agree, and `--bind` updated only the first, so a LAN bind printed a curl to `localhost`: the very address that bind stops answering. They come from one function now (`readyAddressLines`), so neither can change without the other in view.

## Verification

`npm run lint && npm run typecheck && npm test` — **1251 tests**.

New coverage: `test/bind.test.ts` (parser/classifier agreement across every spelling, the name→address boundary, one label per bind), `serveNode` binding only what it was given, `parseBind`/`assertTunnelBindable` exit codes *and* the message naming its source, `http.host` config validation, the deploy gate (unconditional), the LAN warning's content, and the ready lines agreeing on one dialable address.

End to end:

```
$ fastagent start . --bind localhost
[fastagent] http host on 127.0.0.1:8905
[fastagent] try it: curl -s 127.0.0.1:8905/invoke …          → 200

$ fastagent start ./not-an-agent --bind banana                → exit 2  (as --port)
```

## Review

Three rounds. The `--tunnel`/`http.host` edges and the module split are from the first design; the review added the name→address boundary, `bindLabel`, the one-function ready lines, `--bind` parsing before the placement check (a usage error must not depend on the directory being an agent), and turned four assertions that could not fail into ones that can. Rebased onto `main` after the placement refactor, pi 0.83 and the AgentCore target landed underneath.
