### PR TITLE
feat(session-control): commands() — the names a composer completes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -482,6 +482,15 @@ accepted `abort` can still settle `completed`, and an accepted `steer`/`follow_u
 without its prompt being consumed, when the run finishes inside the window — acceptance is not
 outcome; the settlement is the truth.
 
+`commands()` lists what a `/` composer completes: `{ name, description?, source }` per named thing
+the definition exposes (`source: "skill"` today). It is a LISTING, not a dispatch surface — the data
+plane takes prompts as text and nothing expands `/name`, so what typing one means is the client's
+choice. It is read live and uncached (one full definition load per call), so a skill added while
+serving appears at once; `[]` means the agent exposes none. It is also the one read that can REJECT:
+a definition the server cannot read at all is a deployment fault with no truthful degraded value, and
+the rejection carries no stable code (remotely: an uncoded non-2xx → `ControlRequestError`). Wrap the
+call, and expect no `error.code` to branch on.
+
 Boundary mutations run between runs, under the SAME lease (`session_busy` while a run is active,
 retryable at idle):
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -140,12 +140,18 @@ Common options:
 function createPiAgentFromDefinition(
   dir: string,
   options: CreatePiAgentFromDefinitionOptions,
-): Promise<{ agent: Agent; definition: LoadedDefinition }>;
+): Promise<{
+  agent: Agent;
+  definition: LoadedDefinition;
+  readDefinition: () => Promise<LoadedDefinition>;
+}>;
 ```
 
 Load `persona.md`/`skills/` from `dir` (the agent dir) and assemble the pi prompt. `②` project context is sourced via pi's `loadProjectContextFiles({ cwd, agentDir: dir })` — the dir's own `AGENTS.md` plus every `AGENTS.md` walking `cwd` (option; default `dir`) up to root. Pass `cwd` to decouple the workspace (where tools operate, whose repo `AGENTS.md` is context) from the agent dir — `createPiAgentFromDir` always passes the resolved workspace, which is the directory fastagent was pointed at (the agent dir's parent when the agent was found one level inside it, the agent dir itself when you aimed straight at it).
 
 `LoadedDefinition` carries `contextFiles: Array<{ path; content }>` (the ② files), `persona?` (from `persona.md`, ①), `skills`, and diagnostics/collisions (`SkillDiagnostic[]` / `SkillCollision[]` — both exported).
+
+`definition` is the BOOT snapshot (report diagnostics from it); `readDefinition()` is the same live read every invoke performs — a full directory load, side-effect free — for anything that must ANSWER for the definition while serving, such as the control plane's `commands()`. Do not close over `definition` for that: the directory is the agent, live, so a snapshot ages the moment an author edits a skill.
 
 ### `createPiAgentFromDir`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -447,6 +447,10 @@ const watching = (async () => {
 for await (const e of agent.invoke({ session: "s1" }, { text: "hi" })) void e; // the data plane
 await watching;
 
+// What a `/` composer lists: the definition's named invocations, read LIVE (a skill added while
+// serving is invocable next turn, so it is listable now).
+await control.commands(); // [{ name: "triage", description: "Sort an inbox", source: "skill" }]
+
 // After a disconnect, missed history comes from the durable plane, not the live stream:
 const { entries, leafEntryId } = await control.entries("s1", { since: cursor });
 const state = await control.state("s1"); // { status, activeRunId?, leafEntryId? }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -140,18 +140,12 @@ Common options:
 function createPiAgentFromDefinition(
   dir: string,
   options: CreatePiAgentFromDefinitionOptions,
-): Promise<{
-  agent: Agent;
-  definition: LoadedDefinition;
-  readDefinition: () => Promise<LoadedDefinition>;
-}>;
+): Promise<{ agent: Agent; definition: LoadedDefinition }>;
 ```
 
 Load `persona.md`/`skills/` from `dir` (the agent dir) and assemble the pi prompt. `②` project context is sourced via pi's `loadProjectContextFiles({ cwd, agentDir: dir })` — the dir's own `AGENTS.md` plus every `AGENTS.md` walking `cwd` (option; default `dir`) up to root. Pass `cwd` to decouple the workspace (where tools operate, whose repo `AGENTS.md` is context) from the agent dir — `createPiAgentFromDir` always passes the resolved workspace, which is the directory fastagent was pointed at (the agent dir's parent when the agent was found one level inside it, the agent dir itself when you aimed straight at it).
 
 `LoadedDefinition` carries `contextFiles: Array<{ path; content }>` (the ② files), `persona?` (from `persona.md`, ①), `skills`, and diagnostics/collisions (`SkillDiagnostic[]` / `SkillCollision[]` — both exported).
-
-`definition` is the BOOT snapshot (report diagnostics from it); `readDefinition()` is the same live read every invoke performs — a full directory load, side-effect free — for anything that must ANSWER for the definition while serving, such as the control plane's `commands()`. Do not close over `definition` for that: the directory is the agent, live, so a snapshot ages the moment an author edits a skill.
 
 ### `createPiAgentFromDir`
 
@@ -442,8 +436,8 @@ const sessions = inMemorySessionStore();
 const { control, observer } = createPiSessionControl({ sessions });
 const agent = createPiAgent({ model: "openai-codex/gpt-5.5", sessions, observer });
 // This agent has no definition, so `control.commands()` is `[]` — true, not a gap. Over a DIRECTORY
-// agent, pass `commands` (the live read: `createPiAgentFromDefinition`'s `readDefinition`) or the
-// list would claim the definition's skills do not exist. `createPiAgentFromDir` wires it for you.
+// agent, pass `commands` (a live read, e.g. `loadAgentSkills(dir)`) or the list would claim the
+// definition's skills do not exist. `createPiAgentFromDir` wires it for you.
 
 // Live events are NOT durable history: a subscription sees only what happens while it iterates,
 // so start watching BEFORE (or while) the run is driven — never after it drained.
@@ -488,8 +482,9 @@ outcome; the settlement is the truth.
 `commands()` lists what a `/` composer completes: `{ name, description?, source }` per named thing
 the definition exposes (`source: "skill"` today). It is a LISTING, not a dispatch surface — the data
 plane takes prompts as text and nothing expands `/name`, so what typing one means is the client's
-choice. It is read live and uncached (one full definition load per call), so a skill added while
-serving appears at once; `[]` means the agent exposes none. It is also the one read that can REJECT:
+choice. It is read live and uncached — the definition's `skills/` is re-read per call (the ②
+context walk the full load does is skipped: this answers at composer-open frequency) — so a skill
+added while serving appears at once; `[]` means the agent exposes none. It is also the one read that can REJECT:
 a definition the server cannot read at all is a deployment fault with no truthful degraded value, and
 the rejection carries no stable code (remotely: an uncoded non-2xx → `ControlRequestError`). Wrap the
 call, and expect no `error.code` to branch on.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -441,6 +441,9 @@ import { createPiAgent, createPiSessionControl, inMemorySessionStore } from "@fa
 const sessions = inMemorySessionStore();
 const { control, observer } = createPiSessionControl({ sessions });
 const agent = createPiAgent({ model: "openai-codex/gpt-5.5", sessions, observer });
+// This agent has no definition, so `control.commands()` is `[]` — true, not a gap. Over a DIRECTORY
+// agent, pass `commands` (the live read: `createPiAgentFromDefinition`'s `readDefinition`) or the
+// list would claim the definition's skills do not exist. `createPiAgentFromDir` wires it for you.
 
 // Live events are NOT durable history: a subscription sees only what happens while it iterates,
 // so start watching BEFORE (or while) the run is driven — never after it drained.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -436,8 +436,9 @@ const sessions = inMemorySessionStore();
 const { control, observer } = createPiSessionControl({ sessions });
 const agent = createPiAgent({ model: "openai-codex/gpt-5.5", sessions, observer });
 // This agent has no definition, so `control.commands()` is `[]` — true, not a gap. Over a DIRECTORY
-// agent, pass `commands` (a live read, e.g. `loadAgentSkills(dir)`) or the list would claim the
-// definition's skills do not exist. `createPiAgentFromDir` wires it for you.
+// agent, pass `commands: async () => …` returning one `AgentCommand` per name the definition
+// exposes, re-read per call; otherwise the list claims the definition's skills do not exist.
+// `createPiAgentFromDir` wires it for you.
 
 // Live events are NOT durable history: a subscription sees only what happens while it iterates,
 // so start watching BEFORE (or while) the run is driven — never after it drained.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -447,8 +447,8 @@ const watching = (async () => {
 for await (const e of agent.invoke({ session: "s1" }, { text: "hi" })) void e; // the data plane
 await watching;
 
-// What a `/` composer lists: the definition's named invocations, read LIVE (a skill added while
-// serving is invocable next turn, so it is listable now).
+// What a `/` composer LISTS (read live, so a skill added while serving appears at once). A listing
+// only — the data plane takes prompts as text, so what typing `/triage` means is the client's.
 await control.commands(); // [{ name: "triage", description: "Sort an inbox", source: "skill" }]
 
 // After a disconnect, missed history comes from the durable plane, not the live stream:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -152,7 +152,8 @@ fastagent attach <session> [dir] [--url url --token token]
 Attach to a session served by a running `dev`/`start` with `sessionControl: true` in the config:
 stream its live events (text, tool activity, run boundaries), steer the active run by typing a
 line — or, with no run active, start one (the line becomes a new prompt over the remote data
-plane) — `/abort` to stop a run, Ctrl+C to detach. A run YOU started from attach is driven by
+plane) — `/abort` to stop a run, `/commands` to list the names the agent defines (skills; name one in
+a normal message — this composer does not expand `/name`), Ctrl+C to detach. A run YOU started from attach is driven by
 attach's own connection, so detaching cancels it (channel-started runs are unaffected). Discovers the local endpoint from
 `<stateRoot>/control.json`; `--url`/`--token` reach a remote serve. Speaks the same wire protocol a
 Web panel or desktop app uses (`connectSessionControl`).

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -396,7 +396,7 @@ FastAgent adapts pi's concepts, never proxies `pi --mode rpc` unchanged:
 | `bash`, `abort_bash` | Exclude | Unsafe remote-shell bypass; duplicates tools. |
 | `new_session`, `switch_session` by path | Exclude | Sessions are opaque ids; paths are not portable. |
 | `export_html`, session naming | Exclude | Product presentation concerns. |
-| slash/TUI command discovery | Exclude | Conflicts with definition-as-truth. |
+| `get_commands` | Adapt to `commands()` (§5.1.1) | The definition-derived LISTING is included — it is the one thing a client cannot reconstruct. pi's execution and presentation of slash commands stay out: fastagent's data plane takes prompts as text and does not expand `/name`. |
 | extension UI dialogs | Defer behind a future `interactions` capability | Permission/input gates have serving value, but not in the first contract. |
 | extension UI presentation | Exclude | TUI chrome. |
 | `fork`, `clone`, `get_tree` | Defer behind a future `branching` capability | Not required to serve a session. |

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -101,6 +101,7 @@ implementation lives under `engines/pi/` (`session-control.ts`, exported from `/
 ```ts
 interface SessionControl {
   capabilities(): SessionCapabilities;
+  commands(): Promise<AgentCommand[]>;
   state(session: string): Promise<SessionState>;
   entries(session: string, options?: { since?: string }): Promise<SessionEntries>;
   events(session: string): AsyncIterable<SessionEvent>;
@@ -108,8 +109,9 @@ interface SessionControl {
 }
 ```
 
-All methods are session-scoped and flat: no lifecycle calls, no stateful client-visible object.
-Each of the four non-capability methods survives a deletion test:
+`capabilities` and `commands` are sessionless; the rest are session-scoped, and all are flat: no
+lifecycle calls, no stateful client-visible object. Each of the four session-scoped methods survives
+a deletion test:
 
 - delete `state` → a reconnecting client cannot learn whether work is still active (the durable
   record does not know whether the process died);
@@ -152,6 +154,22 @@ type SessionCommand =
   means), and no move to the ROOT — `targetId` is a `string`, so a client rewinds to an entry, and
   "start from nothing" is a new session, not an emptied one.
 - There are no `cycle_*` commands: cycling is a TUI input affordance.
+
+### 5.1.1 Commands
+
+```ts
+interface AgentCommand { name: string; description?: string; source: string }
+```
+
+What a composer's `/` completion lists. There is no way to discover the set by trying — an unknown
+command is just text that reaches the model — and the assembly is the only place that knows the full
+set after collisions were resolved first-wins, which a client cannot reconstruct from the directory.
+
+ASYNC on purpose: a definition is allowed to be LIVE (fastagent re-reads the directory per turn), so
+the list must come from that same read. A boot snapshot would advertise a command set the running
+agent has already left behind. `source` is free-form because which kinds exist is an engine's
+business (`"skill"` today; extension commands and prompt templates as they land), and an engine with
+none answers `[]` — a complete answer, not a missing one.
 
 ### 5.2 Acceptance is not outcome
 
