### PR TITLE
feat(feishu): a thread's first turn reads the room's un-answered discussion

### DIFF
--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -302,18 +302,28 @@ results is fork's exclusive capability — is the reason rung 3 never shipped as
 
 **Rungs 3 and 4 are both implemented, and they carry different halves.** The fork carries what the
 room's SESSION knew; a room's session only advances when the agent is summoned, so discussion since
-its last answered turn sits in the context buffer, absorbed by nothing. A thread turn folds that
-bucket into its prompt, read-only — the room's own next answered turn still commits it, so each place
-sees the discussion exactly once in its own memory, and the fold's attachments cross as real
-attachments on the buffered tier.
+its last answered turn sits in the context buffer, absorbed by nothing. The thread's FIRST turn folds
+that bucket into its prompt, read-only — the room's own next answered turn still commits it, so each
+place sees the discussion exactly once in its own memory, and the fold's attachments cross as real
+attachments on the buffered tier rather than as marker lines.
 
-Folded on EVERY thread turn, not just the first. "First" is the tighter fold, and it was built and
-reverted: every way for a channel to know it is a memory that can be lost (the participants store is
-a cache by contract — bounded, evictable, deletable), and a forgotten entry re-labels an old thread's
-turn as newborn, injecting the room's CURRENT chatter under "what this thread branched from".
-Unconditional folding needs no such memory: it repeats the block while the room stays un-answered,
-and stops by itself the moment the room absorbs its bucket. The cost is a repeated block in a few
-prompts, bounded by the buffer's own char budget.
+**Once, not per turn**, and this is not an optimisation — a prompt is not an independent request. It
+lands in the session, so the thread's second turn already has the first turn's fold in its context;
+re-folding puts a second identical copy of the block, and of its images, in ONE context window
+(measured: three turns, three copies of each). Several copies of one screenshot read as several
+postings. After the first turn the content is already present, so only newly arrived chatter would
+carry any information, and it reaches the thread the ordinary ways — someone says it there, or the
+room answers and the thread's own buffer carries on.
+
+The first-turn fact comes from the participants store, which is a cache by contract (bounded,
+evictable, deletable) — and that is acceptable HERE precisely because the fold is prompt-bound. An
+evicted record costs one extra fold of a block whose label ("discussion in the room this thread
+branched from, not yet answered there") is true whenever it is written, and the record is rewritten
+as soon as that turn answers. The same cache may not gate anything whose label would become a LIE
+after eviction: an earlier revision wrote this content into the newborn session's birth mark under
+"when this thread started", where a forgotten record would permanently attribute the room's CURRENT
+chatter to a thread that branched long before. That is why the room's discussion is folded into a
+prompt and not into a session.
 
 *Rejected: making the room absorb eagerly* — writing each un-summoned message into the room's session
 at ingress. It would delete this rung entirely (the fork would see everything), and it fails on three

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -319,11 +319,13 @@ The first-turn fact comes from the participants store, which is a cache by contr
 evictable, deletable) — and that is acceptable HERE precisely because the fold is prompt-bound. An
 evicted record costs one extra fold of a block whose label ("discussion in the room this thread
 branched from, not yet answered there") is true whenever it is written, and the record is rewritten
-as soon as that turn answers. The same cache may not gate anything whose label would become a LIE
-after eviction: an earlier revision wrote this content into the newborn session's birth mark under
-"when this thread started", where a forgotten record would permanently attribute the room's CURRENT
-chatter to a thread that branched long before. That is why the room's discussion is folded into a
-prompt and not into a session.
+as soon as that turn answers.
+
+The converse is the rule worth keeping: **this cache may not gate a claim that outlives the turn.**
+Write the same content into the newborn session instead — as a birth mark reading "when this thread
+started" — and a forgotten record permanently attributes the room's CURRENT chatter to a thread that
+branched long before. Repetition degrades an answer; a stale durable label misstates the past. That
+is the whole reason this rung is prompt-bound and rung 4 is not.
 
 *Rejected: making the room absorb eagerly* — writing each un-summoned message into the room's session
 at ingress. It would delete this rung entirely (the fork would see everything), and it fails on three

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -311,9 +311,10 @@ attachments on the buffered tier rather than as marker lines.
 lands in the session, so the thread's second turn already has the first turn's fold in its context;
 re-folding puts a second identical copy of the block, and of its images, in ONE context window
 (measured: three turns, three copies of each). Several copies of one screenshot read as several
-postings. After the first turn the content is already present, so only newly arrived chatter would
-carry any information, and it reaches the thread the ordinary ways — someone says it there, or the
-room answers and the thread's own buffer carries on.
+postings. After the first turn the content is already present, so only chatter arriving LATER could
+carry anything new — and that does not reach the thread at all. It is the same asymmetry stated at
+the end of this section: what a room says after a thread branches stays in the room, until someone
+repeats it there or an asker quotes the message and rung 2 loads it.
 
 The first-turn fact comes from the participants store, which is a cache by contract (bounded,
 evictable, deletable) — and that is acceptable HERE precisely because the fold is prompt-bound. An

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -239,7 +239,7 @@ A thread must start from something. Four rungs, increasing in cost:
 |---|---|---|---|
 | 1 | referent anchor, truncated | the followed-up message, cut at some display-sized bound | rejected |
 | **2** | **referent anchor, bounded by the platform** | **the followed-up message in full (`REFERENT_MAX_CODE_POINTS`)** | implemented |
-| 3 | seed injection | the room's last N exchanges, in the thread's first prompt | subsumed by rung 4 |
+| **3** | **room-buffer fold, in the prompt** | **what the room heard but no session absorbed — text and attachments** | **implemented** |
 | **4** | **session inheritance (fork at the branch point)** | **the room's history up to where the thread branched — text, images, tool results — windowed** | **implemented** |
 
 Rung 1 fails the model's own main path: following up on the agent's answer, where the answer is
@@ -300,9 +300,34 @@ conflated storage with context (disk keeps the full inspectable copy; the mark g
 the model — different budgets). The one prediction it got right — preserving reasoning and tool
 results is fork's exclusive capability — is the reason rung 3 never shipped as prompt text.
 
+**Rungs 3 and 4 are both implemented, and they carry different halves.** The fork carries what the
+room's SESSION knew; a room's session only advances when the agent is summoned, so discussion since
+its last answered turn sits in the context buffer, absorbed by nothing. A thread turn folds that
+bucket into its prompt, read-only — the room's own next answered turn still commits it, so each place
+sees the discussion exactly once in its own memory, and the fold's attachments cross as real
+attachments on the buffered tier.
+
+Folded on EVERY thread turn, not just the first. "First" is the tighter fold, and it was built and
+reverted: every way for a channel to know it is a memory that can be lost (the participants store is
+a cache by contract — bounded, evictable, deletable), and a forgotten entry re-labels an old thread's
+turn as newborn, injecting the room's CURRENT chatter under "what this thread branched from".
+Unconditional folding needs no such memory: it repeats the block while the room stays un-answered,
+and stops by itself the moment the room absorbs its bucket. The cost is a repeated block in a few
+prompts, bounded by the buffer's own char budget.
+
+*Rejected: making the room absorb eagerly* — writing each un-summoned message into the room's session
+at ingress. It would delete this rung entirely (the fork would see everything), and it fails on three
+counts, all measured rather than assumed: durable session writes take the run lease
+([session-control.md](session-control.md) §9), so ingress would block behind a multi-minute turn; that
+blocking sits on the PRE-ACK path, where the webhook must answer before the platform re-pushes; and
+consecutive ambient user entries reach the provider unmerged — the direct Anthropic API now combines
+same-role turns, but Bedrock still rejects them (`roles must alternate`), and `deploy agentcore` is a
+shipped host. The room's session advancing only when summoned is therefore a constraint, not an
+oversight.
+
 Adoption is per channel, because only a channel knows its places' lineage: Feishu/Lark set the
-scope fields (threads inherit); Telegram and Slack do not yet (their threads still start empty —
-the fields are one wiring change away).
+scope fields and fold the room bucket (threads inherit); Telegram and Slack do not yet (their threads
+still start empty — the fields are one wiring change away).
 
 *Known asymmetry, accepted:* room → thread transfers once, when the thread starts, and nothing flows
 back (§7). A thread neither learns about later room activity nor reports its own.

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -258,6 +258,11 @@ thread branched from, windowed to the newest ≈50 exchanges), including images 
 inheritance happens once, when the thread's session is created; after that the two places are
 independent, and the room never sees what the thread discusses.
 
