### PR TITLE
feat(feishu): resolve a quoted message's reply chain to its root

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -509,8 +509,11 @@ a stable hand-authored surface. What is platform-different:
   place's next answered turn. The Telegram consume invariant carries over: peek at dequeue, commit only
   on `completed`, and retain failures plus messages arriving in-flight. Non-`user` senders are dropped.
   Summon matches the `mentions` array by the bot's open_id (fail-closed until resolved). A reply summon
-  carries only `parent_id` — the referent's content and attachments are fetched as primary input;
-  buffered attachments are background input and degrade per resource.
+  carries only `parent_id` — the referent's content and attachments are fetched as primary input, and
+  the chain ABOVE the referent is resolved as context (oldest-first; one shared text budget;
+  ancestors' attachments join the buffered tier under its cap; a walk ending short of the root leaves
+  a visible truncation line — participant-model.md §8); buffered attachments are background input and
+  degrade per resource.
 - **Ingress is an onboarding-time app choice.** `add feishu|lark` asks for WebSocket or webhook and
   writes the corresponding transport-specific factory into the channel module. WebSocket needs only App ID/Secret, skips token capture,
   tunnel, Request URL registration, and platform crypto; the official SDK authenticates the outbound

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -238,7 +238,7 @@ A thread must start from something. Four rungs, increasing in cost:
 | Rung | Mechanism | Gives the thread |
 |---|---|---|
 | 1 | referent anchor, truncated | the followed-up message, cut at some display-sized bound |
-| **2** | **referent anchor, bounded by the platform** | **the followed-up message in full (`REFERENT_MAX_CODE_POINTS`), plus its reply chain up to the root** |
+| **2** | **referent anchor, bounded by the platform** | **the followed-up message in full (`REFERENT_MAX_CODE_POINTS`)** |
 | 3 | seed injection | the room's last N exchanges, in the thread's first prompt |
 | 4 | session fork | the room's entire history, reasoning and tool results included |
 
@@ -255,17 +255,26 @@ while the record is durable. Every way of gating it failed toward a silently mis
 price of one extra read.) An unreadable referent degrades to a marker in
 the prompt: context is not the ask, and losing it must not cost the answer.
 
-The anchor resolves the referent's whole reply CHAIN, not just its last link: quoting a reply points
-at one link of an exchange, and the pointer is only fully resolved when the model can read what that
-link was replying to — walked to the platform-defined root (every reply threads back to one), capped
-at 8 ancestors as an IO guard that says so visibly when it trips. Ancestors' attachments ride the
-BUFFERED tier: nobody pointed at them, so an unloadable one costs a note, never the turn — only the
-referent's own resources stay primary. A one-hop version of this walk was once added and removed as a
-memory substitute; the questions that killed it (how many levels? deduplicated against the session
-how? an image two levels up serialised into prompt text how?) dissolved when the walk was rescoped to
-pointer resolution — the bound is the chain's own root rather than a picked number, attachments have
-a degradable tier, and history stays the session's job (the rungs below). Rung 3 is the next
-increment if anchors prove too narrow.
+On Feishu/Lark — and only there, because that platform threads every reply to a parent while
+Telegram's update embeds exactly one `reply_to_message` object (no chain to walk) and Slack carries
+none — the anchor also resolves the referent's reply CHAIN: the ancestors above the quoted message,
+walked to the platform-defined root and rendered oldest-first as context. Ancestors are context, not
+the ask, and every bound follows from that: their text shares ONE further `REFERENT_MAX_CODE_POINTS`
+budget across the whole chain (the referent itself keeps its full fidelity bound), their attachments
+share the buffered tier's `BUFFER_ATTACH_MAX` budget with the context buffer (chain refs take slots
+first — the direct upstream of what the user pointed at outranks ambient discussion), and an
+unloadable one costs a note, never the turn. Any walk that ends short of the root — the 8-ancestor
+IO cap, an exhausted budget, an unreadable ancestor, a cycle in corrupt data — leaves the same
+visible truncation line: a chain rendered without it would read as complete, and the model would
+take the oldest fetched node for the original ask. One cost is carried deliberately: the walk
+repeats per reply turn, so an established session re-reads chain text it may already hold
+(attachments are deduplicated by message identity; text cannot be, from a layer that cannot read
+the session). Bounded to one referent's worth per turn by the shared budget, that is the price of an
+unconditional, stateless guarantee that what a quote points into is visible. A one-hop version of
+this walk was once added and removed as a memory substitute; what changed is the job — resolving
+the pointer, with history left to the rungs below — and the bounds, which are the chain's own root
+plus explicit budgets rather than a picked level count. Rung 3 is the next increment if anchors
+prove too narrow.
 
 Rung 4 (`SessionRepo.fork`, which would need an optional lineage field on `Scope`) is **not planned**:
 it over-delivers by copying the whole room — including everyone's unrelated conversations — into a

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -238,7 +238,7 @@ A thread must start from something. Four rungs, increasing in cost:
 | Rung | Mechanism | Gives the thread |
 |---|---|---|
 | 1 | referent anchor, truncated | the followed-up message, cut at some display-sized bound |
-| **2** | **referent anchor, bounded by the platform** | **the followed-up message in full (`REFERENT_MAX_CODE_POINTS`)** |
+| **2** | **referent anchor, bounded by the platform** | **the followed-up message in full (`REFERENT_MAX_CODE_POINTS`), plus its reply chain up to the root** |
 | 3 | seed injection | the room's last N exchanges, in the thread's first prompt |
 | 4 | session fork | the room's entire history, reasoning and tool results included |
 
@@ -253,7 +253,18 @@ already answered in was tried: deciding whether the session really held it needs
 the channel RECEIVED the messages in between, which depends on a permission that changes over time
 while the record is durable. Every way of gating it failed toward a silently missing quote, for the
 price of one extra read.) An unreadable referent degrades to a marker in
