### PR TITLE
feat(pi+feishu): a new thread session starts from what the room knew

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -146,6 +146,7 @@ The core stays small. The following extensions attach through additional `scope`
 |---|---|
 | Identity / multi-tenancy | `scope.principal`, e.g. `{ type, issuer, subject }` |
 | Source / trace | `scope.source` and other identifying fields |
+| Session lineage | `scope.parentSession` (+ optional `scope.branchHints`) — read once, when the named session is first CREATED, to seed it from the session it branched off; ignored for existing sessions and by engines without the capability |
 | Execution constraints such as deadline / budget | Middleware; for example, `budget_exceeded` becomes a `failed` event produced by Middleware |
 | Mid-turn steering | **Extension, not part of the v0.1 core signature** — provided by the [session control plane](design/session-control.md): `dispatch(session, { type: "steer" \| "follow_up" \| "abort", … })` modulates the run an invoke is driving, beside the invoke rather than through its signature. (An earlier sketch — an optional third `input?: AsyncIterable<Prompt>` parameter — was rejected in favor of the control plane.) If the desired behavior is “discard the current turn and go another way”, cancel + a new `invoke` with the same `session` still works without any extension. |
 | Thinking / citations / artifact streaming | Add new non-terminal `AgentEvent` types |

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -287,7 +287,9 @@ to the end of its exchange — a mid-exchange fork inherits a question without i
 falls back to the room's present, with a warn). What the model sees is then bounded by one
 mechanical compaction mark — the newest 50 exchanges within a ~50K-token estimate, images priced
 flat — which IS rung 3's seed, generated from real session entries instead of re-serialized prompt
