### PR TITLE
fix(agentcore): defer channel construction until the state root is restored

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -614,7 +614,15 @@ JSON object on the first ingress envelope and pushes a coalesced snapshot on the
 mints SigV4-presigned GET/PUT URLs and rides them on every envelope — keeping the container AWS-SDK-free
 and credential-free. Failure policy is fail-visible: a snapshot that exists but cannot be restored 503s
 the request (serving an empty agent would then overwrite the good copy with that emptiness), while a 404
-is first boot.
+is first boot. Channel construction is deferred to that same moment (`start` hands the adapter a LAZY
+channel surface, resolved memoized on the first envelope after `ready()`): channels load their state
+files and replay durable turn intent at construction, so building them at boot — against the
+pre-restore mount — would cache emptiness (thread participation, delivery dedup, pending turns) and
+then clobber the restored files with it. A construction failure 503s the envelope with its message and
+is retried on the next one; the deploy driver's post-deploy health probe (`deploy/agentcore/run.ts`)
+warms one session through the forwarder BEFORE webhook registration, so a bad credential or broken
+`channels/` module gates the deploy with its error text — the boot-time `failStartup` this host cannot
+have, restored at deploy time.
 
 **Credentials ride that snapshot, so the secrets dir is INSIDE the state root** (`/mnt/state/.secrets`,
 `deploy/agentcore/plan.ts` `SECRETS_DIR`) — the one place AgentCore departs from the sibling layout the

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -615,14 +615,21 @@ mints SigV4-presigned GET/PUT URLs and rides them on every envelope — keeping 
 and credential-free. Failure policy is fail-visible: a snapshot that exists but cannot be restored 503s
 the request (serving an empty agent would then overwrite the good copy with that emptiness), while a 404
 is first boot. Channel construction is deferred to that same moment (`start` hands the adapter a LAZY
-channel surface, resolved memoized on the first envelope after `ready()`): channels load their state
-files and replay durable turn intent at construction, so building them at boot — against the
-pre-restore mount — would cache emptiness (thread participation, delivery dedup, pending turns) and
-then clobber the restored files with it. A construction failure 503s the envelope with its message and
-is retried on the next one; the deploy driver's post-deploy health probe (`deploy/agentcore/run.ts`)
-warms one session through the forwarder BEFORE webhook registration, so a bad credential or broken
-`channels/` module gates the deploy with its error text — the boot-time `failStartup` this host cannot
-have, restored at deploy time.
+channel surface, resolved on the first trusted ingress — webhook, schedule fire, wake poke, or probe —
+after `ready()`): channels load their state files and replay durable turn intent at construction, so
+building them at boot — against the pre-restore mount — would cache emptiness (thread participation,
+delivery dedup, pending turns) and then clobber the restored files with it. The outcome is cached
+EITHER WAY, one activation per process: construction has side effects (healthy channels start and
+replay before another module's failure is reported) and no cleanup contract, so a retry could replay
+the same recovered turn concurrently — the retry boundary is a fresh session. A construction failure
+fails webhook/wake-poke requests (503) but not a schedule fire (cron does not consume channels; the
+error is logged). Verification moved to deploy time — the boot-time `failStartup` this host cannot
+have: `deploy agentcore --run` gates on a failed ingress-session stop (the probe must not "verify"
+the previous image), then drives the forwarder's reserved `/__fastagent/probe` path (answers on every
+forwarder topology; schedule-only URLs refuse ordinary public traffic), which relays a trusted
+`probe` envelope and passes back the runtime's transport-200 structured verdict `{ ok, error? }` —
+transport-200 because the ordinary webhook relay folds a non-200 into an opaque 502, which would
+strip exactly these diagnostics.
 
 **Credentials ride that snapshot, so the secrets dir is INSIDE the state root** (`/mnt/state/.secrets`,
 `deploy/agentcore/plan.ts` `SECRETS_DIR`) — the one place AgentCore departs from the sibling layout the

--- a/src/channels/agentcore.ts
+++ b/src/channels/agentcore.ts
@@ -30,7 +30,7 @@ import { timingSafeEqual } from "node:crypto";
 import type { Agent } from "../agent.ts";
 import type { StateSync, StateUrls } from "./agentcore-state.ts";
 import { beginWork, onIdle } from "./busy.ts";
-import type { Routes } from "../host/node.ts";
+import type { ChannelHandler, Routes } from "../host/node.ts";
 import { router } from "../host/node.ts";
 import { log } from "../log.ts";
 import { rememberWakeAlarmUrl } from "../schedule/wake-alarm.ts";
@@ -98,8 +98,13 @@ export interface WebhookReply {
 }
 
 export interface AgentcoreAdapterOptions {
-  /** The serving routes a direct deployment would mount (channels or the builtin invoke + health). */
-  routes: Routes;
+  /** The serving routes a direct deployment would mount (channels or the builtin invoke + health).
+   *  The serving path passes a LAZY factory: channel construction loads channel state and replays
+   *  durable turn intent, so on AgentCore it must not run until the state root is authoritative —
+   *  which happens at the first envelope's `stateSync.ready()` (the restore URLs only an envelope
+   *  carries), never at boot, where the mount is pre-restore (empty after every version update).
+   *  An eager `Routes` value remains supported for wirings whose state root is already durable. */
+  routes: Routes | (() => Promise<Routes> | Routes);
   agent: Agent;
   /** Where the forwarder URL from envelopes is persisted for the wake-alarm sink (the state root). */
   stateRoot: string;
@@ -144,7 +149,21 @@ function secretMatches(actual: unknown, expected: string | undefined): boolean {
  */
 export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
   const { routes, agent, stateRoot, isBusy, fire, stateSync, ingressSecret, onStateReady } = options;
-  const dispatch = router(routes);
+  // Lazy channel construction (see AgentcoreAdapterOptions.routes). Memoized on SUCCESS — one
+  // construction per process, the same resident channels a direct host keeps. A rejection is NOT
+  // cached: a transient failure (disk IO) heals on the next envelope, and a deterministic one (bad
+  // credentials, a broken channels/ module) then fails every envelope — and the deploy driver's
+  // post-deploy health probe — with its message, instead of one 503 followed by silence.
+  let dispatchP: Promise<ChannelHandler> | undefined;
+  const resolveDispatch = (): Promise<ChannelHandler> => {
+    if (dispatchP) return dispatchP;
+    const p = Promise.resolve(typeof routes === "function" ? routes() : routes).then(router);
+    dispatchP = p;
+    p.catch(() => {
+      if (dispatchP === p) dispatchP = undefined;
+    });
+    return p;
+  };
   const invokeHandler = createInvokeHandler(agent);
   // Snapshot on the 0-in-flight edge: webhook channels ACK fast and finish the turn in the
   // background, so "the request returned" is NOT when the state root settles.
@@ -245,6 +264,17 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
                 : undefined,
           },
         );
+        // Constructed HERE — after ready() — never at boot: the channels read their state files and
+        // replay turn intent at construction, and only now is the state root authoritative. A
+        // construction failure is the request's failure (503 through the forwarder, so the platform
+        // retries and the operator sees the message), never a silently-empty channel.
+        let dispatch: ChannelHandler;
+        try {
+          dispatch = await resolveDispatch();
+        } catch (e) {
+          log.error(`[agentcore] channel construction failed: ${String(e)}`);
+          return text(`channel construction failed: ${String(e)}\n`, 503);
+        }
         const response = await dispatch(inner);
         // Buffer the channel's ACK (webhook ACKs are small by design — the turn itself runs
         // fire-and-forget) and ride it inside the transport reply, byte-exact.
