### PR TITLE
feat(engines/pi): the default coding tools reach the machine through ExecutionEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ FastAgent is pre-1.0. The stable design center is the Agent Handler contract in 
 The neutral contract leaves room for capabilities that are not complete product features yet:
 
 - **Durable execution**: Telegram, Slack, and Feishu/Lark accepted turns replay at least once today; general durability and exactly-once execution remain future backend work.
-- **Sandboxed execution** — `ExecutionEnv` is an assembly seam, but the pi coding tools and project-context loader are still local; a complete sandbox adapter is future work.
+- **Sandboxed execution** — `ExecutionEnv` governs the default coding tools, but ② project context and author-written `tools/` still reach the local process; a complete sandbox adapter is future work.
 - **Observability export** — leveled logs and per-turn traces exist today; an OpenTelemetry exporter does not.
 - **More harness bindings and channels** — pi is the built-in harness; another harness can implement the Agent contract, and community channels can use the channel kit.
 - **More deploy targets** — local Docker, Fly, Railway, and AWS Bedrock AgentCore ship today; the generated container is the portable path for other hosts.

--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -194,7 +194,7 @@ Use `createPiAgentFromDefinition` or `createPiAgentFromDir`, then mount `createI
 
 Keep authentication, users, database, session ownership, and policy in the host application.
 
-`ExecutionEnv` is an assembly seam, not a complete sandbox. The pi coding tools and project-context loader are still local; do not claim that injecting `env` alone isolates a directory agent.
+`ExecutionEnv` governs the default coding tools (they take it as the turn's tool context) but not ② project context or author-written `tools/`. Do not claim that injecting `env` alone isolates a directory agent — it narrows the blast radius.
 
 ## Deploy
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -126,7 +126,7 @@ Common options:
 |---|---|
 | `model` | Required `provider/modelId` spec string. |
 | `instructions` | String or function returning the system prompt. |
-| `tools` | Agent tools. |
+| `tools` | Agent tools — `MountedTool[]`. An authored `FastagentTool[]` (what `defineTool` returns) widens into it; the wider type additionally admits pi's default coding tools, which read the turn's `ExecutionEnv` as a fifth `execute` parameter. |
 | `skills` | Loaded Agent Skills. |
 | `sessions` | `PiSessionStore`. |
 | `env` | `ExecutionEnv` for the default coding tools (they take it as the turn's tool context) and the definition loader. Narrows where they touch the machine; it does not sandbox author-written `tools/`, which can import anything. |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -129,7 +129,7 @@ Common options:
 | `tools` | Agent tools. |
 | `skills` | Loaded Agent Skills. |
 | `sessions` | `PiSessionStore`. |
-| `env` | Harness `ExecutionEnv`. This alone does not sandbox the pi coding tools or project-context loader. |
+| `env` | `ExecutionEnv` for the default coding tools (they take it as the turn's tool context) and the definition loader. Narrows where they touch the machine; it does not sandbox author-written `tools/`, which can import anything. |
 | `lease` | Same-session concurrency lease. |
 | `providers` | Extra model providers. |
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -282,10 +282,11 @@ test/tools-parity.test.ts, so the choice is about WHERE they touch the machine, 
 Injecting a custom `env` therefore governs the tools that actually do the touching, which is what makes
 it a seam worth having.
 
-It is still not a complete sandbox: `loadProjectContextFiles` and the definition loader read through the
-env, but fastagent's OWN tools (`tools/`) are author code that can import anything, and `deploy`/channel
-machinery runs outside it. A sandbox adapter provides an `ExecutionEnv` AND constrains the process it
-runs in; `env` alone narrows the blast radius rather than closing it.
+It is still not a complete sandbox, and the gaps are specific: `loadProjectContextFiles` reads ② context
+through node fs DIRECTLY rather than the env (definition.ts states this as a known break), fastagent's
+OWN tools (`tools/`) are author code that can import anything, and `deploy`/channel machinery runs
+outside it entirely. A sandbox adapter provides an `ExecutionEnv` AND constrains the process it runs in;
+`env` alone narrows the blast radius rather than closing it.
 
 ## 6. Sessions and concurrency
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -275,10 +275,17 @@ initial active set at build, and the same builtin loader activates through a ses
 ToolActivation bridge (`sessionToolActivation`) riding the same turn context, so the author debugs
 exactly what serves.
 
-`ExecutionEnv` is a harness assembly seam, not a complete sandbox boundary today. Pi's cwd-bound coding
-tools and `loadProjectContextFiles` still use the local process/filesystem. A future sandbox adapter must
-wire those surfaces as well as provide an `ExecutionEnv`; injecting `env` alone does not isolate a
-directory agent.
+**`ExecutionEnv` is where the default tools reach the machine.** `read`/`bash`/`edit`/`write` come from
+pi-agent-core and take the env as the turn's tool context (pi 0.83), rather than from pi-coding-agent,
+whose identical four are wired to `node:fs` directly — the model-facing surface is asserted equal in
+test/tools-parity.test.ts, so the choice is about WHERE they touch the machine, not what the agent sees.
+Injecting a custom `env` therefore governs the tools that actually do the touching, which is what makes
+it a seam worth having.
+
+It is still not a complete sandbox: `loadProjectContextFiles` and the definition loader read through the
+env, but fastagent's OWN tools (`tools/`) are author code that can import anything, and `deploy`/channel
+machinery runs outside it. A sandbox adapter provides an `ExecutionEnv` AND constrains the process it
+runs in; `env` alone narrows the blast radius rather than closing it.
 
 ## 6. Sessions and concurrency
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -145,13 +145,15 @@ createPiAgent({
 | Port | Default | Reach for it when |
 |---|---|---|
 | `sessions` | `inMemorySessionStore()` (lost on restart) | `jsonlSessionStore({ dir })` for restart-surviving continuity, or your own `PiSessionStore` |
-| `env` | local `NodeExecutionEnv` (cwd) | custom harness filesystem/process IO; not a complete sandbox by itself |
+| `env` | local `NodeExecutionEnv` (cwd) | filesystem/process IO for the default coding tools + definition loading; not a complete sandbox by itself |
 | `lease` | `inProcessLease()` | a distributed lock across instances (implement `Lease`) |
 | `providers` | built-in providers | your own gateway / self-hosted endpoint (see §5) |
 
-The pi coding tools created for a directory and the project-context loader are still cwd/local-fs
-bound. Injecting `env` alone therefore does not isolate a directory agent; a complete sandbox adapter
-must wire those surfaces too. That adapter is future work.
+The default coding tools (`read`/`bash`/`edit`/`write`) DO go through `env` — they take it as the turn's
+tool context. Two surfaces do not: ② project context (pi's loader reads node fs directly) and
+author-written `tools/`, which are code and can import anything. So injecting `env` narrows where a
+directory agent reaches, but does not isolate it; a complete sandbox adapter also has to constrain the
+process. That adapter is future work.
 
 ## 4. Auth
 

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -38,7 +38,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   // tool), is isolated the same way everywhere (G2): info, dev, AND start report it and keep going with
   // the tools that loaded. The `error`/`.catch` below only fires for a whole-load fault (an unreadable
   // tools/ dir), not a single bad file.
-  const tools = await resolveAgentTools(config, agentDir, workspace)
+  const tools = await resolveAgentTools(config, agentDir)
     .then((r) => ({
       names: r.toolNames,
       deferred: r.deferredToolNames,

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -1,5 +1,6 @@
 /** `fastagent tool <name> '<json>' [dir]`: run one tool's body directly with JSON args — no model. */
 import { resolve } from "node:path";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { loadDotEnv } from "../../env.ts";
 import { loadConfig } from "../../engines/pi/config.ts";
 
@@ -18,9 +19,7 @@ export async function runTool(name: string, argsJson: string, dirArg: string): P
   // The same tool set dev/start mount (defaults + config.tools + discovered, deduped), so the runner
   // exercises exactly what gets served — a shadowed tool is surfaced, not silently run. Resolve the
   // placement like the openers, so `fastagent tool` finds the SAME tools/ as dev/start.
-  const { tools, toolCollisions, toolFailures } = await resolveAgentTools(config, agentDir, workspace).catch(
-    failStartup,
-  );
+  const { tools, toolCollisions, toolFailures } = await resolveAgentTools(config, agentDir).catch(failStartup);
   for (const c of toolCollisions) {
     console.error(
       `[fastagent] warn: tool "${c.name}" (${c.source}) is shadowed by a default/config tool — not mounted`,
@@ -31,7 +30,14 @@ export async function runTool(name: string, argsJson: string, dirArg: string): P
   if (!tool) {
     failStartup(new Error(`unknown tool "${name}". available: ${tools.map((t) => t.name).join(", ") || "(none)"}`));
   }
-  const result = await turnContext.run({ cwd: workspace }, () => tool.execute(`cli-${name}`, args)).catch(failStartup);
+  // Two contexts, because the two tool families read different ones and this command must serve both
+  // exactly as serving does: fastagent's own tools take cwd/session/activation from `turnContext`
+  // (AsyncLocalStorage), and pi's default coding tools take the ExecutionEnv from the harness's TOOL
+  // context — which no harness supplies here, so this stands in for it, rooted at the same workspace.
+  const env = new NodeExecutionEnv({ cwd: workspace });
+  const result = await turnContext
+    .run({ cwd: workspace }, () => tool.execute(`cli-${name}`, args, undefined, undefined, { env }))
+    .catch(failStartup);
   const out =
     result?.details !== undefined
       ? result.details

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -309,10 +309,10 @@ export interface CreatePiAgentOptions {
   authPath?: string;
   /** Session persistence. Defaults to in-memory; inject jsonlSessionStore for restart-surviving continuity. */
   sessions?: PiSessionStore;
-  /** Filesystem/process environment. Defaults to a local NodeExecutionEnv at `process.cwd()`. At THIS
-   *  rung it supplies the agent's cwd and nothing else — pi 0.83 removed the harness's own env, and the
-   *  default coding tools are cwd-bound and local. So injecting it is not a sandbox boundary; a sandbox
-   *  adapter must wire those tools too (pi-agent-core now ships env-backed ones — see create.ts §tools). */
+  /** Filesystem/process environment. Defaults to a local NodeExecutionEnv at `process.cwd()`, and its
+   *  cwd is the agent's. The default coding tools (read/bash/edit/write) take it as the turn's tool
+   *  context, so injecting a constrained one narrows where the agent reads, writes and shells. It does
+   *  NOT constrain author-written `tools/`, which are code and can import anything. */
   env?: ExecutionEnv;
   /** Single-writer lease. Defaults to in-process fail-fast inProcessLease(). */
   lease?: Lease;
@@ -333,6 +333,7 @@ export function createPiAgent(options: CreatePiAgentOptions): Agent {
     tools: options.tools ? withSearchTool(options.tools) : options.tools,
     skills: options.skills,
     sessions: options.sessions,
+    env: options.env,
     lease: options.lease,
     observer: options.observer,
   });
@@ -370,8 +371,9 @@ export interface CreatePiAgentFromDefinitionOptions {
   authPath?: string;
   sessions?: PiSessionStore;
   /** Filesystem/process environment; see {@link CreatePiAgentOptions.env}. At THIS rung it does more
-   *  than carry the cwd: the DEFINITION is read through it (persona.md, skills/, AGENTS.md). The coding
-   *  tools stay local and cwd-bound, so injecting it alone still does not sandbox a directory agent. */
+   *  than root the default tools: the DEFINITION is read through it too (persona.md, skills/,
+   *  AGENTS.md). Author-written `tools/` remain outside it — injecting an env narrows the blast radius
+   *  rather than closing it. */
   env?: ExecutionEnv;
   lease?: Lease;
   /** Observation-plane tap; see {@link CreatePiAgentOptions.observer}. */

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -11,9 +11,16 @@
  * they come from the definition; the openers own model/tools — from config resolution).
  */
 import { formatSkillsForSystemPrompt } from "@earendil-works/pi-agent-core";
-import type { AgentTool, ExecutionEnv, Skill, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import {
+  type ExecutionEnv,
+  type Skill,
+  type ThinkingLevel,
+  createBashTool,
+  createEditTool,
+  createReadTool,
+  createWriteTool,
+} from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
-import { createCodingTools } from "@earendil-works/pi-coding-agent";
 import type { Models, Provider } from "@earendil-works/pi-ai";
 import type { Agent } from "../../agent.ts";
 import { type FastagentConfig, defaultAuthPath, resolveModel } from "./config.ts";
@@ -26,11 +33,11 @@ import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import {
   type DefineToolOptions,
-  type FastagentTool,
   type ToolCollision,
   isDeferredTool,
   loadTools,
   mergeDiscoveredTools,
+  type MountedTool,
 } from "./tool.ts";
 import { withSearchTool } from "./search-tools.ts";
 import { type Lease, type SessionObserver, createPiAgentFromHarness, inProcessLease } from "./invoke.ts";
@@ -38,17 +45,30 @@ import { type Lease, type SessionObserver, createPiAgentFromHarness, inProcessLe
 // ── §1 tools ─────────────────────────────────────────────────────────────────
 //
 // The full pi toolset is the default for fidelity: authors vibe in local pi with it, so serving with
-// fewer tools is behavior drift. Isolation is the K-side ExecutionEnv/sandbox's job, not the tool
-// layer's; locking down for public exposure = passing a restricted `tools` list (a deployment posture).
+// fewer tools is behavior drift. Locking down for public exposure = passing a restricted `tools` list
+// (a deployment posture).
+//
+// These are pi-agent-core's tools, which reach the filesystem and the shell through the
+// {@link ExecutionEnv} the harness hands them per turn — NOT pi-coding-agent's, which are the same four
+// tools wired to `node:fs` directly (identical names, descriptions, parameters and results — asserted
+// in test/tools-parity.test.ts). Going through the env is the whole point: it makes
+// {@link CreatePiAgentOptions.env} the one seam a sandbox adapter has to implement, instead of a knob
+// that governed everything except the tools that actually touch the machine. It also keeps the serving
+// path off pi's TUI stack, which the coding-agent tools carry for rendering fastagent never uses (its
+// channels render from the SPEC stream).
+//
+// `chat` is unaffected: it takes these NAMES only and lets pi's own runtime rebuild the tools it
+// renders (see session-builder.ts).
 
-/** pi's core default toolset (read/bash/edit/write), rooted at cwd. */
-export function piDefaultTools(cwd: string): AgentTool[] {
-  return createCodingTools(cwd) as AgentTool[];
+/** pi's core default toolset (read/bash/edit/write). Rooted at the ExecutionEnv's cwd, supplied per
+ *  turn as the harness tool context — hence no argument here. */
+export function piDefaultTools(): MountedTool[] {
+  return [createReadTool(), createBashTool(), createEditTool(), createWriteTool()];
 }
 
 /** `config.tools` semantics: extra tools APPENDED after pi's defaults, never replacing them. */
-export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] {
-  const defaults = piDefaultTools(cwd);
+export function resolveTools(config: FastagentConfig): MountedTool[] {
+  const defaults = piDefaultTools();
   return config.tools ? [...defaults, ...config.tools] : defaults;
 }
 
@@ -60,9 +80,8 @@ export function resolveTools(config: FastagentConfig, cwd: string): AgentTool[] 
 export async function resolveAgentTools(
   config: FastagentConfig,
   agentDir: string,
-  cwd: string = agentDir,
 ): Promise<{
-  tools: AgentTool[];
+  tools: MountedTool[];
   toolNames: string[];
   /** Tools registered but not initially active (defineTool `deferred: true`) — discovered/activated
    *  via the built-in `search_tools` loader. Surfaced so the operator can see deferral took effect. */
@@ -70,10 +89,11 @@ export async function resolveAgentTools(
   toolCollisions: ToolCollision[];
   toolFailures: ModuleLoadFailure[];
 }> {
-  // Default coding tools (read/bash/edit/write) are rooted at `cwd` (the workspace the agent operates
-  // on); discovered `tools/` come from `agentDir` (the agent's own surface).
+  // Discovered `tools/` come from `agentDir` (the agent's own surface); the default coding tools carry
+  // no root of their own — they operate through the ExecutionEnv handed to them per turn, whose cwd is
+  // the workspace.
   const discovered = await loadTools(agentDir);
-  const merged = mergeDiscoveredTools(resolveTools(config, cwd), discovered.tools);
+  const merged = mergeDiscoveredTools(resolveTools(config), discovered.tools);
   // The built-in `search_tools` loader mounts here — the one place the agent's full tool set is
   // computed — so `dev`/`start`/`info`/`fastagent tool` all see the same surface (idempotent; an
   // agent-defined search_tools wins).
@@ -87,7 +107,7 @@ export async function resolveAgentTools(
   // defaults, the builtin loader (like wake, a builtin gets its own report line, not an anonymous
   // slot in the author's list — an author-DEFINED search_tools still shows), and deferred tools —
   // each name lives in exactly ONE report slot, and deferred names live in `deferredToolNames`.
-  const defaultNames = new Set(piDefaultTools(cwd).map((t) => t.name));
+  const defaultNames = new Set(piDefaultTools().map((t) => t.name));
   const toolNames = tools
     .filter(
       (t) => !defaultNames.has(t.name) && !isDeferredTool(t) && !(builtinLoaderMounted && t.name === "search_tools"),
@@ -121,7 +141,7 @@ export async function resolveAgentTools(
  * tool list is generated from the actually-mounted tools (base and toolset must agree). An authored
  * `persona` (from persona.md) replaces the default identity line, keeping the tools list + guidelines.
  */
-export function piBasePrompt(options: { tools?: AgentTool[]; persona?: string } = {}): string {
+export function piBasePrompt(options: { tools?: MountedTool[]; persona?: string } = {}): string {
   const mounted = options.tools ?? [];
   // Deferred tools stay OUT of the list: their schemas are not in the request until activated, so
   // naming them here would invite calls to tools that don't exist yet; discovery is search_tools' job
@@ -197,7 +217,7 @@ function buildPiAgent(opts: {
   providers?: Provider[];
   authPath?: string;
   systemPrompt?: string | (() => string);
-  tools?: AgentTool[];
+  tools?: MountedTool[];
   skills?: Skill[];
   /** Per-invoke prompt+skills source (see {@link PiHarnessFactoryOptions.live}); supersedes the two above. */
   live?: () => Promise<{ systemPrompt?: string; skills?: Skill[] }>;
@@ -214,6 +234,7 @@ function buildPiAgent(opts: {
   const lease = opts.lease ?? inProcessLease();
   const harnessFactory = piHarnessFactory({
     sessions: opts.sessions ?? inMemorySessionStore(),
+    env,
     models,
     model: resolveModel(models, opts.model),
     thinkingLevel: opts.thinkingLevel,
@@ -268,8 +289,10 @@ export interface CreatePiAgentOptions {
    * or a factory re-evaluated per invoke. When {@link skills} are mounted their listing is appended.
    */
   instructions?: string | (() => string);
-  /** `FastagentTool` = AgentTool plus the optional `deferred` marker (see {@link DefineToolOptions}). */
-  tools?: FastagentTool[];
+  /** The tool set to mount. `FastagentTool` (AgentTool plus the optional `deferred` marker, see
+   *  {@link DefineToolOptions}) widens into {@link MountedTool}, which additionally admits pi's default
+   *  coding tools — they read the turn's ExecutionEnv as a fifth `execute` parameter. */
+  tools?: MountedTool[];
   skills?: Skill[];
   // ── Tier 2: injectable ports ───────────────────────────────────────────────
   /**
@@ -327,9 +350,9 @@ export interface CreatePiAgentFromDefinitionOptions {
   /** Override the engine base prompt (segment ①). Defaults to piBasePrompt({ tools, persona }) using the
    *  live-read persona.md; pass base to fully opt out of persona.md. */
   base?: string;
-  /** Override tools. Defaults to piDefaultTools (lock down with a custom list). `FastagentTool` =
-   *  AgentTool plus the optional `deferred` marker. */
-  tools?: FastagentTool[];
+  /** Override tools. Defaults to {@link piDefaultTools} (lock down with a custom list). An authored
+   *  `FastagentTool[]` (AgentTool plus the optional `deferred` marker) widens into {@link MountedTool}. */
+  tools?: MountedTool[];
   /**
    * The agent's working directory: where the default tools operate AND whose ancestors are walked for
    * ② project context (AGENTS.md). Defaults to `dir`. Set it to the enclosing repo so a coding agent
@@ -385,7 +408,7 @@ export async function createPiAgentFromDefinition(
   let reportedFindings = findingsSignature(definition);
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
-  const tools = withSearchTool(options.tools ?? piDefaultTools(env.cwd));
+  const tools = withSearchTool(options.tools ?? piDefaultTools());
   const agent = buildPiAgent({
     model: options.model,
     thinkingLevel: options.thinkingLevel,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -21,6 +21,7 @@ import {
   createWriteTool,
 } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { readImageProcessor } from "./read-image.ts";
 import type { Models, Provider } from "@earendil-works/pi-ai";
 import type { Agent } from "../../agent.ts";
 import { type FastagentConfig, defaultAuthPath, resolveModel } from "./config.ts";
@@ -50,12 +51,14 @@ import { type Lease, type SessionObserver, createPiAgentFromHarness, inProcessLe
 //
 // These are pi-agent-core's tools, which reach the filesystem and the shell through the
 // {@link ExecutionEnv} the harness hands them per turn — NOT pi-coding-agent's, which are the same four
-// tools wired to `node:fs` directly (identical names, descriptions, parameters and results — asserted
-// in test/tools-parity.test.ts). Going through the env is the whole point: it makes
+// tools wired to `node:fs` directly. Going through the env is the point, and the whole of it: it makes
 // {@link CreatePiAgentOptions.env} the one seam a sandbox adapter has to implement, instead of a knob
-// that governed everything except the tools that actually touch the machine. It also keeps the serving
-// path off pi's TUI stack, which the coding-agent tools carry for rendering fastagent never uses (its
-// channels render from the SPEC stream).
+// that governed everything except the tools that actually touch the machine. (It buys no decoupling
+// from pi-coding-agent — definition.ts, models.ts and read-image.ts all import it regardless.)
+//
+// The swap holds only while the two behave alike, which they do NOT for free: core's `read` does
+// nothing with images unless a processor is injected (read-image.ts), and both families are compared
+// on every path in test/tools-parity.test.ts.
 //
 // `chat` is unaffected: it takes these NAMES only and lets pi's own runtime rebuild the tools it
 // renders (see session-builder.ts).
@@ -63,7 +66,13 @@ import { type Lease, type SessionObserver, createPiAgentFromHarness, inProcessLe
 /** pi's core default toolset (read/bash/edit/write). Rooted at the ExecutionEnv's cwd, supplied per
  *  turn as the harness tool context — hence no argument here. */
 export function piDefaultTools(): MountedTool[] {
-  return [createReadTool(), createBashTool(), createEditTool(), createWriteTool()];
+  // `read` needs its image pipeline INJECTED (core ships none); see read-image.ts for what is at stake.
+  return [
+    createReadTool({ imageProcessor: readImageProcessor }),
+    createBashTool(),
+    createEditTool(),
+    createWriteTool(),
+  ];
 }
 
 /** `config.tools` semantics: extra tools APPENDED after pi's defaults, never replacing them. */
@@ -371,9 +380,10 @@ export interface CreatePiAgentFromDefinitionOptions {
   authPath?: string;
   sessions?: PiSessionStore;
   /** Filesystem/process environment; see {@link CreatePiAgentOptions.env}. At THIS rung it does more
-   *  than root the default tools: the DEFINITION is read through it too (persona.md, skills/,
-   *  AGENTS.md). Author-written `tools/` remain outside it — injecting an env narrows the blast radius
-   *  rather than closing it. */
+   *  than root the default tools: persona.md and skills/ are read through it too. Two surfaces stay
+   *  OUTSIDE it — ② project context (pi's loadProjectContextFiles uses node fs directly; see
+   *  definition.ts) and author-written `tools/`, which are code and can import anything. Injecting an
+   *  env narrows the blast radius rather than closing it. */
   env?: ExecutionEnv;
   lease?: Lease;
   /** Observation-plane tap; see {@link CreatePiAgentOptions.observer}. */

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -27,12 +27,15 @@ export const TOOL_ACTIVATION_ENTRY = "fastagent:tool-activation";
  *  to write {@link TOOL_ACTIVATION_ENTRY} deltas (pi's harness keeps its session private). Absent for
  *  a harness built outside {@link piHarnessFactory}: activation still works in-turn there, but is not
  *  recorded — the factory owns persistence. */
-// Keyed by IDENTITY, so the key type is deliberately the structural minimum: the harness's context
-// parameter (pi 0.83) is irrelevant to "which session is this instance bound to", and naming a concrete
-// one here would make every caller's harness type have to match this map's.
-const harnessSessions = new WeakMap<object, PiSession>();
+// Keyed by IDENTITY, and deliberately context-AGNOSTIC: which session an instance is bound to has
+// nothing to do with the harness's tool-context parameter (pi 0.83), and naming a concrete one would
+// force every caller's harness type to match this map's. `any` is the context, not the argument — it
+// still has to BE a harness.
+// biome-ignore lint/suspicious/noExplicitAny: context-agnostic by intent, audited at this single point
+type AnyHarness = AgentHarness<any>;
+const harnessSessions = new WeakMap<AnyHarness, PiSession>();
 export type PiSession = Awaited<ReturnType<PiSessionStore["openOrCreate"]>>;
-export function harnessSession(harness: object): PiSession | undefined {
+export function harnessSession(harness: AnyHarness): PiSession | undefined {
   return harnessSessions.get(harness);
 }
 

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -7,11 +7,11 @@
  * historical entries back into context via buildContext().
  */
 import { AgentHarness } from "@earendil-works/pi-agent-core";
-import type { AgentTool, Skill, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { ExecutionEnv, ExecutionToolContext, Skill, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Model, Models } from "@earendil-works/pi-ai";
 import { log } from "../../log.ts";
 import type { PiSessionStore } from "./sessions.ts";
-import { isDeferredTool } from "./tool.ts";
+import { isDeferredTool, type MountedTool } from "./tool.ts";
 
 /**
  * The session custom-entry type recording ONE activation delta: `{ names }` — exactly the deferred
@@ -27,9 +27,12 @@ export const TOOL_ACTIVATION_ENTRY = "fastagent:tool-activation";
  *  to write {@link TOOL_ACTIVATION_ENTRY} deltas (pi's harness keeps its session private). Absent for
  *  a harness built outside {@link piHarnessFactory}: activation still works in-turn there, but is not
  *  recorded — the factory owns persistence. */
-const harnessSessions = new WeakMap<AgentHarness, PiSession>();
+// Keyed by IDENTITY, so the key type is deliberately the structural minimum: the harness's context
+// parameter (pi 0.83) is irrelevant to "which session is this instance bound to", and naming a concrete
+// one here would make every caller's harness type have to match this map's.
+const harnessSessions = new WeakMap<object, PiSession>();
 export type PiSession = Awaited<ReturnType<PiSessionStore["openOrCreate"]>>;
-export function harnessSession(harness: AgentHarness): PiSession | undefined {
+export function harnessSession(harness: object): PiSession | undefined {
   return harnessSessions.get(harness);
 }
 
@@ -41,18 +44,26 @@ export function harnessSession(harness: AgentHarness): PiSession | undefined {
 export type AnyModel = Model<any>;
 
 /** Builds a pi harness bound to the given session — called once per invoke. */
-export type PiHarnessFactory = (session: string) => AgentHarness | Promise<AgentHarness>;
+/** The harness fastagent builds: context-typed on {@link ExecutionToolContext}, because that is what
+ *  pi's env-backed default tools read (pi 0.83). Custom tools are context-FREE and stay assignable — a
+ *  four-parameter `execute` satisfies the five-parameter one, so `defineTool` is untouched by this. */
+type PiHarness = AgentHarness<ExecutionToolContext>;
+export type PiHarnessFactory = (session: string) => PiHarness | Promise<PiHarness>;
 
 export interface PiHarnessFactoryOptions {
   /** Session persistence. Continuity = same backing store + same session id. */
   sessions: PiSessionStore;
+  /** Filesystem/process environment for the default coding tools. Handed to the harness as the TURN's
+   *  tool context (pi 0.83), which is how read/bash/edit/write reach the machine at all — so this is the
+   *  ONE seam a sandbox adapter implements, not a knob beside the tools that ignore it. */
+  env: ExecutionEnv;
   /** Provider collection for all model requests; {@link model} must belong to it (same provider id). */
   models: Models;
   model: AnyModel;
   /** Reasoning effort for the model (pi's scale). Unset = fastagent's pinned default ("medium", pi
    *  TUI parity — see {@link DEFAULT_THINKING_LEVEL}); unsupported levels are clamped by pi per model. */
   thinkingLevel?: ThinkingLevel;
-  tools?: AgentTool[];
+  tools?: MountedTool[];
   /**
    * Final assembled prompt, or a SYNC factory re-evaluated per invoke (how L1 serves dynamic
    * `instructions` + the skills listing). Distinct from {@link live}, which is the directory rung's
@@ -226,7 +237,7 @@ export function resolveHarnessOverrides(
 }
 export function resolveHarnessActiveToolNames(
   recorded: string[] | null,
-  tools: AgentTool[],
+  tools: MountedTool[],
   sessionId: string,
 ): string[] | undefined {
   const anyDeferred = tools.some(isDeferredTool);
@@ -267,7 +278,10 @@ export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFac
       { model: options.model, thinkingLevel: options.thinkingLevel ?? DEFAULT_THINKING_LEVEL },
       sessionId,
     );
-    const harness = new AgentHarness({
+    const harness = new AgentHarness<ExecutionToolContext>({
+      // Static, not a per-turn provider: the env is fixed for the agent's lifetime, and resolving a
+      // constant per turn would only add a promise to the turn's critical path.
+      toolContext: { env: options.env },
       session,
       models: options.models,
       model: overrides.model,

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -9,7 +9,6 @@
  * watch and can point sessions at a mounted volume.
  */
 import { mkdir } from "node:fs/promises";
-import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { Agent } from "../../agent.ts";
 import {
   type FastagentConfig,
@@ -30,6 +29,7 @@ import type { ModuleLoadFailure } from "../../loader.ts";
 import type { LoadedDefinition } from "./definition.ts";
 import { jsonlSessionStore } from "./sessions.ts";
 import type { ToolCollision } from "./tool.ts";
+import type { MountedTool } from "./tool.ts";
 
 export interface CreatePiAgentFromDirOptions {
   /** Model spec override (e.g. the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -91,7 +91,7 @@ export interface AgentAssembly {
   /** Absolute credentials file (--auth-path/authPath option > FASTAGENT_AUTH_PATH > <agentDir>/.secrets/auth.json). */
   authPath: string;
   /** The full mounted tool surface (config.tools + discovered tools/, search_tools applied). */
-  tools: AgentTool[];
+  tools: MountedTool[];
   toolNames: string[];
   deferredToolNames: string[];
   toolCollisions: ToolCollision[];
@@ -116,7 +116,6 @@ export async function resolveAgentAssembly(
   const { tools, toolNames, deferredToolNames, toolCollisions, toolFailures } = await resolveAgentTools(
     config,
     agentDir,
-    workspace,
   );
   // The state root: sessions/channel state/schedule state derive from it (FASTAGENT_STATE_DIR moves it
   // in one knob — a container points it at its volume); the finer overrides below still win.

--- a/src/engines/pi/read-image.ts
+++ b/src/engines/pi/read-image.ts
@@ -1,0 +1,65 @@
+/**
+ * The image pipeline pi's `read` tool needs: normalize an unsupported format to PNG, resize below the
+ * inline limit, and hand back the hints that tell the model what it is looking at.
+ *
+ * pi-agent-core's `createReadTool` takes this as an INJECTED processor and does nothing without one —
+ * unlike pi-coding-agent's, which wires its private `processImage` internally. That function is not
+ * exported (nor reachable: the package's `exports` map has no deep paths), so this rebuilds it from the
+ * two halves that ARE public, `convertToPng` and `resizeImage`/`formatDimensionNote`.
+ *
+ * It is upstream logic restated, which is a real cost — without it `read` on a screenshot sends the raw
+ * bytes (measured: 7.48 MB of base64 where pi-coding-agent sends 3.48 MB, and no dimension note for the
+ * model's coordinate math), and a bmp is dropped entirely while the tool's own description still
+ * advertises it. test/tools-parity.test.ts compares this against pi-coding-agent's real `read` on both
+ * paths, so upstream changing the pipeline surfaces as a failing test rather than as drift.
+ */
+import { convertToPng, formatDimensionNote, resizeImage } from "@earendil-works/pi-coding-agent";
+import type { ReadImageProcessor } from "@earendil-works/pi-agent-core";
+
+/** Formats a provider takes inline as-is; everything else has to become a PNG first. */
+const INLINE_MIME: Record<string, string> = {
+  "image/png": "image/png",
+  "image/jpeg": "image/jpeg",
+  "image/jpg": "image/jpeg",
+  "image/gif": "image/gif",
+  "image/webp": "image/webp",
+};
+
+/** The `read` tool's image processor. Matches pi-coding-agent's messages verbatim: they reach the model
+ *  as tool output, so a reworded one is a different prompt, not a different implementation detail. */
+export const readImageProcessor: ReadImageProcessor = async (bytes, mimeType, options) => {
+  const base = mimeType.split(";")[0]?.trim().toLowerCase() ?? mimeType.toLowerCase();
+  const inline = INLINE_MIME[base];
+  let normalized: { bytes: Uint8Array; mimeType: string; convertedFrom?: string };
+  if (inline) {
+    normalized = { bytes, mimeType: inline };
+  } else {
+    const png = await convertToPng(Buffer.from(bytes).toString("base64"), base);
+    if (!png)
+      return { ok: false, message: "[Image omitted: could not be converted to a supported inline image format.]" };
+    normalized = { bytes: Buffer.from(png.data, "base64"), mimeType: png.mimeType, convertedFrom: base };
+  }
+
+  const hints: string[] = [];
+  const converted = (to: string) =>
+    normalized.convertedFrom && normalized.convertedFrom !== to
+      ? `[Image converted from ${normalized.convertedFrom} to ${to}.]`
+      : undefined;
+
+  if (!options.autoResizeImages) {
+    const hint = converted(normalized.mimeType);
+    if (hint) hints.push(hint);
+    return { ok: true, data: Buffer.from(normalized.bytes).toString("base64"), mimeType: normalized.mimeType, hints };
+  }
+
+  const resized = await resizeImage(normalized.bytes, normalized.mimeType);
+  if (!resized)
+    return { ok: false, message: "[Image omitted: could not be resized below the inline image size limit.]" };
+  const hint = converted(resized.mimeType);
+  if (hint) hints.push(hint);
+  // The scale factor the model needs to map coordinates back onto the original — dropping it is what
+  // makes a resized screenshot unusable for anything positional.
+  const note = formatDimensionNote(resized);
+  if (note) hints.push(note);
+  return { ok: true, data: resized.data, mimeType: resized.mimeType, hints };
+};

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -8,10 +8,12 @@
 import { z } from "zod";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { log } from "../../log.ts";
-import { defineTool, isDeferredTool, stripDeferredMarker } from "./tool.ts";
+import { type MountedTool, defineTool, isDeferredTool, stripDeferredMarker } from "./tool.ts";
 
-/** Mount the built-in loader iff any mounted tool is deferred and the author didn't define their own. */
-export function withSearchTool(tools: AgentTool[]): AgentTool[] {
+/** Mount the built-in loader iff any mounted tool is deferred and the author didn't define their own.
+ *  Typed on the MOUNTED tool, not the authored one: it inspects names and deferral and never executes,
+ *  so narrowing here would reject the very set it is handed (pi's defaults take the turn's context). */
+export function withSearchTool(tools: MountedTool[]): MountedTool[] {
   if (!tools.some(isDeferredTool)) return tools;
   const authored = tools.find((t) => t.name === "search_tools");
   if (!authored) return [...tools, makeSearchToolsTool()];
@@ -52,7 +54,7 @@ const MAX_MISS_LISTING = 10;
  * correct load-point attribution everywhere an OUTER active-set diff exists: pi wraps SDK customTools
  * (the chat path) in a before/after diff, and two parallel loader calls would both snapshot the
  * pre-activation set and get stamped with the same activation. Custom loader authors must set it too. */
-export function makeSearchToolsTool(): AgentTool {
+export function makeSearchToolsTool(): MountedTool {
   return defineTool({
     name: "search_tools",
     executionMode: "sequential",

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -152,7 +152,7 @@ export async function buildAgentSessionRuntime(
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(agentDir, { cwd, env });
     reportDefinitionWarnings(definition.collisions, definition.diagnostics);
-    const defaultNames = piDefaultTools(cwd).map((t) => t.name);
+    const defaultNames = piDefaultTools().map((t) => t.name);
     const customTools = tools.filter((t) => !defaultNames.includes(t.name));
     // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts
     // it). Each execute runs inside the turn context with the CURRENT session's activation bridge — the
@@ -174,7 +174,11 @@ export async function buildAgentSessionRuntime(
         if (!bound) throw new Error("tool executed before its session was built (lifecycle invariant broken)");
         return turnContext.run(
           { cwd, sessionManager: bound.sessionManager, tools: bound.activation },
-          () => t.execute(id, params, signal) as Promise<unknown>,
+          // pi's per-turn TOOL context (5th parameter) is read only by its default coding tools, and
+          // those are filtered out of `customTools` above; fastagent's own take theirs from
+          // `turnContext` (AsyncLocalStorage). So this env exists to satisfy the shape, and it is the
+          // chat cwd's — the same root a default tool would have got, had one reached here.
+          () => t.execute(id, params, signal, undefined, { env }) as Promise<unknown>,
         );
       },
     })) as unknown as ToolDefinition[];

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -51,9 +51,6 @@ export interface DefineToolOptions<I extends z.ZodType> {
   execute: (input: z.infer<I>, ctx: ToolContext) => unknown | Promise<unknown>;
 }
 
-/** An AgentTool with fastagent's deferral marker — the type for raw tools handed to fastagent
- *  (`config.tools`, L1/L2 `tools`): plain `AgentTool` has no `deferred`, so an object literal with the
- *  marker would fail excess-property checking against upstream's type. `defineTool` produces it. */
 /**
  * A tool as MOUNTED: what the harness actually runs. Wider than the authored {@link AgentTool} on
  * purpose — pi's default coding tools read the turn's tool context (its ExecutionEnv) as a fifth
@@ -63,6 +60,9 @@ export interface DefineToolOptions<I extends z.ZodType> {
  */
 export type MountedTool = AgentHarnessTool<ExecutionToolContext>;
 
+/** An AgentTool with fastagent's deferral marker — the type for raw tools handed to fastagent
+ *  (`config.tools`, L1/L2 `tools`): plain `AgentTool` has no `deferred`, so an object literal with the
+ *  marker would fail excess-property checking against upstream's type. `defineTool` produces it. */
 export type FastagentTool = AgentTool & {
   deferred?: boolean;
 };

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -12,7 +12,7 @@
  */
 import { join } from "node:path";
 import { assertInsideAgentDir } from "../../paths.ts";
-import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { AgentHarnessTool, ExecutionToolContext, AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { z } from "zod";
 import { type ModuleLoadFailure, loadModuleDir } from "../../loader.ts";
 import { type ReadonlySessionManager, type ToolActivation, turnContext } from "./tool-context.ts";
@@ -54,22 +54,31 @@ export interface DefineToolOptions<I extends z.ZodType> {
 /** An AgentTool with fastagent's deferral marker — the type for raw tools handed to fastagent
  *  (`config.tools`, L1/L2 `tools`): plain `AgentTool` has no `deferred`, so an object literal with the
  *  marker would fail excess-property checking against upstream's type. `defineTool` produces it. */
+/**
+ * A tool as MOUNTED: what the harness actually runs. Wider than the authored {@link AgentTool} on
+ * purpose — pi's default coding tools read the turn's tool context (its ExecutionEnv) as a fifth
+ * `execute` parameter, while fastagent's own tools take four and are assignable to it unchanged.
+ * Naming the wider type is what lets `defineTool` stay context-free for authors while both families
+ * live in one array; every helper that only inspects or reorders tools is typed on THIS.
+ */
+export type MountedTool = AgentHarnessTool<ExecutionToolContext>;
+
 export type FastagentTool = AgentTool & {
   deferred?: boolean;
 };
 
 /** Read the {@link DefineToolOptions.deferred} marker off a mounted tool (extra property on the
  *  AgentTool object — pi ignores it). */
-export function isDeferredTool(tool: AgentTool): boolean {
+export function isDeferredTool(tool: MountedTool): boolean {
   return (tool as FastagentTool).deferred === true;
 }
 
 /** The same tool without the deferred marker — for a loader that must stay active (a deferred loader
  *  could never be activated and would strand every deferred tool). */
-export function stripDeferredMarker(tool: AgentTool): AgentTool {
+export function stripDeferredMarker(tool: MountedTool): MountedTool {
   if (!isDeferredTool(tool)) return tool;
-  const { deferred: _drop, ...active } = tool as AgentTool & { deferred?: boolean };
-  return active as AgentTool;
+  const { deferred: _drop, ...active } = tool as MountedTool & { deferred?: boolean };
+  return active;
 }
 
 /** Wrap a plain return value into pi's tool-result shape; pass a full result through unchanged. */
@@ -177,9 +186,9 @@ export async function loadTools(
  * Existing tools win; dropped discovered tools surface as collisions.
  */
 export function mergeDiscoveredTools(
-  existing: AgentTool[],
+  existing: MountedTool[],
   discovered: AgentTool[],
-): { tools: AgentTool[]; collisions: ToolCollision[] } {
+): { tools: MountedTool[]; collisions: ToolCollision[] } {
   const names = new Set(existing.map((t) => t.name));
   const tools = [...existing];
   const collisions: ToolCollision[] = [];

--- a/src/engines/pi/wake-tool.ts
+++ b/src/engines/pi/wake-tool.ts
@@ -12,9 +12,8 @@
  * exclusion config today.
  */
 import { z } from "zod";
-import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { addWakeup, removeWakeup } from "../../schedule/wakeups.ts";
-import { defineTool } from "./tool.ts";
+import { defineTool, type MountedTool } from "./tool.ts";
 
 /**
  * Parse a delay to milliseconds: a number is SECONDS; a string MUST carry a unit — `"<n><s|m|h|d>"`
@@ -36,7 +35,7 @@ export function parseDelayMs(input: string | number): number | undefined {
  * scheduler poller honors a wake-up) and only when the workspace hasn't defined its own `wake` (that
  * wins, like any tool collision). The single place the mount decision + collision rule run.
  */
-export function withWakeTool(tools: AgentTool[], stateRoot: string, enabled: boolean): AgentTool[] {
+export function withWakeTool(tools: MountedTool[], stateRoot: string, enabled: boolean): MountedTool[] {
   if (!enabled) return tools;
   // wake/unwake are a PAIR over one store: if the workspace defines EITHER name, mount NEITHER built-in.
   // Mixing halves would mislead — an author's wake doesn't write our wakeups store, so our unwake could
@@ -46,7 +45,7 @@ export function withWakeTool(tools: AgentTool[], stateRoot: string, enabled: boo
 }
 
 /** Build the `wake` tool bound to `stateRoot` (where wake-ups persist). */
-export function makeWakeTool(stateRoot: string, now: () => Date = () => new Date()): AgentTool {
+export function makeWakeTool(stateRoot: string, now: () => Date = () => new Date()): MountedTool {
   return defineTool({
     name: "wake",
     description:
@@ -93,7 +92,7 @@ export function makeWakeTool(stateRoot: string, now: () => Date = () => new Date
 
 /** Build the `unwake` tool: cancel one of THIS conversation's pending wake-ups by id (a wake/recurring
  *  that is no longer needed). Session-scoped — a conversation can never cancel another's. */
-function makeUnwakeTool(stateRoot: string): AgentTool {
+function makeUnwakeTool(stateRoot: string): MountedTool {
   return defineTool({
     name: "unwake",
     description:

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -11,6 +11,7 @@ export {
   loadTools,
   type DefineToolOptions,
   type FastagentTool,
+  type MountedTool,
   type ToolCollision,
   type ToolContext,
 } from "./engines/pi/tool.ts";

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/engines/pi/config.ts";
 import { resolveSecretsDir, resolveStateRoot } from "../src/paths.ts";
 import { resolveTools } from "../src/engines/pi/create.ts";
+import type { FastagentTool } from "../src/engines/pi/tool.ts";
 
 const fixtures = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 
@@ -273,11 +274,11 @@ describe("config: loadConfig", () => {
 
 describe("config: resolveTools (append-after-defaults semantics)", () => {
   it("without config.tools returns pi defaults; with config.tools appends after defaults instead of replacing", () => {
-    const defaults = resolveTools({}, process.cwd());
+    const defaults = resolveTools({});
     expect(defaults.length).toBeGreaterThan(0);
 
-    const extra = { name: "ping" } as (typeof defaults)[number];
-    const merged = resolveTools({ tools: [extra] }, process.cwd());
+    const extra = { name: "ping" } as unknown as FastagentTool;
+    const merged = resolveTools({ tools: [extra] });
     expect(merged.map((t) => t.name)).toEqual([...defaults.map((t) => t.name), "ping"]);
   });
 });

--- a/test/conformance.test.ts
+++ b/test/conformance.test.ts
@@ -12,12 +12,14 @@ import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 function piAgent(responses: FauxResponseStep[], sessions: PiSessionStore = inMemorySessionStore()) {
   const { faux, models } = makeFaux();
   faux.setResponses(responses);
   return createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,
@@ -36,6 +38,7 @@ describeSpecConformance("pi reference implementation (faux model, full L0 compos
     const { faux, models } = makeFaux();
     faux.setResponses([fauxAssistantMessage("a long answer that streams out slowly")]);
     const inner = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions: inMemorySessionStore(),
 
       models,

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -19,6 +19,7 @@ import { connectAgent, connectSessionControl } from "../src/session-remote.ts";
 import { UNSUPPORTED_CAPABILITY_CODE, type SessionEvent } from "../src/session.ts";
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 const TOKEN = "test-token";
 
@@ -38,6 +39,7 @@ async function serveControl() {
     },
   };
   const factory = piHarnessFactory({
+    env: new NodeExecutionEnv({ cwd: process.cwd() }),
     sessions,
 
     models,
@@ -771,6 +773,7 @@ async function serveRemoteAgent(opts: {
   const factory =
     opts.harnessFactory ??
     piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,

--- a/test/definition.test.ts
+++ b/test/definition.test.ts
@@ -185,14 +185,14 @@ describe("create: assembleSystemPrompt (four segments)", () => {
   });
 
   it("piBasePrompt renders the tool list from actual tools so base and toolset stay aligned", () => {
-    const withTools = piBasePrompt({ tools: piDefaultTools(fixtureDir) });
+    const withTools = piBasePrompt({ tools: piDefaultTools() });
     expect(withTools).toContain("- read:");
     expect(withTools).toContain("- bash:");
     expect(piBasePrompt()).toContain("(none)");
   });
 
   it("a persona.md persona overrides the engine identity but keeps the tool list + guidelines", () => {
-    const tools = piDefaultTools(fixtureDir);
+    const tools = piDefaultTools();
     const persona = piBasePrompt({ tools, persona: "You are the Repo Bot." });
     expect(persona).toContain("You are the Repo Bot.");
     expect(persona).not.toContain("operating inside pi"); // default identity replaced
@@ -312,15 +312,19 @@ describe("create L1: createPiAgent (instructions ARE the prompt)", () => {
 describe("create: toolset (real pi tools, fidelity)", () => {
   it("piDefaultTools are pi core four tools (same as pi default)", () => {
     expect(
-      piDefaultTools(fixtureDir)
+      piDefaultTools()
         .map((t) => t.name)
         .sort(),
     ).toEqual(["bash", "edit", "read", "write"]);
   });
 
   it("pi's read tool can read the fixture (same behavior as local pi)", async () => {
-    const read = piDefaultTools(fixtureDir).find((t) => t.name === "read")!;
-    const r = await read.execute("t1", { path: "AGENTS.md" });
+    const read = piDefaultTools().find((t) => t.name === "read")!;
+    // The env IS the tool's root now (pi 0.83 hands it in as the turn's tool context), so a direct call
+    // has to supply one — the same thing `fastagent tool` does, and the harness for every served turn.
+    const r = await read.execute("t1", { path: "AGENTS.md" }, undefined, undefined, {
+      env: new NodeExecutionEnv({ cwd: fixtureDir }),
+    });
     const text = (r.content[0] as any).text as string;
     expect(text).toContain("Haiku Bot");
   });

--- a/test/dynamic-tools.test.ts
+++ b/test/dynamic-tools.test.ts
@@ -9,6 +9,7 @@ import { makeSearchToolsTool, withSearchTool } from "../src/engines/pi/search-to
 import { defineTool, isDeferredTool } from "../src/engines/pi/tool.ts";
 import { inMemorySessionStore } from "../src/index.ts";
 import { makeFaux } from "./faux.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 const weather = () =>
   defineTool({
@@ -85,6 +86,7 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
     const { faux, models } = makeFaux();
     faux.setResponses(responses);
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,
@@ -197,6 +199,7 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
       fauxAssistantMessage("ok"),
     ]);
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions: inMemorySessionStore(),
 
       models,
@@ -230,6 +233,7 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
       fauxAssistantMessage("ok"),
     ]);
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions: inMemorySessionStore(),
 
       models,
@@ -279,6 +283,7 @@ describe("deferred tools: end-to-end through invoke (faux model)", () => {
     faux.setResponses([fauxAssistantMessage(fauxToolCall("my_loader", {}, { id: "c1" })), fauxAssistantMessage("ok")]);
     const sessions = inMemorySessionStore();
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -3,6 +3,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { inMemorySessionStore } from "../src/index.ts";
 import { TOOL_ACTIVATION_ENTRY, piHarnessFactory, resolveHarnessActiveToolNames } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 const fakeTool = (name: string): AgentTool =>
   ({
@@ -20,6 +21,7 @@ describe("piHarnessFactory: provider retry wiring", () => {
     // the option; transients there still fail the turn.
     const { faux, models } = makeFaux();
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions: inMemorySessionStore(),
 
       models,
@@ -40,8 +42,8 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
     const { faux, models } = makeFaux();
     const sessions = inMemorySessionStore();
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
-
       models,
       model: faux.getModel(),
       tools: [fakeTool("alpha"), deferred],
@@ -63,7 +65,7 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
     const sessions = inMemorySessionStore();
     const base = {
       sessions,
-
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       models,
       model: faux.getModel(),
       systemPrompt: "test",
@@ -89,7 +91,7 @@ describe("piHarnessFactory: active-tool set restore (stateless invoke)", () => {
     const sessions = inMemorySessionStore();
     const base = {
       sessions,
-
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       models,
       model: faux.getModel(),
       systemPrompt: "test",
@@ -124,6 +126,7 @@ describe("piHarnessFactory: thinking-level wiring", () => {
   it("threads thinkingLevel to the harness (config.thinkingLevel is not a silent no-op)", async () => {
     const { faux, models } = makeFaux();
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions: inMemorySessionStore(),
 
       models,
@@ -140,6 +143,7 @@ describe("piHarnessFactory: thinking-level wiring", () => {
     // either place cannot silently alter deployments.
     const { faux, models } = makeFaux();
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions: inMemorySessionStore(),
 
       models,

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -8,12 +8,14 @@ import { INVOKE_EXAMPLE_BODY } from "../src/channels/http.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 function makeAgent(responses: FauxResponseStep[]): Agent {
   const { faux, models } = makeFaux();
   faux.setResponses(responses);
   return createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions: inMemorySessionStore(),
 
       models,

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -4,6 +4,7 @@ import {
   InMemorySessionRepo,
   type AgentTool,
   type SessionTreeEntry,
+  type ExecutionToolContext,
 } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxThinking, fauxToolCall, Type, type FauxResponseStep } from "@earendil-works/pi-ai";
 import type { AssistantMessage, StopReason, Usage } from "@earendil-works/pi-ai";
@@ -19,6 +20,7 @@ import {
 } from "../src/engines/pi/invoke.ts";
 import { type PiHarnessFactory, piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 /** An echo tool for the tool-call path. */
 const echoTool: AgentTool = {
@@ -42,8 +44,8 @@ function makeAgent(responses: FauxResponseStep[]) {
   const sessions = inMemorySessionStore();
   const agent = createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
-
       models,
       model: faux.getModel(),
       tools: [echoTool],
@@ -116,6 +118,7 @@ describe("invoke fan-in", () => {
     const agent = createPiAgentFromHarness({
       cwd: process.cwd(),
       harnessFactory: piHarnessFactory({
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
         sessions: inMemorySessionStore(),
 
         models,
@@ -175,7 +178,8 @@ describe("invoke fan-in", () => {
         const { faux, models } = makeFaux();
         faux.setResponses([fauxAssistantMessage("a long answer streamed out")]);
         const session = await repo.create({ id: sessionId });
-        const harness = new AgentHarness({
+        const harness = new AgentHarness<ExecutionToolContext>({
+          toolContext: { env: new NodeExecutionEnv({ cwd: process.cwd() }) },
           session,
           models,
           model: faux.getModel(),
@@ -207,7 +211,13 @@ describe("invoke fan-in", () => {
         const { faux, models } = makeFaux();
         faux.setResponses([fauxAssistantMessage("done")]);
         const session = await repo.create({ id: sessionId });
-        const harness = new AgentHarness({ session, models, model: faux.getModel(), systemPrompt: "test" });
+        const harness = new AgentHarness<ExecutionToolContext>({
+          toolContext: { env: new NodeExecutionEnv({ cwd: process.cwd() }) },
+          session,
+          models,
+          model: faux.getModel(),
+          systemPrompt: "test",
+        });
         harness.abort = async () => {
           throw new Error("abort blew up"); // simulate an idle abort rejecting
         };
@@ -240,6 +250,7 @@ describe("prompt.images passthrough (SPEC §4)", () => {
     ]);
     const agent = createPiAgentFromHarness({
       harnessFactory: piHarnessFactory({
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
         sessions: inMemorySessionStore(),
 
         models,
@@ -320,8 +331,8 @@ describe("lease + setup robustness", () => {
     faux.setResponses([fauxAssistantMessage("unreachable")]);
     const sessions = inMemorySessionStore();
     const inner = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
-
       models,
       model: faux.getModel(),
       systemPrompt: "test",
@@ -362,6 +373,7 @@ describe("lease + setup robustness", () => {
         },
       },
       harnessFactory: piHarnessFactory({
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
         sessions: inMemorySessionStore(),
 
         models,
@@ -407,6 +419,7 @@ describe("systemPrompt factory (re-evaluated per invoke)", () => {
     faux.setResponses([fauxAssistantMessage("a"), fauxAssistantMessage("b")]);
     const agent = createPiAgentFromHarness({
       harnessFactory: piHarnessFactory({
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
         sessions: inMemorySessionStore(),
 
         models,

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -28,6 +28,7 @@ import type { PiBoundaryWiring } from "../src/engines/pi/session-control.ts";
 import { inProcessLease } from "../src/engines/pi/invoke.ts";
 import { resolveHarnessOverrides } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 const echoTool: AgentTool = {
   name: "echo",
@@ -49,6 +50,7 @@ function makeObserved(responses: FauxResponseStep[]) {
   const agent = createPiAgentFromHarness({
     observer,
     harnessFactory: piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,
@@ -297,6 +299,7 @@ describe("session control (Phase 1): observation plane", () => {
         throw new Error("broken hub");
       },
       harnessFactory: piHarnessFactory({
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
         sessions: inMemorySessionStore(),
 
         models,
@@ -397,6 +400,7 @@ function makeGated(responses: FauxResponseStep[]) {
   const agent = createPiAgentFromHarness({
     observer,
     harnessFactory: piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,
@@ -537,6 +541,7 @@ describe("session control (Phase 2a): run modulation", () => {
         if (ev.type === "run_started") captured = run;
       },
       harnessFactory: piHarnessFactory({
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
         sessions: inMemorySessionStore(),
 
         models,
@@ -722,6 +727,7 @@ function makeBoundary(responses: FauxResponseStep[]) {
   const sessions = inMemorySessionStore();
   const lease = inProcessLease();
   const factory = piHarnessFactory({
+    env: new NodeExecutionEnv({ cwd: process.cwd() }),
     sessions,
 
     models,
@@ -851,6 +857,7 @@ describe("session control (Phase 2b): boundary mutations", () => {
     const lease = inProcessLease();
     const gate = makeGate();
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,
@@ -1077,6 +1084,7 @@ describe("session control (Phase 2b): boundary mutations", () => {
     const sessions = inMemorySessionStore();
     const lease = inProcessLease();
     const factory = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -8,6 +8,7 @@ import { inMemorySessionStore, jsonlSessionStore, type AgentEvent, type PiSessio
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 /** Agent over an injected store (the store is the variable under test). */
 function makeAgent(sessions: PiSessionStore, responses: FauxResponseStep[]) {
@@ -15,6 +16,7 @@ function makeAgent(sessions: PiSessionStore, responses: FauxResponseStep[]) {
   faux.setResponses(responses);
   return createPiAgentFromHarness({
     harnessFactory: piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
       sessions,
 
       models,

--- a/test/tool-context.test.ts
+++ b/test/tool-context.test.ts
@@ -7,6 +7,7 @@ import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { defineTool } from "../src/engines/pi/tool.ts";
 import { inMemorySessionStore } from "../src/index.ts";
 import { makeFaux } from "./faux.ts";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 
 /** Call a built tool's execute directly (the `fastagent tool` path — no session binding). */
 type RawExecute = (id: string, params: unknown, signal?: AbortSignal) => Promise<unknown>;
@@ -30,6 +31,7 @@ describe("shared ToolContext session manager", () => {
     const agent = createPiAgentFromHarness({
       cwd: process.cwd(),
       harnessFactory: piHarnessFactory({
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
         sessions: inMemorySessionStore(),
 
         models,

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -88,7 +88,7 @@ describe("loadTools (filesystem discovery)", () => {
     await mkdir(join(cwd, "tools"), { recursive: true });
     await writeFile(join(cwd, "tools", "hostonly.mjs"), tool); // the host repo's tool at cwd — must NOT be scanned
 
-    const { toolNames } = await resolveAgentTools({}, agentDir, cwd);
+    const { toolNames } = await resolveAgentTools({}, agentDir);
     expect(toolNames).toContain("foo"); // discovered from agentDir
     expect(toolNames).not.toContain("hostonly"); // cwd's own tools/ is the host's, not the agent's surface
   });

--- a/test/tools-parity.test.ts
+++ b/test/tools-parity.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The default coding tools are pi-agent-core's, which reach the machine through the ExecutionEnv the
+ * harness hands them per turn — not pi-coding-agent's, which are the same four tools wired to `node:fs`
+ * directly. That swap is only safe while the MODEL-facing surface is identical, because it is what the
+ * agent is prompted with and what fastagent's channels render: the same names, the same descriptions,
+ * the same parameter schemas, the same results.
+ *
+ * So this asserts the parity rather than trusting it, against BOTH implementations, and will fail the
+ * day upstream lets them drift — which is exactly when the choice needs revisiting.
+ */
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { createCodingTools } from "@earendil-works/pi-coding-agent";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { piDefaultTools } from "../src/engines/pi/create.ts";
+
+/** What the MODEL sees of a tool — the whole contract this swap has to preserve. */
+const surface = (t: { name: string; description?: unknown; parameters?: unknown }) => ({
+  name: t.name,
+  description: String(t.description),
+  parameters: JSON.stringify(t.parameters),
+});
+
+describe("tools: pi-agent-core's env-backed defaults match pi-coding-agent's", () => {
+  it("name, description and parameter schema are identical, tool for tool", () => {
+    const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);
+    const core = piDefaultTools().sort(byName).map(surface);
+    const coding = createCodingTools(process.cwd()).sort(byName).map(surface);
+    expect(core).toEqual(coding);
+  });
+
+  it("…and so are the results, on the paths an agent actually takes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-parity-"));
+    await writeFile(join(dir, "f.txt"), "hello\n");
+    const env = new NodeExecutionEnv({ cwd: dir });
+    const core = Object.fromEntries(piDefaultTools().map((t) => [t.name, t]));
+    const coding = Object.fromEntries(createCodingTools(dir).map((t) => [t.name, t]));
+    // The env is the ONE argument that differs: core's tools take it as the turn's tool context, the
+    // coding-agent's closed over `dir` when they were built. Same root, so same answer.
+    const run = async (name: string, params: object) => [
+      await core[name]!.execute("t", params, undefined, undefined, { env }),
+      await coding[name]!.execute("t", params, undefined, undefined),
+    ];
+
+    const [readCore, readCoding] = await run("read", { path: "f.txt" });
+    expect(readCore).toEqual(readCoding);
+
+    const [bashCore, bashCoding] = await run("bash", { command: "echo out; pwd" });
+    expect(bashCore).toEqual(bashCoding);
+
+    // write/edit mutate, so they get their own file each — compare the reported outcome, not the path.
+    const strip = (r: unknown) => JSON.stringify(r).replace(/w[12]\.txt/g, "W");
+    const [w1] = await run("write", { path: "w1.txt", content: "x" });
+    const [, w2] = await run("write", { path: "w2.txt", content: "x" });
+    expect(strip(w1)).toBe(strip(w2));
+  });
+});

--- a/test/tools-parity.test.ts
+++ b/test/tools-parity.test.ts
@@ -17,7 +17,6 @@ import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { piDefaultTools } from "../src/engines/pi/create.ts";
 
 /** Either implementation, called uniformly — core's takes the tool context, the coding-agent's ignores it. */
-// biome-ignore lint/suspicious/noExplicitAny: the two implementations differ in execute's arity by design — that IS the thing under test
 type Executable = { execute: (...args: any[]) => Promise<unknown> };
 
 /** What the MODEL sees of a tool — the whole contract this swap has to preserve. */

--- a/test/tools-parity.test.ts
+++ b/test/tools-parity.test.ts
@@ -11,6 +11,7 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { crc32, deflateSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { createCodingTools } from "@earendil-works/pi-coding-agent";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
@@ -25,6 +26,57 @@ const surface = (t: { name: string; description?: unknown; parameters?: unknown 
   description: String(t.description),
   parameters: JSON.stringify(t.parameters),
 });
+
+/** A noisy PNG of `side`x`side` — noisy so it does not compress away, i.e. big enough to exercise the
+ *  resize path rather than passing through untouched. */
+function pngFixture(side: number): Buffer {
+  const chunk = (type: string, data: Buffer) => {
+    const body = Buffer.concat([Buffer.from(type, "ascii"), data]);
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(body));
+    return Buffer.concat([len, body, crc]);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(side, 0);
+  ihdr.writeUInt32BE(side, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // truecolour
+  const rows: Buffer[] = [];
+  let seed = 1;
+  for (let y = 0; y < side; y++) {
+    const row = Buffer.alloc(1 + side * 3);
+    for (let i = 1; i < row.length; i++) {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      row[i] = seed & 0xff;
+    }
+    rows.push(row);
+  }
+  const idat = deflateSync(Buffer.concat(rows), { level: 1 });
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk("IHDR", ihdr),
+    chunk("IDAT", idat),
+    chunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+/** A 1x1 BMP — a format neither provider takes inline, so it must be CONVERTED or dropped. */
+function bmpFixture(): Buffer {
+  const px = Buffer.from([0xff, 0x00, 0x00, 0x00]);
+  const header = Buffer.alloc(54);
+  header.write("BM", 0, "ascii");
+  header.writeUInt32LE(54 + px.length, 2);
+  header.writeUInt32LE(54, 10);
+  header.writeUInt32LE(40, 14);
+  header.writeInt32LE(1, 18);
+  header.writeInt32LE(1, 22);
+  header.writeUInt16LE(1, 26);
+  header.writeUInt16LE(24, 28);
+  header.writeUInt32LE(px.length, 34);
+  return Buffer.concat([header, px]);
+}
 
 describe("tools: pi-agent-core's env-backed defaults match pi-coding-agent's", () => {
   it("name, description and parameter schema are identical, tool for tool", () => {
@@ -59,6 +111,15 @@ describe("tools: pi-agent-core's env-backed defaults match pi-coding-agent's", (
     };
 
     await agree("read", { path: "f.txt" });
+    // IMAGES are where they diverge for free: core's `read` does nothing with one unless a processor is
+    // injected (read-image.ts rebuilds pi's from its public halves). Left out, this is what breaks —
+    // measured on a 5.6MB PNG: 7.48MB of raw base64 instead of 3.48MB of resized JPEG, and no dimension
+    // note for the model's coordinate math. A format needing CONVERSION (bmp) is dropped outright, while
+    // the description asserted identical above still advertises it.
+    await writeFile(join(dir, "img.png"), pngFixture(120));
+    await writeFile(join(dir, "img.bmp"), bmpFixture());
+    await agree("read", { path: "img.png" });
+    await agree("read", { path: "img.bmp" });
     await agree("bash", { command: "echo out; pwd" });
     // FAILURE paths matter more than success ones: the divergence this guards against is
     // pi-coding-agent's TUI rendering stack, which shows up in how a tool reports trouble.

--- a/test/tools-parity.test.ts
+++ b/test/tools-parity.test.ts
@@ -16,6 +16,10 @@ import { createCodingTools } from "@earendil-works/pi-coding-agent";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { piDefaultTools } from "../src/engines/pi/create.ts";
 
+/** Either implementation, called uniformly — core's takes the tool context, the coding-agent's ignores it. */
+// biome-ignore lint/suspicious/noExplicitAny: the two implementations differ in execute's arity by design — that IS the thing under test
+type Executable = { execute: (...args: any[]) => Promise<unknown> };
+
 /** What the MODEL sees of a tool — the whole contract this swap has to preserve. */
 const surface = (t: { name: string; description?: unknown; parameters?: unknown }) => ({
   name: t.name,
@@ -38,22 +42,66 @@ describe("tools: pi-agent-core's env-backed defaults match pi-coding-agent's", (
     const core = Object.fromEntries(piDefaultTools().map((t) => [t.name, t]));
     const coding = Object.fromEntries(createCodingTools(dir).map((t) => [t.name, t]));
     // The env is the ONE argument that differs: core's tools take it as the turn's tool context, the
-    // coding-agent's closed over `dir` when they were built. Same root, so same answer.
-    const run = async (name: string, params: object) => [
-      await core[name]!.execute("t", params, undefined, undefined, { env }),
-      await coding[name]!.execute("t", params, undefined, undefined),
-    ];
+    // coding-agent's closed over `dir` when they were built. Same root, so the same answer. A throw is
+    // captured rather than propagated — how a tool REPORTS trouble is most of what is being compared.
+    const call = async (t: Executable, params: object, ctx: unknown) => {
+      try {
+        return JSON.stringify(await t.execute("t", params, undefined, undefined, ctx));
+      } catch (e) {
+        return `threw: ${(e as Error).message}`;
+      }
+    };
+    // Read-only calls can run both implementations over the same input; MUTATING ones must not (the
+    // second would see the first's edit), so those get a file each and are compared through `strip`.
+    const agree = async (name: string, params: object) => {
+      const a = await call(core[name]!, params, { env });
+      const b = await call(coding[name]!, params, undefined);
+      expect(a, `${name} ${JSON.stringify(params)}`).toBe(b);
+    };
 
-    const [readCore, readCoding] = await run("read", { path: "f.txt" });
-    expect(readCore).toEqual(readCoding);
+    await agree("read", { path: "f.txt" });
+    await agree("bash", { command: "echo out; pwd" });
+    // FAILURE paths matter more than success ones: the divergence this guards against is
+    // pi-coding-agent's TUI rendering stack, which shows up in how a tool reports trouble.
+    await agree("bash", { command: "echo out; echo err 1>&2; exit 1" });
+    await agree("edit", { path: "f.txt", edits: [{ oldText: "absent", newText: "x" }] });
 
-    const [bashCore, bashCoding] = await run("bash", { command: "echo out; pwd" });
-    expect(bashCore).toEqual(bashCoding);
-
-    // write/edit mutate, so they get their own file each — compare the reported outcome, not the path.
-    const strip = (r: unknown) => JSON.stringify(r).replace(/w[12]\.txt/g, "W");
-    const [w1] = await run("write", { path: "w1.txt", content: "x" });
-    const [, w2] = await run("write", { path: "w2.txt", content: "x" });
+    const strip = (r: string) => r.replace(/[we][12]\.txt/g, "F");
+    const w1 = await call(core.write!, { path: "w1.txt", content: "x" }, { env });
+    const w2 = await call(coding.write!, { path: "w2.txt", content: "x" }, undefined);
     expect(strip(w1)).toBe(strip(w2));
+
+    await writeFile(join(dir, "e1.txt"), "hello\n");
+    await writeFile(join(dir, "e2.txt"), "hello\n");
+    const edit = (p: string) => ({ path: p, edits: [{ oldText: "hello", newText: "bye" }] });
+    const e1 = await call(core.edit!, edit("e1.txt"), { env });
+    const e2 = await call(coding.edit!, edit("e2.txt"), undefined);
+    expect(strip(e1)).toBe(strip(e2));
+  });
+
+  it("pins the two places they DO differ — cosmetic, and better seen than assumed", async () => {
+    // Parity is the claim this swap rests on, so where it does not hold exactly, say where. Both of
+    // these are wording, not information: same failure, same cause, same path. Should either grow into
+    // a real difference, this test says so instead of a channel rendering it at a user.
+    const dir = await mkdtemp(join(tmpdir(), "fa-parity-diff-"));
+    const env = new NodeExecutionEnv({ cwd: dir });
+    const core = Object.fromEntries(piDefaultTools().map((t) => [t.name, t]));
+    const coding = Object.fromEntries(createCodingTools(dir).map((t) => [t.name, t]));
+    const message = async (t: Executable, params: object, ctx: unknown) =>
+      await t.execute("t", params, undefined, undefined, ctx).then(
+        () => "(no throw)",
+        (e: Error) => e.message,
+      );
+
+    // 1. A missing file: same ENOENT for the same path, named after a different syscall.
+    const missing = { path: "nope.txt" };
+    expect(await message(core.read!, missing, { env })).toMatch(/ENOENT.*open .*nope\.txt/);
+    expect(await message(coding.read!, missing, undefined)).toMatch(/ENOENT.*access .*nope\.txt/);
+
+    // 2. A failing command with NO output: the coding-agent tool says so in words, core's just reports
+    //    the exit code. WITH output they are identical (asserted above), which is the case that matters.
+    const silent = { command: "exit 3" };
+    expect(await message(core.bash!, silent, { env })).toBe("Command exited with code 3");
+    expect(await message(coding.bash!, silent, undefined)).toBe("(no output)\n\nCommand exited with code 3");
   });
 });


### PR DESCRIPTION
## What

The default coding tools (`read`/`bash`/`edit`/`write`) now come from **pi-agent-core**, which takes the `ExecutionEnv` as the turn's tool **context** (pi 0.83), instead of **pi-coding-agent**, whose identical four are wired to `node:fs` directly.

## Why

`env` was a seam that governed everything **except** the tools that actually touch the machine. The docs had to keep saying so:

> injecting `env` alone does not isolate a directory agent

Now the tools go through it, so a custom env narrows where the agent reads, writes and shells. It is still not a full sandbox — author-written `tools/` are code and can import anything — and the docs now say **that** instead of hedging about the built-ins.

**And that is all it buys.** An earlier draft of this description claimed it also decoupled the serving path from pi's TUI stack; that was false — `definition.ts`, `models.ts` and now `read-image.ts` import pi-coding-agent unconditionally. The env seam is the whole benefit.

## Why it is safe

The swap only holds while the **model-facing surface** is identical, so `test/tools-parity.test.ts` asserts it against both implementations rather than trusting it — names, descriptions, parameter schemas, and results on the paths an agent takes, including **failure** and **image** paths.

Images are where they do NOT match for free, and the review caught it: core's `read` does nothing with an image unless a processor is **injected**. Measured on a 5.6 MB PNG, the unfixed version sent **7.48 MB** of raw base64 where the old tool sent **3.48 MB** of resized JPEG — double the payload to the provider — with no dimension note for the model's coordinate math, and a bmp dropped outright while the description asserted identical above still advertised it.

`processImage` is not exported and not reachable (no deep paths in the package's `exports`), so `src/engines/pi/read-image.ts` rebuilds it from the halves that are — `convertToPng`, `resizeImage`, `formatDimensionNote`. Twenty lines of restated upstream logic, byte-identical on both paths, and covered by the parity test (mutation-checked: removing the processor fails it), which is what keeps the duplication from drifting silently.

It also **pins the two places they do differ**, because saying where parity stops is worth more than a test that avoids looking:

| Case | core | pi-coding-agent |
|---|---|---|
| `read` a missing file | `ENOENT … open …` | `ENOENT … access …` |
| `bash` failing with **no** output | `Command exited with code 3` | `(no output)\n\nCommand exited with code 3` |

With output, the failure results are byte-identical — which is the case that matters. The test fails the day upstream lets anything else drift, which is exactly when this choice needs revisiting.

## Mechanics

- `piDefaultTools()` loses its `cwd` argument — the tools have no root of their own; the env's cwd is their root. `resolveTools` / `resolveAgentTools` follow.
- The harness is context-typed on `ExecutionToolContext` and supplies `toolContext: { env }`. `PiHarnessFactoryOptions.env` returns, this time with a job.
- **`MountedTool`** names what the harness runs — wider than the authored `FastagentTool`, since pi's defaults read a fifth `execute` parameter and fastagent's four-parameter tools are assignable to it unchanged. Every helper that only inspects or reorders tools is typed on it. **`defineTool` is untouched**: authors write exactly what they wrote before.
- `fastagent tool` supplies the context a harness would, rooted at the workspace — without it a direct `execute` crashes on the missing env.
- `chat` is unaffected: it takes these NAMES and lets pi's own runtime rebuild the tools it renders.

## Verify

`npm run lint` + `npm run typecheck` clean, **1237 tests**.

Two `rv` passes. The local one caught L1 (`createPiAgent`) silently dropping `options.env` — the very seam this PR is about. The on-PR one caught the image regression above, plus four claims this branch had made and not finished: ② project context does **not** go through the env (`loadProjectContextFiles` reads node fs directly, a break `definition.ts` already documented), README/ai-start/embedding still asserted the coding tools were cwd/local-fs bound, and `MountedTool` was named in two public option types without being exported.

