### PR TITLE
fix(agentcore): send time_of_last_update on /ping — the keep-alive silently requires it

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -590,7 +590,11 @@ unwraps the envelope — a webhook is reconstructed verbatim and dispatched to t
 reply so the forwarder re-emits it byte-exact), a schedule fire goes through `fireScheduleOnce` with the
 slot as the idempotency key (EventBridge delivery is at-least-once), and an invoke streams back as SSE.
 `GET /ping` reports `HealthyBusy` while background turns run (the shared turn-queue/task-tracker report
-into `channels/busy.ts`) so an idle reclaim cannot kill a post-ACK turn. All ingress traffic shares ONE
+into `channels/busy.ts`) so an idle reclaim cannot kill a post-ACK turn — and it always carries
+`time_of_last_update` (updated only on real status transitions). The field is documented as optional,
+but measured platform behavior reads ONLY it: without the field, the idle timer counts from the last
+`InvokeAgentRuntime` and reclaims mid-turn regardless of `HealthyBusy` (see the handler comment in
+`channels/agentcore.ts`). All ingress traffic shares ONE
 fixed runtime session — channel state is single-writer by design, and a stopped session's id stays valid
 until the runtime is deleted.
 

--- a/src/channels/agentcore.ts
+++ b/src/channels/agentcore.ts
@@ -19,7 +19,8 @@
  *  - `{ kind: "invoke", session, text }` — the programmatic data plane; streams the invoke back as
  *    SSE (AgentCore's streaming response form), reusing the HTTP channel's handler wholesale.
  *
- * `/ping` reports `HealthyBusy` while process-wide background work is in flight (busy.ts) — webhook
+ * `/ping` reports `HealthyBusy` (+ `time_of_last_update`, required — see the handler) while
+ * process-wide background work is in flight (busy.ts) — webhook
  * channels ACK fast and run turns fire-and-forget, and AgentCore ends an idle session, so without
  * this signal a long turn would be killed mid-flight right after its ACK. `Healthy` when idle lets
  * the platform reclaim the microVM (that idle-to-zero IS the point of this deployment).
@@ -328,12 +329,30 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
     return response;
   };
 
+  // The Runtime ping contract: Healthy = reclaimable, HealthyBusy = keep the session alive
+  // (background turns in flight). `time_of_last_update` is REQUIRED for the keep-alive to work,
+  // despite the contract documenting it as optional ("If you omit the field, the platform tracks
+  // status changes on its own"): measured on a live Runtime (us-east-1, 2026-08-04), the platform's
+  // idle measurement reads ONLY this field — with it omitted, a session polling every ~2s and
+  // receiving HealthyBusy 200s was still reclaimed at exactly IdleRuntimeSessionTimeout after the
+  // last InvokeAgentRuntime, mid-turn, 2s after the last HealthyBusy answer; with the field present
+  // the same turn survived 3.5× the idle timeout with zero invocations and completed. The value
+  // updates ONLY on a real status change: a timestamp advancing on every ping declares a perpetual
+  // status change, so the idle timeout never fires and dead-idle sessions live to MaxLifetime
+  // (quota exhaustion — the failure mode the contract's warning describes).
+  let lastStatus = "Healthy";
+  let lastTransition = Math.floor(Date.now() / 1000);
   return {
     "POST /invocations": invocations,
-    // The Runtime ping contract: Healthy = reclaimable, HealthyBusy = keep the session alive
-    // (background turns in flight). No time_of_last_update — the platform tracks status changes
-    // itself, and a timestamp advancing every ping would defeat the idle timeout (their docs warn).
-    "GET /ping": () => json({ status: isBusy() ? "HealthyBusy" : "Healthy" }, 200),
+    "GET /ping": () => {
+      const status = isBusy() ? "HealthyBusy" : "Healthy";
+      if (status !== lastStatus) {
+        lastTransition = Math.floor(Date.now() / 1000);
+        log.debug(`[agentcore] ping status: ${lastStatus} → ${status}`);
+        lastStatus = status;
+      }
+      return json({ status, time_of_last_update: lastTransition }, 200);
+    },
   };
 }
 

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -99,8 +99,9 @@ export const SECRETS_DIR = `${MOUNT}/${SECRETS_DIRNAME}`;
  * — idle included, at the peak level reached — so this tail is the standing cost of every burst of
  * activity, while CPU stops billing the moment the agent stops working. 3 minutes rather than the
  * platform's 15: the tail shrinks 5×, and the cost is a cold start (image + Node + snapshot restore)