+Discussion the room heard but never answered has not entered its session yet, so the fork cannot
+carry it — a thread's turns fold that pending discussion into their prompt instead, attachments
+included. Reading it does not consume it: the room's own next answer still folds the same messages,
+and once it does, the thread stops repeating them.
+
 **Starting a thread.** Mention the Agent inside a thread once (typically by replying to one of its
 messages and creating a topic). It answers there, which makes it a participant, and every later bare
 message in that thread reaches it. When a second person speaks in the thread, addressing becomes

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -259,9 +259,9 @@ inheritance happens once, when the thread's session is created; after that the t
 independent, and the room never sees what the thread discusses.
 
 Discussion the room heard but never answered has not entered its session yet, so the fork cannot
-carry it — a thread's turns fold that pending discussion into their prompt instead, attachments
-included. Reading it does not consume it: the room's own next answer still folds the same messages,
-and once it does, the thread stops repeating them.
+carry it — the thread's first turn reads that pending discussion instead, attachments included.
+Reading it does not consume it: the room's own next answer still folds the same messages, so each
+place sees the discussion once.
 
 **Starting a thread.** Mention the Agent inside a thread once (typically by replying to one of its
 messages and creating a topic). It answers there, which makes it a participant, and every later bare

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -98,10 +98,12 @@ interface StoredFeishuTurn {
   /** The place this thread branched from (§5 lineage) — recorded at ingress, where the session's
    *  routed-ness is known; absent for main places, routed (opaque) sessions, and pre-upgrade records. */
   parentSession?: string;
-  /** The ROOM's buffer bucket, folded READ-ONLY into this thread turn (§5's other half: the room's
+  /** The ROOM's buffer bucket, folded READ-ONLY into this turn (§5's other half: the room's
    *  not-yet-answered discussion is part of "what the room knew", and the session fork cannot carry
-   *  what no session has absorbed). Recorded at ingress because only there is the SOURCE chat known
-   *  — a route may point the answer at a different one. Never committed from here. */
+   *  what no session has absorbed). Set only on a thread's FIRST turn, and recorded at ingress
+   *  because only there are both facts known — whether the agent has answered here before, and which
+   *  chat the message came FROM (a route may point the answer at a different one). Never committed
+   *  from here. */
   roomBufferKey?: string;
   images: { msg: string; key: string }[];
   files: { msg: string; key: string; name?: string }[];
