### PR TITLE
docs(design): conformance levels — state locality and engine class are two deployment axes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ fastagent *is* a developer-experience product: its whole promise is turning an e
 
 - **The contract is engine-neutral.** `src/agent.ts` must not import any engine (`@earendil-works/pi-*` only under `src/engines/`).
 - **Fail visibly.** Errors must surface; no swallowed exceptions, no silent fallbacks. On the invoke path, failures become `failed` events (SPEC MUST 2), never thrown iteration errors.
-- **Stateless invoke.** Each invoke builds a fresh harness and discards it; durable state lives behind `PiSessionStore`. Do not introduce in-process session state.
+- **Per-invoke state is the DEFAULT level, not an axiom.** Today's serving path builds a fresh harness per invoke and discards it; durable state lives behind `PiSessionStore`. Do not introduce in-process session state *into that path* — it is what satisfies SPEC MUST 6 (no location dependence), which AgentCore and every horizontally-scaled channel host require. The SPEC permits a resident Agent at the cost of portable conformance; if a deployment posture wants one, that is a deliberate level choice with its own bill ([conformance-levels.md](docs/design/conformance-levels.md)), never a quiet drift in this one.
 - **Public surface is scoped on purpose.** `src/core.ts` is engine-neutral, `src/pi.ts` is the pi reference surface, and `src/index.ts` combines them. Pi-coupled internals (L0 `createPiAgentFromHarness`, `piHarnessFactory`, assembly helpers) remain unexported — import them from their modules for tests/custom wiring, do not re-export them.
 - **The artifact is the truth.** Deployment behavior must come from the bundled definition, not the builder machine's global state.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -166,7 +166,7 @@ fastagent logs agentcore --source forwarder --follow
 
 AWS creates each log group on first use. Before the first Runtime invocation or forwarder event, the command says which trigger is missing instead of sending `aws logs tail` to a nonexistent group. Pass the same `[dir]` used for deploy when running from somewhere else.
 
-AgentCore differs from the resident-box hosts in kind — the platform has **no public URL** (ingress is the SigV4 `InvokeAgentRuntime` API only) and **no resident process** (compute is per-session microVMs, reclaimed 3 minutes after the agent goes idle). The stack therefore carries:
+AgentCore differs from the resident-box hosts in kind — the platform has **no public URL** (ingress is the SigV4 `InvokeAgentRuntime` API only) and **no resident process** (compute is per-session microVMs, reclaimed 3 minutes after the agent goes idle). The second half is a hard constraint on the agent, not just on the host: a turn here cannot require the previous turn's process, which is SPEC MUST 6 — see [conformance levels](design/conformance-levels.md). The stack therefore carries:
 
 - the **Runtime** (your container, unchanged — the AgentCore adapter mounts `POST /invocations` + `GET /ping` via `FASTAGENT_AGENTCORE=1`);
 - a **forwarder Lambda** with a public Function URL fronting the webhooks (channels verify signatures exactly as on every host);

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -32,5 +32,6 @@ Do **not** keep private strategy here: market positioning, competitor analysis, 
 | Document | Purpose |
 |---|---|
 | [core.md](core.md) | Current architecture of the pi reference implementation. |