-the prompt: context is not the ask, and losing it must not cost the answer. Rung 3 is the next
+the prompt: context is not the ask, and losing it must not cost the answer.
+
+The anchor resolves the referent's whole reply CHAIN, not just its last link: quoting a reply points
+at one link of an exchange, and the pointer is only fully resolved when the model can read what that
+link was replying to — walked to the platform-defined root (every reply threads back to one), capped
+at 8 ancestors as an IO guard that says so visibly when it trips. Ancestors' attachments ride the
+BUFFERED tier: nobody pointed at them, so an unloadable one costs a note, never the turn — only the
+referent's own resources stay primary. A one-hop version of this walk was once added and removed as a
+memory substitute; the questions that killed it (how many levels? deduplicated against the session
+how? an image two levels up serialised into prompt text how?) dissolved when the walk was rescoped to
+pointer resolution — the bound is the chain's own root rather than a picked number, attachments have
+a degradable tier, and history stays the session's job (the rungs below). Rung 3 is the next
 increment if anchors prove too narrow.
 
 Rung 4 (`SessionRepo.fork`, which would need an optional lineage field on `Scope`) is **not planned**:

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -316,7 +316,8 @@ Message payloads are resolved by the channel before the agent turn runs — all 
 
 - images (`image` messages, or images inside a rich-text `post`) are downloaded and passed as `prompt.images` — the selected model must support vision,
 - files / audio / video are downloaded to `<state root>/channels/<kind>/files/<chat>/` and listed in the prompt so the agent reads them with its tools,
-- a **reply summon** fetches the replied-to message (its content is not in the event), injects its text into the prompt, and loads its attachments too — "@bot summarize this" as a reply to a file works.
+- a **reply summon** fetches the replied-to message (its content is not in the event), injects its text into the prompt, and loads its attachments too — "@bot summarize this" as a reply to a file works,
+- the **reply chain above** the quoted message is resolved as background context: up to 8 ancestors, oldest first, sharing one referent-sized text budget; their images/files load degradably like buffered attachments (a failure becomes a note, not an error). A chain cut short for any reason — cap, budget, an unreadable message — is marked visibly in the prompt so a partial chain never reads as the whole conversation.
 
 ## State & restarts
 