@@ -467,14 +469,17 @@ function createFeishuRuntimeFactory(
         // this snapshot before either commits it. That fan-out loses nothing; claiming by buffer key
         // would instead couple otherwise-independent root sessions and require failure rollback.
         const { text: recent, consumed } = buffer.peek(rec.bufferKey);
-        // A thread turn also reads the ROOM's bucket — READ-ONLY, and on EVERY turn, not just the
-        // first. "First turn" would be the tighter fold, but every way of knowing it is a
-        // channel-side memory that can be lost (the participants store is a cache by contract:
-        // bounded, evictable, deletable), and a forgotten entry re-labels an old thread's turn as
-        // newborn. Folding unconditionally needs no such memory: it repeats the block while the room
-        // stays un-answered, and stops by itself the moment the room's own next turn commits its
-        // bucket. Committing from HERE would steal it from the room, so each place still sees the
-        // discussion exactly once in its own memory.
+        // A thread's FIRST turn also reads the ROOM's bucket — READ-ONLY. Committing from HERE would
+        // steal it from the room, so each place still sees the discussion exactly once in its own
+        // memory: the room's own next answered turn folds AND commits the same messages.
+        //
+        // First turn only, because a prompt is not an independent request — it lands in the session
+        // and every later turn's context contains it. Re-folding would put a second identical copy of
+        // the block, and of its images, in ONE context window (measured: three turns → three copies),
+        // which reads as three separate postings rather than one. After turn one the content is
+        // already there; only newly arrived chatter would be new, and it reaches the thread the same
+        // way anything else does — by someone saying it there, or by the room answering and the
+        // thread's own buffer carrying on.
         const room = rec.roomBufferKey !== undefined ? buffer.peek(rec.roomBufferKey) : undefined;
         const roomBlock = room?.text
           ? `[recent discussion in the room this thread branched from — not yet answered there:\n${room.text}\n]\n\n`
@@ -681,13 +686,23 @@ function createFeishuRuntimeFactory(
       // time, where routed-ness is still known; the dequeue path only reads it back.
       const parentSession =
         routed === undefined && m.thread_id !== undefined ? placeKey(kind, { chat_id: m.chat_id }) : undefined;
-      // The room's un-summoned chatter is the half of "what the room knew" that no session holds yet.
-      // Recorded here because the SOURCE chat is only known here (a route may answer elsewhere), and
-      // derived FROM the lineage rather than beside it: a place with no parent has no room to read,
-      // and an opaque routed session must get neither. (Untested on purpose — the two cannot diverge,
-      // and a routed deployment never fills a room bucket anyway: route-null messages are dropped,
-      // not buffered.)
-      const roomBufferKey = parentSession !== undefined ? feishuBufferPlaceKey({ chatId: m.chat_id }) : undefined;
+      // The room's un-summoned chatter is the half of "what the room knew" that no session holds yet
+      // — folded into the thread's FIRST turn. `agentSpokeIn` read HERE, before this turn's own
+      // participation is recorded below, is exactly that fact.
+      //
+      // The store is a cache (bounded, evictable, deletable) and that is ACCEPTABLE for this gate,
+      // unlike for anything that would outlive the turn: an evicted record costs one extra fold of a
+      // block whose label stays true whenever it is written, and the record is rewritten the moment
+      // this turn answers. Gating a session-BOUND copy on the same cache is what made an earlier
+      // revision lie about which room a thread branched from; a prompt-bound copy cannot.
+      //
+      // Derived FROM the lineage rather than beside it: a place with no parent has no room to read,
+      // and an opaque routed session must get neither. Keyed by the SOURCE chat — a route may answer
+      // elsewhere, but a thread branches from where its message was said.
+      const roomBufferKey =
+        parentSession !== undefined && !threadParticipants.agentSpokeIn(session)
+          ? feishuBufferPlaceKey({ chatId: m.chat_id })
+          : undefined;
       const chatId = r.chatId ?? m.chat_id;
       const sameTarget = chatId === m.chat_id;
       // Answer where asked (§4): quote in a group so the ask is identifiable among many speakers,

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -98,12 +98,10 @@ interface StoredFeishuTurn {
   /** The place this thread branched from (§5 lineage) — recorded at ingress, where the session's
    *  routed-ness is known; absent for main places, routed (opaque) sessions, and pre-upgrade records. */
   parentSession?: string;
-  /** The ROOM's buffer bucket, folded READ-ONLY into this turn (§5's other half: the room's
-   *  not-yet-answered discussion is part of "what the room knew", and the session fork cannot carry
-   *  what no session has absorbed). Set only on a thread's FIRST turn, and recorded at ingress
-   *  because only there are both facts known — whether the agent has answered here before, and which
-   *  chat the message came FROM (a route may point the answer at a different one). Never committed
-   *  from here. */
+  /** The ROOM's bucket to fold READ-ONLY into this turn — the half of "what the room knew" that no
+   *  session has absorbed (§8). Recorded at ingress, where both facts live: the source chat (a route
+   *  may answer elsewhere) and whether this is the thread's first answered turn. Absent = nothing to
+   *  fold, for either reason. */
   roomBufferKey?: string;
   images: { msg: string; key: string }[];
   files: { msg: string; key: string; name?: string }[];
@@ -469,17 +467,10 @@ function createFeishuRuntimeFactory(
         // this snapshot before either commits it. That fan-out loses nothing; claiming by buffer key
         // would instead couple otherwise-independent root sessions and require failure rollback.
         const { text: recent, consumed } = buffer.peek(rec.bufferKey);
-        // A thread's FIRST turn also reads the ROOM's bucket — READ-ONLY. Committing from HERE would
-        // steal it from the room, so each place still sees the discussion exactly once in its own
-        // memory: the room's own next answered turn folds AND commits the same messages.
-        //
-        // First turn only, because a prompt is not an independent request — it lands in the session
-        // and every later turn's context contains it. Re-folding would put a second identical copy of
-        // the block, and of its images, in ONE context window (measured: three turns → three copies),
-        // which reads as three separate postings rather than one. After turn one the content is
-        // already there; only newly arrived chatter would be new, and it reaches the thread the same
-        // way anything else does — by someone saying it there, or by the room answering and the
-        // thread's own buffer carrying on.
+        // The ROOM's pending discussion, on a thread's first answered turn only (§8). PEEKED, never
+        // committed: the room's own next answered turn still delivers the same messages to its own
+        // memory. Folding it again later would duplicate the block — and its images — inside one
+        // context window, since this turn's prompt is itself in the session from then on.
         const room = rec.roomBufferKey !== undefined ? buffer.peek(rec.roomBufferKey) : undefined;
         const roomBlock = room?.text
           ? `[recent discussion in the room this thread branched from — not yet answered there:\n${room.text}\n]\n\n`
@@ -686,19 +677,11 @@ function createFeishuRuntimeFactory(
       // time, where routed-ness is still known; the dequeue path only reads it back.
       const parentSession =
         routed === undefined && m.thread_id !== undefined ? placeKey(kind, { chat_id: m.chat_id }) : undefined;
-      // The room's un-summoned chatter is the half of "what the room knew" that no session holds yet
-      // — folded into the thread's FIRST turn. `agentSpokeIn` read HERE, before this turn's own
-      // participation is recorded below, is exactly that fact.
-      //
-      // The store is a cache (bounded, evictable, deletable) and that is ACCEPTABLE for this gate,
-      // unlike for anything that would outlive the turn: an evicted record costs one extra fold of a
-      // block whose label stays true whenever it is written, and the record is rewritten the moment
-      // this turn answers. Gating a session-BOUND copy on the same cache is what made an earlier
-      // revision lie about which room a thread branched from; a prompt-bound copy cannot.
-      //
-      // Derived FROM the lineage rather than beside it: a place with no parent has no room to read,
-      // and an opaque routed session must get neither. Keyed by the SOURCE chat — a route may answer
-      // elsewhere, but a thread branches from where its message was said.
+      // The room's pending discussion, folded into this thread's first answered turn (§8).
+      // `agentSpokeIn` is read HERE, before this turn records its own participation below. Keyed by
+      // the SOURCE chat: a route may answer elsewhere, but a thread branches from where it was said.
+      // Gating on an evictable cache is sound for this and not for a durable claim — the fold is
+      // repeatable prompt text, so a forgotten record costs one extra fold (§8).
       const roomBufferKey =
         parentSession !== undefined && !threadParticipants.agentSpokeIn(session)
           ? feishuBufferPlaceKey({ chatId: m.chat_id })

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -98,6 +98,11 @@ interface StoredFeishuTurn {
   /** The place this thread branched from (§5 lineage) — recorded at ingress, where the session's
    *  routed-ness is known; absent for main places, routed (opaque) sessions, and pre-upgrade records. */
   parentSession?: string;
+  /** The ROOM's buffer bucket, folded READ-ONLY into this thread turn (§5's other half: the room's
+   *  not-yet-answered discussion is part of "what the room knew", and the session fork cannot carry
+   *  what no session has absorbed). Recorded at ingress because only there is the SOURCE chat known
+   *  — a route may point the answer at a different one. Never committed from here. */
+  roomBufferKey?: string;
   images: { msg: string; key: string }[];
   files: { msg: string; key: string; name?: string }[];
   attempts: number;
@@ -123,6 +128,7 @@ function isStoredFeishuTurn(t: unknown): t is StoredFeishuTurn {
     (r.replyInThread === undefined || typeof r.replyInThread === "boolean") &&
     (r.parentId === undefined || typeof r.parentId === "string") &&
     (r.parentSession === undefined || typeof r.parentSession === "string") &&
+    (r.roomBufferKey === undefined || typeof r.roomBufferKey === "string") &&
     refs(r.images) &&
     refs(r.files) &&
     typeof r.attempts === "number"
@@ -461,8 +467,23 @@ function createFeishuRuntimeFactory(
         // this snapshot before either commits it. That fan-out loses nothing; claiming by buffer key
         // would instead couple otherwise-independent root sessions and require failure rollback.
         const { text: recent, consumed } = buffer.peek(rec.bufferKey);
-        const prompt = recent ? `[recent group discussion:\n${recent}\n]\n\n${rec.baseText}` : rec.baseText;
-        const buffered = collectFeishuBufferedAttachments(consumed, {
+        // A thread turn also reads the ROOM's bucket — READ-ONLY, and on EVERY turn, not just the
+        // first. "First turn" would be the tighter fold, but every way of knowing it is a
+        // channel-side memory that can be lost (the participants store is a cache by contract:
+        // bounded, evictable, deletable), and a forgotten entry re-labels an old thread's turn as
+        // newborn. Folding unconditionally needs no such memory: it repeats the block while the room
+        // stays un-answered, and stops by itself the moment the room's own next turn commits its
+        // bucket. Committing from HERE would steal it from the room, so each place still sees the
+        // discussion exactly once in its own memory.
+        const room = rec.roomBufferKey !== undefined ? buffer.peek(rec.roomBufferKey) : undefined;
+        const roomBlock = room?.text
+          ? `[recent discussion in the room this thread branched from — not yet answered there:\n${room.text}\n]\n\n`
+          : "";
+        const threadBlock = recent ? `[recent group discussion:\n${recent}\n]\n\n` : "";
+        const prompt = `${roomBlock}${threadBlock}${rec.baseText}`;
+        // Room entries FIRST: the collector keeps the tail under its cap, so the thread's own
+        // discussion outranks the parent room's when both compete for attachment slots.
+        const buffered = collectFeishuBufferedAttachments([...(room?.consumed ?? []), ...consumed], {
           images: rec.images.map((ref) => ({ messageId: ref.msg, key: ref.key })),
           files: rec.files.map((ref) => ({ messageId: ref.msg, key: ref.key, name: ref.name })),
         });
@@ -660,6 +681,13 @@ function createFeishuRuntimeFactory(
       // time, where routed-ness is still known; the dequeue path only reads it back.
       const parentSession =
         routed === undefined && m.thread_id !== undefined ? placeKey(kind, { chat_id: m.chat_id }) : undefined;
+      // The room's un-summoned chatter is the half of "what the room knew" that no session holds yet.
+      // Recorded here because the SOURCE chat is only known here (a route may answer elsewhere), and
+      // derived FROM the lineage rather than beside it: a place with no parent has no room to read,
+      // and an opaque routed session must get neither. (Untested on purpose — the two cannot diverge,
+      // and a routed deployment never fills a room bucket anyway: route-null messages are dropped,
+      // not buffered.)
+      const roomBufferKey = parentSession !== undefined ? feishuBufferPlaceKey({ chatId: m.chat_id }) : undefined;
       const chatId = r.chatId ?? m.chat_id;
       const sameTarget = chatId === m.chat_id;
       // Answer where asked (§4): quote in a group so the ask is identifiable among many speakers,
@@ -715,6 +743,7 @@ function createFeishuRuntimeFactory(
           // from anyway.
           parentId: m.parent_id,
           ...(parentSession !== undefined ? { parentSession } : {}),
+          ...(roomBufferKey !== undefined ? { roomBufferKey } : {}),
           images,
           files,
         },

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -98,10 +98,8 @@ interface StoredFeishuTurn {
   /** The place this thread branched from (§5 lineage) — recorded at ingress, where the session's
    *  routed-ness is known; absent for main places, routed (opaque) sessions, and pre-upgrade records. */
   parentSession?: string;
-  /** The ROOM's bucket to fold READ-ONLY into this turn — the half of "what the room knew" that no
-   *  session has absorbed (§8). Recorded at ingress, where both facts live: the source chat (a route
-   *  may answer elsewhere) and whether this is the thread's first answered turn. Absent = nothing to
-   *  fold, for either reason. */
+  /** The ROOM's bucket to fold read-only into this turn (§8). Decided at ingress — only there are the
+   *  source chat and the first-turn fact known. */
   roomBufferKey?: string;
   images: { msg: string; key: string }[];
   files: { msg: string; key: string; name?: string }[];
@@ -467,18 +465,15 @@ function createFeishuRuntimeFactory(
         // this snapshot before either commits it. That fan-out loses nothing; claiming by buffer key
         // would instead couple otherwise-independent root sessions and require failure rollback.
         const { text: recent, consumed } = buffer.peek(rec.bufferKey);
-        // The ROOM's pending discussion, on a thread's first answered turn only (§8). PEEKED, never
-        // committed: the room's own next answered turn still delivers the same messages to its own
-        // memory. Folding it again later would duplicate the block — and its images — inside one
-        // context window, since this turn's prompt is itself in the session from then on.
+        // PEEK and never commit: the room still owes this discussion to its OWN memory (§8).
         const room = rec.roomBufferKey !== undefined ? buffer.peek(rec.roomBufferKey) : undefined;
         const roomBlock = room?.text
           ? `[recent discussion in the room this thread branched from — not yet answered there:\n${room.text}\n]\n\n`
           : "";
         const threadBlock = recent ? `[recent group discussion:\n${recent}\n]\n\n` : "";
         const prompt = `${roomBlock}${threadBlock}${rec.baseText}`;
-        // Room entries FIRST: the collector keeps the tail under its cap, so the thread's own
-        // discussion outranks the parent room's when both compete for attachment slots.
+        // Room entries FIRST: the collector keeps the TAIL under its cap, so the thread's own
+        // attachments win the slots.
         const buffered = collectFeishuBufferedAttachments([...(room?.consumed ?? []), ...consumed], {
           images: rec.images.map((ref) => ({ messageId: ref.msg, key: ref.key })),
           files: rec.files.map((ref) => ({ messageId: ref.msg, key: ref.key, name: ref.name })),
@@ -677,11 +672,8 @@ function createFeishuRuntimeFactory(
       // time, where routed-ness is still known; the dequeue path only reads it back.
       const parentSession =
         routed === undefined && m.thread_id !== undefined ? placeKey(kind, { chat_id: m.chat_id }) : undefined;
-      // The room's pending discussion, folded into this thread's first answered turn (§8).
-      // `agentSpokeIn` is read HERE, before this turn records its own participation below. Keyed by
-      // the SOURCE chat: a route may answer elsewhere, but a thread branches from where it was said.
-      // Gating on an evictable cache is sound for this and not for a durable claim — the fold is
-      // repeatable prompt text, so a forgotten record costs one extra fold (§8).
+      // Read BEFORE this turn records its own participation below, or it is always true. Keyed by the
+      // SOURCE chat, never the answer target a route may name (§8).
       const roomBufferKey =
         parentSession !== undefined && !threadParticipants.agentSpokeIn(session)
           ? feishuBufferPlaceKey({ chatId: m.chat_id })

--- a/src/channels/thread-participants.ts
+++ b/src/channels/thread-participants.ts
@@ -61,21 +61,15 @@ export interface ThreadParticipants {
   admitsBareMessage(key: string): boolean;
   /**
    * Has the agent answered into this thread before? A DIFFERENT question from
-   * {@link ThreadParticipants.admitsBareMessage} (which also weighs the second-human rule): this one
-   * marks the thread's FIRST turn — the moment it is born out of its room — which is when a channel
-   * folds the room's not-yet-answered discussion into it (read-only; see the feishu channel).
+   * {@link ThreadParticipants.admitsBareMessage}, which also weighs the second-human rule: this one
+   * is only "is this the thread's first answered turn", the moment a channel folds the room's
+   * pending discussion into it (participant-model.md §8).
    *
-   * This reader tolerates the store's forgetting in a way the summon rule's does not, and the
-   * difference is worth stating because it is what makes the read legitimate here: the fold is
-   * prompt text under a label that is true whenever it is written ("discussion in the room this
-   * thread branched from, not yet answered there"), so an evicted record costs ONE extra fold and
-   * then self-heals when this turn records participation again. The same store may not gate anything
-   * whose label would become a LIE after eviction — which is why the room's discussion is folded into
-   * a prompt rather than written into a session's birth mark.
+   * A caller must tolerate a false from an EVICTED record (this store is a cache — see the header):
+   * gate a repeatable read on it, never a durable claim about when a thread began.
    *
-   * False for threads the store has never seen, including p2p threads, where participation is
-   * deliberately not recorded — harmless there, because a p2p main place never buffers (every message
-   * answers).
+   * False for threads the store has never seen, p2p included — participation is not recorded there,
+   * and a p2p main place never buffers anyway.
    */
   agentSpokeIn(key: string): boolean;
   /**

--- a/src/channels/thread-participants.ts
+++ b/src/channels/thread-participants.ts
@@ -60,6 +60,25 @@ export interface ThreadParticipants {
    */
   admitsBareMessage(key: string): boolean;
   /**
+   * Has the agent answered into this thread before? A DIFFERENT question from
+   * {@link ThreadParticipants.admitsBareMessage} (which also weighs the second-human rule): this one
+   * marks the thread's FIRST turn — the moment it is born out of its room — which is when a channel
+   * folds the room's not-yet-answered discussion into it (read-only; see the feishu channel).
+   *
+   * This reader tolerates the store's forgetting in a way the summon rule's does not, and the
+   * difference is worth stating because it is what makes the read legitimate here: the fold is
+   * prompt text under a label that is true whenever it is written ("discussion in the room this
+   * thread branched from, not yet answered there"), so an evicted record costs ONE extra fold and
+   * then self-heals when this turn records participation again. The same store may not gate anything
+   * whose label would become a LIE after eviction — which is why the room's discussion is folded into
+   * a prompt rather than written into a session's birth mark.
+   *
+   * False for threads the store has never seen, including p2p threads, where participation is
+   * deliberately not recorded — harmless there, because a p2p main place never buffers (every message
+   * answers).
+   */
+  agentSpokeIn(key: string): boolean;
+  /**
    * Merge in what was just heard. Idempotent; a failed write is a warning, never a failed delivery.
    *
    * The parameter only admits values the store can honour: observations accumulate, so `agentSpoke`
@@ -100,6 +119,9 @@ export function createThreadParticipants(path: string, label: string): ThreadPar
     admitsBareMessage(key) {
       const heard = records.get(key);
       return heard?.agentSpoke === true && heard.humans.length <= 1;
+    },
+    agentSpokeIn(key) {
+      return records.get(key)?.agentSpoke === true;
     },
     merge(key, heard) {
       const previous = records.get(key);

--- a/src/channels/thread-participants.ts
+++ b/src/channels/thread-participants.ts
@@ -60,16 +60,10 @@ export interface ThreadParticipants {
    */
   admitsBareMessage(key: string): boolean;
   /**
-   * Has the agent answered into this thread before? A DIFFERENT question from
-   * {@link ThreadParticipants.admitsBareMessage}, which also weighs the second-human rule: this one
-   * is only "is this the thread's first answered turn", the moment a channel folds the room's
-   * pending discussion into it (participant-model.md §8).
-   *
-   * A caller must tolerate a false from an EVICTED record (this store is a cache — see the header):
-   * gate a repeatable read on it, never a durable claim about when a thread began.
-   *
-   * False for threads the store has never seen, p2p included — participation is not recorded there,
-   * and a p2p main place never buffers anyway.
+   * Has the agent answered into this thread before — the "first answered turn" fact
+   * (participant-model.md §8), unlike {@link ThreadParticipants.admitsBareMessage} which also weighs
+   * the second-human rule. An evicted record answers false (this store is a cache — see the header),
+   * so gate a repeatable read on it, never a durable claim.
    */
   agentSpokeIn(key: string): boolean;
   /**

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -1768,17 +1768,15 @@ describe("turn flow", () => {
     expect(calls[0]?.scope.branchHints).toBeUndefined();
   });
 
-  it("a thread turn folds the room's un-answered discussion, and stops when the room absorbs it", async () => {
+  it("a thread's FIRST turn folds the room's un-answered discussion — read-only, and once", async () => {
     // The fork (scope.parentSession) carries what the room's SESSION knew; chatter since the room's
-    // last answered turn sits only in its context buffer, absorbed by no session. A thread turn
-    // folds that bucket read-only.
+    // last answered turn sits only in its context buffer, absorbed by nothing. The thread's first
+    // turn folds that bucket — read-only, so the room's own next answered turn still delivers the
+    // same messages to its own memory. Each place sees the discussion exactly once.
     //
-    // Folded on EVERY turn, not just the thread's first. "First" is the tighter fold, but every way
-    // of knowing it is a channel-side memory that can be lost — the participants store is a cache by
-    // contract — and a forgotten entry re-labels an old thread's turn as newborn. Unconditional
-    // folding needs no such memory: it repeats while the room stays un-answered and stops by itself
-    // once the room's own turn commits its bucket. The thread never commits, so nothing is stolen:
-    // the room still folds the same chatter into its own next answer.
+    // ONCE, not per turn: a prompt lands in the session, so turn two's context already holds turn
+    // one's fold. Re-folding would put a second identical copy of the block, and of its images, in
+    // one context window.
     feishuFetch();
     const { handler, calls, idle } = buildChannel();
     await flush();
@@ -1806,16 +1804,17 @@ describe("turn flow", () => {
     expect(first).toContain("蓝色背景");
     expect(first).toContain("同意，蓝色好");
 
-    // A SECOND thread turn still folds it: the room has not answered, so the discussion is still
-    // absorbed by nobody, and the channel does not claim to know which turn was the thread's first.
+    // A SECOND thread turn does NOT fold it again: the agent has answered here, and the block is
+    // already in this session from turn one.
     await handler(
       feishuRequest(messageEvent({ id: "om_t2", chatType: "group", threadId: "omt_new", text: "那用深蓝还是浅蓝" })),
     );
     await idle();
     expect(calls).toHaveLength(2);
-    expect(calls[1]?.prompt.text ?? "").toContain("蓝色背景");
+    expect(calls[1]?.prompt.text ?? "").not.toContain("branched from");
 
-    // The ROOM's own next answered turn folds AND commits the chatter — nothing was stolen from it.
+    // …and the ROOM's own next answered turn still folds AND commits the same chatter: the thread
+    // only peeked, so nothing was stolen from the room.
     await handler(
       feishuRequest(
         messageEvent({
@@ -1831,19 +1830,14 @@ describe("turn flow", () => {
     const roomTurn = calls[2]?.prompt.text ?? "";
     expect(roomTurn).toContain("[recent group discussion:");
     expect(roomTurn).toContain("蓝色背景");
-
-    // …after which the fold stops by itself: the bucket is the only source of truth, and it is empty.
-    await handler(
-      feishuRequest(messageEvent({ id: "om_t3", chatType: "group", threadId: "omt_new", text: "好，定了" })),
-    );
-    await idle();
-    expect(calls).toHaveLength(4);
-    expect(calls[3]?.prompt.text ?? "").not.toContain("branched from");
   });
 
-  it("the room fold's attachments ride the buffered tier into a thread turn", async () => {
+  it("the room fold's attachments ride the buffered tier into the thread's first turn — once", async () => {
     // The fold is prompt text plus real attachments — the room's image crosses as an image, not as a
-    // marker line. This is what a session-bound seed could not do.
+    // marker line. This is what a session-bound seed could not do, and it is also what makes the
+    // first-turn gate load-bearing rather than an optimisation: an image re-sent on every turn would
+    // sit in one context window several times over, reading as several separate postings, and would
+    // be re-fetched from the platform each time.
     const fx = feishuFetch();
     const { handler, calls, idle } = buildChannel();
     await flush();
@@ -1876,6 +1870,16 @@ describe("turn flow", () => {
     expect(prompt).toContain("branched from"); // the fold is there…
     expect(calls[0]?.prompt.images).toHaveLength(1); // …and the image crossed with it
     expect(prompt).toContain("vision image 1: from user ou_alice, msg om_room_img");
+    expect(fx.calls("/im/v1/messages/om_room_img/resources/room_shot", "GET")).toHaveLength(1);
+
+    // A later turn in the same thread neither re-fetches it nor re-attaches it: one copy in the
+    // session is the whole point, and the model must not see the same screenshot twice.
+    await handler(
+      feishuRequest(messageEvent({ id: "om_t_second", chatType: "group", threadId: "omt_pic", text: "还有别的吗" })),
+    );
+    await idle();
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.prompt.images ?? []).toHaveLength(0);
     expect(fx.calls("/im/v1/messages/om_room_img/resources/room_shot", "GET")).toHaveLength(1);
   });
 

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -1768,6 +1768,117 @@ describe("turn flow", () => {
     expect(calls[0]?.scope.branchHints).toBeUndefined();
   });
 
+  it("a thread turn folds the room's un-answered discussion, and stops when the room absorbs it", async () => {
+    // The fork (scope.parentSession) carries what the room's SESSION knew; chatter since the room's
+    // last answered turn sits only in its context buffer, absorbed by no session. A thread turn
+    // folds that bucket read-only.
+    //
+    // Folded on EVERY turn, not just the thread's first. "First" is the tighter fold, but every way
+    // of knowing it is a channel-side memory that can be lost — the participants store is a cache by
+    // contract — and a forgotten entry re-labels an old thread's turn as newborn. Unconditional
+    // folding needs no such memory: it repeats while the room stays un-answered and stops by itself
+    // once the room's own turn commits its bucket. The thread never commits, so nothing is stolen:
+    // the room still folds the same chatter into its own next answer.
+    feishuFetch();
+    const { handler, calls, idle } = buildChannel();
+    await flush();
+    const mention = [{ key: "@_bot", name: "Bot", id: { open_id: "ou_bot" } }];
+    // Two un-summoned ROOM messages → the main bucket.
+    await handler(feishuRequest(messageEvent({ id: "om_room1", chatType: "group", text: "我们该用蓝色背景" })));
+    await handler(feishuRequest(messageEvent({ id: "om_room2", chatType: "group", text: "同意，蓝色好" })));
+    // First message of a NEW topic summons the agent.
+    await handler(
+      feishuRequest(
+        messageEvent({
+          id: "om_t1",
+          chatType: "group",
+          threadId: "omt_new",
+          content: JSON.stringify({ text: "@_bot 背景色定了吗？" }),
+          mentions: mention,
+        }),
+      ),
+    );
+    await idle();
+
+    expect(calls).toHaveLength(1);
+    const first = calls[0]?.prompt.text ?? "";
+    expect(first).toContain("[recent discussion in the room this thread branched from — not yet answered there:");
+    expect(first).toContain("蓝色背景");
+    expect(first).toContain("同意，蓝色好");
+
+    // A SECOND thread turn still folds it: the room has not answered, so the discussion is still
+    // absorbed by nobody, and the channel does not claim to know which turn was the thread's first.
+    await handler(
+      feishuRequest(messageEvent({ id: "om_t2", chatType: "group", threadId: "omt_new", text: "那用深蓝还是浅蓝" })),
+    );
+    await idle();
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.prompt.text ?? "").toContain("蓝色背景");
+
+    // The ROOM's own next answered turn folds AND commits the chatter — nothing was stolen from it.
+    await handler(
+      feishuRequest(
+        messageEvent({
+          id: "om_room_ask",
+          chatType: "group",
+          content: JSON.stringify({ text: "@_bot 总结一下大家的意见" }),
+          mentions: mention,
+        }),
+      ),
+    );
+    await idle();
+    expect(calls).toHaveLength(3);
+    const roomTurn = calls[2]?.prompt.text ?? "";
+    expect(roomTurn).toContain("[recent group discussion:");
+    expect(roomTurn).toContain("蓝色背景");
+
+    // …after which the fold stops by itself: the bucket is the only source of truth, and it is empty.
+    await handler(
+      feishuRequest(messageEvent({ id: "om_t3", chatType: "group", threadId: "omt_new", text: "好，定了" })),
+    );
+    await idle();
+    expect(calls).toHaveLength(4);
+    expect(calls[3]?.prompt.text ?? "").not.toContain("branched from");
+  });
+
+  it("the room fold's attachments ride the buffered tier into a thread turn", async () => {
+    // The fold is prompt text plus real attachments — the room's image crosses as an image, not as a
+    // marker line. This is what a session-bound seed could not do.
+    const fx = feishuFetch();
+    const { handler, calls, idle } = buildChannel();
+    await flush();
+    const mention = [{ key: "@_bot", name: "Bot", id: { open_id: "ou_bot" } }];
+    await handler(
+      feishuRequest(
+        messageEvent({
+          id: "om_room_img",
+          chatType: "group",
+          msgType: "image",
+          content: JSON.stringify({ image_key: "room_shot" }),
+        }),
+      ),
+    );
+    await handler(
+      feishuRequest(
+        messageEvent({
+          id: "om_t_first",
+          chatType: "group",
+          threadId: "omt_pic",
+          content: JSON.stringify({ text: "@_bot 那张图里是什么" }),
+          mentions: mention,
+        }),
+      ),
+    );
+    await idle();
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.prompt.text ?? "";
+    expect(prompt).toContain("branched from"); // the fold is there…
+    expect(calls[0]?.prompt.images).toHaveLength(1); // …and the image crossed with it
+    expect(prompt).toContain("vision image 1: from user ou_alice, msg om_room_img");
+    expect(fx.calls("/im/v1/messages/om_room_img/resources/room_shot", "GET")).toHaveLength(1);
+  });
+
   it("a ROUTED session is opaque: no lineage, even when its id looks like a place key", async () => {
     // route().session's contract is opaque. A three-segment id like "tenant:user:alice" must not be
     // re-parsed as `<kind>:<chat>:<thread>` — that would let a thread message inherit from a session


### PR DESCRIPTION
Part 3 of 3 in the thread-context work (#327 reply chain → #328 session inheritance → **#330 room-buffer fold**), and the last piece of participant-model.md §5's "a thread starts from what the room knew".

## Problem

"What the room knew" has two halves. The fork (#328) carries the half that is in the room's **session** — but a room's session only advances when the agent is summoned, so discussion since its last answered turn sits in the context buffer, absorbed by nothing. Open a topic right after a burst of chatter and the inherited memory ends *before* the chatter began.

## Mechanism

The thread's first answered turn folds the room's bucket into its prompt: its own labelled block above the thread's usual fold, its attachments riding the buffered tier behind the thread's own. **Peeked, never committed** — the room's own next answered turn still folds and commits the same messages, so each place delivers the discussion to its own memory exactly once.

## Why the first turn only

A prompt is not an independent request: it lands in the session, so the thread's second turn already carries the first turn's fold in its context. Re-folding would put a second identical copy of the block — **and of its images** — inside one context window (measured: three turns, three copies of each, three re-fetches of the same resource). Several copies of one screenshot read as several postings. The gate is therefore part of the feature, not an optimisation.

## Why an evictable cache may gate it

The first-turn fact is `agentSpokeIn`, a new reader on the shared participants store, asked at ingress before this turn records its own participation. That store is a cache by contract — bounded at 1000, LRU-evicted, warn-only persistence, documented as deletable — and that is sound **here** for a reason worth stating as a rule, because it does not generalise:

| Where the copy lives | What an evicted record costs |
|---|---|
| A prompt (this change) | One extra fold of a block whose label — *discussion in the room this thread branched from, not yet answered there* — is true whenever it is written. The record is rewritten as soon as that turn answers. |
| A session (rejected) | A permanent claim that the room's **current** chatter is *what this thread branched from*, for a thread that branched long before. |

Repetition degrades an answer; a stale durable label misstates the past. So this rung is prompt-bound, and rung 4 — which is session-bound — is gated on the session's own existence instead.

Two designs were built and dropped on the way here: the same fold gated on the same cache but written into the newborn session's birth mark (the right-hand column above), and a `Scope.seedContext` extension that made the gate unforgeable by moving it into the engine — correct, but it spread one best-effort context feature across eleven files, a SPEC extension row, the HTTP boundary and the remote client, and could only carry attachments as decoded marker lines.

## Rejected: making the room absorb eagerly

Writing each un-summoned message into the room's session at ingress would delete this rung entirely — the fork would see everything. It fails on three counts, measured rather than assumed:

- durable session writes take the run lease ([session-control.md](docs/design/session-control.md) §9), so ingress would block behind a multi-minute turn;
- that blocking sits on the pre-ACK path, where the webhook must answer before the platform re-pushes;
- consecutive ambient user entries reach the provider unmerged — the direct Anthropic API now combines same-role turns, but Bedrock still rejects them (`roles must alternate`), and `deploy agentcore` is a shipped host.

A room's session advancing only when summoned is therefore a constraint, not an oversight. Recorded in §8 so the question does not get re-opened from scratch.

## Size

18 lines of code and 13 of comment, across the feishu channel and one reader on the participants store. No contract change: nothing added to `Scope`, the wire, or the HTTP boundary.

## Tests

Lifecycle: the first thread turn folds the chatter, the second does not, and the room's own next answered turn still folds **and** commits the same messages — proof nothing was stolen. Attachments: the room's image crosses as a real image on the first turn, and a later turn neither re-attaches nor re-fetches it.

Mutation-verified: removing the first-turn gate fails two tests; committing the room bucket from the thread fails one; dropping the room attachments fails one.

Independent of #335, which carries the session-store work this branch once accumulated.