+| [conformance-levels.md](conformance-levels.md) | Where a session's state lives, and which engine class serves it: two independent deployment axes, the postures that pin them, and what each owes. |
 | [participant-model.md](participant-model.md) | How a chat bot behaves in a collaboration tool: the participant axiom and the summon/placement/memory rules derived from it. |
 | [session-control.md](session-control.md) | Session control plane beside `invoke`: observation plane shipped; control plane (dispatch) proposed. |

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -75,8 +75,11 @@ The seam is **L0 only** ([core.md](core.md) §3: `createPiAgentFromHarness` is t
 
 ## 5. What each level owes
 
-**`per-invoke` owes MUST 6**: state reconstructible from the store, no process affinity, and — because
-fastagent's directory is the agent, live — a fresh definition read per turn.
+**`per-invoke` owes MUST 6**: state reconstructible from the store, no process affinity. Nothing more —
+in particular, "the directory is the agent, LIVE" is a fastagent product property, not part of this
+level: the harness path buys it by re-reading the definition every turn, while a `session`-class
+factory that shares one `ResourceLoader` across turns (what makes its per-turn cost ~1ms) trades that
+freshness away. Which one is in force is the factory's choice and must be stated by it.
 
 **`resident` owes an explicit lifecycle**: when a session is created, evicted, and rebuilt, plus a
 rebind path when the definition changes (an `AgentSession` snapshots its assembly at build). It also

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -1,0 +1,111 @@
+---
+title: Conformance levels
+description: "Where a session's state lives is a deployment choice the SPEC already defines — not an implementation detail. Two axes (state locality × engine class), the postures that pin them, and what each owes."
+status: current
+---
+
+# Conformance levels
+
+## 1. Decision
+
+**Where a session's state lives is an explicit deployment choice, and the engine class that serves it
+is a separate one.** Neither is a property of "fastagent"; both are properties of a deployment.
+
+The protocol says so already. [SPEC](../SPEC.md) §6, under *Portable conformance (optional; required
+for Agents claiming serverless portability)*:
+
+> **No location dependence**: the Agent MUST NOT require multiple invocations with the same `session`
+> to land in the same process or instance. Session state must be reconstructible from external state.
+> **A resident stateful Agent can still conform to Agent Handler, but it does not satisfy portable
+> conformance.**
+
+A resident Agent is permitted, the cost is named, and the level is optional. `test/spec-conformance.ts`
+encodes the same shape: `pair?()` is an OPTIONAL subject capability, because MUST 6 is optional.
+
+So the recurring question — "should `invoke` be built on pi's `AgentSession` instead of its
+`AgentHarness`?" — is malformed. It conflates two independent axes.
+
+## 2. Two axes, not one
+
+| Axis | Values | What it decides |
+|---|---|---|
+| **State locality** | `per-invoke` \| `resident` | SPEC MUST 6. Whether a turn may require the previous turn's process. |
+| **Engine class** | `harness` (pi-agent-core) \| `session` (pi-coding-agent `AgentSession`) | Which engine surface exists: extensions, slash-command dispatch, branch summaries, fork/clone. |
+
+The axes are independent, and the combination that looked impossible is the interesting one:
+
+| | `harness` | `session` |
+|---|---|---|
+| **per-invoke** | today's serving path | **portable AND extension-hosting** — measured: shared assembly once (~3 ms), then ~1 ms to build a fresh `AgentSession` over the same session file per turn; extension hooks fire every turn; one jsonl accumulates across turns |
+| **resident** | pointless (residency buys nothing without the surface) | today's `chat`; a desktop client's natural posture |
+
+Two facts make the top-right cell real rather than theoretical:
+
+- **One durable record.** pi-agent-core's `JsonlSessionStorage` and pi-coding-agent's `SessionManager`
+  read and write the same versioned jsonl (`{"type":"session","version":3,…}` + entries). A record
+  written by one is read by the other, leaf and parent chain intact, with no migration.
+- **The expensive half is shareable.** Extension modules load in the `ResourceLoader`, which is built
+  once with the assembly; only the per-session binding is per turn.
+
+## 3. Posture pins the level
+
+The mapping is derived from deployment facts, not preference:
+
+| Posture | State locality | Why |
+|---|---|---|
+| channels, schedules | `per-invoke` | Many concurrent "places" (a room, a thread) and horizontal scaling. Residency would make the live-session set an unbounded resource with an eviction policy attached. |
+| AgentCore | `per-invoke` | The platform has no resident process — compute exists per invocation ([core.md](core.md) §9). MUST 6 is not a preference here, it is the runtime. |
+| `chat`, a desktop client | either | One user, one workspace, one live conversation. Location dependence costs nothing, and residency buys the engine's own continuity (queues, in-flight state) for free. |
+
+A deployment that claims serverless portability MUST be `per-invoke`. Everything else is a choice with
+a stated bill (§5).
+
+## 4. What does not change
+
+The seam is **L0 only** ([core.md](core.md) §3: `createPiAgentFromHarness` is the L0 rung).
+
+- **`Agent`** — `invoke(scope, prompt) => AsyncIterable<AgentEvent>`. Both engine classes satisfy it;
+  the SPEC calls the Agent "a black box to the Caller".
+- **`SessionControl`** — engine-neutral, and it was designed with only one implementation in existence.
+  Every method maps onto `AgentSession` natively, most of them more directly than onto the harness
+  (`dispatch`'s verbs are `steer`/`followUp`/`abort`/`compact`/`setModel`/`setThinkingLevel`/
+  `navigateTree`; `commands()` is the extension+prompt+skill registry). Nothing in the contract bends.
+- **The assembly ladder, the definition, tools, channels, schedules** — level-agnostic. They produce
+  inputs; the level decides who consumes them.
+
+## 5. What each level owes
+
+**`per-invoke` owes MUST 6**: state reconstructible from the store, no process affinity, and — because
+fastagent's directory is the agent, live — a fresh definition read per turn.
+
+**`resident` owes an explicit lifecycle**: when a session is created, evicted, and rebuilt, plus a
+rebind path when the definition changes (an `AgentSession` snapshots its assembly at build). It also
+owes honesty in `capabilities()`: a resident deployment is not portable, and a client that migrates
+between the two must not discover this from behavior.
+
+**Both owe the same durable record.** One known gap, measured: `SessionManager` buffers a NEW session's
+entries until the first assistant message arrives, so a crash between "the user asked" and "the model
+answered" loses the question — pi-agent-core's storage persists it immediately. Any `session`-class
+implementation must close this gap (or state it) before it serves a channel.
+
+The engineering bill for `resident`, measured: ~25 KB per idle `AgentSession`, and the real cost is
+transcript retention at roughly the size of the record on disk (~8.6 KB per turn of ~8 KB text) — about
+0.8 GB for 1000 sessions of 100 turns. Nothing for a desktop; an eviction policy for a channel host.
+
+## 6. Consequences for the roadmap
+
+The engine class — not the locality — is what decides whether an agent's `extensions/` directory does
+anything, whether `/name` is a command or text, and whether branch navigation can summarize. Under
+`harness` those are absent by construction: pi-agent-core has no extension vocabulary at all.
+
+That reframes a class of requests. Rebuilding the `session` class's surface on the `harness` class, one
+verb at a time, is how `navigate` and `commands()` landed — each an adaptation with its own contract
+extension and its own divergence from the native semantics (`commands()` is a listing here because
+nothing in this class expands `/name`; on the other class the same read is a dispatch surface). That is
+a legitimate cost when the verb must work on the portable-and-harness path anyway. It is the wrong
+answer when the request is "give me the other engine class".
+
+Extension loading and extension dialogs (`ExtensionUIContext`'s `select`/`confirm`/`input`/`notify`,
+which pi already exposes as an injectable `bindExtensions({ uiContext, mode })` seam — the same door
+its RPC mode uses) are `session`-class features. They are not blocked by state locality, and they are
+not implementable on the `harness` class at any price short of writing a second extension host.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -204,7 +204,10 @@ model, auth, tools, sessions, and machinery paths. `dev`, `start`, `invoke`, and
 assembly rather than carrying parallel implementations.
 
 Each invocation builds a fresh harness for its session and discards it after the turn. Conversation
-continuity comes from `PiSessionStore`, not a resident harness. Reopening is faithful to the whole
+continuity comes from `PiSessionStore`, not a resident harness. That is L0's choice on two axes a
+deployment owns rather than the architecture: per-invoke state (SPEC MUST 6 — what AgentCore and every
+scaled channel host require) and the `harness` engine class. Both are swappable at this rung alone;
+[conformance-levels.md](conformance-levels.md) states what each combination owes. Reopening is faithful to the whole
 record, not just the messages: pi's harness writes active-tool changes to the session but never reads
 them back (its own TUI harness is resident), so `piHarnessFactory` resolves the active-tool set itself
 (`harness.ts` `resolveHarnessActiveToolNames`): the UNION of the initial set (every non-deferred tool;


### PR DESCRIPTION
## What

A design note establishing that **where a session's state lives, and which engine class serves it,
are two independent deployment choices** — plus the companion-text corrections that follow.

No code changes.

## Why now

Four issues in a row (#284 navigate, #287 commands, #286 fork/clone/name, #285+#289 extensions) are
the same request wearing different hats: *give me the surface pi's `AgentSession` has*. Two of them
shipped as adaptations onto the harness path, each with its own contract extension and its own
divergence from the native semantics — `commands()` is a listing here precisely because nothing in
this engine class expands `/name`, while on the other class the same read is a dispatch surface.

That is a reasonable price when the verb has to work on the portable path anyway. It is the wrong
answer when the request is "use the other engine class", and by the third verb it was worth stopping
to re-derive rather than continuing to patch.

## What the note decides

SPEC §6 already settled half of it, and I had been reading it as an axiom rather than a level:

> A resident stateful Agent can still conform to Agent Handler, but it does not satisfy portable
> conformance.

Permitted, cost named, level optional — and `test/spec-conformance.ts` already encodes it (`pair?()`
is an OPTIONAL subject capability). So the question "should `invoke` be built on `AgentSession`?"
conflates two axes:

| Axis | Values | Decides |
|---|---|---|
| State locality | `per-invoke` \| `resident` | SPEC MUST 6 — whether a turn may require the previous turn's process |
| Engine class | `harness` \| `session` | Whether `extensions/` does anything, whether `/name` dispatches, whether branch navigation can summarize |

## The measured surprise

The cell I had assumed impossible is the cheap one. `per-invoke` + `session`:

- shared assembly (resource loader + extension modules) **once**: ~3 ms
- a fresh `AgentSession` over the same jsonl, **per turn**: ~1 ms
- extension hooks fire every turn; one durable record accumulates across turns

Both engine classes read and write the same versioned session format (`{"type":"session","version":3,…}`),
verified in both directions with the leaf and parent chain intact — so this is a swap at **L0 alone**,
with `Agent`, `SessionControl`, the assembly ladder, tools and channels untouched.

Portability is therefore not the price of extensions. Residency is a separate choice with a separate
bill (~25 KB per idle session, transcript retention ≈ the record on disk, ~0.8 GB for 1000×100-turn
sessions), which only a resident posture pays.

## Companion text

- `AGENTS.md` — the "Stateless invoke" rule is re-scoped: it is the default level's invariant (what
  MUST 6, AgentCore and scaled channel hosts require of *that path*), not an axiom that overrides the
  contract. As written it would have vetoed something the SPEC explicitly permits — it vetoed it in my
  own reasoning for three rounds.
- `docs/design/core.md` §3 — names the two axes at the L0 rung where they are decided.
- `docs/deploy.md` — AgentCore's "no resident process" is stated as a constraint on the **agent**
  (MUST 6), not only on the host.

## Known gap recorded, not hidden

`SessionManager` buffers a NEW session's entries until the first assistant message, so a crash between
"the user asked" and "the model answered" loses the question; pi-agent-core's storage persists it
immediately. Any `session`-class implementation must close or state that before it serves a channel.
