### PR TITLE
fix(feishu): read a quoted card, and say when it is the agent's own

### DIFF
--- a/src/channels/feishu/feishu-api.ts
+++ b/src/channels/feishu/feishu-api.ts
@@ -160,11 +160,21 @@ export interface FeishuApi {
   editTextMessage(messageId: string, text: string): Promise<void>;
   /** Recall (delete) a message the bot sent. */
   deleteMessage(messageId: string): Promise<void>;
-  /** Fetch one message (the reply-referent path). Undefined when the API returns no item. */
-  getMessage(
-    messageId: string,
-  ): Promise<
-    | { message_id?: string; msg_type?: string; body?: { content?: string }; mentions?: unknown[]; sender?: unknown }
+  /** Fetch one message (the reply-referent path). Undefined when the API returns no item.
+   *
+   *  `parent_id` and `sender.sender_type` are part of the platform's message object and are named here
+   *  because the referent path READS them: an app-sent referent is the agent's own message (label it
+   *  as such instead of "user cli_…"), and its own `parent_id` is the ask it was answering — the one
+   *  hop that recovers the room's question when a thread is opened on the agent's answer. */
+  getMessage(messageId: string): Promise<
+    | {
+        message_id?: string;
+        msg_type?: string;
+        parent_id?: string;
+        body?: { content?: string };
+        mentions?: unknown[];
+        sender?: { id?: string; id_type?: string; sender_type?: string };
+      }
     | undefined
   >;
   /** Download a message resource (image/file bytes). Caps at {@link MAX_DOWNLOAD_BYTES}. */

--- a/src/channels/feishu/feishu-api.ts
+++ b/src/channels/feishu/feishu-api.ts
@@ -162,15 +162,14 @@ export interface FeishuApi {
   deleteMessage(messageId: string): Promise<void>;
   /** Fetch one message (the reply-referent path). Undefined when the API returns no item.
    *
-   *  `parent_id` and `sender.sender_type` are part of the platform's message object and are named here
-   *  because the referent path READS them: an app-sent referent is the agent's own message (label it
-   *  as such instead of "user cli_…"), and its own `parent_id` is the ask it was answering — the one
-   *  hop that recovers the room's question when a thread is opened on the agent's answer. */
+   *  `sender` is typed rather than `unknown` because the referent path READS it: an app-sent message
+   *  whose id is THIS app's is the agent's own, which the prompt must say instead of attributing it to
+   *  "user cli_…". The message object carries more (`parent_id`, `root_id`, `thread_id`); they stay
+   *  unnamed until something reads them — this type is the surface in use, not a mirror of the wire. */
   getMessage(messageId: string): Promise<
     | {
         message_id?: string;
         msg_type?: string;
-        parent_id?: string;
         body?: { content?: string };
         mentions?: unknown[];
         sender?: { id?: string; id_type?: string; sender_type?: string };

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -468,7 +468,7 @@ function createFeishuRuntimeFactory(
               agent,
               rec.session,
               prompt,
-              { api, chatId: rec.chatId, filesDir: join(stateHome, "files"), label },
+              { api, chatId: rec.chatId, filesDir: join(stateHome, "files"), label, appId },
               { primary: { images: rec.images, files: rec.files, parentId: rec.parentId }, buffered },
               () => {
                 // Drop intent first: a crash between these writes may re-fold answered context later,

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -118,10 +118,10 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
       //
       // OWN means THIS app, not "an app". A group can hold several bots, and `sender_type === "app"`
       // is true for every one of them — matching on it alone would tell the model it wrote another
-      // bot's message and would walk that bot's reply chain (below). The identity to compare is the
-      // app id, because an app sender carries `id_type: "app_id"`: the cached bot open_id answers a
-      // different question (who was @mentioned) and would never match here. A missing or unexpected
-      // id fails CLOSED — not own, no extra hop — which is the pre-existing behaviour.
+      // bot's message. The identity to compare is the app id, because an app sender carries
+      // `id_type: "app_id"`: the cached bot open_id answers a different question (who was @mentioned)
+      // and would never match here. A missing or unexpected id fails CLOSED — labelled by id, never
+      // claimed as the agent's own.
       const appSender = parent.sender?.sender_type === "app";
       const senderId = parent.sender?.id;
       const ownMessage = appSender && senderId === t.appId;
@@ -129,32 +129,16 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
       // in a quieter form, so the noun follows the sender type.
       const from = ownMessage ? "you, the agent" : senderId ? `${appSender ? "app" : "user"} ${senderId}` : undefined;
       referentBlock = `\n\n[replied-to message (msg ${parentId}${from ? `, from ${from}` : ""}): ${truncateCodePointPrefix(parsed.text, REFERENT_MAX_CODE_POINTS) || "(empty)"}]`;
-      // ONE further hop, and only through the agent's OWN message: quoting an answer means pointing at
-      // an exchange, and the half that says what was ASKED is the message that answer was replying to.
-      // This is the thread-bootstrap case — a topic opened on a room-level answer starts with an empty
-      // session, so without this the model gets its own reply with no idea what prompted it.
-      //
-      // Bounded deliberately: one hop, text only. Never through a human's message (there the quote IS
-      // what the user pointed at, and walking further would drag in messages nobody referenced), and
-      // no resources — an attachment two hops away was not pointed at by anyone in this turn, and
-      // loading it is a primary failure that could cost the answer.
-      if (ownMessage && parent.parent_id !== undefined) {
-        const askId = parent.parent_id;
-        const ask = await t.api.getMessage(askId).catch(() => undefined);
-        if (ask) {
-          const askText = truncateCodePointPrefix(
-            parseContent({
-              message_type: ask.msg_type ?? "unknown",
-              content: ask.body?.content ?? "",
-              mentions: ask.mentions as FeishuMention[] | undefined,
-            }).text,
-            REFERENT_MAX_CODE_POINTS,
-          );
-          // Silence beats a marker here: unlike the referent itself, nobody pointed at this message, so
-          // an empty or unreadable one is not a loss the model needs to be told about.
-          if (askText) referentBlock += `\n[which answered (msg ${askId}): ${askText}]`;
-        }
-      }
+      // The chain STOPS here, at the one message the user pointed at. Walking further — to what that
+      // message was itself replying to — was built and removed: it reconstructs HISTORY out of reply
+      // pointers, and history is the session's job. That framing has no non-arbitrary answers (how
+      // many levels? what about the level above that? how is it deduplicated against what the session
+      // already holds? how does an IMAGE two levels up become prompt text at all?), and every one of
+      // those questions is a symptom of solving a session-layer problem in the prompt layer. The real
+      // gap it was papering over — a thread opened on a room answer starts with an EMPTY session while
+      // the room's session holds the exchange — belongs to memory inheritance (design/participant-
+      // model.md §8, rungs 3-4), where images and tool results come along for free because they are
+      // already in the history rather than being re-serialised into a prompt string.
     }
   }
 

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -43,6 +43,10 @@ export interface FeishuTurnTransport {
   chatId: string;
   filesDir: string;
   label: string;
+  /** THIS app's own id (`cli_…`) — the identity a fetched message's `sender.id` carries when the
+   *  sender is an app. Needed to tell the agent's OWN messages from any other bot's in the same chat:
+   *  `sender_type` alone says "some app", which is not the question the referent path asks. */
+  appId: string;
 }
 
 /** An attachment reference: the resource key inside its CARRYING message (the resource API addresses
@@ -111,9 +115,46 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
       for (const ref of parsed.fileRefs) files.push({ msg: parentId, key: ref.key, name: ref.name });
       // getMessage's sender is `{ id, id_type, sender_type }` — a DIFFERENT shape from the event's
       // sender (`{ sender_id: { open_id } }`), so the label is built here, not via parse.senderLabel.
-      const senderId = (parent.sender as { id?: string } | undefined)?.id;
-      const from = senderId ? `user ${senderId}` : undefined;
+      //
+      // OWN means THIS app, not "an app". A group can hold several bots, and `sender_type === "app"`
+      // is true for every one of them — matching on it alone would tell the model it wrote another
+      // bot's message and would walk that bot's reply chain (below). The identity to compare is the
+      // app id, because an app sender carries `id_type: "app_id"`: the cached bot open_id answers a
+      // different question (who was @mentioned) and would never match here. A missing or unexpected
+      // id fails CLOSED — not own, no extra hop — which is the pre-existing behaviour.
+      const appSender = parent.sender?.sender_type === "app";
+      const senderId = parent.sender?.id;
+      const ownMessage = appSender && senderId === t.appId;
+      // An app is not a person: labelling another bot's message "user cli_…" is the same misattribution
+      // in a quieter form, so the noun follows the sender type.
+      const from = ownMessage ? "you, the agent" : senderId ? `${appSender ? "app" : "user"} ${senderId}` : undefined;
       referentBlock = `\n\n[replied-to message (msg ${parentId}${from ? `, from ${from}` : ""}): ${truncateCodePointPrefix(parsed.text, REFERENT_MAX_CODE_POINTS) || "(empty)"}]`;
+      // ONE further hop, and only through the agent's OWN message: quoting an answer means pointing at
+      // an exchange, and the half that says what was ASKED is the message that answer was replying to.
+      // This is the thread-bootstrap case — a topic opened on a room-level answer starts with an empty
+      // session, so without this the model gets its own reply with no idea what prompted it.
+      //
+      // Bounded deliberately: one hop, text only. Never through a human's message (there the quote IS
+      // what the user pointed at, and walking further would drag in messages nobody referenced), and
+      // no resources — an attachment two hops away was not pointed at by anyone in this turn, and
+      // loading it is a primary failure that could cost the answer.
+      if (ownMessage && parent.parent_id !== undefined) {
+        const askId = parent.parent_id;
+        const ask = await t.api.getMessage(askId).catch(() => undefined);
+        if (ask) {
+          const askText = truncateCodePointPrefix(
+            parseContent({
+              message_type: ask.msg_type ?? "unknown",
+              content: ask.body?.content ?? "",
+              mentions: ask.mentions as FeishuMention[] | undefined,
+            }).text,
+            REFERENT_MAX_CODE_POINTS,
+          );
+          // Silence beats a marker here: unlike the referent itself, nobody pointed at this message, so
+          // an empty or unreadable one is not a loss the model needs to be told about.
+          if (askText) referentBlock += `\n[which answered (msg ${askId}): ${askText}]`;
+        }
+      }
     }
   }
 

--- a/src/channels/feishu/normalize.ts
+++ b/src/channels/feishu/normalize.ts
@@ -22,7 +22,9 @@ export interface DecodedFeishuContent {
   resources: DecodedFeishuResource[];
 }
 
-/** One node of a post (rich text) paragraph — text/a/at/img/media/code_block and friends. */
+/** One node of a post (rich text) paragraph — text/a/at/img/media/code_block and friends. A received
+ *  CARD's elements are the same tagged-node shape (the platform renders a card down to this on the way
+ *  out), so both decoders read one node walker. */
 interface PostNode {
   tag?: string;
   text?: string;
@@ -33,7 +35,52 @@ interface PostNode {
   file_key?: string;
   file_name?: string;
   language?: string;
+  placeholder?: string;
+  elements?: unknown;
   [k: string]: unknown;
+}
+
+/**
+ * Render one paragraph of tagged nodes to a line, pushing any resource it carries.
+ *
+ * Shared by `post` and `interactive` because the platform hands both out in the same shape. Card-only
+ * shapes are handled here rather than in a second walker: `note` nests its own `elements`, and the
+ * widget tags (button/select/overflow/date_picker) carry their user-visible label in `text` or
+ * `placeholder` — a card is read for what it SAYS, so a label is content and an unlabelled control is
+ * nothing.
+ */
+function renderNodes(nodes: unknown, resources: DecodedFeishuResource[]): string {
+  if (!Array.isArray(nodes)) return "";
+  const parts: string[] = [];
+  for (const raw of nodes) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const node = raw as PostNode;
+    if (node.tag === "at") {
+      parts.push(`@${nonEmptyString(node.user_name) ?? nonEmptyString(node.user_id) ?? "user"}`);
+    } else if (node.tag === "a") {
+      parts.push(node.href ? `${nonEmptyString(node.text) ?? node.href} (${node.href})` : (node.text ?? ""));
+    } else if (node.tag === "img") {
+      const key = nonEmptyString(node.image_key);
+      if (key) resources.push({ kind: "image", key });
+      parts.push("[image]");
+    } else if (node.tag === "media") {
+      const key = nonEmptyString(node.file_key);
+      if (key) resources.push({ kind: "video", key, name: nonEmptyString(node.file_name) });
+      parts.push("[video]");
+    } else if (node.tag === "code_block") {
+      parts.push(
+        `\n\`\`\`${nonEmptyString(node.language)?.toLowerCase() ?? ""}\n${nonEmptyString(node.text) ?? ""}\n\`\`\`\n`,
+      );
+    } else if (node.tag === "note") {
+      const nested = renderNodes(node.elements, resources);
+      if (nested) parts.push(nested);
+    } else if (nonEmptyString(node.text)) {
+      parts.push(node.text as string);
+    } else if (nonEmptyString(node.placeholder)) {
+      parts.push(node.placeholder as string);
+    }
+  }
+  return parts.join("").trim();
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -76,34 +123,37 @@ export function decodeFeishuContent(
       if (title) lines.push(title);
       const paragraphs = Array.isArray(content.content) ? (content.content as PostNode[][]) : [];
       for (const paragraph of paragraphs) {
-        if (!Array.isArray(paragraph)) continue;
-        const parts: string[] = [];
-        for (const node of paragraph) {
-          if (typeof node !== "object" || node === null) continue;
-          if (node.tag === "at") {
-            parts.push(`@${nonEmptyString(node.user_name) ?? nonEmptyString(node.user_id) ?? "user"}`);
-          } else if (node.tag === "a") {
-            parts.push(node.href ? `${nonEmptyString(node.text) ?? node.href} (${node.href})` : (node.text ?? ""));
-          } else if (node.tag === "img") {
-            const key = nonEmptyString(node.image_key);
-            if (key) resources.push({ kind: "image", key });
-            parts.push("[image]");
-          } else if (node.tag === "media") {
-            const key = nonEmptyString(node.file_key);
-            if (key) resources.push({ kind: "video", key, name: nonEmptyString(node.file_name) });
-            parts.push("[video]");
-          } else if (node.tag === "code_block") {
-            parts.push(
-              `\n\`\`\`${nonEmptyString(node.language)?.toLowerCase() ?? ""}\n${nonEmptyString(node.text) ?? ""}\n\`\`\`\n`,
-            );
-          } else if (nonEmptyString(node.text)) {
-            parts.push(node.text as string);
-          }
-        }
-        const line = parts.join("").trim();
+        const line = renderNodes(paragraph, resources);
         if (line) lines.push(line);
       }
       return { text: lines.join("\n"), resources };
+    }
+    // A CARD, as the platform hands it BACK. What we send is an entity reference
+    // (`{type:"card",data:{card_id}}`, card.ts) whose text lives in cardkit — but a query API renders
+    // the card down to `title` + `elements` (paragraphs of the same tagged nodes as `post`), so the
+    // content is readable without a second remote call. This is the message type the agent's OWN
+    // answers are, so the case that matters is a user following up on one: without this branch a
+    // reply-referent that is the agent's own card decoded to the bare `[interactive message]` marker
+    // and the model was told its own answer was unreadable (field-observed).
+    //
+    // BOTH spellings on purpose: the platform's own docs disagree with themselves — the field table
+    // says `interactive` (what the receive EVENT carries) while the message-object example shows
+    // `"msg_type": "card"`. Matching one would leave the other silently on the default branch, which
+    // is exactly the symptom this fixes.
+    case "interactive":
+    case "card": {
+      const lines: string[] = [];
+      const title = nonEmptyString(content.title);
+      if (title) lines.push(title);
+      const paragraphs = Array.isArray(content.elements) ? (content.elements as unknown[]) : [];
+      for (const paragraph of paragraphs) {
+        // Tolerate both shapes: elements as paragraphs (array of arrays) and a flat element list.
+        const line = Array.isArray(paragraph) ? renderNodes(paragraph, resources) : renderNodes([paragraph], resources);
+        if (line) lines.push(line);
+      }
+      // An unrenderable card (all controls, no labels) still says something by existing — keep the
+      // marker rather than returning empty, which reads as "the message was blank".
+      return { text: lines.length > 0 ? lines.join("\n") : `[${rawType} message]`, resources };
     }
     case "image": {
       const key = nonEmptyString(content.image_key);

--- a/src/channels/feishu/normalize.ts
+++ b/src/channels/feishu/normalize.ts
@@ -41,15 +41,22 @@ interface PostNode {
 }
 
 /**
- * Render one paragraph of tagged nodes to a line, pushing any resource it carries.
+ * Render one paragraph of tagged nodes to a line, collecting any resource it carries INTO the sink
+ * the caller supplies — or none, when the caller passes no sink.
  *
  * Shared by `post` and `interactive` because the platform hands both out in the same shape. Card-only
  * shapes are handled here rather than in a second walker: `note` nests its own `elements`, and the
  * widget tags (button/select/overflow/date_picker) carry their user-visible label in `text` or
  * `placeholder` — a card is read for what it SAYS, so a label is content and an unlabelled control is
  * nothing.
+ *
+ * The OPTIONAL sink is the whole reason this is a parameter rather than a return value: a card's
+ * resources are documented as unfetchable (see the card branch), so that caller renders the same
+ * `[image]` / `[video]` markers into the text while collecting nothing. The markers still tell the
+ * model what is there; what must not happen is a key entering the turn's PRIMARY inputs, which load
+ * fail-fast.
  */
-function renderNodes(nodes: unknown, resources: DecodedFeishuResource[]): string {
+function renderNodes(nodes: unknown, resources?: DecodedFeishuResource[]): string {
   if (!Array.isArray(nodes)) return "";
   const parts: string[] = [];
   for (const raw of nodes) {
@@ -61,11 +68,11 @@ function renderNodes(nodes: unknown, resources: DecodedFeishuResource[]): string
       parts.push(node.href ? `${nonEmptyString(node.text) ?? node.href} (${node.href})` : (node.text ?? ""));
     } else if (node.tag === "img") {
       const key = nonEmptyString(node.image_key);
-      if (key) resources.push({ kind: "image", key });
+      if (key) resources?.push({ kind: "image", key });
       parts.push("[image]");
     } else if (node.tag === "media") {
       const key = nonEmptyString(node.file_key);
-      if (key) resources.push({ kind: "video", key, name: nonEmptyString(node.file_name) });
+      if (key) resources?.push({ kind: "video", key, name: nonEmptyString(node.file_name) });
       parts.push("[video]");
     } else if (node.tag === "code_block") {
       parts.push(
@@ -147,8 +154,16 @@ export function decodeFeishuContent(
       if (title) lines.push(title);
       const paragraphs = Array.isArray(content.elements) ? (content.elements as unknown[]) : [];
       for (const paragraph of paragraphs) {
+        // NO resource sink, deliberately. The platform documents that a card's resources cannot be
+        // fetched at all: `im/v1/messages/:id/resources/:key` answers 234043 ("Unsupported message
+        // type") for a card message id, by stated limitation rather than by permission. Collecting a
+        // key here would hand the turn a PRIMARY input that is guaranteed to fail its fail-fast load
+        // — turning "the card reads as a marker" (the old behaviour) into "the whole turn errors",
+        // which is strictly worse than the gap this branch exists to close. The text still renders
+        // `[image]` / `[video]`, so the model knows what is there and that it does not have it.
+        //
         // Tolerate both shapes: elements as paragraphs (array of arrays) and a flat element list.
-        const line = Array.isArray(paragraph) ? renderNodes(paragraph, resources) : renderNodes([paragraph], resources);
+        const line = Array.isArray(paragraph) ? renderNodes(paragraph) : renderNodes([paragraph]);
         if (line) lines.push(line);
       }
       // An unrenderable card (all controls, no labels) still says something by existing — keep the

--- a/test/feishu-normalize.test.ts
+++ b/test/feishu-normalize.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import type { FeishuEventHeader, FeishuMessageEvent } from "../src/channels/feishu/model.ts";
-import { normalizeFeishuMessage } from "../src/channels/feishu/normalize.ts";
+import { decodeFeishuContent, normalizeFeishuMessage } from "../src/channels/feishu/normalize.ts";
 
 interface MessageFixture {
   schema: string;
@@ -53,5 +53,62 @@ describe("Feishu/Lark normalized webhook model", () => {
 
   it("rejects an event without a message identity at the normalization boundary", () => {
     expect(normalizeFeishuMessage({ sender: { sender_type: "user" } })).toBeNull();
+  });
+});
+
+describe("card (interactive) decoding — the shape the agent's OWN answers come back as", () => {
+  // What a query API hands back for a card: `title` + `elements` paragraphs of the same tagged nodes
+  // as `post`. NOT what we sent (an entity reference holding only a card_id) — the platform renders it
+  // down on the way out, which is why this needs no cardkit read.
+  const card = {
+    title: "需要先确认两项",
+    elements: [
+      [{ tag: "text", text: "确认后我会给出文件级方案；批准后再实现 SVG 足球页面。" }],
+      [
+        { tag: "a", href: "https://example.test/pr/1", text: "PR" },
+        { tag: "img", image_key: "img_card_1" },
+      ],
+      [{ tag: "note", elements: [{ tag: "text", text: "备注" }] }],
+    ],
+  };
+
+  it("reads a card's text and resources instead of the bare type marker", () => {
+    const decoded = decodeFeishuContent({ message_type: "interactive", content: JSON.stringify(card) });
+
+    expect(decoded.text).toContain("需要先确认两项"); // the title
+    expect(decoded.text).toContain("SVG 足球页面"); // the ask, restated inside the agent's own answer
+    expect(decoded.text).toContain("PR (https://example.test/pr/1)");
+    expect(decoded.text).toContain("备注"); // `note` nests its own elements
+    expect(decoded.text).not.toBe("[interactive message]");
+    expect(decoded.resources).toEqual([{ kind: "image", key: "img_card_1" }]);
+  });
+
+  it("accepts BOTH spellings — the platform's docs disagree with themselves (`interactive` vs `card`)", () => {
+    // The field table says `interactive` (the receive event's spelling); the message-object example
+    // says `"msg_type": "card"`. Matching one would leave the other on the default branch with exactly
+    // the symptom this fixes, so the failure would look identical to no fix at all.
+    const asCard = decodeFeishuContent({ message_type: "card", content: JSON.stringify(card) });
+    expect(asCard.text).toContain("SVG 足球页面");
+  });
+
+  it("keeps the marker when a card renders to nothing — empty would read as a blank message", () => {
+    const controlsOnly = { elements: [[{ tag: "button", type: "primary" }]] };
+    expect(decodeFeishuContent({ message_type: "interactive", content: JSON.stringify(controlsOnly) }).text).toBe(
+      "[interactive message]",
+    );
+  });
+
+  it("reads a widget's visible label, since a card is read for what it SAYS", () => {
+    const labelled = {
+      elements: [
+        [
+          { tag: "button", text: "批准" },
+          { tag: "select_static", placeholder: "选一个" },
+        ],
+      ],
+    };
+    const decoded = decodeFeishuContent({ message_type: "interactive", content: JSON.stringify(labelled) });
+    expect(decoded.text).toContain("批准");
+    expect(decoded.text).toContain("选一个");
   });
 });

--- a/test/feishu-normalize.test.ts
+++ b/test/feishu-normalize.test.ts
@@ -72,7 +72,7 @@ describe("card (interactive) decoding — the shape the agent's OWN answers come
     ],
   };
 
-  it("reads a card's text and resources instead of the bare type marker", () => {
+  it("reads a card's text instead of the bare type marker", () => {
     const decoded = decodeFeishuContent({ message_type: "interactive", content: JSON.stringify(card) });
 
     expect(decoded.text).toContain("需要先确认两项"); // the title
@@ -80,7 +80,29 @@ describe("card (interactive) decoding — the shape the agent's OWN answers come
     expect(decoded.text).toContain("PR (https://example.test/pr/1)");
     expect(decoded.text).toContain("备注"); // `note` nests its own elements
     expect(decoded.text).not.toBe("[interactive message]");
-    expect(decoded.resources).toEqual([{ kind: "image", key: "img_card_1" }]);
+  });
+
+  it("collects NO resources from a card — the platform cannot serve them, so a key here would only fail", () => {
+    // `im/v1/messages/:id/resources/:key` answers 234043 ("Unsupported message type") for a card
+    // message id: a documented limitation, not a permission gap, so the download can never succeed.
+    // A collected key becomes a PRIMARY turn input, and primary loads are fail-fast — so collecting
+    // would turn a card that merely read as a marker into a turn that ERRORS OUT. Strictly worse than
+    // the gap this branch closes.
+    const decoded = decodeFeishuContent({ message_type: "interactive", content: JSON.stringify(card) });
+
+    expect(decoded.resources).toEqual([]);
+    expect(decoded.text).toContain("[image]"); // the model still learns the image is there
+  });
+
+  it("still collects resources from a POST — the restriction is the card's, not the walker's", () => {
+    // The same node walker backs both branches, so pinning this here keeps a future "just don't
+    // collect" simplification from silently disarming rich-text attachments, which DO download.
+    const post = {
+      content: [[{ tag: "img", image_key: "img_post_1" }]],
+    };
+    expect(decodeFeishuContent({ message_type: "post", content: JSON.stringify(post) }).resources).toEqual([
+      { kind: "image", key: "img_post_1" },
+    ]);
   });
 
   it("accepts BOTH spellings — the platform's docs disagree with themselves (`interactive` vs `card`)", () => {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -1684,6 +1684,132 @@ describe("turn flow", () => {
     expect(readFileSync(join(home, "files", "oc_1", "spec.pdf")).toString()).toBe("pdf-bytes");
   });
 
+  it("a thread opened on the agent's own card reads that card AND the ask it answered", async () => {
+    // The thread-bootstrap case. A topic opened on a room-level answer starts with an EMPTY session,
+    // so everything the model knows about the exchange has to arrive through the referent. Two things
+    // used to be lost at once: the card decoded to the bare `[interactive message]` marker, and
+    // nothing said what the card was answering.
+    const fx = feishuFetch({
+      "/im/v1/messages/om_bot_card": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_bot_card",
+                msg_type: "interactive",
+                parent_id: "om_original_ask", // what the agent was answering, in the room
+                body: {
+                  content: JSON.stringify({
+                    elements: [[{ tag: "text", text: "确认后我会给出方案；批准后再实现 SVG 足球页面。" }]],
+                  }),
+                },
+                sender: { id: "cli_self", id_type: "app_id", sender_type: "app" }, // THIS app
+              },
+            ],
+          },
+        }),
+      "/im/v1/messages/om_original_ask": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_original_ask",
+                msg_type: "text",
+                body: { content: JSON.stringify({ text: "加一个新的页面，用 svg 构建一个足球的页面" }) },
+                sender: { id: "ou_alice", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+    });
+    const { handler, calls, idle } = buildChannel({ appId: "cli_self" });
+    await flush(); // the group mention only matches once bot/v3/info has resolved this bot's open_id
+    await handler(
+      feishuRequest(
+        messageEvent({
+          id: "om_in_topic",
+          chatType: "group",
+          threadId: "omt_on_card",
+          parentId: "om_bot_card",
+          content: JSON.stringify({ text: "@_user_1 这个新页面放到 test/下" }),
+          mentions: BOT_MENTION,
+        }),
+      ),
+    );
+    await idle();
+
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(prompt).toContain("SVG 足球页面"); // the card is READ, not reported as unreadable
+    expect(prompt).not.toContain("[interactive message]");
+    expect(prompt).toContain("from you, the agent"); // its own message, not "user cli_app"
+    expect(prompt).toContain("[which answered (msg om_original_ask): 加一个新的页面"); // the room's ask
+    expect(fx.calls("/im/v1/messages/om_original_ask", "GET")).toHaveLength(1); // exactly ONE extra hop
+  });
+
+  it("another BOT's message is not the agent's own: no self-attribution, no reply-chain walk", async () => {
+    // A group can hold several bots, so `sender_type === "app"` answers "some app", not "this app".
+    // Matching on it alone would tell the model it wrote a message it never sent — and would walk a
+    // stranger's reply chain into the prompt. The identity compared is the app id the sender carries.
+    const fx = feishuFetch({
+      "/im/v1/messages/om_other_bot": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_other_bot",
+                msg_type: "interactive",
+                parent_id: "om_other_bots_ask", // present, and deliberately NOT followed
+                body: { content: JSON.stringify({ elements: [[{ tag: "text", text: "another bot's card" }]] }) },
+                sender: { id: "cli_someone_else", id_type: "app_id", sender_type: "app" },
+              },
+            ],
+          },
+        }),
+    });
+    const { handler, calls, idle } = buildChannel({ appId: "cli_self" });
+    await handler(feishuRequest(messageEvent({ id: "om_o1", text: "what is this", parentId: "om_other_bot" })));
+    await idle();
+
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(prompt).toContain("another bot's card"); // still decoded — the card branch is identity-blind
+    expect(prompt).not.toContain("you, the agent"); // …but not claimed as its own
+    expect(prompt).toContain("from app cli_someone_else"); // an app is not a person either
+    expect(fx.calls("/im/v1/messages/om_other_bots_ask", "GET")).toHaveLength(0);
+  });
+
+  it("stops at one hop: a HUMAN referent is what the user pointed at, so its own parent is not walked", async () => {
+    const fx = feishuFetch({
+      "/im/v1/messages/om_human_quote": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_human_quote",
+                msg_type: "text",
+                parent_id: "om_further_back", // present, and deliberately NOT followed
+                body: { content: JSON.stringify({ text: "the quoted line" }) },
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+    });
+    const { handler, calls, idle } = buildChannel();
+    await handler(feishuRequest(messageEvent({ id: "om_h1", text: "about that", parentId: "om_human_quote" })));
+    await idle();
+
+    expect(calls[0]?.prompt.text).toContain("the quoted line");
+    expect(fx.calls("/im/v1/messages/om_further_back", "GET")).toHaveLength(0);
+  });
+
   it("a custom route's null remains a full ignore and does not enter the default context buffer", async () => {
     feishuFetch();
     const { handler, calls, home } = buildChannel({ route: () => null });

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -1684,11 +1684,15 @@ describe("turn flow", () => {
     expect(readFileSync(join(home, "files", "oc_1", "spec.pdf")).toString()).toBe("pdf-bytes");
   });
 
-  it("a thread opened on the agent's own card reads that card AND the ask it answered", async () => {
-    // The thread-bootstrap case. A topic opened on a room-level answer starts with an EMPTY session,
-    // so everything the model knows about the exchange has to arrive through the referent. Two things
-    // used to be lost at once: the card decoded to the bare `[interactive message]` marker, and
-    // nothing said what the card was answering.
+  it("a thread opened on the agent's own card reads that card, and stops at it", async () => {
+    // Two halves. The card is READ (its own answers are cards, so a follow-up on one used to quote a
+    // bare `[interactive message]` marker), and it is attributed to the agent itself.
+    //
+    // The second half is the boundary: the referent's own `parent_id` is NOT followed. Walking it
+    // reconstructs history out of reply pointers, which is the session's job — and the question has no
+    // non-arbitrary answer (how many levels? deduplicated against the session how? an image two levels
+    // up serialised into prompt text how?). A thread starting with an empty session is a memory-
+    // inheritance gap (§8), not a referent-depth one.
     const fx = feishuFetch({
       "/im/v1/messages/om_bot_card": () =>
         Response.json({
@@ -1699,7 +1703,7 @@ describe("turn flow", () => {
               {
                 message_id: "om_bot_card",
                 msg_type: "interactive",
-                parent_id: "om_original_ask", // what the agent was answering, in the room
+                parent_id: "om_original_ask", // present, and deliberately NOT followed
                 body: {
                   content: JSON.stringify({
                     elements: [[{ tag: "text", text: "确认后我会给出方案；批准后再实现 SVG 足球页面。" }]],
@@ -1745,15 +1749,14 @@ describe("turn flow", () => {
     const prompt = calls[0]?.prompt.text ?? "";
     expect(prompt).toContain("SVG 足球页面"); // the card is READ, not reported as unreadable
     expect(prompt).not.toContain("[interactive message]");
-    expect(prompt).toContain("from you, the agent"); // its own message, not "user cli_app"
-    expect(prompt).toContain("[which answered (msg om_original_ask): 加一个新的页面"); // the room's ask
-    expect(fx.calls("/im/v1/messages/om_original_ask", "GET")).toHaveLength(1); // exactly ONE extra hop
+    expect(prompt).toContain("from you, the agent"); // its own message, not "user cli_self"
+    expect(fx.calls("/im/v1/messages/om_original_ask", "GET")).toHaveLength(0); // the chain is not walked
   });
 
-  it("another BOT's message is not the agent's own: no self-attribution, no reply-chain walk", async () => {
+  it("another BOT's message is not the agent's own: no self-attribution", async () => {
     // A group can hold several bots, so `sender_type === "app"` answers "some app", not "this app".
-    // Matching on it alone would tell the model it wrote a message it never sent — and would walk a
-    // stranger's reply chain into the prompt. The identity compared is the app id the sender carries.
+    // Matching on it alone would tell the model it wrote a message it never sent. The identity
+    // compared is the app id the sender carries.
     const fx = feishuFetch({
       "/im/v1/messages/om_other_bot": () =>
         Response.json({
@@ -1781,33 +1784,6 @@ describe("turn flow", () => {
     expect(prompt).not.toContain("you, the agent"); // …but not claimed as its own
     expect(prompt).toContain("from app cli_someone_else"); // an app is not a person either
     expect(fx.calls("/im/v1/messages/om_other_bots_ask", "GET")).toHaveLength(0);
-  });
-
-  it("stops at one hop: a HUMAN referent is what the user pointed at, so its own parent is not walked", async () => {
-    const fx = feishuFetch({
-      "/im/v1/messages/om_human_quote": () =>
-        Response.json({
-          code: 0,
-          msg: "ok",
-          data: {
-            items: [
-              {
-                message_id: "om_human_quote",
-                msg_type: "text",
-                parent_id: "om_further_back", // present, and deliberately NOT followed
-                body: { content: JSON.stringify({ text: "the quoted line" }) },
-                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
-              },
-            ],
-          },
-        }),
-    });
-    const { handler, calls, idle } = buildChannel();
-    await handler(feishuRequest(messageEvent({ id: "om_h1", text: "about that", parentId: "om_human_quote" })));
-    await idle();
-
-    expect(calls[0]?.prompt.text).toContain("the quoted line");
-    expect(fx.calls("/im/v1/messages/om_further_back", "GET")).toHaveLength(0);
   });
 
   it("a custom route's null remains a full ignore and does not enter the default context buffer", async () => {


### PR DESCRIPTION
## Problem (field-observed on Lark)

A user opens a topic on the agent's group answer and asks a follow-up. The agent replies that it cannot read the message it is quoting — showing the literal marker `[interactive message]`.

The agent's own answers **are** cards. So the most ordinary follow-up gesture on this platform quotes a message the channel could not read.

## 1. A quoted card decoded to a placeholder

What the channel **sends** for an answer is a card *entity reference* (`{type:"card",data:{card_id}}`), whose text lives in cardkit. What a query API **returns** is the card rendered back down to `title` + `elements` — paragraphs of the same tagged nodes as a `post`. The decoder had no branch for it, so cards fell to the default `[<type> message]` marker.

`participant-model.md` §8 calls rung 2 (*"the followed-up message in full"*) implemented. It was not — for the one message type the agent itself produces.

The post branch's inline node walk becomes a shared `renderNodes`; the card branch reads through it.

**Both `interactive` and `card` are matched.** The platform's own docs disagree with themselves: the field table says `interactive` (the receive event's spelling), the message-object example shows `"msg_type": "card"`. Matching one would leave the other on the default branch with *exactly* the symptom being fixed — a failure indistinguishable from no fix at all.

### A card's resources are deliberately NOT collected

The card branch renders `[image]` / `[video]` markers but collects no resource keys, because `im/v1/messages/:id/resources/:key` answers **234043 ("Unsupported message type")** for a card message id — a [documented limitation](https://open.feishu.cn/document/server-docs/im-v1/message/get-2), not a permission gap, so the download can never succeed.

This matters because a collected key becomes a **primary** turn input, and primary loads are fail-fast by design (they are what the user pointed at). Collecting would therefore have turned "quoting a card with an image" from *the card reads as a marker, turn completes* into *the turn errors out*. `post` keeps collecting: the restriction belongs to cards, and rich-text attachments do download.

## 2. The agent's own message was attributed to a person

The referent block labelled every sender `user <id>`. Quoting the agent's own answer therefore rendered `from user cli_…` — telling the model a person wrote what it wrote itself.

The noun now follows the sender type, and **own means THIS app**, compared by app id. `sender_type === "app"` answers "some app": a group can hold several bots, and matching on it alone would let another bot's card be claimed as the agent's own. A missing or unexpected id fails closed — labelled by id, never claimed.

## What this PR deliberately does NOT do

An earlier revision also followed one further level up the reply chain, to recover the room-level ask a thread was opened on. It was **removed before merge**.

It worked for text and returned a literal `[image]` placeholder for attachments — which is the tell. The gap it addressed is that a thread opened on a room answer starts with an **empty session** while the room's session holds the exchange. That is memory inheritance (§8, rungs 3-4), and walking reply pointers reconstructs history in the prompt layer instead. That framing has no non-arbitrary answers:

- how many levels — two? to the root?
- how is it deduplicated against what the session already holds from the second turn on?
- how does an image, or a tool result, two levels up become prompt text at all?

Each question is a symptom of solving a session-layer problem one layer up, and shipping it would have signposted the wrong next patch (another level, then the level above that). The referent path keeps doing what it is for: the ONE message the user pointed at, decoded and attributed correctly. Memory inheritance is filed as its own design question, where images and tool results come along for free because they are already in the history.

## Boundaries stated rather than hidden

- `case "card"` comes from the platform's published message-object example (the field table spells the same type `interactive`), and is **not verified against a live tenant**. It is additive: no other message type reaches it.
- `getMessage`'s return is an unchecked cast over the response item. A tenant that spells `sender_type` differently degrades to the pre-change label, with no error.
- A card whose text renders to nothing (all unlabelled controls) keeps the original `[<type> message]` marker rather than returning empty, which would read as a blank message.

## Tests (1332 green: lint / typecheck / test)

Card decoding: both spellings, nested `note`, widget labels, the marker kept when a card renders to nothing, no resources collected from a card, and `post` still collecting. Through the channel: a topic opened on the agent's own card reads that card, attributes it to the agent, and **stops there** — the referent's own `parent_id` going unfollowed is pinned as an invariant; another bot's card is decoded but not claimed.

Mutation-verified — disabling the card branch fails 4 tests, restoring the resource sink fails the no-resources test, and relaxing the identity check to `sender_type` fails the other-bot test.
