### PR TITLE
chore: release 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.16.2",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, Telegram, Slack, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Bump version to 0.17.0.

Changes since v0.16.2:

- feat(session-control): `commands()` — the names a composer completes (#310)
- fix(agentcore): tail Runtime logs without the impossible stream prefix (#312)
- fix(agentcore): send time_of_last_update on /ping — the keep-alive silently requires it (#314)

Minor bump: #310 adds a new public API (`SessionControl.commands()` + `GET /control/commands`).

After merge: tag `v0.17.0` + create the GitHub Release; `publish.yml` publishes to npm via Trusted Publishing.