@@ -303,7 +333,17 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
       }
       case "wake-poke": {
         // The poke's job is DONE by arriving: the invocation woke (or kept awake) the container, and
-        // the wake pump (boot drain + 30s poll) fires whatever is due. Nothing to dispatch.
+        // the wake pump (boot drain + 30s poll) fires whatever is due. Nothing to dispatch — but the
+        // (lazy) channel construction resolves here too: construction is what replays checkpointed
+        // turn intent (turn-store recover()), so the first poke after a cold start re-runs an
+        // interrupted turn without waiting for fresh chat traffic — and the deploy driver's health
+        // probe gets construction failures surfaced instead of a hollow ok.
+        try {
+          await resolveDispatch();
+        } catch (e) {
+          log.error(`[agentcore] channel construction failed: ${String(e)}`);
+          return text(`channel construction failed: ${String(e)}\n`, 503);
+        }
         return json({ ok: true }, 200);
       }
       case "invoke": {

--- a/src/channels/agentcore.ts
+++ b/src/channels/agentcore.ts
@@ -87,6 +87,13 @@ export type AgentcoreEnvelope = {
    *  channel — lives on a mount the version update is about to erase. Flushing first is what makes
    *  "channels with replay re-run it" true rather than aspirational. */
   | { kind: "checkpoint" }
+  /** The deploy driver's post-deploy verification (relayed by the forwarder's reserved
+   *  `/__fastagent/probe` path, which answers on EVERY forwarder topology — schedule-only URLs
+   *  refuse ordinary public traffic). Runs restore + channel construction end to end and answers a
+   *  TRANSPORT-200 structured verdict `{ ok, error? }`: the ordinary webhook path folds a non-200
+   *  transport into an opaque 502 at the forwarder, which would strip exactly the diagnostics this
+   *  probe exists to carry. */
+  | { kind: "probe" }
 );
 
 /** The webhook envelope's reply: the channel's real HTTP response, ridden inside a transport-200
@@ -149,20 +156,27 @@ function secretMatches(actual: unknown, expected: string | undefined): boolean {
  */
 export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
   const { routes, agent, stateRoot, isBusy, fire, stateSync, ingressSecret, onStateReady } = options;
-  // Lazy channel construction (see AgentcoreAdapterOptions.routes). Memoized on SUCCESS — one
-  // construction per process, the same resident channels a direct host keeps. A rejection is NOT
-  // cached: a transient failure (disk IO) heals on the next envelope, and a deterministic one (bad
-  // credentials, a broken channels/ module) then fails every envelope — and the deploy driver's
-  // post-deploy health probe — with its message, instead of one 503 followed by silence.
+  // Lazy channel construction (see AgentcoreAdapterOptions.routes) — resolved ONCE per process, on
+  // the first trusted envelope after the state root is authoritative, and the outcome is cached
+  // EITHER WAY. Success: the same resident channels a direct host keeps. Failure too: construction
+  // is an ACTIVATION with side effects — loadChannels builds every healthy channel (starting its
+  // queues and replaying durable turn intent) before reporting another module's failure — and there
+  // is no cleanup contract to unwind it, so re-running it per envelope could replay the same
+  // recovered turn concurrently. The first rejection is therefore the process's answer: every later
+  // envelope fails with the same message (visible each time), the retry boundary is a fresh session
+  // (which scale-to-zero provides naturally), and the deploy driver's probe catches deterministic
+  // failures at deploy time.
   let dispatchP: Promise<ChannelHandler> | undefined;
   const resolveDispatch = (): Promise<ChannelHandler> => {
-    if (dispatchP) return dispatchP;
-    const p = Promise.resolve(typeof routes === "function" ? routes() : routes).then(router);
-    dispatchP = p;
-    p.catch(() => {
-      if (dispatchP === p) dispatchP = undefined;
-    });
-    return p;
+    if (!dispatchP) {
+      // The factory runs INSIDE the chain: a synchronous throw must land in the cached rejection,
+      // not escape before `dispatchP` is assigned (which would silently re-run the activation).
+      dispatchP = Promise.resolve()
+        .then(() => (typeof routes === "function" ? routes() : routes))
+        .then(router);
+      dispatchP.catch(() => {}); // observed here so the CACHED rejection is never "unhandled"
+    }
+    return dispatchP;
   };
   const invokeHandler = createInvokeHandler(agent);
   // Snapshot on the 0-in-flight edge: webhook channels ACK fast and finish the turn in the
@@ -181,7 +195,10 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
       return text("invalid json\n", 400);
     }
     if (envelope === null || typeof envelope !== "object" || typeof envelope.kind !== "string") {
-      return text('need { "kind": "webhook" | "schedule-fire" | "invoke" | "wake-poke" | "checkpoint", ... }\n', 400);
+      return text(
+        'need { "kind": "webhook" | "schedule-fire" | "invoke" | "wake-poke" | "checkpoint" | "probe", ... }\n',
+        400,
+      );
     }
     // AUTHENTICATION BOUNDARY. `InvokeAgentRuntime` is an ordinary IAM action, so "reached this
     // handler" proves nothing about the sender. Only an envelope carrying the shared secret is the
@@ -216,7 +233,7 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
       if (envelope.state && typeof envelope.state.getUrl === "string" && typeof envelope.state.putUrl === "string") {
         stateSync.use(envelope.state);
       } else if (envelope.kind !== "invoke" && !stateSync.configured() && !warnedUnsnapshotted) {
-        // webhook/schedule-fire/wake-poke reach us ONLY through the forwarder, which always mints the
+        // webhook/schedule-fire/wake-poke/probe reach us ONLY through the forwarder, which mints the
         // pair. Missing = a broken/stale topology whose state dies at the next deploy: say so, loudly,
         // once per process (a direct `invoke` legitimately has none — its session storage is its own).
         warnedUnsnapshotted = true;
@@ -226,6 +243,10 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
         await stateSync.ready();
       } catch (e) {
         log.error(`[agentcore] state restore failed: ${String(e)}`);
+        // The probe is the deploy driver's verification channel: its diagnostics must survive the
+        // forwarder, which folds a non-200 transport into an opaque 502 — so for it the failure
+        // rides a transport-200 structured verdict; every other kind keeps the plain 503.
+        if (envelope.kind === "probe") return json({ ok: false, error: `state restore failed: ${String(e)}` }, 200);
         return text(`state restore failed: ${String(e)}\n`, 503);
       }
     }
@@ -235,6 +256,25 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
     if (onStateReady && !stateReadyFired) {
       stateReadyFired = true;
       onStateReady();
+    }
+    // PROCESS INITIALIZATION, kind-independent: the (lazy) channels are constructed on the first
+    // trusted ingress after the state root became authoritative — whichever kind carries it, so a
+    // cold start woken by a schedule fire or an alarm poke still replays checkpointed turn intent.
+    // Two deliberate exceptions: `checkpoint` must push state even when a channel is broken, and a
+    // public `invoke` runs in its own isolated storage — constructing against THAT root would cache
+    // pre-restore emptiness for the ingress session. Failure policy is per kind below: webhook and
+    // wake-poke fail their request (503), the probe reports it structurally, and a schedule fire
+    // proceeds — cron does not consume channels, and letting an unrelated channel misconfiguration
+    // silence the clock would turn one fault into two (the error is logged here either way).
+    let constructionError: string | undefined;
+    let dispatch: ChannelHandler | undefined;
+    if (trusted && envelope.kind !== "checkpoint" && envelope.kind !== "invoke") {
+      try {
+        dispatch = await resolveDispatch();
+      } catch (e) {
+        constructionError = String(e);
+        log.error(`[agentcore] channel construction failed: ${constructionError}`);
+      }
     }
 
     switch (envelope.kind) {
@@ -264,17 +304,9 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
                 : undefined,
           },
         );
-        // Constructed HERE — after ready() — never at boot: the channels read their state files and
-        // replay turn intent at construction, and only now is the state root authoritative. A
-        // construction failure is the request's failure (503 through the forwarder, so the platform
-        // retries and the operator sees the message), never a silently-empty channel.
-        let dispatch: ChannelHandler;
-        try {
-          dispatch = await resolveDispatch();
-        } catch (e) {
-          log.error(`[agentcore] channel construction failed: ${String(e)}`);
-          return text(`channel construction failed: ${String(e)}\n`, 503);
-        }
+        // A construction failure is the request's failure (503 through the forwarder, so the
+        // platform retries and the operator sees the message), never a silently-empty channel.
+        if (!dispatch) return text(`channel construction failed: ${constructionError ?? "unavailable"}\n`, 503);
         const response = await dispatch(inner);
         // Buffer the channel's ACK (webhook ACKs are small by design — the turn itself runs
         // fire-and-forget) and ride it inside the transport reply, byte-exact.
