### PR TITLE
fix(feishu): split the streaming card into process + answer elements

### DIFF
--- a/src/channels/feishu/card.ts
+++ b/src/channels/feishu/card.ts
@@ -3,10 +3,16 @@
  * final card, and the message content that mounts a card entity into a chat. Kept out of preview.ts so
  * the card DSL is data-in → string-out and testable without the pump.
  *
- * The preview is ONE markdown element (`element_id` below) inside a card with `streaming_mode` on:
- * the pump PUTs full-text snapshots at that element (feishu-api.ts `updateCardElement`) and the client
- * renders the typewriter effect. Settling replaces the whole entity (`updateCard`) with the same
- * element, `streaming_mode` off — one write flips content and mode together.
+ * The streaming card is TWO markdown elements: `process` (the volatile block — thinking tail, tool
+ * lines, retry notice) and `answer` (append-only). The pump PUTs full-text snapshots per element
+ * (feishu-api.ts `updateCardElement`) and the client renders the typewriter effect. The split is the
+ * prefix-stability rule made structural: the client animates an element's update only when the old
+ * text is a PREFIX of the new — otherwise it re-types everything after the first divergent character.
+ * The process block's head changes every frame (a sliding thinking tail, `…`→`✓` status flips), so
+ * sharing one element with the answer re-typed the whole card once a second; two elements confine the
+ * churn to the small process block and keep the answer's typewriter smooth. Settling replaces the
+ * whole entity (`updateCard`) with the answer element alone, `streaming_mode` off — one write flips
+ * content and mode together and drops the process block.
  *
  * Budget: a card entity is capped at 30 KB, so the final answer's card chunk (and the live view) stay
  * well under it; longer answers overflow into follow-up messages (preview.ts owns that policy).
@@ -14,8 +20,11 @@
 
 import { truncateCodePointPrefix } from "../text.ts";
 
-/** The one streamed element's id — shared by create (card.ts) and update (preview.ts). */
+/** The append-only answer element's id — shared by create (card.ts) and update (preview.ts). */
 export const ANSWER_ELEMENT_ID = "answer";
+
+/** The volatile process element's id (thinking tail + tool lines + retry notice; live-only). */
+export const PROCESS_ELEMENT_ID = "process";
 
 /** Byte budget for markdown carried by ONE card (entity cap 30 KB minus JSON envelope + escaping room). */
 export const CARD_MARKDOWN_MAX_BYTES = 20 * 1024;
@@ -47,7 +56,13 @@ export function cardSummary(markdown: string): string {
   return truncateCodePointPrefix(line, SUMMARY_MAX_CHARS);
 }
 
