### PR TITLE
chore: release 0.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, Telegram, Slack, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Release v0.16.2

Bump @fastagent-sh/fastagent from 0.16.1 to 0.16.2.

### Verification

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm pack --dry-run --json`

### After merge

Create and publish the GitHub Release `v0.16.2`. The protected publish workflow will verify and publish the package to npm via Trusted Publishing.