@@ -333,18 +365,22 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
       }
       case "wake-poke": {
         // The poke's job is DONE by arriving: the invocation woke (or kept awake) the container, and
-        // the wake pump (boot drain + 30s poll) fires whatever is due. Nothing to dispatch — but the
-        // (lazy) channel construction resolves here too: construction is what replays checkpointed
-        // turn intent (turn-store recover()), so the first poke after a cold start re-runs an
-        // interrupted turn without waiting for fresh chat traffic — and the deploy driver's health
-        // probe gets construction failures surfaced instead of a hollow ok.
-        try {
-          await resolveDispatch();
-        } catch (e) {
-          log.error(`[agentcore] channel construction failed: ${String(e)}`);
-          return text(`channel construction failed: ${String(e)}\n`, 503);
-        }
+        // the wake pump (boot drain + 30s poll) fires whatever is due. Nothing to dispatch — the
+        // initialization above already resolved construction (replaying checkpointed turn intent),
+        // and its failure is this request's failure so the alarm's log line names it.
+        if (constructionError !== undefined) return text(`channel construction failed: ${constructionError}\n`, 503);
         return json({ ok: true }, 200);
+      }
+      case "probe": {
+        // The structured verdict (transport-200 — see the envelope doc): the deploy driver reads it
+        // through the forwarder's reserved path, so the error text survives the hop that turns any
+        // non-200 transport into an opaque 502.
+        return json(
+          constructionError === undefined
+            ? { ok: true }
+            : { ok: false, error: `channel construction failed: ${constructionError}` },
+          200,
+        );
       }
       case "invoke": {
         // Reuse the HTTP channel's handler wholesale (SSE, cancellation, backpressure) by handing it

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -18,7 +18,7 @@ import { logAgentLoop } from "../../observe.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { exists } from "../../paths.ts";
 import { bindAddress } from "../../bind.ts";
-import type { Routes } from "../../host/node.ts";
+import { type Routes, parseRouteKey } from "../../host/node.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import {
   assertTunnelBindable,
@@ -188,6 +188,17 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
         throw new Error(
           `long-connection channel(s) ${surface.longConnections.map((c) => c.name).join(", ")} cannot serve on ` +
             `AgentCore (scale-to-zero severs resident connections) — use the channel's webhook form`,
+        );
+      }
+      // mountSessionControl's PATH-level collision rule, re-asserted here: with no channels at boot
+      // its own check ran against an empty base, and a spread merge would silently let control win —
+      // but a channel on /control/* is the same configuration error it is on every other host.
+      const controlPaths = new Set(Object.keys(withControl.routes).map((key) => parseRouteKey(key).path));
+      const collisions = Object.keys(surface.routes).filter((key) => controlPaths.has(parseRouteKey(key).path));
+      if (collisions.length > 0) {
+        throw new Error(
+          `channel route(s) ${collisions.map((key) => `"${key}"`).join(", ")} collide with the session control ` +
+            `plane — rename the channel route or disable sessionControl in fastagent.config`,
         );
       }
       return { ...surface.routes, ...withControl.routes };

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -18,6 +18,7 @@ import { logAgentLoop } from "../../observe.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { exists } from "../../paths.ts";
 import { bindAddress } from "../../bind.ts";
+import type { Routes } from "../../host/node.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import {
   assertTunnelBindable,
@@ -130,15 +131,21 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   const agentcore = process.env.FASTAGENT_AGENTCORE === "1";
   // Same debug turn trace as dev; gated out here by the info level (see dev.ts serveOnce).
   const traced = logAgentLoop(agent);
-  const routed = await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: !agentcore }).catch(
-    failStartup,
-  );
+  // On AgentCore the channels are constructed LAZILY (mountAgentcore's lazyChannels, resolved on the
+  // first envelope after the state-snapshot restore): construction loads channel state and replays
+  // turn intent, and at boot the state mount is PRE-RESTORE — empty after every version update — so
+  // an eager build would cache that emptiness (thread participation, delivery dedup, pending turns)
+  // and then clobber the restored files with it. Everywhere else the state root is durable at boot,
+  // so channels mount eagerly and a broken channel fails startup.
+  const routed = agentcore
+    ? undefined
+    : await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: true }).catch(failStartup);
   // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
   // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
   const configured = config.http?.host;
   const host = bindFlag ?? (configured === undefined ? undefined : bindAddress(configured));
   assertTunnelBindable(host, opts.tunnel ?? false, bindFlag ? "flag" : "config");