@@ -425,7 +443,7 @@ safe for untrusted users; `ExecutionEnv` is still not a complete sandbox boundar
 | 1 | **Done.** Observation plane: pi events translate ONCE to `SessionEvent` inside the invoke path (`toSessionEvent`), `AgentEvent` is its projection (`projectAgentEvent`); the `session` subpath types + pi `createPiSessionControl` (`state`/`entries`/`events` over a read-only `PiSessionReader`); conformance tests for projection fidelity, run boundaries (incl. cancellation → exactly-one `run_settled{aborted}`), reconnect, and single-writer. | An L0 client can watch and reconnect to any invoke-driven run. |
 | 2a | **Done.** Run modulation: `dispatch` routes `steer`/`follow_up`/`abort` to the live run via {@link RunControls} registered with `run_started`; the settle window spans steered/queued continuations inside one invoke (pi's agent loop drains both queues within one `prompt()`); `queue_changed` + live `pending` in state; a control-plane abort terminates as `failed{code: "aborted"}` / `run_settled{aborted}`; idle-session run commands reject `no_active_run` before acceptance. | L1 clients. |
 | 2b | **Done.** Boundary mutations under the lease: `set_model`/`set_thinking` append durable session overrides (validated against the registry / the MODEL's own thinking levels — `reasoning` + `thinkingLevelMap`, not the bare scale; `invalid_command` before acceptance) and the fresh-harness resolve (`resolveHarnessOverrides`, the active-tools precedent) applies them on every later turn — a registry change across deploys falls back to the default with a deduped warn instead of bricking the session. `compact` is ACCEPT-FAST (§5.2 has no exceptions: a summarization is a full model call, so the dispatch answers on admission — lease held, harness built — and the outcome travels as `compaction_finished{summary|error|aborted}`, emitted after the lease frees); pre-acceptance failures (the harness build and the local preparation — admission ends where the work becomes a model call) reject `boundary_command_failed` with nothing durable landed, and a session with no compactable history rejects `nothing_to_compact` (a no-op, not a failure — the `no_active_run` pattern: re-dispatch once the session grows); an in-flight compaction is abortable — `abort` during `compacting` aborts the summarization's controller (run/compaction symmetry: both are model calls a client must be able to stop) and converges as `compaction_finished{aborted}` with the lease released, mirroring `run_settled{aborted}`. Mutations contend on the SAME lease as runs (`session_busy` when busy); capabilities report `allowedModels` from the live wiring (`PiBoundaryWiring`, a lazy thunk — the hub exists before the assembly that produces the parts), while the session's model, executing level and available levels come from ONE resolution (`resolveSessionSettings`) that `state()`, the `set_thinking` gate and the fresh-harness resolve all read — model and thinking level are one setting, so deriving them separately is what let the surfaces disagree. `navigate` moves the leaf through pi's `Session.moveTo` (the `SessionStorage.setLeafId` primitive) under the same lease — an unknown `targetId` rejects `invalid_command` before it, and the move rides out as `state_changed{leafEntryId, model, thinkingLevel}` (a move can change which settings apply). Because the leaf is now MOVABLE, every last-wins read — the fresh-harness activation/override walk, `state()`, the `set_thinking` gate — reads the ACTIVE PATH rather than the flat journal: a record on an abandoned branch no longer governs the session. An unreadable chain never resolves silently to the assembly defaults: `state()` stays TOTAL but leaves the settings pair ABSENT, and the fault surfaces where an error code exists — the next invoke's `failed` event and a boundary dispatch's `boundary_command_failed`. | L2 clients. |
-| 3 | **Done** (HTTP+SSE; subprocess adapter stays demand-driven). One transport serves every remote consumer — Web panel, desktop app, `fastagent attach`: `controlRoutes` (engine-neutral, bearer-token REQUIRED) serves `/control/capabilities\|state\|entries\|dispatch\|events`, with the envelope born at the wire (`{sessionId, epoch, seq, event}` per SSE message; HTTP itself is the request correlation). `connectSessionControl` re-exposes the SAME `SessionControl` interface and consumes the envelope internally — a seq gap ends the iterator into the standard reconnect steps; a server restart is covered by the same rule (its connections drop), and `epoch` is informational for consumers correlating ACROSS connections — within one connection it cannot change, so the client does not compare it. The DATA plane travels too: `POST /control/invoke` (the standard invoke handler behind the same token, mounted when the serve wires an agent) + `connectAgent` client-side — a remote consumer holds a full fastagent instance through the same two contracts local code uses. Serve wiring: `config.sessionControl: true` → dev/start mount the routes, mint a per-boot token, and write `<stateRoot>/control.json` (0600) for local discovery; product runners still own real authentication, idempotency, event persistence, and routing (§14). | Remote `SessionControl` is isomorphic to local (conformance-tested). |
+| 3 | **Done** (HTTP+SSE; subprocess adapter stays demand-driven). One transport serves every remote consumer — Web panel, desktop app, `fastagent attach`: `controlRoutes` (engine-neutral, bearer-token REQUIRED) serves `/control/capabilities\|commands\|state\|entries\|dispatch\|events`, with the envelope born at the wire (`{sessionId, epoch, seq, event}` per SSE message; HTTP itself is the request correlation). `connectSessionControl` re-exposes the SAME `SessionControl` interface and consumes the envelope internally — a seq gap ends the iterator into the standard reconnect steps; a server restart is covered by the same rule (its connections drop), and `epoch` is informational for consumers correlating ACROSS connections — within one connection it cannot change, so the client does not compare it. The DATA plane travels too: `POST /control/invoke` (the standard invoke handler behind the same token, mounted when the serve wires an agent) + `connectAgent` client-side — a remote consumer holds a full fastagent instance through the same two contracts local code uses. Serve wiring: `config.sessionControl: true` → dev/start mount the routes, mint a per-boot token, and write `<stateRoot>/control.json` (0600) for local discovery; product runners still own real authentication, idempotency, event persistence, and routing (§14). | Remote `SessionControl` is isomorphic to local (conformance-tested). |
 
 Phase 1 modifies the existing invoke pipeline incrementally (translation + projection); it does not
 build a parallel runtime that later needs reconciling. Demand-driven follow-ons, explicitly not

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -161,15 +161,21 @@ type SessionCommand =
 interface AgentCommand { name: string; description?: string; source: string }
 ```
 
-What a composer's `/` completion lists. There is no way to discover the set by trying — an unknown
-command is just text that reaches the model — and the assembly is the only place that knows the full
-set after collisions were resolved first-wins, which a client cannot reconstruct from the directory.
+What a composer's `/` completion LISTS. A listing, deliberately not a dispatch surface: the data
+plane takes prompts as text, and nothing in it expands `/name` — so what typing one means (expanding
+the skill, sending "use the X skill", filtering a menu) is the client's business, and the contract
+says so rather than implying an invocation path that does not exist.
+
+It still cannot be reconstructed client-side: the assembly is the only place that knows the set after
+collisions were resolved first-wins, and there is no way to discover it by trying.
 
 ASYNC on purpose: a definition is allowed to be LIVE (fastagent re-reads the directory per turn), so
-the list must come from that same read. A boot snapshot would advertise a command set the running
-agent has already left behind. `source` is free-form because which kinds exist is an engine's
-business (`"skill"` today; extension commands and prompt templates as they land), and an engine with
-none answers `[]` — a complete answer, not a missing one.
+the list must come from that same read. A boot snapshot would advertise names the running agent has
+already left behind. `source` is free-form because which kinds exist is an engine's business
+(`"skill"` today; extension commands and prompt templates as they land), and an engine with none
+answers `[]` — a complete answer, not a missing one. A definition that cannot be READ at all is a
+deployment fault, and this read may reject: unlike a session-scoped condition, there is no truthful
+degraded value (`[]` would claim the agent has no names).
 
 ### 5.2 Acceptance is not outcome
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -40,7 +40,7 @@ The stream ends with exactly one `completed` / `failed`, or is cancelled by the 
 | You have | Use | Returns |
 |---|---|---|
 | An agent directory (`persona.md` + `skills/` + `tools/` + config) | `createPiAgentFromDir(dir, { model? })` | `{ agent, definition, modelSpec, … }` — auto-discovers everything |
-| A definition directory, but you want to control the K ports | `createPiAgentFromDefinition(dir, { model, … })` | `{ agent, definition, readDefinition }` — `definition` is the boot snapshot, `readDefinition()` the live re-read |
+| A definition directory, but you want to control the K ports | `createPiAgentFromDefinition(dir, { model, … })` | `{ agent, definition }` |
 | No directory — assemble from code | `createPiAgent({ model, instructions, tools })` | `agent` |
 
 ```ts

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -40,7 +40,7 @@ The stream ends with exactly one `completed` / `failed`, or is cancelled by the 
 | You have | Use | Returns |
 |---|---|---|
 | An agent directory (`persona.md` + `skills/` + `tools/` + config) | `createPiAgentFromDir(dir, { model? })` | `{ agent, definition, modelSpec, … }` — auto-discovers everything |
-| A definition directory, but you want to control the K ports | `createPiAgentFromDefinition(dir, { model, … })` | `{ agent, definition }` |
+| A definition directory, but you want to control the K ports | `createPiAgentFromDefinition(dir, { model, … })` | `{ agent, definition, readDefinition }` — `definition` is the boot snapshot, `readDefinition()` the live re-read |
 | No directory — assemble from code | `createPiAgent({ model, instructions, tools })` | `agent` |
 
 ```ts

--- a/src/channels/control.ts
+++ b/src/channels/control.ts
@@ -131,7 +131,7 @@ export interface ControlRoutesOptions {
 }
 
 /**
- * Mount the control plane: `GET /control/capabilities|state|entries|events` + `POST
+ * Mount the control plane: `GET /control/capabilities|commands|state|entries|events` + `POST
  * /control/dispatch`, all bearer-authenticated. `events` streams SSE (`data: <WireEvent>` lines).
  */
 export function controlRoutes(control: SessionControl, options: ControlRoutesOptions): Routes {
@@ -160,6 +160,8 @@ export function controlRoutes(control: SessionControl, options: ControlRoutesOpt
   return {
     ...(invokeHandler ? { "POST /control/invoke": guard((req) => invokeHandler(req)) } : {}),
     "GET /control/capabilities": guard(() => json(control.capabilities())),
+
+    "GET /control/commands": guard(async () => json(await control.commands())),
 
     "GET /control/state": guard(async (_req, url) => {
       const session = sessionParam(url);

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -217,20 +217,22 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
     // `/` is a reserved command prefix: a typo'd /aboort silently steering the model (injecting a
     // prompt when the user meant to STOP the run) is the dangerous direction of the ambiguity.
     if (trimmed.startsWith("/") && trimmed !== "/abort") {
-      // The agent's own names are worth showing here rather than only "unknown": this composer
-      // cannot INVOKE them (the data plane takes prompts as text), but the author asking "/x" is
-      // asking what exists — and reading it live is the only way to answer honestly.
+      // Two answers with two certainties, so they are printed separately: that `/foo` is not a
+      // command is known HERE and now; which names the agent defines is a remote read that can be
+      // slow or fail, and waiting on it would leave the user's input unanswered.
+      console.log(`[unknown command ${trimmed} — /abort stops the run; a leading / is reserved]`);
       void control.commands().then(
         (commands) => {
           const names = commands.map((c) => `/${c.name}`).join(", ");
+          // This composer cannot INVOKE them (the data plane takes prompts as text) — but the author
+          // typing "/x" is asking what exists, and reading it live is the only honest answer.
           console.log(
-            `[unknown command ${trimmed} — /abort stops the run; a leading / is reserved. ` +
-              `${names ? `this agent defines ${names} (send one as plain text to use it)` : "this agent defines no names"}]`,
+            names
+              ? `[this agent defines ${names} — send one as plain text to use it]`
+              : "[this agent defines no names]",
           );
         },
-        // The one read that may reject (an unreadable definition): say so instead of nothing.
-        (error) =>
-          console.log(`[unknown command ${trimmed} — /abort stops the run; command list unavailable: ${error}]`),
+        (error) => console.log(`[command list unavailable: ${error}]`),
       );
       return;
     }

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -223,13 +223,12 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
       console.log(`[unknown command ${trimmed} — /abort stops the run; a leading / is reserved]`);
       void control.commands().then(
         (commands) => {
-          const names = commands.map((c) => `/${c.name}`).join(", ");
-          // This composer cannot INVOKE them (the data plane takes prompts as text) — but the author
-          // typing "/x" is asking what exists, and reading it live is the only honest answer.
+          // BARE names, deliberately: this composer cannot expand `/name` (the data plane takes
+          // prompts as text), so printing them with the slash would invite the user straight back
+          // into the branch that just rejected them.
+          const names = commands.map((c) => c.name).join(", ");
           console.log(
-            names
-              ? `[this agent defines ${names} — send one as plain text to use it]`
-              : "[this agent defines no names]",
+            names ? `[this agent defines: ${names} — name one in a normal message]` : "[this agent defines no names]",
           );
         },
         (error) => console.log(`[command list unavailable: ${error}]`),

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -184,7 +184,9 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
     // invoke) — give the human a corrective signal.
     log.warn(`[fastagent] no durable record for "${sessionArg}" yet — a new session, or a typo?`);
   }
-  log.info(`[fastagent] type to steer the active run; /abort to stop it; Ctrl+C to detach`);
+  log.info(
+    `[fastagent] type to steer the active run; /abort to stop it; /commands to list what this agent defines; Ctrl+C to detach`,
+  );
 
   // stdin → the two planes: a line steers the ACTIVE run; with no run to join (no_active_run) it
   // falls back to STARTING one over the remote data plane (`POST /control/invoke`) — try-steer-
@@ -221,10 +223,12 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
       // be); the rest is a remote read that can be slow or fail, and waiting on it would leave the
       // user's input unanswered. It deliberately does not pre-judge the token as unknown — the read
       // may be about to prove it names a real skill.
-      const listing = trimmed === "/commands";
+      // The first WORD is the token: slash input naturally carries arguments (`/triage my inbox`),
+      // and taking the whole line would answer "names nothing" for a name the user did give.
+      const word = trimmed.slice(1).split(/\s+/)[0] ?? "";
+      const listing = word === "commands";
       if (!listing)
         console.log("[a leading / is reserved — /abort stops the run, /commands lists what this agent defines]");
-      const typed = trimmed.slice(1);
       void control.commands().then(
         (commands) => {
           // Names print BARE: this composer cannot expand `/name` (the data plane takes prompts as
@@ -234,13 +238,13 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
             console.log(names.length ? `[this agent defines: ${names.join(", ")}]` : "[this agent defines no names]");
             return;
           }
-          const hit = commands.find((c) => c.name === typed);
+          const hit = commands.find((c) => c.name === word);
           // The enumeration answers `/commands` only: dumping every skill at a mistyped `/aboort`
           // answers an intent the typo did not express.
           console.log(
             hit
               ? `[${hit.name} is a ${hit.source} — name it in a normal message, without the /]`
-              : `[${trimmed} names nothing this agent defines]`,
+              : `[/${word} names nothing this agent defines]`,
           );
         },
         (error) => console.log(`[command list unavailable: ${error}]`),

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -217,24 +217,30 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
     // `/` is a reserved command prefix: a typo'd /aboort silently steering the model (injecting a
     // prompt when the user meant to STOP the run) is the dangerous direction of the ambiguity.
     if (trimmed.startsWith("/") && trimmed !== "/abort") {
-      // Two answers with two certainties, printed separately: that a leading `/` is reserved here is
-      // known NOW; whether the token names something is a remote read that can be slow or fail, and
-      // waiting on it would leave the user's input unanswered. The first line therefore does not
-      // pre-judge the token as "unknown" — the read may be about to prove it is a real name.
-      console.log(`[a leading / is reserved — /abort stops the run]`);
+      // The certain half prints NOW (a leading `/` is reserved here, whatever the token turns out to
+      // be); the rest is a remote read that can be slow or fail, and waiting on it would leave the
+      // user's input unanswered. It deliberately does not pre-judge the token as unknown — the read
+      // may be about to prove it names a real skill.
+      const listing = trimmed === "/commands";
+      if (!listing)
+        console.log("[a leading / is reserved — /abort stops the run, /commands lists what this agent defines]");
       const typed = trimmed.slice(1);
       void control.commands().then(
         (commands) => {
-          // Names are printed BARE: this composer cannot expand `/name` (the data plane takes prompts
-          // as text), so a slash would invite the user straight back into this branch.
-          const hit = commands.find((c) => c.name === typed);
-          if (hit) {
-            console.log(`[${hit.name} is a ${hit.source} — name it in a normal message, without the /]`);
+          // Names print BARE: this composer cannot expand `/name` (the data plane takes prompts as
+          // text), so a slash would invite the user straight back into this branch.
+          const names = commands.map((c) => c.name);
+          if (listing) {
+            console.log(names.length ? `[this agent defines: ${names.join(", ")}]` : "[this agent defines no names]");
             return;
           }
-          const names = commands.map((c) => c.name).join(", ");
+          const hit = commands.find((c) => c.name === typed);
+          // The enumeration answers `/commands` only: dumping every skill at a mistyped `/aboort`
+          // answers an intent the typo did not express.
           console.log(
-            names ? `[this agent defines: ${names} — name one in a normal message]` : "[this agent defines no names]",
+            hit
+              ? `[${hit.name} is a ${hit.source} — name it in a normal message, without the /]`
+              : `[${trimmed} names nothing this agent defines]`,
           );
         },
         (error) => console.log(`[command list unavailable: ${error}]`),

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -233,9 +233,11 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
         (commands) => {
           // Names print BARE: this composer cannot expand `/name` (the data plane takes prompts as
           // text), so a slash would invite the user straight back into this branch.
-          const names = commands.map((c) => c.name);
           if (listing) {
-            console.log(names.length ? `[this agent defines: ${names.join(", ")}]` : "[this agent defines no names]");
+            // `description` is what makes a listing usable — a bare name tells the author nothing
+            // they did not already know from the directory.
+            const listed = commands.map((c) => (c.description ? `${c.name} — ${c.description}` : c.name));
+            console.log(listed.length ? `[this agent defines: ${listed.join("; ")}]` : "[this agent defines no names]");
             return;
           }
           const hit = commands.find((c) => c.name === word);
@@ -243,7 +245,7 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
           // answers an intent the typo did not express.
           console.log(
             hit
-              ? `[${hit.name} is a ${hit.source} — name it in a normal message, without the /]`
+              ? `[${hit.name} is a ${hit.source}${hit.description ? ` — ${hit.description}` : ""}; name it in a normal message, without the /]`
               : `[/${word} names nothing this agent defines]`,
           );
         },

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -217,7 +217,21 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
     // `/` is a reserved command prefix: a typo'd /aboort silently steering the model (injecting a
     // prompt when the user meant to STOP the run) is the dangerous direction of the ambiguity.
     if (trimmed.startsWith("/") && trimmed !== "/abort") {
-      console.log(`[unknown command ${trimmed} — /abort stops the run; a leading / is reserved]`);
+      // The agent's own names are worth showing here rather than only "unknown": this composer
+      // cannot INVOKE them (the data plane takes prompts as text), but the author asking "/x" is
+      // asking what exists — and reading it live is the only way to answer honestly.
+      void control.commands().then(
+        (commands) => {
+          const names = commands.map((c) => `/${c.name}`).join(", ");
+          console.log(
+            `[unknown command ${trimmed} — /abort stops the run; a leading / is reserved. ` +
+              `${names ? `this agent defines ${names} (send one as plain text to use it)` : "this agent defines no names"}]`,
+          );
+        },
+        // The one read that may reject (an unreadable definition): say so instead of nothing.
+        (error) =>
+          console.log(`[unknown command ${trimmed} — /abort stops the run; command list unavailable: ${error}]`),
+      );
       return;
     }
     const command =

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -18,7 +18,7 @@ import { log, setLogLevel } from "../../log.ts";
 import { ABORTED_CODE, SESSION_BUSY_CODE } from "../../agent.ts";
 import { NO_ACTIVE_RUN_CODE } from "../../session.ts";
 import { ControlRequestError, connectAgent, connectSessionControl } from "../../session-remote.ts";
-import type { SessionControl, SessionEntry, SessionEvent, SessionState } from "../../session.ts";
+import type { AgentCommand, SessionControl, SessionEntry, SessionEvent, SessionState } from "../../session.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 
 export interface AttachOptions {
@@ -219,39 +219,7 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
     // `/` is a reserved command prefix: a typo'd /aboort silently steering the model (injecting a
     // prompt when the user meant to STOP the run) is the dangerous direction of the ambiguity.
     if (trimmed.startsWith("/") && trimmed !== "/abort") {
-      // For a MISTYPED slash the certain half prints NOW (a leading `/` is reserved here, whatever
-      // the token turns out to be), because waiting on a remote read that can be slow or fail would
-      // leave the input unanswered; it deliberately does not pre-judge the token as unknown — the
-      // read may be about to prove it names a real skill. `/commands` prints nothing first: its
-      // whole answer IS the read, and a placeholder would just be noise before it.
-      // The first WORD is the token: slash input naturally carries arguments (`/triage my inbox`),
-      // and taking the whole line would answer "names nothing" for a name the user did give.
-      const word = trimmed.slice(1).split(/\s+/)[0] ?? "";
-      const listing = word === "commands";
-      if (!listing)
-        console.log("[a leading / is reserved — /abort stops the run, /commands lists what this agent defines]");
-      void control.commands().then(
-        (commands) => {
-          // Names print BARE: this composer cannot expand `/name` (the data plane takes prompts as
-          // text), so a slash would invite the user straight back into this branch.
-          if (listing) {
-            // `description` is what makes a listing usable — a bare name tells the author nothing
-            // they did not already know from the directory.
-            const listed = commands.map((c) => (c.description ? `${c.name} — ${c.description}` : c.name));
-            console.log(listed.length ? `[this agent defines: ${listed.join("; ")}]` : "[this agent defines no names]");
-            return;
-          }
-          const hit = commands.find((c) => c.name === word);
-          // The enumeration answers `/commands` only: dumping every skill at a mistyped `/aboort`
-          // answers an intent the typo did not express.
-          console.log(
-            hit
-              ? `[${hit.name} is a ${hit.source}${hit.description ? ` — ${hit.description}` : ""}; name it in a normal message, without the /]`
-              : `[/${word} names nothing this agent defines]`,
-          );
-        },
-        (error) => console.log(`[command list unavailable: ${error}]`),
-      );
+      void answerSlashInput(trimmed, control, (l) => console.log(l));
       return;
     }
     const command =
@@ -512,6 +480,55 @@ export function activePathSlice(entries: SessionEntry[], leafEntryId: string | u
     onPath.add(cur.id);
   }
   return entries.filter((e) => onPath.has(e.id));
+}
+
+/**
+ * Answer a RESERVED-SLASH line (anything starting with `/` that is not `/abort`). Two intents share
+ * the prefix — a mistyped control command and an attempt to invoke a name — and they are answered
+ * differently:
+ *
+ * - a mistyped slash gets the certain half NOW (a leading `/` is reserved here, whatever the token
+ *   turns out to be), because waiting on a remote read that can be slow or fail would leave the
+ *   input unanswered; it deliberately does not pre-judge the token as unknown — the read may be
+ *   about to prove it names a real skill;
+ * - `/commands` prints nothing first: its whole answer IS the read, and a placeholder is noise;
+ * - the enumeration answers `/commands` ONLY — dumping every skill at a mistyped `/aboort` answers
+ *   an intent the typo did not express.
+ *
+ * Names print BARE: this composer cannot expand `/name` (the data plane takes prompts as text), so
+ * printing them with a slash would invite the user straight back into this branch. Returns the
+ * promise for the remote half, so a caller (or a test) can await the second line.
+ */
+export async function answerSlashInput(
+  trimmed: string,
+  control: Pick<SessionControl, "commands">,
+  println: (line: string) => void,
+): Promise<void> {
+  // The first WORD is the token: slash input naturally carries arguments (`/triage my inbox`), and
+  // taking the whole line would answer "names nothing" for a name the user did give.
+  const word = trimmed.slice(1).split(/\s+/)[0] ?? "";
+  const listing = word === "commands";
+  if (!listing) println("[a leading / is reserved — /abort stops the run, /commands lists what this agent defines]");
+  let commands: AgentCommand[];
+  try {
+    commands = await control.commands();
+  } catch (error) {
+    println(`[command list unavailable: ${error}]`);
+    return;
+  }
+  if (listing) {
+    // `description` is what makes a listing usable — a bare name tells the author nothing they did
+    // not already know from the directory.
+    const listed = commands.map((c) => (c.description ? `${c.name} — ${c.description}` : c.name));
+    println(listed.length ? `[this agent defines: ${listed.join("; ")}]` : "[this agent defines no names]");
+    return;
+  }
+  const hit = commands.find((c) => c.name === word);
+  println(
+    hit
+      ? `[${hit.name} is a ${hit.source}${hit.description ? ` — ${hit.description}` : ""}; name it in a normal message, without the /]`
+      : `[/${word} names nothing this agent defines]`,
+  );
 }
 
 /**

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -219,10 +219,11 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
     // `/` is a reserved command prefix: a typo'd /aboort silently steering the model (injecting a
     // prompt when the user meant to STOP the run) is the dangerous direction of the ambiguity.
     if (trimmed.startsWith("/") && trimmed !== "/abort") {
-      // The certain half prints NOW (a leading `/` is reserved here, whatever the token turns out to
-      // be); the rest is a remote read that can be slow or fail, and waiting on it would leave the
-      // user's input unanswered. It deliberately does not pre-judge the token as unknown — the read
-      // may be about to prove it names a real skill.
+      // For a MISTYPED slash the certain half prints NOW (a leading `/` is reserved here, whatever
+      // the token turns out to be), because waiting on a remote read that can be slow or fail would
+      // leave the input unanswered; it deliberately does not pre-judge the token as unknown — the
+      // read may be about to prove it names a real skill. `/commands` prints nothing first: its
+      // whole answer IS the read, and a placeholder would just be noise before it.
       // The first WORD is the token: slash input naturally carries arguments (`/triage my inbox`),
       // and taking the whole line would answer "names nothing" for a name the user did give.
       const word = trimmed.slice(1).split(/\s+/)[0] ?? "";

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -217,15 +217,21 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
     // `/` is a reserved command prefix: a typo'd /aboort silently steering the model (injecting a
     // prompt when the user meant to STOP the run) is the dangerous direction of the ambiguity.
     if (trimmed.startsWith("/") && trimmed !== "/abort") {
-      // Two answers with two certainties, so they are printed separately: that `/foo` is not a
-      // command is known HERE and now; which names the agent defines is a remote read that can be
-      // slow or fail, and waiting on it would leave the user's input unanswered.
-      console.log(`[unknown command ${trimmed} — /abort stops the run; a leading / is reserved]`);
+      // Two answers with two certainties, printed separately: that a leading `/` is reserved here is
+      // known NOW; whether the token names something is a remote read that can be slow or fail, and
+      // waiting on it would leave the user's input unanswered. The first line therefore does not
+      // pre-judge the token as "unknown" — the read may be about to prove it is a real name.
+      console.log(`[a leading / is reserved — /abort stops the run]`);
+      const typed = trimmed.slice(1);
       void control.commands().then(
         (commands) => {
-          // BARE names, deliberately: this composer cannot expand `/name` (the data plane takes
-          // prompts as text), so printing them with the slash would invite the user straight back
-          // into the branch that just rejected them.
+          // Names are printed BARE: this composer cannot expand `/name` (the data plane takes prompts
+          // as text), so a slash would invite the user straight back into this branch.
+          const hit = commands.find((c) => c.name === typed);
+          if (hit) {
+            console.log(`[${hit.name} is a ${hit.source} — name it in a normal message, without the /]`);
+            return;
+          }
           const names = commands.map((c) => c.name).join(", ");
           console.log(
             names ? `[this agent defines: ${names} — name one in a normal message]` : "[this agent defines no names]",

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -7,7 +7,7 @@ import { resolve } from "node:path";
 import { runDevSupervisor } from "../../dev-supervisor.ts";
 import { loadDotEnv } from "../../env.ts";
 
-import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
+import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { setLogLevel } from "../../log.ts";
 import { logAgentLoop } from "../../observe.ts";
@@ -108,5 +108,5 @@ function reportAgentsSkillsTools(a: Assembled): void {
   }
   reportToolCollisions(a.toolCollisions);
   reportModuleLoadFailures(a.toolFailures);
-  reportDefinitionWarnings(a.definition.collisions, a.definition.diagnostics);
+  reportFindingsIfChanged(a.definition.dir, a.definition);
 }

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -12,7 +12,7 @@ import {
 import { resolveStateRoot, workspaceHint } from "../../paths.ts";
 import { resolveAgentTools } from "../../engines/pi/create.ts";
 import { loadAgentDefinition } from "../../engines/pi/definition.ts";
-import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
+import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
 import { log } from "../../log.ts";
 import { nextRun } from "../../schedule/cron.ts";
 import { loadSchedules } from "../../schedule/discover.ts";
@@ -128,5 +128,5 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   reportModuleLoadFailures(tools.failures);
   reportModuleLoadFailures(sched.failures);
   if (tools.error) log.warn(`[fastagent] ${tools.error}`);
-  reportDefinitionWarnings(definition.collisions, definition.diagnostics);
+  reportFindingsIfChanged(definition.dir, definition);
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -9,7 +9,7 @@ import { loadDotEnv } from "../../env.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
 import { resolveSecretsDir, workspaceHint } from "../../paths.ts";
 import { isUnderDir } from "../../engines/pi/definition.ts";
-import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
+import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { log, setLogLevel } from "../../log.ts";
 import { createWakeAlarmSink, reconcileWakeAlarms } from "../../schedule/wake-alarm.ts";
@@ -120,7 +120,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
         `FASTAGENT_SECRETS_DIR at a persistent volume so a redeploy that replaces the dir does not wipe them.`,
     );
   }
-  reportDefinitionWarnings(definition.collisions, definition.diagnostics);
+  reportFindingsIfChanged(definition.dir, definition);
 
   // AgentCore Runtime posture (FASTAGENT_AGENTCORE=1, set by the generated deploy artifacts): the
   // adapter (POST /invocations + GET /ping) is the container's only reachable surface, and cron

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -409,12 +409,15 @@ function findingsSignature(def: LoadedDefinition): string {
 
 /**
  * L2: "point at a directory → agent": load + assemble (base + AGENTS.md + skills + env) + L1 in one
- * call. Returns the definition so callers can surface diagnostics/collisions.
+ * call. Returns the boot `definition` so callers can surface diagnostics/collisions, and
+ * `readDefinition` — the SAME live read every invoke performs — so a caller that must ANSWER for
+ * the definition (the control plane's command list) reads what the next turn will run, not a boot
+ * snapshot that quietly ages.
  */
 export async function createPiAgentFromDefinition(
   dir: string,
   options: CreatePiAgentFromDefinitionOptions,
-): Promise<{ agent: Agent; definition: LoadedDefinition }> {
+): Promise<{ agent: Agent; definition: LoadedDefinition; readDefinition: () => Promise<LoadedDefinition> }> {
   // `dir` = the agent-definition dir (persona.md/skills/); `cwd` (default = dir) is the run root where
   // tools operate and whose ancestors are walked for ② context.
   const cwd = options.cwd ?? dir;
@@ -426,6 +429,15 @@ export async function createPiAgentFromDefinition(
   // runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
   // every turn's log. A log-dedup memo, not session state (stateless invoke holds).
   let reportedFindings = findingsSignature(definition);
+  const readDefinition = async (): Promise<LoadedDefinition> => {
+    const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
+    const sig = findingsSignature(def);
+    if (sig !== reportedFindings) {
+      reportedFindings = sig;
+      reportDefinitionWarnings(def.collisions, def.diagnostics);
+    }
+    return def;
+  };
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());
@@ -447,12 +459,7 @@ export async function createPiAgentFromDefinition(
     // not silently vanish from the agent, and a static one must not spam every turn's log. The
     // next good edit heals both.
     live: async () => {
-      const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
-      const sig = findingsSignature(def);
-      if (sig !== reportedFindings) {
-        reportedFindings = sig;
-        reportDefinitionWarnings(def.collisions, def.diagnostics);
-      }
+      const def = await readDefinition();
       return {
         systemPrompt: assembleSystemPrompt({
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,
@@ -473,5 +480,5 @@ export async function createPiAgentFromDefinition(
     observer: options.observer,
     onAssembly: options.onAssembly,
   });
-  return { agent, definition };
+  return { agent, definition, readDefinition };
 }

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -412,7 +412,8 @@ function findingsSignature(def: LoadedDefinition): string {
  * call. Returns the boot `definition` so callers can surface diagnostics/collisions, and
  * `readDefinition` — the SAME live read every invoke performs — so a caller that must ANSWER for
  * the definition (the control plane's command list) reads what the next turn will run, not a boot
- * snapshot that quietly ages.
+ * snapshot that quietly ages. It is a full directory load and it is SIDE-EFFECT FREE: the findings
+ * report rides the invoke path only.
  */
 export async function createPiAgentFromDefinition(
   dir: string,
@@ -429,14 +430,15 @@ export async function createPiAgentFromDefinition(
   // runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
   // every turn's log. A log-dedup memo, not session state (stateless invoke holds).
   let reportedFindings = findingsSignature(definition);
-  const readDefinition = async (): Promise<LoadedDefinition> => {
-    const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
+  const readDefinition = (): Promise<LoadedDefinition> => loadAgentDefinition(dir, { cwd: env.cwd, env });
+  /** The findings edge belongs to the TURN, not to any reader: a polling control-plane call must not
+   *  consume the change and leave the next invoke silent about a skill that just broke. */
+  const reportIfChanged = (def: LoadedDefinition): void => {
     const sig = findingsSignature(def);
     if (sig !== reportedFindings) {
       reportedFindings = sig;
       reportDefinitionWarnings(def.collisions, def.diagnostics);
     }
-    return def;
   };
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
@@ -460,6 +462,7 @@ export async function createPiAgentFromDefinition(
     // next good edit heals both.
     live: async () => {
       const def = await readDefinition();
+      reportIfChanged(def);
       return {
         systemPrompt: assembleSystemPrompt({
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -29,7 +29,7 @@ import { resolveSecretsDir } from "../../paths.ts";
 import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, DEFAULT_THINKING_LEVEL, piHarnessFactory } from "./harness.ts";
 import { createPiModels } from "./models.ts";
-import { reportDefinitionWarnings } from "./report.ts";
+import { findingsSignature, reportDefinitionWarnings } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import {
@@ -400,13 +400,6 @@ export interface CreatePiAgentFromDefinitionOptions {
   onAssembly?: OnAssembly;
 }
 
-/** Stable identity of a definition's non-fatal findings, for change-detection in `live` (dedup only). */
-function findingsSignature(def: LoadedDefinition): string {
-  const collisions = def.collisions.map((c) => `c:${c.name}:${c.winnerPath}:${c.loserPath}`);
-  const diagnostics = def.diagnostics.map((d) => `d:${d.code}:${d.path}`);
-  return [...collisions, ...diagnostics].sort().join("\n");
-}
-
 /**
  * L2: "point at a directory → agent": load + assemble (base + AGENTS.md + skills + env) + L1 in one
  * call. Returns the definition so callers can surface diagnostics/collisions.
@@ -426,7 +419,6 @@ export async function createPiAgentFromDefinition(
   // runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
   // every turn's log. A log-dedup memo, not session state (stateless invoke holds).
   let reportedFindings = findingsSignature(definition);
-
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -419,7 +419,7 @@ export async function createPiAgentFromDefinition(
   // a runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
   // every turn's log. The memo lives in report.ts, keyed by dir, and is SHARED with every other
   // reader of this definition (the control plane's command list) — log dedup, not session state.
-  noteFindings(dir, definition);
+  noteFindings(definition.dir, definition);
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());
@@ -442,7 +442,7 @@ export async function createPiAgentFromDefinition(
     // next good edit heals both.
     live: async () => {
       const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
-      reportFindingsIfChanged(dir, def);
+      reportFindingsIfChanged(def.dir, def);
       return {
         systemPrompt: assembleSystemPrompt({
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -29,7 +29,7 @@ import { resolveSecretsDir } from "../../paths.ts";
 import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, DEFAULT_THINKING_LEVEL, piHarnessFactory } from "./harness.ts";
 import { createPiModels } from "./models.ts";
-import { noteFindings, reportFindingsIfChanged } from "./report.ts";
+import { reportFindingsIfChanged } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import {
@@ -415,11 +415,11 @@ export async function createPiAgentFromDefinition(
   // Boot-time load: fail-visibly at startup on a broken directory, and give callers the snapshot to
   // report (skills/diagnostics/collisions). Serving does NOT close over it — see `live` below.
   const definition = await loadAgentDefinition(dir, { cwd: env.cwd, env });
-  // Findings the caller already reported at boot; later reads re-report only when the set CHANGES —
-  // a runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
-  // every turn's log. The memo lives in report.ts, keyed by dir, and is SHARED with every other
-  // reader of this definition (the control plane's command list) — log dedup, not session state.
-  noteFindings(definition.dir, definition);
+  // Boot findings go through the SAME memoized reporter every later reader uses (report.ts, keyed by
+  // the resolved dir): announced once here, and re-announced by a turn or by the control plane's
+  // command list only when the set CHANGES — a runtime-written bad skill surfaces the moment it
+  // appears, a static one does not spam. Log dedup, not session state (stateless invoke holds).
+  reportFindingsIfChanged(definition.dir, definition);
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -409,16 +409,12 @@ function findingsSignature(def: LoadedDefinition): string {
 
 /**
  * L2: "point at a directory → agent": load + assemble (base + AGENTS.md + skills + env) + L1 in one
- * call. Returns the boot `definition` so callers can surface diagnostics/collisions, and
- * `readDefinition` — the SAME live read every invoke performs — so a caller that must ANSWER for
- * the definition (the control plane's command list) reads what the next turn will run, not a boot
- * snapshot that quietly ages. It is a full directory load and it is SIDE-EFFECT FREE: the findings
- * report rides the invoke path only.
+ * call. Returns the definition so callers can surface diagnostics/collisions.
  */
 export async function createPiAgentFromDefinition(
   dir: string,
   options: CreatePiAgentFromDefinitionOptions,
-): Promise<{ agent: Agent; definition: LoadedDefinition; readDefinition: () => Promise<LoadedDefinition> }> {
+): Promise<{ agent: Agent; definition: LoadedDefinition }> {
   // `dir` = the agent-definition dir (persona.md/skills/); `cwd` (default = dir) is the run root where
   // tools operate and whose ancestors are walked for ② context.
   const cwd = options.cwd ?? dir;
@@ -430,16 +426,7 @@ export async function createPiAgentFromDefinition(
   // runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
   // every turn's log. A log-dedup memo, not session state (stateless invoke holds).
   let reportedFindings = findingsSignature(definition);
-  const readDefinition = (): Promise<LoadedDefinition> => loadAgentDefinition(dir, { cwd: env.cwd, env });
-  /** The findings edge belongs to the TURN, not to any reader: a polling control-plane call must not
-   *  consume the change and leave the next invoke silent about a skill that just broke. */
-  const reportIfChanged = (def: LoadedDefinition): void => {
-    const sig = findingsSignature(def);
-    if (sig !== reportedFindings) {
-      reportedFindings = sig;
-      reportDefinitionWarnings(def.collisions, def.diagnostics);
-    }
-  };
+
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());
@@ -461,8 +448,12 @@ export async function createPiAgentFromDefinition(
     // not silently vanish from the agent, and a static one must not spam every turn's log. The
     // next good edit heals both.
     live: async () => {
-      const def = await readDefinition();
-      reportIfChanged(def);
+      const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
+      const sig = findingsSignature(def);
+      if (sig !== reportedFindings) {
+        reportedFindings = sig;
+        reportDefinitionWarnings(def.collisions, def.diagnostics);
+      }
       return {
         systemPrompt: assembleSystemPrompt({
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,
@@ -483,5 +474,5 @@ export async function createPiAgentFromDefinition(
     observer: options.observer,
     onAssembly: options.onAssembly,
   });
-  return { agent, definition, readDefinition };
+  return { agent, definition };
 }

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -29,7 +29,7 @@ import { resolveSecretsDir } from "../../paths.ts";
 import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, DEFAULT_THINKING_LEVEL, piHarnessFactory } from "./harness.ts";
 import { createPiModels } from "./models.ts";
-import { findingsSignature, reportDefinitionWarnings } from "./report.ts";
+import { noteFindings, reportFindingsIfChanged } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import {
@@ -415,10 +415,11 @@ export async function createPiAgentFromDefinition(
   // Boot-time load: fail-visibly at startup on a broken directory, and give callers the snapshot to
   // report (skills/diagnostics/collisions). Serving does NOT close over it — see `live` below.
   const definition = await loadAgentDefinition(dir, { cwd: env.cwd, env });
-  // Findings the caller already reported at boot; `live` re-reports only when the set CHANGES — a
-  // runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
-  // every turn's log. A log-dedup memo, not session state (stateless invoke holds).
-  let reportedFindings = findingsSignature(definition);
+  // Findings the caller already reported at boot; later reads re-report only when the set CHANGES —
+  // a runtime-written bad skill surfaces the moment it appears, while a static finding does not spam
+  // every turn's log. The memo lives in report.ts, keyed by dir, and is SHARED with every other
+  // reader of this definition (the control plane's command list) — log dedup, not session state.
+  noteFindings(dir, definition);
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());
@@ -441,11 +442,7 @@ export async function createPiAgentFromDefinition(
     // next good edit heals both.
     live: async () => {
       const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
-      const sig = findingsSignature(def);
-      if (sig !== reportedFindings) {
-        reportedFindings = sig;
-        reportDefinitionWarnings(def.collisions, def.diagnostics);
-      }
+      reportFindingsIfChanged(dir, def);
       return {
         systemPrompt: assembleSystemPrompt({
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -90,6 +90,15 @@ export async function loadAgentDefinition(
   }
   const persona = personaRead.ok ? personaRead.value : undefined;
 
+  const { skills, diagnostics, collisions } = await readSkills(e, root);
+  return { contextFiles, persona, skills, diagnostics, collisions, dir: root };
+}
+
+/** The skills half, shared by the full load and {@link loadAgentSkills}. `root` is already resolved. */
+async function readSkills(
+  e: ExecutionEnv,
+  root: string,
+): Promise<{ skills: Skill[]; diagnostics: SkillDiagnostic[]; collisions: SkillCollision[] }> {
   // Skills come ONLY from the definition's own skills/ (no external/global mount), so the same
   // definition loads the same skills on every machine — and, like tools/channels/schedules, a symlink
   // that escapes the agent dir is refused rather than followed (the fourth of four surfaces).
@@ -105,8 +114,24 @@ export async function loadAgentDefinition(
       byName.set(skill.name, skill);
     }
   }
+  return { skills: [...byName.values()], diagnostics, collisions };
+}
 
-  return { contextFiles, persona, skills: [...byName.values()], diagnostics, collisions, dir: root };
+/**
+ * The definition's skills ALONE, resolved the same way `loadAgentDefinition` resolves them (same
+ * loader, same containment guard, same first-wins collision rule) — for readers that need only the
+ * names and must not pay the full load's ② context walk (every AGENTS.md from cwd to root) for them.
+ * The control plane's `commands()` is that reader, and it is called at keystroke frequency.
+ */
+export async function loadAgentSkills(
+  agentDir: string,
+  options: { cwd?: string; env?: ExecutionEnv } = {},
+): Promise<{ skills: Skill[]; diagnostics: SkillDiagnostic[]; collisions: SkillCollision[] }> {
+  const cwd = options.cwd ?? agentDir;
+  const e = options.env ?? new NodeExecutionEnv({ cwd });
+  const rootResult = await e.absolutePath(agentDir);
+  if (!rootResult.ok) throw new Error(`cannot resolve agent dir "${agentDir}": ${rootResult.error.message}`);
+  return readSkills(e, rootResult.value);
 }
 
 /**

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -121,7 +121,7 @@ async function readSkills(
  * The definition's skills ALONE, resolved the same way `loadAgentDefinition` resolves them (same
  * loader, same containment guard, same first-wins collision rule) — for readers that need only the
  * names and must not pay the full load's ② context walk (every AGENTS.md from cwd to root) for them.
- * The control plane's `commands()` is that reader, and it is called at keystroke frequency.
+ * The control plane's `commands()` is that reader, called when a composer opens its completion list.
  */
 export async function loadAgentSkills(
   agentDir: string,

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -126,12 +126,14 @@ async function readSkills(
 export async function loadAgentSkills(
   agentDir: string,
   options: { cwd?: string; env?: ExecutionEnv } = {},
-): Promise<{ skills: Skill[]; diagnostics: SkillDiagnostic[]; collisions: SkillCollision[] }> {
+): Promise<{ skills: Skill[]; diagnostics: SkillDiagnostic[]; collisions: SkillCollision[]; dir: string }> {
   const cwd = options.cwd ?? agentDir;
   const e = options.env ?? new NodeExecutionEnv({ cwd });
   const rootResult = await e.absolutePath(agentDir);
   if (!rootResult.ok) throw new Error(`cannot resolve agent dir "${agentDir}": ${rootResult.error.message}`);
-  return readSkills(e, rootResult.value);
+  // `dir` is the RESOLVED root, like {@link LoadedDefinition.dir}: readers key per-definition state
+  // (the findings memo) on it, and "./agent" vs an absolute path must not become two definitions.
+  return { ...(await readSkills(e, rootResult.value)), dir: rootResult.value };
 }
 
 /**

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -221,7 +221,7 @@ export async function createPiAgentFromDir(
           // A skill whose frontmatter broke simply is not in `skills` — it would disappear from the
           // author's composer with no signal anywhere. The memo is SHARED with the turn path (keyed
           // by dir), so a finding is warned when it appears, not once per reader that notices it.
-          reportFindingsIfChanged(agentDir, loaded);
+          reportFindingsIfChanged(loaded.dir, loaded);
           return loaded.skills.map((skill) => ({
             name: skill.name,
             description: skill.description,

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -215,12 +215,18 @@ export async function createPiAgentFromDir(
         // Skills ARE the commands a user invokes by name — the resolved set, after collisions were
         // decided first-wins, which a client cannot reconstruct from the directory. Read live: a
         // skill added while serving is invocable on the next turn, so it must be listable now.
-        commands: async () =>
-          ((await readDefinition?.())?.skills ?? []).map((skill) => ({
+        commands: async () => {
+          // Unlike `boundaryParts` (undefined is a real deployment state, gated in capabilities),
+          // an unset reader here is a WIRING BUG — the hub is unreachable until this function
+          // returns. Answering [] would spell it as "this agent has no names", which the contract
+          // defines as a complete answer.
+          if (!readDefinition) throw new Error("commands() before the assembly ran (opener invariant broken)");
+          return (await readDefinition()).skills.map((skill) => ({
             name: skill.name,
             description: skill.description,
             source: "skill",
-          })),
+          }));
+        },
         // The caller tap's boundary-event half: state_changed/compaction_* originate in the hub
         // and never cross the data plane's observer seam — without this, an audit tap wired here
         // would miss exactly the mutations it most needs to see (set_model).

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -27,7 +27,7 @@ import type { PiSessionReader, PiSessionStore } from "./sessions.ts";
 import { withWakeTool } from "./wake-tool.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import { type LoadedDefinition, loadAgentSkills } from "./definition.ts";
-import { findingsSignature, reportDefinitionWarnings } from "./report.ts";
+import { reportFindingsIfChanged } from "./report.ts";
 import { jsonlSessionStore } from "./sessions.ts";
 import type { ToolCollision } from "./tool.ts";
 import type { MountedTool } from "./tool.ts";
@@ -205,17 +205,12 @@ export async function createPiAgentFromDir(
   // assembly's onAssembly callback (assembly completes before this function returns, so every
   // dispatch sees them). An extra caller observer composes after the hub's (TRUSTED seam).
   let boundaryParts: PiBoundaryWiring | undefined;
-  /** Log-dedup memo for the commands read (see below) — seeded by the boot report the caller prints. */
-  let reportedCommandFindings: string | undefined;
   const caller = options.observer;
   const wantControl = options.sessionControl ?? (config.sessionControl === true && options.serving === true);
   const hub = wantControl
     ? createPiSessionControl({
         sessions,
         boundary: () => boundaryParts,
-        // Skills ARE the commands a user invokes by name — the resolved set, after collisions were
-        // decided first-wins, which a client cannot reconstruct from the directory. Read live: a
-        // skill added while serving is invocable on the next turn, so it must be listable now.
         // Skills ARE the names a client offers — the resolved set, after collisions were decided
         // first-wins, which a client cannot reconstruct from the directory. Read LIVE (the directory
         // is the agent: a skill added while serving is in play on the next turn, so it must be
@@ -224,13 +219,9 @@ export async function createPiAgentFromDir(
         commands: async () => {
           const loaded = await loadAgentSkills(agentDir, { cwd: workspace });
           // A skill whose frontmatter broke simply is not in `skills` — it would disappear from the
-          // author's composer with no signal anywhere. Same dedup discipline as the turn path: warn
-          // when the finding set CHANGES, so a composer opening twice does not spam.
-          const sig = findingsSignature(loaded);
-          if (sig !== reportedCommandFindings) {
-            reportedCommandFindings = sig;
-            reportDefinitionWarnings(loaded.collisions, loaded.diagnostics);
-          }
+          // author's composer with no signal anywhere. The memo is SHARED with the turn path (keyed
+          // by dir), so a finding is warned when it appears, not once per reader that notices it.
+          reportFindingsIfChanged(agentDir, loaded);
           return loaded.skills.map((skill) => ({
             name: skill.name,
             description: skill.description,

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -27,6 +27,7 @@ import type { PiSessionReader, PiSessionStore } from "./sessions.ts";
 import { withWakeTool } from "./wake-tool.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import { type LoadedDefinition, loadAgentSkills } from "./definition.ts";
+import { findingsSignature, reportDefinitionWarnings } from "./report.ts";
 import { jsonlSessionStore } from "./sessions.ts";
 import type { ToolCollision } from "./tool.ts";
 import type { MountedTool } from "./tool.ts";
@@ -204,6 +205,8 @@ export async function createPiAgentFromDir(
   // assembly's onAssembly callback (assembly completes before this function returns, so every
   // dispatch sees them). An extra caller observer composes after the hub's (TRUSTED seam).
   let boundaryParts: PiBoundaryWiring | undefined;
+  /** Log-dedup memo for the commands read (see below) — seeded by the boot report the caller prints. */
+  let reportedCommandFindings: string | undefined;
   const caller = options.observer;
   const wantControl = options.sessionControl ?? (config.sessionControl === true && options.serving === true);
   const hub = wantControl
@@ -218,12 +221,22 @@ export async function createPiAgentFromDir(
         // is the agent: a skill added while serving is in play on the next turn, so it must be
         // listable now) and SKILLS-ONLY: this is called when a composer opens its completion list,
         // and the full load's ② context walk buys nothing here.
-        commands: async () =>
-          (await loadAgentSkills(agentDir, { cwd: workspace })).skills.map((skill) => ({
+        commands: async () => {
+          const loaded = await loadAgentSkills(agentDir, { cwd: workspace });
+          // A skill whose frontmatter broke simply is not in `skills` — it would disappear from the
+          // author's composer with no signal anywhere. Same dedup discipline as the turn path: warn
+          // when the finding set CHANGES, so a composer opening twice does not spam.
+          const sig = findingsSignature(loaded);
+          if (sig !== reportedCommandFindings) {
+            reportedCommandFindings = sig;
+            reportDefinitionWarnings(loaded.collisions, loaded.diagnostics);
+          }
+          return loaded.skills.map((skill) => ({
             name: skill.name,
             description: skill.description,
             source: "skill",
-          })),
+          }));
+        },
         // The caller tap's boundary-event half: state_changed/compaction_* originate in the hub
         // and never cross the data plane's observer seam — without this, an audit tap wired here
         // would miss exactly the mutations it most needs to see (set_model).

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -204,12 +204,23 @@ export async function createPiAgentFromDir(
   // assembly's onAssembly callback (assembly completes before this function returns, so every
   // dispatch sees them). An extra caller observer composes after the hub's (TRUSTED seam).
   let boundaryParts: PiBoundaryWiring | undefined;
+  /** Filled by the assembly below, for the same reason as {@link boundaryParts}. */
+  let readDefinition: (() => Promise<LoadedDefinition>) | undefined;
   const caller = options.observer;
   const wantControl = options.sessionControl ?? (config.sessionControl === true && options.serving === true);
   const hub = wantControl
     ? createPiSessionControl({
         sessions,
         boundary: () => boundaryParts,
+        // Skills ARE the commands a user invokes by name — the resolved set, after collisions were
+        // decided first-wins, which a client cannot reconstruct from the directory. Read live: a
+        // skill added while serving is invocable on the next turn, so it must be listable now.
+        commands: async () =>
+          ((await readDefinition?.())?.skills ?? []).map((skill) => ({
+            name: skill.name,
+            description: skill.description,
+            source: "skill",
+          })),
         // The caller tap's boundary-event half: state_changed/compaction_* originate in the hub
         // and never cross the data plane's observer seam — without this, an audit tap wired here
         // would miss exactly the mutations it most needs to see (set_model).
@@ -224,7 +235,7 @@ export async function createPiAgentFromDir(
         }
       : hub.observer
     : caller;
-  const { agent, definition } = await createPiAgentFromDefinition(agentDir, {
+  const assembled = await createPiAgentFromDefinition(agentDir, {
     model: modelSpec,
     thinkingLevel: config.thinkingLevel,
     cwd: workspace,
@@ -244,6 +255,8 @@ export async function createPiAgentFromDir(
         }
       : undefined,
   });
+  const { agent, definition } = assembled;
+  readDefinition = assembled.readDefinition;
   return {
     agent,
     definition,

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -26,7 +26,7 @@ import { type PiBoundaryWiring, createPiSessionControl } from "./session-control
 import type { PiSessionReader, PiSessionStore } from "./sessions.ts";
 import { withWakeTool } from "./wake-tool.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
-import type { LoadedDefinition } from "./definition.ts";
+import { type LoadedDefinition, loadAgentSkills } from "./definition.ts";
 import { jsonlSessionStore } from "./sessions.ts";
 import type { ToolCollision } from "./tool.ts";
 import type { MountedTool } from "./tool.ts";
@@ -204,8 +204,6 @@ export async function createPiAgentFromDir(
   // assembly's onAssembly callback (assembly completes before this function returns, so every
   // dispatch sees them). An extra caller observer composes after the hub's (TRUSTED seam).
   let boundaryParts: PiBoundaryWiring | undefined;
-  /** Filled by the assembly below, for the same reason as {@link boundaryParts}. */
-  let readDefinition: (() => Promise<LoadedDefinition>) | undefined;
   const caller = options.observer;
   const wantControl = options.sessionControl ?? (config.sessionControl === true && options.serving === true);
   const hub = wantControl
@@ -215,18 +213,17 @@ export async function createPiAgentFromDir(
         // Skills ARE the commands a user invokes by name — the resolved set, after collisions were
         // decided first-wins, which a client cannot reconstruct from the directory. Read live: a
         // skill added while serving is invocable on the next turn, so it must be listable now.
-        commands: async () => {
-          // Unlike `boundaryParts` (undefined is a real deployment state, gated in capabilities),
-          // an unset reader here is a WIRING BUG — the hub is unreachable until this function
-          // returns. Answering [] would spell it as "this agent has no names", which the contract
-          // defines as a complete answer.
-          if (!readDefinition) throw new Error("commands() before the assembly ran (opener invariant broken)");
-          return (await readDefinition()).skills.map((skill) => ({
+        // Skills ARE the names a client offers — the resolved set, after collisions were decided
+        // first-wins, which a client cannot reconstruct from the directory. Read LIVE (the directory
+        // is the agent: a skill added while serving is in play on the next turn, so it must be
+        // listable now) and SKILLS-ONLY: this is called when a composer opens its completion list,
+        // and the full load's ② context walk buys nothing here.
+        commands: async () =>
+          (await loadAgentSkills(agentDir, { cwd: workspace })).skills.map((skill) => ({
             name: skill.name,
             description: skill.description,
             source: "skill",
-          }));
-        },
+          })),
         // The caller tap's boundary-event half: state_changed/compaction_* originate in the hub
         // and never cross the data plane's observer seam — without this, an audit tap wired here
         // would miss exactly the mutations it most needs to see (set_model).
@@ -241,7 +238,7 @@ export async function createPiAgentFromDir(
         }
       : hub.observer
     : caller;
-  const assembled = await createPiAgentFromDefinition(agentDir, {
+  const { agent, definition } = await createPiAgentFromDefinition(agentDir, {
     model: modelSpec,
     thinkingLevel: config.thinkingLevel,
     cwd: workspace,
@@ -261,8 +258,6 @@ export async function createPiAgentFromDir(
         }
       : undefined,
   });
-  const { agent, definition } = assembled;
-  readDefinition = assembled.readDefinition;
   return {
     agent,
     definition,

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -25,7 +25,9 @@ function findingsSignature(def: Findings): string {
  */
 const lastFindings = new Map<string, string>();
 
-/** Record the current findings WITHOUT printing — for a caller that already reported them (boot). */
+/** Record the current findings WITHOUT printing — for a caller that already reported them (boot).
+ *  `dir` must be the RESOLVED definition root (`LoadedDefinition.dir`), or two spellings of one path
+ *  become two memos and warn twice. */
 export function noteFindings(dir: string, def: Findings): void {
   lastFindings.set(dir, findingsSignature(def));
 }

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -25,14 +25,16 @@ function findingsSignature(def: Findings): string {
  */
 const lastFindings = new Map<string, string>();
 
-/** Record the current findings WITHOUT printing — for a caller that already reported them (boot).
- *  `dir` must be the RESOLVED definition root (`LoadedDefinition.dir`), or two spellings of one path
- *  become two memos and warn twice. */
-export function noteFindings(dir: string, def: Findings): void {
-  lastFindings.set(dir, findingsSignature(def));
-}
-
-/** Warn only if this dir's finding set changed since the last note/report. */
+/**
+ * THE door for definition findings: warns only when this dir's set CHANGED since the last report.
+ * Every reader calls it — boot, the per-turn live read, the control plane's command list — so a
+ * finding is announced when it appears and never repeated. There is deliberately no "record without
+ * printing" variant: a memo entry that trusts some other caller to have printed would silently
+ * swallow findings for a caller that does not.
+ *
+ * `dir` must be the RESOLVED definition root (`LoadedDefinition.dir`), or two spellings of one path
+ * become two memos and warn twice.
+ */
 export function reportFindingsIfChanged(dir: string, def: Findings): void {
   const sig = findingsSignature(def);
   if (lastFindings.get(dir) === sig) return;

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -8,6 +8,14 @@ import type { SkillCollision } from "./definition.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import type { ToolCollision } from "./tool.ts";
 
+/** Stable identity of a definition's non-fatal findings — the dedup key every reporter of them uses,
+ *  so a finding is warned when it APPEARS and not on every read that happens to notice it. */
+export function findingsSignature(def: { collisions: SkillCollision[]; diagnostics: SkillDiagnostic[] }): string {
+  const collisions = def.collisions.map((c) => `c:${c.name}:${c.winnerPath}:${c.loserPath}`);
+  const diagnostics = def.diagnostics.map((d) => `d:${d.code}:${d.path}`);
+  return [...collisions, ...diagnostics].sort().join("\n");
+}
+
 export function reportDefinitionWarnings(collisions: SkillCollision[], diagnostics: SkillDiagnostic[]): void {
   for (const c of collisions) {
     log.warn(`[fastagent] skill "${c.name}" collision — using ${c.winnerPath}, ignoring ${c.loserPath}`);

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -8,12 +8,34 @@ import type { SkillCollision } from "./definition.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import type { ToolCollision } from "./tool.ts";
 
-/** Stable identity of a definition's non-fatal findings — the dedup key every reporter of them uses,
- *  so a finding is warned when it APPEARS and not on every read that happens to notice it. */
-export function findingsSignature(def: { collisions: SkillCollision[]; diagnostics: SkillDiagnostic[] }): string {
+type Findings = { collisions: SkillCollision[]; diagnostics: SkillDiagnostic[] };
+
+/** Stable identity of a definition's non-fatal findings — the dedup key below. */
+function findingsSignature(def: Findings): string {
   const collisions = def.collisions.map((c) => `c:${c.name}:${c.winnerPath}:${c.loserPath}`);
   const diagnostics = def.diagnostics.map((d) => `d:${d.code}:${d.path}`);
   return [...collisions, ...diagnostics].sort().join("\n");
+}
+
+/**
+ * The last reported finding set PER DEFINITION DIR. One memo for every reader of a definition (the
+ * per-turn live read, the control plane's command list), because the thing being deduped is the
+ * FINDING, not the reader: a newly broken skill deserves one warning, not one per code path that
+ * noticed it, and a static one deserves none at all.
+ */
+const lastFindings = new Map<string, string>();
+
+/** Record the current findings WITHOUT printing — for a caller that already reported them (boot). */
+export function noteFindings(dir: string, def: Findings): void {
+  lastFindings.set(dir, findingsSignature(def));
+}
+
+/** Warn only if this dir's finding set changed since the last note/report. */
+export function reportFindingsIfChanged(dir: string, def: Findings): void {
+  const sig = findingsSignature(def);
+  if (lastFindings.get(dir) === sig) return;
+  lastFindings.set(dir, sig);
+  reportDefinitionWarnings(def.collisions, def.diagnostics);
 }
 
 export function reportDefinitionWarnings(collisions: SkillCollision[], diagnostics: SkillDiagnostic[]): void {

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -48,7 +48,7 @@ import { canonicalPath, loadAgentDefinition } from "./definition.ts";
 import { createPiModelRuntime, probeAuthSource } from "./models.ts";
 import { log } from "../../log.ts";
 import { type ReadonlySessionManager, type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
-import { reportDefinitionWarnings, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
+import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 import { resolveAgentAssembly } from "./open.ts";
 
 /** Adapt coding-agent's resident SessionManager to FastAgent's shared tool-runtime manager port. */
@@ -151,7 +151,7 @@ export async function buildAgentSessionRuntime(
     const model = resolveModel(modelRuntime, modelSpec);
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(agentDir, { cwd, env });
-    reportDefinitionWarnings(definition.collisions, definition.diagnostics);
+    reportFindingsIfChanged(definition.dir, definition);
     const defaultNames = piDefaultTools().map((t) => t.name);
     const customTools = tools.filter((t) => !defaultNames.includes(t.name));
     // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -207,8 +207,7 @@ export interface CreatePiSessionControlOptions {
    *  OPTIONAL because absence is a TRUE answer for the assembly that omits it: a hub over an L1
    *  agent (`createPiAgent({ model, instructions, tools })`) has no definition and therefore no
    *  names, and `[]` says exactly that. Wire it whenever the agent came from a DIRECTORY — there
-   *  `[]` would be a lie, which is why the one production constructor (`open.ts`) throws rather than
-   *  defaults if its reader is missing. */
+   *  `[]` would be a lie; the directory constructor (`createPiAgentFromDir`) always does. */
   commands?: () => Promise<AgentCommand[]>;
   /** Tap for the events the HUB ITSELF generates (boundary mutations: `state_changed`,
    *  `compaction_*`) — those never pass through the data plane's observer seam, so a consumer

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -199,10 +199,16 @@ export interface CreatePiSessionControlOptions {
    *  (assembly completes before any dispatch can arrive). Absent / undefined → boundary commands
    *  are gated off in `capabilities()` and rejected `unsupported_capability`. */
   boundary?: () => PiBoundaryWiring | undefined;
-  /** The definition's names, as a LAZY thunk for the same reason {@link boundary} is
-   *  one (the hub exists before the assembly that can read a definition) — and async because the
-   *  definition is live: this must re-read it, not close over a boot snapshot, or `commands()` would
-   *  advertise a list the next turn no longer runs. Absent → `[]`. */
+  /** The definition's names, as a LAZY thunk for the same reason {@link boundary} is one (the hub
+   *  exists before the assembly that can read a definition) — and async because the definition is
+   *  live: this must re-read it, not close over a boot snapshot, or `commands()` would advertise a
+   *  list the next turn no longer runs.
+   *
+   *  OPTIONAL because absence is a TRUE answer for the assembly that omits it: a hub over an L1
+   *  agent (`createPiAgent({ model, instructions, tools })`) has no definition and therefore no
+   *  names, and `[]` says exactly that. Wire it whenever the agent came from a DIRECTORY — there
+   *  `[]` would be a lie, which is why the one production constructor (`open.ts`) throws rather than
+   *  defaults if its reader is missing. */
   commands?: () => Promise<AgentCommand[]>;
   /** Tap for the events the HUB ITSELF generates (boundary mutations: `state_changed`,
    *  `compaction_*`) — those never pass through the data plane's observer seam, so a consumer

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -199,7 +199,7 @@ export interface CreatePiSessionControlOptions {
    *  (assembly completes before any dispatch can arrive). Absent / undefined → boundary commands
    *  are gated off in `capabilities()` and rejected `unsupported_capability`. */
   boundary?: () => PiBoundaryWiring | undefined;
-  /** The definition's named invocations, as a LAZY thunk for the same reason {@link boundary} is
+  /** The definition's names, as a LAZY thunk for the same reason {@link boundary} is
    *  one (the hub exists before the assembly that can read a definition) — and async because the
    *  definition is live: this must re-read it, not close over a boot snapshot, or `commands()` would
    *  advertise a list the next turn no longer runs. Absent → `[]`. */

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -17,6 +17,7 @@ import type { SessionTreeEntry, ThinkingLevel } from "@earendil-works/pi-agent-c
 import type { Models } from "@earendil-works/pi-ai";
 import { type Json, SESSION_BUSY_CODE } from "../../agent.ts";
 import {
+  type AgentCommand,
   BOUNDARY_COMMAND_FAILED_CODE,
   INVALID_COMMAND_CODE,
   NO_ACTIVE_RUN_CODE,
@@ -198,6 +199,11 @@ export interface CreatePiSessionControlOptions {
    *  (assembly completes before any dispatch can arrive). Absent / undefined → boundary commands
    *  are gated off in `capabilities()` and rejected `unsupported_capability`. */
   boundary?: () => PiBoundaryWiring | undefined;
+  /** The definition's named invocations, as a LAZY thunk for the same reason {@link boundary} is
+   *  one (the hub exists before the assembly that can read a definition) — and async because the
+   *  definition is live: this must re-read it, not close over a boot snapshot, or `commands()` would
+   *  advertise a list the next turn no longer runs. Absent → `[]`. */
+  commands?: () => Promise<AgentCommand[]>;
   /** Tap for the events the HUB ITSELF generates (boundary mutations: `state_changed`,
    *  `compaction_*`) — those never pass through the data plane's observer seam, so a consumer
    *  composing a full-vocabulary tap wires the run events via the observer AND this. Called after
@@ -263,6 +269,10 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
   };
 
   const control: SessionControl = {
+    async commands(): Promise<AgentCommand[]> {
+      return (await options.commands?.()) ?? [];
+    },
+
     capabilities: (): SessionCapabilities => {
       const b = boundary?.();
       return {

--- a/src/session-remote.ts
+++ b/src/session-remote.ts
@@ -123,9 +123,9 @@ export async function connectSessionControl(options: RemoteEndpointOptions): Pro
     capabilities: () => capabilities,
 
     // NOT prefetched like capabilities: a live definition can grow a skill between calls, so the
-    // list is fetched per call. The endpoint is UNCACHED server-side — one full definition load
-    // (every SKILL.md, plus the context-file walk) per request, which is what keeps it honest about
-    // a directory that changes underneath it.
+    // list is fetched per call. The endpoint is UNCACHED server-side (it re-reads the definition's
+    // skills/ per request), which is what keeps it honest about a directory that changes underneath
+    // it.
     commands: () => get<AgentCommand[]>("/control/commands"),
 
     state: (session) => get<SessionState>(`/control/state?session=${encodeURIComponent(session)}`),

--- a/src/session-remote.ts
+++ b/src/session-remote.ts
@@ -125,8 +125,19 @@ export async function connectSessionControl(options: RemoteEndpointOptions): Pro
     // NOT prefetched like capabilities: a live definition can grow a skill between calls, so the
     // list is fetched per call. The endpoint is UNCACHED server-side (it re-reads the definition's
     // skills/ per request), which is what keeps it honest about a directory that changes underneath
-    // it.
-    commands: () => get<AgentCommand[]>("/control/commands"),
+    // it. A 404 is SKEW, not a fault in the definition: without this the two read identically
+    // (uncoded non-2xx), and a client would report "this agent's skills are unreadable" about a
+    // serve that simply predates the route.
+    async commands() {
+      try {
+        return await get<AgentCommand[]>("/control/commands");
+      } catch (error) {
+        if (error instanceof ControlRequestError && error.status === 404) {
+          throw new ControlRequestError(404, "this serve does not implement /control/commands (it predates the route)");
+        }
+        throw error;
+      }
+    },
 
     state: (session) => get<SessionState>(`/control/state?session=${encodeURIComponent(session)}`),
 

--- a/src/session-remote.ts
+++ b/src/session-remote.ts
@@ -123,9 +123,9 @@ export async function connectSessionControl(options: RemoteEndpointOptions): Pro
     capabilities: () => capabilities,
 
     // NOT prefetched like capabilities: a live definition can grow a skill between calls, so the
-    // list is fetched per call. The RESPONSE is small; the server-side work is a full definition
-    // load (every SKILL.md, plus the context-file walk) — fine for a composer opening its
-    // completion list, wrong to poll on a timer.
+    // list is fetched per call. The endpoint is UNCACHED server-side — one full definition load
+    // (every SKILL.md, plus the context-file walk) per request, which is what keeps it honest about
+    // a directory that changes underneath it.
     commands: () => get<AgentCommand[]>("/control/commands"),
 
     state: (session) => get<SessionState>(`/control/state?session=${encodeURIComponent(session)}`),

--- a/src/session-remote.ts
+++ b/src/session-remote.ts
@@ -123,7 +123,9 @@ export async function connectSessionControl(options: RemoteEndpointOptions): Pro
     capabilities: () => capabilities,
 
     // NOT prefetched like capabilities: a live definition can grow a skill between calls, so the
-    // list is fetched per call — it is small by contract, same as state().
+    // list is fetched per call. The RESPONSE is small; the server-side work is a full definition
+    // load (every SKILL.md, plus the context-file walk) — fine for a composer opening its
+    // completion list, wrong to poll on a timer.
     commands: () => get<AgentCommand[]>("/control/commands"),
 
     state: (session) => get<SessionState>(`/control/state?session=${encodeURIComponent(session)}`),

--- a/src/session-remote.ts
+++ b/src/session-remote.ts
@@ -59,7 +59,14 @@ function idleWatchdog(abort: AbortController): ReadWatch {
     stop: () => clearInterval(timer),
   };
 }
-import type { SessionCapabilities, SessionControl, SessionEntries, SessionEvent, SessionState } from "./session.ts";
+import type {
+  AgentCommand,
+  SessionCapabilities,
+  SessionControl,
+  SessionEntries,
+  SessionEvent,
+  SessionState,
+} from "./session.ts";
 
 /** A control request the server answered with a non-2xx status. Carries the STRUCTURED status so a
  *  consumer distinguishing auth failure (401 — stale token, unrecoverable) from transient transport
@@ -114,6 +121,10 @@ export async function connectSessionControl(options: RemoteEndpointOptions): Pro
 
   return {
     capabilities: () => capabilities,
+
+    // NOT prefetched like capabilities: a live definition can grow a skill between calls, so the
+    // list is fetched per call — it is small by contract, same as state().
+    commands: () => get<AgentCommand[]>("/control/commands"),
 
     state: (session) => get<SessionState>(`/control/state?session=${encodeURIComponent(session)}`),
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -12,6 +12,11 @@ import type { Json, Prompt } from "./agent.ts";
 
 export interface SessionControl {
   capabilities(): SessionCapabilities;
+  /** The named invocations this agent exposes — what a composer's `/` completion lists. Sessionless
+   *  (the definition is a deployment fact, not a per-session one) but ASYNC, because a definition is
+   *  allowed to be live: an implementation that re-reads it per turn must answer from that same read
+   *  or the list and the behavior diverge. `[]` is a complete answer, not a missing one. */
+  commands(): Promise<AgentCommand[]>;
   state(session: string): Promise<SessionState>;
   /** `since` is an APPEND-ORDER position cursor: "every record appended after the one with this
    *  id", regardless of branch structure. Reconstructing the active path in a branched session is
@@ -52,6 +57,18 @@ export interface SessionCapabilities {
   navigate: boolean;
   toolProgress: boolean;
   usage: boolean;
+}
+
+/**
+ * One named invocation a user can type (pi's slash commands, and the same fields its RPC
+ * `get_commands` answers with, so a client can map 1:1). `source` is FREE-FORM on purpose: which
+ * kinds exist is an engine's business ("skill" is the only one fastagent assembles today), and an
+ * engine with none returns an empty list rather than the contract enumerating a closed set.
+ */
+export interface AgentCommand {
+  name: string;
+  description?: string;
+  source: string;
 }
 
 /** Stable `SessionResult.error.code` for a command the implementation does not support. */

--- a/src/session.ts
+++ b/src/session.ts
@@ -12,10 +12,13 @@ import type { Json, Prompt } from "./agent.ts";
 
 export interface SessionControl {
   capabilities(): SessionCapabilities;
-  /** The named invocations this agent exposes — what a composer's `/` completion lists. Sessionless
-   *  (the definition is a deployment fact, not a per-session one) but ASYNC, because a definition is
-   *  allowed to be live: an implementation that re-reads it per turn must answer from that same read
-   *  or the list and the behavior diverge. `[]` is a complete answer, not a missing one. */
+  /** The names this agent exposes — what a composer's `/` completion LISTS. A listing, not a
+   *  dispatch surface: the data plane takes prompts as text, so what typing one means (expanding it,
+   *  sending "use the X skill", filtering a menu) is the client's business. Sessionless (the
+   *  definition is a deployment fact) but ASYNC, because a definition is allowed to be live: an
+   *  implementation that re-reads it per turn must answer from that same read, or the list and the
+   *  behavior diverge. `[]` is a complete answer, not a missing one; a definition the implementation
+   *  cannot read at all is a deployment fault and MAY reject. */
   commands(): Promise<AgentCommand[]>;
   state(session: string): Promise<SessionState>;
   /** `since` is an APPEND-ORDER position cursor: "every record appended after the one with this
@@ -60,10 +63,11 @@ export interface SessionCapabilities {
 }
 
 /**
- * One named invocation a user can type (pi's slash commands, and the same fields its RPC
- * `get_commands` answers with, so a client can map 1:1). `source` is FREE-FORM on purpose: which
- * kinds exist is an engine's business ("skill" is the only one fastagent assembles today), and an
- * engine with none returns an empty list rather than the contract enumerating a closed set.
+ * One name a client can offer the user. Field NAMES follow pi's RPC `get_commands` so a client
+ * porting from it maps directly; its `sourceInfo` (file provenance) is deliberately not carried, and
+ * `source` is a free-form string rather than pi's closed union — which kinds exist is an engine's
+ * business ("skill" is the only one fastagent assembles today), and an engine with none answers `[]`
+ * rather than the contract enumerating a set it cannot know.
  */
 export interface AgentCommand {
   name: string;

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -67,11 +67,13 @@ async function serveControl() {
     commands: async () => [...commandList],
   });
   const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
-  const server = serveNode(router(controlRoutes(control, { token: TOKEN, agent })), { port: 0 });
+  const mounted = controlRoutes(control, { token: TOKEN, agent });
+  const server = serveNode(router(mounted), { port: 0 });
   const port = await server.listening;
   return {
     agent,
     commandList,
+    routeKeys: Object.keys(mounted),
     localControl: control,
     url: `http://127.0.0.1:${port}`,
     close: () => server.close(),
@@ -89,12 +91,11 @@ describe("session control over HTTP (Phase 3)", () => {
   it("fails closed: no/wrong token is 401 on every route, and connect() rejects", async () => {
     const served = await serveControl();
     try {
-      // DERIVED from the mounted route keys, not a hand-kept list: "every control route requires the
-      // token" must fail when a NEW route forgets `guard`, which a literal array cannot do.
-      const { control } = createPiSessionControl({ sessions: inMemorySessionStore() });
-      const keys = Object.keys(controlRoutes(control, { token: TOKEN, agent: served.agent }));
-      expect(keys.length).toBeGreaterThan(5);
-      for (const key of keys) {
+      // DERIVED from the routes this server actually MOUNTS — not a hand-kept list, and not a second
+      // controlRoutes() call that could drift from it: "every control route requires the token" has
+      // to fail when a NEW route forgets `guard`, which a literal array cannot do.
+      expect(served.routeKeys.length).toBeGreaterThan(5);
+      for (const key of served.routeKeys) {
         const [method, path] = key.split(" ") as [string, string];
         const url = `${served.url}${path}?session=s`;
         expect((await fetch(url, { method, body: method === "POST" ? "{}" : undefined })).status).toBe(401);

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -649,6 +649,57 @@ describe("session control over HTTP (Phase 3)", () => {
     expect(activePathSlice(slice, "older")).toEqual([]);
   });
 
+  it("answerSlashInput: every reserved-slash answer, and the order they arrive in", async () => {
+    const { answerSlashInput } = await import("../src/cli/commands/attach.ts");
+    const commands = [
+      { name: "triage", description: "Sort an inbox", source: "skill" },
+      { name: "digest", source: "skill" },
+    ];
+    const say = (list: typeof commands | Error) => {
+      const lines: string[] = [];
+      const control = {
+        commands: async () => {
+          if (list instanceof Error) throw list;
+          return list;
+        },
+      };
+      return { lines, run: (input: string) => answerSlashInput(input, control as never, (l) => lines.push(l)) };
+    };
+
+    // A mistyped control command: the reserved-prefix line is certain and lands FIRST (before the
+    // remote read resolves), and the token is reported as naming nothing — not answered with a dump
+    // of every skill, which is an intent the typo did not express.
+    const typo = say(commands);
+    const pending = typo.run("/aboort");
+    expect(typo.lines).toEqual([
+      "[a leading / is reserved — /abort stops the run, /commands lists what this agent defines]",
+    ]);
+    await pending;
+    expect(typo.lines[1]).toBe("[/aboort names nothing this agent defines]");
+
+    // A real name, WITH arguments: the first word is the token — the whole line would answer "names
+    // nothing" for a name the user did give.
+    const named = say(commands);
+    await named.run("/triage summarize my inbox");
+    expect(named.lines[1]).toBe("[triage is a skill — Sort an inbox; name it in a normal message, without the /]");
+
+    // The enumeration: `/commands` alone, with descriptions, and NO reserved-prefix preamble (its
+    // whole answer is the read).
+    const listed = say(commands);
+    await listed.run("/commands");
+    expect(listed.lines).toEqual(["[this agent defines: triage — Sort an inbox; digest]"]);
+
+    const none = say([]);
+    await none.run("/commands");
+    expect(none.lines).toEqual(["[this agent defines no names]"]);
+
+    // The read may reject (an unreadable definition, or a serve predating the route): said, not
+    // swallowed — an unhandled rejection here would leave the user with only the preamble.
+    const broken = say(new Error("boom"));
+    await broken.run("/triage");
+    expect(broken.lines[1]).toContain("command list unavailable");
+  });
+
   it("decideRound: every reconnect-loop diagnosis and budget claim, pinned", async () => {
     const { decideRound } = await import("../src/cli/commands/attach.ts");
     const err = (over: Partial<Parameters<typeof decideRound>[0] & { type: "error" }> = {}) =>

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -25,11 +25,12 @@ const TOKEN = "test-token";
 
 /** A served control plane over a real HTTP server + the agent driving it. Reasoning-capable model:
  *  thinking levels are per model, and the default faux supports only "off". */
-/** The command list the served control answers with — mutable, so a test can change it mid-connection. */
-let commandList: Array<{ name: string; description?: string; source: string }> = [];
-
 async function serveControl() {
-  commandList = [{ name: "triage", description: "Sort an inbox", source: "skill" }];
+  /** What the served control answers `commands()` with — mutable, so a test can change it while a
+   *  client is connected (the definition behind it is live). */
+  const commandList: Array<{ name: string; description?: string; source: string }> = [
+    { name: "triage", description: "Sort an inbox", source: "skill" },
+  ];
   const { faux, models } = makeFaux({ models: [{ id: "faux-thinker", reasoning: true }] });
   faux.setResponses([fauxAssistantMessage("hello over the wire")]);
   const sessions = inMemorySessionStore();
@@ -63,13 +64,14 @@ async function serveControl() {
     // A non-empty, MUTABLE list: non-empty so the isomorphism check compares a real payload rather
     // than [] === [], mutable so the wire is pinned as per-call rather than prefetched-and-cached
     // like capabilities (the definition it answers for is live).
-    commands: async () => commandList,
+    commands: async () => [...commandList],
   });
   const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
   const server = serveNode(router(controlRoutes(control, { token: TOKEN, agent })), { port: 0 });
   const port = await server.listening;
   return {
     agent,
+    commandList,
     localControl: control,
     url: `http://127.0.0.1:${port}`,
     close: () => server.close(),
@@ -87,12 +89,25 @@ describe("session control over HTTP (Phase 3)", () => {
   it("fails closed: no/wrong token is 401 on every route, and connect() rejects", async () => {
     const served = await serveControl();
     try {
-      for (const path of ["/control/capabilities", "/control/state?session=s", "/control/events?session=s"]) {
-        expect((await fetch(`${served.url}${path}`)).status).toBe(401);
-        expect((await fetch(`${served.url}${path}`, { headers: { authorization: "Bearer wrong" } })).status).toBe(401);
+      // DERIVED from the mounted route keys, not a hand-kept list: "every control route requires the
+      // token" must fail when a NEW route forgets `guard`, which a literal array cannot do.
+      const { control } = createPiSessionControl({ sessions: inMemorySessionStore() });
+      const keys = Object.keys(controlRoutes(control, { token: TOKEN, agent: served.agent }));
+      expect(keys.length).toBeGreaterThan(5);
+      for (const key of keys) {
+        const [method, path] = key.split(" ") as [string, string];
+        const url = `${served.url}${path}?session=s`;
+        expect((await fetch(url, { method, body: method === "POST" ? "{}" : undefined })).status).toBe(401);
+        expect(
+          (
+            await fetch(url, {
+              method,
+              body: method === "POST" ? "{}" : undefined,
+              headers: { authorization: "Bearer wrong" },
+            })
+          ).status,
+        ).toBe(401);
       }
-      const dispatch = await fetch(`${served.url}/control/dispatch`, { method: "POST", body: "{}" });
-      expect(dispatch.status).toBe(401);
       await expect(connectSessionControl({ url: served.url, token: "wrong" })).rejects.toThrow(/401/);
     } finally {
       served.close();
@@ -107,9 +122,6 @@ describe("session control over HTTP (Phase 3)", () => {
 
       expect(remote.capabilities()).toEqual(served.localControl.capabilities());
       expect(await remote.commands()).toEqual(await served.localControl.commands());
-      // Per call, not cached at connect: the definition behind it is live.
-      commandList = [...commandList, { name: "digest", source: "skill" }];
-      expect((await remote.commands()).map((c) => c.name)).toEqual(["triage", "digest"]);
       expect(await remote.state("sW")).toEqual(await served.localControl.state("sW"));
       const [remoteEntries, localEntries] = [await remote.entries("sW"), await served.localControl.entries("sW")];
       expect(remoteEntries).toEqual(localEntries);
@@ -129,6 +141,20 @@ describe("session control over HTTP (Phase 3)", () => {
       const target = localEntries.entries.find((e) => e.kind === "user")?.id as string;
       expect(await remote.dispatch("sW", { type: "navigate", targetId: target })).toEqual({ ok: true });
       expect((await remote.state("sW")).leafEntryId).toBe(target);
+    } finally {
+      served.close();
+    }
+  });
+
+  it("commands() is read per call, not cached at connect like capabilities", async () => {
+    // Why the method is async at all: the definition behind it is live, so a list fetched once at
+    // connect would advertise names the running agent has already left behind.
+    const served = await serveControl();
+    try {
+      const remote = await connectSessionControl({ url: served.url, token: TOKEN });
+      expect((await remote.commands()).map((c) => c.name)).toEqual(["triage"]);
+      served.commandList.push({ name: "digest", source: "skill" });
+      expect((await remote.commands()).map((c) => c.name)).toEqual(["triage", "digest"]);
     } finally {
       served.close();
     }

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -25,7 +25,11 @@ const TOKEN = "test-token";
 
 /** A served control plane over a real HTTP server + the agent driving it. Reasoning-capable model:
  *  thinking levels are per model, and the default faux supports only "off". */
+/** The command list the served control answers with — mutable, so a test can change it mid-connection. */
+let commandList: Array<{ name: string; description?: string; source: string }> = [];
+
 async function serveControl() {
+  commandList = [{ name: "triage", description: "Sort an inbox", source: "skill" }];
   const { faux, models } = makeFaux({ models: [{ id: "faux-thinker", reasoning: true }] });
   faux.setResponses([fauxAssistantMessage("hello over the wire")]);
   const sessions = inMemorySessionStore();
@@ -56,8 +60,10 @@ async function serveControl() {
       harnessFactory: factory,
       defaults: { model: faux.getModel(), thinkingLevel: "medium" },
     }),
-    // A non-empty list, so the isomorphism check below compares a real payload rather than [] === [].
-    commands: async () => [{ name: "triage", description: "Sort an inbox", source: "skill" }],
+    // A non-empty, MUTABLE list: non-empty so the isomorphism check compares a real payload rather
+    // than [] === [], mutable so the wire is pinned as per-call rather than prefetched-and-cached
+    // like capabilities (the definition it answers for is live).
+    commands: async () => commandList,
   });
   const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
   const server = serveNode(router(controlRoutes(control, { token: TOKEN, agent })), { port: 0 });
@@ -101,6 +107,9 @@ describe("session control over HTTP (Phase 3)", () => {
 
       expect(remote.capabilities()).toEqual(served.localControl.capabilities());
       expect(await remote.commands()).toEqual(await served.localControl.commands());
+      // Per call, not cached at connect: the definition behind it is live.
+      commandList = [...commandList, { name: "digest", source: "skill" }];
+      expect((await remote.commands()).map((c) => c.name)).toEqual(["triage", "digest"]);
       expect(await remote.state("sW")).toEqual(await served.localControl.state("sW"));
       const [remoteEntries, localEntries] = [await remote.entries("sW"), await served.localControl.entries("sW")];
       expect(remoteEntries).toEqual(localEntries);
@@ -229,6 +238,32 @@ describe("session control over HTTP (Phase 3)", () => {
         expect(rejected.ok).toBe(false);
         expect(rejected.error?.code).toBe("invalid_command");
       }
+    } finally {
+      server.close();
+    }
+  });
+
+  it("a definition it cannot read is a deployment fault: commands() rejects, and the wire has no code for it", async () => {
+    // The one failure the contract admits on this read — `[]` would claim the agent has no names.
+    // A client author should see what it looks like: an opaque non-2xx, not a coded answer. That is
+    // the read-side gap tracked on the session-lifecycle issue, not a special case of this route.
+    const { control } = createPiSessionControl({
+      sessions: inMemorySessionStore(),
+      commands: async () => {
+        throw new Error("skills/ unreadable: permission denied");
+      },
+    });
+    const server = serveNode(router(controlRoutes(control, { token: TOKEN })), { port: 0 });
+    const port = await server.listening;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/control/commands`, {
+        headers: { authorization: `Bearer ${TOKEN}` },
+      });
+      expect(res.ok).toBe(false);
+      expect(res.status).toBeGreaterThanOrEqual(500);
+      const { ControlRequestError } = await import("../src/session-remote.ts");
+      const remote = await connectSessionControl({ url: `http://127.0.0.1:${port}`, token: TOKEN });
+      await expect(remote.commands()).rejects.toBeInstanceOf(ControlRequestError);
     } finally {
       server.close();
     }

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -147,6 +147,21 @@ describe("session control over HTTP (Phase 3)", () => {
     }
   });
 
+  it("a serve without the route reads as SKEW, not as an unreadable definition", async () => {
+    // Both arrive as an uncoded non-2xx; without the distinction a client reports "this agent's
+    // skills are unreadable" about a serve that simply predates the route.
+    const { control } = createPiSessionControl({ sessions: inMemorySessionStore() });
+    const { "GET /control/commands": _dropped, ...withoutCommands } = controlRoutes(control, { token: TOKEN });
+    const server = serveNode(router(withoutCommands), { port: 0 });
+    const port = await server.listening;
+    try {
+      const remote = await connectSessionControl({ url: `http://127.0.0.1:${port}`, token: TOKEN });
+      await expect(remote.commands()).rejects.toThrow(/predates the route/);
+    } finally {
+      server.close();
+    }
+  });
+
   it("commands() is read per call, not cached at connect like capabilities", async () => {
     // Why the method is async at all: the definition behind it is live, so a list fetched once at
     // connect would advertise names the running agent has already left behind.

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -94,7 +94,7 @@ describe("session control over HTTP (Phase 3)", () => {
       // DERIVED from the routes this server actually MOUNTS — not a hand-kept list, and not a second
       // controlRoutes() call that could drift from it: "every control route requires the token" has
       // to fail when a NEW route forgets `guard`, which a literal array cannot do.
-      expect(served.routeKeys.length).toBeGreaterThan(5);
+      expect(served.routeKeys).toContain("GET /control/commands"); // the route this PR adds is in the sweep
       for (const key of served.routeKeys) {
         const [method, path] = key.split(" ") as [string, string];
         const url = `${served.url}${path}?session=s`;

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -56,6 +56,8 @@ async function serveControl() {
       harnessFactory: factory,
       defaults: { model: faux.getModel(), thinkingLevel: "medium" },
     }),
+    // A non-empty list, so the isomorphism check below compares a real payload rather than [] === [].
+    commands: async () => [{ name: "triage", description: "Sort an inbox", source: "skill" }],
   });
   const agent = createPiAgentFromHarness({ observer, lease, harnessFactory: factory });
   const server = serveNode(router(controlRoutes(control, { token: TOKEN, agent })), { port: 0 });
@@ -98,6 +100,7 @@ describe("session control over HTTP (Phase 3)", () => {
       const remote = await connectSessionControl({ url: served.url, token: TOKEN });
 
       expect(remote.capabilities()).toEqual(served.localControl.capabilities());
+      expect(await remote.commands()).toEqual(await served.localControl.commands());
       expect(await remote.state("sW")).toEqual(await served.localControl.state("sW"));
       const [remoteEntries, localEntries] = [await remote.entries("sW"), await served.localControl.entries("sW")];
       expect(remoteEntries).toEqual(localEntries);

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -1,11 +1,6 @@
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  noteFindings,
-  reportDefinitionWarnings,
-  reportFindingsIfChanged,
-  reportToolCollisions,
-} from "../src/engines/pi/report.ts";
+import { reportDefinitionWarnings, reportFindingsIfChanged, reportToolCollisions } from "../src/engines/pi/report.ts";
 
 // Locks the warning WORDING shared by the CLI runners and `chat` (the reason A1 deduped these into one
 // module: two copies could drift). Spies on console.error rather than going through a runner.
@@ -42,9 +37,11 @@ describe("report", () => {
     reportFindingsIfChanged("/other-agent", findings);
     expect(lines(err)).toMatch(/invalid_metadata/);
     err.mockClear();
-    // … and a boot report is recorded, not re-printed, by the reader that follows it.
-    noteFindings("/third-agent", findings);
-    reportFindingsIfChanged("/third-agent", findings);
+    // There is no record-without-printing door: the boot report goes through this same function, so
+    // a caller that never reports cannot silently consume the announcement for every later reader.
+    reportFindingsIfChanged("/third-agent", findings); // boot
+    err.mockClear();
+    reportFindingsIfChanged("/third-agent", findings); // a turn, then commands() — already said
     expect(err).not.toHaveBeenCalled();
   });
 

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -1,6 +1,11 @@
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { reportDefinitionWarnings, reportToolCollisions } from "../src/engines/pi/report.ts";
+import {
+  noteFindings,
+  reportDefinitionWarnings,
+  reportFindingsIfChanged,
+  reportToolCollisions,
+} from "../src/engines/pi/report.ts";
 
 // Locks the warning WORDING shared by the CLI runners and `chat` (the reason A1 deduped these into one
 // module: two copies could drift). Spies on console.error rather than going through a runner.
@@ -15,6 +20,32 @@ describe("report", () => {
     ] as SkillDiagnostic[]);
     expect(lines(err)).toMatch(/skill "greet" collision — using \/a\/SKILL.md, ignoring \/b\/SKILL.md/);
     expect(lines(err)).toMatch(/invalid_metadata: description is required \(\/c\/SKILL.md\)/);
+  });
+
+  it("the findings memo is per DEFINITION, not per reader: two readers of one dir warn once", () => {
+    // Why the memo is module state keyed by the resolved dir instead of a closure inside the
+    // assembly: the thing being deduped is the FINDING. A broken skill discovered by the turn's live
+    // read and then by the control plane's command list is ONE event for the author.
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const findings = {
+      collisions: [],
+      diagnostics: [
+        { type: "warning", code: "invalid_metadata", message: "description is required", path: "/a/x/SKILL.md" },
+      ] as SkillDiagnostic[],
+    };
+    reportFindingsIfChanged("/agent", findings); // reader A (a turn)
+    expect(lines(err)).toMatch(/invalid_metadata/);
+    err.mockClear();
+    reportFindingsIfChanged("/agent", findings); // reader B (commands()) — same finding, same dir
+    expect(err).not.toHaveBeenCalled();
+    // A DIFFERENT definition keeps its own budget …
+    reportFindingsIfChanged("/other-agent", findings);
+    expect(lines(err)).toMatch(/invalid_metadata/);
+    err.mockClear();
+    // … and a boot report is recorded, not re-printed, by the reader that follows it.
+    noteFindings("/third-agent", findings);
+    reportFindingsIfChanged("/third-agent", findings);
+    expect(err).not.toHaveBeenCalled();
   });
 
   it("renders tool collisions to stderr", () => {

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -380,22 +380,6 @@ describe("session control (Phase 1): observation plane", () => {
         `---\nname: triage\ndescription: A second claim on the same name\n---\n\nDo it differently.\n`,
       );
       expect(await control.commands()).toEqual([{ name: "triage", description: "Sort an inbox", source: "skill" }]);
-      // A skill that FAILED to load is simply absent from the list, so the read is also the only
-      // place that can say so — warned when the finding set changes, silent when it has not (a
-      // composer opening twice must not spam).
-      const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
-      try {
-        await mkdir(join(dir, "fastagent", "skills", "broken"), { recursive: true });
-        await writeFile(join(dir, "fastagent", "skills", "broken", "SKILL.md"), `no frontmatter here\n`);
-        expect((await control.commands()).map((c) => c.name)).toEqual(["triage"]); // the broken one is gone …
-        expect(warn.mock.calls.flat().join(" ")).toContain("broken"); // … and said so, once
-        warn.mockClear();
-        await control.commands();
-        expect(warn).not.toHaveBeenCalled();
-      } finally {
-        warn.mockRestore();
-      }
-
       // Live in BOTH directions — a cached read would only ever grow the list.
       await rm(join(dir, "fastagent", "skills"), { recursive: true, force: true });
       expect(await control.commands()).toEqual([]);
@@ -1060,6 +1044,38 @@ describe("session control (Phase 2b): boundary mutations", () => {
       "sB1",
     );
     expect(resolved.thinkingLevel).toBe("high");
+  });
+
+  it("a skill that failed to load is absent from commands() and warned once", async () => {
+    const { mkdtemp, mkdir, rm, writeFile } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "fa-sc-bad-"));
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      await mkdir(join(dir, "fastagent"), { recursive: true });
+      await writeFile(
+        join(dir, "fastagent", "fastagent.config.mjs"),
+        `export default { model: "openai-codex/gpt-5.5" };\n`,
+      );
+      const opened = await createPiAgentFromDir(dir, { sessionControl: true });
+      const control = opened.sessionControl as NonNullable<typeof opened.sessionControl>;
+      // Broken AFTER boot — which is the case the read exists for: a finding already present at
+      // startup was reported by the caller's boot report, and re-printing it is the spam the memo
+      // prevents (test/report.test.ts pins that half).
+      await mkdir(join(dir, "fastagent", "skills", "broken"), { recursive: true });
+      await writeFile(join(dir, "fastagent", "skills", "broken", "SKILL.md"), `no frontmatter here\n`);
+      // The broken file cannot be listed — so this read is the only place that can say it exists.
+      expect(await control.commands()).toEqual([]);
+      expect(warn.mock.calls.flat().join(" ")).toContain("broken");
+      // … once: a composer opening twice must not spam a finding that has not changed.
+      warn.mockClear();
+      await control.commands();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("navigate moves the leaf, so the NEXT turn branches from the target", async () => {

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -6,7 +6,8 @@
  */
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type, type FauxResponseStep, fauxAssistantMessage, fauxThinking, fauxToolCall } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { log } from "../src/log.ts";
 import { ABORTED_CODE, type AgentEvent } from "../src/agent.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
@@ -379,6 +380,22 @@ describe("session control (Phase 1): observation plane", () => {
         `---\nname: triage\ndescription: A second claim on the same name\n---\n\nDo it differently.\n`,
       );
       expect(await control.commands()).toEqual([{ name: "triage", description: "Sort an inbox", source: "skill" }]);
+      // A skill that FAILED to load is simply absent from the list, so the read is also the only
+      // place that can say so — warned when the finding set changes, silent when it has not (a
+      // composer opening twice must not spam).
+      const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+      try {
+        await mkdir(join(dir, "fastagent", "skills", "broken"), { recursive: true });
+        await writeFile(join(dir, "fastagent", "skills", "broken", "SKILL.md"), `no frontmatter here\n`);
+        expect((await control.commands()).map((c) => c.name)).toEqual(["triage"]); // the broken one is gone …
+        expect(warn.mock.calls.flat().join(" ")).toContain("broken"); // … and said so, once
+        warn.mockClear();
+        await control.commands();
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+
       // Live in BOTH directions — a cached read would only ever grow the list.
       await rm(join(dir, "fastagent", "skills"), { recursive: true, force: true });
       expect(await control.commands()).toEqual([]);

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -319,6 +319,38 @@ describe("session control (Phase 1): observation plane", () => {
     expect(text).toBe("resilient");
   });
 
+  it("a skill that failed to load is absent from commands() and warned once", async () => {
+    const { mkdtemp, mkdir, rm, writeFile } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "fa-sc-bad-"));
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      await mkdir(join(dir, "fastagent"), { recursive: true });
+      await writeFile(
+        join(dir, "fastagent", "fastagent.config.mjs"),
+        `export default { model: "openai-codex/gpt-5.5" };\n`,
+      );
+      const opened = await createPiAgentFromDir(dir, { sessionControl: true });
+      const control = opened.sessionControl as NonNullable<typeof opened.sessionControl>;
+      // Broken AFTER boot — which is the case the read exists for: a finding already present at
+      // startup was reported by the caller's boot report, and re-printing it is the spam the memo
+      // prevents (test/report.test.ts pins that half).
+      await mkdir(join(dir, "fastagent", "skills", "broken"), { recursive: true });
+      await writeFile(join(dir, "fastagent", "skills", "broken", "SKILL.md"), `no frontmatter here\n`);
+      // The broken file cannot be listed — so this read is the only place that can say it exists.
+      expect(await control.commands()).toEqual([]);
+      expect(warn.mock.calls.flat().join(" ")).toContain("broken");
+      // … once: a composer opening twice must not spam a finding that has not changed.
+      warn.mockClear();
+      await control.commands();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("workspace opener wires the hub itself (sessionControl: true) — the seam is executable", async () => {
     const { mkdtemp, rm, writeFile } = await import("node:fs/promises");
     const { tmpdir } = await import("node:os");
@@ -1044,38 +1076,6 @@ describe("session control (Phase 2b): boundary mutations", () => {
       "sB1",
     );
     expect(resolved.thinkingLevel).toBe("high");
-  });
-
-  it("a skill that failed to load is absent from commands() and warned once", async () => {
-    const { mkdtemp, mkdir, rm, writeFile } = await import("node:fs/promises");
-    const { tmpdir } = await import("node:os");
-    const { join } = await import("node:path");
-    const dir = await mkdtemp(join(tmpdir(), "fa-sc-bad-"));
-    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
-    try {
-      await mkdir(join(dir, "fastagent"), { recursive: true });
-      await writeFile(
-        join(dir, "fastagent", "fastagent.config.mjs"),
-        `export default { model: "openai-codex/gpt-5.5" };\n`,
-      );
-      const opened = await createPiAgentFromDir(dir, { sessionControl: true });
-      const control = opened.sessionControl as NonNullable<typeof opened.sessionControl>;
-      // Broken AFTER boot — which is the case the read exists for: a finding already present at
-      // startup was reported by the caller's boot report, and re-printing it is the spam the memo
-      // prevents (test/report.test.ts pins that half).
-      await mkdir(join(dir, "fastagent", "skills", "broken"), { recursive: true });
-      await writeFile(join(dir, "fastagent", "skills", "broken", "SKILL.md"), `no frontmatter here\n`);
-      // The broken file cannot be listed — so this read is the only place that can say it exists.
-      expect(await control.commands()).toEqual([]);
-      expect(warn.mock.calls.flat().join(" ")).toContain("broken");
-      // … once: a composer opening twice must not spam a finding that has not changed.
-      warn.mockClear();
-      await control.commands();
-      expect(warn).not.toHaveBeenCalled();
-    } finally {
-      warn.mockRestore();
-      await rm(dir, { recursive: true, force: true });
-    }
   });
 
   it("navigate moves the leaf, so the NEXT turn branches from the target", async () => {

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -341,8 +341,26 @@ describe("session control (Phase 1): observation plane", () => {
       // Not requested → not built.
       const plain = await createPiAgentFromDir(dir, {});
       expect(plain.sessionControl).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 
-      // commands(): the definition's named invocations. Empty is a complete answer …
+  it("commands() re-reads the definition per call: added and removed skills, collisions first-wins", async () => {
+    const { mkdtemp, mkdir, rm, writeFile } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "fa-sc-cmd-"));
+    try {
+      await mkdir(join(dir, "fastagent"));
+      await writeFile(
+        join(dir, "fastagent", "fastagent.config.mjs"),
+        `export default { model: "openai-codex/gpt-5.5" };\n`,
+      );
+      const opened = await createPiAgentFromDir(dir, { sessionControl: true });
+      const control = opened.sessionControl as NonNullable<typeof opened.sessionControl>;
+
+      // Empty is a complete answer …
       expect(await control.commands()).toEqual([]);
       // … and the read is LIVE, like the definition itself: a skill written while serving is
       // invocable on the next turn, so it must be listable NOW — a boot snapshot would advertise a

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -341,6 +341,18 @@ describe("session control (Phase 1): observation plane", () => {
       // Not requested → not built.
       const plain = await createPiAgentFromDir(dir, {});
       expect(plain.sessionControl).toBeUndefined();
+
+      // commands(): the definition's named invocations. Empty is a complete answer …
+      expect(await control.commands()).toEqual([]);
+      // … and the read is LIVE, like the definition itself: a skill written while serving is
+      // invocable on the next turn, so it must be listable NOW — a boot snapshot would advertise a
+      // command set the running agent has already left behind.
+      await mkdir(join(dir, "fastagent", "skills", "triage"), { recursive: true });
+      await writeFile(
+        join(dir, "fastagent", "skills", "triage", "SKILL.md"),
+        `---\nname: triage\ndescription: Sort an inbox\n---\n\nDo the thing.\n`,
+      );
+      expect(await control.commands()).toEqual([{ name: "triage", description: "Sort an inbox", source: "skill" }]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -378,7 +378,7 @@ describe("session control (Phase 1): observation plane", () => {
         join(dir, "fastagent", "skills", "triage-copy", "SKILL.md"),
         `---\nname: triage\ndescription: A second claim on the same name\n---\n\nDo it differently.\n`,
       );
-      expect((await control.commands()).map((c) => c.name)).toEqual(["triage"]);
+      expect(await control.commands()).toEqual([{ name: "triage", description: "Sort an inbox", source: "skill" }]);
       // Live in BOTH directions — a cached read would only ever grow the list.
       await rm(join(dir, "fastagent", "skills"), { recursive: true, force: true });
       expect(await control.commands()).toEqual([]);

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -353,6 +353,17 @@ describe("session control (Phase 1): observation plane", () => {
         `---\nname: triage\ndescription: Sort an inbox\n---\n\nDo the thing.\n`,
       );
       expect(await control.commands()).toEqual([{ name: "triage", description: "Sort an inbox", source: "skill" }]);
+      // The RESOLVED set, which is the reason this read exists: a same-name collision is decided
+      // first-wins at assembly, and a client reading the directory would list the name twice.
+      await mkdir(join(dir, "fastagent", "skills", "triage-copy"), { recursive: true });
+      await writeFile(
+        join(dir, "fastagent", "skills", "triage-copy", "SKILL.md"),
+        `---\nname: triage\ndescription: A second claim on the same name\n---\n\nDo it differently.\n`,
+      );
+      expect((await control.commands()).map((c) => c.name)).toEqual(["triage"]);
+      // Live in BOTH directions — a cached read would only ever grow the list.
+      await rm(join(dir, "fastagent", "skills"), { recursive: true, force: true });
+      expect(await control.commands()).toEqual([]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What

`SessionControl.commands()` — the names an agent exposes, so a client can populate a `/` completion
list. Closes #287.

```ts
interface AgentCommand { name: string; description?: string; source: string }
commands(): Promise<AgentCommand[]>;   // GET /control/commands
```

Sessionless like `capabilities()`, but **async**, and that is the whole design: the directory is the
agent *live* (fastagent re-reads it per turn), so a boot snapshot would advertise names the running
agent has already left behind. It reads `skills/` only — the full definition load's ② context walk
(every `AGENTS.md` from cwd to root) buys nothing for a name list.

## A listing, not a dispatch surface

The issue frames skills as "commands users invoke by name". In fastagent they are not: nothing in the
data plane expands `/name`, and a prompt is text. Rather than imply an invocation path that does not
exist, the contract says what is true — this LISTS, and what typing one means is the client's choice.

The one in-repo consumer now makes that choice: `fastagent attach` gained `/commands` (list), answers
a typed `/triage` with what that name actually is, and tells the user to name it without the slash.

## Notable decisions

| | |
|---|---|
| `source: string`, free-form | which kinds exist is an engine's business; pi's closed union would make `AgentCommand` a pi type. Field names still follow pi's `get_commands` so a client maps directly |
| `[]` is complete | an L1 agent (`createPiAgent({ model, instructions, tools })`) genuinely has no names. `commands` is therefore an optional hub option — but the directory constructor always wires it, where `[]` would be a lie |
| may reject | a definition the server cannot READ has no truthful degraded value. It carries no code (the read-side error-channel gap tracked on #286); a missing route is mapped to a distinguishable "predates the route" so skew never reads as a broken definition |
| one findings memo | a broken `SKILL.md` vanishes from the list, so this read must warn — through the SAME memoized reporter the turn path uses (keyed by the resolved definition dir), so a finding is announced once, by whichever reader sees it first. The "record without printing" door was removed: it could swallow findings for a caller that never printed |

## Verification

`npm run lint && npm run typecheck && npm test` — 1282 passing. New coverage: live re-read in both
directions (added / removed) plus first-wins collision resolution, a failed skill warned exactly once,
the wire read per call rather than cached at connect, the auth sweep derived from the mounted routes
(so a new route that forgets `guard` fails it), the rejection shape, and route skew.
