### PR TITLE
fix(feishu): state the reply-delivery contract where the model reads it

### DIFF
--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -27,11 +27,12 @@ import type { DownloadedFile, FeishuApi } from "./feishu-api.ts";
 import { type FeishuMention, parseContent } from "./parse.ts";
 import { REFERENT_MAX_CODE_POINTS, truncateCodePointPrefix } from "../text.ts";
 
-/** Appended to the prompt (not the system prompt): the channel renders the reply in a card, and the
- *  card's markdown element is the natural fit for LLM output — steer away from HTML/plain. The
- *  second sentence heads off the observed failure of answering through a send TOOL instead: the
- *  channel then settles an empty turn as "(no reply)" next to the tool's un-threaded duplicate. */
-const MARKDOWN_INSTRUCTION =
+/** The per-turn REPLY CONTRACT, appended to the prompt (not the system prompt). Two halves, one
+ *  concept — what happens to the reply: its FORMAT (rendered in a card whose markdown element is the
+ *  natural fit for LLM output — steer away from HTML/plain) and its DELIVERY OWNERSHIP (the channel
+ *  itself delivers it; answering through a send TOOL instead is the observed failure — the channel
+ *  then settles an empty turn as "(no reply)" next to the tool's un-threaded duplicate). */
+const REPLY_INSTRUCTION =
   "\n\n(Format your reply in standard Markdown — it is rendered in a Feishu/Lark card. This reply is " +
   "delivered to the current chat by the channel itself: do not call a send tool to answer the " +
   "current chat.)";
@@ -199,6 +200,6 @@ export async function* invokeFeishuTurn(
     yield { type: "failed", details: `could not load attachment: ${String(e)}`, retryable: true };
     return;
   }
