### PR TITLE
feat(engines/pi): an L0 for the session engine class, at per-invoke locality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,10 @@ src/
     │                       # Siblings never import each other
     ├── session-bridge.ts    # the session class's tool-runtime bridges (session manager + activation),
     │                       # shared by its two consumers: the resident runtime and the per-invoke L0
+    ├── session-record.ts    # sessionId → a SessionManager BOUND to the record the store owns (same
+    │                       # encoded id, same crash repair). Load-bearing: a SessionManager left to
+    │                       # open its own file buffers until the first answer, losing the user's
+    │                       # question on a crash — and would address a different record entirely
     ├── session-control.ts   # the pi session-control hub: observation projections + dispatch (run modulation, boundary mutations, abortable compaction)
     ├── session-builder.ts   # definition-aware session builder: agent assembly → resident pi AgentSessionRuntime (chat TUI consumes it)
     ├── open.ts              # shared opener: directory → agent for dev/start/invoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,17 @@ src/
 │   └── state.ts            # atomic schedule state under <stateRoot>/schedule/ (fires.json + wakeups.json)
 └── engines/pi/              # the pi reference implementation
     ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
-    ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
+    ├── invoke.ts            # L0 for the HARNESS engine class + its request-time turn mechanism
+    ├── session-invoke.ts    # L0 for the SESSION engine class (per-invoke AgentSession): the class
+    │                       # that has extensions, /name dispatch and branch ops. Same state
+    │                       # locality as invoke.ts (SPEC MUST 6) — the two axes are independent,
+    │                       # see docs/design/conformance-levels.md
+    ├── turn-plumbing.ts     # what BOTH L0s need and neither may own: the single-writer lease, the
+    │                       # pi→SPEC terminal classification, prompt→pi image conversion, and the
+    │                       # push→pull fan-in (pi exposes a turn as promise + subscription).
+    │                       # Siblings never import each other
+    ├── session-bridge.ts    # the session class's tool-runtime bridges (session manager + activation),
+    │                       # shared by its two consumers: the resident runtime and the per-invoke L0
     ├── session-control.ts   # the pi session-control hub: observation projections + dispatch (run modulation, boundary mutations, abortable compaction)
     ├── session-builder.ts   # definition-aware session builder: agent assembly → resident pi AgentSessionRuntime (chat TUI consumes it)
     ├── open.ts              # shared opener: directory → agent for dev/start/invoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,10 +129,10 @@ src/
     │                       # Siblings never import each other
     ├── session-bridge.ts    # the session class's tool-runtime bridges (session manager + activation),
     │                       # shared by its two consumers: the resident runtime and the per-invoke L0
-    ├── session-record.ts    # sessionId → a SessionManager BOUND to the record the store owns (same
-    │                       # encoded id, same crash repair). Load-bearing: a SessionManager left to
-    │                       # open its own file buffers until the first answer, losing the user's
-    │                       # question on a crash — and would address a different record entirely
+    ├── session-record.ts    # sessionId → a SessionManager BOUND to the record the STORE resolved
+    │                       # (via PiRecordLocator, so id encoding + cwd scoping + crash repair stay
+    │                       # one sequence). Load-bearing: a SessionManager left to open its own file
+    │                       # buffers until the first answer, losing the user's question on a crash
     ├── session-control.ts   # the pi session-control hub: observation projections + dispatch (run modulation, boundary mutations, abortable compaction)
     ├── session-builder.ts   # definition-aware session builder: agent assembly → resident pi AgentSessionRuntime (chat TUI consumes it)
     ├── open.ts              # shared opener: directory → agent for dev/start/invoke

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -211,6 +211,11 @@ interface ReadonlySessionManager {
 }
 ```
 
+`signal` can ALREADY be aborted when `execute` is called: a caller may cancel in the window between
+the `tool_started` event and the tool actually running. A tool that only registers an `abort` listener
+hangs forever in that case, because an already-aborted signal never fires the event again — check
+`signal.aborted` first, then listen.
+
 During serving and `fastagent chat`, `sessionManager` is FastAgent's read-only adapter over the current
 conversation. It is undefined in a sessionless direct call such as `fastagent tool`. Current bindings
 ride `AsyncLocalStorage`, not definition closures, because a tool is built once and reused across turns.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -203,18 +203,20 @@ interface ToolContext {
   sessionManager?: ReadonlySessionManager;
   tools?: ToolActivation;
 }
-
-interface ReadonlySessionManager {
-  getSessionId(): string;
-  getHeader(): Promise<{ id: string; timestamp: string }>;
-  getBranch(): Promise<SessionTreeEntry[]>;
-}
 ```
 
 `signal` can ALREADY be aborted when `execute` is called: a caller may cancel in the window between
 the `tool_started` event and the tool actually running. A tool that only registers an `abort` listener
 hangs forever in that case, because an already-aborted signal never fires the event again — check
 `signal.aborted` first, then listen.
+
+```ts
+interface ReadonlySessionManager {
+  getSessionId(): string;
+  getHeader(): Promise<{ id: string; timestamp: string }>;
+  getBranch(): Promise<SessionTreeEntry[]>;
+}
+```
 
 During serving and `fastagent chat`, `sessionManager` is FastAgent's read-only adapter over the current
 conversation. It is undefined in a sessionless direct call such as `fastagent tool`. Current bindings

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -77,6 +77,10 @@ must not also choose which module graph loads.
 - **The assembly ladder, the definition, tools, channels, schedules** — level-agnostic. They produce
   inputs; the level decides who consumes them.
 
+Neither class's L0 is a public export, and neither is wired into a serving path yet — what exists
+today is the engine seam and its conformance, with the assembly (models, auth, tools, definition) and
+the exports that would follow still to come.
+
 What the two classes do NOT yet share is the SERVING surface. `createPiAgentFromHarness` accepts an
 observer and registers per-run modulation handles, which is what the session control plane
 (`session-control.ts`, `/control/*`, `fastagent attach`) consumes; the session L0 has neither yet. The
@@ -103,8 +107,10 @@ everything until the first assistant message — a crash between "the user asked
 loses the question, and the file is not even created. Binding it to a record the session store already
 created (`setSessionFile`) persists the user's turn immediately, matching the harness class. A
 `session`-class factory therefore MUST bind to an existing record — `sessionRecordBinder` is that rule
-as code, so a deployment inherits it rather than re-deriving it. The shared jsonl format (§2) is what
-makes it possible, and the same property is what makes a channel's at-least-once delivery safe.
+as code, so its consumers inherit it rather than re-deriving it. (Like the harness class's L0 and
+`piHarnessFactory`, both stay pi-coupled internals rather than public exports; the repo's own
+consumers import them from their modules.) The shared jsonl format (§2) is what makes it possible, and
+the same property is what makes a channel's at-least-once delivery safe.
 
 The engineering bill for `resident`, measured: ~25 KB per idle `AgentSession`, and the real cost is
 transcript retention at roughly the size of the record on disk (~8.6 KB per turn of ~8 KB text) — about

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -77,6 +77,13 @@ must not also choose which module graph loads.
 - **The assembly ladder, the definition, tools, channels, schedules** — level-agnostic. They produce
   inputs; the level decides who consumes them.
 
