### PR TITLE
fix(deploy/agentcore): grant s3:ListBucket so a first deploy's missing snapshot reads 404, not 403

### DIFF
--- a/src/channels/agentcore-state.ts
+++ b/src/channels/agentcore-state.ts
@@ -185,16 +185,26 @@ export function createStateSync(options: StateSyncOptions): StateSync {
 
   const runRestore = async (urls: StateUrls): Promise<void> => {
     const res = await doFetch(urls.getUrl, { method: "GET" });
-    // ONLY a proven 404 is "first deploy". The signer holds s3:GetObject on exactly this key, so a
-    // missing object answers NoSuchKey/404; a 403 means an expired or malformed signature, or a
-    // revoked permission — i.e. the snapshot may well exist. Reading 403 as "absent" would serve an
-    // empty agent and then overwrite the real snapshot with that emptiness.
+    // ONLY a proven 404 is "first deploy". A missing key answers 404 only because the generated
+    // template grants the signer s3:ListBucket on the snapshot prefix — without it S3 folds "absent"
+    // into 403 (anti-enumeration). A 403 therefore means an expired or malformed signature, a
+    // revoked permission, or a template from before that grant — i.e. the snapshot may well exist.
+    // Reading 403 as "absent" would serve an empty agent and then overwrite the real snapshot with
+    // that emptiness.
     if (res.status === 404) {
       log.info("[agentcore] no state snapshot yet — starting from an empty state root (first deploy)");
       restored = true;
       return;
     }
-    if (!res.ok) throw new Error(`state snapshot GET failed: ${res.status}`);
+    if (!res.ok) {
+      const hint =
+        res.status === 403
+          ? " (an expired presigned URL, a revoked permission, or a template generated before the " +
+            "ForwarderRole granted s3:ListBucket — S3 answers 403 even for a MISSING first-deploy " +
+            "snapshot without it; regenerate with `fastagent deploy agentcore --force` and redeploy)"
+          : "";
+      throw new Error(`state snapshot GET failed: ${res.status}${hint}`);
+    }
     const written = await unpackIntoStateRoot(stateRoot, Buffer.from(await res.arrayBuffer()));
     log.info(`[agentcore] restored ${written} state file(s) from the snapshot`);
     restored = true;

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -640,6 +640,16 @@ function template(input: AgentcorePlanInput, translated: { fact: ScheduleFact; e
       `              - Effect: Allow # mint the presigned URLs the container uses for its state snapshot`,
       `                Action: [s3:GetObject, s3:PutObject]`,
       `                Resource: !Sub arn:aws:s3:::\${StateBucket}/${STATE_KEY}`,
+      `              # Without s3:ListBucket, S3 folds "key absent" into 403 (anti-enumeration), which is`,
+      `              # indistinguishable from a broken signature — so the container's restore contract`,
+      `              # (agentcore-state.ts: ONLY 404 means first deploy) would dead-end every first deploy.`,
+      `              # Scoped to the snapshot prefix: this grants "may know whether the snapshot exists",`,
+      `              # not a listing of the whole deployment bucket.`,
+      `              - Effect: Allow`,
+      `                Action: s3:ListBucket`,
+      `                Resource: !Sub arn:aws:s3:::\${StateBucket}`,
+      `                Condition:`,
+      `                  StringLike: { s3:prefix: state/* }`,
       ...(input.selfSchedule
         ? [
             `              - Effect: Allow # wake alarms: mirror pending wake-ups into one-shot schedules`,

--- a/test/agentcore-state.test.ts
+++ b/test/agentcore-state.test.ts
@@ -175,6 +175,21 @@ describe("agentcore state snapshot", () => {
       expect(calls.map((c) => c.method)).toEqual(["GET", "PUT"]);
     });
 
+    it("a 403 is NOT first boot — it rejects with the ListBucket/expiry diagnosis instead of serving empty", async () => {
+      // S3 answers 403 for a missing key when the signer lacks s3:ListBucket — indistinguishable from
+      // a revoked permission, under which the snapshot may well EXIST. Treating it as "absent" would
+      // boot an empty agent and overwrite the real snapshot; the error must say what to check instead.
+      const local = await stateRoot();
+      const { impl, calls } = fakeFetch(() => new Response("AccessDenied", { status: 403 }));
+      const sync = createStateSync({ stateRoot: local, fetchImpl: impl });
+      sync.use(urls);
+
+      await expect(sync.ready()).rejects.toThrow(/GET failed: 403.*s3:ListBucket/);
+      sync.save();
+      await sync.flush();
+      expect(calls.filter((c) => c.method === "PUT")).toHaveLength(0);
+    });
+
     it("a FAILED restore rejects and blocks saving — never overwrite good state with an empty root", async () => {
       const local = await stateRoot();
       const { impl, calls } = fakeFetch(() => new Response("boom", { status: 500 }));

--- a/test/deploy-agentcore.test.ts
+++ b/test/deploy-agentcore.test.ts
@@ -357,10 +357,21 @@ describe("deploy agentcore: the plan", () => {
     expect(template).toContain(`STATE_KEY: ${STATE_KEY}`);
   });
 
+  it("grants s3:ListBucket on the snapshot prefix — without it a MISSING first-deploy snapshot reads 403, not 404", () => {
+    // S3 folds "key absent" into 403 unless the caller may list (anti-enumeration), and the restore
+    // contract accepts ONLY 404 as first deploy — dropping this statement deadlocks every first boot.
+    const template = planAgentcoreDeploy(baseInput({ routeChannels: ["telegram"], channels: ["telegram"] }))
+      .artifacts[0]!.content;
+    expect(template).toContain("Action: s3:ListBucket");
+    expect(template).toContain(`Resource: !Sub arn:aws:s3:::\${StateBucket}\n`); // the BUCKET arn, not an object
+    expect(template).toContain("StringLike: { s3:prefix: state/* }"); // scoped: existence of the snapshot, not a full listing
+  });
+
   it("an invoke-only deployment (no forwarder) carries no bucket wiring at all", () => {
     const template = planAgentcoreDeploy(baseInput()).artifacts[0]!.content;
     expect(template).not.toContain("StateBucket");
     expect(template).not.toContain("s3:GetObject");
+    expect(template).not.toContain("s3:ListBucket");
   });
 
   it("holds an idle session for 3 minutes — within the platform's 60–28800 range, and only after work settles", () => {


### PR DESCRIPTION
## Problem

First deploys of `fastagent deploy agentcore . --run` dead-ended even though every piece of infrastructure succeeded (stack `CREATE_COMPLETE`, runtime `READY`, forwarder active): the runtime looped on

```
[agentcore] state restore failed: Error: state snapshot GET failed: 403
```

so `/health` answered 502 and automatic webhook/event-URL registration (observed with Lark) timed out.

## Root cause

A contract mismatch between the generated IAM policy and the state-restore contract:

- The ForwarderRole granted only `s3:GetObject`/`s3:PutObject` on the exact snapshot key (`state/snapshot.json.gz`) — no `s3:ListBucket` on the bucket.
- Per S3's documented anti-enumeration design ([GetObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html)), `GetObject` on a **missing** key returns **404** only when the caller also holds `s3:ListBucket`; without it, S3 folds "absent" into **403** so callers cannot probe key existence.
- `runRestore` (`src/channels/agentcore-state.ts`) accepts **only 404** as the first-deploy/no-snapshot signal. That policy is correct and unchanged: a 403 can mean the snapshot *exists* behind an expired signature or revoked permission — treating it as "absent" would boot an empty agent and then overwrite the real snapshot with that emptiness (silent, total memory loss).

So on the very first deploy — snapshot object legitimately not yet written — the presigned GET answered 403, restore rejected (sticky, by design), and the session never became ready.

## Fix

Align the generated infrastructure with the restore contract instead of loosening the contract:

- **`src/deploy/agentcore/plan.ts`** — ForwarderRole gains `s3:ListBucket` on the bucket ARN, scoped with a `s3:prefix: state/*` condition: it grants "may know whether the snapshot exists", not a listing of the whole deployment bucket. A missing key now answers 404, the restore contract's first-deploy signal.
- **`src/channels/agentcore-state.ts`** — fixes the incorrect comment (exact-key `GetObject` alone never yielded 404 for a missing object) and gives the 403 failure a diagnosable hint: expired presigned URL, revoked permission, or a template generated before this grant — regenerate with `fastagent deploy agentcore --force`. 403 stays fatal.

## Tests

- `test/deploy-agentcore.test.ts`: the template carries the scoped `s3:ListBucket` statement (bucket ARN + prefix condition); invoke-only topologies (no forwarder) carry none of it.
- `test/agentcore-state.test.ts`: a restore GET 403 rejects with the ListBucket/expiry hint and never PUTs (a genuine denial must not overwrite a possibly-existing snapshot). Existing coverage already pins the 404 first-boot path and snapshot restore.

`npm run lint && npm run typecheck && npm test` — all green locally (100 files / 1239 tests).

## Migration for existing deployments

The next `deploy agentcore` hits the template drift gate and asks for `--force`; regenerating and redeploying applies the IAM change, after which a missing first snapshot reads 404 and restore converges. No action needed for deployments that already have a snapshot object.