-  const prompt = { text: `${text}${resolved.promptSuffix}${MARKDOWN_INSTRUCTION}`, images: resolved.images };
+  const prompt = { text: `${text}${resolved.promptSuffix}${REPLY_INSTRUCTION}`, images: resolved.images };
   yield* streamTurnWithBusyRetry(agent, session, prompt, { label: transport.label, onCompleted, busyRetry });
 }

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -28,8 +28,13 @@ import { type FeishuMention, parseContent } from "./parse.ts";
 import { REFERENT_MAX_CODE_POINTS, truncateCodePointPrefix } from "../text.ts";
 
 /** Appended to the prompt (not the system prompt): the channel renders the reply in a card, and the
- *  card's markdown element is the natural fit for LLM output — steer away from HTML/plain. */
-const MARKDOWN_INSTRUCTION = "\n\n(Format your reply in standard Markdown — it is rendered in a Feishu/Lark card.)";
+ *  card's markdown element is the natural fit for LLM output — steer away from HTML/plain. The
+ *  second sentence heads off the observed failure of answering through a send TOOL instead: the
+ *  channel then settles an empty turn as "(no reply)" next to the tool's un-threaded duplicate. */
+const MARKDOWN_INSTRUCTION =
+  "\n\n(Format your reply in standard Markdown — it is rendered in a Feishu/Lark card. This reply is " +
+  "delivered to the current chat by the channel itself: do not call a send tool to answer the " +
+  "current chat.)";
 
 /** Everything the transport needs to fetch a turn's attachments. */
 export interface FeishuTurnTransport {

--- a/src/channels/feishu/scaffold/feishu-send.ts
+++ b/src/channels/feishu/scaffold/feishu-send.ts
@@ -60,10 +60,11 @@ export default defineTool({
     "channel is carrying — a scheduled or self-scheduled (wake) turn, whose plain reply goes " +
     "nowhere — or to reach a chat OTHER than the one you are answering. In a normal chat turn the " +
     "channel streams and delivers your reply itself, so do NOT call this to answer the current " +
-    "chat: it would post the message twice, outside the conversation thread. `chatId` (oc_…) comes " +
-    "from the [feishu: chat …] context line in a chat turn; a scheduled/woken turn has no context " +
-    "line, so the destination must be named in your instructions. Pass exactly ONE of `text` " +
-    "(plain) or `markdown` (rendered as a card: headings, bold, code blocks, links).",
+    "chat: it would post the message twice, outside the conversation thread. `chatId` (oc_…) names " +
+    "the DESTINATION and must come from your instructions (the asking message, the schedule prompt, " +
+    "or memory); the [feishu: chat …] context line only identifies the chat you are answering — the " +
+    "one chat this tool must not target in a chat turn. Pass exactly ONE of `text` (plain) or " +
+    "`markdown` (rendered as a card: headings, bold, code blocks, links).",
   input: z.object({
     chatId: z.string().describe("target chat id (oc_…)"),
     text: z.string().optional().describe("plain text message to send"),

--- a/src/channels/feishu/scaffold/feishu-send.ts
+++ b/src/channels/feishu/scaffold/feishu-send.ts
@@ -56,12 +56,14 @@ async function tenantToken(): Promise<string> {
 
 export default defineTool({
   description:
-    "Send a message to a Feishu chat: plain `text`, or `markdown` (rendered as a card — headings, " +
-    "bold, code blocks, links). Exactly one of the two. Use it for a turn NO channel is carrying — a " +
-    "scheduled or self-scheduled (wake) turn — or to reach a chat OTHER than the one you are " +
-    "answering. In a normal chat turn the channel already delivers your reply, so do NOT call this to " +
-    "answer (it would post the message twice). chatId comes from the [feishu: chat …] context line in a " +
-    "chat turn; a scheduled/woken turn has no context line, so name the destination in your instruction.",
+    "Send a message to a Feishu chat, OUTSIDE the normal reply path. Call it only for a turn NO " +
+    "channel is carrying — a scheduled or self-scheduled (wake) turn, whose plain reply goes " +
+    "nowhere — or to reach a chat OTHER than the one you are answering. In a normal chat turn the " +
+    "channel streams and delivers your reply itself, so do NOT call this to answer the current " +
+    "chat: it would post the message twice, outside the conversation thread. `chatId` (oc_…) comes " +
+    "from the [feishu: chat …] context line in a chat turn; a scheduled/woken turn has no context " +
+    "line, so the destination must be named in your instructions. Pass exactly ONE of `text` " +
+    "(plain) or `markdown` (rendered as a card: headings, bold, code blocks, links).",
   input: z.object({
     chatId: z.string().describe("target chat id (oc_…)"),
     text: z.string().optional().describe("plain text message to send"),

--- a/src/channels/lark/scaffold/lark-send.ts
+++ b/src/channels/lark/scaffold/lark-send.ts
@@ -56,12 +56,14 @@ async function tenantToken(): Promise<string> {
 
 export default defineTool({
   description:
-    "Send a message to a Lark chat: plain `text`, or `markdown` (rendered as a card — headings, " +
-    "bold, code blocks, links). Exactly one of the two. Use it for a turn NO channel is carrying — a " +
-    "scheduled or self-scheduled (wake) turn — or to reach a chat OTHER than the one you are " +
-    "answering. In a normal chat turn the channel already delivers your reply, so do NOT call this to " +
-    "answer (it would post the message twice). chatId comes from the [lark: chat …] context line in a " +
-    "chat turn; a scheduled/woken turn has no context line, so name the destination in your instruction.",
+    "Send a message to a Lark chat, OUTSIDE the normal reply path. Call it only for a turn NO " +
+    "channel is carrying — a scheduled or self-scheduled (wake) turn, whose plain reply goes " +
+    "nowhere — or to reach a chat OTHER than the one you are answering. In a normal chat turn the " +
+    "channel streams and delivers your reply itself, so do NOT call this to answer the current " +
+    "chat: it would post the message twice, outside the conversation thread. `chatId` (oc_…) comes " +
+    "from the [lark: chat …] context line in a chat turn; a scheduled/woken turn has no context " +
+    "line, so the destination must be named in your instructions. Pass exactly ONE of `text` " +
+    "(plain) or `markdown` (rendered as a card: headings, bold, code blocks, links).",
   input: z.object({
     chatId: z.string().describe("target chat id (oc_…)"),
     text: z.string().optional().describe("plain text message to send"),

--- a/src/channels/lark/scaffold/lark-send.ts
+++ b/src/channels/lark/scaffold/lark-send.ts
@@ -60,10 +60,11 @@ export default defineTool({
     "channel is carrying — a scheduled or self-scheduled (wake) turn, whose plain reply goes " +
     "nowhere — or to reach a chat OTHER than the one you are answering. In a normal chat turn the " +
     "channel streams and delivers your reply itself, so do NOT call this to answer the current " +
-    "chat: it would post the message twice, outside the conversation thread. `chatId` (oc_…) comes " +
-    "from the [lark: chat …] context line in a chat turn; a scheduled/woken turn has no context " +
-    "line, so the destination must be named in your instructions. Pass exactly ONE of `text` " +
-    "(plain) or `markdown` (rendered as a card: headings, bold, code blocks, links).",
+    "chat: it would post the message twice, outside the conversation thread. `chatId` (oc_…) names " +
+    "the DESTINATION and must come from your instructions (the asking message, the schedule prompt, " +
+    "or memory); the [lark: chat …] context line only identifies the chat you are answering — the " +
+    "one chat this tool must not target in a chat turn. Pass exactly ONE of `text` (plain) or " +
+    "`markdown` (rendered as a card: headings, bold, code blocks, links).",
   input: z.object({
     chatId: z.string().describe("target chat id (oc_…)"),
     text: z.string().optional().describe("plain text message to send"),

--- a/test/feishu-send-tool.test.ts
+++ b/test/feishu-send-tool.test.ts
@@ -38,6 +38,12 @@ describe("canonical scaffold feishu-send: text-or-markdown mode switch", () => {
   it("steers the model away from using it to answer a normal chat turn (the channel already delivers)", () => {
     expect(description).toMatch(/do not call this to answer/i);
     expect(description).toMatch(/post the message twice/i);
+    // The tool's role is stated up front, and the addressing rule cannot point at the forbidden
+    // target: the destination comes from instructions — the context line only IDENTIFIES the
+    // current chat (the one chat a chat turn must not target).
+    expect(description).toMatch(/OUTSIDE the normal reply path/);
+    expect(description).toMatch(/must come from your instructions/i);
+    expect(description).toMatch(/only identifies the chat you are answering/i);
   });
 
   afterEach(() => {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -353,6 +353,9 @@ describe("turn flow", () => {
     expect(encodeURIComponent(worstCase).length).toBeLessThan(255);
     expect(calls[0]?.prompt.text).toContain("[feishu: chat oc_1 (p2p), from user ou_alice]");
     expect(calls[0]?.prompt.text).toContain("hello there");
+    // The reply contract rides every chat prompt: the channel owns delivery — no send-tool answering.
+    expect(calls[0]?.prompt.text).toContain("delivered to the current chat by the channel itself");
+    expect(calls[0]?.prompt.text).toContain("do not call a send tool");
     // Rule 2 (answer where asked): a plain send, neither quoted nor pushed into a thread.
     const mount = fx.calls("receive_id_type=chat_id", "POST").find((call) => call.body?.msg_type === "interactive");
     expect(mount).toBeDefined();
@@ -1782,6 +1785,8 @@ describe("the Lark compatibility profile", () => {
     expect(res.status).toBe(200);
     await maybeIdle?.();
     expect(calls[0]?.prompt.text).toContain("[lark: chat oc_1 (p2p)");
+    // The lark-branded assembly path carries the same reply contract as canonical feishu.
+    expect(calls[0]?.prompt.text).toContain("delivered to the current chat by the channel itself");
     expect(calls[0]?.scope.session).toBe("lark:oc_1"); // branded per channel, not per engine
     // A direct message is answered in place: a plain send, not a quoted thread reply.
     const mount = fx.calls("receive_id_type=chat_id", "POST").find((call) => call.body?.msg_type === "interactive");


### PR DESCRIPTION
## Problem

Field-observed on Lark: the model answered a chat turn by calling the scaffold send tool (an inline card via `sendMessage`), then streamed no final text. The turn ended as **two messages** — the tool's un-threaded card carrying the real answer, plus the preview card settled to a literal `(no reply)` under the reply quote.

## Fix

This is a model-behavior problem, so it is fixed **where behavior is set — the text the model reads** — not with channel-side heuristics policing the outcome after the fact (an earlier revision of this PR sniffed tool args and deleted the residue; that direction was dropped deliberately):

- **`invoke-turn.ts`** — the per-turn markdown instruction now states the channel itself delivers this reply to the current chat: do not answer through a send tool.
- **`feishu-send.ts` / `lark-send.ts` (scaffold)** — the send tool's description restated: it now leads with the tool's role (`OUTSIDE the normal reply path`), then the call/don't-call rule (scheduled/wake turns and OTHER chats vs. the current chat, where calling it posts the answer twice and outside the thread), then how to address a target — instead of burying the prohibition mid-paragraph in a run-on sentence.

No runtime behavior changes. `(no reply)` remains the honest terminal for a turn that truly said nothing — if the model still violates the contract, the residue stays visible rather than being masked by code.

## Tests

No new tests: prompt/description wording only. The existing `feishu-send-tool.test.ts` assertions (`do not call this to answer`, `post the message twice`) still pass verbatim against the new wording.

`npm run lint && npm run typecheck && npm test` — all green locally (1302 tests).