-  const withControl = mountSessionControl(routed.routes, sessionControl, stateRoot, {
+  const withControl = mountSessionControl(routed?.routes ?? {}, sessionControl, stateRoot, {
     tunnel: opts.tunnel ?? false,
     agent: traced,
     host,
@@ -170,19 +177,37 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   });
   let routes = withControl.routes;
   if (agentcore) {
+    // The lazy channel surface the adapter resolves post-restore. Control routes ride along so a
+    // forwarder-relayed /control/* request dispatches the same as on a direct host. Long-connection
+    // channels cannot serve here — scale-to-zero severs a resident connection and nothing
+    // re-establishes it — so their presence is a configuration error, surfaced per envelope and by
+    // the deploy driver's health probe (there is no boot to fail on this host).
+    const lazyChannels = async (): Promise<Routes> => {
+      const surface = await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: false });
+      if (surface.longConnections.length > 0) {
+        throw new Error(
+          `long-connection channel(s) ${surface.longConnections.map((c) => c.name).join(", ")} cannot serve on ` +
+            `AgentCore (scale-to-zero severs resident connections) — use the channel's webhook form`,
+        );
+      }
+      return { ...surface.routes, ...withControl.routes };
+    };
     try {
-      routes = mountAgentcore(routes, { agent: traced, stateRoot, schedules, onStateReady });
+      routes = mountAgentcore(routes, { agent: traced, stateRoot, schedules, onStateReady, lazyChannels });
     } catch (e) {
       failStartup(e);
     }
     log.info(`[fastagent] agentcore: serving POST /invocations + GET /ping (FASTAGENT_AGENTCORE=1)`);
   }
   serve(
-    { ...routed, routes },
+    {
+      ...(routed ?? { longConnections: [], routeChannels: [], builtinInvoke: false, markReady() {} }),
+      routes,
+    },
     { port: portFlag ?? parsePort(process.env.PORT, "PORT env", "env") ?? config.http?.port ?? 8787, host },
     (p) => {
       withControl.announce(p);
-      maybeTunnel(agentDir, routed.routeChannels, p, opts.tunnel ?? false, stateRoot);
+      maybeTunnel(agentDir, routed?.routeChannels ?? [], p, opts.tunnel ?? false, stateRoot);
     },
   );
   // No graceful drain: webhook turns run fire-and-forget; SIGTERM just exits mid-turn. Whether an

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -188,11 +188,20 @@ export function mountSessionControl(
  */
 export function mountAgentcore(
   routes: Routes,
-  options: { agent: Agent; stateRoot: string; schedules: LoadedSchedule[]; onStateReady?: () => void },
+  options: {
+    agent: Agent;
+    stateRoot: string;
+    schedules: LoadedSchedule[];
+    onStateReady?: () => void;
+    /** The serving path's LAZY channel surface: constructed by the adapter on the first envelope
+     *  AFTER the state-snapshot restore, never at boot (channels/agentcore.ts). When absent,
+     *  `routes` is the dispatch target — for wirings whose state root is already authoritative. */
+    lazyChannels?: () => Promise<Routes>;
+  },
 ): Routes {
-  const { agent, stateRoot, schedules, onStateReady } = options;
+  const { agent, stateRoot, schedules, onStateReady, lazyChannels } = options;
   const mounted = agentcoreRoutes({
-    routes,
+    routes: lazyChannels ?? routes,
     agent,
     stateRoot,
     isBusy: () => activeWork() > 0,

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -450,6 +450,23 @@ exports.handler = async (event, ctx) => {
     if (failed > 0) return { statusCode: 500, body: \`\${failed} alarm(s) failed\\n\` };
     return { statusCode: 200, body: "ok\\n" };
   }
+  // The deploy driver's probe (reserved path, ingress secret): wake the runtime through the SAME
+  // trusted envelope pipeline (state URLs included — a direct InvokeAgentRuntime call could not mint
+  // them, and would make the runtime construct against a pre-restore mount) and pass its structured
+  // transport-200 verdict back VERBATIM. The ordinary webhook path below folds a non-200 transport
+  // into an opaque 502, which would strip exactly the diagnostics the probe exists to carry — and it
+  // sits BEFORE the WEBHOOKS_ENABLED gate so schedule-only topologies (whose URLs refuse ordinary
+  // public traffic) are probeable too.
+  if (event.rawPath === "/__fastagent/probe") {
+    const req = JSON.parse(event.isBase64Encoded ? Buffer.from(event.body, "base64").toString() : event.body || "{}");
+    if (!process.env.INGRESS_SECRET || req.auth !== process.env.INGRESS_SECRET) return { statusCode: 403, body: "forbidden\\n" };
+    const r = await invoke({ kind: "probe" });
+    if (r.status !== 200) {
+      console.log(\`probe transport error \${r.status}: \${r.body}\`);
+      return { statusCode: 502, body: "upstream error\\n" };
+    }
+    return { statusCode: 200, headers: { "content-type": "application/json" }, body: r.body.toString() };
+  }
   // Enforce the advertised ORIGINAL-body ceiling before base64 adds another 4/3 inside the runtime
   // envelope. This also leaves deterministic room for headers/query/JSON under Lambda's 6 MB cap.
   const webhookBytes = event.body === undefined ? 0

--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -57,6 +57,40 @@ export interface AgentcoreRunPlan {
 
 export type AgentcoreRunOutcome = { ok: true; runtimeArn: string; url?: string } | { ok: false; gate: string };
 
+/** How long the post-deploy health probe waits for the fresh session (image pull + microVM boot +
+ *  snapshot restore + channel construction) before gating with the last answer. */
+const PROBE_TIMEOUT_MS = 120_000;
+const PROBE_INTERVAL_MS = 3_000;
+
+/**
+ * Poll the forwarder-relayed `/health` until it answers 200 or the deadline passes; report the LAST
+ * failing answer (status + first body line). Every non-200 is retried until the deadline — the
+ * budget's job is to absorb cold-start provisioning, and a deterministic failure (the 503 whose body
+ * names a bad credential or broken channels/ module) simply holds until the deadline and then gates
+ * with that text. Network errors keep whatever answer was last seen.
+ */
+async function probeForwarderHealth(
+  healthUrl: string,
+  fetchImpl: typeof fetch,
+  timeoutMs = PROBE_TIMEOUT_MS,
+  intervalMs = PROBE_INTERVAL_MS,
+): Promise<{ ok: boolean; last?: string }> {
+  const deadline = Date.now() + timeoutMs;
+  let last: string | undefined;
+  for (;;) {
+    try {
+      const res = await fetchImpl(healthUrl, { signal: AbortSignal.timeout(65_000) });
+      if (res.ok) return { ok: true };
+      const body = (await res.text()).trim().split("\n")[0] ?? "";
+      last = `${res.status}${body ? ` ${body}` : ""}`;
+    } catch {
+      /* not routable yet (Function URL DNS, cold start) — keep polling until the deadline */
+    }
+    if (Date.now() >= deadline) return { ok: false, last };
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
 /** Stack outputs (`describe-stacks --query "Stacks[0].Outputs"`) → { OutputKey: OutputValue }. */
 export function parseStackOutputs(stdout: string): Record<string, string> {
   try {
@@ -135,6 +169,8 @@ export async function deployAgentcoreRun(
   registerTelegram: (baseUrl: string) => Promise<RegistrationOutcome>,
   registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<RegistrationOutcome>,
   registerSlack?: (baseUrl: string) => Promise<RegistrationOutcome>,
+  /** Injected in tests; the probe itself stays inside the run so no deploy can skip it. */
+  probe: { fetchImpl?: typeof fetch; timeoutMs?: number; intervalMs?: number } = {},
 ): Promise<AgentcoreRunOutcome> {
   const gate = (g: string): AgentcoreRunOutcome => ({ ok: false, gate: g });
   const stack = `fastagent-${plan.name}`;
@@ -460,6 +496,31 @@ export async function deployAgentcoreRun(
         if (firstLine) log(`warn: ${firstLine}`);
       }
     }
+  }
+
+  // 8c. Warm + verify the NEW serving path end to end, BEFORE registration: one GET /health through
+  //     the forwarder wakes a fresh session on the new image, which restores the state snapshot and
+  //     then constructs the channels — construction is deferred to exactly that moment
+  //     (channels/agentcore.ts), so this probe is where a bad credential, a broken channels/ module,
+  //     or an unrestorable snapshot surfaces AT DEPLOY TIME with its error text. There is no
+  //     boot-time failStartup on this host to catch those: construction must wait for the restore,
+  //     whose presigned URLs only an envelope carries.
+  if (url) {
+    log("warming the ingress session (state restore + channel construction)…");
+    const warmed = await probeForwarderHealth(
+      `${url}/health`,
+      probe.fetchImpl ?? fetch,
+      probe.timeoutMs,
+      probe.intervalMs,
+    );
+    if (!warmed.ok) {
+      return gate(
+        warmed.last
+          ? `the deployed runtime failed its health probe: ${warmed.last} — fix and re-run`
+          : "the forwarder URL never answered the health probe — check the Function URL / runtime logs and re-run",
+      );
+    }
+    log("ingress session warmed (state restored, channels constructed)");
   }
 
   // 9. Post-deploy webhook registration — same registrar seam as every host, pointed at the

--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -57,36 +57,67 @@ export interface AgentcoreRunPlan {
 
 export type AgentcoreRunOutcome = { ok: true; runtimeArn: string; url?: string } | { ok: false; gate: string };
 
-/** How long the post-deploy health probe waits for the fresh session (image pull + microVM boot +
- *  snapshot restore + channel construction) before gating with the last answer. */
+/** How long the post-deploy probe waits for the fresh session (image pull + microVM boot + snapshot
+ *  restore + channel construction) before gating with the last answer. */
 const PROBE_TIMEOUT_MS = 120_000;
 const PROBE_INTERVAL_MS = 3_000;
 
 /**
- * Poll the forwarder-relayed `/health` until it answers 200 or the deadline passes; report the LAST
- * failing answer (status + first body line). Every non-200 is retried until the deadline — the
- * budget's job is to absorb cold-start provisioning, and a deterministic failure (the 503 whose body
- * names a bad credential or broken channels/ module) simply holds until the deadline and then gates
- * with that text. Network errors keep whatever answer was last seen.
+ * Drive the forwarder's reserved `/__fastagent/probe` path until it answers, and read the runtime's
+ * STRUCTURED verdict. The path answers on every forwarder topology (a schedule-only URL refuses
+ * ordinary public traffic, so a plain `GET /health` would 404 there), and the verdict rides a
+ * transport-200 JSON body `{ ok, error? }` — the ordinary webhook relay folds a non-200 transport
+ * into an opaque 502, which would strip the very diagnostics this probe exists to carry.
+ *
+ * Outcome policy: `ok:true` verifies the deploy; `ok:false` gates IMMEDIATELY with the runtime's own
+ * error text (construction rejections are cached per session, so polling cannot change the answer);
+ * anything else (unroutable URL, forwarder 4xx/5xx, malformed body) is retried to the deadline —
+ * that budget's job is absorbing cold-start provisioning — and then gates with the last answer seen.
  */
-async function probeForwarderHealth(
-  healthUrl: string,
+async function probeRuntime(
+  probeUrl: string,
+  auth: string,
   fetchImpl: typeof fetch,
   timeoutMs = PROBE_TIMEOUT_MS,
   intervalMs = PROBE_INTERVAL_MS,
-): Promise<{ ok: boolean; last?: string }> {
+): Promise<{ ok: true } | { ok: false; gate: string }> {
   const deadline = Date.now() + timeoutMs;
   let last: string | undefined;
   for (;;) {
     try {
-      const res = await fetchImpl(healthUrl, { signal: AbortSignal.timeout(65_000) });
-      if (res.ok) return { ok: true };
-      const body = (await res.text()).trim().split("\n")[0] ?? "";
-      last = `${res.status}${body ? ` ${body}` : ""}`;
+      const res = await fetchImpl(probeUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ auth }),
+        signal: AbortSignal.timeout(65_000),
+      });
+      const bodyText = await res.text();
+      if (res.status === 200) {
+        let verdict: { ok?: unknown; error?: unknown } | undefined;
+        try {
+          verdict = JSON.parse(bodyText) as { ok?: unknown; error?: unknown };
+        } catch {
+          /* malformed — fall through to retry with it as the last answer */
+        }
+        if (verdict?.ok === true) return { ok: true };
+        if (verdict?.ok === false) {
+          const error = typeof verdict.error === "string" ? verdict.error : "unknown error";
+          return { ok: false, gate: `the deployed runtime failed its probe: ${error} — fix and re-run` };
+        }
+      }
+      const firstLine = bodyText.trim().split("\n")[0] ?? "";
+      last = `${res.status}${firstLine ? ` ${firstLine}` : ""}`;
     } catch {
       /* not routable yet (Function URL DNS, cold start) — keep polling until the deadline */
     }
-    if (Date.now() >= deadline) return { ok: false, last };
+    if (Date.now() >= deadline) {
+      return {
+        ok: false,
+        gate: last
+          ? `the forwarder probe never verified the deployment (last answer: ${last}) — check the runtime logs and re-run`
+          : "the forwarder URL never answered the probe — check the Function URL / runtime logs and re-run",
+      };
+    }
     await new Promise((r) => setTimeout(r, intervalMs));
   }
 }
@@ -488,48 +519,54 @@ export async function deployAgentcoreRun(
       if (/ResourceNotFound|not\s*found|does not exist/i.test(stderr)) {
         log("note: no ingress session to stop (first deploy, or already reclaimed)");
       } else {
-        log(
-          `warn: could not stop the ingress session — an ACTIVE session may keep serving the PREVIOUS ` +
-            `image until reclaimed (idle timeout / 8 h ceiling). Stop it manually: aws ${stopCommand.join(" ")}`,
-        );
+        // A GATE, not a warning: the probe below reaches the SAME fixed session id, so a session
+        // still running the previous image would answer it and the deploy would claim to have
+        // verified a serving path it never touched. Unable to guarantee the session is fresh =
+        // unable to verify = stop.
         const firstLine = stderr.trim().split("\n")[0];
-        if (firstLine) log(`warn: ${firstLine}`);
+        return gate(
+          `could not stop the ingress session — it may still be serving the PREVIOUS image, so the ` +
+            `deploy cannot verify the new one${firstLine ? ` (${firstLine})` : ""}. ` +
+            `Stop it manually (aws ${stopCommand.join(" ")}) and re-run`,
+        );
       }
     }
   }
 
-  // 8c. Warm + verify the NEW serving path end to end, BEFORE registration: one GET /health through
-  //     the forwarder wakes a fresh session on the new image, which restores the state snapshot and
-  //     then constructs the channels — construction is deferred to exactly that moment
-  //     (channels/agentcore.ts), so this probe is where a bad credential, a broken channels/ module,
-  //     or an unrestorable snapshot surfaces AT DEPLOY TIME with its error text. There is no
-  //     boot-time failStartup on this host to catch those: construction must wait for the restore,
-  //     whose presigned URLs only an envelope carries.
+  // 8c. Every forwarder topology MUST carry the ForwarderUrl output — schedule-only and
+  //     selfSchedule-only deployments included, since the probe below is their only construction
+  //     check (there is no boot-time failStartup on this host). A missing output means an edited
+  //     template; skipping the probe silently would let such a deploy report success unverified.
+  //     Only a pure-invoke deployment (no forwarder) legitimately has no URL and nothing to probe.
+  //     `channels.length` is belt-and-braces: the planner derives needsForwarder FROM the channel
+  //     list, but this gate must not silently trust that invariant across callers.
+  if ((plan.needsForwarder || plan.channels.length > 0) && !url) {
+    return gate(
+      "this deployment needs the forwarder but the stack has no ForwarderUrl output — regenerate the " +
+        "template with --force",
+    );
+  }
+
+  // 8d. Warm + verify the NEW serving path end to end, BEFORE registration: the probe wakes a fresh
+  //     session on the new image through the forwarder's reserved path, which restores the state
+  //     snapshot and constructs the channels — construction is deferred to exactly that moment
+  //     (channels/agentcore.ts), so this is where a bad credential, a broken channels/ module, or an
+  //     unrestorable snapshot surfaces AT DEPLOY TIME with the runtime's own error text.
   if (url) {
-    log("warming the ingress session (state restore + channel construction)…");
-    const warmed = await probeForwarderHealth(
-      `${url}/health`,
+    log("probing the deployed runtime (state restore + channel construction)…");
+    const verdict = await probeRuntime(
+      `${url}/__fastagent/probe`,
+      plan.secrets.FASTAGENT_INGRESS_SECRET ?? "",
       probe.fetchImpl ?? fetch,
       probe.timeoutMs,
       probe.intervalMs,
     );
-    if (!warmed.ok) {
-      return gate(
-        warmed.last
-          ? `the deployed runtime failed its health probe: ${warmed.last} — fix and re-run`
-          : "the forwarder URL never answered the health probe — check the Function URL / runtime logs and re-run",
-      );
-    }
-    log("ingress session warmed (state restored, channels constructed)");
+    if (!verdict.ok) return gate(verdict.gate);
+    log("runtime verified (state restored, channels constructed)");
   }
 
   // 9. Post-deploy webhook registration — same registrar seam as every host, pointed at the
   //    forwarder's Function URL. Gate policy is the shared registration-gate kernel.
-  if (plan.channels.length > 0 && !url) {
-    return gate(
-      "channels are declared but the stack has no ForwarderUrl output — regenerate the template with --force",
-    );
-  }
   const reg = registrationGate(log, "re-run to retry registration (steps already done are skipped)");
   if (url) {
     if (plan.channels.includes("telegram")) {

--- a/test/agentcore-adapter.test.ts
+++ b/test/agentcore-adapter.test.ts
@@ -110,21 +110,96 @@ describe("agentcore adapter: lazy channel construction", () => {
     expect(built).toBe(1); // memoized — the same resident channels a direct host keeps
   });
 
-  it("a failed construction 503s the envelope with its message, and the NEXT envelope retries", async () => {
-    let attempt = 0;
+  it("a failed construction 503s EVERY envelope with the same message — one activation per process", async () => {
+    // Construction is an ACTIVATION with side effects (loadChannels builds every healthy channel —
+    // replaying its durable turn intent — before reporting another module's failure) and has no
+    // cleanup contract, so the rejection is CACHED: a retry per envelope would re-run the healthy
+    // channels' recovery concurrently. The factory must run exactly once, however many envelopes
+    // (and 3s-apart deploy probes) follow; a fresh session is the retry boundary.
+    let attempts = 0;
     const routes = adapter({
       routes: () => {
-        attempt += 1;
-        if (attempt === 1) throw new Error("FEISHU_APP_SECRET is not set");
-        return health;
+        attempts += 1;
+        throw new Error("FEISHU_APP_SECRET is not set");
       },
     });
     const env: AgentcoreEnvelope = { kind: "webhook", method: "GET", path: "/health" };
     const failed = await postEnvelope(routes, env);
     expect(failed.status).toBe(503);
     expect(await failed.text()).toContain("FEISHU_APP_SECRET"); // named, never a silently-empty channel
-    const healed = await postEnvelope(routes, env); // a transient failure heals; a deterministic one keeps failing visibly
-    expect(healed.status).toBe(200);
+    const second = await postEnvelope(routes, env);
+    expect(second.status).toBe(503);
+    expect(await second.text()).toContain("FEISHU_APP_SECRET"); // visible every time, not one 503 then silence
+    expect(attempts).toBe(1); // the healthy channels' side effects ran once, not per envelope
+  });
+
+  it("a probe reports construction structurally over transport-200 (diagnostics must survive the forwarder)", async () => {
+    const ok = adapter({ routes: () => health });
+    const okRes = await postEnvelope(ok, { kind: "probe" });
+    expect(okRes.status).toBe(200);
+    expect(await okRes.json()).toEqual({ ok: true });
+
+    // The forwarder rewrites any non-200 transport into an opaque 502, so the failure verdict MUST
+    // ride a transport-200 body — that is the whole reason the probe kind exists.
+    const broken = adapter({
+      routes: () => {
+        throw new Error("FEISHU_APP_SECRET is not set");
+      },
+    });
+    const res = await postEnvelope(broken, { kind: "probe" });
+    expect(res.status).toBe(200);
+    const verdict = (await res.json()) as { ok: boolean; error?: string };
+    expect(verdict.ok).toBe(false);
+    expect(verdict.error).toContain("FEISHU_APP_SECRET");
+  });
+
+  it("a probe reports a FAILED RESTORE structurally too, and an unauthenticated probe is refused", async () => {
+    const sync = fakeStateSync({
+      ready: async () => {
+        throw new Error("snapshot GET failed: 403");
+      },
+    });
+    const routes = adapter({ stateSync: sync, routes: () => health });
+    const res = await postEnvelope(routes, {
+      kind: "probe",
+      state: { getUrl: "https://s3/g", putUrl: "https://s3/p" },
+    });
+    expect(res.status).toBe(200); // structured — not the plain 503 other kinds get
+    const verdict = (await res.json()) as { ok: boolean; error?: string };
+    expect(verdict.ok).toBe(false);
+    expect(verdict.error).toContain("state restore failed");
+
+    expect((await postUntrusted(adapter({ routes: () => health }), { kind: "probe" })).status).toBe(403);
+  });
+
+  it("a schedule fire initializes the channels first, and a broken channel does NOT silence the clock", async () => {
+    const order: string[] = [];
+    const fire = vi.fn(async (): Promise<ScheduleFireOutcome> => {
+      order.push("fire");
+      return { fired: true, ms: 5 };
+    });
+    const routes = adapter({
+      fire,
+      routes: () => {
+        order.push("construct");
+        return health;
+      },
+    });
+    const env: AgentcoreEnvelope = { kind: "schedule-fire", name: "job", slot: "2026-07-07T10:00:00Z" };
+    expect((await postEnvelope(routes, env)).status).toBe(200);
+    expect(order).toEqual(["construct", "fire"]); // cold start woken by cron still replays turn intent
+
+    // Construction failure: logged, but the fire still runs — cron does not consume channels, and an
+    // unrelated channel misconfiguration must not turn one fault into two.
+    const fire2 = vi.fn(async (): Promise<ScheduleFireOutcome> => ({ fired: true, ms: 5 }));
+    const broken = adapter({
+      fire: fire2,
+      routes: () => {
+        throw new Error("channels/lark.ts is broken");
+      },
+    });
+    expect((await postEnvelope(broken, env)).status).toBe(200);
+    expect(fire2).toHaveBeenCalledTimes(1);
   });
 
   it("a wake-poke resolves construction too (the deploy probe; alarm wakes replay checkpointed turns)", async () => {

--- a/test/agentcore-adapter.test.ts
+++ b/test/agentcore-adapter.test.ts
@@ -29,7 +29,7 @@ function scriptedAgent(events: AgentEvent[] = [{ type: "text", delta: "hi" }, { 
 const SECRET = "ingress-s3cret";
 
 interface AdapterOverrides {
-  routes?: Routes;
+  routes?: Routes | (() => Promise<Routes> | Routes);
   agent?: Agent;
   isBusy?: () => boolean;
   fire?: (name: string, slot: Date) => Promise<ScheduleFireOutcome>;
@@ -79,6 +79,75 @@ const postEnvelope = (routes: Routes, envelope: AgentcoreEnvelope): Promise<Resp
 /** Post as ANY IAM principal holding InvokeAgentRuntime (no shared secret). */
 const postUntrusted = (routes: Routes, envelope: AgentcoreEnvelope): Promise<Response> | Response =>
   post(routes, JSON.stringify(envelope));
+
+describe("agentcore adapter: lazy channel construction", () => {
+  const health: Routes = { "GET /health": () => new Response("ok\n") };
+  const stateUrls = { getUrl: "https://s3/get", putUrl: "https://s3/put" };
+
+  it("constructs the channels AFTER the state restore — once — and reuses them across envelopes", async () => {
+    const order: string[] = [];
+    const sync = fakeStateSync({
+      ready: async () => {
+        order.push("restore");
+      },
+    });
+    let built = 0;
+    const routes = adapter({
+      stateSync: sync,
+      routes: () => {
+        order.push("construct");
+        built += 1;
+        return health;
+      },
+    });
+    expect(built).toBe(0); // never at boot — the mount is pre-restore there
+    const env: AgentcoreEnvelope = { kind: "webhook", method: "GET", path: "/health", state: stateUrls };
+    const first = await postEnvelope(routes, env);
+    expect(first.status).toBe(200);
+    expect(((await first.json()) as WebhookReply).status).toBe(200);
+    expect(order).toEqual(["restore", "construct"]); // construction strictly after ready()
+    await postEnvelope(routes, env);
+    expect(built).toBe(1); // memoized — the same resident channels a direct host keeps
+  });
+
+  it("a failed construction 503s the envelope with its message, and the NEXT envelope retries", async () => {
+    let attempt = 0;
+    const routes = adapter({
+      routes: () => {
+        attempt += 1;
+        if (attempt === 1) throw new Error("FEISHU_APP_SECRET is not set");
+        return health;
+      },
+    });
+    const env: AgentcoreEnvelope = { kind: "webhook", method: "GET", path: "/health" };
+    const failed = await postEnvelope(routes, env);
+    expect(failed.status).toBe(503);
+    expect(await failed.text()).toContain("FEISHU_APP_SECRET"); // named, never a silently-empty channel
+    const healed = await postEnvelope(routes, env); // a transient failure heals; a deterministic one keeps failing visibly
+    expect(healed.status).toBe(200);
+  });
+
+  it("a wake-poke resolves construction too (the deploy probe; alarm wakes replay checkpointed turns)", async () => {
+    let built = 0;
+    const routes = adapter({
+      routes: () => {
+        built += 1;
+        return {};
+      },
+    });
+    expect((await postEnvelope(routes, { kind: "wake-poke" })).status).toBe(200);
+    expect(built).toBe(1);
+
+    const broken = adapter({
+      routes: () => {
+        throw new Error("channels/lark.ts is broken");
+      },
+    });
+    const res = await postEnvelope(broken, { kind: "wake-poke" });
+    expect(res.status).toBe(503);
+    expect(await res.text()).toContain("channels/lark.ts is broken");
+  });
+});
 
 describe("agentcore adapter: /ping", () => {
   it("reports Healthy when idle and HealthyBusy while background work is in flight", async () => {

--- a/test/agentcore-forwarder.test.ts
+++ b/test/agentcore-forwarder.test.ts
@@ -181,6 +181,44 @@ const webhookEvent = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
+describe("agentcore forwarder: the reserved probe path", () => {
+  const probeEvent = (auth: string) => webhookEvent({ rawPath: "/__fastagent/probe", body: JSON.stringify({ auth }) });
+
+  it("answers on a schedule-only URL (WEBHOOKS_ENABLED unset) and passes the verdict body through VERBATIM", async () => {
+    // Both halves of the probe's reason to exist: it must work where ordinary public traffic 404s,
+    // and the runtime's transport-200 structured verdict — including the failure text — must reach
+    // the deploy driver unrewritten (the webhook relay would fold it into an opaque 502).
+    const f = loadForwarder({
+      env: { WEBHOOKS_ENABLED: "" },
+      containerReply: (envelope) =>
+        envelope.kind === "probe"
+          ? { body: { ok: false, error: "channel construction failed: FEISHU_APP_SECRET is not set" } }
+          : { body: {} },
+    });
+    const res = await f.handler(probeEvent("ingress-s3cret"));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(String(res.body))).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("FEISHU_APP_SECRET"),
+    });
+    expect(f.envelopes).toHaveLength(1);
+    expect(f.envelopes[0]).toMatchObject({ kind: "probe", auth: "ingress-s3cret" }); // the trusted pipeline, not a webhook
+  });
+
+  it("refuses a probe without the ingress secret — the path must not become a public wake lever", async () => {
+    const f = loadForwarder();
+    const res = await f.handler(probeEvent("wrong"));
+    expect(res.statusCode).toBe(403);
+    expect(f.envelopes).toHaveLength(0); // rejected BEFORE waking AgentCore (cost/DoS)
+  });
+
+  it("a non-200 transport (old image without the probe kind, a runtime fault) is a 502, never a false verdict", async () => {
+    const f = loadForwarder({ containerReply: () => ({ statusCode: 424, body: "RuntimeClientError" }) });
+    const res = await f.handler(probeEvent("ingress-s3cret"));
+    expect(res.statusCode).toBe(502);
+  });
+});
+
 describe("agentcore forwarder (executed)", () => {
   it("a schedule-only URL rejects arbitrary HTTP before waking AgentCore", async () => {
     const f = loadForwarder({ env: { WEBHOOKS_ENABLED: "" } });

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -50,12 +50,12 @@ const plan = (over: Partial<AgentcoreRunPlan> = {}): AgentcoreRunPlan => ({
 const writeParams = vi.fn(async (_content: string) => "/tmp/params.json");
 const writeZip = vi.fn(async (_bytes: Uint8Array) => "/tmp/forwarder.zip");
 
-// The post-deploy health probe rides the global fetch by default; answer 200 so every existing flow
-// proceeds — the probe's own describe overrides this per test.
+// The post-deploy probe rides the global fetch by default; answer the ok verdict so every existing
+// flow proceeds — the probe's own describe overrides this per test.
 beforeEach(() => {
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => new Response("ok\n", { status: 200 })),
+    vi.fn(async () => Response.json({ ok: true })),
   );
 });
 afterEach(() => {
@@ -441,8 +441,12 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
     expect(logs.join("\n")).not.toContain("PREVIOUS");
   });
 
-  it("any OTHER stop failure warns loudly with the manual command — the old image may keep serving", async () => {
-    const logs: string[] = [];
+  it("any OTHER stop failure GATES — the probe would otherwise 'verify' the old image still serving", async () => {
+    // The probe reaches the same fixed ingress session id; if the stop cannot be confirmed, a
+    // session still running the previous image would answer it and the deploy would claim a
+    // verification it never performed. Unable to guarantee freshness = unable to verify = gate.
+    const probe = vi.fn();
+    vi.stubGlobal("fetch", probe);
     const { cli: aws } = fakeCli((a) =>
       a[0] === "bedrock-agentcore" && a[1] === "stop-runtime-session"
         ? { code: 254, stderr: "An error occurred (AccessDeniedException): not authorized" }
@@ -452,16 +456,14 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
       plan({ needsForwarder: true }),
       aws,
       fakeCli().cli,
-      (m) => logs.push(m),
+      () => {},
       writeParams,
       writeZip,
       async () => "registered",
     );
-    expect(out).toMatchObject({ ok: true }); // still not a gate — the deploy itself succeeded
-    const joined = logs.join("\n");
-    expect(joined).toContain("PREVIOUS");
-    expect(joined).toContain("stop-runtime-session");
-    expect(joined).toContain("AccessDeniedException");
+    expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("stop-runtime-session") });
+    expect((out as { gate: string }).gate).toContain("AccessDeniedException");
+    expect(probe).not.toHaveBeenCalled(); // no probe against a session of unknown vintage
   });
 
   it("a pure-invoke deployment (no ForwarderUrl output) stops no session", async () => {
@@ -540,14 +542,14 @@ describe("deploy/agentcore/run: helpers", () => {
   });
 });
 
-describe("the post-deploy health probe (warm + verify the new serving path before registration)", () => {
-  it("probes /health through the forwarder BEFORE registration and proceeds on 200", async () => {
-    const urls: string[] = [];
+describe("the post-deploy probe (verify restore + construction before registration)", () => {
+  it("POSTs the reserved probe path with the ingress secret BEFORE registration and proceeds on ok:true", async () => {
+    const requests: { url: string; body: string }[] = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (u: string | URL) => {
-        urls.push(String(u));
-        return new Response("ok\n", { status: 200 });
+      vi.fn(async (u: string | URL, init?: RequestInit) => {
+        requests.push({ url: String(u), body: String(init?.body) });
+        return Response.json({ ok: true });
       }),
     );
     const logs: string[] = [];
@@ -557,7 +559,7 @@ describe("the post-deploy health probe (warm + verify the new serving path befor
       return "registered";
     });
     const out = await deployAgentcoreRun(
-      plan({ channels: ["telegram"], needsForwarder: true }),
+      plan({ channels: ["telegram"], needsForwarder: true, secrets: { FASTAGENT_INGRESS_SECRET: "s3cret" } }),
       fakeCli(happyAws).cli,
       fakeCli().cli,
       (m) => logs.push(m),
@@ -566,21 +568,43 @@ describe("the post-deploy health probe (warm + verify the new serving path befor
       tg,
     );
     expect(out).toMatchObject({ ok: true });
-    expect(urls[0]).toBe("https://xyz.lambda-url.us-west-2.on.aws/health");
+    // The reserved path (works on EVERY forwarder topology — a schedule-only URL 404s /health), with
+    // the deploy's own credential in the body, never argv.
+    expect(requests[0]?.url).toBe("https://xyz.lambda-url.us-west-2.on.aws/__fastagent/probe");
+    expect(JSON.parse(requests[0]?.body ?? "{}")).toEqual({ auth: "s3cret" });
     // The probe ran BEFORE the registrar: registration verifies the URL, so the container must
     // already be restored + constructed when the platform's challenge arrives.
-    expect(logs.findIndex((l) => l.includes("warming"))).toBeLessThan(
+    expect(logs.findIndex((l) => l.includes("probing"))).toBeLessThan(
       logs.findIndex((l) => l.includes("registering telegram")),
     );
     expect(registered).toEqual(["telegram"]);
   });
 
-  it("gates with the runtime's OWN error text when the probe keeps answering non-200", async () => {
-    // The lazy channel construction's 503 body (channels/agentcore.ts) rides back verbatim through
-    // the forwarder — the deploy fails AT DEPLOY TIME with the misconfiguration named.
-    const fetchImpl = vi.fn(
-      async () => new Response("channel construction failed: FEISHU_APP_SECRET is not set\n", { status: 503 }),
+  it("gates IMMEDIATELY with the runtime's OWN error text on an ok:false verdict", async () => {
+    // The verdict rides a transport-200 structured reply (channels/agentcore.ts) precisely because
+    // the forwarder rewrites non-200 transports into an opaque 502 — and construction rejections are
+    // cached per session, so polling cannot change the answer: one round trip, one gate.
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ ok: false, error: "channel construction failed: FEISHU_APP_SECRET is not set" }),
     );
+    const out = await deployAgentcoreRun(
+      plan({ needsForwarder: true }),
+      fakeCli(happyAws).cli,
+      fakeCli().cli,
+      () => {},
+      writeParams,
+      writeZip,
+      async () => "registered",
+      undefined,
+      undefined,
+      { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 5_000, intervalMs: 1_000 },
+    );
+    expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("FEISHU_APP_SECRET is not set") });
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // deterministic — no pointless polling
+  });
+
+  it("retries a non-200 forwarder answer to the deadline, then gates with the LAST answer", async () => {
+    const fetchImpl = vi.fn(async () => new Response("forbidden\n", { status: 403 }));
     const out = await deployAgentcoreRun(
       plan({ needsForwarder: true }),
       fakeCli(happyAws).cli,
@@ -593,8 +617,8 @@ describe("the post-deploy health probe (warm + verify the new serving path befor
       undefined,
       { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 20, intervalMs: 1 },
     );
-    expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("FEISHU_APP_SECRET is not set") });
-    expect(fetchImpl.mock.calls.length).toBeGreaterThan(1); // non-200 is retried until the deadline
+    expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("403 forbidden") });
+    expect(fetchImpl.mock.calls.length).toBeGreaterThan(1);
   });
 
   it("a forwarder URL that never answers gates with the reachability message", async () => {
@@ -616,7 +640,22 @@ describe("the post-deploy health probe (warm + verify the new serving path befor
     expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("never answered") });
   });
 
-  it("a pure-invoke deployment (no ForwarderUrl) skips the probe — nothing to warm through", async () => {
+  it("a forwarder topology whose stack LOST the ForwarderUrl output gates — even with no channels", async () => {
+    // schedule-only / selfSchedule-only: needsForwarder without first-party channels. The probe is
+    // their ONLY construction check, so a missing URL must be a gate, not a silent skip + success.
+    const probe = vi.fn();
+    vi.stubGlobal("fetch", probe);
+    const { cli: aws } = fakeCli((a) =>
+      a[0] === "cloudformation" && a[1] === "describe-stacks"
+        ? { stdout: JSON.stringify([{ OutputKey: "RuntimeArn", OutputValue: "arn:x" }]) }
+        : happyAws(a),
+    );
+    const out = await run(plan({ needsForwarder: true }), aws, fakeCli().cli);
+    expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("ForwarderUrl") });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("a pure-invoke deployment (no forwarder) legitimately has no URL and skips the probe", async () => {
     const probe = vi.fn();
     vi.stubGlobal("fetch", probe);
     const { cli: aws } = fakeCli((a) =>

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RegistrationOutcome } from "../src/channels/registration.ts";
 import { AUTH_SEED_MAX_CHUNKS, ingressSessionId } from "../src/deploy/agentcore/plan.ts";
 import {
@@ -49,6 +49,18 @@ const plan = (over: Partial<AgentcoreRunPlan> = {}): AgentcoreRunPlan => ({
 
 const writeParams = vi.fn(async (_content: string) => "/tmp/params.json");
 const writeZip = vi.fn(async (_bytes: Uint8Array) => "/tmp/forwarder.zip");
+
+// The post-deploy health probe rides the global fetch by default; answer 200 so every existing flow
+// proceeds — the probe's own describe overrides this per test.
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response("ok\n", { status: 200 })),
+  );
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 const run = (
   p: AgentcoreRunPlan,
@@ -525,5 +537,95 @@ describe("deploy/agentcore/run: helpers", () => {
     for (const invalid of ["not json", "{}", '{"written":"true"}', "null"]) {
       expect(parseCheckpointReply(invalid)).toBeUndefined();
     }
+  });
+});
+
+describe("the post-deploy health probe (warm + verify the new serving path before registration)", () => {
+  it("probes /health through the forwarder BEFORE registration and proceeds on 200", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (u: string | URL) => {
+        urls.push(String(u));
+        return new Response("ok\n", { status: 200 });
+      }),
+    );
+    const logs: string[] = [];
+    const registered: string[] = [];
+    const tg = vi.fn(async (): Promise<RegistrationOutcome> => {
+      registered.push("telegram");
+      return "registered";
+    });
+    const out = await deployAgentcoreRun(
+      plan({ channels: ["telegram"], needsForwarder: true }),
+      fakeCli(happyAws).cli,
+      fakeCli().cli,
+      (m) => logs.push(m),
+      writeParams,
+      writeZip,
+      tg,
+    );
+    expect(out).toMatchObject({ ok: true });
+    expect(urls[0]).toBe("https://xyz.lambda-url.us-west-2.on.aws/health");
+    // The probe ran BEFORE the registrar: registration verifies the URL, so the container must
+    // already be restored + constructed when the platform's challenge arrives.
+    expect(logs.findIndex((l) => l.includes("warming"))).toBeLessThan(
+      logs.findIndex((l) => l.includes("registering telegram")),
+    );
+    expect(registered).toEqual(["telegram"]);
+  });
+
+  it("gates with the runtime's OWN error text when the probe keeps answering non-200", async () => {
+    // The lazy channel construction's 503 body (channels/agentcore.ts) rides back verbatim through
+    // the forwarder — the deploy fails AT DEPLOY TIME with the misconfiguration named.
+    const fetchImpl = vi.fn(
+      async () => new Response("channel construction failed: FEISHU_APP_SECRET is not set\n", { status: 503 }),
+    );
+    const out = await deployAgentcoreRun(
+      plan({ needsForwarder: true }),
+      fakeCli(happyAws).cli,
+      fakeCli().cli,
+      () => {},
+      writeParams,
+      writeZip,
+      async () => "registered",
+      undefined,
+      undefined,
+      { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 20, intervalMs: 1 },
+    );
+    expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("FEISHU_APP_SECRET is not set") });
+    expect(fetchImpl.mock.calls.length).toBeGreaterThan(1); // non-200 is retried until the deadline
+  });
+
+  it("a forwarder URL that never answers gates with the reachability message", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND");
+    });
+    const out = await deployAgentcoreRun(
+      plan({ needsForwarder: true }),
+      fakeCli(happyAws).cli,
+      fakeCli().cli,
+      () => {},
+      writeParams,
+      writeZip,
+      async () => "registered",
+      undefined,
+      undefined,
+      { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 20, intervalMs: 1 },
+    );
+    expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("never answered") });
+  });
+
+  it("a pure-invoke deployment (no ForwarderUrl) skips the probe — nothing to warm through", async () => {
+    const probe = vi.fn();
+    vi.stubGlobal("fetch", probe);
+    const { cli: aws } = fakeCli((a) =>
+      a[0] === "cloudformation" && a[1] === "describe-stacks"
+        ? { stdout: JSON.stringify([{ OutputKey: "RuntimeArn", OutputValue: "arn:x" }]) }
+        : happyAws(a),
+    );
+    const out = await run(plan(), aws, fakeCli().cli);
+    expect(out).toMatchObject({ ok: true });
+    expect(probe).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem (field-observed on a live AgentCore deployment)

After every cold start the agent forgot which threads it takes part in: a bare reply in a thread it had been serving was buffered as bystander discussion until someone @mentioned it again. That is the visible symptom of a worse fault — **silent state clobbering**:

- Channels load their state files ONCE at construction (thread participation, delivery dedup, context buffers, pending turns) and replay durable turn intent there (`turn-store recover()`).
- On AgentCore the state root becomes authoritative only at the **first envelope** — the snapshot's presigned URLs are minted per envelope by the forwarder, so the restore cannot run at boot.
- But `start` built the channels **at boot**, against the pre-restore (empty) mount: restored files were invisible, whole-map persists overwrote them with near-empty state, the idle snapshot pushed that emptiness back to S3, and checkpointed turn intent never replayed.

## Fix

**Lazy channel construction** — `start` hands `mountAgentcore` a lazy channel surface; the adapter resolves it after `stateSync.ready()` on the first trusted ingress (**webhook, schedule-fire, wake-poke, or probe** — a cold start woken by cron still replays checkpointed turns; `checkpoint` and public `invoke` stay excluded by design). The outcome is **cached either way, one activation per process**: construction has side effects (healthy channels start and replay before another module's failure is reported) and no cleanup contract, so a per-envelope retry could replay the same recovered turn concurrently — every later envelope fails with the same visible message, and a fresh session is the retry boundary. Failure policy per kind: webhook/wake-poke 503, probe reports structurally, schedule-fire logs and still fires (cron does not consume channels). The lazy surface re-asserts `mountSessionControl`'s path-level collision rule (a channel on `/control/*` stays a configuration error) and refuses long-connection channels (scale-to-zero severs resident connections).

**Deploy-time verification** — boot-time `failStartup` cannot exist on this host, so `deploy agentcore --run` verifies instead, with an end-to-end diagnostic path:

- The forwarder gains a reserved **`/__fastagent/probe`** path (ingress-secret authed, before the `WEBHOOKS_ENABLED` gate — so schedule-only/selfSchedule-only topologies, whose URLs refuse ordinary public traffic, are probeable too). It relays a trusted `probe` envelope through the same pipeline that mints state URLs.
- The runtime answers a **transport-200 structured verdict** `{ ok, error? }` (state-restore failures included) and the forwarder passes the body through verbatim — the ordinary webhook relay folds any non-200 transport into an opaque 502, which would strip exactly these diagnostics.
- The driver **gates**: on a failed ingress-session stop (the probe must not "verify" the previous image still serving), on a forwarder topology whose stack lost its `ForwarderUrl` output (previously a silent skip + reported success for schedule-only deploys), and on an `ok:false` verdict — immediately, with the runtime's own error text.

Other hosts are unchanged: their state roots are durable at boot, so channels keep mounting eagerly and failing startup loudly.

## Tests (1317 all green: lint / typecheck / npm test)

- **adapter**: construction strictly after `ready()`, never at boot; memoized across envelopes; cached rejection — factory runs exactly once while every envelope 503s with the message; probe verdicts (ok / construction failure / restore failure / unauthenticated 403); schedule-fire initializes first and still fires on construction failure.
- **forwarder (executing `forwarderSource()`)**: probe answers on a schedule-only URL and passes the verdict body through verbatim; wrong secret 403s before waking AgentCore; non-200 transport → 502, never a false verdict.
- **run**: probe POSTs the reserved path with the secret before registration; `ok:false` gates immediately with the runtime's text; non-200 retried to deadline then gates with the last answer; unreachable URL gates; stop failure gates (and the probe is not sent); missing `ForwarderUrl` on a forwarder topology gates; pure-invoke skips.
- `docs/design/core.md` §9 updated.