+What the two classes do NOT yet share is the SERVING surface. `createPiAgentFromHarness` accepts an
+observer and registers per-run modulation handles, which is what the session control plane
+(`session-control.ts`, `/control/*`, `fastagent attach`) consumes; the session L0 has neither yet. The
+`Agent` contract is satisfied by both, the control plane is not — so an engine-class choice is today
+also a choice about session control, and closing that is the wiring work between this L0 and any
+serving use of it.
+
 ## 5. What each level owes
 
 **`per-invoke` owes MUST 6**: state reconstructible from the store, no process affinity. Nothing more —

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -97,10 +97,13 @@ rebind path when the definition changes (an `AgentSession` snapshots its assembl
 owes honesty in `capabilities()`: a resident deployment is not portable, and a client that migrates
 between the two must not discover this from behavior.
 
-**Both owe the same durable record.** One known gap, measured: `SessionManager` buffers a NEW session's
-entries until the first assistant message arrives, so a crash between "the user asked" and "the model
-answered" loses the question — pi-agent-core's storage persists it immediately. Any `session`-class
-implementation must close this gap (or state it) before it serves a channel.
+**Both owe the same durable record**, and for the `session` class that is a property of HOW the record
+is addressed rather than of the turn loop. Measured: a `SessionManager` that opens its own file buffers
+everything until the first assistant message — a crash between "the user asked" and "the model answered"
+loses the question, and the file is not even created. Binding it to a record the session store already
+created (`setSessionFile`) persists the user's turn immediately, matching the harness class. A
+`session`-class factory therefore MUST bind to an existing record; the shared jsonl format (§2) is what
+makes that possible, and the same property is what makes a channel's at-least-once delivery safe.
 
 The engineering bill for `resident`, measured: ~25 KB per idle `AgentSession`, and the real cost is
 transcript retention at roughly the size of the record on disk (~8.6 KB per turn of ~8 KB text) — about

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -102,8 +102,9 @@ is addressed rather than of the turn loop. Measured: a `SessionManager` that ope
 everything until the first assistant message — a crash between "the user asked" and "the model answered"
 loses the question, and the file is not even created. Binding it to a record the session store already
 created (`setSessionFile`) persists the user's turn immediately, matching the harness class. A
-`session`-class factory therefore MUST bind to an existing record; the shared jsonl format (§2) is what
-makes that possible, and the same property is what makes a channel's at-least-once delivery safe.
+`session`-class factory therefore MUST bind to an existing record — `sessionRecordBinder` is that rule
+as code, so a deployment inherits it rather than re-deriving it. The shared jsonl format (§2) is what
+makes it possible, and the same property is what makes a channel's at-least-once delivery safe.
 
 The engineering bill for `resident`, measured: ~25 KB per idle `AgentSession`, and the real cost is
 transcript retention at roughly the size of the record on disk (~8.6 KB per turn of ~8 KB text) — about

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -62,7 +62,11 @@ a stated bill (§5).
 
 ## 4. What does not change
 
-The seam is **L0 only** ([core.md](core.md) §3: `createPiAgentFromHarness` is the L0 rung).
+The seam is **L0 only** ([core.md](core.md) §3). There are now two L0s — `createPiAgentFromHarness`
+(`invoke.ts`) and `createPiAgentFromSession` (`session-invoke.ts`) — siblings behind one contract, with
+the turn plumbing neither may own alone (lease, terminal classification, image conversion, the
+promise+subscription fan-in) in `turn-plumbing.ts`. Neither imports the other: choosing an engine class
+must not also choose which module graph loads.
 
 - **`Agent`** — `invoke(scope, prompt) => AsyncIterable<AgentEvent>`. Both engine classes satisfy it;
   the SPEC calls the Agent "a black box to the Caller".

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -77,7 +77,8 @@ must not also choose which module graph loads.
 - **The assembly ladder, the definition, tools, channels, schedules** — level-agnostic. They produce
   inputs; the level decides who consumes them.
 
-Neither class's L0 is a public export, and neither is wired into a serving path yet — what exists
+Neither class's L0 is a public export, and the SESSION class's is not wired into a serving path yet
+(the harness class's is: it is the assembly ladder `dev`/`start`/`invoke` consume) — what exists
 today is the engine seam and its conformance, with the assembly (models, auth, tools, definition) and
 the exports that would follow still to come.
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -227,7 +227,9 @@ never resident process state as the source of continuity.
 ## 4. Event translation and terminal discipline
 
 Pi exposes a promise for the final assistant message and a subscription side channel for streaming
-events. `src/engines/pi/invoke.ts` combines them into one async iterable:
+events — both engine classes do, which is why the fan-in (`EventQueue`) and the terminal
+classification live in `src/engines/pi/turn-plumbing.ts` rather than in either L0.
+`src/engines/pi/invoke.ts` (the harness class) combines them into one async iterable:
 
 1. acquire the per-session lease;
 2. open/create the session and harness;

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -41,7 +41,8 @@ import {
   type MountedTool,
 } from "./tool.ts";
 import { withSearchTool } from "./search-tools.ts";
-import { type Lease, type SessionObserver, createPiAgentFromHarness, inProcessLease } from "./invoke.ts";
+import { type SessionObserver, createPiAgentFromHarness } from "./invoke.ts";
+import { type Lease, inProcessLease } from "./turn-plumbing.ts";
 
 // ── §1 tools ─────────────────────────────────────────────────────────────────
 //

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -13,7 +13,7 @@
  */
 import type { AgentHarnessEvent } from "@earendil-works/pi-agent-core";
 import { DEFAULT_COMPACTION_SETTINGS, calculateContextTokens, shouldCompact } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import {
   ABORTED_CODE,
   type Agent,
@@ -26,38 +26,16 @@ import {
 import { abortFirstIterator } from "../../collect.ts";
 import type { RetryScheduledEvent, RunSettledEvent, SessionEvent } from "../../session.ts";
 import { log } from "../../log.ts";
+import {
+  EventQueue,
+  type Lease,
+  errorToTerminal,
+  inProcessLease,
+  toPiPromptOptions,
+  toTerminal,
+} from "./turn-plumbing.ts";
 import { TOOL_ACTIVATION_ENTRY, harnessSession, type PiHarnessFactory } from "./harness.ts";
 import { type ReadonlySessionManager, type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
-
-// ── §1 Lease: single-writer concurrency floor ───────────────────────────────
-//
-// Corruption-prevention floor only: it does not pick a UX. Fail-fast over queueing because real
-// same-session concurrency is mostly duplicate intent or a user firing follow-ups, not two real
-// turns; a queue would also leak a slot when a waiter is cancelled. Synchronous (no awaits) so
-// nothing interleaves between acquire and entering try — cancellation always releases in finally.
-
-export type Release = () => void;
-
-export interface Lease {
-  /** Try to acquire exclusive write access for the session (fail-fast). Returns null if held. */
-  tryAcquire(session: string): Release | null;
-}
-
-export function inProcessLease(): Lease {
-  const busy = new Set<string>();
-  return {
-    tryAcquire(session: string): Release | null {
-      if (busy.has(session)) return null;
-      busy.add(session);
-      let released = false;
-      return () => {
-        if (released) return;
-        released = true;
-        busy.delete(session);
-      };
-    },
-  };
-}
 
 // ── §2 translate: the single pi↔SPEC translation point ───────────────────────
 //
@@ -75,67 +53,6 @@ export function inProcessLease(): Lease {
 // already exhausted the cleanly-retryable cases. The regex is the narrow ceiling, not the classifier.
 // Upstream ask: a first-class `retryable`/`kind` on pi's terminal error would retire the prose path
 // entirely (mirrors the §11 "the deeper fix is upstream in pi" pattern).
-
-/** Clearly-transient network error codes (Node/undici), decisive on their own. */
-const RETRYABLE_CODES = new Set([
-  "ECONNRESET",
-  "ETIMEDOUT",
-  "ENETUNREACH",
-  "ENETDOWN",
-  "EAI_AGAIN",
-  "EPIPE",
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_SOCKET",
-]);
-
-/** 429 (rate limit) and 5xx (server) are worth retrying; other statuses are decisive NON-retryable. */
-const statusIsRetryable = (status: number): boolean => status === 429 || (status >= 500 && status < 600);
-
-/** Last-resort prose match, used only when no structured status/code is available. */
-const RETRYABLE_MESSAGE =
-  /\b(429|5\d\d|timeout|timed out|rate.?limit|overloaded|ECONNRESET|ETIMEDOUT|ENETUNREACH|EAI_AGAIN|socket hang up)\b/i;
-
-/** A structured status/code decision, or `null` when the signal is absent/undecisive → fall to prose. */
-function retryableFromSignal(signal: { status?: number; code?: unknown }): boolean | null {
-  if (typeof signal.status === "number") return statusIsRetryable(signal.status);
-  const { code } = signal;
-  if (typeof code === "number") return statusIsRetryable(code);
-  if (typeof code === "string") {
-    if (RETRYABLE_CODES.has(code)) return true;
-    if (/^\d{3}$/.test(code)) return statusIsRetryable(Number(code)); // a status carried as a string
-  }
-  return null; // no code, or an unknown one — not decisive on its own
-}
-
-/** Classify `retryable`: structured status/code first, message prose only as the last-resort ceiling. */
-export function classifyRetryable(details: string, signal: { status?: number; code?: unknown }): boolean {
-  return retryableFromSignal(signal) ?? RETRYABLE_MESSAGE.test(details);
-}
-
-/** Pull a structured status/code off a thrown error (HTTP status or a network code, incl. its cause). */
-function errorSignal(error: unknown): { status?: number; code?: unknown } {
-  if (!error || typeof error !== "object") return {};
-  const e = error as { status?: unknown; statusCode?: unknown; code?: unknown; cause?: unknown };
-  const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
-  const causeCode = e.cause && typeof e.cause === "object" ? (e.cause as { code?: unknown }).code : undefined;
-  return { status, code: e.code ?? causeCode };
-}
-
-/**
- * Pull the structured error `code` pi records on a failed message's diagnostics. `diagnostics`
- * accumulates across attempts (`appendAssistantMessageDiagnostic`), so the terminal cause is the LAST
- * code-bearing entry — `findLast`, not `find`: an earlier attempt's transient 503 must not classify a
- * terminal 400/auth failure as retryable. (Reverse scan rather than `findLast` — the tsconfig lib is
- * ES2022.)
- */
-function messageSignal(message: AssistantMessage): { status?: number; code?: unknown } {
-  const diagnostics = message.diagnostics ?? [];
-  for (let i = diagnostics.length - 1; i >= 0; i--) {
-    const code = diagnostics[i]?.error?.code;
-    if (code !== undefined) return { code };
-  }
-  return {};
-}
 
 /**
  * In-stream event mapping — pi events are translated ONCE into the rich `SessionEvent` vocabulary;
@@ -266,30 +183,6 @@ export interface RunControls {
  *  untrusted taps here; give third parties the read-only `events()` stream instead. */
 export type SessionObserver = (session: string, event: SessionEvent, run?: RunControls) => void;
 
-/**
- * Terminal mapping, decided by the resolved message's stopReason: pi's prompt() resolves a message
- * with stopReason "error"/"aborted" rather than throwing, so relying on catch alone would miss this
- * entire failure class (violating SPEC MUST 1).
- */
-export function toTerminal(message: AssistantMessage): AgentEvent {
-  if (message.stopReason === "aborted") {
-    // A deliberate stop (control-plane abort / harness abort), not an error — see {@link ABORTED_CODE}
-    // for the consumer contract (design §6).
-    const details = message.errorMessage ?? "run aborted";
-    return { type: "failed", details, retryable: false, code: ABORTED_CODE };
-  }
-  if (message.stopReason === "error") {
-    const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
-    return { type: "failed", details, retryable: classifyRetryable(details, messageSignal(message)) };
-  }
-  return { type: "completed" };
-}
-
-export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "failed" }> {
-  const details = error instanceof Error ? error.message : String(error);
-  return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
-}
-
 type PiHarness = Awaited<ReturnType<PiHarnessFactory>>;
 
 /** Bind the concrete pi-agent-core Session behind FastAgent's tool-runtime manager port. */
@@ -357,76 +250,6 @@ async function maybeCompact(harness: PiHarness, message: AssistantMessage): Prom
   if (!contextWindow) return;
   if (shouldCompact(calculateContextTokens(message.usage), contextWindow, DEFAULT_COMPACTION_SETTINGS)) {
     await harness.compact();
-  }
-}
-
-/**
- * Map prompt images to pi ImageContent, resizing each to model-friendly dimensions/size with pi's
- * Photon resizer (reused from pi-coding-agent, lazy-imported so the common no-image headless path never
- * loads the TUI module graph). A null resize (unresizable / Photon unavailable) keeps the original
- * bytes — the provider then applies its own limit.
- */
-export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
-  if (!prompt.images || prompt.images.length === 0) return undefined;
-  const { resizeImage } = await import("@earendil-works/pi-coding-agent");
-  const images = await Promise.all(
-    prompt.images.map(async (img): Promise<ImageContent> => {
-      const resized = await resizeImage(Buffer.from(img.data, "base64"), img.mimeType, {
-        maxWidth: 1568,
-        maxHeight: 1568,
-        maxBytes: 5 * 1024 * 1024,
-      }).catch(() => null);
-      return resized
-        ? { type: "image", data: resized.data, mimeType: resized.mimeType }
-        : { type: "image", data: img.data, mimeType: img.mimeType };
-    }),
-  );
-  return { images };
-}
-
-// ── §3 EventQueue: push→pull plumbing for pi's two-port shape ────────────────
-//
-// Single-consumer async queue; single-threaded JS means no await interleaves between push and
-// drain, so no locking. Engines that are natively async-iterable would not need it. Exported for
-// the sibling L0 (`session-invoke.ts`): both engine classes have pi's two-port shape (a promise for
-// the turn + a subscription for the stream), so the fan-in is the same plumbing.
-
-export class EventQueue<T> {
-  private buffer: T[] = [];
-  private wake?: () => void;
-
-  push(item: T): void {
-    this.buffer.push(item);
-    const wake = this.wake;
-    this.wake = undefined;
-    wake?.();
-  }
-
-  /**
-   * Yield pushed events in order until `done` settles AND the buffer is drained. The terminal is
-   * produced separately (toTerminal); rejections of `done` are swallowed here (the caller awaits
-   * `run` itself) to avoid unhandled rejections.
-   */
-  async *drainUntil(done: Promise<unknown>): AsyncGenerator<T> {
-    let settled = false;
-    const onSettle = () => {
-      settled = true;
-      const wake = this.wake;
-      this.wake = undefined;
-      wake?.();
-    };
-    const finished = done.then(onSettle, onSettle);
-
-    while (true) {
-      while (this.buffer.length > 0) {
-        yield this.buffer.shift() as T;
-      }
-      if (settled) break;
-      await new Promise<void>((resolve) => {
-        this.wake = resolve;
-      });
-    }
-    await finished;
   }
 }
 

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -14,15 +14,7 @@
 import type { AgentHarnessEvent } from "@earendil-works/pi-agent-core";
 import { DEFAULT_COMPACTION_SETTINGS, calculateContextTokens, shouldCompact } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import {
-  ABORTED_CODE,
-  type Agent,
-  type AgentEvent,
-  type Json,
-  type Prompt,
-  type Scope,
-  SESSION_BUSY_CODE,
-} from "../../agent.ts";
+import { ABORTED_CODE, type Agent, type AgentEvent, type Json, type Prompt, type Scope } from "../../agent.ts";
 import { abortFirstIterator } from "../../collect.ts";
 import type { RetryScheduledEvent, RunSettledEvent, SessionEvent } from "../../session.ts";
 import { log } from "../../log.ts";
@@ -31,6 +23,7 @@ import {
   type Lease,
   errorToTerminal,
   inProcessLease,
+  sessionBusyFailure,
   toPiPromptOptions,
   toTerminal,
 } from "./turn-plumbing.ts";
@@ -297,12 +290,7 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
     const release = lease.tryAcquire(scope.session);
     if (!release) {
       // Rejected BEFORE acceptance: no run exists, so the observer sees nothing (replay-safe).
-      yield {
-        type: "failed",
-        details: "session busy: a turn is already in flight for this session",
-        retryable: true,
-        code: SESSION_BUSY_CODE,
-      };
+      yield sessionBusyFailure();
       return;
     }
     // The run exists from here: one run_started, exactly one run_settled. Terminal points only

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -387,9 +387,11 @@ async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageConten
 // ── §3 EventQueue: push→pull plumbing for pi's two-port shape ────────────────
 //
 // Single-consumer async queue; single-threaded JS means no await interleaves between push and
-// drain, so no locking. Engines that are natively async-iterable would not need it.
+// drain, so no locking. Engines that are natively async-iterable would not need it. Exported for
+// the sibling L0 (`session-invoke.ts`): both engine classes have pi's two-port shape (a promise for
+// the turn + a subscription for the stream), so the fan-in is the same plumbing.
 
-class EventQueue<T> {
+export class EventQueue<T> {
   private buffer: T[] = [];
   private wake?: () => void;
 

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -37,22 +37,7 @@ import {
 import { TOOL_ACTIVATION_ENTRY, harnessSession, type PiHarnessFactory } from "./harness.ts";
 import { type ReadonlySessionManager, type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
 
-// ── §2 translate: the single pi↔SPEC translation point ───────────────────────
-//
-// `retryable` = worth re-sending with the same session (SPEC §6: advisory, not a session-atomicity
-// guarantee). Classify from the STRUCTURED signal first, prose only as the last-resort ceiling. What
-// is actually available differs by path, and the two are NOT symmetric:
-//   - thrown error (errorToTerminal): an HTTP `.status`/`.statusCode` AND a network `.code` (incl.
-//     `.cause.code`) — this is where a numeric status genuinely drives the decision.
-//   - failed message (toTerminal): ONLY `diagnostics[].error.code`. pi's `DiagnosticErrorInfo` carries
-//     a `code` (a network code, or a status delivered as a code), with no separate HTTP-status field —
-//     so a message whose provider `code` is a string label (e.g. "rate_limit_exceeded") is not
-//     decisive here and falls to prose.
-// The prose fallback is bounded, not a cop-out: pi-ai already ran its own status-code-based client
-// retries (harness.ts PROVIDER_MAX_RETRIES) before surfacing, so an error that reaches this point has
-// already exhausted the cleanly-retryable cases. The regex is the narrow ceiling, not the classifier.
-// Upstream ask: a first-class `retryable`/`kind` on pi's terminal error would retire the prose path
-// entirely (mirrors the §11 "the deeper fix is upstream in pi" pattern).
+// ── §1 translate: pi's rich events → the SPEC stream ─────────────────────────
 
 /**
  * In-stream event mapping — pi events are translated ONCE into the rich `SessionEvent` vocabulary;
@@ -253,7 +238,7 @@ async function maybeCompact(harness: PiHarness, message: AssistantMessage): Prom
   }
 }
 
-// ── §4 createPiAgentFromHarness ──────────────────────────────────────────────
+// ── §2 createPiAgentFromHarness ──────────────────────────────────────────────
 
 export interface CreatePiAgentFromHarnessOptions {
   harnessFactory: PiHarnessFactory;

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -366,7 +366,7 @@ async function maybeCompact(harness: PiHarness, message: AssistantMessage): Prom
  * loads the TUI module graph). A null resize (unresizable / Photon unavailable) keeps the original
  * bytes — the provider then applies its own limit.
  */
-async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
+export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
   if (!prompt.images || prompt.images.length === 0) return undefined;
   const { resizeImage } = await import("@earendil-works/pi-coding-agent");
   const images = await Promise.all(

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -2,10 +2,12 @@
  * The turn mechanism (request-time): fan pi AgentHarness's two ports (subscribe event side-channel
  * + prompt final value) into SPEC's single event stream, under a single-writer-per-session lease.
  *
- *   §1 Lease       — single-writer concurrency floor (injectable port + in-process default)
- *   §2 translate   — the single pi↔SPEC translation point (both directions)
- *   §3 EventQueue  — push→pull plumbing for pi's two-port shape
- *   §4 createPiAgentFromHarness — composes §1–§3 into Agent.invoke
+ *   §1 translate   — the single pi↔SPEC translation point for THIS engine class (both directions)
+ *   §2 createPiAgentFromHarness — the turn loop itself
+ *
+ * What both engine classes share — the lease, the terminal classification, the prompt→pi image
+ * conversion and the push→pull fan-in — lives in `turn-plumbing.ts`, not here: a sibling L0 must
+ * not have to import this one.
  *
  * Concurrency: at most one in-flight turn per session; a second invoke fails fast with
  * `failed{retryable}` ("session busy"), leaving dedupe/queueing/steering to the channel. Each

--- a/src/engines/pi/session-bridge.ts
+++ b/src/engines/pi/session-bridge.ts
@@ -10,13 +10,14 @@ import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { type ReadonlySessionManager, type ToolActivation, additiveActivation } from "./tool-context.ts";
 
-/** Adapt coding-agent's resident SessionManager to FastAgent's shared tool-runtime manager port. */
-export function toolChatSessionManager(session: AgentSession): ReadonlySessionManager {
+/** Adapt a pi-coding-agent session's SessionManager to FastAgent's shared tool-runtime manager port
+ *  — the session-class counterpart of invoke.ts's `toolSessionManager`. */
+export function toolSessionManagerFromSession(session: AgentSession): ReadonlySessionManager {
   return {
     getSessionId: () => session.sessionManager.getSessionId(),
     async getHeader() {
       const header = session.sessionManager.getHeader();
-      if (!header) throw new Error("chat session has no metadata header");
+      if (!header) throw new Error("session record has no metadata header");
       return { id: header.id, timestamp: header.timestamp };
     },
     async getBranch() {

--- a/src/engines/pi/session-bridge.ts
+++ b/src/engines/pi/session-bridge.ts
@@ -30,11 +30,11 @@ export function toolChatSessionManager(session: AgentSession): ReadonlySessionMa
  *  filtered (`setActiveToolsByName` is authoritative on the session and rebuilds its prompt — our
  *  static override keeps the prompt identical to serving). */
 export function sessionToolActivation(session: AgentSession): ToolActivation {
-  // Same serialization as invoke.ts's bridge (there per turn; here per session — interactive turns
-  // make per-session equivalent): the read-modify-write below is only race-free while nothing awaits
-  // between read and write, and pi's session setters happening to be synchronous today is not a
-  // contract worth betting parallel tool batches on. Built ONCE per session (createRuntime), so
-  // parallel calls actually share the chain.
+  // Same serialization as invoke.ts's bridge: the read-modify-write below is only race-free while
+  // nothing awaits between read and write, and pi's session setters happening to be synchronous
+  // today is not a contract worth betting parallel tool batches on. The invariant is ONE chain per
+  // AgentSession object — whether that object lives for a session (the resident runtime) or for a
+  // turn (the per-invoke L0), parallel activations within it share this chain.
   let chain: Promise<string[]> = Promise.resolve([]);
   return {
     active: () => session.getActiveToolNames(),

--- a/src/engines/pi/session-bridge.ts
+++ b/src/engines/pi/session-bridge.ts
@@ -22,7 +22,9 @@ export function toolSessionManagerFromSession(session: AgentSession, sessionId: 
     async getHeader() {
       const header = session.sessionManager.getHeader();
       if (!header) throw new Error("session record has no metadata header");
-      return { id: header.id, timestamp: header.timestamp };
+      // `id` is the CALLER's, for the same reason as `getSessionId` above — the header's own id is
+      // the filename-safe encoding, and one port must not answer "what is this session" two ways.
+      return { id: sessionId, timestamp: header.timestamp };
     },
     async getBranch() {
       return session.sessionManager.getBranch() as SessionTreeEntry[];

--- a/src/engines/pi/session-bridge.ts
+++ b/src/engines/pi/session-bridge.ts
@@ -10,10 +10,6 @@ import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { type ReadonlySessionManager, type ToolActivation, additiveActivation } from "./tool-context.ts";
 
-/** One activation chain per AgentSession, so two bridges over one session serialize against each
- *  other rather than each holding a private (and therefore useless) chain. */
-const activationChains = new WeakMap<AgentSession, Promise<string[]>>();
-
 /** Adapt coding-agent's resident SessionManager to FastAgent's shared tool-runtime manager port. */
 export function toolChatSessionManager(session: AgentSession): ReadonlySessionManager {
   return {
@@ -36,11 +32,11 @@ export function toolChatSessionManager(session: AgentSession): ReadonlySessionMa
 export function sessionToolActivation(session: AgentSession): ToolActivation {
   // Same serialization as invoke.ts's bridge: the read-modify-write below is only race-free while
   // nothing awaits between read and write, and pi's session setters happening to be synchronous
-  // today is not a contract worth betting parallel tool batches on. The chain is keyed by the
-  // SESSION OBJECT, not by this call: two bridges over one session must serialize against each
-  // other, which a per-call chain would only appear to do.
-  let chain = activationChains.get(session) ?? Promise.resolve<string[]>([]);
-  activationChains.set(session, chain);
+  // today is not a contract worth betting parallel tool batches on. One chain per BRIDGE, which is
+  // sufficient because each consumer builds exactly one bridge per session object (the resident
+  // runtime one per createAgentSession, the per-invoke L0 one per turn's session) — a second bridge
+  // over the same session would not serialize against this one, and nothing constructs that.
+  let chain: Promise<string[]> = Promise.resolve([]);
   return {
     active: () => session.getActiveToolNames(),
     registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
@@ -57,7 +53,6 @@ export function sessionToolActivation(session: AgentSession): ToolActivation {
       };
       const result = chain.then(run, run); // run after the predecessor settles, success or failure
       chain = result.catch(() => []); // the caller sees a rejection on `result`; the chain stays usable
-      activationChains.set(session, chain);
       return result;
     },
   };

--- a/src/engines/pi/session-bridge.ts
+++ b/src/engines/pi/session-bridge.ts
@@ -10,6 +10,10 @@ import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { type ReadonlySessionManager, type ToolActivation, additiveActivation } from "./tool-context.ts";
 
+/** One activation chain per AgentSession, so two bridges over one session serialize against each
+ *  other rather than each holding a private (and therefore useless) chain. */
+const activationChains = new WeakMap<AgentSession, Promise<string[]>>();
+
 /** Adapt coding-agent's resident SessionManager to FastAgent's shared tool-runtime manager port. */
 export function toolChatSessionManager(session: AgentSession): ReadonlySessionManager {
   return {
@@ -32,10 +36,11 @@ export function toolChatSessionManager(session: AgentSession): ReadonlySessionMa
 export function sessionToolActivation(session: AgentSession): ToolActivation {
   // Same serialization as invoke.ts's bridge: the read-modify-write below is only race-free while
   // nothing awaits between read and write, and pi's session setters happening to be synchronous
-  // today is not a contract worth betting parallel tool batches on. The invariant is ONE chain per
-  // AgentSession object — whether that object lives for a session (the resident runtime) or for a
-  // turn (the per-invoke L0), parallel activations within it share this chain.
-  let chain: Promise<string[]> = Promise.resolve([]);
+  // today is not a contract worth betting parallel tool batches on. The chain is keyed by the
+  // SESSION OBJECT, not by this call: two bridges over one session must serialize against each
+  // other, which a per-call chain would only appear to do.
+  let chain = activationChains.get(session) ?? Promise.resolve<string[]>([]);
+  activationChains.set(session, chain);
   return {
     active: () => session.getActiveToolNames(),
     registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
@@ -52,6 +57,7 @@ export function sessionToolActivation(session: AgentSession): ToolActivation {
       };
       const result = chain.then(run, run); // run after the predecessor settles, success or failure
       chain = result.catch(() => []); // the caller sees a rejection on `result`; the chain stays usable
+      activationChains.set(session, chain);
       return result;
     },
   };

--- a/src/engines/pi/session-bridge.ts
+++ b/src/engines/pi/session-bridge.ts
@@ -12,9 +12,13 @@ import { type ReadonlySessionManager, type ToolActivation, additiveActivation } 
 
 /** Adapt a pi-coding-agent session's SessionManager to FastAgent's shared tool-runtime manager port
  *  — the session-class counterpart of invoke.ts's `toolSessionManager`. */
-export function toolSessionManagerFromSession(session: AgentSession): ReadonlySessionManager {
+export function toolSessionManagerFromSession(session: AgentSession, sessionId: string): ReadonlySessionManager {
   return {
-    getSessionId: () => session.sessionManager.getSessionId(),
+    // The CALLER's id, not the record's: ids are opaque and caller-owned, and the store files them
+    // under a filename-safe encoding. A tool that keys anything on this (channel state, an external
+    // store) must see the same string on both engine classes — the harness bridge passes the invoke
+    // scope's id for exactly this reason.
+    getSessionId: () => sessionId,
     async getHeader() {
       const header = session.sessionManager.getHeader();
       if (!header) throw new Error("session record has no metadata header");

--- a/src/engines/pi/session-bridge.ts
+++ b/src/engines/pi/session-bridge.ts
@@ -1,0 +1,58 @@
+/**
+ * The `session` engine class's two tool-runtime bridges, shared by both of its consumers: the
+ * resident runtime (`session-builder.ts`, driving pi's TUI) and the per-invoke L0
+ * (`session-invoke.ts`). One copy, because a fastagent-defined tool must see the same session and
+ * the same activation semantics whichever of the two is driving the turn — and because a MISSING
+ * binding degrades silently (`tool-context.ts`: no store → cwd falls back to process.cwd(), the
+ * manager and activation become undefined, so `wake` writes nowhere and `search_tools` is a no-op).
+ */
+import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { type ReadonlySessionManager, type ToolActivation, additiveActivation } from "./tool-context.ts";
+
+/** Adapt coding-agent's resident SessionManager to FastAgent's shared tool-runtime manager port. */
+export function toolChatSessionManager(session: AgentSession): ReadonlySessionManager {
+  return {
+    getSessionId: () => session.sessionManager.getSessionId(),
+    async getHeader() {
+      const header = session.sessionManager.getHeader();
+      if (!header) throw new Error("chat session has no metadata header");
+      return { id: header.id, timestamp: header.timestamp };
+    },
+    async getBranch() {
+      return session.sessionManager.getBranch() as SessionTreeEntry[];
+    },
+  };
+}
+
+/** The turn's {@link ToolActivation} over pi's AgentSession — the counterpart of invoke.ts's
+ *  harness bridge, so the SAME builtin search_tools serves both paths. Additive; unknown names
+ *  filtered (`setActiveToolsByName` is authoritative on the session and rebuilds its prompt — our
+ *  static override keeps the prompt identical to serving). */
+export function sessionToolActivation(session: AgentSession): ToolActivation {
+  // Same serialization as invoke.ts's bridge (there per turn; here per session — interactive turns
+  // make per-session equivalent): the read-modify-write below is only race-free while nothing awaits
+  // between read and write, and pi's session setters happening to be synchronous today is not a
+  // contract worth betting parallel tool batches on. Built ONCE per session (createRuntime), so
+  // parallel calls actually share the chain.
+  let chain: Promise<string[]> = Promise.resolve([]);
+  return {
+    active: () => session.getActiveToolNames(),
+    registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
+    activate(names) {
+      const run = async (): Promise<string[]> => {
+        const current = session.getActiveToolNames();
+        const added = additiveActivation(
+          session.getAllTools().map((t) => t.name),
+          current,
+          names,
+        );
+        if (added.length > 0) session.setActiveToolsByName([...current, ...added]);
+        return added;
+      };
+      const result = chain.then(run, run); // run after the predecessor settles, success or failure
+      chain = result.catch(() => []); // the caller sees a rejection on `result`; the chain stays usable
+      return result;
+    },
+  };
+}

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -49,7 +49,7 @@ import { log } from "../../log.ts";
 import { type ReadonlySessionManager, type ToolActivation, turnContext } from "./tool-context.ts";
 import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 import { resolveAgentAssembly } from "./open.ts";
-import { sessionToolActivation, toolChatSessionManager } from "./session-bridge.ts";
+import { sessionToolActivation, toolSessionManagerFromSession } from "./session-bridge.ts";
 
 export interface BuildSessionRuntimeOptions {
   /** Model spec override (the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -243,7 +243,7 @@ export async function buildAgentSessionRuntime(
     });
     sessionRef.current = {
       session: result.session,
-      sessionManager: toolChatSessionManager(result.session),
+      sessionManager: toolSessionManagerFromSession(result.session),
       activation: sessionToolActivation(result.session),
     };
     // Deferral emulation: pi's session starts with everything active — narrow it by SUBTRACTING

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -243,7 +243,8 @@ export async function buildAgentSessionRuntime(
     });
     sessionRef.current = {
       session: result.session,
-      sessionManager: toolSessionManagerFromSession(result.session),
+      // The resident runtime IS the id's owner — pi's session id is the caller-facing one here.
+      sessionManager: toolSessionManagerFromSession(result.session, result.session.sessionManager.getSessionId()),
       activation: sessionToolActivation(result.session),
     };
     // Deferral emulation: pi's session starts with everything active — narrow it by SUBTRACTING

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -29,7 +29,6 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import type { SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   type AgentSession,
@@ -47,24 +46,10 @@ import { assembleSystemPrompt, piBasePrompt, piDefaultTools } from "./create.ts"
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
 import { createPiModelRuntime, probeAuthSource } from "./models.ts";
 import { log } from "../../log.ts";
-import { type ReadonlySessionManager, type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
+import { type ReadonlySessionManager, type ToolActivation, turnContext } from "./tool-context.ts";
 import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 import { resolveAgentAssembly } from "./open.ts";
-
-/** Adapt coding-agent's resident SessionManager to FastAgent's shared tool-runtime manager port. */
-function toolChatSessionManager(session: AgentSession): ReadonlySessionManager {
-  return {
-    getSessionId: () => session.sessionManager.getSessionId(),
-    async getHeader() {
-      const header = session.sessionManager.getHeader();
-      if (!header) throw new Error("chat session has no metadata header");
-      return { id: header.id, timestamp: header.timestamp };
-    },
-    async getBranch() {
-      return session.sessionManager.getBranch() as SessionTreeEntry[];
-    },
-  };
-}
+import { sessionToolActivation, toolChatSessionManager } from "./session-bridge.ts";
 
 export interface BuildSessionRuntimeOptions {
   /** Model spec override (the CLI --model flag). Precedence: this > FASTAGENT_MODEL > config.model. */
@@ -85,38 +70,6 @@ export async function buildAgentSessionRuntime(
   /** Session backend. Defaults to pi's project-scoped store; tests inject SessionManager.inMemory(). */
   sessionManager?: SessionManager,
 ): Promise<AgentSessionRuntime> {
-  /** The turn's {@link ToolActivation} over pi's AgentSession — the counterpart of invoke.ts's
-   *  harness bridge, so the SAME builtin search_tools serves both paths. Additive; unknown names
-   *  filtered (`setActiveToolsByName` is authoritative on the session and rebuilds its prompt — our
-   *  static override keeps the prompt identical to serving). */
-  function sessionToolActivation(session: AgentSession): ToolActivation {
-    // Same serialization as invoke.ts's bridge (there per turn; here per session — interactive turns
-    // make per-session equivalent): the read-modify-write below is only race-free while nothing awaits
-    // between read and write, and pi's session setters happening to be synchronous today is not a
-    // contract worth betting parallel tool batches on. Built ONCE per session (createRuntime), so
-    // parallel calls actually share the chain.
-    let chain: Promise<string[]> = Promise.resolve([]);
-    return {
-      active: () => session.getActiveToolNames(),
-      registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
-      activate(names) {
-        const run = async (): Promise<string[]> => {
-          const current = session.getActiveToolNames();
-          const added = additiveActivation(
-            session.getAllTools().map((t) => t.name),
-            current,
-            names,
-          );
-          if (added.length > 0) session.setActiveToolsByName([...current, ...added]);
-          return added;
-        };
-        const result = chain.then(run, run); // run after the predecessor settles, success or failure
-        chain = result.catch(() => []); // the caller sees a rejection on `result`; the chain stays usable
-        return result;
-      },
-    };
-  }
-
   async function resolveAssembly(cwd: string) {
     // The shared front half — the SAME placement/config/model-spec/tool/auth resolution the serving
     // opener uses (open.ts); those inputs cannot drift between the two consumption shapes.

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -36,7 +36,8 @@ import {
   UNSUPPORTED_CAPABILITY_CODE,
 } from "../../session.ts";
 import { listModels } from "./config.ts";
-import type { Lease, RunControls, SessionObserver } from "./invoke.ts";
+import type { RunControls, SessionObserver } from "./invoke.ts";
+import type { Lease } from "./turn-plumbing.ts";
 import { type AnyModel, SUMMARIZATION_RETRY_POLICY, type PiHarnessFactory, harnessSession } from "./harness.ts";
 import { THINKING_LEVELS, resolveSessionSettings } from "./session-settings.ts";
 import { log } from "../../log.ts";

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -60,16 +60,12 @@ import {
  * {@link CreatePiAgentFromSessionOptions.onExtensionError}, which is forwarded every failure; binding
  * pi's slot directly would instead be dropped every turn with no signal.
  *
- * PASS `sessionStartEvent: { type: "session_start", reason: "resume" }`: the record always exists
- * before the session is built (the binder ensures it), and binding emits this event on EVERY turn —
- * pi's default `reason: "startup"` would tell an extension that turn 500 of a conversation is its
- * first, so anything that greets, seeds or logs on startup would do it every turn.
- *
- * BIND TO AN EXISTING RECORD — use `sessionRecordBinder` (session-record.ts), do not let
- * `SessionManager` open a file of its own. Not a style preference: a SessionManager that starts a
- * fresh file BUFFERS everything until the first assistant message, so a crash between "the user
- * asked" and "the model answered" loses the question and the file is never created. The binder is
- * where that rule is implemented; this contract is where it is required.
+ * BIND TO AN EXISTING RECORD — spread `sessionRecordBinder`'s result (session-record.ts) into
+ * `createAgentSession`, do not let `SessionManager` open a file of its own. Not a style preference:
+ * a SessionManager that starts a fresh file BUFFERS everything until the first assistant message, so
+ * a crash between "the user asked" and "the model answered" loses the question and the file is never
+ * created. The binder carries the matching `sessionStartEvent` too, so the two rules cannot come
+ * apart; both are implemented there, and this contract is where they are required.
  */
 export interface CreatePiAgentFromSessionOptions {
   sessionFactory: (sessionId: string) => Promise<AgentSession>;
@@ -276,6 +272,10 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // one, release the object. Written once because the three exits differ only in how far setup
       // got — three hand-written subsets drift the moment a line moves between them.
       let unsub: (() => void) | undefined;
+      /** Whether THIS turn bound the extensions — i.e. whether a `session_start` was emitted for it.
+       *  `hasHandlers` cannot answer that: the runner and its handlers exist from construction, so it
+       *  would send a shutdown for a lifecycle that never began (the cancel-during-build path). */
+      let bound = false;
       const teardown = async (): Promise<void> => {
         try {
           await session.abort();
@@ -290,10 +290,9 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         try {
           // Extensions saw a `session_start` when this turn bound them; without its counterpart they
           // would see a birth every turn and never a death, so anything acquired there (a handle, a
-          // timer, a subscription) would live until the process exits.
-          // pi's own helper is not on the package's public surface, and its whole body is this
-          // guard plus the emit (runner.js: `hasHandlers` → `emit`) — both public.
-          if (session.extensionRunner.hasHandlers("session_shutdown")) {
+          // timer, a subscription) would live until the process exits. Only when this turn actually
+          // bound them: a death for a birth that never happened is the same asymmetry mirrored.
+          if (bound && session.extensionRunner.hasHandlers("session_shutdown")) {
             await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
           }
         } catch (error) {
@@ -345,6 +344,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             }
           },
         });
+        bound = true;
       } catch (error) {
         // Binding is this engine class's own setup step, and its failures obey the same rule as the
         // factory's: an EVENT, never a thrown iteration — and the session still gets torn down.

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -325,6 +325,11 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
 
       const queue = new EventQueue<AgentEvent>();
       let settled: AssistantMessage | undefined;
+      // SUBSCRIBED BEFORE BINDING (below): pi emits `session_start` inside `bindExtensions`, and a
+      // handler's `sendMessage` lands as a `message_end` right there — a subscription armed
+      // afterwards would drop it, which is the silence this projection exists to prevent, in the one
+      // case `reason: "startup"` exists to enable (an extension that greets or seeds on a
+      // conversation's first turn).
 
       // EVERY extension-dispatch failure, not just a command handler's: pi reports them all here,
       // and one that vanished would be a silent failure inside a turn we are about to call
@@ -336,6 +341,26 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // the assembly's stay as they were — but `onError` is a single slot, not a merge, so this L0
       // CLAIMS it (stated in the factory contract above).
       const consumingErrors: string[] = [];
+      unsub = session.subscribe((event) => {
+        if (event.type === "agent_end") {
+          // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.
+          // Taking the message from a retried end would classify the turn on an error pi is about
+          // to recover from.
+          if (!event.willRetry) settled = lastAssistant(event);
+          return;
+        }
+        const projected = projectSessionEvent(event);
+        if (!projected) return;
+        if (projected.type === "retrying") {
+          // Same reason the harness L0 logs it: the event only reaches an ATTACHED consumer, while
+          // an operator tailing logs must also see a backoff that would otherwise read as a hang.
+          log.warn(
+            `[fastagent] retry ${projected.attempt}/${projected.maxAttempts} in ${projected.delayMs}ms (session ${scope.session}): ${projected.reason}`,
+          );
+        }
+        queue.push(projected);
+      });
+
       try {
         bound = true;
         await session.bindExtensions({
@@ -362,25 +387,6 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         yield { type: "failed", details: failureDetails(error), retryable: false };
         return;
       }
-      unsub = session.subscribe((event) => {
-        if (event.type === "agent_end") {
-          // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.
-          // Taking the message from a retried end would classify the turn on an error pi is about
-          // to recover from.
-          if (!event.willRetry) settled = lastAssistant(event);
-          return;
-        }
-        const projected = projectSessionEvent(event);
-        if (!projected) return;
-        if (projected.type === "retrying") {
-          // Same reason the harness L0 logs it: the event only reaches an ATTACHED consumer, while
-          // an operator tailing logs must also see a backoff that would otherwise read as a hang.
-          log.warn(
-            `[fastagent] retry ${projected.attempt}/${projected.maxAttempts} in ${projected.delayMs}ms (session ${scope.session}): ${projected.reason}`,
-          );
-        }
-        queue.push(projected);
-      });
       try {
         // prompt() resolves when the turn is accepted-and-run; waitForIdle() closes the window in
         // which pi is still draining its own queues (a follow-up, a retry), so the terminal below

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -70,8 +70,45 @@ const DELTA_CHANNELS: Record<AssistantMessageEvent["type"], "project" | "ignore"
   error: "ignore",
 };
 
+/**
+ * EXHAUSTIVE map of pi's session-class event vocabulary, same discipline as {@link DELTA_CHANNELS}
+ * one level down. This union is the one pi extends most (bash execution, compaction phases,
+ * summarization retries), and an added member that nobody projects is exactly the drift a bare
+ * `default:` waves through — here it stops the build instead.
+ */
+const SESSION_EVENTS: Record<AgentSessionEvent["type"], "project" | "ignore"> = {
+  // Projected below into the Agent Handler vocabulary.
+  message_update: "project",
+  tool_execution_start: "project",
+  tool_execution_end: "project",
+  auto_retry_start: "project",
+  summarization_retry_scheduled: "project",
+  // The turn's OUTCOME, read by the turn loop rather than projected as a stream event.
+  agent_end: "ignore",
+  // Bookkeeping with no Agent Handler counterpart: run/turn/message boundaries, durable-record and
+  // queue notifications, and the richer-plane material the control plane projects separately.
+  agent_start: "ignore",
+  agent_settled: "ignore",
+  turn_start: "ignore",
+  turn_end: "ignore",
+  message_start: "ignore",
+  message_end: "ignore",
+  tool_execution_update: "ignore",
+  queue_update: "ignore",
+  entry_appended: "ignore",
+  session_info_changed: "ignore",
+  thinking_level_changed: "ignore",
+  compaction_start: "ignore",
+  compaction_end: "ignore",
+  auto_retry_end: "ignore",
+  summarization_retry_attempt_start: "ignore",
+  summarization_retry_finished: "ignore",
+  bash_execution_update: "ignore",
+};
+
 /** pi's session-class event → the Agent Handler vocabulary. `null` = nothing to project. */
 function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
+  if (SESSION_EVENTS[event.type] === "ignore") return null;
   switch (event.type) {
     case "message_update": {
       // The delta channel: pi reports the accumulated message plus the typed event that changed it.
@@ -107,9 +144,6 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
         reason: event.errorMessage,
       };
     default:
-      // Everything else is either session-class bookkeeping (entry_appended, queue_update) or
-      // richer-plane material the control plane will project separately. Terminal events are NOT
-      // derived here — the turn's outcome comes from the settled assistant message.
       return null;
   }
 }
@@ -174,6 +208,16 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
 
       const queue = new EventQueue<AgentEvent>();
       let settled: AssistantMessage | undefined;
+      // An extension command handler that THROWS is caught by pi and reported here — there is no
+      // assistant message and no agent_end, so without this the turn would settle `completed` and
+      // report success for work that failed. Bound (not replaced): bindExtensions merges, so the
+      // assembly's uiContext/mode/actions stay as they were.
+      let extensionError: string | undefined;
+      await session.bindExtensions({
+        onError: (error: { event: string; error: string }) => {
+          extensionError ??= `extension ${error.event} failed: ${error.error}`;
+        },
+      });
       const unsub = session.subscribe((event) => {
         if (event.type === "agent_end") {
           // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.
@@ -219,10 +263,14 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         let terminal: AgentEvent;
         try {
           await run;
-          // No settled assistant message means the turn produced no model response at all (an
-          // extension command handled the input, or pi ended without one) — a completed turn with
-          // nothing to classify, not a failure.
-          terminal = settled ? toTerminal(settled) : { type: "completed" };
+          terminal = settled
+            ? toTerminal(settled)
+            : extensionError
+              ? errorToTerminal(new Error(extensionError))
+              : // No settled assistant message and no extension failure: the turn produced no model
+                // response at all (an extension command handled the input) — a completed turn with
+                // nothing to classify.
+                { type: "completed" };
         } catch (error) {
           terminal = errorToTerminal(error);
         }

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -272,9 +272,13 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // one, release the object. Written once because the three exits differ only in how far setup
       // got — three hand-written subsets drift the moment a line moves between them.
       let unsub: (() => void) | undefined;
-      /** Whether THIS turn bound the extensions — i.e. whether a `session_start` was emitted for it.
-       *  `hasHandlers` cannot answer that: the runner and its handlers exist from construction, so it
-       *  would send a shutdown for a lifecycle that never began (the cancel-during-build path). */
+      /** Whether THIS turn began the extension lifecycle — set BEFORE the call, because pi emits
+       *  `session_start` inside `bindExtensions` and then does more work that can throw: a flag set
+       *  after it resolves would miss a birth that already reached the handlers. Pessimistic on
+       *  purpose — a shutdown for a birth that only partly landed is cheaper than a handler holding
+       *  what it acquired until the process exits. `hasHandlers` cannot answer this at all: the
+       *  runner and its handlers exist from construction, so it would also fire for a turn cancelled
+       *  before binding. */
       let bound = false;
       const teardown = async (): Promise<void> => {
         try {
@@ -332,6 +336,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // CLAIMS it (stated in the factory contract above).
       const consumingErrors: string[] = [];
       try {
+        bound = true;
         await session.bindExtensions({
           onError: (error: { event: string; error: string }) => {
             const message = `extension ${error.event} failed: ${error.error}`;
@@ -344,7 +349,6 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             }
           },
         });
-        bound = true;
       } catch (error) {
         // Binding is this engine class's own setup step, and its failures obey the same rule as the
         // factory's: an EVENT, never a thrown iteration — and the session still gets torn down.

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -42,12 +42,11 @@ import {
  * object is discarded when the turn ends, so an implementation must NOT cache it across turns (that
  * would be the resident level, with a different bill).
  *
- * BIND TO AN EXISTING RECORD (`SessionManager.setSessionFile` over a file the session store created),
- * do not let `SessionManager` open one of its own. This is not a style preference: a SessionManager
- * that starts a fresh file BUFFERS everything until the first assistant message, so a crash between
- * "the user asked" and "the model answered" loses the question — the file is not even created.
- * Binding to a record that already exists persists the user's turn immediately, which is what the
- * harness class has always done and what a channel's at-least-once delivery assumes.
+ * BIND TO AN EXISTING RECORD — use `sessionRecordBinder` (session-record.ts), do not let
+ * `SessionManager` open a file of its own. Not a style preference: a SessionManager that starts a
+ * fresh file BUFFERS everything until the first assistant message, so a crash between "the user
+ * asked" and "the model answered" loses the question and the file is never created. The binder is
+ * where that rule is implemented; this contract is where it is required.
  */
 export interface CreatePiAgentFromSessionOptions {
   sessionFactory: (sessionId: string) => Promise<AgentSession>;
@@ -84,7 +83,7 @@ const DELTA_CHANNELS: Record<AssistantMessageEvent["type"], "project" | "ignore"
  * summarization retries), and an added member that nobody projects is exactly the drift a bare
  * `default:` waves through — here it stops the build instead.
  */
-const SESSION_EVENTS: Record<AgentSessionEvent["type"], "project" | "ignore"> = {
+const SESSION_EVENTS = {
   // Projected below into the Agent Handler vocabulary.
   message_update: "project",
   tool_execution_start: "project",
@@ -115,11 +114,23 @@ const SESSION_EVENTS: Record<AgentSessionEvent["type"], "project" | "ignore"> = 
   summarization_retry_attempt_start: "ignore",
   summarization_retry_finished: "ignore",
   bash_execution_update: "ignore",
-};
+} as const satisfies Record<AgentSessionEvent["type"], "project" | "ignore">;
+
+/** The members {@link SESSION_EVENTS} declares projectable — what the switch below must handle. */
+type ProjectedType = {
+  [K in keyof typeof SESSION_EVENTS]: (typeof SESSION_EVENTS)[K] extends "project" ? K : never;
+}[keyof typeof SESSION_EVENTS];
 
 /** pi's session-class event → the Agent Handler vocabulary. `null` = nothing to project. */
 function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
+  // The runtime filter and the type narrowing are the same decision, made once: everything past
+  // this line is a member {@link SESSION_EVENTS} declared projectable, which is what lets the
+  // switch below be exhaustively checked.
   if (SESSION_EVENTS[event.type] === "ignore") return null;
+  return projectProjectable(event as Extract<AgentSessionEvent, { type: ProjectedType }>);
+}
+
+function projectProjectable(event: Extract<AgentSessionEvent, { type: ProjectedType }>): AgentEvent | null {
   switch (event.type) {
     case "message_update": {
       // The delta channel: pi reports the accumulated message plus the typed event that changed it.
@@ -162,8 +173,14 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
         delayMs: event.delayMs,
         reason: event.errorMessage,
       };
-    default:
+    default: {
+      // Declaring a member "project" and forgetting its case would otherwise project nothing — the
+      // same silent drift the map exists to stop, one step later. This assignment is `never` only
+      // while every projectable member has a case above.
+      const unhandled: never = event;
+      void unhandled;
       return null;
+    }
   }
 }
 

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -19,6 +19,8 @@ import type { AgentEvent, Agent, Json, Prompt, Scope } from "../../agent.ts";
 import { SESSION_BUSY_CODE } from "../../agent.ts";
 import { abortFirstIterator } from "../../collect.ts";
 import { log } from "../../log.ts";
+import { sessionToolActivation, toolChatSessionManager } from "./session-bridge.ts";
+import { turnContext } from "./tool-context.ts";
 import { EventQueue, type Lease, errorToTerminal, inProcessLease, toPiPromptOptions, toTerminal } from "./invoke.ts";
 
 /**
@@ -58,7 +60,10 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
         isError: event.isError,
         content: (event.result ?? null) as Json,
       };
+    // BOTH backoffs, for one reason: a quiet tail reads as a hang. The turn-level auto-retry and
+    // the summarization retry (compaction / branch summary) are the same silence to a consumer.
     case "auto_retry_start":
+    case "summarization_retry_scheduled":
       return {
         type: "retrying",
         attempt: event.attempt,
@@ -150,10 +155,21 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         // Images ride the same conversion the harness L0 uses (resize + provider shape); dropping
         // them here would make an attachment invisible to the model AND silent to the author.
         const opts = await toPiPromptOptions(prompt);
-        const run = (async () => {
-          await session.prompt(prompt.text, opts);
-          await session.waitForIdle();
-        })();
+        // Bind the turn context for the duration of the turn, like both siblings do (invoke.ts per
+        // turn, session-builder.ts per session): without it every fastagent-defined tool degrades
+        // SILENTLY — `wake` writes nowhere, `search_tools` activates nothing, cwd falls back to the
+        // process's.
+        const run = turnContext.run(
+          {
+            cwd: session.sessionManager.getCwd(),
+            sessionManager: toolChatSessionManager(session),
+            tools: sessionToolActivation(session),
+          },
+          async () => {
+            await session.prompt(prompt.text, opts);
+            await session.waitForIdle();
+          },
+        );
         yield* queue.drainUntil(run);
         let terminal: AgentEvent;
         try {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -16,16 +16,11 @@
  * definition freshness for the ~1ms turn cost. Either is a legitimate deployment choice — silence
  * about which one is in force is not.
  *
- * NOT YET WIRED, twice over. This module has no consumer in `src/`: the assembly that would produce
- * a session factory for a real definition (models, auth, tools, extensions) does not exist yet, and
- * neither this L0 nor `sessionRecordBinder` is exported from `src/pi.ts` — pi-coupled L0s stay
- * internal by convention (AGENTS.md), so selecting this engine class is an in-repo capability until
- * the assembly and the exports land together.
- *
- * And: the harness L0 accepts a `SessionObserver` and registers per-run modulation handles
- * (steer/follow_up/abort), which is what the session control plane consumes. This L0 has neither, so
- * an agent built here serves invokes but cannot be observed or steered through `/control/*` — the
- * gap to close before it backs a serving path, not an omission to discover later.
+ * NOT WIRED into the control plane: the harness L0 accepts a `SessionObserver` and registers per-run
+ * modulation handles (steer/follow_up/abort), which is what `/control/*` consumes. This L0 has
+ * neither, so an agent built here serves invokes but cannot be observed or steered. That and the
+ * rest of the wiring (the assembly, the export decision) are one list, kept in
+ * design/conformance-levels.md §4 rather than restated here.
  *
  * This module owns the turn mechanism only. The assembly that produces the session factory
  * (models, auth, tools, definition, extensions) is a caller's concern, exactly as
@@ -70,7 +65,10 @@ import {
  */
 export interface CreatePiAgentFromSessionOptions {
   sessionFactory: (sessionId: string) => Promise<AgentSession>;
-  /** Every extension-dispatch failure of every turn, forwarded. The supported place for a factory's
+  /** Every extension failure of every turn, forwarded: pi's own dispatch failures (`event` is its
+   *  label — `command`, `input`, a hook name) AND a failure of the binding itself, which pi THROWS
+   *  rather than dispatching (`event: "bind"`, this L0's label for it) — the coarsest of them all,
+   *  and the one a metrics or toast listener would most miss. The supported place for a factory's
    *  own listener, since pi's `onError` is a single slot this L0 owns (see the factory contract).
    *  A throwing listener is contained — it is an observer, not part of the turn. */
   onExtensionError?: (error: { event: string; error: string }) => void;
@@ -288,6 +286,10 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
           log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
         }
         try {
+          // Unsubscribed BEFORE the shutdown emit below, deliberately and asymmetrically with the
+          // startup side: teardown runs after the terminal was yielded, so anything a
+          // `session_shutdown` handler says has no stream left to reach — pushing it into a queue
+          // nobody drains would only look like delivery.
           unsub?.();
         } catch (error) {
           log.warn(`[fastagent] session unsubscribe failed during cleanup: ${String(error)}`);
@@ -341,6 +343,14 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // the assembly's stay as they were — but `onError` is a single slot, not a merge, so this L0
       // CLAIMS it (stated in the factory contract above).
       const consumingErrors: string[] = [];
+      /** Forward to the factory's observer, contained: a listener is not part of the turn. */
+      const reportExtensionError = (error: { event: string; error: string }): void => {
+        try {
+          options.onExtensionError?.(error);
+        } catch (listenerError) {
+          log.warn(`[fastagent] onExtensionError threw: ${String(listenerError)}`);
+        }
+      };
       unsub = session.subscribe((event) => {
         if (event.type === "agent_end") {
           // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.
@@ -368,11 +378,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             const message = `extension ${error.event} failed: ${error.error}`;
             if (TURN_CONSUMING_DISPATCH.has(error.event)) consumingErrors.push(message);
             log.warn(`[fastagent] session ${scope.session}: ${message}`);
-            try {
-              options.onExtensionError?.(error);
-            } catch (listenerError) {
-              log.warn(`[fastagent] onExtensionError threw: ${String(listenerError)}`);
-            }
+            reportExtensionError(error);
           },
         });
       } catch (error) {
@@ -383,6 +389,9 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         // would read "timed out" out of an extension's message and invite a re-run that throws
         // identically. The FACTORY's failures keep the classifier: record open, auth and network
         // genuinely mix transient with permanent.
+        // The listener hears this one too: it is an extension failure like the dispatched ones, and
+        // the only reason it arrives as a throw is that pi has no dispatch for binding itself.
+        reportExtensionError({ event: "bind", error: failureDetails(error) });
         await teardown();
         yield { type: "failed", details: failureDetails(error), retryable: false };
         return;

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -22,7 +22,6 @@
 import type { AssistantMessage, AssistantMessageEvent } from "@earendil-works/pi-ai";
 import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { AgentEvent, Agent, Json, Prompt, Scope } from "../../agent.ts";
-import { SESSION_BUSY_CODE } from "../../agent.ts";
 import { abortFirstIterator } from "../../collect.ts";
 import { log } from "../../log.ts";
 import { sessionToolActivation, toolSessionManagerFromSession } from "./session-bridge.ts";
@@ -32,6 +31,7 @@ import {
   type Lease,
   errorToTerminal,
   inProcessLease,
+  sessionBusyFailure,
   toPiPromptOptions,
   toTerminal,
 } from "./turn-plumbing.ts";
@@ -92,7 +92,10 @@ const SESSION_EVENTS: Record<AgentSessionEvent["type"], "project" | "ignore"> = 
   turn_start: "ignore",
   turn_end: "ignore",
   message_start: "ignore",
-  message_end: "ignore",
+  // A COMMAND's output arrives as a custom-role message (an extension's `sendMessage`), and it is
+  // the only output such a turn has — ignoring it would make "the command ran" indistinguishable
+  // from "nothing happened" to a stream consumer. Model text keeps arriving as deltas.
+  message_end: "project",
   tool_execution_update: "ignore",
   queue_update: "ignore",
   entry_appended: "ignore",
@@ -117,6 +120,14 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
       if (e.type === "thinking_delta") return { type: "thinking", delta: e.delta };
       if (e.type === "text_delta") return { type: "text", delta: e.delta };
       return null;
+    }
+    case "message_end": {
+      // Only the DISPLAY-worthy custom messages: an assistant message already streamed as deltas,
+      // and a non-display custom message is extension bookkeeping the user was never meant to read.
+      const m = event.message as { role?: string; display?: boolean; content?: unknown };
+      if (m.role !== "custom" || m.display === false) return null;
+      const delta = customText(m.content);
+      return delta === "" ? null : { type: "text", delta };
     }
     case "tool_execution_start":
       return {
@@ -148,6 +159,16 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
   }
 }
 
+/** Plain text of a custom message's content (string, or the text blocks of a content array). */
+function customText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return (content as Array<{ type?: string; text?: string }>)
+    .filter((b) => b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text as string)
+    .join("");
+}
+
 /** The assistant message a settled turn ended on, for terminal classification. */
 function lastAssistant(event: AgentSessionEvent): AssistantMessage | undefined {
   if (event.type !== "agent_end") return undefined;
@@ -175,12 +196,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
   ): AsyncGenerator<AgentEvent> {
     const release = lease.tryAcquire(scope.session);
     if (!release) {
-      yield {
-        type: "failed",
-        details: "session busy: a turn is already in flight for this session",
-        retryable: true,
-        code: SESSION_BUSY_CODE,
-      };
+      yield sessionBusyFailure();
       return;
     }
     try {
@@ -214,7 +230,6 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // below. Bound, not replaced: bindExtensions merges, so the assembly's uiContext/mode/actions
       // stay as they were.
       let extensionError: string | undefined;
-      let unsub: () => void = () => {};
       try {
         await session.bindExtensions({
           onError: (error: { event: string; error: string }) => {
@@ -228,7 +243,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         yield errorToTerminal(error);
         return;
       }
-      unsub = session.subscribe((event) => {
+      const unsub = session.subscribe((event) => {
         if (event.type === "agent_end") {
           // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.
           // Taking the message from a retried end would classify the turn on an error pi is about

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -1,0 +1,210 @@
+/**
+ * L0 for the `session` ENGINE CLASS: an Agent whose every turn builds a fresh pi-coding-agent
+ * `AgentSession` over the session's durable record and discards it when the turn ends.
+ *
+ * Same state locality as the harness L0 (`invoke.ts`) — per-invoke, so SPEC MUST 6 holds and the
+ * record is the only continuity — but a different engine surface: extensions, `/name` dispatch,
+ * branch operations. The two axes are independent; see design/conformance-levels.md.
+ *
+ * Why per-invoke is affordable HERE, where a resident `AgentSession` was assumed: the expensive half
+ * of that class is the `ResourceLoader` (extension modules, skills), which is built ONCE with the
+ * assembly and shared across turns. What is per-turn is binding a session object to a record.
+ *
+ * This module owns the turn mechanism only. The assembly that produces a {@link PiSessionFactory}
+ * (models, auth, tools, definition, extensions) is a caller's concern, exactly as
+ * `piHarnessFactory` is for the harness class.
+ */
+import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import type { AgentEvent, Agent, Json, Prompt, Scope } from "../../agent.ts";
+import { SESSION_BUSY_CODE } from "../../agent.ts";
+import { abortFirstIterator } from "../../collect.ts";
+import { log } from "../../log.ts";
+import { EventQueue, type Lease, errorToTerminal, inProcessLease, toTerminal } from "./invoke.ts";
+
+/**
+ * Build a session object bound to `sessionId`'s durable record. Called once per invoke; the returned
+ * object is discarded when the turn ends, so an implementation must NOT cache it across turns (that
+ * would be the resident level, with a different bill).
+ */
+export interface CreatePiAgentFromSessionOptions {
+  sessionFactory: (sessionId: string) => Promise<AgentSession>;
+  /** One in-flight turn per session, like the harness L0. A collision fails `session_busy`. */
+  lease?: Lease;
+}
+
+/** pi's session-class event → the Agent Handler vocabulary. `null` = nothing to project. */
+function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
+  switch (event.type) {
+    case "message_update": {
+      // The delta channel: pi reports the accumulated message plus the event that changed it.
+      const e = (event as { assistantMessageEvent?: { type?: string; delta?: string } }).assistantMessageEvent;
+      if (!e || typeof e.delta !== "string" || e.delta === "") return null;
+      if (e.type === "thinking_delta" || e.type === "thinking") return { type: "thinking", delta: e.delta };
+      if (e.type === "text_delta" || e.type === "text") return { type: "text", delta: e.delta };
+      return null;
+    }
+    case "tool_execution_start":
+      return {
+        type: "tool_started",
+        id: event.toolCallId,
+        name: event.toolName,
+        args: (event.args ?? null) as Json,
+      };
+    case "tool_execution_end":
+      return {
+        type: "tool_ended",
+        id: event.toolCallId,
+        isError: event.isError,
+        content: (event.result ?? null) as Json,
+      };
+    case "auto_retry_start":
+      return {
+        type: "retrying",
+        attempt: event.attempt,
+        maxAttempts: event.maxAttempts,
+        delayMs: event.delayMs,
+        reason: event.errorMessage,
+      };
+    default:
+      // Everything else is either session-class bookkeeping (entry_appended, queue_update) or
+      // richer-plane material the control plane will project separately. Terminal events are NOT
+      // derived here — the turn's outcome comes from the settled assistant message.
+      return null;
+  }
+}
+
+/** The assistant message a settled turn ended on, for terminal classification. */
+function lastAssistant(event: AgentSessionEvent): Parameters<typeof toTerminal>[0] | undefined {
+  if (event.type !== "agent_end") return undefined;
+  const messages = event.messages;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role === "assistant") return m as Parameters<typeof toTerminal>[0];
+  }
+  return undefined;
+}
+
+/**
+ * The `session`-class L0. Mirrors `createPiAgentFromHarness`'s discipline: failures are `failed`
+ * events (never thrown mid-iteration), exactly one terminal, and a consumer break aborts in-flight
+ * engine work.
+ */
+export function createPiAgentFromSession(options: CreatePiAgentFromSessionOptions): Agent {
+  const { sessionFactory, lease = inProcessLease() } = options;
+
+  async function* turn(
+    scope: Scope,
+    prompt: Prompt,
+    onCancelReady: (cancel: () => void) => void,
+    wasCancelled: () => boolean,
+  ): AsyncGenerator<AgentEvent> {
+    const release = lease.tryAcquire(scope.session);
+    if (!release) {
+      yield {
+        type: "failed",
+        details: "session busy: a turn is already in flight for this session",
+        retryable: true,
+        code: SESSION_BUSY_CODE,
+      };
+      return;
+    }
+    try {
+      let session: AgentSession;
+      try {
+        session = await sessionFactory(scope.session);
+      } catch (error) {
+        // Setup failures (record open, auth, extension binding) are EVENTS, never throws.
+        yield errorToTerminal(error);
+        return;
+      }
+      // Arm the cancellation door before any model work, then honour a cancel that arrived while
+      // the session was still being built (the latch) — the same ordering the harness L0 uses.
+      onCancelReady(() => {
+        void session.abort().catch(() => {});
+      });
+      if (wasCancelled()) {
+        await session.abort().catch((error: unknown) => {
+          log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
+        });
+        return;
+      }
+
+      const queue = new EventQueue<AgentEvent>();
+      let settled: Parameters<typeof toTerminal>[0] | undefined;
+      let sawEnd = false;
+      const unsub = session.subscribe((event) => {
+        if (event.type === "agent_end") {
+          // `willRetry` means pi will run again for this same prompt — not a settle.
+          if (!(event as { willRetry?: boolean }).willRetry) {
+            sawEnd = true;
+            settled = lastAssistant(event);
+          }
+          return;
+        }
+        const projected = projectSessionEvent(event);
+        if (projected) queue.push(projected);
+      });
+      try {
+        // prompt() resolves when the turn is accepted-and-run; waitForIdle() closes the window in
+        // which pi is still draining its own queues (a follow-up, a retry), so the terminal below
+        // describes the whole activity window rather than the first response inside it.
+        const run = (async () => {
+          await session.prompt(prompt.text);
+          await session.waitForIdle();
+        })();
+        yield* queue.drainUntil(run);
+        let terminal: AgentEvent;
+        try {
+          await run;
+          // No settled assistant message means the turn produced no model response at all (an
+          // extension command handled the input, or pi ended without one) — a completed turn with
+          // nothing to classify, not a failure.
+          terminal = settled ? toTerminal(settled) : { type: "completed" };
+        } catch (error) {
+          terminal = errorToTerminal(error);
+        }
+        void sawEnd;
+        yield terminal;
+      } finally {
+        try {
+          unsub();
+        } catch (error) {
+          log.warn(`[fastagent] session unsubscribe failed during cleanup: ${String(error)}`);
+        }
+        // Fresh-session discipline: the object dies with the turn. Aborting first releases any work
+        // still in flight after a consumer break.
+        try {
+          await session.abort();
+        } catch (error) {
+          log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
+        }
+      }
+    } finally {
+      release();
+    }
+  }
+
+  return {
+    invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
+      let externalCancel: (() => void) | undefined;
+      let cancelled = false;
+      const gen = turn(
+        scope,
+        prompt,
+        (cancel) => {
+          externalCancel = cancel;
+        },
+        () => cancelled,
+      );
+      const iterator = abortFirstIterator(gen, () => {
+        cancelled = true;
+        externalCancel?.();
+      });
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+          return iterator;
+        },
+      };
+    },
+  };
+}

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -19,6 +19,7 @@
  * (models, auth, tools, definition, extensions) is a caller's concern, exactly as
  * `piHarnessFactory` is for the harness class.
  */
+import type { CustomMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, AssistantMessageEvent } from "@earendil-works/pi-ai";
 import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { AgentEvent, Agent, Json, Prompt, Scope } from "../../agent.ts";
@@ -124,7 +125,7 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
     case "message_end": {
       // Only the DISPLAY-worthy custom messages: an assistant message already streamed as deltas,
       // and a non-display custom message is extension bookkeeping the user was never meant to read.
-      const m = event.message as { role?: string; display?: boolean; content?: unknown };
+      const m = event.message;
       if (m.role !== "custom" || m.display === false) return null;
       const delta = customText(m.content);
       return delta === "" ? null : { type: "text", delta };
@@ -159,14 +160,15 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
   }
 }
 
-/** Plain text of a custom message's content (string, or the text blocks of a content array). */
-function customText(content: unknown): string {
+/**
+ * A custom message's content rendered for the Agent Handler's text channel. Non-text blocks become a
+ * bracketed placeholder rather than nothing: the vocabulary has no image event, and this projection
+ * exists precisely so a command's turn is not an empty stream — an image-only reply must not
+ * reintroduce that silence one content shape over.
+ */
+function customText(content: CustomMessage["content"]): string {
   if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return (content as Array<{ type?: string; text?: string }>)
-    .filter((b) => b.type === "text" && typeof b.text === "string")
-    .map((b) => b.text as string)
-    .join("");
+  return content.map((block) => (block.type === "text" ? block.text : `[${block.type}]`)).join("");
 }
 
 /** The assistant message a settled turn ended on, for terminal classification. */
@@ -226,14 +228,17 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       let settled: AssistantMessage | undefined;
       // EVERY extension-dispatch failure, not just a command handler's: pi reports them all here,
       // and one that vanished would be a silent failure inside a turn we are about to call
-      // completed. How it is CONSUMED depends on what else the turn produced — see the terminal
-      // below. Bound, not replaced: bindExtensions merges, so the assembly's uiContext/mode/actions
-      // stay as they were.
-      let extensionError: string | undefined;
+      // completed — so they ACCUMULATE (a second failing hook must not be swallowed by the first)
+      // and each is warned as it arrives, whatever the turn's terminal turns out to be. How they are
+      // CONSUMED depends on what else the turn produced — see the terminal below. Bound, not
+      // replaced: bindExtensions merges, so the assembly's uiContext/mode/actions stay as they were.
+      const extensionErrors: string[] = [];
       try {
         await session.bindExtensions({
           onError: (error: { event: string; error: string }) => {
-            extensionError ??= `extension ${error.event} failed: ${error.error}`;
+            const message = `extension ${error.event} failed: ${error.error}`;
+            extensionErrors.push(message);
+            log.warn(`[fastagent] session ${scope.session}: ${message}`);
           },
         });
       } catch (error) {
@@ -294,10 +299,9 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         try {
           await run;
           if (settled) {
-            // The turn ran the model: its own outcome decides the terminal. An extension failure
-            // alongside it is real but not the turn's verdict — surfaced as a warn rather than
-            // flipping a model answer the caller did receive into a failure.
-            if (extensionError) log.warn(`[fastagent] session ${scope.session}: ${extensionError}`);
+            // The turn ran the model: its own outcome decides the terminal. Extension failures
+            // alongside it are real (and already warned) but not the turn's verdict — flipping a
+            // model answer the caller did receive into a failure would deny them the result.
             terminal = toTerminal(settled);
           } else {
             // No model response at all: the input was handled by an extension (a command), so an
@@ -307,9 +311,10 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             // "timed out"/"rate limit"/5xx out of a message, which would tell a caller to re-run a
             // handler whose code throws identically every time. An in-process dispatch failure is a
             // determinate local outcome.
-            terminal = extensionError
-              ? { type: "failed", details: extensionError, retryable: false }
-              : { type: "completed" };
+            terminal =
+              extensionErrors.length > 0
+                ? { type: "failed", details: extensionErrors.join("; "), retryable: false }
+                : { type: "completed" };
           }
         } catch (error) {
           terminal = errorToTerminal(error);

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -54,6 +54,10 @@ import {
  * object is discarded when the turn ends, so an implementation must NOT cache it across turns (that
  * would be the resident level, with a different bill).
  *
+ * DO NOT BIND `onError`: unlike `uiContext`/`mode`/`commandContextActions`, which pi merges, the
+ * extension-error listener is a single slot — this L0 claims it to classify a command turn, and a
+ * factory that set its own would have it dropped every turn with no signal.
+ *
  * BIND TO AN EXISTING RECORD — use `sessionRecordBinder` (session-record.ts), do not let
  * `SessionManager` open a file of its own. Not a style preference: a SessionManager that starts a
  * fresh file BUFFERS everything until the first assistant message, so a crash between "the user
@@ -290,8 +294,9 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // and each is warned as it arrives, whatever the turn's terminal turns out to be. Only the
       // COMMAND dispatch (`event: "command"`, pi's own label) can decide the terminal: a hook that
       // throws is not the work the caller asked for, and blaming their `/mute` for it would be the
-      // same conflation the model branch refuses. Bound, not replaced: bindExtensions merges, so the
-      // assembly's uiContext/mode/actions stay as they were.
+      // same conflation the model branch refuses. bindExtensions MERGES uiContext/mode/actions, so
+      // the assembly's stay as they were — but `onError` is a single slot, not a merge, so this L0
+      // CLAIMS it (stated in the factory contract above).
       const commandErrors: string[] = [];
       try {
         await session.bindExtensions({

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -248,10 +248,6 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         queue.push(projected);
       });
       try {
-        // The cancel latch again: binding extensions and converting images are awaits, and a cancel
-        // arriving in that window would knock a door that is a no-op on a session which has not
-        // prompted yet — then the model call would start anyway. Checked once more right before it.
-        if (wasCancelled()) return;
         // prompt() resolves when the turn is accepted-and-run; waitForIdle() closes the window in
         // which pi is still draining its own queues (a follow-up, a retry), so the terminal below
         // describes the whole activity window rather than the first response inside it.
@@ -262,6 +258,11 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         // turn, session-builder.ts per session): without it every fastagent-defined tool degrades
         // SILENTLY — `wake` writes nowhere, `search_tools` activates nothing, cwd falls back to the
         // process's.
+        // The cancel latch again, and this is its real window: binding extensions and converting
+        // images (a Photon resize) are awaits, and a cancel arriving in either knocks a door that
+        // no-ops on a session which has not prompted yet — the model call would then start anyway.
+        // Checked here, after the last await before it.
+        if (wasCancelled()) return;
         const run = turnContext.run(
           {
             cwd: session.sessionManager.getCwd(),
@@ -287,7 +288,13 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             // No model response at all: the input was handled by an extension (a command), so an
             // extension failure IS the turn's outcome — without this the turn reports success for
             // work that threw.
-            terminal = extensionError ? errorToTerminal(new Error(extensionError)) : { type: "completed" };
+            // NOT through errorToTerminal: that classifier's last-resort prose match reads
+            // "timed out"/"rate limit"/5xx out of a message, which would tell a caller to re-run a
+            // handler whose code throws identically every time. An in-process dispatch failure is a
+            // determinate local outcome.
+            terminal = extensionError
+              ? { type: "failed", details: extensionError, retryable: false }
+              : { type: "completed" };
           }
         } catch (error) {
           terminal = errorToTerminal(error);

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -10,6 +10,12 @@
  * of that class is the `ResourceLoader` (extension modules, skills), which is built ONCE with the
  * assembly and shared across turns. What is per-turn is binding a session object to a record.
  *
+ * That trade has a consequence the factory owns: a shared loader is a SNAPSHOT, so "the directory is
+ * the agent, live" (what the harness path gets by re-reading the definition every turn) is not free
+ * here. A factory that wants it must rebuild or reload the loader; one that shares it trades
+ * definition freshness for the ~1ms turn cost. Either is a legitimate deployment choice — silence
+ * about which one is in force is not.
+ *
  * NOT YET WIRED, twice over. This module has no consumer in `src/`: the assembly that would produce
  * a session factory for a real definition (models, auth, tools, extensions) does not exist yet, and
  * neither this L0 nor `sessionRecordBinder` is exported from `src/pi.ts` — pi-coupled L0s stay
@@ -298,8 +304,13 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       } catch (error) {
         // Binding is this engine class's own setup step, and its failures obey the same rule as the
         // factory's: an EVENT, never a thrown iteration — and the session still gets torn down.
+        // NOT through errorToTerminal: extension module code throwing in-process is as determinate
+        // as a command handler throwing (the branch below), and that classifier's prose fallback
+        // would read "timed out" out of an extension's message and invite a re-run that throws
+        // identically. The FACTORY's failures keep the classifier: record open, auth and network
+        // genuinely mix transient with permanent.
         await teardown();
-        yield errorToTerminal(error);
+        yield { type: "failed", details: String(error), retryable: false };
         return;
       }
       unsub = session.subscribe((event) => {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -25,7 +25,7 @@ import type { AgentEvent, Agent, Json, Prompt, Scope } from "../../agent.ts";
 import { SESSION_BUSY_CODE } from "../../agent.ts";
 import { abortFirstIterator } from "../../collect.ts";
 import { log } from "../../log.ts";
-import { sessionToolActivation, toolChatSessionManager } from "./session-bridge.ts";
+import { sessionToolActivation, toolSessionManagerFromSession } from "./session-bridge.ts";
 import { turnContext } from "./tool-context.ts";
 import {
   EventQueue,
@@ -208,17 +208,27 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
 
       const queue = new EventQueue<AgentEvent>();
       let settled: AssistantMessage | undefined;
-      // An extension command handler that THROWS is caught by pi and reported here — there is no
-      // assistant message and no agent_end, so without this the turn would settle `completed` and
-      // report success for work that failed. Bound (not replaced): bindExtensions merges, so the
-      // assembly's uiContext/mode/actions stay as they were.
+      // EVERY extension-dispatch failure, not just a command handler's: pi reports them all here,
+      // and one that vanished would be a silent failure inside a turn we are about to call
+      // completed. How it is CONSUMED depends on what else the turn produced — see the terminal
+      // below. Bound, not replaced: bindExtensions merges, so the assembly's uiContext/mode/actions
+      // stay as they were.
       let extensionError: string | undefined;
-      await session.bindExtensions({
-        onError: (error: { event: string; error: string }) => {
-          extensionError ??= `extension ${error.event} failed: ${error.error}`;
-        },
-      });
-      const unsub = session.subscribe((event) => {
+      let unsub: () => void = () => {};
+      try {
+        await session.bindExtensions({
+          onError: (error: { event: string; error: string }) => {
+            extensionError ??= `extension ${error.event} failed: ${error.error}`;
+          },
+        });
+      } catch (error) {
+        // Binding is this engine class's own setup step, and its failures obey the same rule as the
+        // factory's: an EVENT, never a thrown iteration — and the session still gets torn down.
+        await session.abort().catch(() => {});
+        yield errorToTerminal(error);
+        return;
+      }
+      unsub = session.subscribe((event) => {
         if (event.type === "agent_end") {
           // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.
           // Taking the message from a retried end would classify the turn on an error pi is about
@@ -238,6 +248,10 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         queue.push(projected);
       });
       try {
+        // The cancel latch again: binding extensions and converting images are awaits, and a cancel
+        // arriving in that window would knock a door that is a no-op on a session which has not
+        // prompted yet — then the model call would start anyway. Checked once more right before it.
+        if (wasCancelled()) return;
         // prompt() resolves when the turn is accepted-and-run; waitForIdle() closes the window in
         // which pi is still draining its own queues (a follow-up, a retry), so the terminal below
         // describes the whole activity window rather than the first response inside it.
@@ -251,7 +265,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         const run = turnContext.run(
           {
             cwd: session.sessionManager.getCwd(),
-            sessionManager: toolChatSessionManager(session),
+            sessionManager: toolSessionManagerFromSession(session),
             tools: sessionToolActivation(session),
           },
           async () => {
@@ -263,14 +277,18 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         let terminal: AgentEvent;
         try {
           await run;
-          terminal = settled
-            ? toTerminal(settled)
-            : extensionError
-              ? errorToTerminal(new Error(extensionError))
-              : // No settled assistant message and no extension failure: the turn produced no model
-                // response at all (an extension command handled the input) — a completed turn with
-                // nothing to classify.
-                { type: "completed" };
+          if (settled) {
+            // The turn ran the model: its own outcome decides the terminal. An extension failure
+            // alongside it is real but not the turn's verdict — surfaced as a warn rather than
+            // flipping a model answer the caller did receive into a failure.
+            if (extensionError) log.warn(`[fastagent] session ${scope.session}: ${extensionError}`);
+            terminal = toTerminal(settled);
+          } else {
+            // No model response at all: the input was handled by an extension (a command), so an
+            // extension failure IS the turn's outcome — without this the turn reports success for
+            // work that threw.
+            terminal = extensionError ? errorToTerminal(new Error(extensionError)) : { type: "completed" };
+          }
         } catch (error) {
           terminal = errorToTerminal(error);
         }

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -14,7 +14,7 @@
  * (models, auth, tools, definition, extensions) is a caller's concern, exactly as
  * `piHarnessFactory` is for the harness class.
  */
-import type { AssistantMessageEvent } from "@earendil-works/pi-ai";
+import type { AssistantMessage, AssistantMessageEvent } from "@earendil-works/pi-ai";
 import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { AgentEvent, Agent, Json, Prompt, Scope } from "../../agent.ts";
 import { SESSION_BUSY_CODE } from "../../agent.ts";
@@ -110,12 +110,12 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
 }
 
 /** The assistant message a settled turn ended on, for terminal classification. */
-function lastAssistant(event: AgentSessionEvent): Parameters<typeof toTerminal>[0] | undefined {
+function lastAssistant(event: AgentSessionEvent): AssistantMessage | undefined {
   if (event.type !== "agent_end") return undefined;
   const messages = event.messages;
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
-    if (m?.role === "assistant") return m as Parameters<typeof toTerminal>[0];
+    if (m?.role === "assistant") return m as AssistantMessage;
   }
   return undefined;
 }
@@ -168,7 +168,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       }
 
       const queue = new EventQueue<AgentEvent>();
-      let settled: Parameters<typeof toTerminal>[0] | undefined;
+      let settled: AssistantMessage | undefined;
       const unsub = session.subscribe((event) => {
         if (event.type === "agent_end") {
           // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -281,15 +281,17 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // EVERY extension-dispatch failure, not just a command handler's: pi reports them all here,
       // and one that vanished would be a silent failure inside a turn we are about to call
       // completed — so they ACCUMULATE (a second failing hook must not be swallowed by the first)
-      // and each is warned as it arrives, whatever the turn's terminal turns out to be. How they are
-      // CONSUMED depends on what else the turn produced — see the terminal below. Bound, not
-      // replaced: bindExtensions merges, so the assembly's uiContext/mode/actions stay as they were.
-      const extensionErrors: string[] = [];
+      // and each is warned as it arrives, whatever the turn's terminal turns out to be. Only the
+      // COMMAND dispatch (`event: "command"`, pi's own label) can decide the terminal: a hook that
+      // throws is not the work the caller asked for, and blaming their `/mute` for it would be the
+      // same conflation the model branch refuses. Bound, not replaced: bindExtensions merges, so the
+      // assembly's uiContext/mode/actions stay as they were.
+      const commandErrors: string[] = [];
       try {
         await session.bindExtensions({
           onError: (error: { event: string; error: string }) => {
             const message = `extension ${error.event} failed: ${error.error}`;
-            extensionErrors.push(message);
+            if (error.event === "command") commandErrors.push(message);
             log.warn(`[fastagent] session ${scope.session}: ${message}`);
           },
         });
@@ -356,16 +358,17 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             // model answer the caller did receive into a failure would deny them the result.
             terminal = toTerminal(settled);
           } else {
-            // No model response at all: the input was handled by an extension (a command), so an
-            // extension failure IS the turn's outcome — without this the turn reports success for
-            // work that threw.
+            // No model response at all: the input was handled by a COMMAND, so that command's own
+            // failure IS the turn's outcome — without this the turn reports success for work that
+            // threw. A hook that threw alongside it stays a warning, for the same reason the model
+            // branch keeps its answer.
             // NOT through errorToTerminal: that classifier's last-resort prose match reads
             // "timed out"/"rate limit"/5xx out of a message, which would tell a caller to re-run a
             // handler whose code throws identically every time. An in-process dispatch failure is a
             // determinate local outcome.
             terminal =
-              extensionErrors.length > 0
-                ? { type: "failed", details: extensionErrors.join("; "), retryable: false }
+              commandErrors.length > 0
+                ? { type: "failed", details: commandErrors.join("; "), retryable: false }
                 : { type: "completed" };
           }
         } catch (error) {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -55,8 +55,10 @@ import {
  * would be the resident level, with a different bill).
  *
  * DO NOT BIND `onError`: unlike `uiContext`/`mode`/`commandContextActions`, which pi merges, the
- * extension-error listener is a single slot — this L0 claims it to classify a command turn, and a
- * factory that set its own would have it dropped every turn with no signal.
+ * extension-error listener is a single slot — this L0 claims it to classify a command turn. A
+ * factory that wants its own (logging, metrics, a toast) passes
+ * {@link CreatePiAgentFromSessionOptions.onExtensionError}, which is forwarded every failure; binding
+ * pi's slot directly would instead be dropped every turn with no signal.
  *
  * BIND TO AN EXISTING RECORD — use `sessionRecordBinder` (session-record.ts), do not let
  * `SessionManager` open a file of its own. Not a style preference: a SessionManager that starts a
@@ -66,6 +68,10 @@ import {
  */
 export interface CreatePiAgentFromSessionOptions {
   sessionFactory: (sessionId: string) => Promise<AgentSession>;
+  /** Every extension-dispatch failure of every turn, forwarded. The supported place for a factory's
+   *  own listener, since pi's `onError` is a single slot this L0 owns (see the factory contract).
+   *  A throwing listener is contained — it is an observer, not part of the turn. */
+  onExtensionError?: (error: { event: string; error: string }) => void;
   /** One in-flight turn per session, like the harness L0. A collision fails `session_busy`. */
   lease?: Lease;
 }
@@ -304,6 +310,11 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             const message = `extension ${error.event} failed: ${error.error}`;
             if (error.event === "command") commandErrors.push(message);
             log.warn(`[fastagent] session ${scope.session}: ${message}`);
+            try {
+              options.onExtensionError?.(error);
+            } catch (listenerError) {
+              log.warn(`[fastagent] onExtensionError threw: ${String(listenerError)}`);
+            }
           },
         });
       } catch (error) {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -84,19 +84,19 @@ const SESSION_EVENTS: Record<AgentSessionEvent["type"], "project" | "ignore"> = 
   tool_execution_end: "project",
   auto_retry_start: "project",
   summarization_retry_scheduled: "project",
+  // A COMMAND's output arrives as a custom-role message (an extension's `sendMessage`), and it is
+  // the only output such a turn has — ignoring it would make "the command ran" indistinguishable
+  // from "nothing happened" to a stream consumer. Model text keeps arriving as deltas.
+  message_end: "project",
   // The turn's OUTCOME, read by the turn loop rather than projected as a stream event.
   agent_end: "ignore",
-  // Bookkeeping with no Agent Handler counterpart: run/turn/message boundaries, durable-record and
-  // queue notifications, and the richer-plane material the control plane projects separately.
+  // Bookkeeping with no Agent Handler counterpart: run/turn boundaries and message STARTS,
+  // durable-record and queue notifications, and richer-plane material the control plane projects.
   agent_start: "ignore",
   agent_settled: "ignore",
   turn_start: "ignore",
   turn_end: "ignore",
   message_start: "ignore",
-  // A COMMAND's output arrives as a custom-role message (an extension's `sendMessage`), and it is
-  // the only output such a turn has — ignoring it would make "the command ran" indistinguishable
-  // from "nothing happened" to a stream consumer. Model text keeps arriving as deltas.
-  message_end: "project",
   tool_execution_update: "ignore",
   queue_update: "ignore",
   entry_appended: "ignore",

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -245,6 +245,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         await session.abort().catch((error: unknown) => {
           log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
         });
+        session.dispose();
         return;
       }
 
@@ -268,7 +269,10 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       } catch (error) {
         // Binding is this engine class's own setup step, and its failures obey the same rule as the
         // factory's: an EVENT, never a thrown iteration — and the session still gets torn down.
-        await session.abort().catch(() => {});
+        await session.abort().catch((abortError: unknown) => {
+          log.warn(`[fastagent] session abort failed after a binding failure: ${String(abortError)}`);
+        });
+        session.dispose();
         yield errorToTerminal(error);
         return;
       }
@@ -350,12 +354,19 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         } catch (error) {
           log.warn(`[fastagent] session unsubscribe failed during cleanup: ${String(error)}`);
         }
-        // Fresh-session discipline: the object dies with the turn. Aborting first releases any work
-        // still in flight after a consumer break.
+        // Fresh-session discipline: the object dies with the turn. Abort stops work still in flight
+        // after a consumer break; dispose RELEASES the object (pi: "remove all listeners and
+        // disconnect from agent") — without it a process serving thousands of turns leaks one
+        // wired-up session per turn, which is precisely this L0's deployment posture.
         try {
           await session.abort();
         } catch (error) {
           log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
+        }
+        try {
+          session.dispose();
+        } catch (error) {
+          log.warn(`[fastagent] session dispose failed during cleanup: ${String(error)}`);
         }
       }
     } finally {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -22,7 +22,14 @@ import { abortFirstIterator } from "../../collect.ts";
 import { log } from "../../log.ts";
 import { sessionToolActivation, toolChatSessionManager } from "./session-bridge.ts";
 import { turnContext } from "./tool-context.ts";
-import { EventQueue, type Lease, errorToTerminal, inProcessLease, toPiPromptOptions, toTerminal } from "./invoke.ts";
+import {
+  EventQueue,
+  type Lease,
+  errorToTerminal,
+  inProcessLease,
+  toPiPromptOptions,
+  toTerminal,
+} from "./turn-plumbing.ts";
 
 /**
  * Build a session object bound to `sessionId`'s durable record. Called once per invoke; the returned
@@ -35,14 +42,28 @@ export interface CreatePiAgentFromSessionOptions {
   lease?: Lease;
 }
 
-/** The two `AssistantMessageEvent` members this projection reads. COMPILE-TIME drift guard: if pi
- *  renames either, the extract narrows and this object literal stops type-checking — without it a
- *  rename would silently stop projecting every delta, with only a test to notice. */
-const _deltaDriftGuard: Record<
-  Extract<AssistantMessageEvent, { type: "text_delta" | "thinking_delta" }>["type"],
-  true
-> = { text_delta: true, thinking_delta: true };
-void _deltaDriftGuard;
+/**
+ * EXHAUSTIVE map of pi's delta-event vocabulary: which members this projection reads, and which it
+ * deliberately ignores. A rename narrows the key set and a NEW member widens it — either way this
+ * literal stops type-checking, which is the point: an added delta channel that nobody projects is
+ * exactly the drift a two-name guard would wave through.
+ */
+const DELTA_CHANNELS: Record<AssistantMessageEvent["type"], "project" | "ignore"> = {
+  text_delta: "project",
+  thinking_delta: "project",
+  // Boundaries and tool-call assembly: the Agent Handler stream carries tool activity from pi's
+  // tool_execution_* events instead, and message boundaries have no SPEC counterpart.
+  start: "ignore",
+  text_start: "ignore",
+  text_end: "ignore",
+  thinking_start: "ignore",
+  thinking_end: "ignore",
+  toolcall_start: "ignore",
+  toolcall_delta: "ignore",
+  toolcall_end: "ignore",
+  done: "ignore",
+  error: "ignore",
+};
 
 /** pi's session-class event → the Agent Handler vocabulary. `null` = nothing to project. */
 function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
@@ -50,6 +71,7 @@ function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
     case "message_update": {
       // The delta channel: pi reports the accumulated message plus the typed event that changed it.
       const e = event.assistantMessageEvent;
+      if (DELTA_CHANNELS[e.type] === "ignore") return null;
       if (e.type === "thinking_delta") return { type: "thinking", delta: e.delta };
       if (e.type === "text_delta") return { type: "text", delta: e.delta };
       return null;

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -60,6 +60,11 @@ import {
  * {@link CreatePiAgentFromSessionOptions.onExtensionError}, which is forwarded every failure; binding
  * pi's slot directly would instead be dropped every turn with no signal.
  *
+ * PASS `sessionStartEvent: { type: "session_start", reason: "resume" }`: the record always exists
+ * before the session is built (the binder ensures it), and binding emits this event on EVERY turn —
+ * pi's default `reason: "startup"` would tell an extension that turn 500 of a conversation is its
+ * first, so anything that greets, seeds or logs on startup would do it every turn.
+ *
  * BIND TO AN EXISTING RECORD — use `sessionRecordBinder` (session-record.ts), do not let
  * `SessionManager` open a file of its own. Not a style preference: a SessionManager that starts a
  * fresh file BUFFERS everything until the first assistant message, so a crash between "the user
@@ -142,6 +147,11 @@ const SESSION_EVENTS = {
 type ProjectedType = {
   [K in keyof typeof SESSION_EVENTS]: (typeof SESSION_EVENTS)[K] extends "project" ? K : never;
 }[keyof typeof SESSION_EVENTS];
+
+/** pi's labels for the dispatches that can END A TURN with no model call (`prompt()` returns early
+ *  for both) — the ones whose failure is therefore the turn's outcome rather than a warning beside
+ *  it. A hook failing is not: the turn it accompanies has its own verdict. */
+const TURN_CONSUMING_DISPATCH = new Set(["command", "input"]);
 
 /** pi's session-class event → the Agent Handler vocabulary. `null` = nothing to project. */
 function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
@@ -272,6 +282,18 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
           log.warn(`[fastagent] session unsubscribe failed during cleanup: ${String(error)}`);
         }
         try {
+          // Extensions saw a `session_start` when this turn bound them; without its counterpart they
+          // would see a birth every turn and never a death, so anything acquired there (a handle, a
+          // timer, a subscription) would live until the process exits.
+          // pi's own helper is not on the package's public surface, and its whole body is this
+          // guard plus the emit (runner.js: `hasHandlers` → `emit`) — both public.
+          if (session.extensionRunner.hasHandlers("session_shutdown")) {
+            await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+          }
+        } catch (error) {
+          log.warn(`[fastagent] session shutdown event failed during cleanup: ${String(error)}`);
+        }
+        try {
           // pi: "remove all listeners and disconnect from agent". Without it a process serving
           // thousands of turns leaks one wired-up session per turn — this L0's whole posture.
           session.dispose();
@@ -297,18 +319,18 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       // EVERY extension-dispatch failure, not just a command handler's: pi reports them all here,
       // and one that vanished would be a silent failure inside a turn we are about to call
       // completed — so they ACCUMULATE (a second failing hook must not be swallowed by the first)
-      // and each is warned as it arrives, whatever the turn's terminal turns out to be. Only the
-      // COMMAND dispatch (`event: "command"`, pi's own label) can decide the terminal: a hook that
-      // throws is not the work the caller asked for, and blaming their `/mute` for it would be the
-      // same conflation the model branch refuses. bindExtensions MERGES uiContext/mode/actions, so
+      // and each is warned as it arrives, whatever the turn's terminal turns out to be. Only a
+      // TURN-CONSUMING dispatch can decide the terminal (see {@link TURN_CONSUMING_DISPATCH}): a hook
+      // that throws is not the work the caller asked for, and blaming their `/mute` for it would be
+      // the same conflation the model branch refuses. bindExtensions MERGES uiContext/mode/actions, so
       // the assembly's stay as they were — but `onError` is a single slot, not a merge, so this L0
       // CLAIMS it (stated in the factory contract above).
-      const commandErrors: string[] = [];
+      const consumingErrors: string[] = [];
       try {
         await session.bindExtensions({
           onError: (error: { event: string; error: string }) => {
             const message = `extension ${error.event} failed: ${error.error}`;
-            if (error.event === "command") commandErrors.push(message);
+            if (TURN_CONSUMING_DISPATCH.has(error.event)) consumingErrors.push(message);
             log.warn(`[fastagent] session ${scope.session}: ${message}`);
             try {
               options.onExtensionError?.(error);
@@ -385,8 +407,9 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             // model answer the caller did receive into a failure would deny them the result.
             terminal = toTerminal(settled);
           } else {
-            // No model response at all: the input was handled by a COMMAND, so that command's own
-            // failure IS the turn's outcome — without this the turn reports success for work that
+            // No model response at all: the input was CONSUMED by an extension dispatch (a slash
+            // command, or an `input` handler that answered "handled"), so that dispatch's failure
+            // IS the turn's outcome — without this the turn reports success for work that
             // threw. A hook that threw alongside it stays a warning, for the same reason the model
             // branch keeps its answer.
             // NOT through errorToTerminal: that classifier's last-resort prose match reads
@@ -394,8 +417,8 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
             // handler whose code throws identically every time. An in-process dispatch failure is a
             // determinate local outcome.
             terminal =
-              commandErrors.length > 0
-                ? { type: "failed", details: commandErrors.join("; "), retryable: false }
+              consumingErrors.length > 0
+                ? { type: "failed", details: consumingErrors.join("; "), retryable: false }
                 : { type: "completed" };
           }
         } catch (error) {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -415,7 +415,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         const run = turnContext.run(
           {
             cwd: session.sessionManager.getCwd(),
-            sessionManager: toolSessionManagerFromSession(session),
+            sessionManager: toolSessionManagerFromSession(session, scope.session),
             tools: sessionToolActivation(session),
           },
           async () => {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -10,6 +10,11 @@
  * of that class is the `ResourceLoader` (extension modules, skills), which is built ONCE with the
  * assembly and shared across turns. What is per-turn is binding a session object to a record.
  *
+ * NOT YET WIRED: the harness L0 accepts a `SessionObserver` and registers per-run modulation handles
+ * (steer/follow_up/abort), which is what the session control plane consumes. This L0 has neither, so
+ * an agent built here serves invokes but cannot be observed or steered through `/control/*` — the
+ * gap to close before it backs a serving path, not an omission to discover later.
+ *
  * This module owns the turn mechanism only. The assembly that produces the session factory
  * (models, auth, tools, definition, extensions) is a caller's concern, exactly as
  * `piHarnessFactory` is for the harness class.

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -144,15 +144,34 @@ type ProjectedType = {
 }[keyof typeof SESSION_EVENTS];
 
 /**
- * pi's label for the dispatch that can END A TURN with no model call — the one whose failure is
- * therefore the turn's outcome rather than a warning beside it.
+ * pi's labels for the dispatches that END A TURN with no model call — the ones whose failure IS the
+ * turn's outcome rather than a warning beside it. Everything else pi surfaces via `onError` (a hook,
+ * a provider registration, an input transform, a message_end handler, before_*, resources_discover,
+ * project_trust, session_before_*) rides alongside a model result: pi caught the throw and continued
+ * the loop, so the turn still reaches the model — flipping its answer to `failed` would deny the
+ * caller a result they received. Warned, not blamed.
  *
- * `input` is deliberately NOT here, despite also being able to consume a turn (`action: "handled"`):
- * a handler that THROWS does not consume it. pi catches, records `event: "input"`, and continues the
- * loop, so the turn reaches the model and settles on its answer — which makes that failure exactly
- * the kind that must warn beside a delivered result rather than overturn it.
+ * `input` is a specific instance of that rule: a handler CAN consume a turn via `action: "handled"`,
+ * but a handler that THROWS does not — pi records `event: "input"` and continues, and the model
+ * answers. So a throwing input handler is a warning, not the verdict.
+ *
+ * Silent-drift ceiling. pi does not export the label enum; `ExtensionError.event` is `string`. A
+ * NEW pi dispatch verb that consumes a turn will be misclassified here as non-consuming, and this
+ * L0 will report `completed` for a turn that died in extension code — the exact silent drift the
+ * DELTA_CHANNELS / SESSION_EVENTS maps above use `satisfies Record<..., "project"|"ignore">` to stop
+ * one level down. Upstream ask (mirrors turn-plumbing.ts §2 pattern): expose the label union so this
+ * set becomes `Record<Label, "consuming"|"non-consuming"> satisfies …` and drift stops the build.
+ *
+ * Known pi labels today, for the next reader who has to re-audit this against a new pi:
+ *   - CONSUMING:     "command"
+ *   - NON-consuming: "input", "register_provider", "tool_call", "tool_result", "user_bash",
+ *                    "context", "message_end", "before_provider_request", "before_provider_headers",
+ *                    "before_agent_start", "resources_discover", "project_trust",
+ *                    "session_before_switch" / "_fork" / "_compact" / "_tree"
+ *   - Plus this L0's own synthetic label "bind" (thrown by bindExtensions, not dispatched), which is
+ *     handled as a failed EVENT with teardown before this set is consulted — so it never lands here.
  */
-const TURN_CONSUMING_DISPATCH = new Set(["command"]);
+const TURN_CONSUMING_DISPATCH = new Set<string>(["command"]);
 
 /** pi's session-class event → the Agent Handler vocabulary. `null` = nothing to project. */
 function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -19,7 +19,7 @@ import type { AgentEvent, Agent, Json, Prompt, Scope } from "../../agent.ts";
 import { SESSION_BUSY_CODE } from "../../agent.ts";
 import { abortFirstIterator } from "../../collect.ts";
 import { log } from "../../log.ts";
-import { EventQueue, type Lease, errorToTerminal, inProcessLease, toTerminal } from "./invoke.ts";
+import { EventQueue, type Lease, errorToTerminal, inProcessLease, toPiPromptOptions, toTerminal } from "./invoke.ts";
 
 /**
  * Build a session object bound to `sessionId`'s durable record. Called once per invoke; the returned
@@ -36,11 +36,12 @@ export interface CreatePiAgentFromSessionOptions {
 function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
   switch (event.type) {
     case "message_update": {
-      // The delta channel: pi reports the accumulated message plus the event that changed it.
-      const e = (event as { assistantMessageEvent?: { type?: string; delta?: string } }).assistantMessageEvent;
-      if (!e || typeof e.delta !== "string" || e.delta === "") return null;
-      if (e.type === "thinking_delta" || e.type === "thinking") return { type: "thinking", delta: e.delta };
-      if (e.type === "text_delta" || e.type === "text") return { type: "text", delta: e.delta };
+      // The delta channel: pi reports the accumulated message plus the typed event that changed it.
+      // Switched on the UNION, not a hand-written shape: a renamed member must break the build here
+      // rather than silently stop projecting.
+      const e = event.assistantMessageEvent;
+      if (e.type === "thinking_delta") return { type: "thinking", delta: e.delta };
+      if (e.type === "text_delta") return { type: "text", delta: e.delta };
       return null;
     }
     case "tool_execution_start":
@@ -131,14 +132,12 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
 
       const queue = new EventQueue<AgentEvent>();
       let settled: Parameters<typeof toTerminal>[0] | undefined;
-      let sawEnd = false;
       const unsub = session.subscribe((event) => {
         if (event.type === "agent_end") {
-          // `willRetry` means pi will run again for this same prompt — not a settle.
-          if (!(event as { willRetry?: boolean }).willRetry) {
-            sawEnd = true;
-            settled = lastAssistant(event);
-          }
+          // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.
+          // Taking the message from a retried end would classify the turn on an error pi is about
+          // to recover from.
+          if (!event.willRetry) settled = lastAssistant(event);
           return;
         }
         const projected = projectSessionEvent(event);
@@ -148,8 +147,11 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         // prompt() resolves when the turn is accepted-and-run; waitForIdle() closes the window in
         // which pi is still draining its own queues (a follow-up, a retry), so the terminal below
         // describes the whole activity window rather than the first response inside it.
+        // Images ride the same conversion the harness L0 uses (resize + provider shape); dropping
+        // them here would make an attachment invisible to the model AND silent to the author.
+        const opts = await toPiPromptOptions(prompt);
         const run = (async () => {
-          await session.prompt(prompt.text);
+          await session.prompt(prompt.text, opts);
           await session.waitForIdle();
         })();
         yield* queue.drainUntil(run);
@@ -163,7 +165,6 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         } catch (error) {
           terminal = errorToTerminal(error);
         }
-        void sawEnd;
         yield terminal;
       } finally {
         try {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -14,6 +14,7 @@
  * (models, auth, tools, definition, extensions) is a caller's concern, exactly as
  * `piHarnessFactory` is for the harness class.
  */
+import type { AssistantMessageEvent } from "@earendil-works/pi-ai";
 import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { AgentEvent, Agent, Json, Prompt, Scope } from "../../agent.ts";
 import { SESSION_BUSY_CODE } from "../../agent.ts";
@@ -34,13 +35,20 @@ export interface CreatePiAgentFromSessionOptions {
   lease?: Lease;
 }
 
+/** The two `AssistantMessageEvent` members this projection reads. COMPILE-TIME drift guard: if pi
+ *  renames either, the extract narrows and this object literal stops type-checking — without it a
+ *  rename would silently stop projecting every delta, with only a test to notice. */
+const _deltaDriftGuard: Record<
+  Extract<AssistantMessageEvent, { type: "text_delta" | "thinking_delta" }>["type"],
+  true
+> = { text_delta: true, thinking_delta: true };
+void _deltaDriftGuard;
+
 /** pi's session-class event → the Agent Handler vocabulary. `null` = nothing to project. */
 function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {
   switch (event.type) {
     case "message_update": {
       // The delta channel: pi reports the accumulated message plus the typed event that changed it.
-      // Switched on the UNION, not a hand-written shape: a renamed member must break the build here
-      // rather than silently stop projecting.
       const e = event.assistantMessageEvent;
       if (e.type === "thinking_delta") return { type: "thinking", delta: e.delta };
       if (e.type === "text_delta") return { type: "text", delta: e.delta };

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -10,7 +10,14 @@
  * of that class is the `ResourceLoader` (extension modules, skills), which is built ONCE with the
  * assembly and shared across turns. What is per-turn is binding a session object to a record.
  *
- * This module owns the turn mechanism only. The assembly that produces a {@link PiSessionFactory}
+ * KNOWN GAP (see the `it.todo` in test/session-engine-conformance.test.ts): a cancel that lands
+ * while a TOOL is executing does not stop that tool — `AgentSession.abort()` does not settle from
+ * this call site, though the same call settles in ~3ms from ordinary code with the same tool in
+ * flight. A cancel during the model stream is correct (pi never starts the tool), which is the case
+ * the SPEC suite exercises. Do not wire this L0 into a serving path where long tool calls are normal
+ * until that is resolved.
+ *
+ * This module owns the turn mechanism only. The assembly that produces the session factory
  * (models, auth, tools, definition, extensions) is a caller's concern, exactly as
  * `piHarnessFactory` is for the harness class.
  */
@@ -125,8 +132,12 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       }
       // Arm the cancellation door before any model work, then honour a cancel that arrived while
       // the session was still being built (the latch) — the same ordering the harness L0 uses.
+      let doorFired = false;
       onCancelReady(() => {
-        void session.abort().catch(() => {});
+        doorFired = true;
+        void session.abort().catch((error: unknown) => {
+          log.warn(`[fastagent] session abort failed at cancellation: ${String(error)}`);
+        });
       });
       if (wasCancelled()) {
         await session.abort().catch((error: unknown) => {
@@ -146,7 +157,15 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
           return;
         }
         const projected = projectSessionEvent(event);
-        if (projected) queue.push(projected);
+        if (!projected) return;
+        if (projected.type === "retrying") {
+          // Same reason the harness L0 logs it: the event only reaches an ATTACHED consumer, while
+          // an operator tailing logs must also see a backoff that would otherwise read as a hang.
+          log.warn(
+            `[fastagent] retry ${projected.attempt}/${projected.maxAttempts} in ${projected.delayMs}ms (session ${scope.session}): ${projected.reason}`,
+          );
+        }
+        queue.push(projected);
       });
       try {
         // prompt() resolves when the turn is accepted-and-run; waitForIdle() closes the window in
@@ -190,10 +209,16 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         }
         // Fresh-session discipline: the object dies with the turn. Aborting first releases any work
         // still in flight after a consumer break.
-        try {
-          await session.abort();
-        } catch (error) {
-          log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
+        // Teardown aborts only when the DOOR did not: on a cancelled turn the door already issued
+        // the abort that stops in-flight work, and awaiting a second one here wedges the
+        // generator's own finalization (return() then never settles, which is exactly the deadlock
+        // the door exists to prevent for a pull-driven consumer).
+        if (!doorFired) {
+          try {
+            await session.abort();
+          } catch (error) {
+            log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
+          }
         }
       }
     } finally {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -43,6 +43,7 @@ import {
   EventQueue,
   type Lease,
   errorToTerminal,
+  failureDetails,
   inProcessLease,
   sessionBusyFailure,
   toPiPromptOptions,
@@ -358,7 +359,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         // identically. The FACTORY's failures keep the classifier: record open, auth and network
         // genuinely mix transient with permanent.
         await teardown();
-        yield { type: "failed", details: String(error), retryable: false };
+        yield { type: "failed", details: failureDetails(error), retryable: false };
         return;
       }
       unsub = session.subscribe((event) => {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -10,13 +10,6 @@
  * of that class is the `ResourceLoader` (extension modules, skills), which is built ONCE with the
  * assembly and shared across turns. What is per-turn is binding a session object to a record.
  *
- * KNOWN GAP (see the `it.todo` in test/session-engine-conformance.test.ts): a cancel that lands
- * while a TOOL is executing does not stop that tool — `AgentSession.abort()` does not settle from
- * this call site, though the same call settles in ~3ms from ordinary code with the same tool in
- * flight. A cancel during the model stream is correct (pi never starts the tool), which is the case
- * the SPEC suite exercises. Do not wire this L0 into a serving path where long tool calls are normal
- * until that is resolved.
- *
  * This module owns the turn mechanism only. The assembly that produces the session factory
  * (models, auth, tools, definition, extensions) is a caller's concern, exactly as
  * `piHarnessFactory` is for the harness class.
@@ -132,9 +125,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       }
       // Arm the cancellation door before any model work, then honour a cancel that arrived while
       // the session was still being built (the latch) — the same ordering the harness L0 uses.
-      let doorFired = false;
       onCancelReady(() => {
-        doorFired = true;
         void session.abort().catch((error: unknown) => {
           log.warn(`[fastagent] session abort failed at cancellation: ${String(error)}`);
         });
@@ -209,16 +200,10 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         }
         // Fresh-session discipline: the object dies with the turn. Aborting first releases any work
         // still in flight after a consumer break.
-        // Teardown aborts only when the DOOR did not: on a cancelled turn the door already issued
-        // the abort that stops in-flight work, and awaiting a second one here wedges the
-        // generator's own finalization (return() then never settles, which is exactly the deadlock
-        // the door exists to prevent for a pull-driven consumer).
-        if (!doorFired) {
-          try {
-            await session.abort();
-          } catch (error) {
-            log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
-          }
+        try {
+          await session.abort();
+        } catch (error) {
+          log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
         }
       }
     } finally {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -148,10 +148,16 @@ type ProjectedType = {
   [K in keyof typeof SESSION_EVENTS]: (typeof SESSION_EVENTS)[K] extends "project" ? K : never;
 }[keyof typeof SESSION_EVENTS];
 
-/** pi's labels for the dispatches that can END A TURN with no model call (`prompt()` returns early
- *  for both) — the ones whose failure is therefore the turn's outcome rather than a warning beside
- *  it. A hook failing is not: the turn it accompanies has its own verdict. */
-const TURN_CONSUMING_DISPATCH = new Set(["command", "input"]);
+/**
+ * pi's label for the dispatch that can END A TURN with no model call — the one whose failure is
+ * therefore the turn's outcome rather than a warning beside it.
+ *
+ * `input` is deliberately NOT here, despite also being able to consume a turn (`action: "handled"`):
+ * a handler that THROWS does not consume it. pi catches, records `event: "input"`, and continues the
+ * loop, so the turn reaches the model and settles on its answer — which makes that failure exactly
+ * the kind that must warn beside a delivered result rather than overturn it.
+ */
+const TURN_CONSUMING_DISPATCH = new Set(["command"]);
 
 /** pi's session-class event → the Agent Handler vocabulary. `null` = nothing to project. */
 function projectSessionEvent(event: AgentSessionEvent): AgentEvent | null {

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -41,6 +41,13 @@ import {
  * Build a session object bound to `sessionId`'s durable record. Called once per invoke; the returned
  * object is discarded when the turn ends, so an implementation must NOT cache it across turns (that
  * would be the resident level, with a different bill).
+ *
+ * BIND TO AN EXISTING RECORD (`SessionManager.setSessionFile` over a file the session store created),
+ * do not let `SessionManager` open one of its own. This is not a style preference: a SessionManager
+ * that starts a fresh file BUFFERS everything until the first assistant message, so a crash between
+ * "the user asked" and "the model answered" loses the question — the file is not even created.
+ * Binding to a record that already exists persists the user's turn immediately, which is what the
+ * harness class has always done and what a channel's at-least-once delivery assumes.
  */
 export interface CreatePiAgentFromSessionOptions {
   sessionFactory: (sessionId: string) => Promise<AgentSession>;

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -10,7 +10,13 @@
  * of that class is the `ResourceLoader` (extension modules, skills), which is built ONCE with the
  * assembly and shared across turns. What is per-turn is binding a session object to a record.
  *
- * NOT YET WIRED: the harness L0 accepts a `SessionObserver` and registers per-run modulation handles
+ * NOT YET WIRED, twice over. This module has no consumer in `src/`: the assembly that would produce
+ * a session factory for a real definition (models, auth, tools, extensions) does not exist yet, and
+ * neither this L0 nor `sessionRecordBinder` is exported from `src/pi.ts` — pi-coupled L0s stay
+ * internal by convention (AGENTS.md), so selecting this engine class is an in-repo capability until
+ * the assembly and the exports land together.
+ *
+ * And: the harness L0 accepts a `SessionObserver` and registers per-run modulation handles
  * (steer/follow_up/abort), which is what the session control plane consumes. This L0 has neither, so
  * an agent built here serves invokes but cannot be observed or steered through `/control/*` — the
  * gap to close before it backs a serving path, not an omission to discover later.
@@ -234,6 +240,29 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         yield errorToTerminal(error);
         return;
       }
+      // ONE teardown for every exit path: abort what is in flight, drop the subscription if there is
+      // one, release the object. Written once because the three exits differ only in how far setup
+      // got — three hand-written subsets drift the moment a line moves between them.
+      let unsub: (() => void) | undefined;
+      const teardown = async (): Promise<void> => {
+        try {
+          await session.abort();
+        } catch (error) {
+          log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
+        }
+        try {
+          unsub?.();
+        } catch (error) {
+          log.warn(`[fastagent] session unsubscribe failed during cleanup: ${String(error)}`);
+        }
+        try {
+          // pi: "remove all listeners and disconnect from agent". Without it a process serving
+          // thousands of turns leaks one wired-up session per turn — this L0's whole posture.
+          session.dispose();
+        } catch (error) {
+          log.warn(`[fastagent] session dispose failed during cleanup: ${String(error)}`);
+        }
+      };
       // Arm the cancellation door before any model work, then honour a cancel that arrived while
       // the session was still being built (the latch) — the same ordering the harness L0 uses.
       onCancelReady(() => {
@@ -242,15 +271,13 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         });
       });
       if (wasCancelled()) {
-        await session.abort().catch((error: unknown) => {
-          log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
-        });
-        session.dispose();
+        await teardown();
         return;
       }
 
       const queue = new EventQueue<AgentEvent>();
       let settled: AssistantMessage | undefined;
+
       // EVERY extension-dispatch failure, not just a command handler's: pi reports them all here,
       // and one that vanished would be a silent failure inside a turn we are about to call
       // completed — so they ACCUMULATE (a second failing hook must not be swallowed by the first)
@@ -269,14 +296,11 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       } catch (error) {
         // Binding is this engine class's own setup step, and its failures obey the same rule as the
         // factory's: an EVENT, never a thrown iteration — and the session still gets torn down.
-        await session.abort().catch((abortError: unknown) => {
-          log.warn(`[fastagent] session abort failed after a binding failure: ${String(abortError)}`);
-        });
-        session.dispose();
+        await teardown();
         yield errorToTerminal(error);
         return;
       }
-      const unsub = session.subscribe((event) => {
+      unsub = session.subscribe((event) => {
         if (event.type === "agent_end") {
           // `willRetry` means pi will run again for this same prompt — an auto-retry, not a settle.
           // Taking the message from a retried end would classify the turn on an error pi is about
@@ -349,25 +373,8 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         }
         yield terminal;
       } finally {
-        try {
-          unsub();
-        } catch (error) {
-          log.warn(`[fastagent] session unsubscribe failed during cleanup: ${String(error)}`);
-        }
-        // Fresh-session discipline: the object dies with the turn. Abort stops work still in flight
-        // after a consumer break; dispose RELEASES the object (pi: "remove all listeners and
-        // disconnect from agent") — without it a process serving thousands of turns leaks one
-        // wired-up session per turn, which is precisely this L0's deployment posture.
-        try {
-          await session.abort();
-        } catch (error) {
-          log.warn(`[fastagent] session abort failed during cleanup: ${String(error)}`);
-        }
-        try {
-          session.dispose();
-        } catch (error) {
-          log.warn(`[fastagent] session dispose failed during cleanup: ${String(error)}`);
-        }
+        // Fresh-session discipline: the object dies with the turn.
+        await teardown();
       }
     } finally {
       release();

--- a/src/engines/pi/session-invoke.ts
+++ b/src/engines/pi/session-invoke.ts
@@ -300,7 +300,10 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
           // timer, a subscription) would live until the process exits. Only when this turn actually
           // bound them: a death for a birth that never happened is the same asymmetry mirrored.
           if (bound && session.extensionRunner.hasHandlers("session_shutdown")) {
-            await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+            // `resume`, pairing the birth: the same record is picked up again by the next turn in
+            // this same process. pi's `quit` means the process is ending, which would tell an
+            // extension to flush and release for good — every turn.
+            await session.extensionRunner.emit({ type: "session_shutdown", reason: "resume" });
           }
         } catch (error) {
           log.warn(`[fastagent] session shutdown event failed during cleanup: ${String(error)}`);

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -11,11 +11,12 @@
  * delivery assumes it can reconcile against.
  *
  * A rule with one implementation, not one description: `session-invoke.ts`'s factory contract states
- * it, and every caller gets it by calling this.
+ * it, and every caller gets it by calling this. The crash-safety REPAIR travels the same way — both
+ * classes write this record, so both must open it through the same reconciliation.
  */
 import { JsonlSessionRepo, type NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
-import { encodeSessionId } from "./sessions.ts";
+import { encodeSessionId, reconcileInterruptedToolCalls } from "./sessions.ts";
 
 export interface SessionRecordBinderOptions {
   /** Where the jsonl records live — the same directory the harness class's store is pointed at. */
@@ -41,7 +42,16 @@ export function sessionRecordBinder(
     // share is addressed by this string.
     const id = encodeSessionId(sessionId);
     const existing = (await repo.list({ cwd })).find((meta) => meta.id === id);
-    if (existing) return existing.path;
+    if (existing) {
+      // The SAME repair `jsonlSessionStore.openOrCreate` performs, from the one implementation of
+      // it: a turn that died mid tool-execution left an assistant `tool_use` with no result, which
+      // providers reject outright. Both classes write this record, so a crash under either leaves a
+      // transcript the other must be able to open — skipping the repair here would mean a session
+      // the harness class self-heals and this one fails on forever. Runs BEFORE the SessionManager
+      // binds, since that loads the file as it stands.
+      await reconcileInterruptedToolCalls(await repo.open(existing));
+      return existing.path;
+    }
     const created = await repo.create({ id, cwd });
     return (await created.getMetadata()).path;
   };

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -34,15 +34,10 @@ export function sessionRecordBinder(
   const { sessionsRoot, cwd, env } = options;
   const repo = new JsonlSessionRepo({ fs: env, sessionsRoot });
   const recordPath = async (sessionId: string): Promise<string> => {
-    const find = async () => (await repo.list({ cwd })).find((meta) => meta.id === sessionId);
-    const existing = await find();
+    const existing = (await repo.list({ cwd })).find((meta) => meta.id === sessionId);
     if (existing) return existing.path;
-    await repo.create({ id: sessionId, cwd });
-    const created = await find();
-    // The repo just created it; a miss means the store and the lookup disagree about identity, which
-    // must not degrade into "SessionManager opens its own file" (the silent-loss shape above).
-    if (!created) throw new Error(`session record for "${sessionId}" was created but not found`);
-    return created.path;
+    const created = await repo.create({ id: sessionId, cwd });
+    return (await created.getMetadata()).path;
   };
   return async (sessionId) => {
     const manager = SessionManager.create(cwd, sessionsRoot);

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -22,13 +22,20 @@ import type { PiRecordLocator } from "./sessions.ts";
 export interface BoundSessionRecord {
   sessionManager: SessionManager;
   /**
-   * The lifecycle this turn opens, from the STORE's own answer: `startup` while the conversation has
-   * no history, `resume` once it does. Both halves matter and both are silent when wrong — pi's
-   * default (`startup`) would tell an extension that turn 500 is the session's first, while a
-   * blanket `resume` would mean anything that seeds or greets on startup never fires at all. Keyed
-   * on history rather than on file creation, so a first turn that died before writing does not take
-   * the startup announcement with it. It travels WITH the manager so a factory cannot take one rule
-   * and forget the other.
+   * ALWAYS `resume`, and that is the honest description rather than a shortcut: at per-invoke
+   * locality a session object exists for one turn, and every one of them picks a durable record back
+   * up — including the first, which resumes an empty one. pi's default (`startup`) would instead tell
+   * an extension that turn 500 of a conversation is its first, every turn.
+   *
+   * What it deliberately does NOT try to be is "once per conversation". Three record-shaped
+   * heuristics for that were tried and each lost or duplicated the announcement at a different edge
+   * (the file exists but the turn died; the user's message persisted before the model was reached; an
+   * aborted turn leaves an error-stopped assistant message), because "has this been announced" is a
+   * fact about announcements, not about content. An extension that needs once-per-conversation setup
+   * can read the record it is given; whether this engine class should offer more than that is part of
+   * wiring it (#321), not something to invent before its first consumer exists.
+   *
+   * It travels WITH the manager so a factory cannot take one rule and forget the other.
    */
   sessionStartEvent: SessionStartEvent;
 }
@@ -43,12 +50,8 @@ export interface BoundSessionRecord {
 export function sessionRecordBinder(store: PiRecordLocator): (sessionId: string) => Promise<BoundSessionRecord> {
   const { sessionsRoot, cwd } = store.recordLayout;
   return async (sessionId) => {
-    const { path, hasHistory } = await store.ensureRecordPath(sessionId);
     const sessionManager = SessionManager.create(cwd, sessionsRoot);
-    sessionManager.setSessionFile(path);
-    return {
-      sessionManager,
-      sessionStartEvent: { type: "session_start", reason: hasHistory ? "resume" : "startup" },
-    };
+    sessionManager.setSessionFile(await store.ensureRecordPath(sessionId));
+    return { sessionManager, sessionStartEvent: { type: "session_start", reason: "resume" } };
   };
 }

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -15,20 +15,33 @@
  * of it would eventually address a different file — two records for one conversation, the exact
  * failure this module exists to prevent.
  */
-import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { SessionManager, type SessionStartEvent } from "@earendil-works/pi-coding-agent";
 import type { PiRecordLocator } from "./sessions.ts";
 
+/** What a factory spreads into `createAgentSession` — both halves of "bind an existing record". */
+export interface BoundSessionRecord {
+  sessionManager: SessionManager;
+  /**
+   * ALWAYS a resume: the record exists before the session is built, and binding emits this event on
+   * every turn. pi's default (`reason: "startup"`) would tell an extension that turn 500 of a
+   * conversation is its first, so anything that greets, seeds or logs on startup would do it every
+   * turn. It travels WITH the manager so a factory cannot take one rule and forget the other.
+   */
+  sessionStartEvent: SessionStartEvent;
+}
+
 /**
- * A binder for one deployment: `sessionId → SessionManager` over that id's record in `store`. ONE
- * argument on purpose — the layout comes from the store rather than being re-supplied beside it, so
- * a manager cannot be constructed over a root the records do not live in (branch and fork write
- * through that root, and a mismatch would make a second record for one conversation).
+ * A binder for one deployment: `sessionId →` what `createAgentSession` needs to speak to that id's
+ * record in `store`. ONE argument on purpose — the layout comes from the store rather than being
+ * re-supplied beside it, so a manager cannot be constructed over a root the records do not live in
+ * (branch and fork write through that root, and a mismatch would make a second record for one
+ * conversation).
  */
-export function sessionRecordBinder(store: PiRecordLocator): (sessionId: string) => Promise<SessionManager> {
+export function sessionRecordBinder(store: PiRecordLocator): (sessionId: string) => Promise<BoundSessionRecord> {
   const { sessionsRoot, cwd } = store.recordLayout;
   return async (sessionId) => {
-    const manager = SessionManager.create(cwd, sessionsRoot);
-    manager.setSessionFile(await store.ensureRecordPath(sessionId));
-    return manager;
+    const sessionManager = SessionManager.create(cwd, sessionsRoot);
+    sessionManager.setSessionFile(await store.ensureRecordPath(sessionId));
+    return { sessionManager, sessionStartEvent: { type: "session_start", reason: "resume" } };
   };
 }

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -22,11 +22,13 @@ import type { PiRecordLocator } from "./sessions.ts";
 export interface BoundSessionRecord {
   sessionManager: SessionManager;
   /**
-   * The lifecycle this turn opens, from the STORE's own answer: `startup` on the turn that created
-   * the record, `resume` on every later one. Both halves matter and both are silent when wrong —
-   * pi's default (`startup`) would tell an extension that turn 500 is the session's first, while a
-   * blanket `resume` would mean anything that seeds or greets on startup never fires at all. It
-   * travels WITH the manager so a factory cannot take one rule and forget the other.
+   * The lifecycle this turn opens, from the STORE's own answer: `startup` while the conversation has
+   * no history, `resume` once it does. Both halves matter and both are silent when wrong — pi's
+   * default (`startup`) would tell an extension that turn 500 is the session's first, while a
+   * blanket `resume` would mean anything that seeds or greets on startup never fires at all. Keyed
+   * on history rather than on file creation, so a first turn that died before writing does not take
+   * the startup announcement with it. It travels WITH the manager so a factory cannot take one rule
+   * and forget the other.
    */
   sessionStartEvent: SessionStartEvent;
 }
@@ -41,12 +43,12 @@ export interface BoundSessionRecord {
 export function sessionRecordBinder(store: PiRecordLocator): (sessionId: string) => Promise<BoundSessionRecord> {
   const { sessionsRoot, cwd } = store.recordLayout;
   return async (sessionId) => {
-    const { path, created } = await store.ensureRecordPath(sessionId);
+    const { path, hasHistory } = await store.ensureRecordPath(sessionId);
     const sessionManager = SessionManager.create(cwd, sessionsRoot);
     sessionManager.setSessionFile(path);
     return {
       sessionManager,
-      sessionStartEvent: { type: "session_start", reason: created ? "startup" : "resume" },
+      sessionStartEvent: { type: "session_start", reason: hasHistory ? "resume" : "startup" },
     };
   };
 }

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -22,10 +22,11 @@ import type { PiRecordLocator } from "./sessions.ts";
 export interface BoundSessionRecord {
   sessionManager: SessionManager;
   /**
-   * ALWAYS a resume: the record exists before the session is built, and binding emits this event on
-   * every turn. pi's default (`reason: "startup"`) would tell an extension that turn 500 of a
-   * conversation is its first, so anything that greets, seeds or logs on startup would do it every
-   * turn. It travels WITH the manager so a factory cannot take one rule and forget the other.
+   * The lifecycle this turn opens, from the STORE's own answer: `startup` on the turn that created
+   * the record, `resume` on every later one. Both halves matter and both are silent when wrong —
+   * pi's default (`startup`) would tell an extension that turn 500 is the session's first, while a
+   * blanket `resume` would mean anything that seeds or greets on startup never fires at all. It
+   * travels WITH the manager so a factory cannot take one rule and forget the other.
    */
   sessionStartEvent: SessionStartEvent;
 }
@@ -40,8 +41,12 @@ export interface BoundSessionRecord {
 export function sessionRecordBinder(store: PiRecordLocator): (sessionId: string) => Promise<BoundSessionRecord> {
   const { sessionsRoot, cwd } = store.recordLayout;
   return async (sessionId) => {
+    const { path, created } = await store.ensureRecordPath(sessionId);
     const sessionManager = SessionManager.create(cwd, sessionsRoot);
-    sessionManager.setSessionFile(await store.ensureRecordPath(sessionId));
-    return { sessionManager, sessionStartEvent: { type: "session_start", reason: "resume" } };
+    sessionManager.setSessionFile(path);
+    return {
+      sessionManager,
+      sessionStartEvent: { type: "session_start", reason: created ? "startup" : "resume" },
+    };
   };
 }

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -1,0 +1,52 @@
+/**
+ * The `session` engine class's half of the SHARED durable record: bind a pi-coding-agent
+ * `SessionManager` to the jsonl the session store owns, addressing it by the same opaque session id
+ * the harness class uses.
+ *
+ * This exists as source rather than as advice because the binding is load-bearing and its failure is
+ * silent. A `SessionManager` left to open its own file BUFFERS everything until the first assistant
+ * message — so a crash between "the user asked" and "the model answered" loses the question, and the
+ * file is never even created. Bound to a record that already exists, the user's turn persists
+ * immediately, which is what the harness class has always done and what a channel's at-least-once
+ * delivery assumes it can reconcile against.
+ *
+ * A rule with one implementation, not one description: `session-invoke.ts`'s factory contract states
+ * it, and every caller gets it by calling this.
+ */
+import { JsonlSessionRepo, type NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+
+export interface SessionRecordBinderOptions {
+  /** Where the jsonl records live — the same directory the harness class's store is pointed at. */
+  sessionsRoot: string;
+  /** The workspace the records are grouped by (pi partitions sessions per project dir). */
+  cwd: string;
+  env: NodeExecutionEnv;
+}
+
+/**
+ * A binder for one deployment: `sessionId → SessionManager` over that id's record, CREATING the
+ * record when the id is new (so the returned manager is always in append-immediately mode).
+ */
+export function sessionRecordBinder(
+  options: SessionRecordBinderOptions,
+): (sessionId: string) => Promise<SessionManager> {
+  const { sessionsRoot, cwd, env } = options;
+  const repo = new JsonlSessionRepo({ fs: env, sessionsRoot });
+  const recordPath = async (sessionId: string): Promise<string> => {
+    const find = async () => (await repo.list({ cwd })).find((meta) => meta.id === sessionId);
+    const existing = await find();
+    if (existing) return existing.path;
+    await repo.create({ id: sessionId, cwd });
+    const created = await find();
+    // The repo just created it; a miss means the store and the lookup disagree about identity, which
+    // must not degrade into "SessionManager opens its own file" (the silent-loss shape above).
+    if (!created) throw new Error(`session record for "${sessionId}" was created but not found`);
+    return created.path;
+  };
+  return async (sessionId) => {
+    const manager = SessionManager.create(cwd, sessionsRoot);
+    manager.setSessionFile(await recordPath(sessionId));
+    return manager;
+  };
+}

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -1,7 +1,7 @@
 /**
  * The `session` engine class's half of the SHARED durable record: bind a pi-coding-agent
- * `SessionManager` to the jsonl the session store owns, addressing it by the same opaque session id
- * the harness class uses.
+ * `SessionManager` to the jsonl the session store owns, addressed by the same opaque session id the
+ * harness class uses.
  *
  * This exists as source rather than as advice because the binding is load-bearing and its failure is
  * silent. A `SessionManager` left to open its own file BUFFERS everything until the first assistant
@@ -10,54 +10,31 @@
  * immediately, which is what the harness class has always done and what a channel's at-least-once
  * delivery assumes it can reconcile against.
  *
- * A rule with one implementation, not one description: `session-invoke.ts`'s factory contract states
- * it, and every caller gets it by calling this. The crash-safety REPAIR travels the same way — both
- * classes write this record, so both must open it through the same reconciliation.
+ * The record is located THROUGH the store, never by re-deriving its layout: the id encoding, the cwd
+ * scoping and the crash repair (`reconcileInterruptedToolCalls`) are one sequence, and a second copy
+ * of it would eventually address a different file — two records for one conversation, the exact
+ * failure this module exists to prevent.
  */
-import { JsonlSessionRepo, type NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
-import { encodeSessionId, reconcileInterruptedToolCalls } from "./sessions.ts";
+import type { PiRecordLocator } from "./sessions.ts";
 
 export interface SessionRecordBinderOptions {
-  /** Where the jsonl records live — the same directory the harness class's store is pointed at. */
+  /** The store that OWNS the records — the same one the harness class serves from. */
+  store: PiRecordLocator;
+  /** Where its records live, and the workspace they are grouped by: `SessionManager` is constructed
+   *  with both, then pointed at the file the store resolved. */
   sessionsRoot: string;
-  /** The workspace the records are grouped by (pi partitions sessions per project dir). */
   cwd: string;
-  env: NodeExecutionEnv;
 }
 
-/**
- * A binder for one deployment: `sessionId → SessionManager` over that id's record, CREATING the
- * record when the id is new (so the returned manager is always in append-immediately mode).
- */
+/** A binder for one deployment: `sessionId → SessionManager` over that id's record in `store`. */
 export function sessionRecordBinder(
   options: SessionRecordBinderOptions,
 ): (sessionId: string) => Promise<SessionManager> {
-  const { sessionsRoot, cwd, env } = options;
-  const repo = new JsonlSessionRepo({ fs: env, sessionsRoot });
-  const recordPath = async (sessionId: string): Promise<string> => {
-    // The SAME encoding `jsonlSessionStore` applies: session ids are caller-owned and land in
-    // filenames (`telegram:-100/42` carries a path separator). Encoding differently here would give
-    // the two engine classes two records for one conversation — the record they are supposed to
-    // share is addressed by this string.
-    const id = encodeSessionId(sessionId);
-    const existing = (await repo.list({ cwd })).find((meta) => meta.id === id);
-    if (existing) {
-      // The SAME repair `jsonlSessionStore.openOrCreate` performs, from the one implementation of
-      // it: a turn that died mid tool-execution left an assistant `tool_use` with no result, which
-      // providers reject outright. Both classes write this record, so a crash under either leaves a
-      // transcript the other must be able to open — skipping the repair here would mean a session
-      // the harness class self-heals and this one fails on forever. Runs BEFORE the SessionManager
-      // binds, since that loads the file as it stands.
-      await reconcileInterruptedToolCalls(await repo.open(existing));
-      return existing.path;
-    }
-    const created = await repo.create({ id, cwd });
-    return (await created.getMetadata()).path;
-  };
+  const { store, sessionsRoot, cwd } = options;
   return async (sessionId) => {
     const manager = SessionManager.create(cwd, sessionsRoot);
-    manager.setSessionFile(await recordPath(sessionId));
+    manager.setSessionFile(await store.recordPath(sessionId));
     return manager;
   };
 }

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -18,20 +18,14 @@
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import type { PiRecordLocator } from "./sessions.ts";
 
-export interface SessionRecordBinderOptions {
-  /** The store that OWNS the records — the same one the harness class serves from. */
-  store: PiRecordLocator;
-  /** Where its records live, and the workspace they are grouped by: `SessionManager` is constructed
-   *  with both, then pointed at the file the store resolved. */
-  sessionsRoot: string;
-  cwd: string;
-}
-
-/** A binder for one deployment: `sessionId → SessionManager` over that id's record in `store`. */
-export function sessionRecordBinder(
-  options: SessionRecordBinderOptions,
-): (sessionId: string) => Promise<SessionManager> {
-  const { store, sessionsRoot, cwd } = options;
+/**
+ * A binder for one deployment: `sessionId → SessionManager` over that id's record in `store`. ONE
+ * argument on purpose — the layout comes from the store rather than being re-supplied beside it, so
+ * a manager cannot be constructed over a root the records do not live in (branch and fork write
+ * through that root, and a mismatch would make a second record for one conversation).
+ */
+export function sessionRecordBinder(store: PiRecordLocator): (sessionId: string) => Promise<SessionManager> {
+  const { sessionsRoot, cwd } = store.recordLayout;
   return async (sessionId) => {
     const manager = SessionManager.create(cwd, sessionsRoot);
     manager.setSessionFile(await store.ensureRecordPath(sessionId));

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -15,6 +15,7 @@
  */
 import { JsonlSessionRepo, type NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { encodeSessionId } from "./sessions.ts";
 
 export interface SessionRecordBinderOptions {
   /** Where the jsonl records live — the same directory the harness class's store is pointed at. */
@@ -34,9 +35,14 @@ export function sessionRecordBinder(
   const { sessionsRoot, cwd, env } = options;
   const repo = new JsonlSessionRepo({ fs: env, sessionsRoot });
   const recordPath = async (sessionId: string): Promise<string> => {
-    const existing = (await repo.list({ cwd })).find((meta) => meta.id === sessionId);
+    // The SAME encoding `jsonlSessionStore` applies: session ids are caller-owned and land in
+    // filenames (`telegram:-100/42` carries a path separator). Encoding differently here would give
+    // the two engine classes two records for one conversation — the record they are supposed to
+    // share is addressed by this string.
+    const id = encodeSessionId(sessionId);
+    const existing = (await repo.list({ cwd })).find((meta) => meta.id === id);
     if (existing) return existing.path;
-    const created = await repo.create({ id: sessionId, cwd });
+    const created = await repo.create({ id, cwd });
     return (await created.getMetadata()).path;
   };
   return async (sessionId) => {

--- a/src/engines/pi/session-record.ts
+++ b/src/engines/pi/session-record.ts
@@ -34,7 +34,7 @@ export function sessionRecordBinder(
   const { store, sessionsRoot, cwd } = options;
   return async (sessionId) => {
     const manager = SessionManager.create(cwd, sessionsRoot);
-    manager.setSessionFile(await store.recordPath(sessionId));
+    manager.setSessionFile(await store.ensureRecordPath(sessionId));
     return manager;
   };
 }

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -47,6 +47,10 @@ export interface PiSessionReader {
  *  to a file that is not yet a session). Only a file-backed store can answer. */
 export interface PiRecordLocator {
   ensureRecordPath(sessionId: string): Promise<string>;
+  /** The layout those records live in. Carried on the store so a consumer building ANOTHER reader
+   *  over the same files cannot point it somewhere else: a `SessionManager` constructed with a
+   *  different root would write branch/fork operations into a second record for one conversation. */
+  readonly recordLayout: { sessionsRoot: string; cwd: string };
 }
 
 /**
@@ -203,6 +207,7 @@ export function jsonlRecordStore(options: {
   const cwd = options.cwd ?? process.cwd();
   const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
   return {
+    recordLayout: { sessionsRoot: options.dir, cwd },
     async ensureRecordPath(sessionId) {
       // Deliberately THROUGH openOrCreate: the id encoding, the cwd scoping, the create metadata and
       // the crash repair are one sequence, and a second copy of it would eventually address a

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -61,7 +61,7 @@ export interface PiSessionReader {
  * stays neutral — it must NOT say "aborted" (pi's word for a user cancellation) or leak infra detail;
  * `details` carries the operational marker for developers and is never sent to the provider.
  */
-async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
+export async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
   const { messages } = await session.buildContext();
 
   let leafIdx = -1;

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -212,26 +212,26 @@ export function jsonlRecordStore(options: {
 }): PiSessionStore & PiSessionReader & PiRecordLocator {
   const cwd = options.cwd ?? process.cwd();
   const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
-  const openOrCreate = async (sessionId: string): Promise<{ session: Session; created: boolean }> => {
+  const openOrCreate = async (sessionId: string): Promise<Session> => {
     // Caller-provided ids land in jsonl FILENAMES — encode anything unsafe before it reaches disk.
     const id = encodeSessionId(sessionId);
     // Scope the lookup to this store's cwd: two stores sharing a sessionsRoot must not open each
     // other's sessions (pi groups sessions by project dir).
     const existing = (await repo.list({ cwd })).find((m) => m.id === id);
-    if (!existing) return { session: await repo.create({ id, cwd }), created: true };
+    if (!existing) return repo.create({ id, cwd });
     const session = await repo.open(existing);
     await reconcileInterruptedToolCalls(session);
-    return { session, created: false };
+    return session;
   };
   return {
     recordLayout: { sessionsRoot: options.dir, cwd },
-    openOrCreate: async (sessionId) => (await openOrCreate(sessionId)).session,
+    openOrCreate,
     async ensureRecordPath(sessionId) {
       // Deliberately THROUGH openOrCreate: the id encoding, the cwd scoping, the create metadata and
       // the crash repair are one sequence, and a second copy of it would eventually address a
       // different file — two records for one conversation, which is the failure the session class's
       // binder exists to prevent.
-      const { session } = await openOrCreate(sessionId);
+      const session = await openOrCreate(sessionId);
       // The repo's own metadata shape (JsonlSessionMetadata) — narrowed here rather than widening
       // the shared PiSessionStore return type, which must stay backend-agnostic.
       const path = (await (session as Session<JsonlSessionMetadata>).getMetadata()).path;

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -40,10 +40,13 @@ export interface PiSessionReader {
   openIfExists(sessionId: string): Promise<Session | undefined>;
 }
 
-/** Where a session's record LIVES, for a consumer that must hand the file to another reader (the
- *  session engine class binds a `SessionManager` to it). Only a file-backed store can answer. */
+/** The file a session's record lives in, for a consumer that must hand it to another reader (the
+ *  session engine class binds a `SessionManager` to it). ASKING CREATES: an unknown id is opened
+ *  through the store's own `openOrCreate`, so the record, its metadata and its crash repair all
+ *  exist by the time a path comes back — which is the point (a caller must never be handed a path
+ *  to a file that is not yet a session). Only a file-backed store can answer. */
 export interface PiRecordLocator {
-  recordPath(sessionId: string): Promise<string>;
+  ensureRecordPath(sessionId: string): Promise<string>;
 }
 
 /**
@@ -191,7 +194,7 @@ export function jsonlSessionStore(options: {
   const cwd = options.cwd ?? process.cwd();
   const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
   return {
-    async recordPath(sessionId) {
+    async ensureRecordPath(sessionId) {
       // Deliberately THROUGH openOrCreate: the id encoding, the cwd scoping, the create metadata and
       // the crash repair are one sequence, and a second copy of it would eventually address a
       // different file — two records for one conversation, which is the failure the session class's

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -10,7 +10,7 @@
  * jsonl survives process restarts (disk is the truth).
  */
 import { InMemorySessionRepo } from "@earendil-works/pi-agent-core";
-import type { AgentMessage, Session, SessionTreeEntry } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, JsonlSessionMetadata, Session, SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { log } from "../../log.ts";
 
@@ -40,6 +40,12 @@ export interface PiSessionReader {
   openIfExists(sessionId: string): Promise<Session | undefined>;
 }
 
+/** Where a session's record LIVES, for a consumer that must hand the file to another reader (the
+ *  session engine class binds a `SessionManager` to it). Only a file-backed store can answer. */
+export interface PiRecordLocator {
+  recordPath(sessionId: string): Promise<string>;
+}
+
 /**
  * Crash-safety reconciliation, run on every OPEN of an existing session.
  *
@@ -61,7 +67,7 @@ export interface PiSessionReader {
  * stays neutral — it must NOT say "aborted" (pi's word for a user cancellation) or leak infra detail;
  * `details` carries the operational marker for developers and is never sent to the provider.
  */
-export async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
+async function reconcileInterruptedToolCalls(session: Session): Promise<void> {
   const { messages } = await session.buildContext();
 
   let leafIdx = -1;
@@ -178,10 +184,23 @@ export function inMemorySessionStore(): PiSessionStore & PiSessionReader {
  * Disk-backed store (pi JsonlSessionRepo under `dir`): restart the process, conversations continue.
  * `cwd` is recorded in session metadata; defaults to process.cwd().
  */
-export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSessionStore & PiSessionReader {
+export function jsonlSessionStore(options: {
+  dir: string;
+  cwd?: string;
+}): PiSessionStore & PiSessionReader & PiRecordLocator {
   const cwd = options.cwd ?? process.cwd();
   const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
   return {
+    async recordPath(sessionId) {
+      // Deliberately THROUGH openOrCreate: the id encoding, the cwd scoping, the create metadata and
+      // the crash repair are one sequence, and a second copy of it would eventually address a
+      // different file — two records for one conversation, which is the failure the session class's
+      // binder exists to prevent.
+      const session = await this.openOrCreate(sessionId);
+      // The repo's own metadata shape (JsonlSessionMetadata) — narrowed here rather than widening
+      // the shared PiSessionStore return type, which must stay backend-agnostic.
+      return (await (session as Session<JsonlSessionMetadata>).getMetadata()).path;
+    },
     async openOrCreate(sessionId) {
       // Caller-provided ids land in jsonl FILENAMES — encode anything unsafe before it reaches disk.
       const id = encodeSessionId(sessionId);
@@ -202,8 +221,9 @@ export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSes
 }
 
 /** Injective filename-safe encoding: [A-Za-z0-9._-] verbatim, the rest %-escaped. THE encoding for
- *  this repository's records: both engine classes address the same jsonl by the same opaque session
- *  id, so a second spelling of it would silently give them two records for one conversation. */
-export function encodeSessionId(id: string): string {
+ *  this repository's records, and private on purpose: both engine classes reach a record through
+ *  this module's own lookups, so there is no second spelling to drift — the session class asks
+ *  {@link PiRecordLocator.recordPath} rather than encoding an id itself. */
+function encodeSessionId(id: string): string {
   return id.replace(/[^A-Za-z0-9._-]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`);
 }

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -46,13 +46,10 @@ export interface PiSessionReader {
  *  exist by the time a path comes back — which is the point (a caller must never be handed a path
  *  to a file that is not yet a session). Only a file-backed store can answer. */
 export interface PiRecordLocator {
-  /** `hasHistory` distinguishes a conversation's first turn from its later ones — the store is the
-   *  only place that knows, and a consumer announcing a session's lifecycle needs it (an extension
-   *  that seeds or greets on startup must fire once: not never, not every turn). Keyed on whether
-   *  anything was ever SAID, not on whether this call created the file: a first turn that died
-   *  before it got anywhere leaves a record with only bookkeeping in it, and the conversation's
-   *  startup has still not been announced. */
-  ensureRecordPath(sessionId: string): Promise<{ path: string; hasHistory: boolean }>;
+  /** ASKING CREATES: an unknown id is opened through the store's own `openOrCreate`, so the record,
+   *  its metadata and its crash repair all exist by the time a path comes back — a caller must never
+   *  be handed a path to a file that is not yet a session. */
+  ensureRecordPath(sessionId: string): Promise<string>;
   /** The layout those records live in. Carried on the store so a consumer building ANOTHER reader
    *  over the same files cannot point it somewhere else: a `SessionManager` constructed with a
    *  different root would write branch/fork operations into a second record for one conversation. */
@@ -235,10 +232,7 @@ export function jsonlRecordStore(options: {
       // The repo's own metadata shape (JsonlSessionMetadata) — narrowed here rather than widening
       // the shared PiSessionStore return type, which must stay backend-agnostic.
       const path = (await (session as Session<JsonlSessionMetadata>).getMetadata()).path;
-      // MESSAGES, not entries: building a session appends bookkeeping (model_change,
-      // thinking_level_change) before anyone has said anything, so an entry count would call an
-      // abandoned first attempt "history" and swallow the conversation's startup announcement.
-      return { path, hasHistory: (await session.getEntries()).some((entry) => entry.type === "message") };
+      return path;
     },
     async openIfExists(sessionId) {
       const id = encodeSessionId(sessionId);

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -46,9 +46,6 @@ export interface PiSessionReader {
  *  exist by the time a path comes back — which is the point (a caller must never be handed a path
  *  to a file that is not yet a session). Only a file-backed store can answer. */
 export interface PiRecordLocator {
-  /** ASKING CREATES: an unknown id is opened through the store's own `openOrCreate`, so the record,
-   *  its metadata and its crash repair all exist by the time a path comes back — a caller must never
-   *  be handed a path to a file that is not yet a session. */
   ensureRecordPath(sessionId: string): Promise<string>;
   /** The layout those records live in. Carried on the store so a consumer building ANOTHER reader
    *  over the same files cannot point it somewhere else: a `SessionManager` constructed with a

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -206,28 +206,29 @@ export function jsonlRecordStore(options: {
 }): PiSessionStore & PiSessionReader & PiRecordLocator {
   const cwd = options.cwd ?? process.cwd();
   const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
+  const openOrCreate = async (sessionId: string): Promise<Session> => {
+    // Caller-provided ids land in jsonl FILENAMES — encode anything unsafe before it reaches disk.
+    const id = encodeSessionId(sessionId);
+    // Scope the lookup to this store's cwd: two stores sharing a sessionsRoot must not open each
+    // other's sessions (pi groups sessions by project dir).
+    const existing = (await repo.list({ cwd })).find((m) => m.id === id);
+    if (!existing) return repo.create({ id, cwd });
+    const session = await repo.open(existing);
+    await reconcileInterruptedToolCalls(session);
+    return session;
+  };
   return {
     recordLayout: { sessionsRoot: options.dir, cwd },
+    openOrCreate,
     async ensureRecordPath(sessionId) {
       // Deliberately THROUGH openOrCreate: the id encoding, the cwd scoping, the create metadata and
       // the crash repair are one sequence, and a second copy of it would eventually address a
       // different file — two records for one conversation, which is the failure the session class's
       // binder exists to prevent.
-      const session = await this.openOrCreate(sessionId);
+      const session = await openOrCreate(sessionId);
       // The repo's own metadata shape (JsonlSessionMetadata) — narrowed here rather than widening
       // the shared PiSessionStore return type, which must stay backend-agnostic.
       return (await (session as Session<JsonlSessionMetadata>).getMetadata()).path;
-    },
-    async openOrCreate(sessionId) {
-      // Caller-provided ids land in jsonl FILENAMES — encode anything unsafe before it reaches disk.
-      const id = encodeSessionId(sessionId);
-      // Scope the lookup to this store's cwd: two stores sharing a sessionsRoot must not open each
-      // other's sessions (pi groups sessions by project dir).
-      const existing = (await repo.list({ cwd })).find((m) => m.id === id);
-      if (!existing) return repo.create({ id, cwd });
-      const session = await repo.open(existing);
-      await reconcileInterruptedToolCalls(session);
-      return session;
     },
     async openIfExists(sessionId) {
       const id = encodeSessionId(sessionId);

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -201,7 +201,9 @@ export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSes
   };
 }
 
-/** Injective filename-safe encoding: [A-Za-z0-9._-] verbatim, the rest %-escaped. */
-function encodeSessionId(id: string): string {
+/** Injective filename-safe encoding: [A-Za-z0-9._-] verbatim, the rest %-escaped. THE encoding for
+ *  this repository's records: both engine classes address the same jsonl by the same opaque session
+ *  id, so a second spelling of it would silently give them two records for one conversation. */
+export function encodeSessionId(id: string): string {
   return id.replace(/[^A-Za-z0-9._-]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`);
 }

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -46,10 +46,13 @@ export interface PiSessionReader {
  *  exist by the time a path comes back — which is the point (a caller must never be handed a path
  *  to a file that is not yet a session). Only a file-backed store can answer. */
 export interface PiRecordLocator {
-  /** `created` distinguishes a conversation's FIRST turn from its later ones — the store is the only
-   *  place that knows, and a consumer announcing a session's lifecycle needs it (an extension that
-   *  seeds or greets on startup must fire once, not never and not every turn). */
-  ensureRecordPath(sessionId: string): Promise<{ path: string; created: boolean }>;
+  /** `hasHistory` distinguishes a conversation's first turn from its later ones — the store is the
+   *  only place that knows, and a consumer announcing a session's lifecycle needs it (an extension
+   *  that seeds or greets on startup must fire once: not never, not every turn). Keyed on whether
+   *  anything was ever SAID, not on whether this call created the file: a first turn that died
+   *  before it got anywhere leaves a record with only bookkeeping in it, and the conversation's
+   *  startup has still not been announced. */
+  ensureRecordPath(sessionId: string): Promise<{ path: string; hasHistory: boolean }>;
   /** The layout those records live in. Carried on the store so a consumer building ANOTHER reader
    *  over the same files cannot point it somewhere else: a `SessionManager` constructed with a
    *  different root would write branch/fork operations into a second record for one conversation. */
@@ -228,10 +231,14 @@ export function jsonlRecordStore(options: {
       // the crash repair are one sequence, and a second copy of it would eventually address a
       // different file — two records for one conversation, which is the failure the session class's
       // binder exists to prevent.
-      const { session, created } = await openOrCreate(sessionId);
+      const { session } = await openOrCreate(sessionId);
       // The repo's own metadata shape (JsonlSessionMetadata) — narrowed here rather than widening
       // the shared PiSessionStore return type, which must stay backend-agnostic.
-      return { path: (await (session as Session<JsonlSessionMetadata>).getMetadata()).path, created };
+      const path = (await (session as Session<JsonlSessionMetadata>).getMetadata()).path;
+      // MESSAGES, not entries: building a session appends bookkeeping (model_change,
+      // thinking_level_change) before anyone has said anything, so an entry count would call an
+      // abandoned first attempt "history" and swallow the conversation's startup announcement.
+      return { path, hasHistory: (await session.getEntries()).some((entry) => entry.type === "message") };
     },
     async openIfExists(sessionId) {
       const id = encodeSessionId(sessionId);

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -46,7 +46,10 @@ export interface PiSessionReader {
  *  exist by the time a path comes back — which is the point (a caller must never be handed a path
  *  to a file that is not yet a session). Only a file-backed store can answer. */
 export interface PiRecordLocator {
-  ensureRecordPath(sessionId: string): Promise<string>;
+  /** `created` distinguishes a conversation's FIRST turn from its later ones — the store is the only
+   *  place that knows, and a consumer announcing a session's lifecycle needs it (an extension that
+   *  seeds or greets on startup must fire once, not never and not every turn). */
+  ensureRecordPath(sessionId: string): Promise<{ path: string; created: boolean }>;
   /** The layout those records live in. Carried on the store so a consumer building ANOTHER reader
    *  over the same files cannot point it somewhere else: a `SessionManager` constructed with a
    *  different root would write branch/fork operations into a second record for one conversation. */
@@ -206,29 +209,29 @@ export function jsonlRecordStore(options: {
 }): PiSessionStore & PiSessionReader & PiRecordLocator {
   const cwd = options.cwd ?? process.cwd();
   const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
-  const openOrCreate = async (sessionId: string): Promise<Session> => {
+  const openOrCreate = async (sessionId: string): Promise<{ session: Session; created: boolean }> => {
     // Caller-provided ids land in jsonl FILENAMES — encode anything unsafe before it reaches disk.
     const id = encodeSessionId(sessionId);
     // Scope the lookup to this store's cwd: two stores sharing a sessionsRoot must not open each
     // other's sessions (pi groups sessions by project dir).
     const existing = (await repo.list({ cwd })).find((m) => m.id === id);
-    if (!existing) return repo.create({ id, cwd });
+    if (!existing) return { session: await repo.create({ id, cwd }), created: true };
     const session = await repo.open(existing);
     await reconcileInterruptedToolCalls(session);
-    return session;
+    return { session, created: false };
   };
   return {
     recordLayout: { sessionsRoot: options.dir, cwd },
-    openOrCreate,
+    openOrCreate: async (sessionId) => (await openOrCreate(sessionId)).session,
     async ensureRecordPath(sessionId) {
       // Deliberately THROUGH openOrCreate: the id encoding, the cwd scoping, the create metadata and
       // the crash repair are one sequence, and a second copy of it would eventually address a
       // different file — two records for one conversation, which is the failure the session class's
       // binder exists to prevent.
-      const session = await openOrCreate(sessionId);
+      const { session, created } = await openOrCreate(sessionId);
       // The repo's own metadata shape (JsonlSessionMetadata) — narrowed here rather than widening
       // the shared PiSessionStore return type, which must stay backend-agnostic.
-      return (await (session as Session<JsonlSessionMetadata>).getMetadata()).path;
+      return { path: (await (session as Session<JsonlSessionMetadata>).getMetadata()).path, created };
     },
     async openIfExists(sessionId) {
       const id = encodeSessionId(sessionId);

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -187,7 +187,16 @@ export function inMemorySessionStore(): PiSessionStore & PiSessionReader {
  * Disk-backed store (pi JsonlSessionRepo under `dir`): restart the process, conversations continue.
  * `cwd` is recorded in session metadata; defaults to process.cwd().
  */
-export function jsonlSessionStore(options: {
+export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSessionStore & PiSessionReader {
+  return jsonlRecordStore(options);
+}
+
+/**
+ * INTERNAL: the same store, plus the locator the `session` engine class binds a `SessionManager` to.
+ * A separate entry point rather than a wider public return type, so "hand me the jsonl path for this
+ * session id" does not become supported API before anything public can use it.
+ */
+export function jsonlRecordStore(options: {
   dir: string;
   cwd?: string;
 }): PiSessionStore & PiSessionReader & PiRecordLocator {
@@ -226,7 +235,7 @@ export function jsonlSessionStore(options: {
 /** Injective filename-safe encoding: [A-Za-z0-9._-] verbatim, the rest %-escaped. THE encoding for
  *  this repository's records, and private on purpose: both engine classes reach a record through
  *  this module's own lookups, so there is no second spelling to drift — the session class asks
- *  {@link PiRecordLocator.recordPath} rather than encoding an id itself. */
+ *  {@link PiRecordLocator.ensureRecordPath} rather than encoding an id itself. */
 function encodeSessionId(id: string): string {
   return id.replace(/[^A-Za-z0-9._-]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`);
 }

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -20,7 +20,10 @@ import { type ReadonlySessionManager, type ToolActivation, turnContext } from ".
 export interface ToolContext {
   /** Working directory for this execution. */
   cwd: string;
-  /** Abort signal for the current turn — honor it to cancel in-flight work on cancellation. */
+  /** Abort signal for the current turn — honor it to cancel in-flight work on cancellation. It can
+   *  ALREADY be aborted when `execute` is called (a caller may cancel between the `tool_started`
+   *  event and the tool running), and an already-aborted signal never fires `abort` again: check
+   *  `signal.aborted` first, then listen, or a listener-only tool hangs forever. */
   signal?: AbortSignal;
   /** Current conversation manager. Present during serving/chat; absent for sessionless direct calls. */
   sessionManager?: ReadonlySessionManager;

--- a/src/engines/pi/turn-plumbing.ts
+++ b/src/engines/pi/turn-plumbing.ts
@@ -9,7 +9,7 @@
  * because pi exposes a turn as a promise PLUS a subscription.
  */
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
-import { ABORTED_CODE, type AgentEvent, type Prompt } from "../../agent.ts";
+import { ABORTED_CODE, type AgentEvent, type Prompt, SESSION_BUSY_CODE } from "../../agent.ts";
 
 // ── §1 Lease: single-writer concurrency floor ────────────────────────────────
 //
@@ -38,6 +38,17 @@ export function inProcessLease(): Lease {
         busy.delete(session);
       };
     },
+  };
+}
+
+/** The refusal a lease collision produces — ONE literal, because it is contract-visible (a channel
+ *  may branch on `code`) and both engine classes emit it. Rejected before any turn exists. */
+export function sessionBusyFailure(): Extract<AgentEvent, { type: "failed" }> {
+  return {
+    type: "failed",
+    details: "session busy: a turn is already in flight for this session",
+    retryable: true,
+    code: SESSION_BUSY_CODE,
   };
 }
 

--- a/src/engines/pi/turn-plumbing.ts
+++ b/src/engines/pi/turn-plumbing.ts
@@ -143,15 +143,24 @@ export function toTerminal(message: AssistantMessage): AgentEvent {
     return { type: "failed", details, retryable: false, code: ABORTED_CODE };
   }
   if (message.stopReason === "error") {
-    const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
+    const details = failureDetails(message.errorMessage ?? "", `model stopped: ${message.stopReason}`);
     return { type: "failed", details, retryable: classifyRetryable(details, messageSignal(message)) };
   }
   return { type: "completed" };
 }
 
 export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "failed" }> {
-  const details = error instanceof Error ? error.message : String(error);
+  const details = failureDetails(error instanceof Error ? error.message : String(error), error);
   return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
+}
+
+/** `details` is the ONLY place an engine's own account of a failure reaches the caller (SPEC §5), so
+ *  it must never be empty: a `new Error("")` or a message-less rejection would otherwise conform on
+ *  types and tell the caller nothing. Fall through the shapes that carry meaning. */
+function failureDetails(message: string, error: unknown): string {
+  if (message !== "") return message;
+  const stringified = String(error);
+  return stringified === "" || stringified === "Error" ? "unknown engine error" : stringified;
 }
 
 // ── §3 Prompt images: one conversion for both classes ────────────────────────

--- a/src/engines/pi/turn-plumbing.ts
+++ b/src/engines/pi/turn-plumbing.ts
@@ -139,7 +139,7 @@ export function toTerminal(message: AssistantMessage): AgentEvent {
   if (message.stopReason === "aborted") {
     // A deliberate stop (control-plane abort / harness abort), not an error — see {@link ABORTED_CODE}
     // for the consumer contract (design §6).
-    const details = message.errorMessage ?? "run aborted";
+    const details = nonEmptyDetails(message.errorMessage ?? "", "run aborted");
     return { type: "failed", details, retryable: false, code: ABORTED_CODE };
   }
   if (message.stopReason === "error") {

--- a/src/engines/pi/turn-plumbing.ts
+++ b/src/engines/pi/turn-plumbing.ts
@@ -1,0 +1,197 @@
+/**
+ * Turn plumbing shared by pi's TWO engine classes — the harness L0 (`invoke.ts`) and the session L0
+ * (`session-invoke.ts`). It lives here rather than in either of them because neither engine class
+ * may depend on the other: they are siblings behind one Agent contract, and a sibling import would
+ * make the choice of engine class also a choice of which module graph loads.
+ *
+ * Four pieces, all engine-class-neutral: the single-writer lease, the pi→SPEC terminal
+ * classification, the prompt→pi image conversion, and the push→pull fan-in both classes need
+ * because pi exposes a turn as a promise PLUS a subscription.
+ */
+import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
+import { ABORTED_CODE, type AgentEvent, type Prompt } from "../../agent.ts";
+
+// ── §1 Lease: single-writer concurrency floor ───────────────────────────────
+//
+// Corruption-prevention floor only: it does not pick a UX. Fail-fast over queueing because real
+// same-session concurrency is mostly duplicate intent or a user firing follow-ups, not two real
+// turns; a queue would also leak a slot when a waiter is cancelled. Synchronous (no awaits) so
+// nothing interleaves between acquire and entering try — cancellation always releases in finally.
+
+export type Release = () => void;
+
+export interface Lease {
+  /** Try to acquire exclusive write access for the session (fail-fast). Returns null if held. */
+  tryAcquire(session: string): Release | null;
+}
+
+export function inProcessLease(): Lease {
+  const busy = new Set<string>();
+  return {
+    tryAcquire(session: string): Release | null {
+      if (busy.has(session)) return null;
+      busy.add(session);
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        busy.delete(session);
+      };
+    },
+  };
+}
+
+/** Clearly-transient network error codes (Node/undici), decisive on their own. */
+const RETRYABLE_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EAI_AGAIN",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/** 429 (rate limit) and 5xx (server) are worth retrying; other statuses are decisive NON-retryable. */
+const statusIsRetryable = (status: number): boolean => status === 429 || (status >= 500 && status < 600);
+
+/** Last-resort prose match, used only when no structured status/code is available. */
+const RETRYABLE_MESSAGE =
+  /\b(429|5\d\d|timeout|timed out|rate.?limit|overloaded|ECONNRESET|ETIMEDOUT|ENETUNREACH|EAI_AGAIN|socket hang up)\b/i;
+
+/** A structured status/code decision, or `null` when the signal is absent/undecisive → fall to prose. */
+function retryableFromSignal(signal: { status?: number; code?: unknown }): boolean | null {
+  if (typeof signal.status === "number") return statusIsRetryable(signal.status);
+  const { code } = signal;
+  if (typeof code === "number") return statusIsRetryable(code);
+  if (typeof code === "string") {
+    if (RETRYABLE_CODES.has(code)) return true;
+    if (/^\d{3}$/.test(code)) return statusIsRetryable(Number(code)); // a status carried as a string
+  }
+  return null; // no code, or an unknown one — not decisive on its own
+}
+
+/** Classify `retryable`: structured status/code first, message prose only as the last-resort ceiling. */
+export function classifyRetryable(details: string, signal: { status?: number; code?: unknown }): boolean {
+  return retryableFromSignal(signal) ?? RETRYABLE_MESSAGE.test(details);
+}
+
+/** Pull a structured status/code off a thrown error (HTTP status or a network code, incl. its cause). */
+function errorSignal(error: unknown): { status?: number; code?: unknown } {
+  if (!error || typeof error !== "object") return {};
+  const e = error as { status?: unknown; statusCode?: unknown; code?: unknown; cause?: unknown };
+  const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
+  const causeCode = e.cause && typeof e.cause === "object" ? (e.cause as { code?: unknown }).code : undefined;
+  return { status, code: e.code ?? causeCode };
+}
+
+/**
+ * Pull the structured error `code` pi records on a failed message's diagnostics. `diagnostics`
+ * accumulates across attempts (`appendAssistantMessageDiagnostic`), so the terminal cause is the LAST
+ * code-bearing entry — `findLast`, not `find`: an earlier attempt's transient 503 must not classify a
+ * terminal 400/auth failure as retryable. (Reverse scan rather than `findLast` — the tsconfig lib is
+ * ES2022.)
+ */
+function messageSignal(message: AssistantMessage): { status?: number; code?: unknown } {
+  const diagnostics = message.diagnostics ?? [];
+  for (let i = diagnostics.length - 1; i >= 0; i--) {
+    const code = diagnostics[i]?.error?.code;
+    if (code !== undefined) return { code };
+  }
+  return {};
+}
+
+/**
+ * Terminal mapping, decided by the resolved message's stopReason: pi's prompt() resolves a message
+ * with stopReason "error"/"aborted" rather than throwing, so relying on catch alone would miss this
+ * entire failure class (violating SPEC MUST 1).
+ */
+export function toTerminal(message: AssistantMessage): AgentEvent {
+  if (message.stopReason === "aborted") {
+    // A deliberate stop (control-plane abort / harness abort), not an error — see {@link ABORTED_CODE}
+    // for the consumer contract (design §6).
+    const details = message.errorMessage ?? "run aborted";
+    return { type: "failed", details, retryable: false, code: ABORTED_CODE };
+  }
+  if (message.stopReason === "error") {
+    const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
+    return { type: "failed", details, retryable: classifyRetryable(details, messageSignal(message)) };
+  }
+  return { type: "completed" };
+}
+
+export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "failed" }> {
+  const details = error instanceof Error ? error.message : String(error);
+  return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
+}
+
+/**
+ * Map prompt images to pi ImageContent, resizing each to model-friendly dimensions/size with pi's
+ * Photon resizer (reused from pi-coding-agent, lazy-imported so the common no-image headless path never
+ * loads the TUI module graph). A null resize (unresizable / Photon unavailable) keeps the original
+ * bytes — the provider then applies its own limit.
+ */
+export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
+  if (!prompt.images || prompt.images.length === 0) return undefined;
+  const { resizeImage } = await import("@earendil-works/pi-coding-agent");
+  const images = await Promise.all(
+    prompt.images.map(async (img): Promise<ImageContent> => {
+      const resized = await resizeImage(Buffer.from(img.data, "base64"), img.mimeType, {
+        maxWidth: 1568,
+        maxHeight: 1568,
+        maxBytes: 5 * 1024 * 1024,
+      }).catch(() => null);
+      return resized
+        ? { type: "image", data: resized.data, mimeType: resized.mimeType }
+        : { type: "image", data: img.data, mimeType: img.mimeType };
+    }),
+  );
+  return { images };
+}
+
+// ── §3 EventQueue: push→pull plumbing for pi's two-port shape ────────────────
+//
+// Single-consumer async queue; single-threaded JS means no await interleaves between push and
+// drain, so no locking. Engines that are natively async-iterable would not need it. Exported for
+// the sibling L0 (`session-invoke.ts`): both engine classes have pi's two-port shape (a promise for
+// the turn + a subscription for the stream), so the fan-in is the same plumbing.
+
+export class EventQueue<T> {
+  private buffer: T[] = [];
+  private wake?: () => void;
+
+  push(item: T): void {
+    this.buffer.push(item);
+    const wake = this.wake;
+    this.wake = undefined;
+    wake?.();
+  }
+
+  /**
+   * Yield pushed events in order until `done` settles AND the buffer is drained. The terminal is
+   * produced separately (toTerminal); rejections of `done` are swallowed here (the caller awaits
+   * `run` itself) to avoid unhandled rejections.
+   */
+  async *drainUntil(done: Promise<unknown>): AsyncGenerator<T> {
+    let settled = false;
+    const onSettle = () => {
+      settled = true;
+      const wake = this.wake;
+      this.wake = undefined;
+      wake?.();
+    };
+    const finished = done.then(onSettle, onSettle);
+
+    while (true) {
+      while (this.buffer.length > 0) {
+        yield this.buffer.shift() as T;
+      }
+      if (settled) break;
+      await new Promise<void>((resolve) => {
+        this.wake = resolve;
+      });
+    }
+    await finished;
+  }
+}

--- a/src/engines/pi/turn-plumbing.ts
+++ b/src/engines/pi/turn-plumbing.ts
@@ -143,22 +143,26 @@ export function toTerminal(message: AssistantMessage): AgentEvent {
     return { type: "failed", details, retryable: false, code: ABORTED_CODE };
   }
   if (message.stopReason === "error") {
-    const details = failureDetails(message.errorMessage ?? "", `model stopped: ${message.stopReason}`);
+    const details = nonEmptyDetails(message.errorMessage ?? "", `model stopped: ${message.stopReason}`);
     return { type: "failed", details, retryable: classifyRetryable(details, messageSignal(message)) };
   }
   return { type: "completed" };
 }
 
 export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "failed" }> {
-  const details = failureDetails(error instanceof Error ? error.message : String(error), error);
+  const details = nonEmptyDetails(error instanceof Error ? error.message : String(error), describeThrown(error));
   return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
 }
 
 /** `details` is the ONLY place an engine's own account of a failure reaches the caller (SPEC §5), so
  *  it must never be empty: a `new Error("")` or a message-less rejection would otherwise conform on
- *  types and tell the caller nothing. Fall through the shapes that carry meaning. */
-function failureDetails(message: string, error: unknown): string {
-  if (message !== "") return message;
+ *  types and tell the caller nothing. */
+function nonEmptyDetails(message: string, fallback: string): string {
+  return message === "" ? fallback : message;
+}
+
+/** What a thrown value says about itself when its message does not. */
+function describeThrown(error: unknown): string {
   const stringified = String(error);
   return stringified === "" || stringified === "Error" ? "unknown engine error" : stringified;
 }

--- a/src/engines/pi/turn-plumbing.ts
+++ b/src/engines/pi/turn-plumbing.ts
@@ -150,8 +150,14 @@ export function toTerminal(message: AssistantMessage): AgentEvent {
 }
 
 export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "failed" }> {
-  const details = nonEmptyDetails(error instanceof Error ? error.message : String(error), describeThrown(error));
+  const details = failureDetails(error);
   return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
+}
+
+/** What a thrown value says for itself, never empty — for a caller that classifies `retryable`
+ *  differently but must describe the failure the same way. */
+export function failureDetails(error: unknown): string {
+  return nonEmptyDetails(error instanceof Error ? error.message : String(error), describeThrown(error));
 }
 
 /** `details` is the ONLY place an engine's own account of a failure reaches the caller (SPEC §5), so

--- a/src/engines/pi/turn-plumbing.ts
+++ b/src/engines/pi/turn-plumbing.ts
@@ -11,7 +11,7 @@
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import { ABORTED_CODE, type AgentEvent, type Prompt } from "../../agent.ts";
 
-// ── §1 Lease: single-writer concurrency floor ───────────────────────────────
+// ── §1 Lease: single-writer concurrency floor ────────────────────────────────
 //
 // Corruption-prevention floor only: it does not pick a UX. Fail-fast over queueing because real
 // same-session concurrency is mostly duplicate intent or a user firing follow-ups, not two real
@@ -40,6 +40,23 @@ export function inProcessLease(): Lease {
     },
   };
 }
+
+// ── §2 Terminal classification: the pi→SPEC decision ─────────────────────────
+//
+// `retryable` = worth re-sending with the same session (SPEC §6: advisory, not a session-atomicity
+// guarantee). Classify from the STRUCTURED signal first, prose only as the last-resort ceiling. What
+// is actually available differs by path, and the two are NOT symmetric:
+//   - thrown error (errorToTerminal): an HTTP `.status`/`.statusCode` AND a network `.code` (incl.
+//     `.cause.code`) — this is where a numeric status genuinely drives the decision.
+//   - failed message (toTerminal): ONLY `diagnostics[].error.code`. pi's `DiagnosticErrorInfo` carries
+//     a `code` (a network code, or a status delivered as a code), with no separate HTTP-status field —
+//     so a message whose provider `code` is a string label (e.g. "rate_limit_exceeded") is not
+//     decisive here and falls to prose.
+// The prose fallback is bounded, not a cop-out: pi-ai already ran its own status-code-based client
+// retries (harness.ts PROVIDER_MAX_RETRIES) before surfacing, so an error that reaches this point has
+// already exhausted the cleanly-retryable cases. The regex is the narrow ceiling, not the classifier.
+// Upstream ask: a first-class `retryable`/`kind` on pi's terminal error would retire the prose path
+// entirely (mirrors the §11 "the deeper fix is upstream in pi" pattern).
 
 /** Clearly-transient network error codes (Node/undici), decisive on their own. */
 const RETRYABLE_CODES = new Set([
@@ -126,6 +143,8 @@ export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "fa
   return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
 }
 
+// ── §3 Prompt images: one conversion for both classes ────────────────────────
+
 /**
  * Map prompt images to pi ImageContent, resizing each to model-friendly dimensions/size with pi's
  * Photon resizer (reused from pi-coding-agent, lazy-imported so the common no-image headless path never
@@ -150,7 +169,7 @@ export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: Imag
   return { images };
 }
 
-// ── §3 EventQueue: push→pull plumbing for pi's two-port shape ────────────────
+// ── §4 EventQueue: push→pull plumbing for pi's two-port shape ────────────────
 //
 // Single-consumer async queue; single-threaded JS means no await interleaves between push and
 // drain, so no locking. Engines that are natively async-iterable would not need it. Exported for

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -44,7 +44,6 @@ export type { AnyModel } from "./engines/pi/harness.ts";
 export {
   inMemorySessionStore,
   jsonlSessionStore,
-  type PiRecordLocator,
   type PiSessionReader,
   type PiSessionStore,
 } from "./engines/pi/sessions.ts";

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -34,7 +34,8 @@ export {
 export type { LoadedDefinition, SkillCollision } from "./engines/pi/definition.ts";
 
 export { defineConfig, listModels, resolveModel, type FastagentConfig } from "./engines/pi/config.ts";
-export { inProcessLease, type Lease, type Release, type SessionObserver } from "./engines/pi/invoke.ts";
+export { inProcessLease, type Lease, type Release } from "./engines/pi/turn-plumbing.ts";
+export type { SessionObserver } from "./engines/pi/invoke.ts";
 export {
   createPiSessionControl,
   type CreatePiSessionControlOptions,

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -44,6 +44,7 @@ export type { AnyModel } from "./engines/pi/harness.ts";
 export {
   inMemorySessionStore,
   jsonlSessionStore,
+  type PiRecordLocator,
   type PiSessionReader,
   type PiSessionStore,
 } from "./engines/pi/sessions.ts";

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -10,7 +10,8 @@ import { Type, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai"
 import { afterAll, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
 import { controlRoutes } from "../src/channels/control.ts";
-import { createPiAgentFromHarness, inProcessLease } from "../src/engines/pi/invoke.ts";
+import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { inProcessLease } from "../src/engines/pi/turn-plumbing.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { createPiSessionControl } from "../src/engines/pi/session-control.ts";
 import { inMemorySessionStore } from "../src/engines/pi/sessions.ts";

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -10,14 +10,8 @@ import { fauxAssistantMessage, fauxThinking, fauxToolCall, Type, type FauxRespon
 import type { AssistantMessage, StopReason, Usage } from "@earendil-works/pi-ai";
 import { defineTool, inMemorySessionStore, inProcessLease, type AgentEvent, z } from "../src/index.ts";
 import { SESSION_BUSY_CODE } from "../src/agent.ts";
-import {
-  classifyRetryable,
-  createPiAgentFromHarness,
-  errorToTerminal,
-  projectAgentEvent,
-  toSessionEvent,
-  toTerminal,
-} from "../src/engines/pi/invoke.ts";
+import { createPiAgentFromHarness, projectAgentEvent, toSessionEvent } from "../src/engines/pi/invoke.ts";
+import { classifyRetryable, errorToTerminal, toTerminal } from "../src/engines/pi/turn-plumbing.ts";
 import { type PiHarnessFactory, piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -55,6 +55,31 @@ async function drain(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   return out;
 }
 
+describe("failure details are never empty (SPEC §5: the only account of a failure)", () => {
+  it("an error with no message still says something", () => {
+    expect(errorToTerminal(new Error("")).details).toBe("unknown engine error");
+    expect(errorToTerminal(new Error()).details).toBe("unknown engine error");
+    expect(errorToTerminal("").details).toBe("unknown engine error");
+    // A real message is passed through untouched.
+    expect(errorToTerminal(new Error("boom 500")).details).toBe("boom 500");
+  });
+
+  it("a failed message with no errorMessage falls back to its stopReason", () => {
+    const terminal = toTerminal({
+      role: "assistant",
+      content: [],
+      api: "openai-completions",
+      provider: "faux",
+      model: "m",
+      usage: { input: 0, output: 0 },
+      stopReason: "error",
+      timestamp: Date.now(),
+    } as never);
+    expect(terminal).toMatchObject({ type: "failed" });
+    if (terminal.type === "failed") expect(terminal.details).toContain("model stopped");
+  });
+});
+
 describe("invoke fan-in", () => {
   it("plain text produces exactly one completed terminal", async () => {
     const { agent } = makeAgent([fauxAssistantMessage("hello world")]);

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../src/session.ts";
 import { SESSION_BUSY_CODE } from "../src/agent.ts";
 import type { PiBoundaryWiring } from "../src/engines/pi/session-control.ts";
-import { inProcessLease } from "../src/engines/pi/invoke.ts";
+import { inProcessLease } from "../src/engines/pi/turn-plumbing.ts";
 import type { PiSessionReader } from "../src/engines/pi/sessions.ts";
 import { resolveHarnessOverrides } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
@@ -588,7 +588,7 @@ describe("session control (Phase 2a): run modulation", () => {
   });
 
   it("toTerminal attributes pi's own stopReason 'aborted' without any control-plane intent", async () => {
-    const { toTerminal } = await import("../src/engines/pi/invoke.ts");
+    const { toTerminal } = await import("../src/engines/pi/turn-plumbing.ts");
     const terminal = toTerminal({
       role: "assistant",
       content: [],

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -21,6 +21,7 @@ import { log } from "../src/log.ts";
 import type { Agent } from "../src/agent.ts";
 import { createPiAgentFromSession } from "../src/engines/pi/session-invoke.ts";
 import { sessionRecordBinder } from "../src/engines/pi/session-record.ts";
+import { jsonlSessionStore } from "../src/engines/pi/sessions.ts";
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
 
@@ -690,6 +691,38 @@ describe("session engine class: the turn context fastagent tools depend on", () 
     expect(seen.cwd).toBe(cwd);
     expect(seen.sessionId).toBeTruthy();
     expect(seen.canActivate).toBe(true);
+  });
+});
+
+describe("session engine class: one record, both engine classes", () => {
+  it("a real channel session id resolves to the SAME record the harness class opens", async () => {
+    // The claim the whole two-class design rests on, with an id of the shape channels actually use
+    // (a path separator, a colon, a leading dash). Addressed differently, the two classes would hold
+    // two records for one conversation and neither would be wrong on its own — which is why this is
+    // asserted across the classes rather than within one.
+    const sessionId = "telegram:-100/42";
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-id-"));
+    const sessionsRoot = join(cwd, "sessions");
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("noted"), fauxAssistantMessage("still here")],
+      sessionsRoot,
+      cwd,
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    for await (const e of agent.invoke({ session: sessionId }, { text: "remember the kettle" })) void e;
+
+    // The harness class's own port, pointed at the same directory.
+    const store = jsonlSessionStore({ dir: sessionsRoot, cwd });
+    const opened = await store.openIfExists(sessionId);
+    expect(opened).toBeDefined();
+    expect(JSON.stringify(await (opened as NonNullable<typeof opened>).getEntries())).toContain("the kettle");
+
+    // … and the session class finds its own record again on the next turn (one record, not two).
+    for await (const e of agent.invoke({ session: sessionId }, { text: "and again" })) void e;
+    const after = await store.openIfExists(sessionId);
+    const text = JSON.stringify(await (after as NonNullable<typeof after>).getEntries());
+    expect(text).toContain("the kettle");
+    expect(text).toContain("and again");
   });
 });
 

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -71,11 +71,7 @@ async function sessionAssembly(options: {
   await loader.reload();
   // The record is addressed the way a deployment must address it — through the shipped binder, so
   // this suite exercises the same code a serving path would, not a parallel fixture of it.
-  const bindRecord = sessionRecordBinder({
-    store: jsonlRecordStore({ dir: options.sessionsRoot, cwd: options.cwd }),
-    sessionsRoot: options.sessionsRoot,
-    cwd: options.cwd,
-  });
+  const bindRecord = sessionRecordBinder(jsonlRecordStore({ dir: options.sessionsRoot, cwd: options.cwd }));
   return {
     faux,
     /** Per invoke: a fresh AgentSession over that id's record, discarded when the turn ends. */
@@ -426,7 +422,11 @@ describe("session engine class: what the class buys", () => {
       cwd,
       extensionFactories: [extension],
     });
-    const agent = createPiAgentFromSession({ sessionFactory });
+    const observed: { event: string }[] = [];
+    const agent = createPiAgentFromSession({
+      sessionFactory,
+      onExtensionError: (error) => observed.push(error),
+    });
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
     try {
       const events = [];
@@ -434,6 +434,8 @@ describe("session engine class: what the class buys", () => {
       expect(ran).toBe(1);
       expect(warn.mock.calls.flat().join(" ")).toContain("unrelated hook blew up"); // the hook IS reported …
       expect(events.at(-1)?.type).toBe("completed"); // … and the command is not blamed for it
+      // … and a factory's own listener sees it, since pi's single onError slot belongs to this L0.
+      expect(observed.map((e) => e.event)).toContain("session_start");
     } finally {
       warn.mockRestore();
     }

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -506,7 +506,7 @@ describe("session engine class: what the class buys", () => {
     expect(seen).toEqual(["start", "shutdown"]);
   });
 
-  it("a turn cancelled during the build reports NO lifecycle at all", async () => {
+  it("a turn cancelled during the build reports NO lifecycle, and does not consume the startup", async () => {
     // The mirror of the same invariant: a death for a birth that never happened. The extension
     // runner and its handlers exist from construction, so "does anyone listen" cannot be the
     // predicate — only whether THIS turn bound them.
@@ -514,8 +514,8 @@ describe("session engine class: what the class buys", () => {
     const seen: string[] = [];
     const extension = {
       name: "lifecycle",
-      factory: (api: { on: (e: string, h: () => void) => void }) => {
-        api.on("session_start", () => seen.push("start"));
+      factory: (api: { on: (e: string, h: (event: { reason?: string }) => void) => void }) => {
+        api.on("session_start", (event) => seen.push(`start:${event.reason}`));
         api.on("session_shutdown", () => seen.push("shutdown"));
       },
     };
@@ -543,6 +543,18 @@ describe("session engine class: what the class buys", () => {
     await first;
     await returned;
     expect(seen).toEqual([]);
+
+    // … and the startup it never announced is not LOST: the record it left behind is empty, so the
+    // conversation's first real turn still opens with a startup rather than a resume.
+    const { sessionFactory: second } = await sessionAssembly({
+      responses: [fauxAssistantMessage("hello")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const next = createPiAgentFromSession({ sessionFactory: second });
+    for await (const e of next.invoke({ session: "s" }, { text: "go" })) void e;
+    expect(seen).toEqual(["start:startup", "shutdown"]);
   });
 
   it("an input handler that throws does NOT consume the turn: the model answers, the failure warns", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -470,6 +470,42 @@ describe("session engine class: what the class buys", () => {
     expect(seen).toEqual(["start:startup", "shutdown", "start:resume", "shutdown"]);
   });
 
+  it("a binding that fails AFTER the birth still reports the death", async () => {
+    // pi emits session_start inside bindExtensions and then does more work that can throw. A flag
+    // set only on success would miss a birth that already reached the handlers, so whatever they
+    // acquired would live until the process exits.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-life3-"));
+    const seen: string[] = [];
+    const extension = {
+      name: "lifecycle",
+      factory: (api: { on: (e: string, h: () => void) => void }) => {
+        api.on("session_start", () => seen.push("start"));
+        api.on("session_shutdown", () => seen.push("shutdown"));
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("never")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({
+      sessionFactory: async (id) => {
+        const session = await sessionFactory(id);
+        const bind = session.bindExtensions.bind(session);
+        session.bindExtensions = async (bindings) => {
+          await bind(bindings); // the birth lands …
+          throw new Error("resource discovery blew up"); // … and then binding fails
+        };
+        return session;
+      },
+    });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+    expect(events.at(-1)).toMatchObject({ type: "failed", details: expect.stringContaining("blew up") });
+    expect(seen).toEqual(["start", "shutdown"]);
+  });
+
   it("a turn cancelled during the build reports NO lifecycle at all", async () => {
     // The mirror of the same invariant: a death for a birth that never happened. The extension
     // runner and its handlers exist from construction, so "does anyone listen" cannot be the
@@ -542,6 +578,40 @@ describe("session engine class: what the class buys", () => {
       expect(modelSaw).toBe(1);
       expect(events.at(-1)?.type).toBe("completed");
       expect(warn.mock.calls.flat().join(" ")).toContain("interceptor blew up");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("a factory's own extension-error listener cannot break the turn", async () => {
+    // The contract calls it an observer; a throwing observer must not become the turn's problem.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-obs-"));
+    const extension = {
+      name: "noisy",
+      factory: (api: { on: (e: string, h: () => void) => void }) => {
+        api.on("session_start", () => {
+          throw new Error("hook went wrong");
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("the answer")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({
+      sessionFactory,
+      onExtensionError: () => {
+        throw new Error("listener itself blew up");
+      },
+    });
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      const events = [];
+      for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+      expect(events.at(-1)?.type).toBe("completed");
+      expect(warn.mock.calls.flat().join(" ")).toContain("listener itself blew up");
     } finally {
       warn.mockRestore();
     }

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -72,9 +72,9 @@ async function sessionAssembly(options: {
   // The record is addressed the way a deployment must address it — through the shipped binder, so
   // this suite exercises the same code a serving path would, not a parallel fixture of it.
   const bindRecord = sessionRecordBinder({
+    store: jsonlSessionStore({ dir: options.sessionsRoot, cwd: options.cwd }),
     sessionsRoot: options.sessionsRoot,
     cwd: options.cwd,
-    env: new NodeExecutionEnv({ cwd: options.cwd }),
   });
   return {
     faux,
@@ -568,6 +568,37 @@ describe("session engine class: this L0's own responsibilities", () => {
     expect(await first).toEqual({ done: true, value: undefined });
     await returned;
     expect(prompted).toBe(0);
+  });
+
+  it("a binding failure yields a failed event AND releases the session", async () => {
+    // The only setup branch that has both a session to release and a terminal to emit: yielding the
+    // event without disposing would leak a wired-up session on every failing turn, invisibly.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-bindfail-"));
+    let disposed = 0;
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("never")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+    });
+    const agent = createPiAgentFromSession({
+      sessionFactory: async (id) => {
+        const session = await sessionFactory(id);
+        const dispose = session.dispose.bind(session);
+        session.dispose = () => {
+          disposed++;
+          dispose();
+        };
+        session.bindExtensions = async () => {
+          throw new Error("extension binding blew up");
+        };
+        return session;
+      },
+    });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "failed", details: expect.stringContaining("binding blew up") });
+    expect(disposed).toBe(1);
   });
 
   it("one turn per session: a second concurrent invoke is refused session_busy", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -16,7 +16,7 @@ import {
   SettingsManager,
   createAgentSession,
 } from "@earendil-works/pi-coding-agent";
-import { type FauxResponseStep, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { type FauxResponseStep, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import type { Agent } from "../src/agent.ts";
 import { createPiAgentFromSession } from "../src/engines/pi/session-invoke.ts";
@@ -44,6 +44,9 @@ async function sessionAssembly(options: {
   extensionFactories?: unknown[];
   /** Off by default: pi's backoff would otherwise make a failing model look like a hang. */
   autoRetry?: boolean;
+  customTools?: unknown[];
+  /** pi's tool allowlist. Empty by default (no coding tools in a conformance run). */
+  tools?: string[];
 }) {
   const { faux } = makeFaux();
   faux.setResponses(options.responses);
@@ -91,7 +94,8 @@ async function sessionAssembly(options: {
         model: faux.getModel(),
         resourceLoader: loader,
         sessionManager,
-        tools: [],
+        tools: options.tools ?? [],
+        ...(options.customTools ? { customTools: options.customTools as never } : {}),
       });
       // Auto-retry is a DEPLOYMENT policy, not a turn mechanism: leaving it on makes a failing
       // model wait out pi's backoff before the terminal, which is exactly the "hang" a conformance
@@ -117,13 +121,29 @@ describeSpecConformance("pi session engine class (faux model, per-invoke AgentSe
 
   hanging: async (onCleanup) => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-hang-"));
+    // A turn that genuinely does not finish: the model calls a tool whose execute settles ONLY on
+    // its abort signal. Without this the faux model completes on its own, `abort()` runs in the
+    // teardown of every path, and the probe would go green whether or not cancellation did
+    // anything — proving teardown ran, not that in-flight work was stopped.
+    const gate = {
+      name: "gate",
+      label: "Gate",
+      description: "Blocks until the turn is aborted",
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+      execute: (_id: string, _params: unknown, signal: AbortSignal | undefined) =>
+        new Promise<{ output: string }>((_resolve, reject) => {
+          if (signal?.aborted) return reject(new Error("aborted"));
+          signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        }),
+    };
     const { sessionFactory } = await sessionAssembly({
-      responses: [fauxAssistantMessage("a long answer that streams out slowly")],
+      responses: [fauxAssistantMessage(fauxToolCall("gate", {}, { id: "g1" }))],
       sessionsRoot: join(cwd, "sessions"),
       cwd,
+      customTools: [gate],
+      tools: ["gate"],
     });
-    // The engine's cancel cleanup is session.abort() — intercept it as the probe, mirroring the
-    // harness subject.
+    // The engine's cancel cleanup is session.abort() — intercept it as the probe.
     return createPiAgentFromSession({
       sessionFactory: async (id) => {
         const session = await sessionFactory(id);
@@ -313,6 +333,74 @@ describe("session engine class: this L0's own responsibilities", () => {
     expect(events.filter((e) => e.type === "completed" || e.type === "failed")).toHaveLength(1);
     expect(events.at(-1)?.type).toBe("completed");
   });
+});
+
+describe("session engine class: cancellation reaches in-flight work", () => {
+  it("a PULL-driven consumer that walks away unsticks the turn — the door, not the finally", async () => {
+    // The shared MUST 3 case is a for-await + break, which resumes the generator AT A YIELD, so its
+    // finally runs with or without the cancellation door. The door only earns its place for a
+    // consumer that pulls (the SSE handler's eager reads): there the generator is parked on an
+    // await, and return() would queue behind work that never settles. Asserted with a tool that
+    // hangs until its signal fires, so "never settles" is literal.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-pull-"));
+    let toolAborted = false;
+    let sawAbort!: () => void;
+    const aborted = new Promise<void>((r) => {
+      sawAbort = r;
+    });
+    const gate = {
+      name: "gate",
+      label: "Gate",
+      description: "Blocks until the turn is aborted",
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+      execute: (_id: string, _params: unknown, signal: AbortSignal | undefined) =>
+        new Promise<{ output: string }>((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => {
+              toolAborted = true;
+              sawAbort();
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        }),
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage([{ type: "text", text: "checking" }, fauxToolCall("gate", {}, { id: "g1" })])],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      customTools: [gate],
+      tools: ["gate"],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const iterator = agent.invoke({ session: "s" }, { text: "go" })[Symbol.asyncIterator]();
+    // Pull until the TOOL is actually running. Walking away during the model stream is a different
+    // (also correct) case — pi never starts the tool — and would prove nothing about in-flight work.
+    for (let i = 0; i < 20; i++) {
+      const { value, done } = await iterator.next();
+      if (done) throw new Error("the turn ended before the tool started");
+      if (value?.type === "tool_started") break;
+    }
+    // The consumer is released PROMPTLY — this is what the door buys, and without it `return()`
+    // queues behind a turn parked inside a tool that never settles.
+    await Promise.race([
+      iterator.return?.(undefined) ?? Promise.resolve(),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("return() never settled — the door is not armed")), 3000),
+      ),
+    ]);
+    void toolAborted;
+    void aborted;
+  });
+
+  // KNOWN GAP, reproducible outside vitest: when the cancel lands while a TOOL is executing,
+  // `AgentSession.abort()` does not settle and the tool's abort signal never fires — although the
+  // identical call settles in ~3ms when made from ordinary code with the same tool in flight. The
+  // cancel that lands during the MODEL STREAM (the shared MUST 3 case above) is correct: pi never
+  // starts the tool. Until this is understood, this engine class must not be wired into a serving
+  // path where a long tool call is normal.
+  it.todo("cancelling a turn parked inside a tool aborts that tool's work");
 });
 
 describe("session engine class: the turn context fastagent tools depend on", () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -726,6 +726,43 @@ describe("session engine class: one record, both engine classes", () => {
   });
 });
 
+describe("session engine class: opening a record another turn broke", () => {
+  it("an interrupted tool call is repaired before the next turn, as the harness class repairs it", async () => {
+    // The crash-mid-tool shape: an assistant `tool_use` with no result. Providers reject that
+    // transcript outright, so the store repairs it on open — and because BOTH classes write this
+    // record, a crash under either must leave one the other can open. Without the repair the
+    // session class would fail on that conversation forever while its sibling self-heals.
+    const sessionId = "crashed";
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-repair-"));
+    const sessionsRoot = join(cwd, "sessions");
+    const store = jsonlSessionStore({ dir: sessionsRoot, cwd });
+    const broken = await store.openOrCreate(sessionId);
+    await broken.appendMessage({ role: "user", content: "run the tool", timestamp: Date.now() });
+    await broken.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "t1", name: "gate", arguments: {} }],
+      provider: "faux",
+      model: "faux-1",
+      timestamp: Date.now(),
+      usage: { input: 1, output: 1 },
+    } as never);
+
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("carrying on")],
+      sessionsRoot,
+      cwd,
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const events = [];
+    for await (const e of agent.invoke({ session: sessionId }, { text: "still there?" })) events.push(e);
+    expect(events.at(-1)?.type).toBe("completed");
+    // The repair is IN the shared record: a synthetic result now closes the dangling call.
+    const reopened = await store.openIfExists(sessionId);
+    const text = JSON.stringify(await (reopened as NonNullable<typeof reopened>).getEntries());
+    expect(text).toContain("interrupted-tool-call");
+  });
+});
+
 describe("session engine class: per-invoke discipline", () => {
   it("the user's turn is durable BEFORE the answer exists", async () => {
     // A property of how the factory addresses the record, not of the turn loop: a SessionManager that

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -292,6 +292,36 @@ describe("session engine class: this L0's own responsibilities", () => {
   });
 });
 
+describe("session engine class: the turn context fastagent tools depend on", () => {
+  it("a fastagent tool sees this session and this turn's activation, not the process defaults", async () => {
+    // The binding degrades SILENTLY when missing (cwd → process.cwd(), manager/activation →
+    // undefined), so it is asserted rather than assumed.
+    const { turnContext } = await import("../src/engines/pi/tool-context.ts");
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-ctx-"));
+    let seen: { cwd?: string; sessionId?: string; canActivate?: boolean } = {};
+    const { sessionFactory } = await sessionAssembly({
+      responses: [
+        (() => {
+          const store = turnContext.getStore();
+          seen = {
+            cwd: store?.cwd,
+            sessionId: store?.sessionManager?.getSessionId(),
+            canActivate: typeof store?.tools?.activate === "function",
+          };
+          return fauxAssistantMessage("ok");
+        }) as unknown as FauxResponseStep,
+      ],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    for await (const e of agent.invoke({ session: "ctx" }, { text: "go" })) void e;
+    expect(seen.cwd).toBe(cwd);
+    expect(seen.sessionId).toBeTruthy();
+    expect(seen.canActivate).toBe(true);
+  });
+});
+
 describe("session engine class: per-invoke discipline", () => {
   it("nothing resident survives a turn — the record is the only continuity", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-record-"));

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -84,6 +84,9 @@ async function sessionAssembly(options: {
         model: faux.getModel(),
         resourceLoader: loader,
         sessionManager,
+        // The record always exists by now (the binder ensures it), so every turn is a RESUME — pi's
+        // default would tell an extension that turn 500 is the session's first.
+        sessionStartEvent: { type: "session_start", reason: "resume" },
         tools: options.tools ?? [],
         ...(options.customTools ? { customTools: options.customTools as never } : {}),
       });
@@ -439,6 +442,32 @@ describe("session engine class: what the class buys", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it("extensions see a resume and a shutdown on every turn, not a birth without a death", async () => {
+    // Per-invoke locality means the extension lifecycle runs once per TURN. Both halves matter: the
+    // reason must not claim a 500th turn is the session's first, and anything acquired on start must
+    // get its counterpart or it lives until the process exits.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-life-"));
+    const seen: string[] = [];
+    const extension = {
+      name: "lifecycle",
+      factory: (api: { on: (e: string, h: (event: { reason?: string }) => void) => void }) => {
+        api.on("session_start", (event) => seen.push(`start:${event.reason}`));
+        api.on("session_shutdown", () => seen.push("shutdown"));
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("one"), fauxAssistantMessage("two")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    for (const text of ["first", "second"]) {
+      for await (const e of agent.invoke({ session: "s" }, { text })) void e;
+    }
+    expect(seen).toEqual(["start:resume", "shutdown", "start:resume", "shutdown"]);
   });
 
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -513,6 +513,49 @@ describe("session engine class: what the class buys", () => {
     expect(observed).toEqual([{ event: "bind", error: expect.stringContaining("blew up") }]);
   });
 
+  it("a binding that fails BEFORE the birth still fires shutdown — the pessimism the module documents", async () => {
+    // Mirror of the AFTER case: bindExtensions throws BEFORE it would have emitted session_start,
+    // so no handler ever sees a birth. `bound = true` is set pessimistically before the call, so
+    // teardown still fires shutdown — a shutdown for a birth that never happened is cheaper than
+    // leaking whatever a partly-landed birth would have acquired. This test pins that trade: a
+    // "fix" that moves `bound = true` to after bindExtensions succeeds would still pass the AFTER
+    // case above and quietly reintroduce the leak this case guards.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-life4-"));
+    const seen: string[] = [];
+    const extension: InlineExtension = {
+      name: "lifecycle",
+      factory: (pi) => {
+        pi.on("session_start", () => {
+          seen.push("start");
+        });
+        pi.on("session_shutdown", () => {
+          seen.push("shutdown");
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("never")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({
+      sessionFactory: async (id) => {
+        const session = await sessionFactory(id);
+        // Replace bindExtensions WITHOUT calling the real one: no session_start ever emits.
+        session.bindExtensions = async () => {
+          throw new Error("resource discovery blew up");
+        };
+        return session;
+      },
+    });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+    expect(events.at(-1)).toMatchObject({ type: "failed", details: expect.stringContaining("blew up") });
+    // No `start` reached the handler; `shutdown` fires anyway — the pessimism this test pins.
+    expect(seen).toEqual(["shutdown"]);
+  });
+
   it("a turn cancelled during the build reports NO lifecycle at all", async () => {
     // The mirror of the same invariant: a death for a birth that never happened. The extension
     // runner and its handlers exist from construction, so "does anyone listen" cannot be the

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -984,9 +984,11 @@ describe("session engine class: the turn context fastagent tools depend on", () 
       tools: ["probe"],
     });
     const agent = createPiAgentFromSession({ sessionFactory });
-    for await (const e of agent.invoke({ session: "ctx" }, { text: "go" })) void e;
+    // A channel-shaped id, so "whose session" is actually asserted rather than "a string exists" —
+    // and the tool sees the id the CALLER used, not the encoding the record is filed under.
+    for await (const e of agent.invoke({ session: "telegram:-100/42" }, { text: "go" })) void e;
     expect(seen.cwd).toBe(cwd);
-    expect(seen.sessionId).toBeTruthy();
+    expect(seen.sessionId).toBe("telegram:-100/42");
     expect(seen.canActivate).toBe(true);
   });
 });

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -848,11 +848,17 @@ describe("session engine class: per-invoke discipline", () => {
     // delivery safe here — and what a "simplification" to SessionManager.create() would silently undo.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-durable-"));
     const sessionsRoot = join(cwd, "sessions");
+    let modelEntered!: () => void;
+    const asking = new Promise<void>((r) => {
+      modelEntered = r;
+    });
     const { sessionFactory } = await sessionAssembly({
-      // The model never answers: this IS the crash window. It honours its abort signal (checking
-      // `aborted` first — the same trap the cancellation test documents) so the test can end.
+      // The model never answers: this IS the crash window. It ANNOUNCES that it was entered, so the
+      // assertion waits for the real trigger instead of a timer, and it honours its abort signal
+      // (checking `aborted` first — the same trap the cancellation test documents) so the test ends.
       responses: [
         async (_context, options) => {
+          modelEntered();
           await new Promise<void>((_resolve, reject) => {
             const stop = () => reject(new Error("aborted"));
             if (options?.signal?.aborted) return stop();
@@ -866,7 +872,8 @@ describe("session engine class: per-invoke discipline", () => {
     });
     const agent = createPiAgentFromSession({ sessionFactory });
     const iterator = agent.invoke({ session: "s" }, { text: "the question nobody answered" })[Symbol.asyncIterator]();
-    await Promise.race([iterator.next(), new Promise((r) => setTimeout(r, 500))]);
+    void iterator.next();
+    await asking; // the model call has been entered and will never return: the crash window is open
 
     const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot });
     const meta = (await repo.list({ cwd })).find((m) => m.id === "s");

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -331,6 +331,43 @@ describe("session engine class: what the class buys", () => {
     expect(events.at(-1)?.type).toBe("completed");
   });
 
+  it("a silent command completes with an empty stream; an UNKNOWN slash is just text for the model", async () => {
+    // The two neighbours of the command path, both deliberate: a handler that only changes state has
+    // nothing to say, and an unregistered `/name` is not a command — so there is no "ran or not?"
+    // ambiguity left for a consumer to resolve.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-silent-"));
+    let modelSaw = 0;
+    const extension = {
+      name: "quiet",
+      factory: (api: { registerCommand: (n: string, o: unknown) => void }) => {
+        api.registerCommand("mute", { description: "changes state, says nothing", handler: async () => {} });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [
+        () => {
+          modelSaw++;
+          return fauxAssistantMessage("I do not know that command");
+        },
+      ],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+
+    const silent = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "/mute" })) silent.push(e);
+    expect(silent).toEqual([{ type: "completed" }]);
+    expect(modelSaw).toBe(0);
+
+    const unknown = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "/nope" })) unknown.push(e);
+    expect(modelSaw).toBe(1); // reached the model as ordinary text …
+    expect(unknown.at(-1)?.type).toBe("completed");
+    expect(unknown.some((e) => e.type === "text")).toBe(true); // … and its answer streamed
+  });
+
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-img-"));
     let sawImage = false;

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -491,7 +491,9 @@ describe("session engine class: what the class buys", () => {
       cwd,
       extensionFactories: [extension],
     });
+    const observed: { event: string; error: string }[] = [];
     const agent = createPiAgentFromSession({
+      onExtensionError: (error) => observed.push(error),
       sessionFactory: async (id) => {
         const session = await sessionFactory(id);
         const bind = session.bindExtensions.bind(session);
@@ -506,6 +508,9 @@ describe("session engine class: what the class buys", () => {
     for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
     expect(events.at(-1)).toMatchObject({ type: "failed", details: expect.stringContaining("blew up") });
     expect(seen).toEqual(["start", "shutdown"]);
+    // The coarsest extension failure reaches a factory's listener too, though pi throws it rather
+    // than dispatching it.
+    expect(observed).toEqual([{ event: "bind", error: expect.stringContaining("blew up") }]);
   });
 
   it("a turn cancelled during the build reports NO lifecycle, and does not consume the startup", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -394,6 +394,51 @@ describe("session engine class: what the class buys", () => {
     expect(events.at(-1)?.type).toBe("completed");
   });
 
+  it("a command that SUCCEEDS is not failed by an unrelated hook that throws", async () => {
+    // The conflation the model branch refuses, in the command branch: a hook that throws is not the
+    // work the caller asked for. It warns; the command's own outcome stands.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-hookmix-"));
+    let ran = 0;
+    const extension = {
+      name: "mixed",
+      factory: (api: {
+        registerCommand: (n: string, o: unknown) => void;
+        on: (e: string, h: () => void) => void;
+        sendMessage: (m: unknown) => Promise<void>;
+      }) => {
+        // Fires on EVERY turn of this L0 (binding emits session_start), so it is the reachable shape
+        // of "something else in the extension layer failed while the command itself was fine".
+        api.on("session_start", () => {
+          throw new Error("unrelated hook blew up");
+        });
+        api.registerCommand("mute", {
+          description: "succeeds",
+          handler: async () => {
+            ran++;
+            await api.sendMessage({ customType: "mute", content: "muted", display: true });
+          },
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("never")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      const events = [];
+      for await (const e of agent.invoke({ session: "s" }, { text: "/mute" })) events.push(e);
+      expect(ran).toBe(1);
+      expect(warn.mock.calls.flat().join(" ")).toContain("unrelated hook blew up"); // the hook IS reported …
+      expect(events.at(-1)?.type).toBe("completed"); // … and the command is not blamed for it
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-img-"));
     let sawImage = false;

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -511,7 +511,7 @@ describe("session engine class: per-invoke discipline", () => {
   it("nothing resident survives a turn — the record is the only continuity", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-record-"));
     const sessionsRoot = join(cwd, "sessions");
-    const built: object[] = [];
+    const built: string[] = [];
     const { sessionFactory } = await sessionAssembly({
       responses: [fauxAssistantMessage("one"), fauxAssistantMessage("two")],
       sessionsRoot,
@@ -519,9 +519,8 @@ describe("session engine class: per-invoke discipline", () => {
     });
     const agent: Agent = createPiAgentFromSession({
       sessionFactory: async (id) => {
-        const session = await sessionFactory(id);
-        built.push(session);
-        return session;
+        built.push(id);
+        return sessionFactory(id);
       },
     });
     for (const text of ["turn one", "turn two"]) {
@@ -529,10 +528,10 @@ describe("session engine class: per-invoke discipline", () => {
       for await (const e of agent.invoke({ session: "s" }, { text })) events.push(e);
       expect(events.at(-1)?.type).toBe("completed");
     }
-    // A DIFFERENT session object per turn — identity, not call count: a factory handing back one
-    // cached instance would be the resident level wearing this one's clothes.
+    // The factory is asked once per invoke — this L0 holds nothing across turns. (Whether a factory
+    // hands back a cached object is the caller's choice, not something this L0 can or should police;
+    // what it owes is asking again, and rebuilding the turn from the record below.)
     expect(built).toHaveLength(2);
-    expect(built[0]).not.toBe(built[1]);
     // … and ONE record carrying both turns.
     const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot });
     const meta = (await repo.list({ cwd })).find((m) => m.id === "s");

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -463,9 +463,8 @@ describe("session engine class: what the class buys", () => {
     for (const text of ["first", "second"]) {
       for await (const e of agent.invoke({ session: "s" }, { text })) void e;
     }
-    // The FIRST turn created the record, so it is a startup; every later one resumes. A blanket
-    // "resume" would mean an extension that seeds on startup never fires at all.
-    expect(seen).toEqual(["start:startup", "shutdown", "start:resume", "shutdown"]);
+    // Every turn resumes a durable record — including the first, which resumes an empty one.
+    expect(seen).toEqual(["start:resume", "shutdown", "start:resume", "shutdown"]);
   });
 
   it("a binding that fails AFTER the birth still reports the death", async () => {
@@ -513,7 +512,7 @@ describe("session engine class: what the class buys", () => {
     expect(observed).toEqual([{ event: "bind", error: expect.stringContaining("blew up") }]);
   });
 
-  it("a turn cancelled during the build reports NO lifecycle, and does not consume the startup", async () => {
+  it("a turn cancelled during the build reports NO lifecycle at all", async () => {
     // The mirror of the same invariant: a death for a birth that never happened. The extension
     // runner and its handlers exist from construction, so "does anyone listen" cannot be the
     // predicate — only whether THIS turn bound them.
@@ -554,18 +553,6 @@ describe("session engine class: what the class buys", () => {
     await first;
     await returned;
     expect(seen).toEqual([]);
-
-    // … and the startup it never announced is not LOST: the record it left behind is empty, so the
-    // conversation's first real turn still opens with a startup rather than a resume.
-    const { sessionFactory: second } = await sessionAssembly({
-      responses: [fauxAssistantMessage("hello")],
-      sessionsRoot: join(cwd, "sessions"),
-      cwd,
-      extensionFactories: [extension],
-    });
-    const next = createPiAgentFromSession({ sessionFactory: second });
-    for await (const e of next.invoke({ session: "s" }, { text: "go" })) void e;
-    expect(seen).toEqual(["start:startup", "shutdown"]);
   });
 
   it("an input handler that throws does NOT consume the turn: the model answers, the failure warns", async () => {
@@ -648,8 +635,7 @@ describe("session engine class: what the class buys", () => {
     const extension: InlineExtension = {
       name: "greeter",
       factory: (pi) => {
-        pi.on("session_start", (event) => {
-          if (event.reason !== "startup") return;
+        pi.on("session_start", () => {
           pi.sendMessage({ customType: "greeting", content: "welcome aboard", display: true });
         });
       },

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -597,7 +597,13 @@ describe("session engine class: this L0's own responsibilities", () => {
     const events = [];
     for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
     expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ type: "failed", details: expect.stringContaining("binding blew up") });
+    expect(events[0]).toMatchObject({
+      type: "failed",
+      details: expect.stringContaining("binding blew up"),
+      // Determinate, like a command handler's throw: extension module code that throws in-process
+      // throws again. (The prose classifier would have read a retry out of the message.)
+      retryable: false,
+    });
     expect(disposed).toBe(1);
   });
 

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -12,7 +12,6 @@ import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-cor
 import {
   DefaultResourceLoader,
   ModelRuntime,
-  SessionManager,
   SettingsManager,
   createAgentSession,
 } from "@earendil-works/pi-coding-agent";
@@ -21,6 +20,7 @@ import { describe, expect, it, vi } from "vitest";
 import { log } from "../src/log.ts";
 import type { Agent } from "../src/agent.ts";
 import { createPiAgentFromSession } from "../src/engines/pi/session-invoke.ts";
+import { sessionRecordBinder } from "../src/engines/pi/session-record.ts";
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
 
@@ -68,26 +68,18 @@ async function sessionAssembly(options: {
     ...(options.extensionFactories ? { extensionFactories: options.extensionFactories as never } : {}),
   });
   await loader.reload();
-  // The record is addressed the way fastagent already addresses it — through the repo, so a session
-  // written by either engine class is found by the other.
-  const repo = new JsonlSessionRepo({
-    fs: new NodeExecutionEnv({ cwd: options.cwd }),
+  // The record is addressed the way a deployment must address it — through the shipped binder, so
+  // this suite exercises the same code a serving path would, not a parallel fixture of it.
+  const bindRecord = sessionRecordBinder({
     sessionsRoot: options.sessionsRoot,
+    cwd: options.cwd,
+    env: new NodeExecutionEnv({ cwd: options.cwd }),
   });
-  const filePath = async (sessionId: string): Promise<string> => {
-    const existing = (await repo.list({ cwd: options.cwd })).find((m) => m.id === sessionId);
-    if (existing) return existing.path;
-    await repo.create({ id: sessionId, cwd: options.cwd });
-    const created = (await repo.list({ cwd: options.cwd })).find((m) => m.id === sessionId);
-    if (!created) throw new Error(`session record for "${sessionId}" was not created`);
-    return created.path;
-  };
   return {
     faux,
     /** Per invoke: a fresh AgentSession over that id's record, discarded when the turn ends. */
     sessionFactory: async (sessionId: string) => {
-      const sessionManager = SessionManager.create(options.cwd, options.sessionsRoot);
-      sessionManager.setSessionFile(await filePath(sessionId));
+      const sessionManager = await bindRecord(sessionId);
       const { session } = await createAgentSession({
         cwd: options.cwd,
         agentDir,
@@ -366,6 +358,39 @@ describe("session engine class: what the class buys", () => {
     expect(modelSaw).toBe(1); // reached the model as ordinary text …
     expect(unknown.at(-1)?.type).toBe("completed");
     expect(unknown.some((e) => e.type === "text")).toBe(true); // … and its answer streamed
+  });
+
+  it("a non-display command message stays out of the reply", async () => {
+    // The filter that decides extension bookkeeping is not the answer. Inverted, it lands in every
+    // channel's chat: a channel builds its reply from `text` deltas.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-quietmsg-"));
+    let send: ((m: unknown) => Promise<void>) | undefined;
+    const extension = {
+      name: "bookkeeper",
+      factory: (api: {
+        registerCommand: (n: string, o: unknown) => void;
+        sendMessage: (m: unknown) => Promise<void>;
+      }) => {
+        send = api.sendMessage;
+        api.registerCommand("note", {
+          description: "records something the user must not see",
+          handler: async () => {
+            await send?.({ customType: "audit", content: "internal bookkeeping", display: false });
+          },
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("never")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "/note" })) events.push(e);
+    expect(events.some((e) => e.type === "text")).toBe(false);
+    expect(events.at(-1)?.type).toBe("completed");
   });
 
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -1,0 +1,253 @@
+/**
+ * SPEC conformance for the SECOND engine class (`session`: pi-coding-agent's `AgentSession`), run at
+ * the same per-invoke state locality as the reference harness path — the combination
+ * design/conformance-levels.md claims is real. `pair()` is provided, so MUST 6 (no location
+ * dependence) is asserted rather than assumed: two independent agent instances share only the jsonl
+ * record on disk.
+ */
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import {
+  DefaultResourceLoader,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+  createAgentSession,
+} from "@earendil-works/pi-coding-agent";
+import { type FauxResponseStep, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { Agent } from "../src/agent.ts";
+import { createPiAgentFromSession } from "../src/engines/pi/session-invoke.ts";
+import { makeFaux } from "./faux.ts";
+import { describeSpecConformance } from "./spec-conformance.ts";
+
+/** A credential store that authorizes the faux provider — the seam fastagent fills with auth.json. */
+const fauxCredentials = {
+  read: async () => ({ type: "api_key" as const, key: "conformance" }),
+  list: async () => [{ providerId: "faux", type: "api_key" as const }],
+  modify: async () => undefined,
+  delete: async () => {},
+};
+
+/**
+ * One assembly (the SHARED half: resource loader + model runtime) and a factory that binds a fresh
+ * AgentSession per invoke to `sessionsRoot`'s record for that id — the same jsonl layout the harness
+ * path writes, which is what lets the two classes share one record.
+ */
+async function sessionAssembly(options: {
+  responses: FauxResponseStep[];
+  sessionsRoot: string;
+  cwd: string;
+  /** Inline extensions, standing in for the definition's `extensions/` directory. */
+  extensionFactories?: unknown[];
+}) {
+  const { faux } = makeFaux();
+  faux.setResponses(options.responses);
+  const agentDir = join(options.cwd, ".pi");
+  const modelRuntime = await ModelRuntime.create({
+    credentials: fauxCredentials,
+    modelsPath: null,
+    allowModelNetwork: false,
+  });
+  modelRuntime.registerNativeProvider(faux.provider);
+  const loader = new DefaultResourceLoader({
+    cwd: options.cwd,
+    agentDir,
+    settingsManager: SettingsManager.create(options.cwd, agentDir),
+    noContextFiles: true,
+    noExtensions: true,
+    noPromptTemplates: true,
+    ...(options.extensionFactories ? { extensionFactories: options.extensionFactories as never } : {}),
+  });
+  await loader.reload();
+  // The record is addressed the way fastagent already addresses it — through the repo, so a session
+  // written by either engine class is found by the other.
+  const repo = new JsonlSessionRepo({
+    fs: new NodeExecutionEnv({ cwd: options.cwd }),
+    sessionsRoot: options.sessionsRoot,
+  });
+  const filePath = async (sessionId: string): Promise<string> => {
+    const existing = (await repo.list({ cwd: options.cwd })).find((m) => m.id === sessionId);
+    if (existing) return existing.path;
+    await repo.create({ id: sessionId, cwd: options.cwd });
+    const created = (await repo.list({ cwd: options.cwd })).find((m) => m.id === sessionId);
+    if (!created) throw new Error(`session record for "${sessionId}" was not created`);
+    return created.path;
+  };
+  return {
+    faux,
+    /** Per invoke: a fresh AgentSession over that id's record, discarded when the turn ends. */
+    sessionFactory: async (sessionId: string) => {
+      const sessionManager = SessionManager.create(options.cwd, options.sessionsRoot);
+      sessionManager.setSessionFile(await filePath(sessionId));
+      const { session } = await createAgentSession({
+        cwd: options.cwd,
+        agentDir,
+        modelRuntime,
+        model: faux.getModel(),
+        resourceLoader: loader,
+        sessionManager,
+        tools: [],
+      });
+      // Auto-retry is a DEPLOYMENT policy, not a turn mechanism: leaving it on makes a failing
+      // model wait out pi's backoff before the terminal, which is exactly the "hang" a conformance
+      // suite must not mistake for engine behavior. The reference harness path sets its own policy
+      // the same way (SUMMARIZATION_RETRY_POLICY / PROVIDER_MAX_RETRIES).
+      session.setAutoRetryEnabled(false);
+      return session;
+    },
+  };
+}
+
+async function sessionAgent(responses: FauxResponseStep[], shared?: { sessionsRoot: string; cwd: string }) {
+  const cwd = shared?.cwd ?? (await mkdtemp(join(tmpdir(), "fa-se-")));
+  const sessionsRoot = shared?.sessionsRoot ?? join(cwd, "sessions");
+  const { sessionFactory } = await sessionAssembly({ responses, sessionsRoot, cwd });
+  return createPiAgentFromSession({ sessionFactory });
+}
+
+describeSpecConformance("pi session engine class (faux model, per-invoke AgentSession)", {
+  completing: () => sessionAgent([fauxAssistantMessage("hello world")]),
+
+  failing: () => sessionAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })]),
+
+  hanging: async (onCleanup) => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-hang-"));
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("a long answer that streams out slowly")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+    });
+    // The engine's cancel cleanup is session.abort() — intercept it as the probe, mirroring the
+    // harness subject.
+    return createPiAgentFromSession({
+      sessionFactory: async (id) => {
+        const session = await sessionFactory(id);
+        const abort = session.abort.bind(session);
+        session.abort = async () => {
+          onCleanup();
+          return abort();
+        };
+        return session;
+      },
+    });
+  },
+
+  /** MUST 6: two INSTANCES, one record on disk, nothing in common in process. */
+  pair: async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-pair-"));
+    const sessionsRoot = join(cwd, "sessions");
+    let sawHistory = false;
+    const a = await sessionAgent([fauxAssistantMessage("first")], { sessionsRoot, cwd });
+    // Instance B is assembled independently; its faux model reports whether the context it received
+    // carried instance A's turn.
+    const bAssembly = await sessionAssembly({
+      responses: [
+        ((context: { messages: unknown[] }) => {
+          sawHistory = JSON.stringify(context.messages).includes("turn one");
+          return fauxAssistantMessage("second");
+        }) as unknown as FauxResponseStep,
+      ],
+      sessionsRoot,
+      cwd,
+    });
+    const b = createPiAgentFromSession({ sessionFactory: bAssembly.sessionFactory });
+    return { a, b, sawHistory: () => sawHistory };
+  },
+});
+
+describe("session engine class: what the class buys", () => {
+  it("the stream carries the turn, not just its terminal", async () => {
+    const agent = await sessionAgent([fauxAssistantMessage("hello world")]);
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+    const text = events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as { delta: string }).delta)
+      .join("");
+    expect(text).toBe("hello world");
+  });
+
+  it("an engine failure arrives as a failed event carrying the engine's own message", async () => {
+    const agent = await sessionAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })]);
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+    expect(events.at(-1)).toMatchObject({ type: "failed", details: expect.stringContaining("boom 500") });
+  });
+
+  it("THE point of this class: an extension command runs instead of reaching the model", async () => {
+    // On the harness class this is impossible at any price — pi-agent-core has no extension
+    // vocabulary, so `/ping` is text the model receives. Here the same input is dispatched.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-ext-"));
+    let ran = 0;
+    let modelSaw = 0;
+    const extension = {
+      name: "spike",
+      factory: (api: { registerCommand: (n: string, o: unknown) => void }) => {
+        api.registerCommand("ping", {
+          description: "answer without the model",
+          handler: async () => {
+            ran++;
+          },
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [
+        (() => {
+          modelSaw++;
+          return fauxAssistantMessage("the model answered");
+        }) as unknown as FauxResponseStep,
+      ],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "/ping" })) events.push(e);
+    expect(ran).toBe(1);
+    expect(modelSaw).toBe(0); // the model never saw it …
+    expect(events.at(-1)?.type).toBe("completed"); // … and the turn still settles cleanly
+
+    // An ordinary prompt still goes to the model on the same agent.
+    for await (const e of agent.invoke({ session: "s" }, { text: "hello" })) void e;
+    expect(modelSaw).toBe(1);
+  });
+});
+
+describe("session engine class: per-invoke discipline", () => {
+  it("nothing resident survives a turn — the record is the only continuity", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-record-"));
+    const sessionsRoot = join(cwd, "sessions");
+    const built: string[] = [];
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("one"), fauxAssistantMessage("two")],
+      sessionsRoot,
+      cwd,
+    });
+    const agent: Agent = createPiAgentFromSession({
+      sessionFactory: async (id) => {
+        built.push(id);
+        return sessionFactory(id);
+      },
+    });
+    for (const text of ["turn one", "turn two"]) {
+      const events = [];
+      for await (const e of agent.invoke({ session: "s" }, { text })) events.push(e);
+      expect(events.at(-1)?.type).toBe("completed");
+    }
+    // A fresh session object per turn (the assumption that made residency look mandatory) …
+    expect(built).toEqual(["s", "s"]);
+    // … and ONE record carrying both turns.
+    const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot });
+    const meta = (await repo.list({ cwd })).find((m) => m.id === "s");
+    const record = await repo.open(meta as NonNullable<typeof meta>);
+    const text = JSON.stringify(await record.getEntries());
+    expect(text).toContain("turn one");
+    expect(text).toContain("turn two");
+  });
+});

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -465,7 +465,9 @@ describe("session engine class: what the class buys", () => {
     for (const text of ["first", "second"]) {
       for await (const e of agent.invoke({ session: "s" }, { text })) void e;
     }
-    expect(seen).toEqual(["start:resume", "shutdown", "start:resume", "shutdown"]);
+    // The FIRST turn created the record, so it is a startup; every later one resumes. A blanket
+    // "resume" would mean an extension that seeds on startup never fires at all.
+    expect(seen).toEqual(["start:startup", "shutdown", "start:resume", "shutdown"]);
   });
 
   it("a turn cancelled during the build reports NO lifecycle at all", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -355,15 +355,17 @@ describe("session engine class: cancellation reaches in-flight work", () => {
       parameters: { type: "object", properties: {}, additionalProperties: false },
       execute: (_id: string, _params: unknown, signal: AbortSignal | undefined) =>
         new Promise<{ output: string }>((_resolve, reject) => {
-          signal?.addEventListener(
-            "abort",
-            () => {
-              toolAborted = true;
-              sawAbort();
-              reject(new Error("aborted"));
-            },
-            { once: true },
-          );
+          // The ALREADY-ABORTED check is not defensive boilerplate here, it is the case under test:
+          // `tool_started` is emitted BEFORE pi calls execute, so a consumer that walks away on that
+          // event cancels in the window between the two — and an already-aborted signal never fires
+          // its `abort` event. A tool that only listens would hang forever.
+          const stop = () => {
+            toolAborted = true;
+            sawAbort();
+            reject(new Error("aborted"));
+          };
+          if (signal?.aborted) return stop();
+          signal?.addEventListener("abort", stop, { once: true });
         }),
     };
     const { sessionFactory } = await sessionAssembly({
@@ -390,17 +392,14 @@ describe("session engine class: cancellation reaches in-flight work", () => {
         setTimeout(() => reject(new Error("return() never settled — the door is not armed")), 3000),
       ),
     ]);
-    void toolAborted;
-    void aborted;
+    // … and the work it walked away from is actually stopped. Awaited rather than asserted inline:
+    // the abort is in flight when return() resolves.
+    await Promise.race([
+      aborted,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("in-flight tool was never stopped")), 3000)),
+    ]);
+    expect(toolAborted).toBe(true);
   });
-
-  // KNOWN GAP, reproducible outside vitest: when the cancel lands while a TOOL is executing,
-  // `AgentSession.abort()` does not settle and the tool's abort signal never fires — although the
-  // identical call settles in ~3ms when made from ordinary code with the same tool in flight. The
-  // cancel that lands during the MODEL STREAM (the shared MUST 3 case above) is correct: pi never
-  // starts the tool. Until this is understood, this engine class must not be wired into a serving
-  // path where a long tool call is normal.
-  it.todo("cancelling a turn parked inside a tool aborts that tool's work");
 });
 
 describe("session engine class: the turn context fastagent tools depend on", () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -122,9 +122,10 @@ describeSpecConformance("pi session engine class (faux model, per-invoke AgentSe
   hanging: async (onCleanup) => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-hang-"));
     // A turn that genuinely does not finish: the model calls a tool whose execute settles ONLY on
-    // its abort signal. Without this the faux model completes on its own, `abort()` runs in the
-    // teardown of every path, and the probe would go green whether or not cancellation did
-    // anything — proving teardown ran, not that in-flight work was stopped.
+    // its abort signal, so there is real in-flight work when the consumer walks away. It does NOT
+    // discriminate between the cancellation door and the generator's finally — this case breaks at
+    // a yield, so the finally runs either way; the dedicated pull-driven test below is what
+    // separates the two.
     const gate = {
       name: "gate",
       label: "Gate",

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -294,6 +294,43 @@ describe("session engine class: what the class buys", () => {
     }
   });
 
+  it("a command whose reply is non-text still produces a stream, not silence", async () => {
+    // The projection exists so a command's turn is not an empty stream; an image-only reply must
+    // not reintroduce that silence, and the Agent Handler vocabulary has no image event.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-imgmsg-"));
+    let send: ((m: unknown) => Promise<void>) | undefined;
+    const extension = {
+      name: "shot",
+      factory: (api: {
+        registerCommand: (n: string, o: unknown) => void;
+        sendMessage: (m: unknown) => Promise<void>;
+      }) => {
+        send = api.sendMessage;
+        api.registerCommand("shot", {
+          description: "replies with an image",
+          handler: async () => {
+            await send?.({
+              customType: "shot",
+              content: [{ type: "image", data: "aGk=", mimeType: "image/png" }],
+              display: true,
+            });
+          },
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("never")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "/shot" })) events.push(e);
+    expect(events.filter((e) => e.type === "text").map((e) => (e as { delta: string }).delta)).toEqual(["[image]"]);
+    expect(events.at(-1)?.type).toBe("completed");
+  });
+
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-img-"));
     let sawImage = false;

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -172,11 +172,28 @@ describe("session engine class: what the class buys", () => {
     expect(text).toBe("hello world");
   });
 
-  it("an engine failure arrives as a failed event carrying the engine's own message", async () => {
-    const agent = await sessionAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })]);
-    const events = [];
-    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
-    expect(events.at(-1)).toMatchObject({ type: "failed", details: expect.stringContaining("boom 500") });
+  it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-img-"));
+    let sawImage = false;
+    const { sessionFactory } = await sessionAssembly({
+      responses: [
+        ((context: { messages: unknown[] }) => {
+          sawImage = JSON.stringify(context.messages).includes('"type":"image"');
+          return fauxAssistantMessage("saw it");
+        }) as unknown as FauxResponseStep,
+      ],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    // A 1x1 PNG — enough to travel the whole conversion path.
+    const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+    for await (const e of agent.invoke(
+      { session: "s" },
+      { text: "what is this?", images: [{ mimeType: "image/png", data: png }] },
+    ))
+      void e;
+    expect(sawImage).toBe(true);
   });
 
   it("THE point of this class: an extension command runs instead of reaching the model", async () => {
@@ -238,12 +255,19 @@ describe("session engine class: this L0's own responsibilities", () => {
   it("one turn per session: a second concurrent invoke is refused session_busy", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-busy-"));
     let release!: () => void;
+    let started!: () => void;
     const held = new Promise<void>((r) => {
       release = r;
+    });
+    // The first turn announces itself from INSIDE the model call, so the second invoke races the
+    // lease deterministically instead of racing a timer.
+    const inFlight = new Promise<void>((r) => {
+      started = r;
     });
     const { sessionFactory } = await sessionAssembly({
       responses: [
         (async () => {
+          started();
           await held;
           return fauxAssistantMessage("done");
         }) as unknown as FauxResponseStep,
@@ -258,8 +282,7 @@ describe("session engine class: this L0's own responsibilities", () => {
       for await (const e of agent.invoke({ session: "s" }, { text: "one" })) out.push(e);
       return out;
     })();
-    // Give the first turn time to take the lease before the second asks for it.
-    await new Promise((r) => setTimeout(r, 50));
+    await inFlight;
     const second = [];
     for await (const e of agent.invoke({ session: "s" }, { text: "two" })) second.push(e);
     expect(second).toEqual([

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -272,6 +272,42 @@ describe("session engine class: this L0's own responsibilities", () => {
     expect(events[0]).toMatchObject({ type: "failed", details: expect.stringContaining("auth.json unreadable") });
   });
 
+  it("a cancel that lands DURING the build never starts the model", async () => {
+    // The latch: the cancellation door is armed only after the session exists, so a consumer that
+    // walks away while the factory is still running would otherwise have its turn start anyway —
+    // a model call nobody is reading, on a session about to be discarded.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-latch-"));
+    let prompted = 0;
+    let releaseFactory!: () => void;
+    const factoryHeld = new Promise<void>((r) => {
+      releaseFactory = r;
+    });
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("should never run")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+    });
+    const agent = createPiAgentFromSession({
+      sessionFactory: async (id) => {
+        const session = await sessionFactory(id);
+        const prompt = session.prompt.bind(session);
+        session.prompt = async (...args: Parameters<typeof prompt>) => {
+          prompted++;
+          return prompt(...args);
+        };
+        await factoryHeld; // the consumer cancels while we are in here
+        return session;
+      },
+    });
+    const iterator = agent.invoke({ session: "s" }, { text: "go" })[Symbol.asyncIterator]();
+    const first = iterator.next();
+    const returned = iterator.return?.(undefined); // cancels before the session exists
+    releaseFactory();
+    expect(await first).toEqual({ done: true, value: undefined });
+    await returned;
+    expect(prompted).toBe(0);
+  });
+
   it("one turn per session: a second concurrent invoke is refused session_busy", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-busy-"));
     let release!: () => void;

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -324,13 +324,20 @@ describe("session engine class: what the class buys", () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-ext-"));
     let ran = 0;
     let modelSaw = 0;
+    let sendMessage: ((m: unknown) => Promise<void>) | undefined;
     const extension = {
       name: "spike",
-      factory: (api: { registerCommand: (n: string, o: unknown) => void }) => {
+      factory: (api: {
+        registerCommand: (n: string, o: unknown) => void;
+        sendMessage: (m: unknown) => Promise<void>;
+      }) => {
+        sendMessage = api.sendMessage;
         api.registerCommand("ping", {
           description: "answer without the model",
           handler: async () => {
             ran++;
+            // `sendMessage` is on the extension API (pi.sendMessage), not on the command context.
+            await sendMessage?.({ customType: "ping", content: "pong", display: true });
           },
         });
       },
@@ -350,6 +357,14 @@ describe("session engine class: what the class buys", () => {
 
     const events = [];
     for await (const e of agent.invoke({ session: "s" }, { text: "/ping" })) events.push(e);
+    // What the command SAID has to cross the contract too: a turn that ran work and yielded no
+    // events is indistinguishable from one that did nothing.
+    expect(
+      events
+        .filter((e) => e.type === "text")
+        .map((e) => (e as { delta: string }).delta)
+        .join(""),
+    ).toContain("pong");
     expect(ran).toBe(1);
     expect(modelSaw).toBe(0); // the model never saw it …
     expect(events.at(-1)?.type).toBe("completed"); // … and the turn still settles cleanly

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -733,6 +733,7 @@ describe("session engine class: per-invoke discipline", () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-record-"));
     const sessionsRoot = join(cwd, "sessions");
     const built: string[] = [];
+    let disposed = 0;
     const { sessionFactory } = await sessionAssembly({
       responses: [fauxAssistantMessage("one"), fauxAssistantMessage("two")],
       sessionsRoot,
@@ -741,7 +742,13 @@ describe("session engine class: per-invoke discipline", () => {
     const agent: Agent = createPiAgentFromSession({
       sessionFactory: async (id) => {
         built.push(id);
-        return sessionFactory(id);
+        const session = await sessionFactory(id);
+        const dispose = session.dispose.bind(session);
+        session.dispose = () => {
+          disposed++;
+          dispose();
+        };
+        return session;
       },
     });
     for (const text of ["turn one", "turn two"]) {
@@ -753,6 +760,9 @@ describe("session engine class: per-invoke discipline", () => {
     // hands back a cached object is the caller's choice, not something this L0 can or should police;
     // what it owes is asking again, and rebuilding the turn from the record below.)
     expect(built).toHaveLength(2);
+    // … and each turn's session is RELEASED, not merely stopped: a process serving thousands of
+    // turns would otherwise leak one wired-up session per turn.
+    expect(disposed).toBe(2);
     // … and ONE record carrying both turns.
     const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot });
     const meta = (await repo.list({ cwd })).find((m) => m.id === "s");

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -470,6 +470,44 @@ describe("session engine class: what the class buys", () => {
     expect(seen).toEqual(["start:resume", "shutdown", "start:resume", "shutdown"]);
   });
 
+  it("an input handler that throws does NOT consume the turn: the model answers, the failure warns", async () => {
+    // Why `input` is not a turn-consuming dispatch: pi catches a throwing input handler, records it,
+    // and CONTINUES the loop — so the prompt reaches the model and settles on its answer. Treating
+    // that failure as the turn's verdict would overturn a result the caller received.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-input-"));
+    let modelSaw = 0;
+    const extension = {
+      name: "interceptor",
+      factory: (api: { on: (e: string, h: () => void) => void }) => {
+        api.on("input", () => {
+          throw new Error("interceptor blew up");
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [
+        () => {
+          modelSaw++;
+          return fauxAssistantMessage("answered anyway");
+        },
+      ],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      const events = [];
+      for await (const e of agent.invoke({ session: "s" }, { text: "hello" })) events.push(e);
+      expect(modelSaw).toBe(1);
+      expect(events.at(-1)?.type).toBe("completed");
+      expect(warn.mock.calls.flat().join(" ")).toContain("interceptor blew up");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-img-"));
     let sawImage = false;

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -629,8 +629,8 @@ describe("session engine class: what the class buys", () => {
 
   it("what an extension says while STARTING UP reaches the stream", async () => {
     // The subscription has to be armed before binding: pi emits session_start inside
-    // bindExtensions, and a handler that speaks there lands a message immediately — the one case
-    // `reason: "startup"` exists to enable (a greeting, a seeded note on the first turn).
+    // bindExtensions, and a handler that speaks there lands its message immediately — with the
+    // subscription armed afterwards it would be projected to nobody.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-greet-"));
     const extension: InlineExtension = {
       name: "greeter",

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -76,17 +76,15 @@ async function sessionAssembly(options: {
     faux,
     /** Per invoke: a fresh AgentSession over that id's record, discarded when the turn ends. */
     sessionFactory: async (sessionId: string) => {
-      const sessionManager = await bindRecord(sessionId);
+      const record = await bindRecord(sessionId);
       const { session } = await createAgentSession({
         cwd: options.cwd,
         agentDir,
         modelRuntime,
         model: faux.getModel(),
         resourceLoader: loader,
-        sessionManager,
-        // The record always exists by now (the binder ensures it), so every turn is a RESUME — pi's
-        // default would tell an extension that turn 500 is the session's first.
-        sessionStartEvent: { type: "session_start", reason: "resume" },
+        // Both halves of "bind an existing record", spread together — they cannot come apart.
+        ...record,
         tools: options.tools ?? [],
         ...(options.customTools ? { customTools: options.customTools as never } : {}),
       });
@@ -468,6 +466,45 @@ describe("session engine class: what the class buys", () => {
       for await (const e of agent.invoke({ session: "s" }, { text })) void e;
     }
     expect(seen).toEqual(["start:resume", "shutdown", "start:resume", "shutdown"]);
+  });
+
+  it("a turn cancelled during the build reports NO lifecycle at all", async () => {
+    // The mirror of the same invariant: a death for a birth that never happened. The extension
+    // runner and its handlers exist from construction, so "does anyone listen" cannot be the
+    // predicate — only whether THIS turn bound them.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-life2-"));
+    const seen: string[] = [];
+    const extension = {
+      name: "lifecycle",
+      factory: (api: { on: (e: string, h: () => void) => void }) => {
+        api.on("session_start", () => seen.push("start"));
+        api.on("session_shutdown", () => seen.push("shutdown"));
+      },
+    };
+    let releaseFactory!: () => void;
+    const held = new Promise<void>((r) => {
+      releaseFactory = r;
+    });
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("never")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({
+      sessionFactory: async (id) => {
+        const session = await sessionFactory(id);
+        await held; // the consumer walks away while we are still in here
+        return session;
+      },
+    });
+    const iterator = agent.invoke({ session: "s" }, { text: "go" })[Symbol.asyncIterator]();
+    const first = iterator.next();
+    const returned = iterator.return?.(undefined);
+    releaseFactory();
+    await first;
+    await returned;
+    expect(seen).toEqual([]);
   });
 
   it("an input handler that throws does NOT consume the turn: the model answers, the failure warns", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -168,10 +168,10 @@ describeSpecConformance("pi session engine class (faux model, per-invoke AgentSe
     // carried instance A's turn.
     const bAssembly = await sessionAssembly({
       responses: [
-        ((context: { messages: unknown[] }) => {
+        (context) => {
           sawHistory = JSON.stringify(context.messages).includes("turn one");
           return fauxAssistantMessage("second");
-        }) as unknown as FauxResponseStep,
+        },
       ],
       sessionsRoot,
       cwd,
@@ -231,15 +231,40 @@ describe("session engine class: what the class buys", () => {
     expect(JSON.stringify((ended as { content: unknown }).content)).toContain("it went wrong");
   });
 
+  it("an extension command that throws fails the turn instead of reporting success", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-cmdfail-"));
+    const extension = {
+      name: "spike",
+      factory: (api: { registerCommand: (n: string, o: unknown) => void }) => {
+        api.registerCommand("boom", {
+          description: "throws",
+          handler: async () => {
+            throw new Error("the command exploded");
+          },
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("never")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "/boom" })) events.push(e);
+    expect(events.at(-1)).toMatchObject({ type: "failed", details: expect.stringContaining("exploded") });
+  });
+
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-img-"));
     let sawImage = false;
     const { sessionFactory } = await sessionAssembly({
       responses: [
-        ((context: { messages: unknown[] }) => {
+        (context) => {
           sawImage = JSON.stringify(context.messages).includes('"type":"image"');
           return fauxAssistantMessage("saw it");
-        }) as unknown as FauxResponseStep,
+        },
       ],
       sessionsRoot: join(cwd, "sessions"),
       cwd,
@@ -274,10 +299,10 @@ describe("session engine class: what the class buys", () => {
     };
     const { sessionFactory } = await sessionAssembly({
       responses: [
-        (() => {
+        () => {
           modelSaw++;
           return fauxAssistantMessage("the model answered");
-        }) as unknown as FauxResponseStep,
+        },
       ],
       sessionsRoot: join(cwd, "sessions"),
       cwd,
@@ -361,11 +386,11 @@ describe("session engine class: this L0's own responsibilities", () => {
     });
     const { sessionFactory } = await sessionAssembly({
       responses: [
-        (async () => {
+        async () => {
           started();
           await held;
           return fauxAssistantMessage("done");
-        }) as unknown as FauxResponseStep,
+        },
         fauxAssistantMessage("second"),
       ],
       sessionsRoot: join(cwd, "sessions"),
@@ -484,20 +509,29 @@ describe("session engine class: the turn context fastagent tools depend on", () 
     const { turnContext } = await import("../src/engines/pi/tool-context.ts");
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-ctx-"));
     let seen: { cwd?: string; sessionId?: string; canActivate?: boolean } = {};
+    // Read from a TOOL's execute, not from the model call: the tool path is the one the binding
+    // exists for (`wake`, `search_tools`, cwd), and it is a different resumption of pi's stack.
+    const probe = {
+      name: "probe",
+      label: "Probe",
+      description: "Reports the turn context it sees",
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+      execute: async () => {
+        const store = turnContext.getStore();
+        seen = {
+          cwd: store?.cwd,
+          sessionId: store?.sessionManager?.getSessionId(),
+          canActivate: typeof store?.tools?.activate === "function",
+        };
+        return { content: [{ type: "text", text: "ok" }], details: undefined };
+      },
+    };
     const { sessionFactory } = await sessionAssembly({
-      responses: [
-        (() => {
-          const store = turnContext.getStore();
-          seen = {
-            cwd: store?.cwd,
-            sessionId: store?.sessionManager?.getSessionId(),
-            canActivate: typeof store?.tools?.activate === "function",
-          };
-          return fauxAssistantMessage("ok");
-        }) as unknown as FauxResponseStep,
-      ],
+      responses: [fauxAssistantMessage(fauxToolCall("probe", {}, { id: "p1" })), fauxAssistantMessage("done")],
       sessionsRoot: join(cwd, "sessions"),
       cwd,
+      customTools: [probe],
+      tools: ["probe"],
     });
     const agent = createPiAgentFromSession({ sessionFactory });
     for await (const e of agent.invoke({ session: "ctx" }, { text: "go" })) void e;

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -669,6 +669,42 @@ describe("session engine class: the turn context fastagent tools depend on", () 
 });
 
 describe("session engine class: per-invoke discipline", () => {
+  it("the user's turn is durable BEFORE the answer exists", async () => {
+    // A property of how the factory addresses the record, not of the turn loop: a SessionManager that
+    // opens its own file buffers everything until the first assistant message (the file is not even
+    // created), so a crash in the window between question and answer loses the question. The factory
+    // binds to a record the session store created, which is what makes a channel's at-least-once
+    // delivery safe here — and what a "simplification" to SessionManager.create() would silently undo.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-durable-"));
+    const sessionsRoot = join(cwd, "sessions");
+    const { sessionFactory } = await sessionAssembly({
+      // The model never answers: this IS the crash window. It honours its abort signal (checking
+      // `aborted` first — the same trap the cancellation test documents) so the test can end.
+      responses: [
+        async (_context, options) => {
+          await new Promise<void>((_resolve, reject) => {
+            const stop = () => reject(new Error("aborted"));
+            if (options?.signal?.aborted) return stop();
+            options?.signal?.addEventListener("abort", stop, { once: true });
+          });
+          return fauxAssistantMessage("never");
+        },
+      ],
+      sessionsRoot,
+      cwd,
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const iterator = agent.invoke({ session: "s" }, { text: "the question nobody answered" })[Symbol.asyncIterator]();
+    await Promise.race([iterator.next(), new Promise((r) => setTimeout(r, 500))]);
+
+    const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot });
+    const meta = (await repo.list({ cwd })).find((m) => m.id === "s");
+    const record = await repo.open(meta as NonNullable<typeof meta>);
+    expect(JSON.stringify(await record.getEntries())).toContain("the question nobody answered");
+    await iterator.return?.(undefined);
+  });
+
+
   it("nothing resident survives a turn — the record is the only continuity", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-record-"));
     const sessionsRoot = join(cwd, "sessions");

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -192,6 +192,44 @@ describe("session engine class: what the class buys", () => {
     expect(text).toBe("hello world");
   });
 
+  it("tool activity projects with its args and result, error result included", async () => {
+    // The two tool projections carry payloads (`args`, `content`, `isError`) that nothing else in
+    // the suite reads — a stream consumer renders exactly these.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-tool-"));
+    const boom = {
+      name: "boom",
+      label: "Boom",
+      description: "Always fails",
+      parameters: { type: "object", properties: { why: { type: "string" } }, required: ["why"] },
+      // pi's `AgentToolResult` has NO isError field: a tool reports failure by THROWING, and pi
+      // marks the event. Returning `{ isError: true }` is silently a success.
+      execute: async () => {
+        throw new Error("it went wrong");
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [
+        fauxAssistantMessage(fauxToolCall("boom", { why: "testing" }, { id: "b1" })),
+        fauxAssistantMessage("recovered"),
+      ],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      customTools: [boom],
+      tools: ["boom"],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+    expect(events.find((e) => e.type === "tool_started")).toMatchObject({
+      id: "b1",
+      name: "boom",
+      args: { why: "testing" },
+    });
+    const ended = events.find((e) => e.type === "tool_ended");
+    expect(ended).toMatchObject({ id: "b1", isError: true });
+    expect(JSON.stringify((ended as { content: unknown }).content)).toContain("it went wrong");
+  });
+
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-img-"));
     let sawImage = false;

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -42,6 +42,8 @@ async function sessionAssembly(options: {
   cwd: string;
   /** Inline extensions, standing in for the definition's `extensions/` directory. */
   extensionFactories?: unknown[];
+  /** Off by default: pi's backoff would otherwise make a failing model look like a hang. */
+  autoRetry?: boolean;
 }) {
   const { faux } = makeFaux();
   faux.setResponses(options.responses);
@@ -95,7 +97,7 @@ async function sessionAssembly(options: {
       // model wait out pi's backoff before the terminal, which is exactly the "hang" a conformance
       // suite must not mistake for engine behavior. The reference harness path sets its own policy
       // the same way (SUMMARIZATION_RETRY_POLICY / PROVIDER_MAX_RETRIES).
-      session.setAutoRetryEnabled(false);
+      session.setAutoRetryEnabled(options.autoRetry ?? false);
       return session;
     },
   };
@@ -219,11 +221,82 @@ describe("session engine class: what the class buys", () => {
   });
 });
 
+describe("session engine class: this L0's own responsibilities", () => {
+  it("a factory that throws becomes a failed EVENT, not a thrown iteration", async () => {
+    const agent = createPiAgentFromSession({
+      sessionFactory: async () => {
+        throw new Error("auth.json unreadable");
+      },
+    });
+    const events = [];
+    // The iteration itself must not reject — the module's stated setup-failure discipline.
+    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "failed", details: expect.stringContaining("auth.json unreadable") });
+  });
+
+  it("one turn per session: a second concurrent invoke is refused session_busy", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-busy-"));
+    let release!: () => void;
+    const held = new Promise<void>((r) => {
+      release = r;
+    });
+    const { sessionFactory } = await sessionAssembly({
+      responses: [
+        (async () => {
+          await held;
+          return fauxAssistantMessage("done");
+        }) as unknown as FauxResponseStep,
+        fauxAssistantMessage("second"),
+      ],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const first = (async () => {
+      const out = [];
+      for await (const e of agent.invoke({ session: "s" }, { text: "one" })) out.push(e);
+      return out;
+    })();
+    // Give the first turn time to take the lease before the second asks for it.
+    await new Promise((r) => setTimeout(r, 50));
+    const second = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "two" })) second.push(e);
+    expect(second).toEqual([
+      { type: "failed", details: expect.stringContaining("session busy"), retryable: true, code: "session_busy" },
+    ]);
+    release();
+    expect((await first).at(-1)?.type).toBe("completed");
+  });
+
+  it("an auto-retried failure projects `retrying` and settles on the recovered turn, once", async () => {
+    // The one path auto-retry owns: pi ends the agent loop with an error, retries, and succeeds.
+    // `agent_end{willRetry:true}` must NOT be taken as the settle, or the turn would be classified
+    // on an error the engine went on to recover from.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-retry-"));
+    const { sessionFactory } = await sessionAssembly({
+      responses: [
+        fauxAssistantMessage("x", { stopReason: "error", errorMessage: "transient 503" }),
+        fauxAssistantMessage("recovered"),
+      ],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      autoRetry: true,
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+    expect(events.filter((e) => e.type === "retrying").length).toBeGreaterThan(0);
+    expect(events.filter((e) => e.type === "completed" || e.type === "failed")).toHaveLength(1);
+    expect(events.at(-1)?.type).toBe("completed");
+  });
+});
+
 describe("session engine class: per-invoke discipline", () => {
   it("nothing resident survives a turn — the record is the only continuity", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-record-"));
     const sessionsRoot = join(cwd, "sessions");
-    const built: string[] = [];
+    const built: object[] = [];
     const { sessionFactory } = await sessionAssembly({
       responses: [fauxAssistantMessage("one"), fauxAssistantMessage("two")],
       sessionsRoot,
@@ -231,8 +304,9 @@ describe("session engine class: per-invoke discipline", () => {
     });
     const agent: Agent = createPiAgentFromSession({
       sessionFactory: async (id) => {
-        built.push(id);
-        return sessionFactory(id);
+        const session = await sessionFactory(id);
+        built.push(session);
+        return session;
       },
     });
     for (const text of ["turn one", "turn two"]) {
@@ -240,8 +314,10 @@ describe("session engine class: per-invoke discipline", () => {
       for await (const e of agent.invoke({ session: "s" }, { text })) events.push(e);
       expect(events.at(-1)?.type).toBe("completed");
     }
-    // A fresh session object per turn (the assumption that made residency look mandatory) …
-    expect(built).toEqual(["s", "s"]);
+    // A DIFFERENT session object per turn — identity, not call count: a factory handing back one
+    // cached instance would be the resident level wearing this one's clothes.
+    expect(built).toHaveLength(2);
+    expect(built[0]).not.toBe(built[1]);
     // … and ONE record carrying both turns.
     const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot });
     const meta = (await repo.list({ cwd })).find((m) => m.id === "s");

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -11,11 +11,13 @@ import { join } from "node:path";
 import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   DefaultResourceLoader,
+  type InlineExtension,
   ModelRuntime,
   SettingsManager,
+  type ToolDefinition,
   createAgentSession,
 } from "@earendil-works/pi-coding-agent";
-import { type FauxResponseStep, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { type FauxResponseStep, Type, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { log } from "../src/log.ts";
 import type { Agent } from "../src/agent.ts";
@@ -42,11 +44,13 @@ async function sessionAssembly(options: {
   responses: FauxResponseStep[];
   sessionsRoot: string;
   cwd: string;
-  /** Inline extensions, standing in for the definition's `extensions/` directory. */
-  extensionFactories?: unknown[];
+  /** Inline extensions, standing in for the definition's `extensions/` directory. Typed with pi's
+   *  own shape on purpose: this suite is the only consumer of the session L0, so it is the only
+   *  place a pi API change can surface as a compile error — a cast here would erase exactly that. */
+  extensionFactories?: InlineExtension[];
   /** Off by default: pi's backoff would otherwise make a failing model look like a hang. */
   autoRetry?: boolean;
-  customTools?: unknown[];
+  customTools?: ToolDefinition[];
   /** pi's tool allowlist. Empty by default (no coding tools in a conformance run). */
   tools?: string[];
 }) {
@@ -66,7 +70,7 @@ async function sessionAssembly(options: {
     noContextFiles: true,
     noExtensions: true,
     noPromptTemplates: true,
-    ...(options.extensionFactories ? { extensionFactories: options.extensionFactories as never } : {}),
+    ...(options.extensionFactories ? { extensionFactories: options.extensionFactories } : {}),
   });
   await loader.reload();
   // The record is addressed the way a deployment must address it — through the shipped binder, so
@@ -86,7 +90,7 @@ async function sessionAssembly(options: {
         // Both halves of "bind an existing record", spread together — they cannot come apart.
         ...record,
         tools: options.tools ?? [],
-        ...(options.customTools ? { customTools: options.customTools as never } : {}),
+        ...(options.customTools ? { customTools: options.customTools } : {}),
       });
       // Auto-retry is a DEPLOYMENT policy, not a turn mechanism: leaving it on makes a failing
       // model wait out pi's backoff before the terminal, which is exactly the "hang" a conformance
@@ -117,13 +121,13 @@ describeSpecConformance("pi session engine class (faux model, per-invoke AgentSe
     // discriminate between the cancellation door and the generator's finally — this case breaks at
     // a yield, so the finally runs either way; the dedicated pull-driven test below is what
     // separates the two.
-    const gate = {
+    const gate: ToolDefinition = {
       name: "gate",
       label: "Gate",
       description: "Blocks until the turn is aborted",
-      parameters: { type: "object", properties: {}, additionalProperties: false },
-      execute: (_id: string, _params: unknown, signal: AbortSignal | undefined) =>
-        new Promise<{ output: string }>((_resolve, reject) => {
+      parameters: Type.Object({}),
+      execute: (_id, _params, signal) =>
+        new Promise<never>((_resolve, reject) => {
           if (signal?.aborted) return reject(new Error("aborted"));
           signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
         }),
@@ -188,11 +192,11 @@ describe("session engine class: what the class buys", () => {
     // The two tool projections carry payloads (`args`, `content`, `isError`) that nothing else in
     // the suite reads — a stream consumer renders exactly these.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-tool-"));
-    const boom = {
+    const boom: ToolDefinition = {
       name: "boom",
       label: "Boom",
       description: "Always fails",
-      parameters: { type: "object", properties: { why: { type: "string" } }, required: ["why"] },
+      parameters: Type.Object({ why: Type.String() }),
       // pi's `AgentToolResult` has NO isError field: a tool reports failure by THROWING, and pi
       // marks the event. Returning `{ isError: true }` is silently a success.
       execute: async () => {
@@ -224,10 +228,10 @@ describe("session engine class: what the class buys", () => {
 
   it("an extension command that throws fails the turn instead of reporting success", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-cmdfail-"));
-    const extension = {
+    const extension: InlineExtension = {
       name: "spike",
-      factory: (api: { registerCommand: (n: string, o: unknown) => void }) => {
-        api.registerCommand("boom", {
+      factory: (pi) => {
+        pi.registerCommand("boom", {
           description: "throws",
           handler: async () => {
             throw new Error("the command exploded");
@@ -258,10 +262,10 @@ describe("session engine class: what the class buys", () => {
     // question is what a turn does with one. With a model response in hand, flipping it to `failed`
     // would deny the caller an answer it already streamed — so it warns instead.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-hook-"));
-    const extension = {
+    const extension: InlineExtension = {
       name: "noisy",
-      factory: (api: { on: (e: string, h: () => void) => void }) => {
-        api.on("agent_settled", () => {
+      factory: (pi) => {
+        pi.on("agent_settled", () => {
           throw new Error("hook went wrong");
         });
       },
@@ -288,18 +292,15 @@ describe("session engine class: what the class buys", () => {
     // The projection exists so a command's turn is not an empty stream; an image-only reply must
     // not reintroduce that silence, and the Agent Handler vocabulary has no image event.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-imgmsg-"));
-    let send: ((m: unknown) => Promise<void>) | undefined;
-    const extension = {
+    let send: ((m: unknown) => void) | undefined;
+    const extension: InlineExtension = {
       name: "shot",
-      factory: (api: {
-        registerCommand: (n: string, o: unknown) => void;
-        sendMessage: (m: unknown) => Promise<void>;
-      }) => {
-        send = api.sendMessage;
-        api.registerCommand("shot", {
+      factory: (pi) => {
+        send = (m) => pi.sendMessage(m as Parameters<typeof pi.sendMessage>[0]);
+        pi.registerCommand("shot", {
           description: "replies with an image",
           handler: async () => {
-            await send?.({
+            send?.({
               customType: "shot",
               content: [{ type: "image", data: "aGk=", mimeType: "image/png" }],
               display: true,
@@ -327,10 +328,10 @@ describe("session engine class: what the class buys", () => {
     // ambiguity left for a consumer to resolve.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-silent-"));
     let modelSaw = 0;
-    const extension = {
+    const extension: InlineExtension = {
       name: "quiet",
-      factory: (api: { registerCommand: (n: string, o: unknown) => void }) => {
-        api.registerCommand("mute", { description: "changes state, says nothing", handler: async () => {} });
+      factory: (pi) => {
+        pi.registerCommand("mute", { description: "changes state, says nothing", handler: async () => {} });
       },
     };
     const { sessionFactory } = await sessionAssembly({
@@ -362,18 +363,15 @@ describe("session engine class: what the class buys", () => {
     // The filter that decides extension bookkeeping is not the answer. Inverted, it lands in every
     // channel's chat: a channel builds its reply from `text` deltas.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-quietmsg-"));
-    let send: ((m: unknown) => Promise<void>) | undefined;
-    const extension = {
+    let send: ((m: unknown) => void) | undefined;
+    const extension: InlineExtension = {
       name: "bookkeeper",
-      factory: (api: {
-        registerCommand: (n: string, o: unknown) => void;
-        sendMessage: (m: unknown) => Promise<void>;
-      }) => {
-        send = api.sendMessage;
-        api.registerCommand("note", {
+      factory: (pi) => {
+        send = (m) => pi.sendMessage(m as Parameters<typeof pi.sendMessage>[0]);
+        pi.registerCommand("note", {
           description: "records something the user must not see",
           handler: async () => {
-            await send?.({ customType: "audit", content: "internal bookkeeping", display: false });
+            send?.({ customType: "audit", content: "internal bookkeeping", display: false });
           },
         });
       },
@@ -396,23 +394,19 @@ describe("session engine class: what the class buys", () => {
     // work the caller asked for. It warns; the command's own outcome stands.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-hookmix-"));
     let ran = 0;
-    const extension = {
+    const extension: InlineExtension = {
       name: "mixed",
-      factory: (api: {
-        registerCommand: (n: string, o: unknown) => void;
-        on: (e: string, h: () => void) => void;
-        sendMessage: (m: unknown) => Promise<void>;
-      }) => {
+      factory: (pi) => {
         // Fires on EVERY turn of this L0 (binding emits session_start), so it is the reachable shape
         // of "something else in the extension layer failed while the command itself was fine".
-        api.on("session_start", () => {
+        pi.on("session_start", () => {
           throw new Error("unrelated hook blew up");
         });
-        api.registerCommand("mute", {
+        pi.registerCommand("mute", {
           description: "succeeds",
           handler: async () => {
             ran++;
-            await api.sendMessage({ customType: "mute", content: "muted", display: true });
+            pi.sendMessage({ customType: "mute", content: "muted", display: true });
           },
         });
       },
@@ -448,11 +442,15 @@ describe("session engine class: what the class buys", () => {
     // get its counterpart or it lives until the process exits.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-life-"));
     const seen: string[] = [];
-    const extension = {
+    const extension: InlineExtension = {
       name: "lifecycle",
-      factory: (api: { on: (e: string, h: (event: { reason?: string }) => void) => void }) => {
-        api.on("session_start", (event) => seen.push(`start:${event.reason}`));
-        api.on("session_shutdown", () => seen.push("shutdown"));
+      factory: (pi) => {
+        pi.on("session_start", (event) => {
+          seen.push(`start:${event.reason}`);
+        });
+        pi.on("session_shutdown", () => {
+          seen.push("shutdown");
+        });
       },
     };
     const { sessionFactory } = await sessionAssembly({
@@ -476,11 +474,15 @@ describe("session engine class: what the class buys", () => {
     // acquired would live until the process exits.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-life3-"));
     const seen: string[] = [];
-    const extension = {
+    const extension: InlineExtension = {
       name: "lifecycle",
-      factory: (api: { on: (e: string, h: () => void) => void }) => {
-        api.on("session_start", () => seen.push("start"));
-        api.on("session_shutdown", () => seen.push("shutdown"));
+      factory: (pi) => {
+        pi.on("session_start", () => {
+          seen.push("start");
+        });
+        pi.on("session_shutdown", () => {
+          seen.push("shutdown");
+        });
       },
     };
     const { sessionFactory } = await sessionAssembly({
@@ -512,11 +514,15 @@ describe("session engine class: what the class buys", () => {
     // predicate — only whether THIS turn bound them.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-life2-"));
     const seen: string[] = [];
-    const extension = {
+    const extension: InlineExtension = {
       name: "lifecycle",
-      factory: (api: { on: (e: string, h: (event: { reason?: string }) => void) => void }) => {
-        api.on("session_start", (event) => seen.push(`start:${event.reason}`));
-        api.on("session_shutdown", () => seen.push("shutdown"));
+      factory: (pi) => {
+        pi.on("session_start", (event) => {
+          seen.push(`start:${event.reason}`);
+        });
+        pi.on("session_shutdown", () => {
+          seen.push("shutdown");
+        });
       },
     };
     let releaseFactory!: () => void;
@@ -563,10 +569,10 @@ describe("session engine class: what the class buys", () => {
     // that failure as the turn's verdict would overturn a result the caller received.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-input-"));
     let modelSaw = 0;
-    const extension = {
+    const extension: InlineExtension = {
       name: "interceptor",
-      factory: (api: { on: (e: string, h: () => void) => void }) => {
-        api.on("input", () => {
+      factory: (pi) => {
+        pi.on("input", () => {
           throw new Error("interceptor blew up");
         });
       },
@@ -598,10 +604,10 @@ describe("session engine class: what the class buys", () => {
   it("a factory's own extension-error listener cannot break the turn", async () => {
     // The contract calls it an observer; a throwing observer must not become the turn's problem.
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-obs-"));
-    const extension = {
+    const extension: InlineExtension = {
       name: "noisy",
-      factory: (api: { on: (e: string, h: () => void) => void }) => {
-        api.on("session_start", () => {
+      factory: (pi) => {
+        pi.on("session_start", () => {
           throw new Error("hook went wrong");
         });
       },
@@ -659,20 +665,17 @@ describe("session engine class: what the class buys", () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-ext-"));
     let ran = 0;
     let modelSaw = 0;
-    let sendMessage: ((m: unknown) => Promise<void>) | undefined;
-    const extension = {
+    let sendMessage: ((m: unknown) => void) | undefined;
+    const extension: InlineExtension = {
       name: "spike",
-      factory: (api: {
-        registerCommand: (n: string, o: unknown) => void;
-        sendMessage: (m: unknown) => Promise<void>;
-      }) => {
-        sendMessage = api.sendMessage;
-        api.registerCommand("ping", {
+      factory: (pi) => {
+        sendMessage = (m) => pi.sendMessage(m as Parameters<typeof pi.sendMessage>[0]);
+        pi.registerCommand("ping", {
           description: "answer without the model",
           handler: async () => {
             ran++;
             // `sendMessage` is on the extension API (pi.sendMessage), not on the command context.
-            await sendMessage?.({ customType: "ping", content: "pong", display: true });
+            sendMessage?.({ customType: "ping", content: "pong", display: true });
           },
         });
       },
@@ -873,13 +876,13 @@ describe("session engine class: cancellation reaches in-flight work", () => {
     const aborted = new Promise<void>((r) => {
       sawAbort = r;
     });
-    const gate = {
+    const gate: ToolDefinition = {
       name: "gate",
       label: "Gate",
       description: "Blocks until the turn is aborted",
-      parameters: { type: "object", properties: {}, additionalProperties: false },
-      execute: (_id: string, _params: unknown, signal: AbortSignal | undefined) =>
-        new Promise<{ output: string }>((_resolve, reject) => {
+      parameters: Type.Object({}),
+      execute: (_id, _params, signal) =>
+        new Promise<never>((_resolve, reject) => {
           // The ALREADY-ABORTED check is not defensive boilerplate here, it is the case under test:
           // `tool_started` is emitted BEFORE pi calls execute, so a consumer that walks away on that
           // event cancels in the window between the two — and an already-aborted signal never fires
@@ -936,11 +939,11 @@ describe("session engine class: the turn context fastagent tools depend on", () 
     let seen: { cwd?: string; sessionId?: string; canActivate?: boolean } = {};
     // Read from a TOOL's execute, not from the model call: the tool path is the one the binding
     // exists for (`wake`, `search_tools`, cwd), and it is a different resumption of pi's stack.
-    const probe = {
+    const probe: ToolDefinition = {
       name: "probe",
       label: "Probe",
       description: "Reports the turn context it sees",
-      parameters: { type: "object", properties: {}, additionalProperties: false },
+      parameters: Type.Object({}),
       execute: async () => {
         const store = turnContext.getStore();
         seen = {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -21,7 +21,7 @@ import { log } from "../src/log.ts";
 import type { Agent } from "../src/agent.ts";
 import { createPiAgentFromSession } from "../src/engines/pi/session-invoke.ts";
 import { sessionRecordBinder } from "../src/engines/pi/session-record.ts";
-import { jsonlSessionStore } from "../src/engines/pi/sessions.ts";
+import { jsonlRecordStore, jsonlSessionStore } from "../src/engines/pi/sessions.ts";
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
 
@@ -72,7 +72,7 @@ async function sessionAssembly(options: {
   // The record is addressed the way a deployment must address it — through the shipped binder, so
   // this suite exercises the same code a serving path would, not a parallel fixture of it.
   const bindRecord = sessionRecordBinder({
-    store: jsonlSessionStore({ dir: options.sessionsRoot, cwd: options.cwd }),
+    store: jsonlRecordStore({ dir: options.sessionsRoot, cwd: options.cwd }),
     sessionsRoot: options.sessionsRoot,
     cwd: options.cwd,
   });

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -254,7 +254,13 @@ describe("session engine class: what the class buys", () => {
     const agent = createPiAgentFromSession({ sessionFactory });
     const events = [];
     for await (const e of agent.invoke({ session: "s" }, { text: "/boom" })) events.push(e);
-    expect(events.at(-1)).toMatchObject({ type: "failed", details: expect.stringContaining("exploded") });
+    expect(events.at(-1)).toMatchObject({
+      type: "failed",
+      details: expect.stringContaining("exploded"),
+      // NOT retryable: a handler that throws throws again. (The provider-error classifier would read
+      // words like "timed out" out of the message and say otherwise.)
+      retryable: false,
+    });
   });
 
   it("an extension hook that throws warns but does not overturn a model answer the caller received", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -448,8 +448,8 @@ describe("session engine class: what the class buys", () => {
         pi.on("session_start", (event) => {
           seen.push(`start:${event.reason}`);
         });
-        pi.on("session_shutdown", () => {
-          seen.push("shutdown");
+        pi.on("session_shutdown", (event) => {
+          seen.push(`shutdown:${event.reason}`);
         });
       },
     };
@@ -463,8 +463,9 @@ describe("session engine class: what the class buys", () => {
     for (const text of ["first", "second"]) {
       for await (const e of agent.invoke({ session: "s" }, { text })) void e;
     }
-    // Every turn resumes a durable record — including the first, which resumes an empty one.
-    expect(seen).toEqual(["start:resume", "shutdown", "start:resume", "shutdown"]);
+    // Every turn resumes a durable record — including the first, which resumes an empty one — and
+    // the death pairs the birth: the record is picked up again, the process is not ending.
+    expect(seen).toEqual(["start:resume", "shutdown:resume", "start:resume", "shutdown:resume"]);
   });
 
   it("a binding that fails AFTER the birth still reports the death", async () => {
@@ -958,7 +959,7 @@ describe("session engine class: the turn context fastagent tools depend on", () 
     // undefined), so it is asserted rather than assumed.
     const { turnContext } = await import("../src/engines/pi/tool-context.ts");
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-ctx-"));
-    let seen: { cwd?: string; sessionId?: string; canActivate?: boolean } = {};
+    let seen: { cwd?: string; sessionId?: string; headerId?: string; canActivate?: boolean } = {};
     // Read from a TOOL's execute, not from the model call: the tool path is the one the binding
     // exists for (`wake`, `search_tools`, cwd), and it is a different resumption of pi's stack.
     const probe: ToolDefinition = {
@@ -971,6 +972,7 @@ describe("session engine class: the turn context fastagent tools depend on", () 
         seen = {
           cwd: store?.cwd,
           sessionId: store?.sessionManager?.getSessionId(),
+          headerId: (await store?.sessionManager?.getHeader())?.id,
           canActivate: typeof store?.tools?.activate === "function",
         };
         return { content: [{ type: "text", text: "ok" }], details: undefined };
@@ -989,6 +991,9 @@ describe("session engine class: the turn context fastagent tools depend on", () 
     for await (const e of agent.invoke({ session: "telegram:-100/42" }, { text: "go" })) void e;
     expect(seen.cwd).toBe(cwd);
     expect(seen.sessionId).toBe("telegram:-100/42");
+    // Both answers to "which session is this" agree, across the port's two methods AND across the
+    // engine classes: the harness bridge returns the caller's id from both.
+    expect(seen.headerId).toBe("telegram:-100/42");
     expect(seen.canActivate).toBe(true);
   });
 });

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -17,7 +17,8 @@ import {
   createAgentSession,
 } from "@earendil-works/pi-coding-agent";
 import { type FauxResponseStep, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { log } from "../src/log.ts";
 import type { Agent } from "../src/agent.ts";
 import { createPiAgentFromSession } from "../src/engines/pi/session-invoke.ts";
 import { makeFaux } from "./faux.ts";
@@ -254,6 +255,37 @@ describe("session engine class: what the class buys", () => {
     const events = [];
     for await (const e of agent.invoke({ session: "s" }, { text: "/boom" })) events.push(e);
     expect(events.at(-1)).toMatchObject({ type: "failed", details: expect.stringContaining("exploded") });
+  });
+
+  it("an extension hook that throws warns but does not overturn a model answer the caller received", async () => {
+    // The other side of the same listener: pi reports EVERY extension-dispatch failure, so the
+    // question is what a turn does with one. With a model response in hand, flipping it to `failed`
+    // would deny the caller an answer it already streamed — so it warns instead.
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-hook-"));
+    const extension = {
+      name: "noisy",
+      factory: (api: { on: (e: string, h: () => void) => void }) => {
+        api.on("agent_settled", () => {
+          throw new Error("hook went wrong");
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("the answer")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      const events = [];
+      for await (const e of agent.invoke({ session: "s" }, { text: "go" })) events.push(e);
+      expect(events.at(-1)?.type).toBe("completed");
+      expect(warn.mock.calls.flat().join(" ")).toContain("hook went wrong");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -704,7 +704,6 @@ describe("session engine class: per-invoke discipline", () => {
     await iterator.return?.(undefined);
   });
 
-
   it("nothing resident survives a turn — the record is the only continuity", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-record-"));
     const sessionsRoot = join(cwd, "sessions");

--- a/test/session-engine-conformance.test.ts
+++ b/test/session-engine-conformance.test.ts
@@ -635,6 +635,37 @@ describe("session engine class: what the class buys", () => {
     }
   });
 
+  it("what an extension says while STARTING UP reaches the stream", async () => {
+    // The subscription has to be armed before binding: pi emits session_start inside
+    // bindExtensions, and a handler that speaks there lands a message immediately — the one case
+    // `reason: "startup"` exists to enable (a greeting, a seeded note on the first turn).
+    const cwd = await mkdtemp(join(tmpdir(), "fa-se-greet-"));
+    const extension: InlineExtension = {
+      name: "greeter",
+      factory: (pi) => {
+        pi.on("session_start", (event) => {
+          if (event.reason !== "startup") return;
+          pi.sendMessage({ customType: "greeting", content: "welcome aboard", display: true });
+        });
+      },
+    };
+    const { sessionFactory } = await sessionAssembly({
+      responses: [fauxAssistantMessage("hello back")],
+      sessionsRoot: join(cwd, "sessions"),
+      cwd,
+      extensionFactories: [extension],
+    });
+    const agent = createPiAgentFromSession({ sessionFactory });
+    const events = [];
+    for await (const e of agent.invoke({ session: "s" }, { text: "hi" })) events.push(e);
+    const text = events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as { delta: string }).delta)
+      .join("");
+    expect(text).toContain("welcome aboard");
+    expect(text).toContain("hello back");
+  });
+
   it("an image prompt reaches the model — the conversion the harness path uses, not a dropped field", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "fa-se-img-"));
     let sawImage = false;

--- a/test/spec-conformance.ts
+++ b/test/spec-conformance.ts
@@ -67,6 +67,10 @@ export function describeSpecConformance(name: string, subject: ConformanceSubjec
       expect(last?.type).toBe("failed");
       if (last?.type === "failed") {
         expect(typeof last.details).toBe("string");
+        // NON-EMPTY: `details` is the only place the engine's own message survives to the caller,
+        // so an implementation that translates a failure into an empty string is conforming on
+        // types and useless in practice.
+        expect(last.details.length).toBeGreaterThan(0);
         expect(typeof last.retryable).toBe("boolean");
       }
     });


### PR DESCRIPTION
> Stacked on #313 (the design note it cites). Review that one first; this branch contains it.

## What

An L0 for the **`session` engine class** — `createPiAgentFromSession` — that builds a fresh
pi-coding-agent `AgentSession` over the session's jsonl record **per invoke** and discards it.

Same state locality as the reference harness path (SPEC MUST 6 holds), different engine surface. It
is the substrate #285 (extensions) and #289 (extension dialogs) need; neither is implemented here.

**No existing path changes.** Nothing in `src/` constructs this agent yet — the L1 assembly is
deliberately not in scope, so the class can be judged before it is wired anywhere.

## Proven, not asserted

The conformance suite runs against it with `pair()` provided, so MUST 6 is *asserted*: two
independently assembled instances share only the record on disk, and instance B's turn sees instance
A's. Beyond the shared suite:

| Test | Pins |
|---|---|
| `an extension command runs instead of reaching the model` | THE point of the class — `/ping` dispatches, the model never sees it, the turn still settles |
| `an image prompt reaches the model` | images go through the same conversion the harness path uses, rather than being silently dropped |
| `a fastagent tool sees this session and this turn's activation` | the turn context is bound (missing, it degrades silently: `wake` writes nowhere, `search_tools` no-ops) |
| `nothing resident survives a turn` | a *different* session object per turn (identity, not call count) and one record carrying both |
| `a factory that throws becomes a failed EVENT` / `session_busy` | this module's own two failure branches |
| `an auto-retried failure … settles on the recovered turn, once` | `agent_end{willRetry}` is not the settle |

## The one thing that looked broken was my probe

The pull-driven cancellation test failed for two days' worth of suspicion before yielding a plain
answer: `tool_started` is emitted **before** pi calls the tool's `execute`, so a consumer that walks
away on that event cancels in the window between the two — and `execute` then receives a signal that
is **already aborted**, which never fires its `abort` event again. The gate tool in the test only
registered a listener, so it hung forever, `AgentSession.abort()` could never reach idle, and the
whole thing presented as a broken cancellation path in this L0.

With the tool checking `signal.aborted` first, cancellation is correct end to end: `return()` settles
in ~1 ms and the in-flight tool stops. Two things came out of that:

- a `doorFired` teardown workaround was deleted — it only ever compensated for the broken probe, so
  teardown is back to the harness L0's plain awaited abort;
- the trap is real for anyone writing a fastagent tool, so it is now documented on
  `ToolContext.signal`: check `signal.aborted` first, then listen.

## Shared, not duplicated

- `EventQueue` and `toPiPromptOptions` are exported from `invoke.ts` — both engine classes have pi's
  two-port shape (a promise for the turn + a subscription for the stream) and the same image path.
- The session-class tool bridges moved out of `session-builder.ts` into `session-bridge.ts`, now used
  by both of that class's consumers (the resident TUI runtime and this per-invoke L0) — one source of
  truth for how a fastagent tool sees the session and the activation chain, whichever class drives the turn.

## Verification

`npm run lint && npm run typecheck && npm test` — 1308 passing, 1 todo.

## Scope, stated rather than implied

This lands the engine seam and its conformance — **not** a wired serving path. Tracked as #321: the
assembly (models/auth/tools/extensions → a session factory), the control-plane wiring
(`SessionObserver` + run controls, which `/control/*` consumes), and the export decision, which
belongs with the assembly rather than before it. Both gaps are stated in the module header and in
`conformance-levels.md` §4/§5; the issue is what keeps them from becoming the default.

