### PR TITLE
chore(test): drop a stale biome useYield suppression

### DIFF
--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -678,7 +678,6 @@ describe("session control over HTTP (Phase 3)", () => {
       leafEntryId: "e3",
     };
     const quietEvents = (): AsyncIterable<never> => ({
-      // biome-ignore lint/correctness/useYield: an intentionally empty stream
       [Symbol.asyncIterator]: async function* () {},
     });
     const fake = {


### PR DESCRIPTION
## What

Remove the `biome-ignore lint/correctness/useYield` comment above the empty `quietEvents` async generator in `test/control-http.test.ts`.

## Why

Biome no longer flags an empty generator body, so the suppression is dead code and `npm run lint` fails the `suppressions/unused` check on a clean tree:

```
test/control-http.test.ts:681:7 suppressions/unused
  ⚠ Suppression comment has no effect.
```

## Verification

- `npm run lint` — clean (biome + doc-links + knip)
- `npm run typecheck` — clean
- `npm test` — 101 files / 1253 tests passing