-text, so images and tool results come along for free. Every edge (missing parent, oversize journal,
+text, so images and tool results come along for free. Both limits govern how far the window extends
+into older history; the newest exchange is a floor, kept whole even when it alone exceeds the
+budget — an inheritance that drops the exchange the thread branched off would be no inheritance. Every edge (missing parent, oversize journal,
 torn tail line, a dangling tool call from forking a mid-turn room) fails toward an empty session
 with a warn: context is not the ask, and a thread must not lose its first turn to it.
 

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -235,12 +235,12 @@ commit on `completed`.
 
 A thread must start from something. Four rungs, increasing in cost:
 
-| Rung | Mechanism | Gives the thread |
-|---|---|---|
-| 1 | referent anchor, truncated | the followed-up message, cut at some display-sized bound |
-| **2** | **referent anchor, bounded by the platform** | **the followed-up message in full (`REFERENT_MAX_CODE_POINTS`)** |
-| 3 | seed injection | the room's last N exchanges, in the thread's first prompt |
-| 4 | session fork | the room's entire history, reasoning and tool results included |
+| Rung | Mechanism | Gives the thread | Status |
+|---|---|---|---|
+| 1 | referent anchor, truncated | the followed-up message, cut at some display-sized bound | rejected |
+| **2** | **referent anchor, bounded by the platform** | **the followed-up message in full (`REFERENT_MAX_CODE_POINTS`)** | implemented |
+| 3 | seed injection | the room's last N exchanges, in the thread's first prompt | subsumed by rung 4 |
+| **4** | **session inheritance (fork at the branch point)** | **the room's history up to where the thread branched — text, images, tool results — windowed** | **implemented** |
 
 Rung 1 fails the model's own main path: following up on the agent's answer, where the answer is
 routinely longer than the cut. **Rung 2 is implemented**, with one bound for every channel, derived
@@ -276,11 +276,31 @@ the pointer, with history left to the rungs below — and the bounds, which are 
 plus explicit budgets rather than a picked level count. Rung 3 is the next increment if anchors
 prove too narrow.
 
-Rung 4 (`SessionRepo.fork`, which would need an optional lineage field on `Scope`) is **not planned**:
-it over-delivers by copying the whole room — including everyone's unrelated conversations — into a
-focused side discussion, and it pays that cost on every turn rather than once. Its only exclusive
-capability is preserving the agent's reasoning and tool results; that is worth revisiting when a real
-case appears, not before.
+**Rungs 3 and 4 turned out to be one mechanism with two parameters, and it is implemented as
+session inheritance.** The channel states two facts only it knows — which place this one branched
+from (`scope.parentSession`, SPEC §8's extension mechanism) and which message ids may locate the
+branch point (`scope.branchHints`: the referent and its reply chain, whose ids passed through the
+room's turns) — and the engine does the rest, ONCE, when the thread's session is first created: the
+session existing is the record that the decision was taken, so there is no marker to persist and no
+decision to retry. The fork copies the room's active path up to the branch point (a hit is extended
+to the end of its exchange — a mid-exchange fork inherits a question without its answer; a miss
+falls back to the room's present, with a warn). What the model sees is then bounded by one
+mechanical compaction mark — the newest 50 exchanges within a ~50K-token estimate, images priced
+flat — which IS rung 3's seed, generated from real session entries instead of re-serialized prompt
+text, so images and tool results come along for free. Every edge (missing parent, oversize journal,
+torn tail line, a dangling tool call from forking a mid-turn room) fails toward an empty session
+with a warn: context is not the ask, and a thread must not lose its first turn to it.
+
+An earlier revision of this section declared rung 4 "not planned" on two assumptions, both wrong
+and both corrected by measurement: a fork does not "pay on every turn" (it is one-time by
+construction — fork, then the two sessions never touch again), and "copying the whole room"
+conflated storage with context (disk keeps the full inspectable copy; the mark governs what reaches
+the model — different budgets). The one prediction it got right — preserving reasoning and tool
+results is fork's exclusive capability — is the reason rung 3 never shipped as prompt text.
+
+Adoption is per channel, because only a channel knows its places' lineage: Feishu/Lark set the
+scope fields (threads inherit); Telegram and Slack do not yet (their threads still start empty —
+the fields are one wiring change away).
 
 *Known asymmetry, accepted:* room → thread transfers once, when the thread starts, and nothing flows
 back (§7). A thread neither learns about later room activity nor reports its own.

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -252,7 +252,11 @@ place rather than the individual ask ([design note](design/participant-model.md)
 | Direct-message thread | `<kind>:<chat_id>:<thread_id>` | inside the thread | always answered — a p2p chat has one human, so there is nothing to disambiguate and no participation is recorded |
 
 There are no session modes to choose. A room has one memory that everyone in it shares, so a colleague
-can follow up on someone else's question; a thread is a separate place with its own.
+can follow up on someone else's question; a thread is a separate place with its own — **started from
+what the room knew**: a new thread's session inherits the room's recent history (up to the message the
+thread branched from, windowed to the newest ≈50 exchanges), including images and tool results. The
+inheritance happens once, when the thread's session is created; after that the two places are
+independent, and the room never sees what the thread discusses.
 
 **Starting a thread.** Mention the Agent inside a thread once (typically by replying to one of its
 messages and creating a topic). It answers there, which makes it a participant, and every later bare

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -21,6 +21,17 @@ export interface Prompt {
 export interface Scope {
   /** Opaque session anchor: turns of the same logical conversation MUST reuse the same value. */
   session: string;
+  /** EXTENSION (SPEC §8): the session this one branched from — a channel sets it when the place it
+   *  is invoking for was born out of another place (a thread opened in a room). Read ONLY when
+   *  `session` does not exist yet: an engine that understands it seeds the NEW session from the
+   *  parent once, at creation; after that the field is ignored, and an engine that does not
+   *  understand it ignores it entirely (the session starts empty, yesterday's behavior). */
+  parentSession?: string;
+  /** EXTENSION (SPEC §8): opaque markers that MAY locate the branch point inside `parentSession` —
+   *  e.g. platform message ids its transcript embeds. Best-effort by design: the first marker found
+   *  in the parent's transcript wins, and no match falls back to the parent's present. Meaningless
+   *  without `parentSession`. */
+  branchHints?: string[];
 }
 
 export type AgentEvent =

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -45,6 +45,7 @@ import {
   cloudEnvelope,
   defaultFeishuRoute,
   feishuEnvelope,
+  parentPlaceKey,
   placeKey,
   senderId,
   senderLabel,
@@ -462,13 +463,23 @@ function createFeishuRuntimeFactory(
           images: rec.images.map((ref) => ({ messageId: ref.msg, key: ref.key })),
           files: rec.files.map((ref) => ({ messageId: ref.msg, key: ref.key, name: ref.name })),
         });
+        // A thread place names the room it branched from; a main place has no parent. Derived from
+        // the session key by its format owner (parse.parentPlaceKey) — the key IS the place identity.
+        const parentSession = parentPlaceKey(rec.session);
         try {
           await streamFeishuReply(
             invokeFeishuTurn(
               agent,
               rec.session,
               prompt,
-              { api, chatId: rec.chatId, filesDir: join(stateHome, "files"), label, appId },
+              {
+                api,
+                chatId: rec.chatId,
+                filesDir: join(stateHome, "files"),
+                label,
+                appId,
+                ...(parentSession !== undefined ? { parentSession } : {}),
+              },
               { primary: { images: rec.images, files: rec.files, parentId: rec.parentId }, buffered },
               () => {
                 // Drop intent first: a crash between these writes may re-fold answered context later,

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -45,7 +45,6 @@ import {
   cloudEnvelope,
   defaultFeishuRoute,
   feishuEnvelope,
-  parentPlaceKey,
   placeKey,
   senderId,
   senderLabel,
@@ -96,6 +95,9 @@ interface StoredFeishuTurn {
   queueReplyTo?: string;
   replyInThread?: boolean;
   parentId?: string;
+  /** The place this thread branched from (§5 lineage) — recorded at ingress, where the session's
+   *  routed-ness is known; absent for main places, routed (opaque) sessions, and pre-upgrade records. */
+  parentSession?: string;
   images: { msg: string; key: string }[];
   files: { msg: string; key: string; name?: string }[];
   attempts: number;
@@ -120,6 +122,7 @@ function isStoredFeishuTurn(t: unknown): t is StoredFeishuTurn {
     (r.queueReplyTo === undefined || typeof r.queueReplyTo === "string") &&
     (r.replyInThread === undefined || typeof r.replyInThread === "boolean") &&
     (r.parentId === undefined || typeof r.parentId === "string") &&
+    (r.parentSession === undefined || typeof r.parentSession === "string") &&
     refs(r.images) &&
     refs(r.files) &&
     typeof r.attempts === "number"
@@ -463,9 +466,9 @@ function createFeishuRuntimeFactory(
           images: rec.images.map((ref) => ({ messageId: ref.msg, key: ref.key })),
           files: rec.files.map((ref) => ({ messageId: ref.msg, key: ref.key, name: ref.name })),
         });
-        // A thread place names the room it branched from; a main place has no parent. Derived from
-        // the session key by its format owner (parse.parentPlaceKey) — the key IS the place identity.
-        const parentSession = parentPlaceKey(rec.session);
+        // Recorded at ingress (see submit) — never re-derived from the session key, which may be a
+        // routed OPAQUE id that only looks like a place key.
+        const parentSession = rec.parentSession;
         try {
           await streamFeishuReply(
             invokeFeishuTurn(
@@ -648,7 +651,15 @@ function createFeishuRuntimeFactory(
       // Memory follows the place (participant model §5): one session per chat, and one per thread.
       // Keyed by `thread_id`, never `root_id` — the platform's root_id tracks the reply chain and can
       // differ between messages of ONE thread, which would split a side conversation in two.
-      const session = r.session ?? placeKey(kind, m);
+      const routed = r.session;
+      const session = routed ?? placeKey(kind, m);
+      // Lineage is recorded ONLY for the default place-derived session. A routed session id is
+      // OPAQUE (the route contract), and re-parsing it as a place key would let a three-segment id
+      // like "tenant:user:alice" masquerade as a thread and inherit from "tenant:user" — a
+      // cross-session injection. Derived from the MESSAGE (the fact this channel owns), at record
+      // time, where routed-ness is still known; the dequeue path only reads it back.
+      const parentSession =
+        routed === undefined && m.thread_id !== undefined ? placeKey(kind, { chat_id: m.chat_id }) : undefined;
       const chatId = r.chatId ?? m.chat_id;
       const sameTarget = chatId === m.chat_id;
       // Answer where asked (§4): quote in a group so the ask is identifiable among many speakers,
@@ -703,6 +714,7 @@ function createFeishuRuntimeFactory(
           // already have; it also pins WHICH message is being answered, which a long thread benefits
           // from anyway.
           parentId: m.parent_id,
+          ...(parentSession !== undefined ? { parentSession } : {}),
           images,
           files,
         },

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -12,7 +12,7 @@
  * ancestors, and degrade per attachment: one expired background file must not block the current ask
  * or hide its still-readable siblings.
  */
-import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
+import type { Agent, AgentEvent, ImageRef, Scope } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -49,6 +49,11 @@ export interface FeishuTurnTransport {
    *  sender is an app. Needed to tell the agent's OWN messages from any other bot's in the same chat:
    *  `sender_type` alone says "some app", which is not the question the referent path asks. */
   appId: string;
+  /** The place this thread branched from (the chat's main place), when the turn runs in a thread —
+   *  rides the Scope's lineage extension so a NEW thread session starts from what the room knew
+   *  (participant-model.md §5). The engine reads it once, at session creation; every later turn
+   *  carries it inertly. */
+  parentSession?: string;
 }
 
 /** An attachment reference: the resource key inside its CARRYING message (the resource API addresses
@@ -75,6 +80,8 @@ export interface FeishuTurnAttachments {
 interface ResolvedInputs {
   images: ImageRef[] | undefined;
   promptSuffix: string;
+  /** Branch hints for the scope's lineage extension: the referent + its chain, nearest first. */
+  referentIds: string[];
 }
 
 /** How far up a reply chain the walk reads, beyond the replied-to message itself. The chain's natural
@@ -111,6 +118,10 @@ interface ReplyChain {
   block: string;
   images: FeishuBufferedRef[];
   files: FeishuBufferedRef[];
+  /** The walked ancestors' message ids, nearest first — the natural branch hints: a thread rooted on
+   *  the agent's own answer has an UNFINDABLE root id (the answer was sent after its turn, so its id
+   *  never entered the parent session), but the chain above it is exactly the ids that did. */
+  ids: string[];
 }
 
 /**
@@ -147,7 +158,7 @@ async function walkReplyChain(
   const files: FeishuBufferedRef[] = [];
   // No parent above the referent = no chain — not a truncated one. The marker below is only for
   // walks that END SHORT of a root that exists.
-  if (start === undefined) return { block: "", images, files };
+  if (start === undefined) return { block: "", images, files, ids: [] };
   let reachedRoot = false;
   let textBudget = REFERENT_MAX_CODE_POINTS;
   let next: string | undefined = start;
@@ -193,7 +204,14 @@ async function walkReplyChain(
   // One line for every way of ending short of the root — cap, budget, unreadable, cycle. It names no
   // cause on purpose: the model needs the SHAPE (there is more above), the operator log has the why.
   if (!reachedRoot) lines.unshift("(…the chain continues above this point)");
-  return { block: `\n[reply chain above it, oldest first:\n${lines.join("\n")}]`, images, files };
+  return {
+    block: `\n[reply chain above it, oldest first:\n${lines.join("\n")}]`,
+    images,
+    files,
+    // Walked (fetched) order = nearest first — nodes were reversed for RENDERING above, so read the
+    // hint order off the rendered list backwards.
+    ids: nodes.map((node) => node.id).reverse(),
+  };
 }
 
 /**
@@ -205,7 +223,7 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   const images = [...attachments.primary.images];
   const files = [...attachments.primary.files];
   let referentBlock = "";
-  let chain: ReplyChain = { block: "", images: [], files: [] };
+  let chain: ReplyChain = { block: "", images: [], files: [], ids: [] };
   if (attachments.primary.parentId !== undefined) {
     const parentId = attachments.primary.parentId;
     // A referent is CONTEXT, not the ask. Losing it (deleted, restricted, unreadable) must not cost
@@ -320,6 +338,7 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   return {
     images: allImages.length ? allImages : undefined,
     promptSuffix: `${referentBlock}${missingNote}${backgroundImageManifest}${attachedFilesManifest(allFiles)}`,
+    referentIds: [...(attachments.primary.parentId !== undefined ? [attachments.primary.parentId] : []), ...chain.ids],
   };
 }
 
@@ -345,5 +364,12 @@ export async function* invokeFeishuTurn(
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${REPLY_INSTRUCTION}`, images: resolved.images };
-  yield* streamTurnWithBusyRetry(agent, session, prompt, { label: transport.label, onCompleted, busyRetry });
+  // A thread turn names its lineage: parent place + the message ids that can locate the branch point
+  // (the referent and its chain — nearest first). The engine reads them ONCE, when the thread's
+  // session does not exist yet; on every later turn they ride along inertly.
+  const scope: Scope =
+    transport.parentSession === undefined
+      ? { session }
+      : { session, parentSession: transport.parentSession, branchHints: resolved.referentIds };
+  yield* streamTurnWithBusyRetry(agent, scope, prompt, { label: transport.label, onCompleted, busyRetry });
 }

--- a/src/channels/feishu/parse.ts
+++ b/src/channels/feishu/parse.ts
@@ -68,17 +68,6 @@ export function placeKey(kind: string, message: Pick<FeishuMessage, "chat_id" | 
   return message.thread_id ? `${chat}:${message.thread_id}` : chat;
 }
 
-/**
- * The place a THREAD place branched from — its chat's main place — or undefined for a main place,
- * which branched from nothing. Lives here because this module owns the key format: the split is
- * safe exactly because {@link placeKey} built the key (the kind brand and Feishu's ids carry no
- * `:`), and no other module may assume that.
- */
-export function parentPlaceKey(key: string): string | undefined {
-  const parts = key.split(":");
-  return parts.length === 3 ? `${parts[0]}:${parts[1]}` : undefined;
-}
-
 /** The canonical Feishu-branded prompt envelope. */
 export function feishuEnvelope(event: FeishuMessageEvent): string {
   return cloudEnvelope(event, "feishu");
@@ -93,6 +82,12 @@ export function cloudEnvelope(event: FeishuMessageEvent, tag: FeishuCloudKind): 
     `chat ${message.chat_id} (${message.chat_type})`,
     message.thread_id ? `topic ${message.thread_id}` : undefined,
     from ? `from ${from}` : undefined,
+    // The message's own id is LOAD-BEARING, not decoration: it is the only way this message's id
+    // enters the session transcript, and session inheritance locates a thread's branch point by
+    // searching the parent transcript for exactly these ids (scope.branchHints — sessions.ts).
+    // Remove it and every thread quietly inherits from the room's present instead of the branch
+    // point. It also lets the model name what it is answering in a busy chat.
+    `msg ${message.message_id}`,
   ]
     .filter(Boolean)
     .join(", ");

--- a/src/channels/feishu/parse.ts
+++ b/src/channels/feishu/parse.ts
@@ -68,6 +68,17 @@ export function placeKey(kind: string, message: Pick<FeishuMessage, "chat_id" | 
   return message.thread_id ? `${chat}:${message.thread_id}` : chat;
 }
 
+/**
+ * The place a THREAD place branched from — its chat's main place — or undefined for a main place,
+ * which branched from nothing. Lives here because this module owns the key format: the split is
+ * safe exactly because {@link placeKey} built the key (the kind brand and Feishu's ids carry no
+ * `:`), and no other module may assume that.
+ */
+export function parentPlaceKey(key: string): string | undefined {
+  const parts = key.split(":");
+  return parts.length === 3 ? `${parts[0]}:${parts[1]}` : undefined;
+}
+
 /** The canonical Feishu-branded prompt envelope. */
 export function feishuEnvelope(event: FeishuMessageEvent): string {
   return cloudEnvelope(event, "feishu");

--- a/src/channels/http.ts
+++ b/src/channels/http.ts
@@ -62,15 +62,37 @@ export function createInvokeHandler(agent: Agent): (req: Request) => Promise<Res
     } catch {
       return text("invalid json\n", 400);
     }
-    const { session, text: promptText } = (payload ?? {}) as { session?: unknown; text?: unknown };
+    const {
+      session,
+      text: promptText,
+      parentSession,
+      branchHints,
+    } = (payload ?? {}) as { session?: unknown; text?: unknown; parentSession?: unknown; branchHints?: unknown };
     if (typeof session !== "string" || typeof promptText !== "string") {
       return text('need { "session": string, "text": string }\n', 400);
     }
     // ^ the request shape INVOKE_EXAMPLE_BODY (below) must keep satisfying.
+    // The OPTIONAL lineage extension (Scope): malformed values are a 400, not a silent drop — a
+    // caller that sent them meant them.
+    if (parentSession !== undefined && typeof parentSession !== "string") {
+      return text('"parentSession" must be a string\n', 400);
+    }
+    if (branchHints !== undefined && !(Array.isArray(branchHints) && branchHints.every((h) => typeof h === "string"))) {
+      return text('"branchHints" must be an array of strings\n', 400);
+    }
 
     // Take the iterator explicitly so the stream's cancel() (consumer disconnect) can return() it and
     // run invoke's cancellation cleanup (SPEC MUST 3). pull = backpressure: the next event is produced on demand.
-    const iterator = agent.invoke({ session }, { text: promptText })[Symbol.asyncIterator]();
+    const iterator = agent
+      .invoke(
+        {
+          session,
+          ...(parentSession !== undefined ? { parentSession } : {}),
+          ...(branchHints !== undefined ? { branchHints } : {}),
+        },
+        { text: promptText },
+      )
+      [Symbol.asyncIterator]();
     // Heartbeats: a QUIET stream (a long tool call, no events) is normal here — remote consumers
     // distinguish "quiet but alive" from a dead connection by byte arrival, so silence must not
     // look identical to a black hole (SSE comments are ignored by spec-conforming parsers).

--- a/src/channels/invoke-turn-kit.ts
+++ b/src/channels/invoke-turn-kit.ts
@@ -10,7 +10,7 @@
  * Attachment RESOLUTION stays per channel — the platform resource models (Bot API file_ids,
  * message-scoped Feishu keys, Slack file objects) are real differences.
  */
-import { type Agent, type AgentEvent, type Prompt, SESSION_BUSY_CODE } from "../agent.ts";
+import { type Agent, type AgentEvent, type Prompt, SESSION_BUSY_CODE, type Scope } from "../agent.ts";
 import { log } from "../log.ts";
 
 /** How the busy-wait paces: retry the invoke every `delayMs` while the session's lease is held by an
@@ -45,16 +45,19 @@ export const DEFAULT_BUSY_RETRY: BusyRetry = { delayMs: 5_000, maxWaitMs: 600_00
  */
 export async function* streamTurnWithBusyRetry(
   agent: Agent,
-  session: string,
+  /** The full scope, not a session string — channels that set extension fields (lineage) pass them
+   *  through here; channels that don't pass `{ session }` and nothing changes. */
+  scope: Scope,
   prompt: Prompt,
   options: { label: string; onCompleted?: () => void; busyRetry?: BusyRetry },
 ): AsyncIterable<AgentEvent> {
   const { label, onCompleted, busyRetry = DEFAULT_BUSY_RETRY } = options;
+  const session = scope.session;
   const deadline = Date.now() + busyRetry.maxWaitMs;
   for (;;) {
     let retryBusy = false;
     let first = true;
-    for await (const e of agent.invoke({ session }, prompt)) {
+    for await (const e of agent.invoke(scope, prompt)) {
       if (first && e.type === "failed" && e.code === SESSION_BUSY_CODE && Date.now() + busyRetry.delayMs < deadline) {
         retryBusy = true; // fail-fast reject — the stream ends after this event; wait and re-invoke
         break;

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -108,5 +108,5 @@ export async function* invokeSlackTurn(
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${MARKDOWN_INSTRUCTION}`, images: resolved.images };
-  yield* streamTurnWithBusyRetry(agent, session, prompt, { label: transport.label, onCompleted, busyRetry });
+  yield* streamTurnWithBusyRetry(agent, { session }, prompt, { label: transport.label, onCompleted, busyRetry });
 }

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -124,5 +124,5 @@ export async function* invokeTurn(
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${HTML_INSTRUCTION}`, images: resolved.images };
-  yield* streamTurnWithBusyRetry(agent, session, prompt, { label: "[telegram]", onCompleted, busyRetry });
+  yield* streamTurnWithBusyRetry(agent, { session }, prompt, { label: "[telegram]", onCompleted, busyRetry });
 }

--- a/src/engines/pi/harness.ts
+++ b/src/engines/pi/harness.ts
@@ -10,7 +10,7 @@ import { AgentHarness } from "@earendil-works/pi-agent-core";
 import type { ExecutionEnv, ExecutionToolContext, Skill, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Model, Models } from "@earendil-works/pi-ai";
 import { log } from "../../log.ts";
-import { type PiSessionStore, activePathEntries } from "./sessions.ts";
+import { type PiSessionStore, type SessionInheritance, activePathEntries } from "./sessions.ts";
 import { isDeferredTool, type MountedTool } from "./tool.ts";
 import { type OverrideEntryLike, resolveSessionSettings } from "./session-settings.ts";
 
@@ -52,7 +52,11 @@ export type AnyModel = Model<any>;
  *  pi's env-backed default tools read (pi 0.83). Custom tools are context-FREE and stay assignable — a
  *  four-parameter `execute` satisfies the five-parameter one, so `defineTool` is untouched by this. */
 type PiHarness = AgentHarness<ExecutionToolContext>;
-export type PiHarnessFactory = (session: string) => PiHarness | Promise<PiHarness>;
+export type PiHarnessFactory = (
+  session: string,
+  /** Where a NEW session starts from (sessions.ts) — an existing session ignores it. */
+  inherit?: SessionInheritance,
+) => PiHarness | Promise<PiHarness>;
 
 export interface PiHarnessFactoryOptions {
   /** Session persistence. Continuity = same backing store + same session id. */
@@ -197,10 +201,11 @@ export function resolveHarnessActiveToolNames(
   return [...new Set([...initial, ...known])];
 }
 
-/** Open-or-create the session per invoke: existing → open (history via buildContext); missing → create. */
+/** Open-or-create the session per invoke: existing → open (history via buildContext); missing →
+ *  create, seeded from `inherit` when the scope names a parent. */
 export function piHarnessFactory(options: PiHarnessFactoryOptions): PiHarnessFactory {
-  return async (sessionId) => {
-    const session = await options.sessions.openOrCreate(sessionId);
+  return async (sessionId, inherit) => {
+    const session = await options.sessions.openOrCreate(sessionId, inherit);
     // One extra entry walk per invoke to collect the activation deltas — negligible against the model
     // call, same trade as L2's per-invoke definition re-read. The walk is over the ACTIVE PATH, not
     // the flat journal: `navigate` moves the leaf, so the tree can hold an abandoned branch whose

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -576,7 +576,17 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
     try {
       let harness: Awaited<ReturnType<PiHarnessFactory>>;
       try {
-        harness = await harnessFactory(scope.session);
+        // Scope's lineage extension flows to the store's CREATE path only — an existing session
+        // opens exactly as before, whatever the scope names (inheritance is one-time by construction).
+        harness = await harnessFactory(
+          scope.session,
+          scope.parentSession === undefined
+            ? undefined
+            : {
+                parentSession: scope.parentSession,
+                ...(scope.branchHints !== undefined ? { branchHints: scope.branchHints } : {}),
+              },
+        );
       } catch (error) {
         // Setup failures (session open / auth / …) MUST surface as a failed event, never a throw.
         harnessFailed(error); // a pending dispatch learns the run cannot take commands

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -10,7 +10,8 @@
  * Continuity = same backing store + same session id: in-memory continuity dies with the instance;
  * jsonl survives process restarts (disk is the truth).
  */
-import { stat } from "node:fs/promises";
+import { rename, stat } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import { InMemorySessionRepo } from "@earendil-works/pi-agent-core";
 import type { AgentMessage, Session, SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
@@ -187,8 +188,15 @@ export async function activePathEntries(session: Session): Promise<SessionTreeEn
 
 /** Inheritance window: at most this many exchanges of the parent reach the child's model context. */
 const INHERIT_MAX_EXCHANGES = 50;
-/** …and at most roughly this many tokens (~1/4 of a 200K context: generous, not everything). */
+/** …and at most roughly this many tokens (~1/4 of a 200K context: generous, not everything). Both
+ *  limits govern how far the window EXTENDS into older history — the newest exchange is a FLOOR,
+ *  kept whole even when it alone exceeds the budget: the mark's boundary is entry-granular, and an
+ *  inheritance that drops the exchange the thread branched off would be no inheritance at all. */
 const INHERIT_MAX_TOKENS = 50_000;
+/** Branch hints are IDS, not payloads: each one costs a scan over the parent's serialized path, and
+ *  the wire accepts arbitrary arrays — so the engine caps them where the cost lives. */
+const MAX_BRANCH_HINTS = 16;
+const MAX_BRANCH_HINT_CHARS = 128;
 /** A vision image is priced FLAT — what a provider bills for a resized image, roughly — because its
  *  base64 length (~1M chars for a photo) measures storage, not context: pricing it by chars would
  *  let one photo evict the whole text window. */
@@ -203,10 +211,9 @@ function isUserMessage(entry: SessionTreeEntry | undefined): boolean {
 
 /** Rough token estimate for windowing — text at chars/4, images flat. Precision is not the point:
  *  the window is a budget, and being 20% off moves a boundary by an exchange, not correctness. */
-function estimateEntryTokens(entry: SessionTreeEntry): number {
-  if (entry.type !== "message") return 0;
+function estimateMessageTokens(message: AgentMessage): number {
   // AgentMessage is a role-keyed union and not every member carries `content` — read it loosely.
-  const content = (entry.message as { content?: unknown }).content;
+  const content = (message as { content?: unknown }).content;
   if (typeof content === "string") return Math.ceil(content.length / 4);
   if (!Array.isArray(content)) return 0;
   let tokens = 0;
@@ -219,6 +226,20 @@ function estimateEntryTokens(entry: SessionTreeEntry): number {
   return tokens;
 }
 
+function estimateEntryTokens(entry: SessionTreeEntry): number {
+  if (entry.type !== "message") return 0;
+  return estimateMessageTokens(entry.message);
+}
+
+/** A compaction entry's summary and retained tail DO reach the model — they are the floor under
+ *  every window that starts above the compaction, so the budget must count them. */
+function estimateCompactionTokens(entry: SessionTreeEntry | undefined): number {
+  if (entry?.type !== "compaction") return 0;
+  let tokens = Math.ceil(entry.summary.length / 4);
+  for (const message of entry.retainedTail ?? []) tokens += estimateMessageTokens(message);
+  return tokens;
+}
+
 /**
  * Find the fork target on the parent's active path: the LAST message whose content carries a hint
  * (the most recent turn that talked about that message), extended forward to the end of its exchange
@@ -226,14 +247,22 @@ function estimateEntryTokens(entry: SessionTreeEntry): number {
  * order; the first that matches anywhere wins. No match → undefined (the caller forks the present).
  */
 function locateBranchPoint(path: SessionTreeEntry[], hints: string[]): string | undefined {
-  for (const hint of hints) {
-    if (!hint) continue;
+  const usable = hints
+    .filter((hint) => hint.length > 0 && hint.length <= MAX_BRANCH_HINT_CHARS)
+    .slice(0, MAX_BRANCH_HINTS);
+  if (usable.length < hints.length) {
+    log.warn(
+      `[fastagent] ignored ${hints.length - usable.length} branch hint(s) (over ${MAX_BRANCH_HINTS} hints or ${MAX_BRANCH_HINT_CHARS} chars each) — hints are message ids, not payloads`,
+    );
+  }
+  if (usable.length === 0) return undefined;
+  // Serialize each message ONCE — the scan is hints × entries, and stringify must not sit in the
+  // inner loop. The whole message, not just content: shape-agnostic, and a hint is a platform id —
+  // a false positive would need the id to appear outside content, which is where ids live anyway.
+  const serialized = path.map((entry) => (entry.type === "message" ? JSON.stringify(entry.message) : ""));
+  for (const hint of usable) {
     for (let i = path.length - 1; i >= 0; i--) {
-      const entry = path[i];
-      if (entry?.type !== "message") continue;
-      // The whole message, not just content: shape-agnostic, and a hint is a platform id — a false
-      // positive would need the id to appear outside content, which is where ids live anyway.
-      if (!JSON.stringify(entry.message).includes(hint)) continue;
+      if (!serialized[i]?.includes(hint)) continue;
       let j = i + 1;
       while (j < path.length && !isUserMessage(path[j])) j++;
       return path[j - 1]?.id;
@@ -258,6 +287,9 @@ async function markInheritanceWindow(child: Session): Promise<void> {
     }
   }
   const scanned = path.slice(scanFrom);
+  // The compaction's own summary + retained tail reach the model regardless of where the window
+  // lands, so they charge the budget as a base cost — not estimating them would over-admit.
+  const baseTokens = estimateCompactionTokens(path[scanFrom - 1]);
   const starts: number[] = [];
   scanned.forEach((entry, i) => {
     if (isUserMessage(entry)) starts.push(i);
@@ -273,7 +305,7 @@ async function markInheritanceWindow(child: Session): Promise<void> {
     const exchanges = starts.length - k;
     const startIdx = starts[k];
     if (startIdx === undefined) break;
-    if (exchanges > INHERIT_MAX_EXCHANGES || (suffixTokens[startIdx] ?? 0) > INHERIT_MAX_TOKENS) break;
+    if (exchanges > INHERIT_MAX_EXCHANGES || baseTokens + (suffixTokens[startIdx] ?? 0) > INHERIT_MAX_TOKENS) break;
     chosen = k;
   }
   if (chosen === 0) return; // the whole visible history fits the window
@@ -293,7 +325,13 @@ interface InheritRepo<M> {
   find(id: string): Promise<M | undefined>;
   open(meta: M): Promise<Session>;
   create(id: string): Promise<Session>;
-  fork(meta: M, id: string, atEntryId: string): Promise<Session>;
+  /** Fork the parent into a DRAFT that the store's normal lookups cannot discover — pi's fork
+   *  creates the target file first and appends entries after, so a discoverable half-written child
+   *  would read as "the decision was taken" forever (openOrCreate short-circuits on existence). */
+  forkDraft(meta: M, id: string, atEntryId: string): Promise<Session>;
+  /** Atomically publish a FINISHED draft (repaired + window-marked) under its real id. Everything
+   *  before this is invisible and repeatable; everything after it is complete. */
+  publish(draft: Session, parentMeta: M): Promise<Session>;
   /** Journal size, when the backend has one — guards the read-everything fork. */
   bytes?(meta: M): Promise<number>;
 }
@@ -338,11 +376,13 @@ async function createInheriting<M>(
         `[fastagent] no branch hint matched in parent "${parentId}" — inheriting from its present instead of the branch point`,
       );
     }
-    const child = await repo.fork(parentMeta, id, at ?? leaf.id);
-    await reconcileInterruptedToolCalls(child);
-    await markInheritanceWindow(child);
-    return child;
+    const draft = await repo.forkDraft(parentMeta, id, at ?? leaf.id);
+    await reconcileInterruptedToolCalls(draft);
+    await markInheritanceWindow(draft);
+    return await repo.publish(draft, parentMeta);
   } catch (error) {
+    // A failure ANYWHERE above leaves no discoverable child (drafts live outside the store's
+    // lookups), so falling back to create cannot produce a second file under the same id.
     log.warn(`[fastagent] could not fork parent session "${parentId}" (${String(error)}) — starting empty`);
     return repo.create(id);
   }
@@ -355,7 +395,10 @@ export function inMemorySessionStore(): PiSessionStore & PiSessionReader {
     find: async (id) => (await repo.list()).find((m) => m.id === id),
     open: (m) => repo.open(m),
     create: (id) => repo.create({ id }),
-    fork: (m, id, atEntryId) => repo.fork(m, { id, entryId: atEntryId, position: "at" }),
+    // In-memory needs no draft indirection: partial state cannot outlive the process, which is the
+    // only reader — the crash the jsonl dance guards against has nothing durable to poison here.
+    forkDraft: (m, id, atEntryId) => repo.fork(m, { id, entryId: atEntryId, position: "at" }),
+    publish: async (draft) => draft,
   };
   return {
     async openOrCreate(sessionId, inherit) {
@@ -388,11 +431,34 @@ export function jsonlSessionStore(options: {
   const cwd = options.cwd ?? process.cwd();
   const forkMaxBytes = options.forkMaxBytes ?? FORK_MAX_BYTES;
   const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
+  // Drafts are forked into a sibling root INSIDE the store dir but OUTSIDE every lookup: `list({
+  // cwd })` scans only `<dir>/<encodedCwd>`, and a cwd-less `list()` scans `<dir>/*/​*.jsonl` — one
+  // level, which `.inherit-tmp/<encodedCwd>/*.jsonl` sits below. A crash mid-inheritance therefore
+  // leaves only invisible garbage (bounded by crash count; the next attempt forks a fresh draft —
+  // never resumed, so staleness cannot poison anything), and the real directory gains the child in
+  // exactly one atomic rename, already repaired and window-marked.
+  const draftRepo = new JsonlSessionRepo({
+    fs: new NodeExecutionEnv({ cwd }),
+    sessionsRoot: join(options.dir, ".inherit-tmp"),
+  });
   const adapter: InheritRepo<Awaited<ReturnType<JsonlSessionRepo["list"]>>[number]> = {
     find: async (id) => (await repo.list({ cwd })).find((m) => m.id === id),
     open: (m) => repo.open(m),
     create: (id) => repo.create({ id, cwd }),
-    fork: (m, id, atEntryId) => repo.fork(m, { cwd, id, entryId: atEntryId, position: "at" }),
+    // `fork` opens the source by its metadata's absolute path, so the draft repo reads the real
+    // repo's parent file directly while writing into its own root.
+    forkDraft: (m, id, atEntryId) => draftRepo.fork(m, { cwd, id, entryId: atEntryId, position: "at" }),
+    publish: async (draft, parentMeta) => {
+      // The interface erases the metadata generic; a jsonl draft's metadata always carries `path`.
+      const draftPath = ((await draft.getMetadata()) as unknown as { path: string }).path;
+      // The parent lives in the REAL cwd directory — its metadata is the authoritative way to name
+      // it (no re-deriving pi's cwd encoding). Same filesystem, so the rename is atomic.
+      const target = join(dirname(parentMeta.path), basename(draftPath));
+      await rename(draftPath, target);
+      const published = (await repo.list({ cwd })).find((m) => m.path === target);
+      if (!published) throw new Error(`published session vanished: ${target}`);
+      return repo.open(published);
+    },
     bytes: async (m) => (await stat(m.path)).size,
   };
   return {

--- a/src/engines/pi/sessions.ts
+++ b/src/engines/pi/sessions.ts
@@ -1,22 +1,39 @@
 /**
  * Session persistence — the K-axis port and its first two backends.
  *
- * PiSessionStore is the consumer-owned port: open-or-create by opaque session id, nothing more.
- * pi's full SessionRepo surface (list/open/create/delete/fork) stays behind the adapters. The `Pi`
- * prefix is honest — `openOrCreate` returns pi's `Session`, so this is pi-coupled, not a neutral
+ * PiSessionStore is the consumer-owned port: open-or-create by opaque session id, plus one creation
+ * option — inheritance. pi's full SessionRepo surface (list/open/create/delete) stays behind the
+ * adapters; `fork` is surfaced only through {@link SessionInheritance}, never raw. The `Pi` prefix
+ * is honest — `openOrCreate` returns pi's `Session`, so this is pi-coupled, not a neutral
  * persistence contract.
  *
  * Continuity = same backing store + same session id: in-memory continuity dies with the instance;
  * jsonl survives process restarts (disk is the truth).
  */
+import { stat } from "node:fs/promises";
 import { InMemorySessionRepo } from "@earendil-works/pi-agent-core";
 import type { AgentMessage, Session, SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import { JsonlSessionRepo, NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { log } from "../../log.ts";
 
+/**
+ * Where a NEW session starts from, when it names a parent (participant-model.md §5: "a thread starts
+ * from what the room knew"). Read only on the create path — an EXISTING session ignores it entirely,
+ * which is what makes inheritance one-time by construction: no marker to persist, no decision to
+ * retry per turn; the session existing IS the record that the decision was taken.
+ */
+export interface SessionInheritance {
+  /** The session to fork from. Missing or unreadable → the new session starts empty, with a warn —
+   *  context is not the ask, and losing it must not cost the turn. */
+  parentSession: string;
+  /** Opaque markers that MAY locate the branch point on the parent's active path (searched in
+   *  message content, first hit wins, most recent occurrence). No match → the parent's present. */
+  branchHints?: string[];
+}
+
 /** What fastagent needs from a session backend: open-or-create by opaque id. */
 export interface PiSessionStore {
-  openOrCreate(sessionId: string): Promise<Session>;
+  openOrCreate(sessionId: string, inherit?: SessionInheritance): Promise<Session>;
 }
 
 /**
@@ -156,13 +173,197 @@ export async function activePathEntries(session: Session): Promise<SessionTreeEn
   return path.reverse(); // walked leaf→root; every consumer reads it root→leaf
 }
 
+// ── Inheritance: fork-on-first-open ───────────────────────────────────────────────────────
+//
+// The mechanism behind participant-model.md §5's rule, engine-side and channel-neutral: a channel
+// only names WHERE a place branched from (scope.parentSession) and possibly at WHICH message
+// (branchHints); how much is inherited and where the boundaries sit is decided here.
+//
+// Shape: fork the parent's ACTIVE PATH up to the branch point (everything — text, images, tool
+// results — because they are session entries, not prompt text), then bound what the MODEL sees with
+// one mechanical compaction mark (a plain string; zero model calls). Disk keeps the full copy —
+// storage and context are different budgets (the fork is inspectable; the mark governs the window),
+// and pi's context assembly honors the mark the same as a real compaction.
+
+/** Inheritance window: at most this many exchanges of the parent reach the child's model context. */
+const INHERIT_MAX_EXCHANGES = 50;
+/** …and at most roughly this many tokens (~1/4 of a 200K context: generous, not everything). */
+const INHERIT_MAX_TOKENS = 50_000;
+/** A vision image is priced FLAT — what a provider bills for a resized image, roughly — because its
+ *  base64 length (~1M chars for a photo) measures storage, not context: pricing it by chars would
+ *  let one photo evict the whole text window. */
+const INHERIT_IMAGE_TOKENS = 1_600;
+/** The fork reads the whole parent journal into memory; beyond this it is skipped (empty session +
+ *  warn) rather than stalling the thread's first turn. */
+const FORK_MAX_BYTES = 32 * 1024 * 1024;
+
+function isUserMessage(entry: SessionTreeEntry | undefined): boolean {
+  return entry?.type === "message" && entry.message.role === "user";
+}
+
+/** Rough token estimate for windowing — text at chars/4, images flat. Precision is not the point:
+ *  the window is a budget, and being 20% off moves a boundary by an exchange, not correctness. */
+function estimateEntryTokens(entry: SessionTreeEntry): number {
+  if (entry.type !== "message") return 0;
+  // AgentMessage is a role-keyed union and not every member carries `content` — read it loosely.
+  const content = (entry.message as { content?: unknown }).content;
+  if (typeof content === "string") return Math.ceil(content.length / 4);
+  if (!Array.isArray(content)) return 0;
+  let tokens = 0;
+  // Blocks are role-dependent unions; the estimate only needs `type`/`text`, so read them loosely.
+  for (const block of content as { type?: string; text?: string }[]) {
+    if (block.type === "image") tokens += INHERIT_IMAGE_TOKENS;
+    else if (typeof block.text === "string") tokens += Math.ceil(block.text.length / 4);
+    else tokens += Math.ceil(JSON.stringify(block).length / 4);
+  }
+  return tokens;
+}
+
+/**
+ * Find the fork target on the parent's active path: the LAST message whose content carries a hint
+ * (the most recent turn that talked about that message), extended forward to the end of its exchange
+ * — forking mid-exchange would inherit a question without its answer. Hints are tried in caller
+ * order; the first that matches anywhere wins. No match → undefined (the caller forks the present).
+ */
+function locateBranchPoint(path: SessionTreeEntry[], hints: string[]): string | undefined {
+  for (const hint of hints) {
+    if (!hint) continue;
+    for (let i = path.length - 1; i >= 0; i--) {
+      const entry = path[i];
+      if (entry?.type !== "message") continue;
+      // The whole message, not just content: shape-agnostic, and a hint is a platform id — a false
+      // positive would need the id to appear outside content, which is where ids live anyway.
+      if (!JSON.stringify(entry.message).includes(hint)) continue;
+      let j = i + 1;
+      while (j < path.length && !isUserMessage(path[j])) j++;
+      return path[j - 1]?.id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Bound what the child's MODEL CONTEXT starts with: keep the newest exchange unconditionally, extend
+ * older while both window limits hold, and mark the boundary with a mechanical compaction entry.
+ * Entries above the parent's own last compaction are already outside model context and need no mark;
+ * a child whose visible history fits the window gets no mark at all.
+ */
+async function markInheritanceWindow(child: Session): Promise<void> {
+  const path = await activePathEntries(child);
+  let scanFrom = 0;
+  for (let i = path.length - 1; i >= 0; i--) {
+    if (path[i]?.type === "compaction") {
+      scanFrom = i + 1;
+      break;
+    }
+  }
+  const scanned = path.slice(scanFrom);
+  const starts: number[] = [];
+  scanned.forEach((entry, i) => {
+    if (isUserMessage(entry)) starts.push(i);
+  });
+  if (starts.length <= 1) return; // zero or one visible exchange — nothing to cut
+  const suffixTokens = new Array<number>(scanned.length + 1).fill(0);
+  for (let i = scanned.length - 1; i >= 0; i--) {
+    const entry = scanned[i];
+    suffixTokens[i] = (suffixTokens[i + 1] ?? 0) + (entry ? estimateEntryTokens(entry) : 0);
+  }
+  let chosen = starts.length - 1;
+  for (let k = starts.length - 2; k >= 0; k--) {
+    const exchanges = starts.length - k;
+    const startIdx = starts[k];
+    if (startIdx === undefined) break;
+    if (exchanges > INHERIT_MAX_EXCHANGES || (suffixTokens[startIdx] ?? 0) > INHERIT_MAX_TOKENS) break;
+    chosen = k;
+  }
+  if (chosen === 0) return; // the whole visible history fits the window
+  const boundaryIdx = starts[chosen];
+  if (boundaryIdx === undefined) return;
+  const boundary = scanned[boundaryIdx];
+  if (boundary === undefined) return;
+  await child.appendCompaction(
+    `Inherited from the parent conversation; ${chosen} earlier exchange(s) are not shown.`,
+    boundary.id,
+    (suffixTokens[0] ?? 0) - (suffixTokens[boundaryIdx] ?? 0),
+  );
+}
+
+/** The backend surface inheritance needs — two repos, one decision table. */
+interface InheritRepo<M> {
+  find(id: string): Promise<M | undefined>;
+  open(meta: M): Promise<Session>;
+  create(id: string): Promise<Session>;
+  fork(meta: M, id: string, atEntryId: string): Promise<Session>;
+  /** Journal size, when the backend has one — guards the read-everything fork. */
+  bytes?(meta: M): Promise<number>;
+}
+
+/**
+ * The create-with-parent path (the open path never reaches here). Every failure lands on "start
+ * empty + warn": a thread must not lose its first turn to an inheritance edge — a missing parent, an
+ * oversize journal, a torn tail line from forking WHILE the parent's own turn is appending. The one
+ * repair that must run is {@link reconcileInterruptedToolCalls}: a mid-turn parent forks with a
+ * dangling tool call at its leaf, and the child would hand the provider an invalid transcript.
+ */
+async function createInheriting<M>(
+  repo: InheritRepo<M>,
+  id: string,
+  inherit: SessionInheritance,
+  parentId: string,
+  maxBytes: number,
+): Promise<Session> {
+  const parentMeta = await repo.find(parentId);
+  if (!parentMeta) {
+    log.warn(`[fastagent] session "${id}" names parent "${parentId}", which does not exist — starting empty`);
+    return repo.create(id);
+  }
+  if (repo.bytes) {
+    const bytes = await repo.bytes(parentMeta).catch(() => 0);
+    if (bytes > maxBytes) {
+      log.warn(
+        `[fastagent] parent session "${parentId}" is ${bytes} bytes (limit ${maxBytes}) — starting empty rather than stalling the first turn`,
+      );
+      return repo.create(id);
+    }
+  }
+  try {
+    const parent = await repo.open(parentMeta);
+    const path = await activePathEntries(parent);
+    const leaf = path[path.length - 1];
+    if (leaf === undefined) return repo.create(id); // an empty parent has nothing to inherit
+    const hints = inherit.branchHints ?? [];
+    const at = locateBranchPoint(path, hints);
+    if (at === undefined && hints.length > 0) {
+      log.warn(
+        `[fastagent] no branch hint matched in parent "${parentId}" — inheriting from its present instead of the branch point`,
+      );
+    }
+    const child = await repo.fork(parentMeta, id, at ?? leaf.id);
+    await reconcileInterruptedToolCalls(child);
+    await markInheritanceWindow(child);
+    return child;
+  } catch (error) {
+    log.warn(`[fastagent] could not fork parent session "${parentId}" (${String(error)}) — starting empty`);
+    return repo.create(id);
+  }
+}
+
 /** In-process store (pi InMemorySessionRepo). Continuity lives and dies with the instance. */
 export function inMemorySessionStore(): PiSessionStore & PiSessionReader {
   const repo = new InMemorySessionRepo();
+  const adapter: InheritRepo<Awaited<ReturnType<InMemorySessionRepo["list"]>>[number]> = {
+    find: async (id) => (await repo.list()).find((m) => m.id === id),
+    open: (m) => repo.open(m),
+    create: (id) => repo.create({ id }),
+    fork: (m, id, atEntryId) => repo.fork(m, { id, entryId: atEntryId, position: "at" }),
+  };
   return {
-    async openOrCreate(sessionId) {
+    async openOrCreate(sessionId, inherit) {
       const existing = (await repo.list()).find((m) => m.id === sessionId);
-      if (!existing) return repo.create({ id: sessionId });
+      if (!existing) {
+        if (inherit) return createInheriting(adapter, sessionId, inherit, inherit.parentSession, FORK_MAX_BYTES);
+        return repo.create({ id: sessionId });
+      }
       const session = await repo.open(existing);
       await reconcileInterruptedToolCalls(session);
       return session;
@@ -178,17 +379,34 @@ export function inMemorySessionStore(): PiSessionStore & PiSessionReader {
  * Disk-backed store (pi JsonlSessionRepo under `dir`): restart the process, conversations continue.
  * `cwd` is recorded in session metadata; defaults to process.cwd().
  */
-export function jsonlSessionStore(options: { dir: string; cwd?: string }): PiSessionStore & PiSessionReader {
+export function jsonlSessionStore(options: {
+  dir: string;
+  cwd?: string;
+  /** Inheritance guard override (tests): parent journals above this are not forked. Default 32 MiB. */
+  forkMaxBytes?: number;
+}): PiSessionStore & PiSessionReader {
   const cwd = options.cwd ?? process.cwd();
+  const forkMaxBytes = options.forkMaxBytes ?? FORK_MAX_BYTES;
   const repo = new JsonlSessionRepo({ fs: new NodeExecutionEnv({ cwd }), sessionsRoot: options.dir });
+  const adapter: InheritRepo<Awaited<ReturnType<JsonlSessionRepo["list"]>>[number]> = {
+    find: async (id) => (await repo.list({ cwd })).find((m) => m.id === id),
+    open: (m) => repo.open(m),
+    create: (id) => repo.create({ id, cwd }),
+    fork: (m, id, atEntryId) => repo.fork(m, { cwd, id, entryId: atEntryId, position: "at" }),
+    bytes: async (m) => (await stat(m.path)).size,
+  };
   return {
-    async openOrCreate(sessionId) {
+    async openOrCreate(sessionId, inherit) {
       // Caller-provided ids land in jsonl FILENAMES — encode anything unsafe before it reaches disk.
       const id = encodeSessionId(sessionId);
       // Scope the lookup to this store's cwd: two stores sharing a sessionsRoot must not open each
       // other's sessions (pi groups sessions by project dir).
       const existing = (await repo.list({ cwd })).find((m) => m.id === id);
-      if (!existing) return repo.create({ id, cwd });
+      if (!existing) {
+        if (inherit)
+          return createInheriting(adapter, id, inherit, encodeSessionId(inherit.parentSession), forkMaxBytes);
+        return repo.create({ id, cwd });
+      }
       const session = await repo.open(existing);
       await reconcileInterruptedToolCalls(session);
       return session;

--- a/src/session-remote.ts
+++ b/src/session-remote.ts
@@ -273,8 +273,9 @@ export function connectAgent(options: RemoteEndpointOptions): Agent {
   // (carry it or reject it), never vanish on the wire while the client believes it was sent.
   const _invokeDriftGuard: Record<Exclude<keyof Prompt, "text" | "images">, never> = {};
   void _invokeDriftGuard;
-  // Same guard for Scope: the body carries session only — a new Scope field must force a decision.
-  const _scopeDriftGuard: Record<Exclude<keyof Scope, "session">, never> = {};
+  // Same guard for Scope: the body carries session + the lineage extension — a new Scope field must
+  // force a decision (carry it or reject it), never vanish on the wire.
+  const _scopeDriftGuard: Record<Exclude<keyof Scope, "session" | "parentSession" | "branchHints">, never> = {};
   void _scopeDriftGuard;
   return {
     invoke(scope, prompt): AsyncIterable<AgentEvent> {
@@ -301,7 +302,14 @@ export function connectAgent(options: RemoteEndpointOptions): Agent {
             const res = await fetchFn(`${base}/control/invoke`, {
               method: "POST",
               headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-              body: JSON.stringify({ session: scope.session, text: prompt.text }),
+              body: JSON.stringify({
+                session: scope.session,
+                text: prompt.text,
+                // Lineage rides the wire so a remote thread scope inherits server-side; the server
+                // reads it on the session-create path only, same as in-process.
+                ...(scope.parentSession !== undefined ? { parentSession: scope.parentSession } : {}),
+                ...(scope.branchHints !== undefined ? { branchHints: scope.branchHints } : {}),
+              }),
               signal: abort.signal,
             });
             watchdog.disarm(); // headers arrived

--- a/test/feishu-parse.test.ts
+++ b/test/feishu-parse.test.ts
@@ -143,7 +143,7 @@ describe("envelope + keys", () => {
   it("feishuEnvelope carries meta, the group note, the reply marker, and the decoded body", () => {
     const e = event({ parent_id: "om_prev", thread_id: "omt_2", content: '{"text":"summarize"}' });
     const env = feishuEnvelope(e);
-    expect(env).toContain("[feishu: chat oc_1 (group), topic omt_2, from user ou_alice]");
+    expect(env).toContain("[feishu: chat oc_1 (group), topic omt_2, from user ou_alice, msg om_1]");
     expect(env).toContain("[group chat — multiple people; each message is prefixed with its sender]");
     expect(env).toContain("[in reply to msg om_prev]");
     expect(env).toContain("summarize");

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -505,7 +505,7 @@ describe("turn flow", () => {
     // not a round number: worst-case platform ids stay far under it.
     const worstCase = `feishu:oc_${"a".repeat(32)}:omt_${"b".repeat(32)}`;
     expect(encodeURIComponent(worstCase).length).toBeLessThan(255);
-    expect(calls[0]?.prompt.text).toContain("[feishu: chat oc_1 (p2p), from user ou_alice]");
+    expect(calls[0]?.prompt.text).toContain("[feishu: chat oc_1 (p2p), from user ou_alice, msg om_dm1]");
     expect(calls[0]?.prompt.text).toContain("hello there");
     // The reply contract rides every chat prompt: the channel owns delivery — no send-tool answering.
     expect(calls[0]?.prompt.text).toContain("delivered to the current chat by the channel itself");
@@ -1765,6 +1765,23 @@ describe("turn flow", () => {
     await idle();
     expect(calls[0]?.scope.session).toBe("feishu:oc_1");
     expect(calls[0]?.scope.parentSession).toBeUndefined();
+    expect(calls[0]?.scope.branchHints).toBeUndefined();
+  });
+
+  it("a ROUTED session is opaque: no lineage, even when its id looks like a place key", async () => {
+    // route().session's contract is opaque. A three-segment id like "tenant:user:alice" must not be
+    // re-parsed as `<kind>:<chat>:<thread>` — that would let a thread message inherit from a session
+    // ("tenant:user") that belongs to someone else entirely: cross-session injection.
+    feishuFetch();
+    const { handler, calls, idle } = buildChannel({
+      route: () => ({ session: "tenant:user:alice" }),
+    });
+    await handler(
+      feishuRequest(messageEvent({ id: "om_routed", threadId: "omt_x", parentId: "om_root", text: "in a topic" })),
+    );
+    await idle();
+    expect(calls[0]?.scope.session).toBe("tenant:user:alice");
+    expect(calls[0]?.scope.parentSession).toBeUndefined(); // opaque — never split
     expect(calls[0]?.scope.branchHints).toBeUndefined();
   });
 

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -1750,6 +1750,22 @@ describe("turn flow", () => {
     expect(prompt).toContain("[reply chain above it, oldest first:");
     expect(prompt).toContain("(msg om_original_ask, from user ou_alice): 加一个新的页面，用 svg 构建一个足球的页面");
     expect(fx.calls("/im/v1/messages/om_original_ask", "GET")).toHaveLength(1);
+    // …and the scope names the thread's LINEAGE: the room it branched from, plus the ids that can
+    // locate the branch point in the room's session — the referent (whose id is unfindable there:
+    // the card was sent after its turn) and then the chain, whose ids DID pass through room turns.
+    expect(calls[0]?.scope.session).toBe("feishu:oc_1:omt_on_card");
+    expect(calls[0]?.scope.parentSession).toBe("feishu:oc_1");
+    expect(calls[0]?.scope.branchHints).toEqual(["om_bot_card", "om_original_ask"]);
+  });
+
+  it("a main-timeline turn carries no lineage — the room branched from nothing", async () => {
+    feishuFetch();
+    const { handler, calls, idle } = buildChannel();
+    await handler(feishuRequest(messageEvent({ id: "om_plain", text: "hello" })));
+    await idle();
+    expect(calls[0]?.scope.session).toBe("feishu:oc_1");
+    expect(calls[0]?.scope.parentSession).toBeUndefined();
+    expect(calls[0]?.scope.branchHints).toBeUndefined();
   });
 
   it("another BOT's message is not the agent's own: no self-attribution, chain still walked", async () => {

--- a/test/session-inherit.test.ts
+++ b/test/session-inherit.test.ts
@@ -1,0 +1,240 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage, Session } from "@earendil-works/pi-agent-core";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../src/agent.ts";
+import { piHarnessFactory } from "../src/engines/pi/harness.ts";
+import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { inMemorySessionStore, jsonlSessionStore, type PiSessionStore } from "../src/engines/pi/sessions.ts";
+import { makeFaux } from "./faux.ts";
+
+// Session inheritance (participant-model.md §5: "a thread starts from what the room knew"): a NEW
+// session that names a parent forks it ONCE — at the branch point when a hint locates one — and a
+// mechanical compaction mark bounds what the model sees. Every edge fails toward an empty session
+// with a warn: context is not the ask, and a thread must not lose its first turn to it.
+
+const um = (text: string): AgentMessage =>
+  ({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() }) as AgentMessage;
+const am = (text: string): AgentMessage =>
+  ({ role: "assistant", content: [{ type: "text", text }], stopReason: "stop", timestamp: Date.now() }) as AgentMessage;
+
+/** What the MODEL would see, as one searchable string. */
+async function contextText(session: Session): Promise<string> {
+  return JSON.stringify((await session.buildContext()).messages);
+}
+
+async function freshStore() {
+  const dir = await mkdtemp(join(tmpdir(), "fa-inherit-"));
+  return { dir, store: jsonlSessionStore({ dir }) };
+}
+
+/** A parent with `n` exchanges: "q<i> ask" / "a<i> answer" (space-delimited — "q5 ask" never matches "q55 ask"). */
+async function buildParent(store: PiSessionStore, id: string, n: number): Promise<Session> {
+  const parent = await store.openOrCreate(id);
+  for (let i = 1; i <= n; i++) {
+    await parent.appendMessage(um(`q${i} ask`));
+    await parent.appendMessage(am(`a${i} answer`));
+  }
+  return parent;
+}
+
+describe("session inheritance (fork-on-first-open)", () => {
+  it("a new session naming a parent forks it once, then lives independently", async () => {
+    const { store } = await freshStore();
+    const parent = await buildParent(store, "room", 2);
+
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    const seen = await contextText(child);
+    expect(seen).toContain("q1 ask");
+    expect(seen).toContain("a2 answer");
+
+    // Independence, both directions: later parent writes are invisible to the child, and the
+    // child's writes never reach the parent.
+    await parent.appendMessage(um("q3 after the fork"));
+    await child.appendMessage(um("child-only note"));
+    const reopened = await store.openOrCreate("thread", { parentSession: "room" });
+    const again = await contextText(reopened);
+    expect(again).toContain("child-only note");
+    expect(again).not.toContain("after the fork");
+    expect(await contextText(await store.openOrCreate("room"))).not.toContain("child-only note");
+  });
+
+  it("an existing session ignores inherit entirely — one-time by construction", async () => {
+    const { store } = await freshStore();
+    await buildParent(store, "room", 1);
+    const plain = await store.openOrCreate("thread"); // born WITHOUT a parent
+    await plain.appendMessage(um("born empty"));
+
+    const reopened = await store.openOrCreate("thread", { parentSession: "room" });
+    const seen = await contextText(reopened);
+    expect(seen).toContain("born empty");
+    expect(seen).not.toContain("q1 ask"); // no retroactive inheritance
+  });
+
+  it("a missing parent starts the child empty instead of failing the turn", async () => {
+    const { store } = await freshStore();
+    const child = await store.openOrCreate("thread", { parentSession: "ghost" });
+    expect(await child.getEntries()).toHaveLength(0);
+  });
+
+  it("a branch hint picks the fork point — extended to the end of its exchange", async () => {
+    const { store } = await freshStore();
+    const parent = await store.openOrCreate("room");
+    await parent.appendMessage(um("q1 about (msg om_A)"));
+    await parent.appendMessage(am("a1 answer"));
+    await parent.appendMessage(um("q2 about (msg om_B)"));
+    await parent.appendMessage(am("a2 the branched-from answer"));
+    await parent.appendMessage(um("q3 unrelated later talk"));
+    await parent.appendMessage(am("a3 later answer"));
+
+    const child = await store.openOrCreate("thread", { parentSession: "room", branchHints: ["om_B"] });
+    const seen = await contextText(child);
+    expect(seen).toContain("a2 the branched-from answer"); // the ANSWER of the hinted exchange rides along
+    expect(seen).not.toContain("q3 unrelated"); // nothing after the branch point
+  });
+
+  it("no hint match inherits the parent's present, not nothing", async () => {
+    const { store } = await freshStore();
+    await buildParent(store, "room", 3);
+    const child = await store.openOrCreate("thread", { parentSession: "room", branchHints: ["om_nowhere"] });
+    expect(await contextText(child)).toContain("a3 answer"); // fell back to the leaf
+  });
+
+  it("the window keeps the newest 50 exchanges and says what it cut", async () => {
+    const { store } = await freshStore();
+    await buildParent(store, "room", 55);
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    const { messages } = await child.buildContext();
+    const seen = JSON.stringify(messages);
+    expect(seen).toContain("5 earlier exchange(s) are not shown");
+    expect(seen).toContain("q6 ask"); // the oldest kept exchange
+    expect(seen).not.toContain("q5 ask"); // the newest elided one
+    expect(messages).toHaveLength(1 + 50 * 2); // the mark's summary + 50 whole exchanges
+  });
+
+  it("the token budget cuts deeper than the exchange count when exchanges are heavy", async () => {
+    const { store } = await freshStore();
+    const parent = await store.openOrCreate("room");
+    for (let i = 1; i <= 10; i++) {
+      await parent.appendMessage(um(`q${i} ${"x".repeat(30_000)}`)); // ≈7.5K tokens each
+      await parent.appendMessage(am(`a${i} short`));
+    }
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    const seen = await contextText(child);
+    // 6 exchanges ≈45K fits the 50K budget; a 7th would not.
+    expect(seen).toContain("4 earlier exchange(s) are not shown");
+    expect(seen).toContain("a5 short");
+    expect(seen).not.toContain("a4 short");
+  });
+
+  it("images are priced flat — one photo's base64 must not evict the text window", async () => {
+    const { store } = await freshStore();
+    const parent = await store.openOrCreate("room");
+    await parent.appendMessage(um("q1 look at this"));
+    await parent.appendMessage({
+      role: "user",
+      content: [
+        { type: "text", text: "q2 the photo" },
+        { type: "image", data: "A".repeat(400_000), mimeType: "image/png" }, // ≈100K "tokens" if mispriced by chars
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage);
+    await parent.appendMessage(am("a2 nice photo"));
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    const seen = await contextText(child);
+    expect(seen).not.toContain("earlier exchange(s) are not shown"); // flat pricing: everything fits
+    expect(seen).toContain("q1 look at this");
+    expect(seen).toContain('"type":"image"'); // the image itself rides the fork
+  });
+
+  it("a dangling tool call at the parent's leaf is repaired in the child", async () => {
+    // Forking WHILE the parent is mid-turn captures an assistant tool_use with no result — the same
+    // shape a crash leaves. Without repair, the child's first turn hands the provider an invalid
+    // transcript.
+    const { store } = await freshStore();
+    const parent = await store.openOrCreate("room");
+    await parent.appendMessage(um("q1 run the tool"));
+    await parent.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "c1", name: "exec", arguments: {} }],
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    } as AgentMessage);
+
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    const { messages } = await child.buildContext();
+    expect(messages.at(-1)?.role).toBe("toolResult"); // synthetic "interrupted" result closes the pair
+  });
+
+  it("a torn parent journal falls back to an empty child, never a thrown first turn", async () => {
+    const { dir, store } = await freshStore();
+    await buildParent(store, "room", 2);
+    // Tear the last line mid-write, the way a fork racing the parent's own append would read it.
+    const sessionDir = readdirSync(dir).map((d) => join(dir, d))[0] as string;
+    const file = readdirSync(sessionDir)
+      .filter((f) => f.endsWith(".jsonl"))
+      .map((f) => join(sessionDir, f))[0] as string;
+    const whole = readFileSync(file, "utf8");
+    writeFileSync(file, whole.slice(0, whole.length - 20));
+
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    expect(await child.getEntries()).toHaveLength(0);
+  });
+
+  it("an oversize parent is skipped — inheriting nothing beats stalling the first turn", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-inherit-"));
+    const store = jsonlSessionStore({ dir, forkMaxBytes: 1_000 });
+    await buildParent(store, "room", 5); // a few KB of journal
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    expect(await child.getEntries()).toHaveLength(0);
+  });
+
+  it("the in-memory backend inherits the same way", async () => {
+    const store = inMemorySessionStore();
+    await buildParent(store, "room", 2);
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    expect(await contextText(child)).toContain("a2 answer");
+    const plainAgain = await store.openOrCreate("thread", { parentSession: "room" });
+    await plainAgain.appendMessage(um("child note"));
+    expect(await contextText(await store.openOrCreate("room"))).not.toContain("child note");
+  });
+
+  it("scope.parentSession flows through invoke into the store's create path", async () => {
+    // End-to-end: the channel sets two Scope fields; the engine's first turn on the new session
+    // already SEES the parent's exchange — proof the factory → store plumbing carries the extension.
+    const { store } = await freshStore();
+    await buildParent(store, "room", 1);
+    const { faux, models } = makeFaux();
+    let modelSaw: unknown;
+    faux.setResponses([
+      (context) => {
+        modelSaw = context.messages;
+        return fauxAssistantMessage("inherited fine");
+      },
+    ]);
+    const agent = createPiAgentFromHarness({
+      harnessFactory: piHarnessFactory({
+        env: new NodeExecutionEnv({ cwd: process.cwd() }),
+        sessions: store,
+        models,
+        model: faux.getModel(),
+        systemPrompt: "test",
+      }),
+    });
+    const events: AgentEvent[] = [];
+    for await (const e of agent.invoke(
+      { session: "thread", parentSession: "room", branchHints: ["om_none"] },
+      { text: "so, about that" },
+    )) {
+      events.push(e);
+    }
+    expect(events.at(-1)?.type).toBe("completed");
+    const dump = JSON.stringify(modelSaw);
+    expect(dump).toContain("q1 ask"); // the parent's exchange reached the model on turn ONE
+    expect(dump).toContain("so, about that");
+  });
+});

--- a/test/session-inherit.test.ts
+++ b/test/session-inherit.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { feishuEnvelope } from "../src/channels/feishu/parse.ts";
 import { inMemorySessionStore, jsonlSessionStore, type PiSessionStore } from "../src/engines/pi/sessions.ts";
 import { makeFaux } from "./faux.ts";
 
@@ -97,6 +98,32 @@ describe("session inheritance (fork-on-first-open)", () => {
     expect(seen).not.toContain("q3 unrelated"); // nothing after the branch point
   });
 
+  it("the REAL feishu envelope carries the id the hints search for — no hand-written markers", async () => {
+    // The whole hint mechanism stands on one fact: a summoning message's own id enters the parent
+    // session via the prompt envelope. This test builds the parent text with the actual envelope
+    // (channel code, not a test-crafted string), so if the envelope ever drops the id, THIS fails —
+    // not just the field.
+    const { store } = await freshStore();
+    const parent = await store.openOrCreate("room");
+    const envelope = feishuEnvelope({
+      sender: { sender_id: { open_id: "ou_alice" }, sender_type: "user" },
+      message: { message_id: "om_real_ask", chat_id: "oc_1", chat_type: "group", message_type: "text", content: "{}" },
+    } as never);
+    await parent.appendMessage(um(`${envelope}\n加一个足球页面`));
+    await parent.appendMessage(am("a1 方案如下"));
+    await parent.appendMessage(um("q2 later unrelated"));
+    await parent.appendMessage(am("a2 later answer"));
+
+    // The thread's hints: the card id (never in any session — sent after its turn) then the ask.
+    const child = await store.openOrCreate("thread", {
+      parentSession: "room",
+      branchHints: ["om_bot_card_unfindable", "om_real_ask"],
+    });
+    const seen = await contextText(child);
+    expect(seen).toContain("a1 方案如下"); // fork landed at the hinted exchange…
+    expect(seen).not.toContain("later unrelated"); // …not at the leaf
+  });
+
   it("no hint match inherits the parent's present, not nothing", async () => {
     const { store } = await freshStore();
     await buildParent(store, "room", 3);
@@ -183,6 +210,87 @@ describe("session inheritance (fork-on-first-open)", () => {
 
     const child = await store.openOrCreate("thread", { parentSession: "room" });
     expect(await child.getEntries()).toHaveLength(0);
+  });
+
+  it("a crashed draft cannot poison the store — drafts live outside every lookup", async () => {
+    // Simulates a crash mid-inheritance: garbage under `.inherit-tmp` (where drafts are forked)
+    // must be invisible — openIfExists finds nothing, and the next inheritance attempt runs afresh
+    // and publishes a complete child. Exactly ONE file under the real directory afterwards.
+    const { dir, store } = await freshStore();
+    await buildParent(store, "room", 2);
+    const realCwdDir = readdirSync(dir)
+      .filter((d) => d !== ".inherit-tmp")
+      .map((d) => join(dir, d))[0] as string;
+    const tmpCwdDir = join(dir, ".inherit-tmp", realCwdDir.split("/").at(-1) as string);
+    mkdirSync(tmpCwdDir, { recursive: true });
+    writeFileSync(join(tmpCwdDir, "2020-01-01T00-00-00-000Z_thread.jsonl"), "{torn garbage");
+
+    expect(await store.openIfExists("thread")).toBeUndefined(); // the draft realm is not discoverable
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    expect(await contextText(child)).toContain("a2 answer"); // inheritance ran to completion
+    const published = readdirSync(realCwdDir).filter((f) => f.endsWith("_thread.jsonl"));
+    expect(published).toHaveLength(1); // one atomic publish, no duplicates
+  });
+
+  it("a failed inheritance leaves exactly one file — the empty fallback, never a half-child", async () => {
+    const { dir, store } = await freshStore();
+    await buildParent(store, "room", 2);
+    const realCwdDir = readdirSync(dir)
+      .filter((d) => d !== ".inherit-tmp")
+      .map((d) => join(dir, d))[0] as string;
+    // Tear the parent so the fork's read throws mid-inheritance.
+    const parentFile = readdirSync(realCwdDir)
+      .filter((f) => f.includes("_room"))
+      .map((f) => join(realCwdDir, f))[0] as string;
+    const whole = readFileSync(parentFile, "utf8");
+    writeFileSync(parentFile, whole.slice(0, whole.length - 20));
+
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    expect(await child.getEntries()).toHaveLength(0);
+    const files = readdirSync(realCwdDir).filter((f) => f.endsWith("_thread.jsonl"));
+    expect(files).toHaveLength(1);
+  });
+
+  it("branch hints are capped — ids, not payloads", async () => {
+    const { store } = await freshStore();
+    const parent = await store.openOrCreate("room");
+    await parent.appendMessage(um(`q1 wall ${"L".repeat(300)}`));
+    await parent.appendMessage(am("a1 the early answer"));
+    await parent.appendMessage(um("q2 about (msg om_target)"));
+    await parent.appendMessage(am("a2 the hinted answer"));
+    await parent.appendMessage(um("q3 later"));
+    await parent.appendMessage(am("a3 the leaf answer"));
+
+    // An over-long "hint" (a payload, not an id) WOULD match the wall-of-text message — the length
+    // cap must drop it BEFORE it scans. And a matching id sitting beyond the 16-hint cap is ignored
+    // too. Both dropped → leaf fallback.
+    const child = await store.openOrCreate("thread", {
+      parentSession: "room",
+      branchHints: ["L".repeat(200), ...Array.from({ length: 16 }, (_, i) => `om_nope_${i}`), "om_target"],
+    });
+    const seen = await contextText(child);
+    expect(seen).toContain("a3 the leaf answer"); // fell back to the present
+    expect(seen).toContain("a1 the early answer"); // …which includes everything (no early-fork cut)
+  });
+
+  it("a parent compaction's summary charges the window budget — it reaches the model too", async () => {
+    // The scan starts BELOW the parent's last compaction, but that compaction's summary (and
+    // retained tail) still enter the child's model context. Estimating them as zero would over-admit:
+    // here the summary alone is ~40K of the 50K budget, so only the newest heavy exchange fits.
+    const { store } = await freshStore();
+    const parent = await store.openOrCreate("room");
+    await parent.appendMessage(um("q0 pre-compaction"));
+    await parent.appendMessage(am("a0 pre-compaction"));
+    await parent.appendCompaction(`ROOM SUMMARY ${"S".repeat(160_000)}`, undefined, 99_000);
+    for (let i = 1; i <= 5; i++) {
+      await parent.appendMessage(um(`q${i} ${"x".repeat(30_000)}`)); // ≈7.5K tokens each
+      await parent.appendMessage(am(`a${i} short`));
+    }
+    const child = await store.openOrCreate("thread", { parentSession: "room" });
+    const seen = await contextText(child);
+    expect(seen).toContain("4 earlier exchange(s) are not shown"); // only the newest exchange fit
+    expect(seen).toContain("a5 short");
+    expect(seen).not.toContain("a4 short");
   });
 
   it("an oversize parent is skipped — inheriting nothing beats stalling the first turn", async () => {


### PR DESCRIPTION
Part 2 of 3 in the thread-context work (#327 reply chain → **#328 session inheritance** → #330 room-buffer fold). Stacked on #327; the diff shows only this PR's changes.

## Problem

`participant-model.md` §5 has said from the start: *"A thread starts from what the room knew and keeps its own history … separate, not amnesiac."* The implementation answered with amnesia — a topic opened on a room answer got an **empty session**, and no amount of referent-anchoring (rung 2) can carry images, tool results, or the exchanges nobody quoted.

## The mechanism: fork-on-first-open

Channel-neutral by construction. A channel states the two facts only it knows; the engine owns every boundary:

```text
契约   Scope.parentSession + Scope.branchHints     (SPEC §8's sanctioned extension mechanism)
引擎   PiSessionStore.openOrCreate(id, inherit?)   fork at the branch point + window mark
渠道   feishu: two facts, ~10 lines               telegram/slack: one wiring change away
```

**One-time by construction.** The store's create path forks the parent once; an existing session ignores the fields entirely. The session existing IS the record that the decision was taken — no marker to persist, no decision to retry per turn.

**Fork at the branch point.** `branchHints` carry the referent's id and its reply chain's ids, nearest first (the chain from #327 doubles as the locator). The most recent parent entry carrying a hint wins, extended to the end of its exchange — a mid-exchange fork inherits a question without its answer. The order matters for the own-card case: a thread rooted on the agent's answer has an *unfindable* root id (the card was sent after its turn), but the chain above it is exactly the ids that did pass through room turns. A miss falls back to the room's present, with a warn.

**Windowed by a mechanical mark, not a model call.** One `appendCompaction` with a plain string bounds what the model sees: the newest **50 exchanges** within a **~50K-token estimate**, images priced **flat** at ~1.6K (their base64 length measures storage, not context — priced by chars, one photo would evict the whole text window). Disk keeps the full copy: storage and context are different budgets, and the elided half stays inspectable.

## Fail-open at every edge, visibly

| Edge | Behavior |
|---|---|
| Parent missing / unreadable | empty session + warn — context is not the ask |
| Parent journal > 32 MiB | skipped (the fork reads everything into memory) + warn |
| Torn tail line (fork racing the parent's own append) | empty session + warn |
| Dangling tool call (parent forked mid-turn) | repaired by the existing crash-recovery path — the child's first turn never hands the provider an invalid transcript |

## Wire

The HTTP invoke body and `session-remote` carry the two fields end-to-end; the Scope drift guard is updated so the **next** field forces the same decision. Malformed values are a 400, never a silent drop.

## Docs — §8 corrects its own record

Rungs 3 and 4 were one mechanism with two parameters. The old "not planned" verdict rested on two assumptions, both now corrected in the text: a fork does not "pay on every turn" (one-time by construction), and "copying the whole room" conflated storage with context. The seed rung 3 wanted is exactly the window mark — generated from real session entries, so images and tool results come along for free.

**Flagged for the maintainer:** SPEC §8's extension table gains a `Session lineage` row. §8 is the extension mechanism itself ("extensions attach through additional scope fields"), so this documents a use of it rather than changing locked semantics — but SPEC edits deserve an explicit nod.

## Tests (1352 green: lint / typecheck / test)

Store-level: fork-once + bidirectional independence, existing-session short-circuit, missing parent, hint hit (exchange-complete) and miss, the 50-exchange window with its visible count, the token budget cutting deeper on heavy exchanges, flat image pricing (a 400K-char photo does not evict the window), dangling-tool-call repair, torn journal, oversize skip, in-memory parity, and end-to-end `scope.parentSession → invoke → store`. Channel-level: a thread turn's scope names its room and the hint order; a main-timeline turn carries no lineage.

Mutation-verified: dropping the window mark −2, flat pricing −1, post-fork repair −1, hint matching −1, the channel's parentSession −1.