--- a/src/channels/feishu/feishu-api.ts
+++ b/src/channels/feishu/feishu-api.ts
@@ -164,12 +164,14 @@ export interface FeishuApi {
    *
    *  `sender` is typed rather than `unknown` because the referent path READS it: an app-sent message
    *  whose id is THIS app's is the agent's own, which the prompt must say instead of attributing it to
-   *  "user cli_…". The message object carries more (`parent_id`, `root_id`, `thread_id`); they stay
-   *  unnamed until something reads them — this type is the surface in use, not a mirror of the wire. */
+   *  "user cli_…". `parent_id` is read by the reply-chain walk (invoke-turn): the message this one
+   *  itself replied to. The message object carries more (`root_id`, `thread_id`); they stay unnamed
+   *  until something reads them — this type is the surface in use, not a mirror of the wire. */
   getMessage(messageId: string): Promise<
     | {
         message_id?: string;
         msg_type?: string;
+        parent_id?: string;
         body?: { content?: string };
         mentions?: unknown[];
         sender?: { id?: string; id_type?: string; sender_type?: string };

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -23,6 +23,7 @@ import {
   missingAttachmentsNote,
   streamTurnWithBusyRetry,
 } from "../invoke-turn-kit.ts";
+import { BUFFER_ATTACH_MAX } from "../context-buffer.ts";
 import type { FeishuBufferedRef } from "./context-buffer.ts";
 import type { DownloadedFile, FeishuApi } from "./feishu-api.ts";
 import { type FeishuMention, parseContent } from "./parse.ts";
@@ -122,11 +123,19 @@ interface ReplyChain {
  * different track (design/participant-model.md §8): a one-hop version of this walk was removed once
  * for trying to be that substitute; it returns doing only the pointer's job, which is also why it
  * walks through ANY author's message — the chain is the platform's structure, not a conversation the
- * agent took part in.
+ * agent took part in. The repetition this implies (an established session re-reads chain text it may
+ * already hold, each reply turn) is accepted deliberately and bounded: ancestors are CONTEXT, not
+ * the ask, so their text shares ONE further `REFERENT_MAX_CODE_POINTS` budget across the whole chain
+ * — the walk costs at most one more referent — while the pointed-at referent keeps its own full
+ * fidelity bound.
  *
- * Fail-open at every edge: an unreadable ancestor ends the walk keeping the part already fetched (a
- * warn, not a marker — nobody pointed at it); a cycle ends it silently (platform-data corruption, and
- * ending is the whole fix); a capped walk says so in the block, visibly.
+ * Fail-open at every edge, but never silently at the model: any walk that ends short of the root —
+ * the ancestor cap, an exhausted text budget, an unreadable ancestor, a cycle — leaves the same
+ * neutral truncation line at the top of the block, because a chain rendered without it READS as
+ * complete and the model would take the oldest fetched node for the original ask. Unreadable
+ * ancestors and cycles also warn the operator; a cycle is corrupt platform data (reply chains are
+ * temporally acyclic by construction — a reply can only point at an EARLIER message — so one firing
+ * means the data, not the walk, is wrong).
  */
 async function walkReplyChain(
   t: FeishuTurnTransport,
@@ -136,15 +145,22 @@ async function walkReplyChain(
   const nodes: { id: string; label?: string; text: string }[] = [];
   const images: FeishuBufferedRef[] = [];
   const files: FeishuBufferedRef[] = [];
-  let capped = false;
-  let next = start;
+  // No parent above the referent = no chain — not a truncated one. The marker below is only for
+  // walks that END SHORT of a root that exists.
+  if (start === undefined) return { block: "", images, files };
+  let reachedRoot = false;
+  let textBudget = REFERENT_MAX_CODE_POINTS;
+  let next: string | undefined = start;
   while (next !== undefined) {
-    if (visited.has(next)) break;
-    if (nodes.length >= MAX_CHAIN_ANCESTORS) {
-      capped = true;
+    if (visited.has(next)) {
+      log.warn(
+        `${t.label} reply chain points back to already-visited message ${next} — corrupt platform data; the walk ends here`,
+      );
       break;
     }
-    const id = next;
+    if (nodes.length >= MAX_CHAIN_ANCESTORS || textBudget <= 0) break;
+    // The annotation breaks a control-flow-analysis cycle (id → msg → next → id) that trips TS7022.
+    const id: string = next;
     visited.add(id);
     let failure: string | undefined;
     const msg = await t.api.getMessage(id).catch((error) => {
@@ -166,13 +182,17 @@ async function walkReplyChain(
     const from = label ?? "reply chain";
     for (const key of parsed.imageKeys) images.push({ messageId: id, key, from });
     for (const ref of parsed.fileRefs) files.push({ messageId: id, key: ref.key, name: ref.name, from });
-    nodes.push({ id, label, text: truncateCodePointPrefix(parsed.text, REFERENT_MAX_CODE_POINTS) || "(empty)" });
+    const text = truncateCodePointPrefix(parsed.text, textBudget) || "(empty)";
+    textBudget -= [...text].length;
+    nodes.push({ id, label, text });
+    if (msg.parent_id === undefined) reachedRoot = true;
     next = msg.parent_id;
   }
-  if (nodes.length === 0) return { block: "", images, files };
   nodes.reverse(); // fetched leaf→root; rendered oldest first, the way a transcript reads
   const lines = nodes.map((node) => `(msg ${node.id}${node.label ? `, from ${node.label}` : ""}): ${node.text}`);
-  if (capped) lines.unshift("(…the chain continues above this point)");
+  // One line for every way of ending short of the root — cap, budget, unreadable, cycle. It names no
+  // cause on purpose: the model needs the SHAPE (there is more above), the operator log has the why.
+  if (!reachedRoot) lines.unshift("(…the chain continues above this point)");
   return { block: `\n[reply chain above it, oldest first:\n${lines.join("\n")}]`, images, files };
 }
 
@@ -235,19 +255,27 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   // downloaded twice or rendered twice in the manifest.
   const primaryImages = new Set(images.map((ref) => `${ref.msg}\u0000${ref.key}`));
   const primaryFiles = new Set(files.map((ref) => `${ref.msg}\u0000${ref.key}`));
-  // Chain ancestors join the buffered tier BEHIND the context buffer's refs, deduplicated by the
-  // same message-scoped identity — a reply chain can point back into discussion that is still
-  // sitting in the buffer, and one download is enough.
-  const seenImages = new Set(attachments.buffered.images.map((ref) => `${ref.messageId}\u0000${ref.key}`));
-  const seenFiles = new Set(attachments.buffered.files.map((ref) => `${ref.messageId}\u0000${ref.key}`));
-  const bufferedImages = [
-    ...attachments.buffered.images,
-    ...chain.images.filter((ref) => !seenImages.has(`${ref.messageId}\u0000${ref.key}`)),
-  ].filter((ref) => !primaryImages.has(`${ref.messageId}\u0000${ref.key}`));
-  const bufferedFiles = [
-    ...attachments.buffered.files,
-    ...chain.files.filter((ref) => !seenFiles.has(`${ref.messageId}\u0000${ref.key}`)),
-  ].filter((ref) => !primaryFiles.has(`${ref.messageId}\u0000${ref.key}`));
+  // Chain ancestors and the context buffer share ONE background budget: BUFFER_ATTACH_MAX per kind.
+  // The cap is part of the tier's meaning, not an accident of who collected the ref — a rich-text
+  // ancestor must not turn the walk into an unbounded fan-out of downloads. Chain refs take slots
+  // FIRST: they are the direct upstream of the message the user pointed at, buffer refs are ambient
+  // discussion. Duplicates (a chain that points back into still-buffered discussion) count once, and
+  // what the cap drops is counted into the missing-attachments note like every other unloaded ref.
+  const capMerge = (chainRefs: FeishuBufferedRef[], bufferRefs: FeishuBufferedRef[], primary: Set<string>) => {
+    const seen = new Set<string>();
+    const merged: FeishuBufferedRef[] = [];
+    for (const ref of [...chainRefs, ...bufferRefs]) {
+      const identity = `${ref.messageId}\u0000${ref.key}`;
+      if (primary.has(identity) || seen.has(identity)) continue;
+      seen.add(identity);
+      merged.push(ref);
+    }
+    return { kept: merged.slice(0, BUFFER_ATTACH_MAX), dropped: Math.max(0, merged.length - BUFFER_ATTACH_MAX) };
+  };
+  const mergedImages = capMerge(chain.images, attachments.buffered.images, primaryImages);
+  const mergedFiles = capMerge(chain.files, attachments.buffered.files, primaryFiles);
+  const bufferedImages = mergedImages.kept;
+  const bufferedFiles = mergedFiles.kept;
   const backgroundImages: { image: ImageRef; ref: FeishuBufferedRef }[] = [];
   const backgroundFiles: { file: DownloadedFile; ref: FeishuBufferedRef }[] = [];
   let lost = 0;
@@ -274,7 +302,9 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
       log.warn(`${t.label} could not load an earlier (buffered) attachment: ${String(result.reason)}`);
     }
   }
-  const missingNote = missingAttachmentsNote(lost + attachments.buffered.skipped);
+  const missingNote = missingAttachmentsNote(
+    lost + attachments.buffered.skipped + mergedImages.dropped + mergedFiles.dropped,
+  );
   const backgroundImageManifest = backgroundImagesManifest(
     imageRefs.length,
     backgroundImages.map(({ ref }) => ref),

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -8,8 +8,9 @@
  *
  * Inputs have two tiers. PRIMARY is the summoning message plus the message it explicitly replied to;
  * any load failure there aborts visibly so the Agent never runs without an input the user pointed at.
- * BUFFERED resources come from earlier un-summoned thread/group discussion and degrade per attachment:
- * one expired background file must not block the current ask or hide its still-readable siblings.
+ * BUFFERED resources come from earlier un-summoned thread/group discussion and from reply-chain
+ * ancestors, and degrade per attachment: one expired background file must not block the current ask
+ * or hide its still-readable siblings.
  */
 import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
 import { log } from "../../log.ts";
@@ -75,14 +76,116 @@ interface ResolvedInputs {
   promptSuffix: string;
 }
 
+/** How far up a reply chain the walk reads, beyond the replied-to message itself. The chain's natural
+ *  end is its ROOT — the platform threads every reply back to one — so this is an IO guard, not a
+ *  semantic boundary: each ancestor costs one serial `getMessage`, and a pathological chain must not
+ *  stall the turn. Field chains are 1–3 long; a capped walk says so in the block. */
+const MAX_CHAIN_ANCESTORS = 8;
+
+/** Attribution for a FETCHED message. getMessage's sender is `{ id, id_type, sender_type }` — a
+ *  DIFFERENT shape from the event's sender (`{ sender_id: { open_id } }`) — so the label is built
+ *  here, not via parse.senderLabel.
+ *
+ *  OWN means THIS app, not "an app". A group can hold several bots, and `sender_type === "app"` is
+ *  true for every one of them — matching on it alone would tell the model it wrote another bot's
+ *  message. The identity to compare is the app id, because an app sender carries `id_type: "app_id"`:
+ *  the cached bot open_id answers a different question (who was @mentioned) and would never match
+ *  here. A missing or unexpected id fails CLOSED — labelled by id, never claimed as the agent's own.
+ *  And an app is not a person: labelling another bot's message "user cli_…" is the same
+ *  misattribution in a quieter form, so the noun follows the sender type. */
+function fetchedSenderLabel(
+  sender: { id?: string; id_type?: string; sender_type?: string } | undefined,
+  appId: string,
+): string | undefined {
+  const appSender = sender?.sender_type === "app";
+  const senderId = sender?.id;
+  if (appSender && senderId === appId) return "you, the agent";
+  return senderId ? `${appSender ? "app" : "user"} ${senderId}` : undefined;
+}
+
+/** One walk's yield: the rendered chain block (empty when there are no ancestors), plus the
+ *  ancestors' attachments as BUFFERED-tier refs — context, not the ask, so an unloadable one costs a
+ *  note, never the turn. */
+interface ReplyChain {
+  block: string;
+  images: FeishuBufferedRef[];
+  files: FeishuBufferedRef[];
+}
+
 /**
- * Resolve a turn's inputs (module header): fetch the reply referent's content, then load every image
- * (vision) and file (disk). Primary failures throw; buffered resources degrade independently.
+ * Walk the reply chain ABOVE the replied-to message, to its root. Quoting a reply points at one link
+ * of an exchange; the pointer is only fully resolved when the model can read what that link was
+ * replying to — all the way up, because the platform defines where the chain ends (its root), which
+ * is what makes the walk bounded by STRUCTURE rather than by a level count someone picked.
+ *
+ * This is pointer resolution, not history. Session memory — what this place already knows — is a
+ * different track (design/participant-model.md §8): a one-hop version of this walk was removed once
+ * for trying to be that substitute; it returns doing only the pointer's job, which is also why it
+ * walks through ANY author's message — the chain is the platform's structure, not a conversation the
+ * agent took part in.
+ *
+ * Fail-open at every edge: an unreadable ancestor ends the walk keeping the part already fetched (a
+ * warn, not a marker — nobody pointed at it); a cycle ends it silently (platform-data corruption, and
+ * ending is the whole fix); a capped walk says so in the block, visibly.
+ */
+async function walkReplyChain(
+  t: FeishuTurnTransport,
+  start: string | undefined,
+  visited: Set<string>,
+): Promise<ReplyChain> {
+  const nodes: { id: string; label?: string; text: string }[] = [];
+  const images: FeishuBufferedRef[] = [];
+  const files: FeishuBufferedRef[] = [];
+  let capped = false;
+  let next = start;
+  while (next !== undefined) {
+    if (visited.has(next)) break;
+    if (nodes.length >= MAX_CHAIN_ANCESTORS) {
+      capped = true;
+      break;
+    }
+    const id = next;
+    visited.add(id);
+    let failure: string | undefined;
+    const msg = await t.api.getMessage(id).catch((error) => {
+      failure = String(error);
+      return undefined;
+    });
+    if (!msg) {
+      log.warn(
+        `${t.label} could not read reply-chain message ${id} (${failure ?? "no such message"}) — the chain is rendered up to it`,
+      );
+      break;
+    }
+    const parsed = parseContent({
+      message_type: msg.msg_type ?? "unknown",
+      content: msg.body?.content ?? "",
+      mentions: msg.mentions as FeishuMention[] | undefined,
+    });
+    const label = fetchedSenderLabel(msg.sender, t.appId);
+    const from = label ?? "reply chain";
+    for (const key of parsed.imageKeys) images.push({ messageId: id, key, from });
+    for (const ref of parsed.fileRefs) files.push({ messageId: id, key: ref.key, name: ref.name, from });
+    nodes.push({ id, label, text: truncateCodePointPrefix(parsed.text, REFERENT_MAX_CODE_POINTS) || "(empty)" });
+    next = msg.parent_id;
+  }
+  if (nodes.length === 0) return { block: "", images, files };
+  nodes.reverse(); // fetched leaf→root; rendered oldest first, the way a transcript reads
+  const lines = nodes.map((node) => `(msg ${node.id}${node.label ? `, from ${node.label}` : ""}): ${node.text}`);
+  if (capped) lines.unshift("(…the chain continues above this point)");
+  return { block: `\n[reply chain above it, oldest first:\n${lines.join("\n")}]`, images, files };
+}
+
+/**
+ * Resolve a turn's inputs (module header): fetch the reply referent's content and resolve its reply
+ * chain, then load every image (vision) and file (disk). Primary failures throw; buffered resources
+ * degrade independently.
  */
 async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurnAttachments): Promise<ResolvedInputs> {
   const images = [...attachments.primary.images];
   const files = [...attachments.primary.files];
   let referentBlock = "";
+  let chain: ReplyChain = { block: "", images: [], files: [] };
   if (attachments.primary.parentId !== undefined) {
     const parentId = attachments.primary.parentId;
     // A referent is CONTEXT, not the ask. Losing it (deleted, restricted, unreadable) must not cost
@@ -113,32 +216,11 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
       // The referent's own resources join the turn as primary inputs, carried by the PARENT message id.
       for (const key of parsed.imageKeys) images.push({ msg: parentId, key });
       for (const ref of parsed.fileRefs) files.push({ msg: parentId, key: ref.key, name: ref.name });
-      // getMessage's sender is `{ id, id_type, sender_type }` — a DIFFERENT shape from the event's
-      // sender (`{ sender_id: { open_id } }`), so the label is built here, not via parse.senderLabel.
-      //
-      // OWN means THIS app, not "an app". A group can hold several bots, and `sender_type === "app"`
-      // is true for every one of them — matching on it alone would tell the model it wrote another
-      // bot's message. The identity to compare is the app id, because an app sender carries
-      // `id_type: "app_id"`: the cached bot open_id answers a different question (who was @mentioned)
-      // and would never match here. A missing or unexpected id fails CLOSED — labelled by id, never
-      // claimed as the agent's own.
-      const appSender = parent.sender?.sender_type === "app";
-      const senderId = parent.sender?.id;
-      const ownMessage = appSender && senderId === t.appId;
-      // An app is not a person: labelling another bot's message "user cli_…" is the same misattribution
-      // in a quieter form, so the noun follows the sender type.
-      const from = ownMessage ? "you, the agent" : senderId ? `${appSender ? "app" : "user"} ${senderId}` : undefined;
+      const from = fetchedSenderLabel(parent.sender, t.appId);
       referentBlock = `\n\n[replied-to message (msg ${parentId}${from ? `, from ${from}` : ""}): ${truncateCodePointPrefix(parsed.text, REFERENT_MAX_CODE_POINTS) || "(empty)"}]`;
-      // The chain STOPS here, at the one message the user pointed at. Walking further — to what that
-      // message was itself replying to — was built and removed: it reconstructs HISTORY out of reply
-      // pointers, and history is the session's job. That framing has no non-arbitrary answers (how
-      // many levels? what about the level above that? how is it deduplicated against what the session
-      // already holds? how does an IMAGE two levels up become prompt text at all?), and every one of
-      // those questions is a symptom of solving a session-layer problem in the prompt layer. The real
-      // gap it was papering over — a thread opened on a room answer starts with an EMPTY session while
-      // the room's session holds the exchange — belongs to memory inheritance (design/participant-
-      // model.md §8, rungs 3-4), where images and tool results come along for free because they are
-      // already in the history rather than being re-serialised into a prompt string.
+      // The referent's own parent starts the chain walk; the referent id seeds the cycle guard.
+      chain = await walkReplyChain(t, parent.parent_id, new Set([parentId]));
+      referentBlock += chain.block;
     }
   }
 
@@ -153,12 +235,19 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   // downloaded twice or rendered twice in the manifest.
   const primaryImages = new Set(images.map((ref) => `${ref.msg}\u0000${ref.key}`));
   const primaryFiles = new Set(files.map((ref) => `${ref.msg}\u0000${ref.key}`));
-  const bufferedImages = attachments.buffered.images.filter(
-    (ref) => !primaryImages.has(`${ref.messageId}\u0000${ref.key}`),
-  );
-  const bufferedFiles = attachments.buffered.files.filter(
-    (ref) => !primaryFiles.has(`${ref.messageId}\u0000${ref.key}`),
-  );
+  // Chain ancestors join the buffered tier BEHIND the context buffer's refs, deduplicated by the
+  // same message-scoped identity — a reply chain can point back into discussion that is still
+  // sitting in the buffer, and one download is enough.
+  const seenImages = new Set(attachments.buffered.images.map((ref) => `${ref.messageId}\u0000${ref.key}`));
+  const seenFiles = new Set(attachments.buffered.files.map((ref) => `${ref.messageId}\u0000${ref.key}`));
+  const bufferedImages = [
+    ...attachments.buffered.images,
+    ...chain.images.filter((ref) => !seenImages.has(`${ref.messageId}\u0000${ref.key}`)),
+  ].filter((ref) => !primaryImages.has(`${ref.messageId}\u0000${ref.key}`));
+  const bufferedFiles = [
+    ...attachments.buffered.files,
+    ...chain.files.filter((ref) => !seenFiles.has(`${ref.messageId}\u0000${ref.key}`)),
+  ].filter((ref) => !primaryFiles.has(`${ref.messageId}\u0000${ref.key}`));
   const backgroundImages: { image: ImageRef; ref: FeishuBufferedRef }[] = [];
   const backgroundFiles: { file: DownloadedFile; ref: FeishuBufferedRef }[] = [];
   let lost = 0;

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -1892,6 +1892,8 @@ describe("turn flow", () => {
     expect(msgFetches).toHaveLength(1);
     const prompt = calls[0]?.prompt.text ?? "";
     expect(prompt).toContain("(msg om_s, from user ou_alice): [image]");
+    // a cycle ends SHORT of a root — the block must not read as complete
+    expect(prompt).toContain("(…the chain continues above this point)");
     // the image itself arrived through the buffered path, attributed to its chain position
     expect(prompt).toContain("vision image 1: from user ou_alice, msg om_s");
     expect(calls[0]?.prompt.images).toHaveLength(1);
@@ -1991,8 +1993,180 @@ describe("turn flow", () => {
 
     const prompt = calls[0]?.prompt.text ?? "";
     expect(prompt).toContain("(msg om_w, from user ou_bob): still here"); // the fetched part is kept
-    expect(prompt).not.toContain("om_gone"); // the unreadable one is a warn, not a marker
+    // The cut is VISIBLE but neutral: the block must not read as if om_w were the root — the model
+    // would take it for the original ask — yet the marker names no id and no error detail.
+    expect(prompt).toContain("(…the chain continues above this point)");
+    expect(prompt).not.toContain("om_gone");
     expect(fx.calls("/im/v1/messages/om_gone", "GET")).toHaveLength(1); // tried, then stopped
+  });
+
+  it("the chain's text shares one referent-sized budget, cut visibly from the far end", async () => {
+    // Ancestors are context, not the ask: the whole chain spends at most one further
+    // REFERENT_MAX_CODE_POINTS. A wall-of-text ancestor exhausts it, the walk stops — saving the
+    // fetches too — and the same truncation line keeps the cut from reading as the root.
+    const fx = feishuFetch({
+      "/im/v1/messages/om_e0": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_e0",
+                msg_type: "text",
+                parent_id: "om_e1",
+                body: { content: JSON.stringify({ text: "quoted" }) },
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+      "/im/v1/messages/om_e1": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_e1",
+                msg_type: "text",
+                parent_id: "om_e2",
+                body: { content: JSON.stringify({ text: "w".repeat(5000) }) }, // > the whole budget
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+      "/im/v1/messages/om_e2": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_e2",
+                msg_type: "text",
+                body: { content: JSON.stringify({ text: "beyond the budget" }) },
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+    });
+    const { handler, calls, idle } = buildChannel();
+    await handler(feishuRequest(messageEvent({ id: "om_q5", text: "context?", parentId: "om_e0" })));
+    await idle();
+
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(prompt).toContain("(…the chain continues above this point)");
+    expect(prompt).not.toContain("beyond the budget");
+    expect(fx.calls("/im/v1/messages/om_e2", "GET")).toHaveLength(0); // the budget also stops the IO
+  });
+
+  it("chain attachments obey the buffered tier's cap, with chain refs taking slots first", async () => {
+    // BUFFERED means the whole tier contract, cap included: chain ancestors and the context buffer
+    // share ONE budget of BUFFER_ATTACH_MAX images. Chain refs outrank buffer refs (the direct
+    // upstream of what the user pointed at beats ambient discussion), and whatever the cap drops is
+    // counted into the note — the model must not hold references it silently cannot see.
+    const fx = feishuFetch({
+      // Resource routes FIRST — a resource URL contains its message path as a prefix (see the cycle
+      // test), and these must serve BYTES, not the message JSON.
+      "/resources/chain_a": () =>
+        new Response(Buffer.from("img-bytes"), { status: 200, headers: { "content-type": "image/png" } }),
+      "/resources/chain_b": () =>
+        new Response(Buffer.from("img-bytes"), { status: 200, headers: { "content-type": "image/png" } }),
+      "/im/v1/messages/om_g1": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_g1",
+                msg_type: "post",
+                body: {
+                  content: JSON.stringify({
+                    content: [
+                      [
+                        { tag: "text", text: "two shots " },
+                        { tag: "img", image_key: "chain_a" },
+                        { tag: "img", image_key: "chain_b" },
+                      ],
+                    ],
+                  }),
+                },
+                sender: { id: "ou_carol", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+      "/im/v1/messages/om_g0": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_g0",
+                msg_type: "text",
+                parent_id: "om_g1",
+                body: { content: JSON.stringify({ text: "see the shots above" }) },
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+    });
+    const { handler, calls, idle } = buildChannel();
+    await flush();
+    const mention = [{ key: "@_bot", name: "Bot", id: { open_id: "ou_bot" } }];
+    // Two un-summoned group images land in the context buffer…
+    await handler(
+      feishuRequest(
+        messageEvent({
+          id: "om_buf1",
+          chatType: "group",
+          msgType: "image",
+          content: JSON.stringify({ image_key: "buf_one" }),
+        }),
+      ),
+    );
+    await handler(
+      feishuRequest(
+        messageEvent({
+          id: "om_buf2",
+          chatType: "group",
+          msgType: "image",
+          content: JSON.stringify({ image_key: "buf_two" }),
+        }),
+      ),
+    );
+    // …then a reply summon whose chain ancestor carries two more. 4 background refs, budget 3.
+    await handler(
+      feishuRequest(
+        messageEvent({
+          id: "om_g_ask",
+          chatType: "group",
+          parentId: "om_g0",
+          content: JSON.stringify({ text: "@_bot what do the shots show" }),
+          mentions: mention,
+        }),
+      ),
+    );
+    await idle();
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(calls[0]?.prompt.images).toHaveLength(3); // the tier's cap, not 4
+    expect(prompt).toContain("1 attachment(s) from the earlier discussion are not loaded");
+    // chain first: both chain images made it, one buffered image was dropped
+    expect(fx.calls("/im/v1/messages/om_g1/resources/chain_a", "GET")).toHaveLength(1);
+    expect(fx.calls("/im/v1/messages/om_g1/resources/chain_b", "GET")).toHaveLength(1);
+    const bufferFetches = [
+      ...fx.calls("/im/v1/messages/om_buf1/resources/buf_one", "GET"),
+      ...fx.calls("/im/v1/messages/om_buf2/resources/buf_two", "GET"),
+    ];
+    expect(bufferFetches).toHaveLength(1);
   });
 
   it("a custom route's null remains a full ignore and does not enter the default context buffer", async () => {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -1684,15 +1684,11 @@ describe("turn flow", () => {
     expect(readFileSync(join(home, "files", "oc_1", "spec.pdf")).toString()).toBe("pdf-bytes");
   });
 
-  it("a thread opened on the agent's own card reads that card, and stops at it", async () => {
-    // Two halves. The card is READ (its own answers are cards, so a follow-up on one used to quote a
-    // bare `[interactive message]` marker), and it is attributed to the agent itself.
-    //
-    // The second half is the boundary: the referent's own `parent_id` is NOT followed. Walking it
-    // reconstructs history out of reply pointers, which is the session's job — and the question has no
-    // non-arbitrary answer (how many levels? deduplicated against the session how? an image two levels
-    // up serialised into prompt text how?). A thread starting with an empty session is a memory-
-    // inheritance gap (§8), not a referent-depth one.
+  it("a thread opened on the agent's own card reads that card AND the chain up to the ask", async () => {
+    // Three halves of pointer resolution. The card is READ (its own answers are cards, so a follow-up
+    // on one used to quote a bare `[interactive message]` marker); it is attributed to the agent
+    // itself; and the chain above it is walked to its root — the ask the card answered — so the model
+    // sees the exchange the user is pointing INTO, not just its last link.
     const fx = feishuFetch({
       "/im/v1/messages/om_bot_card": () =>
         Response.json({
@@ -1703,7 +1699,7 @@ describe("turn flow", () => {
               {
                 message_id: "om_bot_card",
                 msg_type: "interactive",
-                parent_id: "om_original_ask", // present, and deliberately NOT followed
+                parent_id: "om_original_ask", // the chain's next link — walked
                 body: {
                   content: JSON.stringify({
                     elements: [[{ tag: "text", text: "确认后我会给出方案；批准后再实现 SVG 足球页面。" }]],
@@ -1750,13 +1746,17 @@ describe("turn flow", () => {
     expect(prompt).toContain("SVG 足球页面"); // the card is READ, not reported as unreadable
     expect(prompt).not.toContain("[interactive message]");
     expect(prompt).toContain("from you, the agent"); // its own message, not "user cli_self"
-    expect(fx.calls("/im/v1/messages/om_original_ask", "GET")).toHaveLength(0); // the chain is not walked
+    // the ask arrives as the chain above the card, reaching its root
+    expect(prompt).toContain("[reply chain above it, oldest first:");
+    expect(prompt).toContain("(msg om_original_ask, from user ou_alice): 加一个新的页面，用 svg 构建一个足球的页面");
+    expect(fx.calls("/im/v1/messages/om_original_ask", "GET")).toHaveLength(1);
   });
 
-  it("another BOT's message is not the agent's own: no self-attribution", async () => {
+  it("another BOT's message is not the agent's own: no self-attribution, chain still walked", async () => {
     // A group can hold several bots, so `sender_type === "app"` answers "some app", not "this app".
     // Matching on it alone would tell the model it wrote a message it never sent. The identity
-    // compared is the app id the sender carries.
+    // compared is the app id the sender carries. The chain walks through the stranger's message all
+    // the same — it is the platform's structure, not a conversation the agent took part in.
     const fx = feishuFetch({
       "/im/v1/messages/om_other_bot": () =>
         Response.json({
@@ -1767,9 +1767,24 @@ describe("turn flow", () => {
               {
                 message_id: "om_other_bot",
                 msg_type: "interactive",
-                parent_id: "om_other_bots_ask", // present, and deliberately NOT followed
+                parent_id: "om_stranger_ask", // no shared prefix with om_other_bot — feishuFetch matches by substring
                 body: { content: JSON.stringify({ elements: [[{ tag: "text", text: "another bot's card" }]] }) },
                 sender: { id: "cli_someone_else", id_type: "app_id", sender_type: "app" },
+              },
+            ],
+          },
+        }),
+      "/im/v1/messages/om_stranger_ask": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_stranger_ask",
+                msg_type: "text",
+                body: { content: JSON.stringify({ text: "what the other bot answered" }) },
+                sender: { id: "ou_carol", id_type: "open_id", sender_type: "user" },
               },
             ],
           },
@@ -1783,7 +1798,201 @@ describe("turn flow", () => {
     expect(prompt).toContain("another bot's card"); // still decoded — the card branch is identity-blind
     expect(prompt).not.toContain("you, the agent"); // …but not claimed as its own
     expect(prompt).toContain("from app cli_someone_else"); // an app is not a person either
-    expect(fx.calls("/im/v1/messages/om_other_bots_ask", "GET")).toHaveLength(0);
+    expect(prompt).toContain("(msg om_stranger_ask, from user ou_carol): what the other bot answered");
+    expect(fx.calls("/im/v1/messages/om_stranger_ask", "GET")).toHaveLength(1);
+  });
+
+  it("resolves a reply chain to its root, capped visibly at 8 ancestors", async () => {
+    // The chain's natural bound is the platform's root; the cap is an IO guard. When it trips, the
+    // block SAYS the chain continues — a silent cut would read as the root.
+    const chainMsg = (id: string, text: string, parentId?: string) => () =>
+      Response.json({
+        code: 0,
+        msg: "ok",
+        data: {
+          items: [
+            {
+              message_id: id,
+              msg_type: "text",
+              ...(parentId ? { parent_id: parentId } : {}),
+              body: { content: JSON.stringify({ text }) },
+              sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+            },
+          ],
+        },
+      });
+    const routes: Record<string, () => Response> = {};
+    // om_c0 (the referent) … om_c9: each replies to the next — 9 ancestors above the referent.
+    for (let i = 0; i <= 9; i++)
+      routes[`/im/v1/messages/om_c${i}`] = chainMsg(`om_c${i}`, `hop ${i}`, i < 9 ? `om_c${i + 1}` : undefined);
+    const fx = feishuFetch(routes);
+    const { handler, calls, idle } = buildChannel();
+    await handler(feishuRequest(messageEvent({ id: "om_q1", text: "context?", parentId: "om_c0" })));
+    await idle();
+
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(prompt).toContain("[replied-to message (msg om_c0, from user ou_bob): hop 0]");
+    expect(prompt).toContain("(…the chain continues above this point)");
+    expect(prompt).toContain("(msg om_c8, from user ou_bob): hop 8"); // the 8th ancestor made it
+    expect(prompt).not.toContain("hop 9"); // the 9th did not…
+    expect(fx.calls("/im/v1/messages/om_c9", "GET")).toHaveLength(0); // …and was never fetched
+    // oldest first: the deepest fetched ancestor renders before the referent's immediate parent
+    expect(prompt.indexOf("hop 8")).toBeLessThan(prompt.indexOf("hop 1"));
+  });
+
+  it("a reply-chain cycle terminates, and a chain ancestor's image rides the buffered tier", async () => {
+    // Two boundaries in one walk. The cycle guard: om_r replies to om_s which replies back to om_r —
+    // corrupt platform data must end the walk, not the process. And the ancestor's image: chain
+    // attachments are CONTEXT, so they load on the buffered path (attributed in the manifest), never
+    // as primary inputs.
+    const fx = feishuFetch({
+      // Resource routes FIRST: a resource URL contains its message path as a prefix, and feishuFetch
+      // matches by substring in insertion order — a message route listed earlier would intercept it.
+      "/resources/chain_img": () =>
+        new Response(Buffer.from("img-bytes"), { status: 200, headers: { "content-type": "image/png" } }),
+      "/im/v1/messages/om_r": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_r",
+                msg_type: "text",
+                parent_id: "om_s",
+                body: { content: JSON.stringify({ text: "the quoted reply" }) },
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+      "/im/v1/messages/om_s": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_s",
+                msg_type: "image",
+                parent_id: "om_r", // the cycle
+                body: { content: JSON.stringify({ image_key: "chain_img" }) },
+                sender: { id: "ou_alice", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+    });
+    const { handler, calls, idle } = buildChannel();
+    await handler(feishuRequest(messageEvent({ id: "om_q2", text: "what image?", parentId: "om_r" })));
+    await idle();
+
+    // fetched once — the cycle ended the walk (the resources fetch shares the URL prefix, so exclude it)
+    const msgFetches = fx.calls("/im/v1/messages/om_s", "GET").filter((c) => !c.url.includes("/resources/"));
+    expect(msgFetches).toHaveLength(1);
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(prompt).toContain("(msg om_s, from user ou_alice): [image]");
+    // the image itself arrived through the buffered path, attributed to its chain position
+    expect(prompt).toContain("vision image 1: from user ou_alice, msg om_s");
+    expect(calls[0]?.prompt.images).toHaveLength(1);
+    expect(fx.calls("/im/v1/messages/om_s/resources/chain_img", "GET")).toHaveLength(1);
+  });
+
+  it("an unloadable chain-ancestor attachment costs a note, never the turn", async () => {
+    // The referent's own resources are primary (fail-fast: the user pointed at them). A chain
+    // ancestor's are not — nobody pointed at them — so losing one degrades exactly like a buffered
+    // attachment: the turn runs and the model is told what is missing.
+    const fx = feishuFetch({
+      // Resource route FIRST — see the cycle test for why insertion order matters here.
+      "/resources/gone_img": () => Response.json({ code: 234001, msg: "resource expired" }, { status: 410 }),
+      "/im/v1/messages/om_t": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_t",
+                msg_type: "text",
+                parent_id: "om_u",
+                body: { content: JSON.stringify({ text: "about that picture" }) },
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+      "/im/v1/messages/om_u": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_u",
+                msg_type: "image",
+                body: { content: JSON.stringify({ image_key: "gone_img" }) },
+                sender: { id: "ou_alice", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+    });
+    const { handler, calls, idle } = buildChannel();
+    await handler(feishuRequest(messageEvent({ id: "om_q3", text: "that pic?", parentId: "om_t" })));
+    await idle();
+
+    expect(calls).toHaveLength(1); // the turn ran — a chain attachment is never primary
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(prompt).toContain("(msg om_u, from user ou_alice): [image]");
+    expect(prompt).toContain("1 attachment(s) from the earlier discussion are not loaded");
+    expect(calls[0]?.prompt.images ?? []).toHaveLength(0);
+    expect(fx.calls("/resources/gone_img", "GET")).toHaveLength(1);
+  });
+
+  it("an unreadable chain ancestor ends the walk with the fetched part kept", async () => {
+    const fx = feishuFetch({
+      "/im/v1/messages/om_v": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_v",
+                msg_type: "text",
+                parent_id: "om_w",
+                body: { content: JSON.stringify({ text: "quoted" }) },
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+      "/im/v1/messages/om_w": () =>
+        Response.json({
+          code: 0,
+          msg: "ok",
+          data: {
+            items: [
+              {
+                message_id: "om_w",
+                msg_type: "text",
+                parent_id: "om_gone", // resolves to an empty item list — deleted or invisible
+                body: { content: JSON.stringify({ text: "still here" }) },
+                sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+              },
+            ],
+          },
+        }),
+      // om_gone: the default GET handler answers { items: [] }
+    });
+    const { handler, calls, idle } = buildChannel();
+    await handler(feishuRequest(messageEvent({ id: "om_q4", text: "context?", parentId: "om_v" })));
+    await idle();
+
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(prompt).toContain("(msg om_w, from user ou_bob): still here"); // the fetched part is kept
+    expect(prompt).not.toContain("om_gone"); // the unreadable one is a warn, not a marker
+    expect(fx.calls("/im/v1/messages/om_gone", "GET")).toHaveLength(1); // tried, then stopped
   });
 
   it("a custom route's null remains a full ignore and does not enter the default context buffer", async () => {


### PR DESCRIPTION
Part 1 of 3 in the thread-context work (#327 reply chain → #328 session inheritance → #330 room-buffer fold). This PR stands alone; the other two build on it.

## Problem (field-observed on Lark)

A user posts an image, the agent answers with a card, and a topic opened on that card asks about the image. The referent path read exactly ONE link — the card — so the model saw `[image]`'s placeholder two hops away and reported it could not see any picture.

Quoting a reply points at one link of an exchange. Reading only that link resolves the pointer halfway.

## The walk

The referent path now resolves the reply chain ABOVE the replied-to message: each ancestor fetched, decoded (cards included, via the #324 branch), attributed (`from you, the agent` / `from app …` / `from user …`), and rendered oldest-first — a transcript of the exchange the user is pointing into.

```text
[replied-to message (msg om_card, from you, the agent): 需要先确认两项…]
[reply chain above it, oldest first:
(msg om_ask, from user ou_alice): 看看这个 [image]]
```

**The bound is structure, not a picked number.** Every Feishu reply threads back to a root; the walk ends where the platform says the chain ends. The guards each answer one failure mode:

| Guard | Behavior |
|---|---|
| 8-ancestor cap | IO guard (one serial `getMessage` per hop; field chains are 1–3). Trips **visibly**: `(…the chain continues above this point)` |
| Cycle | Ends the walk silently — corrupt platform data, and ending is the whole fix |
| Unreadable ancestor | Keeps the part already fetched; a warn, not a marker — nobody pointed at it |
| Any author | The chain is the platform's structure, not a conversation the agent took part in — it walks through other bots' messages and attributes them honestly |

## Ancestor attachments: buffered, never primary

A chain ancestor's images/files join the **buffered** tier, deduplicated against the context buffer's refs by message-scoped identity. Nobody pointed at them, so an unloadable one costs the standard missing-attachment note — never the turn. The referent's own resources stay primary (fail-fast), unchanged.

This is the half that fixes the field case: the image behind the card now reaches the model as a background vision image, and its loss degrades instead of erroring.

## Relation to the hop removed in dc6f7da

A one-hop version of this walk was built and removed as a memory substitute. The questions that killed it — how many levels? deduplicated against the session how? an image two levels up as prompt text how? — are answered here by a **narrower job**, not a better hop: pointer resolution bounded by the chain's own root, attachments on the degradable tier, and history left to session inheritance (`participant-model.md` §8 — #328 and #330). §8's rung-2 entry now records both halves of that story.

## Tests (1336 green: lint / typecheck / test)

Own-card topic resolves the chain to the ask; another bot's card is walked but not self-attributed; cap at 8 with the visible marker and oldest-first order pinned; cycle terminates with the ancestor's image riding the buffered tier (manifest attribution included); an unloadable chain attachment yields the note while the turn runs; an unreadable ancestor keeps the fetched part. Mutation-verified: disabling the walk fails 6 tests.