-function cardJson(markdown: string, streaming: boolean, summary?: string): string {
+interface CardElement {
+  tag: "markdown";
+  content: string;
+  element_id: string;
+}
+
+function cardJson(elements: CardElement[], streaming: boolean, summary?: string): string {
   return JSON.stringify({
     schema: "2.0",
     config: {
@@ -57,19 +72,32 @@ function cardJson(markdown: string, streaming: boolean, summary?: string): strin
       // "[Generating…]") is better than any fixed text we could pin.
       ...(summary ? { summary: { content: summary } } : {}),
     },
-    body: { elements: [{ tag: "markdown", content: markdown, element_id: ANSWER_ELEMENT_ID }] },
+    body: { elements },
   });
 }
 
-/** The live-preview card entity: streaming on, seeded with the placeholder/first view. */
-export function streamingCardJson(initial: string): string {
-  return cardJson(initial, true);
+/** The live-preview card entity: streaming on, the process element seeded with the placeholder/queue
+ *  status and the answer element seeded EMPTY (the platform accepts an empty markdown element; it
+ *  renders zero-height until the first answer snapshot lands as a clean prefix extension of ""). */
+export function streamingCardJson(initialProcess: string): string {
+  return cardJson(
+    [
+      { tag: "markdown", content: initialProcess, element_id: PROCESS_ELEMENT_ID },
+      { tag: "markdown", content: "", element_id: ANSWER_ELEMENT_ID },
+    ],
+    true,
+  );
 }
 
-/** The settled card: final markdown, streaming off (stops the client's streaming affordance), plus
- *  the answer-derived summary so the chat list / notification shows the reply, not "[Card]". */
+/** The settled card: final markdown alone (the process block was preview-only), streaming off (stops
+ *  the client's streaming affordance), plus the answer-derived summary so the chat list / notification
+ *  shows the reply, not "[Card]". */
 export function finalCardJson(markdown: string): string {
-  return cardJson(markdown, false, cardSummary(markdown));
+  return cardJson(
+    [{ tag: "markdown", content: markdown, element_id: ANSWER_ELEMENT_ID }],
+    false,
+    cardSummary(markdown),
+  );
 }
 
 /** The `interactive` message content that mounts a card ENTITY (vs an inline static card). */

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -1,8 +1,10 @@
 /**
  * Canonical Feishu live-preview rendering (also reused by Lark compatibility). The preview is ONE
- * streaming CARD (create entity → mount it with a reply/send → stream full-text snapshots at its
- * markdown element with a strictly increasing `sequence`; the client renders the typewriter effect);
- * on completion the same card is settled in place with the final answer (streaming off). Streaming
+ * streaming CARD of TWO elements — the volatile `process` block and the append-only `answer` (see
+ * card.ts for why the split is the prefix-stability fix) — (create entity → mount it with a
+ * reply/send → stream full-text snapshots per element with a strictly increasing `sequence`; the
+ * client renders the typewriter effect); on completion the same card is settled in place with the
+ * final answer alone (streaming off). Streaming
  * updates ride the cardkit quota (50 QPS per app, 10 QPS per card entity, no edit ceiling) — NOT the
  * 5 QPS per-chat message quota or
  * the 20-edit cap on text messages, which is why the preview is a card and not an edited text message.
@@ -25,6 +27,7 @@ import { log } from "../../log.ts";
 import {
   ANSWER_ELEMENT_ID,
   CARD_MARKDOWN_MAX_BYTES,
+  PROCESS_ELEMENT_ID,
   cardEntityContent,
   finalCardJson,
   streamingCardJson,
@@ -43,7 +46,7 @@ import {
   thinkingLine,
   toolLines,
 } from "../preview-kit.ts";
-import { truncateUtf8 } from "../text.ts";
+import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
 
 /** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
 export type FeishuFailure = ChannelFailure;
@@ -58,9 +61,15 @@ const STREAM_THROTTLE_MS = 1000;
 /** How much of the (growing) reasoning to peek at in the live view — the most recent tail. */
 const THINKING_PREVIEW = 280;
 
-/** Cap a live view to the card budget, PREFIX-STABLE: the streaming client animates only when the old
- *  text is a prefix of the new, so an over-budget view freezes at its head rather than sliding a tail
- *  window (which would redraw the whole card every frame). The full answer still lands at settle. */
+/** Cap (code points) on the whole process block — thinking tail + tool lines + retry notice. It
+ *  redraws wholly on change anyway (it is volatile by nature), so an over-long block keeps its TAIL:
+ *  the newest tools are the ones worth showing. ≤1000 points is ≤4 KB UTF-8, which together with the
+ *  answer's byte cap stays inside the 30 KB entity budget. */
+const PROCESS_MAX_POINTS = 1000;
+
+/** Cap the live answer to the card budget, PREFIX-STABLE: the streaming client animates only when the
+ *  old text is a prefix of the new, so an over-budget answer freezes at its head rather than sliding a
+ *  tail window (which would re-type the element every frame). The full answer still lands at settle. */
 function capBytes(s: string, maxBytes: number): string {
   return truncateUtf8(s, maxBytes);
 }
@@ -127,9 +136,10 @@ async function finalize(
 }
 
 /**
- * Mount one preview message: preferably a streaming card entity, with a static text message as the
- * visible fallback. Queue feedback and ordinary turn startup share this constructor so a queued card
- * has exactly the same shape the stream pump expects to take over later.
+ * Mount one preview message: preferably a streaming card entity (`initial` seeds the process element;
+ * the answer element starts empty), with a static text message as the visible fallback. Queue feedback
+ * and ordinary turn startup share this constructor so a queued card has exactly the same shape the
+ * stream pump expects to take over later.
  */
 export async function mountFeishuPreview(
   api: FeishuApi,
@@ -206,17 +216,22 @@ export async function streamFeishuReply(
   label = "[feishu]",
 ): Promise<void> {
   // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
-  // policy, the card-budget cap, and delivery below.
+  // policy, the card-budget caps, and delivery below. The card is TWO elements (card.ts): the process
+  // block's head changes every frame (sliding thinking tail, `…`→`✓` flips), so it must never share
+  // an element with the answer — the client would re-type the whole card from the divergence point
+  // once a second. Each view feeds its own element; only the changed one is written.
   const turn = createTurnView();
-  const view = (): string => {
+  const processView = (): string => {
     const v = composeTurnBody([
       thinkingLine(turn, THINKING_PREVIEW),
       toolLines(turn),
       turn.retrying ? RETRY_NOTICE : "",
-      revealedAnswer(turn, STREAM_THROTTLE_MS),
     ]);
-    return capBytes(v === "" ? THINKING_PLACEHOLDER : v, CARD_MARKDOWN_MAX_BYTES);
+    // Empty → the stable placeholder (never an empty-content write; it also keeps the block from
+    // flickering away between thinking bursts). The settle drops the block entirely.
+    return v === "" ? THINKING_PLACEHOLDER : truncateCodePointSuffix(v, PROCESS_MAX_POINTS);
   };
+  const answerView = (): string => capBytes(revealedAnswer(turn, STREAM_THROTTLE_MS), CARD_MARKDOWN_MAX_BYTES);
 
   // The live preview is ONE message: either the queue card/text handed in by the wiring, or a preview
   // mounted lazily on this turn's first flush. `sequence` must increase strictly per card — the single-
@@ -228,21 +243,33 @@ export async function streamFeishuReply(
   const nextSeq = (): number => ++sequence;
   let streamDead = false; // the platform closed streaming (idle timeout) — freeze the live view
   let finalized = false; // a terminal write (completed/failed) ran — the finally skips its orphan cleanup
-  let lastSent = "";
+  let lastProcess = "";
+  let lastAnswer = "";
 
   const flushPreview = async (): Promise<void> => {
-    const text = view();
+    const process = processView();
     if (!setupAttempted) {
       setupAttempted = true;
-      preview = await mountFeishuPreview(api, target, text, label);
-      lastSent = text;
+      // The mount seeds the process element with the current view; the answer element starts empty
+      // (card.ts), so the first answer snapshot is a clean prefix extension.
+      preview = await mountFeishuPreview(api, target, process, label);
+      lastProcess = process;
       return;
     }
     if (preview.kind !== "card" || streamDead) return; // text tier / dead stream: frozen until the terminal write
-    if (text === lastSent) return; // skip an unchanged snapshot
-    lastSent = text;
     try {
-      await api.updateCardElement(preview.cardId, ANSWER_ELEMENT_ID, text, nextSeq());
+      // `last*` advances BEFORE each write: a frame that fails for a non-streaming reason is logged
+      // once (the pump's onError) and not re-sent until its content actually changes.
+      if (process !== lastProcess) {
+        lastProcess = process;
+        await api.updateCardElement(preview.cardId, PROCESS_ELEMENT_ID, process, nextSeq());
+      }
+      const answer = answerView();
+      // Never write an empty answer snapshot — the element is born empty and the answer only grows.
+      if (answer !== "" && answer !== lastAnswer) {
+        lastAnswer = answer;
+        await api.updateCardElement(preview.cardId, ANSWER_ELEMENT_ID, answer, nextSeq());
+      }
     } catch (e) {
       if (isCardStreamingClosed(e)) {
         // The platform closed streaming (idle timeout). Freeze the live view; the settle write replaces

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -46,7 +46,7 @@ import {
   thinkingLine,
   toolLines,
 } from "../preview-kit.ts";
-import { truncateCodePointSuffix, truncateUtf8 } from "../text.ts";
+import { truncateCodePointPrefix, truncateUtf8 } from "../text.ts";
 
 /** A terminal failure, as the channel hands it to `onError` — the shared channel shape. */
 export type FeishuFailure = ChannelFailure;
@@ -62,9 +62,9 @@ const STREAM_THROTTLE_MS = 1000;
 const THINKING_PREVIEW = 280;
 
 /** Cap (code points) on the whole process block — thinking tail + tool lines + retry notice. It
- *  redraws wholly on change anyway (it is volatile by nature), so an over-long block keeps its TAIL:
- *  the newest tools are the ones worth showing. ≤1000 points is ≤4 KB UTF-8, which together with the
- *  answer's byte cap stays inside the 30 KB entity budget. */
+ *  redraws wholly on change anyway (it is volatile by nature), so over budget the newest COMPLETE
+ *  lines win (see tailLines). ≤1000 points is ≤4 KB UTF-8, which together with the answer's byte cap
+ *  stays inside the 30 KB entity budget. */
 const PROCESS_MAX_POINTS = 1000;
 
 /** Cap the live answer to the card budget, PREFIX-STABLE: the streaming client animates only when the
@@ -72,6 +72,28 @@ const PROCESS_MAX_POINTS = 1000;
  *  tail window (which would re-type the element every frame). The full answer still lands at settle. */
 function capBytes(s: string, maxBytes: number): string {
   return truncateUtf8(s, maxBytes);
+}
+
+/** Tail-select COMPLETE lines within a code-point budget — the process block's cap. The block's
+ *  lines are semantic units (a `🔧` tool call, the `💭` peek, the `⏳` notice): cutting mid-line
+ *  would orphan a marker or tear a label, so elision happens only at line boundaries, newest lines
+ *  kept, with a leading `…` line marking what was dropped. The in-line guard cannot trigger with the
+ *  bounded renderers (a thinking tail ≤ ~283 points, a tool line ≤ ~135) — it exists so a future
+ *  unbounded line degrades to a head-preserving cut instead of an empty block. */
+function tailLines(text: string, maxPoints: number): string {
+  if (Array.from(text).length <= maxPoints) return text;
+  const lines = text.split("\n");
+  const kept: string[] = [];
+  let used = 2; // the leading "…\n" elision marker
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i] ?? "";
+    const cost = Array.from(line).length + (kept.length > 0 ? 1 : 0); // +1 joining newline
+    if (used + cost > maxPoints) break;
+    used += cost;
+    kept.unshift(line);
+  }
+  if (kept.length === 0) return truncateCodePointPrefix(lines.at(-1) ?? "", maxPoints);
+  return `…\n${kept.join("\n")}`;
 }
 
 /** A visible preview mounted into the chat. Exported only for the channel wiring: a queued turn mounts
@@ -227,9 +249,13 @@ export async function streamFeishuReply(
       toolLines(turn),
       turn.retrying ? RETRY_NOTICE : "",
     ]);
-    // Empty → the stable placeholder (never an empty-content write; it also keeps the block from
-    // flickering away between thinking bursts). The settle drops the block entirely.
-    return v === "" ? THINKING_PLACEHOLDER : truncateCodePointSuffix(v, PROCESS_MAX_POINTS);
+    if (v !== "") return tailLines(v, PROCESS_MAX_POINTS);
+    // No process content: the placeholder covers only the silence BEFORE the answer reveals — once
+    // the answer is streaming, an empty block goes (stays) empty; "Thinking…" pinned above a live
+    // answer would misstate the phase. The empty frame is a real write: it clears a mounted
+    // placeholder. (The block cannot otherwise flicker: thinking and tools only grow — only the
+    // retry notice toggles, and its empty state resolves through this same rule.)
+    return revealedAnswer(turn, STREAM_THROTTLE_MS).trim() === "" ? THINKING_PLACEHOLDER : "";
   };
   const answerView = (): string => capBytes(revealedAnswer(turn, STREAM_THROTTLE_MS), CARD_MARKDOWN_MAX_BYTES);
 
@@ -259,7 +285,8 @@ export async function streamFeishuReply(
     if (preview.kind !== "card" || streamDead) return; // text tier / dead stream: frozen until the terminal write
     try {
       // `last*` advances BEFORE each write: a frame that fails for a non-streaming reason is logged
-      // once (the pump's onError) and not re-sent until its content actually changes.
+      // once (the pump's onError) and not re-sent until its content actually changes. An EMPTY
+      // process frame is written like any other — it is the placeholder being cleared (processView).
       if (process !== lastProcess) {
         lastProcess = process;
         await api.updateCardElement(preview.cardId, PROCESS_ELEMENT_ID, process, nextSeq());

--- a/test/feishu-preview.test.ts
+++ b/test/feishu-preview.test.ts
@@ -124,14 +124,22 @@ describe("streamFeishuReply two-element streaming (direct)", () => {
     await vi.advanceTimersByTimeAsync(1100);
     src.push({ type: "text", delta: "hello" });
     await vi.advanceTimersByTimeAsync(1100); // answer ages past the reveal window
-    src.push({ type: "text", delta: " world" });
-    await vi.advanceTimersByTimeAsync(1100);
+    src.push({ type: "text", delta: " wor" });
+    await vi.advanceTimersByTimeAsync(1100); // → answer frame 1
+    src.push({ type: "text", delta: "ld" });
+    await vi.advanceTimersByTimeAsync(1100); // → answer frame 2 (strict prefix extension of frame 1)
+
+    // Churn-only phase: the answer element must FREEZE while the process block keeps changing —
+    // an equal-content rewrite here would burn quota and re-trigger the client's animation.
+    const answerWritesBeforeChurn = elementWrites.filter((w) => w.elementId === ANSWER_ELEMENT_ID).length;
     src.push({ type: "thinking", delta: "b".repeat(50) }); // slides the tail again
     await vi.advanceTimersByTimeAsync(1100);
     src.push({ type: "tool_started", id: "t1", name: "bash", args: { cmd: "ls" } });
     await vi.advanceTimersByTimeAsync(1100);
     src.push({ type: "tool_ended", id: "t1", isError: false, content: "ok" }); // the …→✓ flip is process churn too
     await vi.advanceTimersByTimeAsync(1100);
+    expect(elementWrites.filter((w) => w.elementId === ANSWER_ELEMENT_ID).length).toBe(answerWritesBeforeChurn);
+
     src.push({ type: "completed" });
     src.end();
     await turn;
@@ -146,11 +154,15 @@ describe("streamFeishuReply two-element streaming (direct)", () => {
     expect(processWrites.some((w) => w.content.includes("🔧 Bash ls ✓"))).toBe(true);
     expect(processWrites.every((w) => !w.content.includes("hello"))).toBe(true); // the answer never leaks in
 
-    // The answer element stayed prefix-stable: pure answer text, each write extending the previous.
-    expect(answerWrites.length).toBeGreaterThanOrEqual(1);
+    // The answer element stayed prefix-stable: pure answer text, each frame a STRICT extension of the
+    // previous one (equality would mean a pointless rewrite — the dedup guard is what this pins).
+    expect(answerWrites.length).toBeGreaterThanOrEqual(2);
     expect(answerWrites.every((w) => !/💭|🔧/.test(w.content))).toBe(true);
     for (let i = 1; i < answerWrites.length; i++) {
-      expect(answerWrites[i]?.content.startsWith(answerWrites[i - 1]?.content ?? "")).toBe(true);
+      const prev = answerWrites[i - 1]?.content ?? "";
+      const next = answerWrites[i]?.content ?? "";
+      expect(next.startsWith(prev)).toBe(true);
+      expect(next.length).toBeGreaterThan(prev.length);
     }
     expect(answerWrites.at(-1)?.content).toBe("hello world");
 
@@ -167,6 +179,59 @@ describe("streamFeishuReply two-element streaming (direct)", () => {
     expect(settled.config.streaming_mode).toBe(false);
     expect(settled.body.elements).toHaveLength(1);
     expect(settled.body.elements[0]?.content).toBe("hello world");
+  });
+
+  it("an answer-only stream clears the placeholder: the process element goes empty once the answer reveals", async () => {
+    vi.useFakeTimers();
+    const { api, created, elementWrites } = fakeApi();
+    const src = eventSource();
+    const turn = streamFeishuReply(src.iterable, api, { chatId: "oc_1" }, neutral);
+    await vi.advanceTimersByTimeAsync(0); // mount flush — process seeded with the placeholder
+    const mounted = JSON.parse(created[0] ?? "{}") as { body: { elements: { content: string }[] } };
+    expect(mounted.body.elements[0]?.content).toBe("💭 Thinking…");
+
+    src.push({ type: "text", delta: "OK" });
+    await vi.advanceTimersByTimeAsync(1100); // young answer: placeholder stays, nothing written yet
+    expect(elementWrites).toHaveLength(0);
+    src.push({ type: "text", delta: " then" });
+    await vi.advanceTimersByTimeAsync(1100); // answer reveals → placeholder cleared in the same flush
+    src.push({ type: "completed" });
+    src.end();
+    await turn;
+
+    const processWrites = elementWrites.filter((w) => w.elementId === PROCESS_ELEMENT_ID);
+    const answerWrites = elementWrites.filter((w) => w.elementId === ANSWER_ELEMENT_ID);
+    expect(processWrites.map((w) => w.content)).toEqual([""]); // one write: the placeholder clearing
+    expect(answerWrites.at(-1)?.content).toBe("OK then");
+  });
+
+  it("an over-budget process block elides at LINE boundaries: newest complete tool lines win", async () => {
+    vi.useFakeTimers();
+    const { api, elementWrites } = fakeApi();
+    const src = eventSource();
+    const turn = streamFeishuReply(src.iterable, api, { chatId: "oc_1" }, neutral);
+    await vi.advanceTimersByTimeAsync(0); // mount flush
+    // 30 tool lines × ~60 points ≈ 1800 points — well past the 1000-point process budget.
+    for (let i = 0; i < 30; i++) {
+      src.push({
+        type: "tool_started",
+        id: `t${i}`,
+        name: `tool${String(i).padStart(2, "0")}`,
+        args: { p: "x".repeat(60) },
+      });
+    }
+    await vi.advanceTimersByTimeAsync(1100);
+    src.push({ type: "completed" });
+    src.end();
+    await turn;
+
+    const last = elementWrites.filter((w) => w.elementId === PROCESS_ELEMENT_ID).at(-1)?.content ?? "";
+    expect(Array.from(last).length).toBeLessThanOrEqual(1000);
+    const lines = last.split("\n");
+    expect(lines[0]).toBe("…"); // the elision marker — something WAS dropped
+    expect(lines.slice(1).every((l) => l.startsWith("🔧 Tool"))).toBe(true); // only COMPLETE lines survive
+    expect(last).toContain("Tool29"); // newest kept…
+    expect(last).not.toContain("Tool00"); // …oldest dropped
   });
 
   it("an unchanged view writes nothing (no idle churn against the cardkit quota)", async () => {

--- a/test/feishu-preview.test.ts
+++ b/test/feishu-preview.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "../src/agent.ts";
+import {
+  ANSWER_ELEMENT_ID,
+  PROCESS_ELEMENT_ID,
+  finalCardJson,
+  streamingCardJson,
+} from "../src/channels/feishu/card.ts";
+import type { FeishuApi } from "../src/channels/feishu/feishu-api.ts";
+import { streamFeishuReply } from "../src/channels/feishu/preview.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+/** A push-based event source, so a test controls exactly WHEN each event reaches the stream. */
+const eventSource = () => {
+  const queue: AgentEvent[] = [];
+  let notify: (() => void) | undefined;
+  let ended = false;
+  const iterable: AsyncIterable<AgentEvent> = {
+    async *[Symbol.asyncIterator]() {
+      while (true) {
+        if (queue.length > 0) {
+          yield queue.shift() as AgentEvent;
+          continue;
+        }
+        if (ended) return;
+        await new Promise<void>((r) => {
+          notify = r;
+        });
+      }
+    },
+  };
+  return {
+    iterable,
+    push(e: AgentEvent): void {
+      queue.push(e);
+      notify?.();
+      notify = undefined;
+    },
+    end(): void {
+      ended = true;
+      notify?.();
+      notify = undefined;
+    },
+  };
+};
+
+interface ElementWrite {
+  cardId: string;
+  elementId: string;
+  content: string;
+  sequence: number;
+}
+
+/** A recording FeishuApi fake — only the surface the preview touches. */
+function fakeApi() {
+  const created: string[] = [];
+  const elementWrites: ElementWrite[] = [];
+  const cardWrites: { cardId: string; cardJson: string; sequence: number }[] = [];
+  const api = {
+    async createCard(cardJson: string) {
+      created.push(cardJson);
+      return `c${created.length}`;
+    },
+    async updateCardElement(cardId: string, elementId: string, content: string, sequence: number) {
+      elementWrites.push({ cardId, elementId, content, sequence });
+    },
+    async updateCard(cardId: string, cardJson: string, sequence: number) {
+      cardWrites.push({ cardId, cardJson, sequence });
+    },
+    async sendMessage() {
+      return "om_1";
+    },
+    async replyMessage() {
+      return "om_1";
+    },
+    async sendText() {
+      return "om_2";
+    },
+    async editTextMessage() {},
+    async deleteMessage() {},
+  } as unknown as FeishuApi;
+  return { api, created, elementWrites, cardWrites };
+}
+
+const neutral = (): string => "⚠️ neutral";
+
+describe("streaming card shape (pure)", () => {
+  it("mounts TWO elements: the volatile process block and an EMPTY append-only answer", () => {
+    const card = JSON.parse(streamingCardJson("💭 Thinking…")) as {
+      config: { streaming_mode: boolean };
+      body: { elements: { element_id: string; content: string }[] };
+    };
+    expect(card.config.streaming_mode).toBe(true);
+    expect(card.body.elements.map((e) => e.element_id)).toEqual([PROCESS_ELEMENT_ID, ANSWER_ELEMENT_ID]);
+    expect(card.body.elements[0]?.content).toBe("💭 Thinking…");
+    expect(card.body.elements[1]?.content).toBe(""); // the first answer snapshot is a prefix extension of ""
+  });
+
+  it("settles to the answer element alone (the process block is preview-only)", () => {
+    const card = JSON.parse(finalCardJson("done")) as {
+      config: { streaming_mode: boolean };
+      body: { elements: { element_id: string; content: string }[] };
+    };
+    expect(card.config.streaming_mode).toBe(false);
+    expect(card.body.elements.map((e) => e.element_id)).toEqual([ANSWER_ELEMENT_ID]);
+  });
+});
+
+describe("streamFeishuReply two-element streaming (direct)", () => {
+  it("process churn (sliding thinking tail, tool flips) never rewrites the answer element", async () => {
+    vi.useFakeTimers();
+    const { api, created, elementWrites, cardWrites } = fakeApi();
+    const src = eventSource();
+    const turn = streamFeishuReply(src.iterable, api, { chatId: "oc_1" }, neutral);
+    await vi.advanceTimersByTimeAsync(0); // mount flush
+    expect(created).toHaveLength(1);
+
+    // Thinking longer than the 280-point tail window — every later delta slides the line's HEAD.
+    src.push({ type: "thinking", delta: "a".repeat(300) });
+    await vi.advanceTimersByTimeAsync(1100);
+    src.push({ type: "text", delta: "hello" });
+    await vi.advanceTimersByTimeAsync(1100); // answer ages past the reveal window
+    src.push({ type: "text", delta: " world" });
+    await vi.advanceTimersByTimeAsync(1100);
+    src.push({ type: "thinking", delta: "b".repeat(50) }); // slides the tail again
+    await vi.advanceTimersByTimeAsync(1100);
+    src.push({ type: "tool_started", id: "t1", name: "bash", args: { cmd: "ls" } });
+    await vi.advanceTimersByTimeAsync(1100);
+    src.push({ type: "tool_ended", id: "t1", isError: false, content: "ok" }); // the …→✓ flip is process churn too
+    await vi.advanceTimersByTimeAsync(1100);
+    src.push({ type: "completed" });
+    src.end();
+    await turn;
+
+    const processWrites = elementWrites.filter((w) => w.elementId === PROCESS_ELEMENT_ID);
+    const answerWrites = elementWrites.filter((w) => w.elementId === ANSWER_ELEMENT_ID);
+
+    // The process element carried the churn: thinking tail slides and the tool line in both states.
+    expect(processWrites.length).toBeGreaterThanOrEqual(3);
+    expect(processWrites.every((w) => w.content.startsWith("💭"))).toBe(true);
+    expect(processWrites.some((w) => w.content.includes("🔧 Bash ls …"))).toBe(true);
+    expect(processWrites.some((w) => w.content.includes("🔧 Bash ls ✓"))).toBe(true);
+    expect(processWrites.every((w) => !w.content.includes("hello"))).toBe(true); // the answer never leaks in
+
+    // The answer element stayed prefix-stable: pure answer text, each write extending the previous.
+    expect(answerWrites.length).toBeGreaterThanOrEqual(1);
+    expect(answerWrites.every((w) => !/💭|🔧/.test(w.content))).toBe(true);
+    for (let i = 1; i < answerWrites.length; i++) {
+      expect(answerWrites[i]?.content.startsWith(answerWrites[i - 1]?.content ?? "")).toBe(true);
+    }
+    expect(answerWrites.at(-1)?.content).toBe("hello world");
+
+    // The card's sequence is strictly increasing across BOTH elements (single-writer pump).
+    const sequences = elementWrites.map((w) => w.sequence);
+    expect([...sequences].sort((a, b) => a - b)).toEqual(sequences);
+    expect(new Set(sequences).size).toBe(sequences.length);
+
+    // Settle replaced the entity with the final answer alone, streaming off.
+    const settled = JSON.parse(cardWrites.at(-1)?.cardJson ?? "{}") as {
+      config: { streaming_mode: boolean };
+      body: { elements: { element_id: string; content: string }[] };
+    };
+    expect(settled.config.streaming_mode).toBe(false);
+    expect(settled.body.elements).toHaveLength(1);
+    expect(settled.body.elements[0]?.content).toBe("hello world");
+  });
+
+  it("an unchanged view writes nothing (no idle churn against the cardkit quota)", async () => {
+    vi.useFakeTimers();
+    const { api, elementWrites } = fakeApi();
+    const src = eventSource();
+    const turn = streamFeishuReply(src.iterable, api, { chatId: "oc_1" }, neutral);
+    await vi.advanceTimersByTimeAsync(0); // mount flush
+    src.push({ type: "thinking", delta: "short" });
+    await vi.advanceTimersByTimeAsync(1100);
+    const after = elementWrites.length;
+    // tool_ended for an unknown id changes nothing in the view → no write may follow.
+    src.push({ type: "tool_ended", id: "ghost", isError: false, content: "ok" });
+    await vi.advanceTimersByTimeAsync(2500);
+    expect(elementWrites.length).toBe(after);
+    src.push({ type: "completed" });
+    src.end();
+    await turn;
+  });
+});


### PR DESCRIPTION
## Problem

The live preview composed the thinking tail, tool lines, and the answer into ONE markdown element and streamed full-text snapshots at it. The Feishu/Lark streaming client only animates an element update when the old text is a **prefix** of the new — otherwise it re-types everything after the first divergent character.

The `💭` thinking line is a sliding tail (`truncateCodePointSuffix`, 280 points): once thinking outgrows the window, every new delta changes the line's **head**, so every 1s snapshot diverged on line one and the client visibly re-typed all tool lines and the answer, once a second, for the whole turn. Tool status flips (`… → ✓/✗`) and the retry notice had the same effect at lower frequency. Field-observed on Lark: the card kept re-rendering its tool list mid-character while thinking streamed.

## Fix

Make the prefix-stability rule structural — the streaming card is now TWO elements (`card.ts`):

- `process` — the volatile block (thinking tail + tool lines + retry notice), seeded with the placeholder/queue status; redraws wholly on change, tail-capped at 1000 code points.
- `answer` — append-only, seeded **empty** so the first answer snapshot is a clean prefix extension of `""`; prefix-stable byte cap unchanged (20 KB).

`flushPreview` diffs the two views separately and writes only the element that changed (`updateCardElement` targets by `element_id`), sharing one strictly increasing `sequence` from the single-writer pump. Churn is confined to the small process block; the answer's typewriter stays smooth. Worst case is two element writes per 1s frame — well under the 10 QPS per-entity cardkit quota.

Unchanged: settle still replaces the entity with the answer alone (`finalCardJson`, streaming off — the process block is preview-only), `mountFeishuPreview`'s signature, the queue-card takeover, the text-tier degrade, the streaming-closed freeze, and the terminal-write policy. Lark rides the same engine and inherits the fix.

## Tests

New `test/feishu-preview.test.ts` drives `streamFeishuReply` directly against a recording `FeishuApi` fake:

- streaming card mounts process + empty answer; settled card is the answer element alone;
- process churn (sliding tail, `…→✓` flip) lands only in the process element, and every answer-element write is a prefix extension of the previous one with no `💭`/`🔧` leakage; sequences strictly increase across both elements;
- an unchanged view writes nothing (no idle quota churn).

`npm run lint && npm run typecheck && npm test` — all green locally (1300 tests).