- * for anyone who returns after a longer gap. `/ping` reports HealthyBusy while work is in flight, so
- * this timer only ever starts once the agent has genuinely settled — a long turn is never cut short.
+ * for anyone who returns after a longer gap. `/ping` reports HealthyBusy + time_of_last_update while
+ * work is in flight (the FIELD is what the platform's idle measurement actually reads — agentcore.ts),
+ * so this timer only ever starts once the agent has genuinely settled — a long turn is never cut short.
  * AWS accepts 60–28800.
  */
 export const IDLE_TIMEOUT_SECONDS = 180;
@@ -642,7 +643,7 @@ function template(input: AgentcorePlanInput, translated: { fact: ScheduleFact; e
     `      # forces a NAT gateway for model/channel egress (~$33/mo) — deliberately not the default.`,
     `      FilesystemConfigurations:`,
     `        - SessionStorage: { MountPath: ${MOUNT} }`,
-    `      # Idle ${IDLE_TIMEOUT_SECONDS}s (the ping's HealthyBusy keeps BUSY sessions alive regardless), max compute`,
+    `      # Idle ${IDLE_TIMEOUT_SECONDS}s (the ping's HealthyBusy + time_of_last_update keeps BUSY sessions alive), max compute`,
     `      # lifetime ${MAX_LIFETIME_SECONDS}s — the platform ceiling; the session id stays valid, so the next invoke`,
     `      # just gets fresh compute with the same storage. Memory bills per second for the whole`,
     `      # session INCLUDING the idle tail, so a shorter tail is the main cost lever here.`,
@@ -1014,7 +1015,7 @@ export function planAgentcoreDeploy(input: AgentcorePlanInput): AgentcorePlan {
       `# Set the GitHub webhook (repo Settings → Webhooks): Payload URL = <ForwarderUrl>/webhook,`,
       `#   content type application/json, secret = GITHUB_WEBHOOK_SECRET.`,
       `# NOTE: github turns are fire-and-forget with no replay — a compute reclaimed mid-review drops it`,
-      `#   (the ping's HealthyBusy holds the session while turns run, but the 8 h compute ceiling is hard).`,
+      `#   (the ping's HealthyBusy + time_of_last_update holds the session while turns run, but the 8 h compute ceiling is hard).`,
     );
   }
   if (channels.includes("slack")) {

--- a/test/agentcore-adapter.test.ts
+++ b/test/agentcore-adapter.test.ts
@@ -85,9 +85,53 @@ describe("agentcore adapter: /ping", () => {
     let busy = false;
     const routes = adapter({ isBusy: () => busy });
     const ping = routes["GET /ping"]!;
-    expect(await (await ping(new Request("http://x/ping"))).json()).toEqual({ status: "Healthy" });
+    expect(await (await ping(new Request("http://x/ping"))).json()).toMatchObject({ status: "Healthy" });
     busy = true;
-    expect(await (await ping(new Request("http://x/ping"))).json()).toEqual({ status: "HealthyBusy" });
+    expect(await (await ping(new Request("http://x/ping"))).json()).toMatchObject({ status: "HealthyBusy" });
+  });
+
+  it("always carries time_of_last_update, updated ONLY on a real status transition", async () => {
+    // The platform's idle measurement reads ONLY this field (measured live: with it omitted, a
+    // session answering HealthyBusy every ~2s was still reclaimed mid-turn at exactly the idle
+    // timeout after the last invocation — the documented "the platform tracks status changes on
+    // its own" omission path is not implemented). A value advancing on EVERY ping is the opposite
+    // failure: a perpetual "status change" that never lets idle fire, so sessions live to
+    // MaxLifetime and exhaust the quota. Required shape: always present, frozen between transitions.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-04T06:37:00Z"));
+      let busy = false;
+      const routes = adapter({ isBusy: () => busy });
+      const ping = async () => {
+        const res = await routes["GET /ping"]!(new Request("http://x/ping"));
+        return (await res.json()) as { status: string; time_of_last_update: number };
+      };
+
+      const idle1 = await ping();
+      expect(typeof idle1.time_of_last_update).toBe("number");
+
+      vi.advanceTimersByTime(10_000); // pings keep coming while nothing changes
+      const idle2 = await ping();
+      expect(idle2.time_of_last_update).toBe(idle1.time_of_last_update); // frozen — not "now"
+
+      busy = true; // a turn starts
+      vi.advanceTimersByTime(5_000);
+      const busy1 = await ping();
+      expect(busy1.status).toBe("HealthyBusy");
+      expect(busy1.time_of_last_update).toBe(idle1.time_of_last_update + 15); // stamped at the flip
+
+      vi.advanceTimersByTime(120_000); // a long turn: well past a 60s idle timeout
+      const busy2 = await ping();
+      expect(busy2.time_of_last_update).toBe(busy1.time_of_last_update); // still frozen mid-turn
+
+      busy = false; // turn settles
+      vi.advanceTimersByTime(2_000);
+      const settled = await ping();
+      expect(settled.status).toBe("Healthy");
+      expect(settled.time_of_last_update).toBe(busy2.time_of_last_update + 122); // re-stamped once
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -53,7 +53,9 @@ describe("mountAgentcore", () => {
       { agent, stateRoot: dir, schedules: [] },
     );
     expect(Object.keys(routes).sort()).toEqual(["GET /ping", "POST /invocations", "POST /telegram"]);
-    expect(await (await routes["GET /ping"]!(new Request("http://x/ping"))).json()).toEqual({ status: "Healthy" });
+    expect(await (await routes["GET /ping"]!(new Request("http://x/ping"))).json()).toMatchObject({
+      status: "Healthy",
+    });
   });
 
   it("fails startup on a channel colliding with the adapter's paths", () => {


### PR DESCRIPTION
Any AgentCore fire-and-forget turn longer than `IdleRuntimeSessionTimeout` was killed mid-flight: the microVM reclaimed with no signal, no error anywhere, the turn's work lost (the state snapshot pushes on the idle edge, which a killed container never reaches). The operator-visible symptom: the bot silently stops replying partway through long work.

## Cause

The `/ping` handler answered `{"status":"HealthyBusy"}` **without** `time_of_last_update`, relying on the contract's

> "If you omit the field, the platform tracks status changes on its own."

Measured on a live Runtime (us-east-1, 2026-08-04), that omission path is not implemented — **the platform's idle measurement reads only the field**. Without it the idle timer counts purely from the last `InvokeAgentRuntime`:

| Experiment (fixed session, live Lark traffic) | Result |
|---|---|
| idle=180, omission | killed mid-turn at last invocation **+180.0 s** |
| idle=60, omission | killed at **+61 s** — kill time tracks the config |
| idle=60, a probe invocation every ~22 s | same turn survived 8+ min; died at last-probe +60 s |
| idle=60, debug build logging every served ping | platform polls **every ~2 s**, received **55 consecutive `HealthyBusy` 200s**, killed anyway — the last answer 2 s before death |
| idle=60, **`time_of_last_update` added** (only change) | same turn survived **212 s with zero invocations** (3.5× idle) and completed; after flipping back to `Healthy`, reclaimed on schedule at +~64 s |

So `HealthyBusy` keep-alive silently requires a field the same doc pages mark optional-and-omittable. SDK users never see this (the SDK manages the ping response); doc-compliant custom runtimes are exposed.

## Fix

`agentcoreRoutes`' ping handler now always carries `time_of_last_update`, stamped **only on a real status transition**. The only-on-transition rule is the other cliff the contract warns about: a timestamp advancing on every ping declares a perpetual status change, idle never fires, and dead-idle sessions live to `MaxLifetime` (session-quota exhaustion).

- `src/channels/agentcore.ts` — the handler + a comment recording the measured platform behavior so the field cannot be "simplified away" later
- `test/agentcore-adapter.test.ts` — fake-timer test: field always present, frozen between transitions, re-stamped exactly once per flip (both directions)
- `test/cli-serve.test.ts` — mount test tolerates the field
- `docs/design/core.md`, `plan.ts` runbook comments — drop the wrong "keeps sessions alive regardless" claim; document the field requirement

## Verification

- `npm run lint && npm run typecheck && npm test` — 103 files / 1296 tests green
- Live: the exact handler behavior (as a debug build) ran on a production AgentCore deployment; both directions confirmed in one run — 3m39s turn completed with zero invocations on a 60 s idle config, then normal reclaim ~64 s after settling back to `Healthy`

Full incident evidence (five experiments, wire-level logs from both sides) is packaged separately and is being reported to the AgentCore team.