### PR TITLE
feat(config): make coding tools configurable

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -172,6 +172,25 @@ function createPiAgentFromDir(
 
 The same opener used by `fastagent dev`, `invoke`, and `start`: load config, resolve model/tools, pick session storage, and assemble the directory. Set `serving: true` only for a long-running host that also runs the scheduler; it allows an opted-in workspace to mount its `wake` tool.
 
+Directory config can disable pi's default coding tools without changing the authored tool surface:
+
+```ts
+type CodingToolName = "read" | "bash" | "edit" | "write";
+
+interface FastagentConfig {
+  codingTools?: boolean | CodingToolName[];
+  tools?: FastagentTool[];
+}
+```
+
+Unset/`true` mounts all four; `false`/`[]` mounts none; an array mounts exactly those names in canonical
+order. Every directory-opening workflow (`dev`, `start`, `invoke`, `chat`, `tool`, and `info`) applies
+the same resolved surface. Model-visible skills and chat-channel non-image attachments require the
+built-in `read`; use `codingTools: ["read"]` when those capabilities remain needed. Conditional
+built-ins stay independent: deferred tools may add `search_tools`, and `selfSchedule` may add `wake`
+while serving. The lower-level `createPiAgent` API remains explicit: its `tools` option is the exact set
+supplied by the caller and has no `codingTools` option.
+
 ## Tool authoring
 
 ```ts
@@ -264,6 +283,7 @@ Costs and behavior to know:
 interface ChannelContext {
   agent: Agent;
   stateRoot: string; // resolved state root (FASTAGENT_STATE_DIR > <root>/.state), absolute
+  canReadLocalFiles?: boolean; // standard serving supplies the assembled attachment-path capability
 }
 type ChannelModule = (ctx: ChannelContext) => Routes;
 interface LongConnection {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -283,7 +283,7 @@ Costs and behavior to know:
 interface ChannelContext {
   agent: Agent;
   stateRoot: string; // resolved state root (FASTAGENT_STATE_DIR > <root>/.state), absolute
-  canReadLocalFiles?: boolean; // standard serving supplies the assembled attachment-path capability
+  canReadLocalFiles: boolean; // required: whether the agent has a reader for absolute local paths
 }
 type ChannelModule = (ctx: ChannelContext) => Routes;
 interface LongConnection {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,7 +75,7 @@ Prints the assembled surface without starting a server:
 - model source,
 - config path,
 - persona presence and context files (`AGENTS.md`),
-- skills and diagnostics,
+- skills, their diagnostics, and any assembly findings (`assemblyFindings` — definition-wide, e.g. skills with no reader),
 - the resolved coding-tool names (`read`/`bash`/`edit`/`write`), plus authored tools and collisions,
 - channel files,
 - schedules (name + next fire instant; a broken schedule file is reported here, not first at `dev`),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,7 +76,7 @@ Prints the assembled surface without starting a server:
 - config path,
 - persona presence and context files (`AGENTS.md`),
 - skills and diagnostics,
-- non-default tools and collisions,
+- the resolved coding-tool names (`read`/`bash`/`edit`/`write`), plus authored tools and collisions,
 - channel files,
 - schedules (name + next fire instant; a broken schedule file is reported here, not first at `dev`),
 - whether self-scheduling (`selfSchedule`) is on,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,8 @@ Supported keys:
 |---|---|
 | `model` | Default model spec, in `provider/modelId` form. |
 | `thinkingLevel` | Reasoning effort for the model, on pi's scale: `off` \| `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max`. Default: `medium` — pinned by fastagent to match the pi TUI's default (authors vibe at `medium`, so serving must match; the pin also means an upstream default change cannot silently alter deployments). Levels a model doesn't support are clamped by the engine. |
-| `tools` | Extra programmatic tools appended after default pi tools. Most users should prefer `tools/` discovery. |
+| `codingTools` | Select the built-in coding tools. Unset/`true`: all of `read`, `bash`, `edit`, `write`; `false`/`[]`: none; an array such as `["read"]`: exactly those names. Authored and conditional built-ins are independent. |
+| `tools` | Extra programmatic tools appended after enabled pi coding tools. Most users should prefer `tools/` discovery. |
 | `http.port` | Default port for `dev` / `start`. |
 | `http.host` | Bind address for `dev` / `start`. Unset (or `0.0.0.0`) binds all interfaces — what containers need. `--bind` overrides it; prefer the flag for a local-only bind, since this value travels into a deployed image (see [Bind address](#bind-address)). |
 | `selfSchedule` | Mount the built-in `wake` tool so the agent can schedule its own follow-up turns (self-scheduling). Off by default — an autonomy capability, opt in when you want it; only active on the serving path (`dev`/`start`, where the scheduler poller runs). |
@@ -273,9 +274,40 @@ There are two ways to add tools:
 tools/lookup-order.ts  ->  lookup-order
 ```
 
-`config.tools` are appended after the default pi tools. Discovered `tools/` are appended after those.
-Name collisions are surfaced as warnings; existing tools win. Reusable packages do not need a separate
-plugin contract: export ordinary `FastagentTool[]` and mount them explicitly:
+By default, `config.tools` are appended after the pi coding tools (`read`, `bash`, `edit`, `write`),
+and discovered `tools/` are appended after those. To expose only authored tools:
+
+```ts
+import { defineConfig } from "@fastagent-sh/fastagent";
+
+export default defineConfig({
+  codingTools: false,
+});
+```
+
+For least privilege while retaining file-backed capabilities, select only `read`:
+
+```ts
+export default defineConfig({
+  codingTools: ["read"],
+});
+```
+
+Model-visible skills are loaded on demand from their `SKILL.md` paths, and chat-channel non-image
+attachments are downloaded to local paths. Both need the built-in `read` tool; FastAgent warns when
+model-visible skills have no reader, and channels reject an explicitly attached file rather than hand
+the model an unreadable path. Use `false` only when the agent needs neither capability (images still
+travel inline through vision).
+
+The setting removes only the selected coding tools. Authored `config.tools` and `tools/` still mount;
+`search_tools` still mounts when a deferred tool needs it, and `wake` remains controlled by
+`selfSchedule` on the serving path. Every directory-opening workflow (`dev`, `start`, `invoke`, `chat`,
+`tool`, and `info`) resolves the same setting. Run `fastagent info --json` and inspect `codingTools`
+(the resolved name array) plus `tools`.
+
+Name collisions are surfaced as warnings; existing tools win. With a coding tool enabled, its name
+wins over discovered tools; with it disabled, an authored tool may use that name. Reusable
+packages do not need a separate plugin contract: export ordinary `FastagentTool[]` and mount them explicitly:
 
 ```ts
 import { integrationTools } from "@acme/fastagent-tools";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,6 +299,12 @@ model-visible skills have no reader, and channels reject an explicitly attached 
 the model an unreadable path. Use `false` only when the agent needs neither capability (images still
 travel inline through vision).
 
+A disabled built-in is **refused, not merely hidden**: it never enters the session's tool registry,
+so nothing that activates a tool by name — a `chat` command, the control plane, the deferred-tool
+loader — can bring it back at runtime. That makes `codingTools` usable as a capability boundary for a
+public-facing agent, rather than a default someone can undo. It does not restrict tools you author
+yourself: `tools/` and `config.tools` are yours to scope.
+
 The setting removes only the selected coding tools. Authored `config.tools` and `tools/` still mount;
 `search_tools` still mounts when a deferred tool needs it, and `wake` remains controlled by
 `selfSchedule` on the serving path. Every directory-opening workflow (`dev`, `start`, `invoke`, `chat`,

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -262,11 +262,17 @@ the source.
 
 Workspace tools are merged in this order:
 
-1. pi coding tools (`read`, `bash`, `edit`, `write`);
+1. the pi coding tools selected by `config.codingTools` (`read`, `bash`, `edit`, `write`);
 2. `config.tools`;
 3. discovered `tools/*.ts|js|mjs`.
 
-Earlier names win and collisions are reported. Broken discovered tools are reported and skipped.
+Unset/`true` selects all four for authoring/serving fidelity; `false`/`[]` selects none; an array selects
+exact names in canonical order. The array is deliberate minimum privilege: file-backed skills and
+non-image channel attachments need `read`, while a public-facing read-only agent should not have to
+accept `bash`/`edit`/`write` merely to retain those capabilities. An agent with neither capability can
+remove the full machine-reaching coding surface without changing its standard `fastagent start`
+workflow. Conditional built-ins (`search_tools` for deferred tools, `wake` for self-scheduling) keep
+their own policies. Earlier names win and collisions are reported. Broken discovered tools are reported and skipped.
 Reusable integrations export ordinary `FastagentTool[]` for explicit `config.tools` mounting; package
 origin does not create a second tool runtime.
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -73,6 +73,16 @@ export const SESSION_BUSY_CODE = "session_busy";
 export const ABORTED_CODE = "aborted";
 
 /**
+ * The `failed.code` set when a turn carried an attachment the agent has no way to open — a local
+ * file with no `read` tool mounted. A CONFIGURATION limitation, not an unknown failure: the channel
+ * knows exactly what is wrong and can say so, where the generic "something went wrong" would leave
+ * the user guessing at a problem only the operator can fix. Exported for the same reason as
+ * {@link SESSION_BUSY_CODE}: its consumer (`defaultErrorMessage`, and any channel's own `onError`)
+ * must branch on it rather than string-match the message.
+ */
+export const ATTACHMENT_UNSUPPORTED_CODE = "attachment_unsupported";
+
+/**
  * One turn = one invoke, returning a single async event stream. The stream MUST terminate with
  * exactly one of completed / failed, or be cancelled by the caller (no terminal event). Any
  * AsyncIterable producer that implements this conforms (interface, not base class).

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -218,7 +218,7 @@ function createFeishuRuntimeFactory(
   const baseUrl = opts.apiBaseUrl ?? profile.apiBase;
   const { kind } = profile;
   const label = `[${kind}]`;
-  return ({ agent, stateRoot, control }) => {
+  return ({ agent, stateRoot, canReadLocalFiles, control }) => {
     // Credential checks run when serving starts, not while the authored module is imported: deployment
     // can inspect the module shape before secrets exist, while serving still fails before ready.
     if (!appId || !appSecret) {
@@ -489,6 +489,7 @@ function createFeishuRuntimeFactory(
                 filesDir: join(stateHome, "files"),
                 label,
                 appId,
+                canReadLocalFiles,
                 ...(parentSession !== undefined ? { parentSession } : {}),
               },
               { primary: { images: rec.images, files: rec.files, parentId: rec.parentId }, buffered },

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -12,7 +12,7 @@
  * ancestors, and degrade per attachment: one expired background file must not block the current ask
  * or hide its still-readable siblings.
  */
-import type { Agent, AgentEvent, ImageRef, Scope } from "../../agent.ts";
+import { type Agent, type AgentEvent, ATTACHMENT_UNSUPPORTED_CODE, type ImageRef, type Scope } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -375,7 +375,7 @@ export async function* invokeFeishuTurn(
       type: "failed",
       details: unavailable ? e.message : `could not load attachment: ${String(e)}`,
       retryable: !unavailable,
-      ...(unavailable ? { code: "attachment_unsupported" } : {}),
+      ...(unavailable ? { code: ATTACHMENT_UNSUPPORTED_CODE } : {}),
     };
     return;
   }

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -227,6 +227,11 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   const { canReadLocalFiles } = t;
   const images = [...attachments.primary.images];
   const files = [...attachments.primary.files];
+  // The ASK's own files, before a referent's join them. Fail-fast applies to these only: the user
+  // pointed at them, so silently dropping them would answer a question they did not ask.
+  if (!canReadLocalFiles && files.length > 0) throw new LocalFileAccessUnavailable(t.label);
+  // A referent's unreadable files degrade instead (see below); counted for the note.
+  let unreadableReferentFiles = 0;
   let referentBlock = "";
   let chain: ReplyChain = { block: "", images: [], files: [], ids: [] };
   if (attachments.primary.parentId !== undefined) {
@@ -257,8 +262,14 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
         mentions: parent.mentions as FeishuMention[] | undefined,
       });
       // The referent's own resources join the turn as primary inputs, carried by the PARENT message id.
+      // Images always: vision needs no reader. Files only if there IS one — a quoted file must not
+      // cost the user their turn, which is what this function's own policy says two paragraphs up.
       for (const key of parsed.imageKeys) images.push({ msg: parentId, key });
-      for (const ref of parsed.fileRefs) files.push({ msg: parentId, key: ref.key, name: ref.name });
+      if (canReadLocalFiles) {
+        for (const ref of parsed.fileRefs) files.push({ msg: parentId, key: ref.key, name: ref.name });
+      } else {
+        unreadableReferentFiles += parsed.fileRefs.length;
+      }
       const from = fetchedSenderLabel(parent.sender, t.appId);
       referentBlock = `\n\n[replied-to message (msg ${parentId}${from ? `, from ${from}` : ""}): ${truncateCodePointPrefix(parsed.text, REFERENT_MAX_CODE_POINTS) || "(empty)"}]`;
       // The referent's own parent starts the chain walk; the referent id seeds the cycle guard.
@@ -267,8 +278,6 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
     }
   }
 
-  // Primary first and fail-fast: these are resources the current user explicitly pointed at.
-  if (!canReadLocalFiles && files.length > 0) throw new LocalFileAccessUnavailable();
   const imageRefs: ImageRef[] = [];
   for (const ref of images) imageRefs.push(await t.api.fetchImage(ref.msg, ref.key));
   const downloaded: DownloadedFile[] = [];
@@ -313,7 +322,9 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
       log.warn(`${t.label} could not load an earlier (buffered) image: ${String(result.reason)}`);
     }
   }
-  const unreadable = canReadLocalFiles ? 0 : bufferedFiles.length;
+  // Everything skipped for want of a reader: this turn's buffered files, plus any the referent
+  // carried. One number, one note — the model is told what it did not get.
+  const unreadable = canReadLocalFiles ? 0 : bufferedFiles.length + unreadableReferentFiles;
   const fileResults = canReadLocalFiles
     ? await Promise.allSettled(
         bufferedFiles.map(async (ref) => ({

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -56,8 +56,8 @@ export interface FeishuTurnTransport {
    *  (participant-model.md §5). The engine reads it once, at session creation; every later turn
    *  carries it inertly. */
   parentSession?: string;
-  /** Undefined preserves the legacy embedder posture; standard serving supplies an explicit fact. */
-  canReadLocalFiles?: boolean;
+  /** Whether the agent has a reader for absolute local paths; see ChannelContext. */
+  canReadLocalFiles: boolean;
 }
 
 /** An attachment reference: the resource key inside its CARRYING message (the resource API addresses
@@ -224,7 +224,7 @@ async function walkReplyChain(
  * degrade independently.
  */
 async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurnAttachments): Promise<ResolvedInputs> {
-  const canReadLocalFiles = t.canReadLocalFiles !== false;
+  const { canReadLocalFiles } = t;
   const images = [...attachments.primary.images];
   const files = [...attachments.primary.files];
   let referentBlock = "";

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -17,11 +17,13 @@ import { log } from "../../log.ts";
 import {
   type BusyRetry,
   DEFAULT_BUSY_RETRY,
+  LocalFileAccessUnavailable,
   attachedFilesManifest,
   attributedFileName,
   backgroundImagesManifest,
   missingAttachmentsNote,
   streamTurnWithBusyRetry,
+  unreadableAttachmentsNote,
 } from "../invoke-turn-kit.ts";
 import { BUFFER_ATTACH_MAX } from "../context-buffer.ts";
 import type { FeishuBufferedRef } from "./context-buffer.ts";
@@ -54,6 +56,8 @@ export interface FeishuTurnTransport {
    *  (participant-model.md §5). The engine reads it once, at session creation; every later turn
    *  carries it inertly. */
   parentSession?: string;
+  /** Undefined preserves the legacy embedder posture; standard serving supplies an explicit fact. */
+  canReadLocalFiles?: boolean;
 }
 
 /** An attachment reference: the resource key inside its CARRYING message (the resource API addresses
@@ -220,6 +224,7 @@ async function walkReplyChain(
  * degrade independently.
  */
 async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurnAttachments): Promise<ResolvedInputs> {
+  const canReadLocalFiles = t.canReadLocalFiles !== false;
   const images = [...attachments.primary.images];
   const files = [...attachments.primary.files];
   let referentBlock = "";
@@ -263,6 +268,7 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   }
 
   // Primary first and fail-fast: these are resources the current user explicitly pointed at.
+  if (!canReadLocalFiles && files.length > 0) throw new LocalFileAccessUnavailable();
   const imageRefs: ImageRef[] = [];
   for (const ref of images) imageRefs.push(await t.api.fetchImage(ref.msg, ref.key));
   const downloaded: DownloadedFile[] = [];
@@ -307,12 +313,15 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
       log.warn(`${t.label} could not load an earlier (buffered) image: ${String(result.reason)}`);
     }
   }
-  const fileResults = await Promise.allSettled(
-    bufferedFiles.map(async (ref) => ({
-      ref,
-      file: await t.api.fetchFile(ref.messageId, ref.key, ref.name ?? ref.key, t.chatId, t.filesDir),
-    })),
-  );
+  const unreadable = canReadLocalFiles ? 0 : bufferedFiles.length;
+  const fileResults = canReadLocalFiles
+    ? await Promise.allSettled(
+        bufferedFiles.map(async (ref) => ({
+          ref,
+          file: await t.api.fetchFile(ref.messageId, ref.key, ref.name ?? ref.key, t.chatId, t.filesDir),
+        })),
+      )
+    : [];
   for (const result of fileResults) {
     if (result.status === "fulfilled") backgroundFiles.push(result.value);
     else {
@@ -323,6 +332,7 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   const missingNote = missingAttachmentsNote(
     lost + attachments.buffered.skipped + mergedImages.dropped + mergedFiles.dropped,
   );
+  const unreadableNote = unreadableAttachmentsNote(unreadable);
   const backgroundImageManifest = backgroundImagesManifest(
     imageRefs.length,
     backgroundImages.map(({ ref }) => ref),
@@ -337,7 +347,7 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   const allImages = [...imageRefs, ...backgroundImages.map(({ image }) => image)];
   return {
     images: allImages.length ? allImages : undefined,
-    promptSuffix: `${referentBlock}${missingNote}${backgroundImageManifest}${attachedFilesManifest(allFiles)}`,
+    promptSuffix: `${referentBlock}${missingNote}${unreadableNote}${backgroundImageManifest}${attachedFilesManifest(allFiles)}`,
     referentIds: [...(attachments.primary.parentId !== undefined ? [attachments.primary.parentId] : []), ...chain.ids],
   };
 }
@@ -360,7 +370,13 @@ export async function* invokeFeishuTurn(
   try {
     resolved = await resolveTurnInputs(transport, attachments);
   } catch (e) {
-    yield { type: "failed", details: `could not load attachment: ${String(e)}`, retryable: true };
+    const unavailable = e instanceof LocalFileAccessUnavailable;
+    yield {
+      type: "failed",
+      details: unavailable ? e.message : `could not load attachment: ${String(e)}`,
+      retryable: !unavailable,
+      ...(unavailable ? { code: "attachment_unsupported" } : {}),
+    };
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${REPLY_INSTRUCTION}`, images: resolved.images };

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -344,7 +344,12 @@ export async function streamFeishuReply(
         // we throw below regardless.
         finalized = true;
         {
-          const msg = formatError({ details: e.details, retryable: e.retryable }) ?? "";
+          const msg =
+            formatError({
+              details: e.details,
+              retryable: e.retryable,
+              ...(e.code !== undefined ? { code: e.code } : {}),
+            }) ?? "";
           try {
             await settle(msg);
           } catch (deliveryError) {

--- a/src/channels/invoke-turn-kit.ts
+++ b/src/channels/invoke-turn-kit.ts
@@ -72,6 +72,14 @@ export async function* streamTurnWithBusyRetry(
   }
 }
 
+/** A primary local-file attachment cannot be represented faithfully for an agent without a reader. */
+export class LocalFileAccessUnavailable extends Error {
+  constructor() {
+    super("this agent cannot read local file attachments; mount the read coding tool or send the content as text");
+    this.name = "LocalFileAccessUnavailable";
+  }
+}
+
 /** What the attached-files manifest renders per file: display name, byte size, absolute local path. */
 export interface ManifestFile {
   name: string;
@@ -113,5 +121,13 @@ export function backgroundImagesManifest(
 export function missingAttachmentsNote(missing: number): string {
   return missing > 0
     ? `\n[note: ${missing} attachment(s) from the earlier discussion are not loaded (no longer available, or older than the most recent few)]`
+    : "";
+}
+
+/** Background files omitted because this agent has no declared local-file reader. Never render their
+ *  dead paths: tell the model exactly which context it does not have instead. */
+export function unreadableAttachmentsNote(unreadable: number): string {
+  return unreadable > 0
+    ? `\n[note: ${unreadable} non-image attachment(s) from the earlier discussion are not loaded because this agent has no local-file reader]`
     : "";
 }

--- a/src/channels/invoke-turn-kit.ts
+++ b/src/channels/invoke-turn-kit.ts
@@ -72,11 +72,22 @@ export async function* streamTurnWithBusyRetry(
   }
 }
 
-/** A primary local-file attachment cannot be represented faithfully for an agent without a reader. */
+/**
+ * A primary local-file attachment cannot be represented faithfully for an agent without a reader.
+ *
+ * Constructing this LOGS, because the fix belongs to the operator and nothing else would tell them:
+ * the user gets a customer-facing line (see `defaultErrorMessage`), which by design does not carry
+ * "mount the read coding tool". Without this, a misconfigured agent answers every attachment with a
+ * shrug and no one learns why.
+ */
 export class LocalFileAccessUnavailable extends Error {
-  constructor() {
+  constructor(label = "[fastagent]") {
     super("this agent cannot read local file attachments; mount the read coding tool or send the content as text");
     this.name = "LocalFileAccessUnavailable";
+    log.warn(
+      `${label} an attachment arrived but this agent has no \`read\` tool — the turn was refused. ` +
+        `Enable it with \`codingTools\` (or \`codingTools: ["read"]\` for least privilege).`,
+    );
   }
 }
 

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -8,13 +8,15 @@
  * everything platform-independent lives here, so a new event type or a wording change lands in ONE
  * place instead of one hunk per channel.
  */
-import type { AgentEvent, Json } from "../agent.ts";
+import { type AgentEvent, ATTACHMENT_UNSUPPORTED_CODE, type Json } from "../agent.ts";
 import { truncateCodePointPrefix, truncateCodePointSuffix } from "./text.ts";
 
 /** A terminal failure, as a channel hands it to its `onError`. */
 export interface ChannelFailure {
   details: string;
   retryable: boolean;
+  /** The engine's failure code, when it set one — see `ATTACHMENT_UNSUPPORTED_CODE`. */
+  code?: string;
 }
 
 /** The customer-facing default: neutral, no leaked internals. Differentiate on retryability and always
@@ -22,6 +24,12 @@ export interface ChannelFailure {
  *  The non-retryable branch keeps the "something went wrong" phrase deliberately — it is neutral (we only
  *  know a boolean, never the specific limitation) and shared verbatim across channels. */
 export function defaultErrorMessage(failed: ChannelFailure): string {
+  // A known limitation gets named. The generic line asks the user to rephrase, which cannot help
+  // when the agent simply has no reader — only the operator can fix that, and the user deserves to
+  // know it is not their message.
+  if (failed.code === ATTACHMENT_UNSUPPORTED_CODE) {
+    return "⚠️ I can't open file attachments — please paste the content as text.";
+  }
   return failed.retryable
     ? "⚠️ Temporary problem — please try again in a moment."
     : "⚠️ Sorry, something went wrong. Try rephrasing, or check I have access to what you need.";

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -1,5 +1,5 @@
 /** Resolve Slack file IDs at dequeue, then stream one engine-neutral Agent turn. */
-import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
+import { type Agent, type AgentEvent, ATTACHMENT_UNSUPPORTED_CODE, type ImageRef } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -123,7 +123,7 @@ export async function* invokeSlackTurn(
       type: "failed",
       details: unavailable ? error.message : `could not load Slack attachment: ${String(error)}`,
       retryable: !unavailable,
-      ...(unavailable ? { code: "attachment_unsupported" } : {}),
+      ...(unavailable ? { code: ATTACHMENT_UNSUPPORTED_CODE } : {}),
     };
     return;
   }

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -60,7 +60,7 @@ async function resolveInputs(
     const resolved = await resolveFile(transport, id, canReadLocalFiles);
     if (resolved.image) images.push(resolved.image);
     if (resolved.file) files.push(resolved.file);
-    if (resolved.unreadableFile) throw new LocalFileAccessUnavailable();
+    if (resolved.unreadableFile) throw new LocalFileAccessUnavailable(transport.label);
   }
 
   const backgroundImages: { image: ImageRef; ref: SlackBufferedFileRef }[] = [];

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -23,8 +23,8 @@ export interface SlackTurnTransport {
   channelId: string;
   filesDir: string;
   label: string;
-  /** Undefined preserves the legacy embedder posture; standard serving supplies an explicit fact. */
-  canReadLocalFiles?: boolean;
+  /** Whether the agent has a reader for absolute local paths; see ChannelContext. */
+  canReadLocalFiles: boolean;
 }
 
 export interface SlackTurnAttachments {
@@ -53,7 +53,7 @@ async function resolveInputs(
   transport: SlackTurnTransport,
   attachments: SlackTurnAttachments,
 ): Promise<ResolvedInputs> {
-  const canReadLocalFiles = transport.canReadLocalFiles !== false;
+  const { canReadLocalFiles } = transport;
   const images: ImageRef[] = [];
   const files: DownloadedSlackFile[] = [];
   for (const id of attachments.primaryFileIds) {

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -4,11 +4,13 @@ import { log } from "../../log.ts";
 import {
   type BusyRetry,
   DEFAULT_BUSY_RETRY,
+  LocalFileAccessUnavailable,
   attachedFilesManifest,
   attributedFileName,
   backgroundImagesManifest,
   missingAttachmentsNote,
   streamTurnWithBusyRetry,
+  unreadableAttachmentsNote,
 } from "../invoke-turn-kit.ts";
 import type { SlackBufferedFileRef } from "./context-buffer.ts";
 import type { DownloadedSlackFile, SlackApi } from "./slack-api.ts";
@@ -21,6 +23,8 @@ export interface SlackTurnTransport {
   channelId: string;
   filesDir: string;
   label: string;
+  /** Undefined preserves the legacy embedder posture; standard serving supplies an explicit fact. */
+  canReadLocalFiles?: boolean;
 }
 
 export interface SlackTurnAttachments {
@@ -36,36 +40,45 @@ interface ResolvedInputs {
 async function resolveFile(
   transport: SlackTurnTransport,
   fileId: string,
-): Promise<{ image?: ImageRef; file?: DownloadedSlackFile }> {
+  canReadLocalFiles: boolean,
+): Promise<{ image?: ImageRef; file?: DownloadedSlackFile; unreadableFile?: true }> {
   const info = await transport.api.fileInfo(fileId);
-  return info.mimetype?.toLowerCase().startsWith("image/")
-    ? { image: await transport.api.fetchImage(info) }
-    : { file: await transport.api.fetchFile(info, transport.channelId, transport.filesDir) };
+  if (info.mimetype?.toLowerCase().startsWith("image/")) return { image: await transport.api.fetchImage(info) };
+  return canReadLocalFiles
+    ? { file: await transport.api.fetchFile(info, transport.channelId, transport.filesDir) }
+    : { unreadableFile: true };
 }
 
 async function resolveInputs(
   transport: SlackTurnTransport,
   attachments: SlackTurnAttachments,
 ): Promise<ResolvedInputs> {
+  const canReadLocalFiles = transport.canReadLocalFiles !== false;
   const images: ImageRef[] = [];
   const files: DownloadedSlackFile[] = [];
   for (const id of attachments.primaryFileIds) {
-    const resolved = await resolveFile(transport, id);
+    const resolved = await resolveFile(transport, id, canReadLocalFiles);
     if (resolved.image) images.push(resolved.image);
     if (resolved.file) files.push(resolved.file);
+    if (resolved.unreadableFile) throw new LocalFileAccessUnavailable();
   }
 
   const backgroundImages: { image: ImageRef; ref: SlackBufferedFileRef }[] = [];
   const backgroundFiles: { file: DownloadedSlackFile; ref: SlackBufferedFileRef }[] = [];
   let lost = 0;
   const results = await Promise.allSettled(
-    attachments.buffered.files.map(async (ref) => ({ ref, resolved: await resolveFile(transport, ref.id) })),
+    attachments.buffered.files.map(async (ref) => ({
+      ref,
+      resolved: await resolveFile(transport, ref.id, canReadLocalFiles),
+    })),
   );
+  let unreadable = 0;
   for (const result of results) {
     if (result.status === "fulfilled") {
       const { ref, resolved } = result.value;
       if (resolved.image) backgroundImages.push({ image: resolved.image, ref });
       if (resolved.file) backgroundFiles.push({ file: resolved.file, ref });
+      if (resolved.unreadableFile) unreadable++;
     } else {
       lost++;
       log.warn(`${transport.label} could not load an earlier (buffered) Slack file: ${String(result.reason)}`);
@@ -73,6 +86,7 @@ async function resolveInputs(
   }
 
   const missingNote = missingAttachmentsNote(lost + attachments.buffered.skipped);
+  const unreadableNote = unreadableAttachmentsNote(unreadable);
   const imageManifest = backgroundImagesManifest(
     images.length,
     backgroundImages.map(({ ref }) => ref),
@@ -87,7 +101,7 @@ async function resolveInputs(
   const allImages = [...images, ...backgroundImages.map(({ image }) => image)];
   return {
     images: allImages.length ? allImages : undefined,
-    promptSuffix: `${missingNote}${imageManifest}${attachedFilesManifest(allFiles)}`,
+    promptSuffix: `${missingNote}${unreadableNote}${imageManifest}${attachedFilesManifest(allFiles)}`,
   };
 }
 
@@ -104,7 +118,13 @@ export async function* invokeSlackTurn(
   try {
     resolved = await resolveInputs(transport, attachments);
   } catch (error) {
-    yield { type: "failed", details: `could not load Slack attachment: ${String(error)}`, retryable: true };
+    const unavailable = error instanceof LocalFileAccessUnavailable;
+    yield {
+      type: "failed",
+      details: unavailable ? error.message : `could not load Slack attachment: ${String(error)}`,
+      retryable: !unavailable,
+      ...(unavailable ? { code: "attachment_unsupported" } : {}),
+    };
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${MARKDOWN_INSTRUCTION}`, images: resolved.images };

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -226,7 +226,12 @@ async function streamClassicSlackReply(
       if (event.type === "failed") {
         await finishPump();
         finalized = true;
-        const notice = formatError({ details: event.details, retryable: event.retryable }) ?? "";
+        const notice =
+          formatError({
+            details: event.details,
+            retryable: event.retryable,
+            ...(event.code !== undefined ? { code: event.code } : {}),
+          }) ?? "";
         await finalize(notice).catch((error) =>
           log.error(`${label} failed to deliver the agent-failure notice: ${String(error)}`),
         );
@@ -421,7 +426,12 @@ async function streamNativeSlackReply(
         return;
       } else if (event.type === "failed") {
         finalized = true;
-        const notice = formatError({ details: event.details, retryable: event.retryable }) ?? "";
+        const notice =
+          formatError({
+            details: event.details,
+            retryable: event.retryable,
+            ...(event.code !== undefined ? { code: event.code } : {}),
+          }) ?? "";
         if (notice) {
           pendingText += `${fullAnswer.trim() ? "\n\n" : ""}${notice}`;
           fullAnswer += `${fullAnswer.trim() ? "\n\n" : ""}${notice}`;

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -205,7 +205,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
   }
   const reactionEmojis = resolveReactionEmojis(reactionAck);
 
-  return ({ agent, stateRoot, control }) => {
+  return ({ agent, stateRoot, canReadLocalFiles, control }) => {
     if (!botToken) throw new Error("slackChannel requires a non-empty botToken (Bot User OAuth Token)");
     if (!signingSecret)
       throw new Error("slackChannel requires a non-empty signingSecret (Basic Information → App Credentials)");
@@ -362,7 +362,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
               agent,
               turn.session,
               prompt,
-              { api, channelId: turn.channelId, filesDir: join(stateHome, "files"), label },
+              { api, channelId: turn.channelId, filesDir: join(stateHome, "files"), label, canReadLocalFiles },
               { primaryFileIds: turn.fileIds, buffered },
               () => {
                 store.remove(turn.id);

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -5,7 +5,7 @@
  * pure) because this half touches the Bot API + disk; split from telegram.ts so the factory keeps only
  * wiring and the per-turn lifecycle.
  */
-import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
+import { type Agent, type AgentEvent, ATTACHMENT_UNSUPPORTED_CODE, type ImageRef } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -135,7 +135,7 @@ export async function* invokeTurn(
       type: "failed",
       details: unavailable ? e.message : `could not load attachment: ${String(e)}`,
       retryable: !unavailable,
-      ...(unavailable ? { code: "attachment_unsupported" } : {}),
+      ...(unavailable ? { code: ATTACHMENT_UNSUPPORTED_CODE } : {}),
     };
     return;
   }

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -63,9 +63,11 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
   const { api, botToken, chatId, filesDir } = t;
   const { primary, buffered } = attachments;
   const { canReadLocalFiles } = t;
-  if (!canReadLocalFiles && (primary.fileIds?.length ?? 0) > 0) throw new LocalFileAccessUnavailable();
+  if (!canReadLocalFiles && (primary.fileIds?.length ?? 0) > 0) throw new LocalFileAccessUnavailable("[telegram]");
   const images = await resolveImages(api, botToken, primary.imageFileIds);
-  const files = canReadLocalFiles ? await resolveFiles(api, botToken, primary.fileIds, chatId, filesDir) : undefined;
+  // No reader-check here: the guard above already refused a non-empty list, and an empty one resolves
+  // to nothing either way. Two readings of one rule, two lines apart, is one too many.
+  const files = await resolveFiles(api, botToken, primary.fileIds, chatId, filesDir);
   const bufferedImages: ImageRef[] = [];
   const bufferedFiles: { file: DownloadedFile; ref: BufferedRef }[] = [];
   let lost = 0;

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -30,8 +30,8 @@ export interface TurnTransport {
   botToken: string;
   chatId: number | string;
   filesDir: string;
-  /** Undefined preserves the legacy embedder posture; standard serving supplies an explicit fact. */
-  canReadLocalFiles?: boolean;
+  /** Whether the agent has a reader for absolute local paths; see ChannelContext. */
+  canReadLocalFiles: boolean;
 }
 
 /** A turn's attachment inputs: the summoning message's own file_ids (primary) and the ones folded in
@@ -62,7 +62,7 @@ interface ResolvedAttachments {
 async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachments): Promise<ResolvedAttachments> {
   const { api, botToken, chatId, filesDir } = t;
   const { primary, buffered } = attachments;
-  const canReadLocalFiles = t.canReadLocalFiles !== false;
+  const { canReadLocalFiles } = t;
   if (!canReadLocalFiles && (primary.fileIds?.length ?? 0) > 0) throw new LocalFileAccessUnavailable();
   const images = await resolveImages(api, botToken, primary.imageFileIds);
   const files = canReadLocalFiles ? await resolveFiles(api, botToken, primary.fileIds, chatId, filesDir) : undefined;

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -10,10 +10,12 @@ import { log } from "../../log.ts";
 import {
   type BusyRetry,
   DEFAULT_BUSY_RETRY,
+  LocalFileAccessUnavailable,
   attachedFilesManifest,
   attributedFileName,
   missingAttachmentsNote,
   streamTurnWithBusyRetry,
+  unreadableAttachmentsNote,
 } from "../invoke-turn-kit.ts";
 import type { BufferedRef } from "./context-buffer.ts";
 import { type DownloadedFile, resolveFiles, resolveImages } from "./telegram-api.ts";
@@ -28,6 +30,8 @@ export interface TurnTransport {
   botToken: string;
   chatId: number | string;
   filesDir: string;
+  /** Undefined preserves the legacy embedder posture; standard serving supplies an explicit fact. */
+  canReadLocalFiles?: boolean;
 }
 
 /** A turn's attachment inputs: the summoning message's own file_ids (primary) and the ones folded in
@@ -58,8 +62,10 @@ interface ResolvedAttachments {
 async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachments): Promise<ResolvedAttachments> {
   const { api, botToken, chatId, filesDir } = t;
   const { primary, buffered } = attachments;
+  const canReadLocalFiles = t.canReadLocalFiles !== false;
+  if (!canReadLocalFiles && (primary.fileIds?.length ?? 0) > 0) throw new LocalFileAccessUnavailable();
   const images = await resolveImages(api, botToken, primary.imageFileIds);
-  const files = await resolveFiles(api, botToken, primary.fileIds, chatId, filesDir);
+  const files = canReadLocalFiles ? await resolveFiles(api, botToken, primary.fileIds, chatId, filesDir) : undefined;
   const bufferedImages: ImageRef[] = [];
   const bufferedFiles: { file: DownloadedFile; ref: BufferedRef }[] = [];
   let lost = 0;
@@ -71,12 +77,15 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
       log.warn(`[telegram] could not load an earlier (buffered) photo: ${String(r.reason)}`);
     }
   }
-  const fileResults = await Promise.allSettled(
-    buffered.files.map(async (ref) => ({
-      ref,
-      files: (await resolveFiles(api, botToken, [ref.id], chatId, filesDir)) ?? [],
-    })),
-  );
+  const unreadable = canReadLocalFiles ? 0 : buffered.files.length;
+  const fileResults = canReadLocalFiles
+    ? await Promise.allSettled(
+        buffered.files.map(async (ref) => ({
+          ref,
+          files: (await resolveFiles(api, botToken, [ref.id], chatId, filesDir)) ?? [],
+        })),
+      )
+    : [];
   for (const r of fileResults) {
     if (r.status === "fulfilled") {
       for (const file of r.value.files) bufferedFiles.push({ file, ref: r.value.ref });
@@ -86,6 +95,7 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
     }
   }
   const missingNote = missingAttachmentsNote(lost + buffered.skipped);
+  const unreadableNote = unreadableAttachmentsNote(unreadable);
   // PRIMARY first, background after — consistent with "primary wins": what the user pointed at this
   // turn leads. Buffered file entries are attributed like the fold's text lines ("the file Bob sent"
   // resolves); buffered PHOTOS cannot be (ImageRef carries no label), so their attribution stops at
@@ -98,7 +108,7 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
   const allImages = [...(images ?? []), ...bufferedImages];
   return {
     images: allImages.length ? allImages : undefined,
-    promptSuffix: `${missingNote}${attachedFilesManifest(allFiles)}`,
+    promptSuffix: `${missingNote}${unreadableNote}${attachedFilesManifest(allFiles)}`,
   };
 }
 
@@ -120,7 +130,13 @@ export async function* invokeTurn(
   try {
     resolved = await resolveTurnAttachments(transport, attachments);
   } catch (e) {
-    yield { type: "failed", details: `could not load attachment: ${String(e)}`, retryable: true };
+    const unavailable = e instanceof LocalFileAccessUnavailable;
+    yield {
+      type: "failed",
+      details: unavailable ? e.message : `could not load attachment: ${String(e)}`,
+      retryable: !unavailable,
+      ...(unavailable ? { code: "attachment_unsupported" } : {}),
+    };
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${HTML_INSTRUCTION}`, images: resolved.images };

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -162,7 +162,12 @@ export async function streamReply(
         // below regardless.
         finalized = true;
         {
-          const msg = formatError({ details: e.details, retryable: e.retryable }) ?? "";
+          const msg =
+            formatError({
+              details: e.details,
+              retryable: e.retryable,
+              ...(e.code !== undefined ? { code: e.code } : {}),
+            }) ?? "";
           await finalize(api, botToken, target, messageId, msg).catch(() => {});
         }
         throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -125,7 +125,7 @@ export function telegramChannel({
   botUsername,
   apiBaseUrl = "https://api.telegram.org",
 }: TelegramChannelOptions): ChannelModule {
-  return ({ agent, stateRoot, control }) => {
+  return ({ agent, stateRoot, canReadLocalFiles, control }) => {
     // Validate at activation so deploy may inspect the module shape before secrets are provisioned.
     if (!secretToken) {
       throw new Error(
@@ -273,6 +273,7 @@ export function telegramChannel({
                 botToken,
                 chatId: rec.chatId,
                 filesDir: join(stateHome, "files"),
+                canReadLocalFiles,
               },
               {
                 primary: {

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -7,7 +7,12 @@ import { resolve } from "node:path";
 import { runDevSupervisor } from "../../dev-supervisor.ts";
 import { loadDotEnv } from "../../env.ts";
 
-import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
+import {
+  definitionAssemblyFindings,
+  reportFindingsIfChanged,
+  reportModuleLoadFailures,
+  reportToolCollisions,
+} from "../../engines/pi/report.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { setLogLevel } from "../../log.ts";
 import { logAgentLoop } from "../../observe.ts";
@@ -16,7 +21,15 @@ import { workspaceHint } from "../../paths.ts";
 import { bindAddress } from "../../bind.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import { assertTunnelBindable, maybeTunnel, mountSessionControl, routesFor, serve, startSchedules } from "../serve.ts";
-import { parseBind, parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
+import {
+  codingToolsLabel,
+  parseBind,
+  parsePort,
+  reportAuth,
+  reportLine,
+  resolveFirstRunModel,
+  reportWorkspaceHint,
+} from "../shared.ts";
 
 export interface DevOptions {
   port?: string;
@@ -77,7 +90,9 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const traced = logAgentLoop(a.agent);
-  const routed = await routesFor(a.agentDir, traced, a.stateRoot, a.sessionControl).catch(failStartup);
+  const routed = await routesFor(a.agentDir, traced, a.stateRoot, a.sessionControl, {
+    canReadLocalFiles: a.codingToolNames.includes("read"),
+  }).catch(failStartup);
   // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
   // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
   const configured = a.config.http?.host;
@@ -102,11 +117,16 @@ function reportAgentsSkillsTools(a: Assembled): void {
   reportLine("context", a.definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
   if (a.definition.persona) reportLine("persona", "persona.md");
   reportLine("skills", a.definition.skills.map((s) => s.name).join(", ") || "(none)");
+  reportLine("codingTools", codingToolsLabel(a.codingToolNames));
   if (a.toolNames.length > 0) reportLine("tools", a.toolNames.join(", "));
   if (a.deferredToolNames.length > 0) {
     reportLine("deferred", `${a.deferredToolNames.join(", ")} (activated via search_tools)`);
   }
   reportToolCollisions(a.toolCollisions);
   reportModuleLoadFailures(a.toolFailures);
-  reportFindingsIfChanged(a.definition.dir, a.definition);
+  reportFindingsIfChanged(
+    a.definition.dir,
+    a.definition,
+    definitionAssemblyFindings(a.definition, a.codingToolNames.includes("read")),
+  );
 }

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -121,7 +121,12 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
           stateRoot,
           sessionsDir,
           authPath,
-          diagnostics: [...definition.diagnostics, ...assemblyFindings],
+          // Two entities, two keys: `diagnostics` is per-skill parse problems (path = the SKILL.md),
+          // while an assembly finding describes the definition as a whole (path = the definition dir,
+          // code outside the skill vocabulary). Merged, a machine consumer branching on `code` or
+          // resolving `path` gets a second shape without warning.
+          diagnostics: definition.diagnostics,
+          assemblyFindings,
           skillCollisions: definition.collisions,
           toolCollisions: tools.collisions,
           toolFailures: tools.failures,

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -12,13 +12,19 @@ import {
 } from "../../engines/pi/config.ts";
 import { createPiModelRuntime } from "../../engines/pi/models.ts";
 import { resolveStateRoot, workspaceHint } from "../../paths.ts";
-import { resolveAgentTools } from "../../engines/pi/create.ts";
+import { resolveAgentTools, resolveCodingTools } from "../../engines/pi/create.ts";
 import { loadAgentDefinition } from "../../engines/pi/definition.ts";
-import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
+import {
+  definitionAssemblyFindings,
+  reportFindingsIfChanged,
+  reportModuleLoadFailures,
+  reportToolCollisions,
+} from "../../engines/pi/report.ts";
 import { log } from "../../log.ts";
 import { nextRun } from "../../schedule/cron.ts";
 import { loadSchedules } from "../../schedule/discover.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
+import { codingToolsLabel } from "../shared.ts";
 
 export interface InfoOptions {
   json?: boolean;
@@ -40,8 +46,10 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   // tool), is isolated the same way everywhere (G2): info, dev, AND start report it and keep going with
   // the tools that loaded. The `error`/`.catch` below only fires for a whole-load fault (an unreadable
   // tools/ dir), not a single bad file.
+  const resolvedCodingToolNames = resolveCodingTools(config).names;
   const tools = await resolveAgentTools(config, agentDir)
     .then((r) => ({
+      coding: r.codingToolNames,
       names: r.toolNames,
       deferred: r.deferredToolNames,
       collisions: r.toolCollisions,
@@ -49,12 +57,14 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
       error: undefined as string | undefined,
     }))
     .catch((e: unknown) => ({
+      coding: resolvedCodingToolNames,
       names: [] as string[],
       deferred: [] as string[],
       collisions: [],
       failures: [],
       error: (e as Error).message,
     }));
+  const assemblyFindings = definitionAssemblyFindings(definition, tools.coding.includes("read"));
   const channels = await discoverChannelFiles(agentDir).catch(failStartup);
   // Loaded (imported + validated), not just discovered: info's job is "fix only what it reports", so a
   // broken schedule file (bad cron/tz, failed import) must show up HERE, not first at dev/start — and
@@ -97,6 +107,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
           model: modelSpec ?? null,
           modelError: modelError ?? null,
           thinkingLevel: config.thinkingLevel ?? null,
+          codingTools: tools.coding,
           context: definition.contextFiles.map((f) => f.path),
           persona: definition.persona !== undefined,
           skills: definition.skills.map((skill) => ({ name: skill.name, description: skill.description })),
@@ -110,7 +121,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
           stateRoot,
           sessionsDir,
           authPath,
-          diagnostics: definition.diagnostics,
+          diagnostics: [...definition.diagnostics, ...assemblyFindings],
           skillCollisions: definition.collisions,
           toolCollisions: tools.collisions,
           toolFailures: tools.failures,
@@ -134,6 +145,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   line("model", modelSpec ?? "(not set — pass --model, set FASTAGENT_MODEL, or config.model)");
   if (modelError) cont(`⚠ does not resolve: ${modelError}`);
   if (config.thinkingLevel) line("thinking", config.thinkingLevel);
+  line("codingTools", codingToolsLabel(tools.coding));
   line("context", definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
   line("persona", definition.persona ? "persona.md" : "(none)");
   line("skills", definition.skills.map((skill) => skill.name).join(", ") || "(none)");
@@ -149,5 +161,5 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   reportModuleLoadFailures(tools.failures);
   reportModuleLoadFailures(sched.failures);
   if (tools.error) log.warn(`[fastagent] ${tools.error}`);
-  reportFindingsIfChanged(definition.dir, definition);
+  reportFindingsIfChanged(definition.dir, definition, assemblyFindings);
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -9,7 +9,12 @@ import { loadDotEnv } from "../../env.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
 import { resolveSecretsDir, workspaceHint } from "../../paths.ts";
 import { isUnderDir } from "../../engines/pi/definition.ts";
-import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
+import {
+  definitionAssemblyFindings,
+  reportFindingsIfChanged,
+  reportModuleLoadFailures,
+  reportToolCollisions,
+} from "../../engines/pi/report.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { log, setLogLevel } from "../../log.ts";
 import { createWakeAlarmSink, reconcileWakeAlarms } from "../../schedule/wake-alarm.ts";
@@ -29,7 +34,15 @@ import {
   serve,
   startSchedules,
 } from "../serve.ts";
-import { parseBind, parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
+import {
+  codingToolsLabel,
+  parseBind,
+  parsePort,
+  reportAuth,
+  reportLine,
+  resolveFirstRunModel,
+  reportWorkspaceHint,
+} from "../shared.ts";
 
 export interface StartOptions {
   port?: string;
@@ -71,6 +84,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
     stateRoot,
     sessionsDir,
     authPath,
+    codingToolNames,
     toolNames,
     deferredToolNames,
     toolCollisions,
@@ -91,6 +105,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   reportLine("context", definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
   if (definition.persona) reportLine("persona", "persona.md");
   reportLine("skills", definition.skills.map((s) => s.name).join(", ") || "(none)");
+  reportLine("codingTools", codingToolsLabel(codingToolNames));
   if (toolNames.length > 0) reportLine("tools", toolNames.join(", "));
   if (deferredToolNames.length > 0) {
     reportLine("deferred", `${deferredToolNames.join(", ")} (activated via search_tools)`);
@@ -121,7 +136,11 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
         `FASTAGENT_SECRETS_DIR at a persistent volume so a redeploy that replaces the dir does not wipe them.`,
     );
   }
-  reportFindingsIfChanged(definition.dir, definition);
+  reportFindingsIfChanged(
+    definition.dir,
+    definition,
+    definitionAssemblyFindings(definition, codingToolNames.includes("read")),
+  );
 
   // AgentCore Runtime posture (FASTAGENT_AGENTCORE=1, set by the generated deploy artifacts): the
   // adapter (POST /invocations + GET /ping) is the container's only reachable surface, and cron
@@ -139,7 +158,10 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   // so channels mount eagerly and a broken channel fails startup.
   const routed = agentcore
     ? undefined
-    : await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: true }).catch(failStartup);
+    : await routesFor(agentDir, traced, stateRoot, sessionControl, {
+        builtinInvoke: true,
+        canReadLocalFiles: codingToolNames.includes("read"),
+      }).catch(failStartup);
   // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
   // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
   const configured = config.http?.host;
@@ -183,7 +205,10 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
     // re-establishes it — so their presence is a configuration error, surfaced per envelope and by
     // the deploy driver's health probe (there is no boot to fail on this host).
     const lazyChannels = async (): Promise<Routes> => {
-      const surface = await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: false });
+      const surface = await routesFor(agentDir, traced, stateRoot, sessionControl, {
+        builtinInvoke: false,
+        canReadLocalFiles: codingToolNames.includes("read"),
+      });
       if (surface.longConnections.length > 0) {
         throw new Error(
           `long-connection channel(s) ${surface.longConnections.map((c) => c.name).join(", ")} cannot serve on ` +

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -16,7 +16,7 @@ export async function runTool(name: string, argsJson: string, dirArg: string): P
   const { agentDir, workspace } = placementOrExit(resolve(dirArg));
   loadDotEnv(agentDir); // a tool may read a key from .env
   const { config } = await loadConfig(agentDir).catch(failStartup);
-  // The same tool set dev/start mount (defaults + config.tools + discovered, deduped), so the runner
+  // The same tool set dev/start mount (enabled coding tools + config.tools + discovered, deduped), so the runner
   // exercises exactly what gets served — a shadowed tool is surfaced, not silently run. Resolve the
   // placement like the openers, so `fastagent tool` finds the SAME tools/ as dev/start.
   const { tools, toolCollisions, toolFailures } = await resolveAgentTools(config, agentDir).catch(failStartup);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -193,7 +193,7 @@ const tool: CommandSpec = {
   ],
   examples: [{ cmd: `fastagent tool add '{"a":2,"b":3}'` }],
   notes:
-    "Mounts the same tool set dev/start serve (defaults + config.tools + discovered tools/, " +
+    "Mounts the same tool set dev/start serve (enabled coding tools + config.tools + discovered tools/, " +
     "deduped), so a shadowed or broken tool is surfaced here exactly as it would be when serving.",
   run: async (args) =>
     (await import("./commands/tool.ts")).runTool(args[0] as string, args[1] as string, args[2] as string),

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -42,8 +42,8 @@ export async function routesFor(
   agentDir: string,
   agent: Agent,
   stateRoot: string,
-  control?: SessionControl,
-  options: { builtinInvoke?: boolean; canReadLocalFiles?: boolean } = {},
+  control: SessionControl | undefined,
+  options: { builtinInvoke?: boolean; canReadLocalFiles: boolean },
 ): Promise<ServingSurface> {
   const { routes, longConnections, routeChannels, collisions, failures } = await loadChannels(agentDir, {
     agent,

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -43,11 +43,12 @@ export async function routesFor(
   agent: Agent,
   stateRoot: string,
   control?: SessionControl,
-  options: { builtinInvoke?: boolean } = {},
+  options: { builtinInvoke?: boolean; canReadLocalFiles?: boolean } = {},
 ): Promise<ServingSurface> {
   const { routes, longConnections, routeChannels, collisions, failures } = await loadChannels(agentDir, {
     agent,
     stateRoot,
+    canReadLocalFiles: options.canReadLocalFiles,
     control,
   });
   for (const c of collisions) {

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -36,12 +36,17 @@ import { failStartup, failUsage } from "./fail.ts";
 /**
  * The padded label writer for the STARTUP report (`dev`/`start`, stderr via the log level). Hand-spaced
  * labels drift out of alignment the moment a longer one appears — which is exactly what happened when
- * `workspace:` joined `config:`/`model:`/`state:`. `info` keeps its own writer on purpose: its report is
+ * `codingTools:` joined `workspace:`/`config:`/`model:`/`state:`. `info` keeps its own writer on purpose: its report is
  * stdout DATA (pipeable, its own label set, its own width), not a log line — the shared thing is the
  * policy (pad, never hand-space), not a constant.
  */
 export function reportLine(label: string, value: string): void {
-  log.info(`[fastagent] ${`${label}:`.padEnd(11)}${value}`);
+  log.info(`[fastagent] ${`${label}:`.padEnd(13)}${value}`);
+}
+
+/** Human-facing form of the resolved coding-tool surface; callers pass resolver output, never config. */
+export function codingToolsLabel(names: readonly string[]): string {
+  return names.length > 0 ? names.join(", ") : "(none)";
 }
 
 /** The workspace hint under the `agent:`/`workspace:` pair, when there is one ({@link workspaceHint}):

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -89,6 +89,14 @@ export interface PiAgentSessionFactoryOptions {
    * that entry point upstream, not a workaround here.
    */
   extensionPaths?: string[];
+  /**
+   * Built-in coding tools this definition DISABLED, refused at the registry rather than merely left
+   * inactive. `noTools: "builtin"` only keeps pi's own copies out of the active set, and anything
+   * that can activate a tool by name — a TUI command, the control plane, a deferred-tool loader —
+   * could put one back. `codingTools` is a capability decision for public-facing agents, so the
+   * disabled names must not be mountable at all.
+   */
+  excludedToolNames?: readonly string[];
   /** Filesystem/process environment handed to pi's default coding tools. */
   env: ExecutionEnv;
 }
@@ -257,6 +265,7 @@ export function definitionResourceLoaderOptions(source: {
 export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): PiAgentSessionFactory {
   const { sessions, thinkingLevel, cwd, env } = options;
   const extensionPaths = options.extensionPaths ?? [];
+  const excludedToolNames = options.excludedToolNames ?? [];
   if (extensionPaths.length > 0) {
     log.warn(
       `[fastagent] ${extensionPaths.length} extension(s) in the definition are NOT loaded when serving ` +
@@ -353,6 +362,7 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       // tool set already IS those four (create.ts piDefaultTools), so letting both in would offer
       // the model each one twice, under one name.
       noTools: "builtin",
+      ...(excludedToolNames.length > 0 ? { excludeTools: [...excludedToolNames] } : {}),
       customTools: toolDefinitions(tools, cwd, env, sessionId, bound),
     });
     bound.session = session;

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -24,6 +24,10 @@ import { AGENT_CONFIG_NAMES, resolveOverridePath, resolveSecretsDir } from "../.
 // pi's thinking levels as a runtime value live in session-settings.ts (THE single source, with the
 // exhaustiveness anchor against pi's union) — config validation consumes it, never redefines it.
 
+/** pi's machine-reaching coding tools, in canonical mount/report order. */
+export const CODING_TOOL_NAMES = ["read", "bash", "edit", "write"] as const;
+export type CodingToolName = (typeof CODING_TOOL_NAMES)[number];
+
 export interface FastagentConfig {
   /** "provider/modelId". Precedence: CLI --model > FASTAGENT_MODEL > config. */
   model?: string;
@@ -31,8 +35,12 @@ export interface FastagentConfig {
    *  "xhigh" | "max"). Unset = pi's default. Authors tune thinking in the pi TUI while vibing — this
    *  is the serving-side counterpart (fidelity). Levels a model doesn't support are clamped by pi. */
   thinkingLevel?: ThinkingLevel;
-  /** Extra custom tools, appended after pi defaults — never replaces them. `FastagentTool` = AgentTool
-   *  plus the optional `deferred` marker (see defineTool). */
+  /** Which pi coding tools to mount. Unset/true = all (`read`, `bash`, `edit`, `write`); false/[] =
+   *  none; an array mounts exactly those names, in canonical order. Authored tools (`config.tools` +
+   *  discovered `tools/`) and conditional built-ins (`search_tools`, `wake`) are independent. */
+  codingTools?: boolean | CodingToolName[];
+  /** Extra custom tools, appended after enabled pi coding tools — never replaces them. `FastagentTool`
+   *  = AgentTool plus the optional `deferred` marker (see defineTool). */
   tools?: FastagentTool[];
   /** `host` is the bind address: unset (or `0.0.0.0`) binds all interfaces — what containers need;
    *  `127.0.0.1` keeps the serve (including `/control/*`) off the LAN. Precedence: `--bind` > this. */
@@ -129,6 +137,7 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     if (
       key !== "model" &&
       key !== "thinkingLevel" &&
+      key !== "codingTools" &&
       key !== "tools" &&
       key !== "http" &&
       key !== "deploy" &&
@@ -136,7 +145,7 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
       key !== "sessionControl"
     ) {
       throw new Error(
-        `${path}: unknown key "${key}" (valid keys: model, thinkingLevel, tools, http, deploy, selfSchedule, sessionControl)`,
+        `${path}: unknown key "${key}" (valid keys: model, thinkingLevel, codingTools, tools, http, deploy, selfSchedule, sessionControl)`,
       );
     }
   }
@@ -145,6 +154,20 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   }
   if (c.sessionControl !== undefined && typeof c.sessionControl !== "boolean") {
     throw new Error(`${path}: "sessionControl" must be a boolean`);
+  }
+  if (c.codingTools !== undefined && typeof c.codingTools !== "boolean" && !Array.isArray(c.codingTools)) {
+    throw new Error(`${path}: "codingTools" must be a boolean or an array containing read, bash, edit, write`);
+  }
+  if (Array.isArray(c.codingTools)) {
+    const valid = new Set<string>(CODING_TOOL_NAMES);
+    const seen = new Set<string>();
+    for (const [i, name] of c.codingTools.entries()) {
+      if (typeof name !== "string" || !valid.has(name)) {
+        throw new Error(`${path}: "codingTools[${i}]" must be one of ${CODING_TOOL_NAMES.join(", ")}`);
+      }
+      if (seen.has(name)) throw new Error(`${path}: "codingTools" must not contain duplicate "${name}"`);
+      seen.add(name);
+    }
   }
   if (c.thinkingLevel !== undefined && !(THINKING_LEVELS as ReadonlySet<string>).has(c.thinkingLevel as string)) {
     throw new Error(`${path}: "thinkingLevel" must be one of ${[...THINKING_LEVELS].join(", ")}`);

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -516,10 +516,17 @@ export async function createPiAgentFromDefinition(
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());
-  // An explicit `tools` list is the caller stating the whole surface: no coding tools unless they
-  // named them. Only a directory agent's config decides otherwise (the opener passes the resolved
-  // set), which is what keeps `codingTools` a definition property rather than a library default.
-  const codingToolNames = options.codingToolNames ?? (options.tools === undefined ? [...CODING_TOOL_NAMES] : []);
+  // An explicit `tools` list is the caller stating the whole surface, so the coding capabilities are
+  // whichever built-in NAMES appear in it — not none. A caller passing `piDefaultTools()` has a
+  // reader; telling them otherwise would give the model a capability-neutral identity and warn that
+  // their skills have no reader. Name-based, exactly like the exclusion below, and for the same
+  // reason: the name is the only thing either side can observe. `codingTools` stays a definition
+  // property — the directory opener passes the resolved set explicitly.
+  const codingToolNames =
+    options.codingToolNames ??
+    (options.tools === undefined
+      ? [...CODING_TOOL_NAMES]
+      : CODING_TOOL_NAMES.filter((name) => options.tools?.some((tool) => tool.name === name)));
   // Boot findings go through the SAME memoized reporter every later reader uses (report.ts, keyed by
   // the resolved dir): announced once here, and re-announced by a turn or by the control plane's
   // command list only when the set CHANGES — a runtime-written bad skill surfaces the moment it

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -100,6 +100,20 @@ export function resolveCodingTools(config: FastagentConfig): ResolvedCodingTools
   return { tools, names: tools.map((tool) => tool.name as CodingToolName) };
 }
 
+/**
+ * Built-in coding tools this definition turned off, MINUS any name an authored tool has taken.
+ *
+ * pi's denylist matches by name, so excluding a name an author reused would delete their tool rather
+ * than pi's — and with the built-in disabled, that name is theirs to use (see docs/configuration.md).
+ */
+export function disabledBuiltinNames(
+  codingToolNames: readonly CodingToolName[],
+  mounted: readonly MountedTool[],
+): CodingToolName[] {
+  const authored = new Set(mounted.map((tool) => tool.name));
+  return CODING_TOOL_NAMES.filter((name) => !codingToolNames.includes(name) && !authored.has(name));
+}
+
 /** `config.tools` semantics: extra tools APPENDED after enabled pi coding tools, never replacing them. */
 export function resolveTools(config: FastagentConfig): MountedTool[] {
   const coding = resolveCodingTools(config).tools;
@@ -558,8 +572,10 @@ export async function createPiAgentFromDefinition(
     // apply to the artifact either way) — `chat` is where they load. Boot-resolved: the set cannot
     // change without a restart, which is why this sits outside `live` above.
     extensionPaths: await loadExtensionPaths(dir, { cwd: env.cwd, env }),
-    // The disabled built-ins, refused at the registry — see PiAgentSessionFactoryOptions.
-    excludedToolNames: CODING_TOOL_NAMES.filter((name) => !codingToolNames.includes(name)),
+    // The disabled built-ins, refused at the registry — see PiAgentSessionFactoryOptions. A name an
+    // AUTHORED tool has taken is not excluded: with the built-in off, that name is the author's to
+    // reuse (documented), and pi's denylist works on names, so excluding it would delete their tool.
+    excludedToolNames: disabledBuiltinNames(codingToolNames, tools),
     env,
     lease: options.lease,
     observer: options.observer,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -24,10 +24,16 @@ import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { readImageProcessor } from "./read-image.ts";
 import type { Provider } from "@earendil-works/pi-ai";
 import type { Agent } from "../../agent.ts";
-import { type FastagentConfig, defaultAuthPath, resolveModel } from "./config.ts";
+import {
+  CODING_TOOL_NAMES,
+  type CodingToolName,
+  type FastagentConfig,
+  defaultAuthPath,
+  resolveModel,
+} from "./config.ts";
 import { resolveSecretsDir } from "../../paths.ts";
 import { type LoadedDefinition, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
-import { reportFindingsIfChanged } from "./report.ts";
+import { definitionAssemblyFindings, reportFindingsIfChanged } from "./report.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import {
   type DefineToolOptions,
@@ -48,8 +54,8 @@ import { type Lease, type SessionObserver, inProcessLease } from "./turn-kit.ts"
 // ── §1 tools ─────────────────────────────────────────────────────────────────
 //
 // The full pi toolset is the default for fidelity: authors vibe in local pi with it, so serving with
-// fewer tools is behavior drift. Locking down for public exposure = passing a restricted `tools` list
-// (a deployment posture).
+// fewer tools is behavior drift. A directory agent can narrow with `codingTools: [names]` or opt out
+// with `codingTools: false`; L1/L2 library callers can pass a restricted `tools` list directly.
 //
 // These are pi-agent-core's tools, which reach the filesystem and the shell through the
 // {@link ExecutionEnv} the binding hands them per turn — NOT pi-coding-agent's, which are the same four
@@ -77,14 +83,31 @@ export function piDefaultTools(): MountedTool[] {
   ];
 }
 
-/** `config.tools` semantics: extra tools APPENDED after pi's defaults, never replacing them. */
+export interface ResolvedCodingTools {
+  tools: MountedTool[];
+  names: CodingToolName[];
+}
+
+/** Resolve the config's one coding-tool policy. Every directory consumer uses this result rather than
+ *  re-interpreting undefined/true/false/arrays independently. */
+export function resolveCodingTools(config: FastagentConfig): ResolvedCodingTools {
+  const requested = config.codingTools;
+  const enabled =
+    requested === false
+      ? new Set<CodingToolName>()
+      : new Set<CodingToolName>(Array.isArray(requested) ? requested : CODING_TOOL_NAMES);
+  const tools = piDefaultTools().filter((tool) => enabled.has(tool.name as CodingToolName));
+  return { tools, names: tools.map((tool) => tool.name as CodingToolName) };
+}
+
+/** `config.tools` semantics: extra tools APPENDED after enabled pi coding tools, never replacing them. */
 export function resolveTools(config: FastagentConfig): MountedTool[] {
-  const defaults = piDefaultTools();
-  return config.tools ? [...defaults, ...config.tools] : defaults;
+  const coding = resolveCodingTools(config).tools;
+  return config.tools ? [...coding, ...config.tools] : coding;
 }
 
 /**
- * The full tool set an agent mounts: pi defaults + `config.tools` + discovered `tools/` (deduped,
+ * The full tool set an agent mounts: enabled pi coding tools + `config.tools` + discovered `tools/` (deduped,
  * existing win), plus the non-default tool names and collisions to report. One source for the
  * dev/start openers AND `fastagent tool`, so they all mount exactly the same set.
  */
@@ -93,6 +116,7 @@ export async function resolveAgentTools(
   agentDir: string,
 ): Promise<{
   tools: MountedTool[];
+  codingToolNames: CodingToolName[];
   toolNames: string[];
   /** Tools registered but not initially active (defineTool `deferred: true`) — discovered/activated
    *  via the built-in `search_tools` loader. Surfaced so the operator can see deferral took effect. */
@@ -104,7 +128,9 @@ export async function resolveAgentTools(
   // no root of their own — they operate through the ExecutionEnv handed to them per turn, whose cwd is
   // the workspace.
   const discovered = await loadTools(agentDir);
-  const merged = mergeDiscoveredTools(resolveTools(config), discovered.tools);
+  const coding = resolveCodingTools(config);
+  const configured = config.tools ? [...coding.tools, ...config.tools] : coding.tools;
+  const merged = mergeDiscoveredTools(configured, discovered.tools);
   // The built-in `search_tools` loader mounts here — the one place the agent's full tool set is
   // computed — so `dev`/`start`/`info`/`fastagent tool` all see the same surface (idempotent; an
   // agent-defined search_tools wins).
@@ -114,11 +140,12 @@ export async function resolveAgentTools(
   const builtinLoaderMounted =
     !merged.tools.some((t) => t.name === "search_tools") && tools.some((t) => t.name === "search_tools");
   const toolCollisions = [...discovered.collisions, ...merged.collisions];
-  // `toolNames` is the AUTHOR's active-by-default surface (config.tools + tools/): exclude pi
-  // defaults, the builtin loader (like wake, a builtin gets its own report line, not an anonymous
+  // `toolNames` is the AUTHOR's active-by-default surface (config.tools + tools/): exclude ENABLED pi
+  // coding tools, the builtin loader (like wake, a builtin gets its own report line, not an anonymous
   // slot in the author's list — an author-DEFINED search_tools still shows), and deferred tools —
-  // each name lives in exactly ONE report slot, and deferred names live in `deferredToolNames`.
-  const defaultNames = new Set(piDefaultTools().map((t) => t.name));
+  // each name lives in exactly ONE report slot, and deferred names live in `deferredToolNames`. When
+  // coding tools are disabled, an authored `read`/`bash`/`edit`/`write` is ordinary author surface.
+  const defaultNames = new Set<string>(coding.names);
   const toolNames = tools
     .filter(
       (t) => !defaultNames.has(t.name) && !isDeferredTool(t) && !(builtinLoaderMounted && t.name === "search_tools"),
@@ -126,6 +153,7 @@ export async function resolveAgentTools(
     .map((t) => t.name);
   return {
     tools,
+    codingToolNames: coding.names,
     toolNames,
     deferredToolNames: tools.filter(isDeferredTool).map((t) => t.name),
     toolCollisions,
@@ -152,7 +180,9 @@ export async function resolveAgentTools(
  * tool list is generated from the actually-mounted tools (base and toolset must agree). An authored
  * `persona` (from persona.md) replaces the default identity line, keeping the tools list + guidelines.
  */
-export function piBasePrompt(options: { tools?: MountedTool[]; persona?: string } = {}): string {
+export function piBasePrompt(
+  options: { tools?: MountedTool[]; persona?: string; codingToolNames?: readonly CodingToolName[] } = {},
+): string {
   const mounted = options.tools ?? [];
   // Deferred tools stay OUT of the list: their schemas are not in the request until activated, so
   // naming them here would invite calls to tools that don't exist yet; discovery is search_tools' job
@@ -163,10 +193,16 @@ export function piBasePrompt(options: { tools?: MountedTool[]; persona?: string 
   const toolsList =
     tools.length > 0 ? tools.map((t) => `- ${t.name}: ${(t.description ?? "").split("\n")[0]}`).join("\n") : "(none)";
   // Segment ① identity: an authored persona (persona.md) replaces the default engine identity line
-  // (core.md §11), keeping the tools list + guidelines below.
+  // (core.md §11), keeping the tools list + guidelines below. Preserve pi's coding identity only for
+  // the full coding surface; a partial/empty surface must not claim machine capabilities it lacks.
+  const inferredCodingNames = CODING_TOOL_NAMES.filter((name) => mounted.some((tool) => tool.name === name));
+  const codingNames = options.codingToolNames ?? inferredCodingNames;
+  const fullCodingSurface = CODING_TOOL_NAMES.every((name) => codingNames.includes(name));
   const identity =
     options.persona?.trim() ||
-    "You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.";
+    (fullCodingSurface
+      ? "You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files."
+      : "You are an AI assistant operating inside pi, an agent harness. Help users using only the tools and context available to you.");
   const deferredNote =
     deferredCount > 0
       ? `\n\n${deferredCount} additional tool(s) are registered but inactive — use search_tools to discover and activate them before concluding a capability is missing.`
@@ -413,6 +449,9 @@ export interface CreatePiAgentFromDefinitionOptions {
   /** Override tools. Defaults to {@link piDefaultTools} (lock down with a custom list). An authored
    *  `FastagentTool[]` (AgentTool plus the optional `deferred` marker) widens into {@link MountedTool}. */
   tools?: MountedTool[];
+  /** INTERNAL directory-opener fact: which mounted tools are pi's coding tools. Keeps prompt identity,
+   *  skill findings and chat parity tied to the resolver instead of inferring semantics from authored names. */
+  codingToolNames?: readonly CodingToolName[];
   /**
    * The agent's working directory: where the default tools operate AND whose ancestors are walked for
    * ② project context (AGENTS.md). Defaults to `dir`. Set it to the enclosing repo so a coding agent
@@ -457,14 +496,22 @@ export async function createPiAgentFromDefinition(
   // Boot-time load: fail-visibly at startup on a broken directory, and give callers the snapshot to
   // report (skills/diagnostics/collisions). Serving does NOT close over it — see `live` below.
   const definition = await loadAgentDefinition(dir, { cwd: env.cwd, env });
+  // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
+  // it; a caller's own search_tools wins).
+  const tools = withSearchTool(options.tools ?? piDefaultTools());
+  // An explicit `tools` list is the caller stating the whole surface: no coding tools unless they
+  // named them. Only a directory agent's config decides otherwise (the opener passes the resolved
+  // set), which is what keeps `codingTools` a definition property rather than a library default.
+  const codingToolNames = options.codingToolNames ?? (options.tools === undefined ? [...CODING_TOOL_NAMES] : []);
   // Boot findings go through the SAME memoized reporter every later reader uses (report.ts, keyed by
   // the resolved dir): announced once here, and re-announced by a turn or by the control plane's
   // command list only when the set CHANGES — a runtime-written bad skill surfaces the moment it
   // appears, a static one does not spam. Log dedup, not session state (stateless invoke holds).
-  reportFindingsIfChanged(definition.dir, definition);
-  // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
-  // it; a caller's own search_tools wins).
-  const tools = withSearchTool(options.tools ?? piDefaultTools());
+  reportFindingsIfChanged(
+    definition.dir,
+    definition,
+    definitionAssemblyFindings(definition, codingToolNames.includes("read")),
+  );
   // Dir-aware default: the same secrets-dir-derived file the opener uses for this dir (the opener
   // passes an explicit authPath, so this only affects direct L2 callers).
   const authPath = options.authPath ?? defaultAuthPath(resolveSecretsDir(dir));
@@ -488,12 +535,12 @@ export async function createPiAgentFromDefinition(
     // next good edit heals both.
     live: async () => {
       const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
-      reportFindingsIfChanged(def.dir, def);
+      reportFindingsIfChanged(def.dir, def, definitionAssemblyFindings(def, codingToolNames.includes("read")));
       return {
         systemPrompt: assembleSystemPrompt({
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,
           // re-read per turn like AGENTS.md so edits go live; options.base still wins for full control.
-          base: options.base ?? piBasePrompt({ tools, persona: def.persona }),
+          base: options.base ?? piBasePrompt({ tools, persona: def.persona, codingToolNames }),
           // ② project context: AGENTS.md files (agentDir + cwd-ancestor walk) via loadProjectContextFiles.
           contextFiles: def.contextFiles,
           skills: def.skills,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -280,6 +280,8 @@ function buildPiAgent(opts: {
   agentDir?: string;
   /** The definition's extension entry points; see {@link PiAgentSessionFactoryOptions.extensionPaths}. */
   extensionPaths?: string[];
+  /** Disabled built-ins; see {@link PiAgentSessionFactoryOptions.excludedToolNames}. */
+  excludedToolNames?: readonly string[];
   env?: ExecutionEnv;
   lease?: Lease;
   observer?: SessionObserver;
@@ -318,6 +320,7 @@ function buildPiAgent(opts: {
     cwd: env.cwd,
     ...(opts.agentDir ? { agentDir: opts.agentDir } : {}),
     ...(opts.extensionPaths ? { extensionPaths: opts.extensionPaths } : {}),
+    ...(opts.excludedToolNames?.length ? { excludedToolNames: opts.excludedToolNames } : {}),
     env,
   });
   opts.onAssembly?.({
@@ -555,6 +558,8 @@ export async function createPiAgentFromDefinition(
     // apply to the artifact either way) — `chat` is where they load. Boot-resolved: the set cannot
     // change without a restart, which is why this sits outside `live` above.
     extensionPaths: await loadExtensionPaths(dir, { cwd: env.cwd, env }),
+    // The disabled built-ins, refused at the registry — see PiAgentSessionFactoryOptions.
+    excludedToolNames: CODING_TOOL_NAMES.filter((name) => !codingToolNames.includes(name)),
     env,
     lease: options.lease,
     observer: options.observer,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -100,6 +100,11 @@ export function resolveCodingTools(config: FastagentConfig): ResolvedCodingTools
   return { tools, names: tools.map((tool) => tool.name as CodingToolName) };
 }
 
+/** Which built-in coding capabilities a mounted set provides, read by NAME — the only observable. */
+function codingToolNamesIn(mounted: readonly MountedTool[]): CodingToolName[] {
+  return CODING_TOOL_NAMES.filter((name) => mounted.some((tool) => tool.name === name));
+}
+
 /**
  * Built-in coding tools this definition turned off, MINUS any name an authored tool has taken.
  *
@@ -209,8 +214,7 @@ export function piBasePrompt(
   // Segment ① identity: an authored persona (persona.md) replaces the default engine identity line
   // (core.md §11), keeping the tools list + guidelines below. Preserve pi's coding identity only for
   // the full coding surface; a partial/empty surface must not claim machine capabilities it lacks.
-  const inferredCodingNames = CODING_TOOL_NAMES.filter((name) => mounted.some((tool) => tool.name === name));
-  const codingNames = options.codingToolNames ?? inferredCodingNames;
+  const codingNames = options.codingToolNames ?? codingToolNamesIn(mounted);
   const fullCodingSurface = CODING_TOOL_NAMES.every((name) => codingNames.includes(name));
   const identity =
     options.persona?.trim() ||
@@ -524,9 +528,7 @@ export async function createPiAgentFromDefinition(
   // property — the directory opener passes the resolved set explicitly.
   const codingToolNames =
     options.codingToolNames ??
-    (options.tools === undefined
-      ? [...CODING_TOOL_NAMES]
-      : CODING_TOOL_NAMES.filter((name) => options.tools?.some((tool) => tool.name === name)));
+    (options.tools === undefined ? [...CODING_TOOL_NAMES] : codingToolNamesIn(options.tools));
   // Boot findings go through the SAME memoized reporter every later reader uses (report.ts, keyed by
   // the resolved dir): announced once here, and re-announced by a turn or by the control plane's
   // command list only when the set CHANGES — a runtime-written bad skill surfaces the moment it

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -11,6 +11,7 @@
 import { mkdir } from "node:fs/promises";
 import type { Agent } from "../../agent.ts";
 import {
+  type CodingToolName,
   type FastagentConfig,
   type LoadedConfig,
   defaultSessionsDir,
@@ -27,7 +28,7 @@ import { type PiBoundaryWiring, createPiSessionControl } from "./session-control
 import { withWakeTool } from "./wake-tool.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import { type LoadedDefinition, loadAgentSkills } from "./definition.ts";
-import { reportFindingsIfChanged } from "./report.ts";
+import { definitionAssemblyFindings, reportFindingsIfChanged } from "./report.ts";
 import { type PiSessionRecordStore, piSessionRecordStore } from "./session-store.ts";
 import type { ToolCollision } from "./tool.ts";
 import type { MountedTool } from "./tool.ts";
@@ -91,8 +92,10 @@ export interface AgentAssembly {
   stateRoot: string;
   /** Absolute credentials file (--auth-path/authPath option > FASTAGENT_AUTH_PATH > <agentDir>/.secrets/auth.json). */
   authPath: string;
-  /** The full mounted tool surface (config.tools + discovered tools/, search_tools applied). */
+  /** The full mounted tool surface (enabled coding tools + config.tools + discovered tools/, search_tools applied). */
   tools: MountedTool[];
+  /** The pi coding tools selected by the one config resolver, in canonical order. */
+  codingToolNames: CodingToolName[];
   toolNames: string[];
   deferredToolNames: string[];
   toolCollisions: ToolCollision[];
@@ -114,10 +117,8 @@ export async function resolveAgentAssembly(
       `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
     );
   }
-  const { tools, toolNames, deferredToolNames, toolCollisions, toolFailures } = await resolveAgentTools(
-    config,
-    agentDir,
-  );
+  const { tools, codingToolNames, toolNames, deferredToolNames, toolCollisions, toolFailures } =
+    await resolveAgentTools(config, agentDir);
   // The state root: sessions/channel state/schedule state derive from it (FASTAGENT_STATE_DIR moves it
   // in one knob — a container points it at its volume); the finer overrides below still win.
   const stateRoot = resolveStateRoot(agentDir);
@@ -133,6 +134,7 @@ export async function resolveAgentAssembly(
     stateRoot,
     authPath,
     tools,
+    codingToolNames,
     toolNames,
     deferredToolNames,
     toolCollisions,
@@ -170,6 +172,8 @@ export async function createPiAgentFromDir(
   sessions: PiSessionRecordStore;
   /** The observation plane over this agent's sessions; present iff `options.sessionControl`. */
   sessionControl?: SessionControl;
+  /** pi coding tools selected by config, in canonical order. */
+  codingToolNames: CodingToolName[];
   /** Non-default, active-by-default tool names in effect: config.tools + discovered tools/. Each name
    *  lives in exactly one report slot — deferred names are in {@link deferredToolNames} instead. */
   toolNames: string[];
@@ -188,6 +192,7 @@ export async function createPiAgentFromDir(
     stateRoot,
     authPath,
     tools,
+    codingToolNames,
     toolNames,
     deferredToolNames,
     toolCollisions,
@@ -222,7 +227,11 @@ export async function createPiAgentFromDir(
           // A skill whose frontmatter broke simply is not in `skills` — it would disappear from the
           // author's composer with no signal anywhere. The memo is SHARED with the turn path (keyed
           // by dir), so a finding is warned when it appears, not once per reader that notices it.
-          reportFindingsIfChanged(loaded.dir, loaded);
+          reportFindingsIfChanged(
+            loaded.dir,
+            loaded,
+            definitionAssemblyFindings(loaded, codingToolNames.includes("read")),
+          );
           return loaded.skills.map((skill) => ({
             name: skill.name,
             description: skill.description,
@@ -248,6 +257,7 @@ export async function createPiAgentFromDir(
     thinkingLevel: config.thinkingLevel,
     cwd: workspace,
     tools: mountedTools,
+    codingToolNames,
     authPath,
     // Skills are definition-only (the agent is its directory), so dev mirrors deployment exactly.
     sessions,
@@ -284,6 +294,7 @@ export async function createPiAgentFromDir(
     stateRoot,
     sessionsDir,
     authPath,
+    codingToolNames,
     toolNames,
     deferredToolNames,
     toolCollisions,

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -4,17 +4,43 @@
  */
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { log } from "../../log.ts";
-import type { SkillCollision } from "./definition.ts";
+import type { LoadedDefinition, SkillCollision } from "./definition.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import type { ToolCollision } from "./tool.ts";
 
 type Findings = { collisions: SkillCollision[]; diagnostics: SkillDiagnostic[] };
 
+/** A non-fatal problem created by the assembled capability surface rather than by parsing one skill. */
+export interface AssemblyFinding {
+  code: "skills_require_file_reader";
+  message: string;
+  path: string;
+}
+
+/** A model-visible skill is a path-based capability: pi tells the model to read SKILL.md on demand.
+ *  Without the built-in local reader that listing is a dead instruction, so surface the mismatch. */
+export function definitionAssemblyFindings(
+  definition: Pick<LoadedDefinition, "dir" | "skills">,
+  canReadLocalFiles: boolean,
+): AssemblyFinding[] {
+  const visible = definition.skills.filter((skill) => !skill.disableModelInvocation);
+  return !canReadLocalFiles && visible.length > 0
+    ? [
+        {
+          code: "skills_require_file_reader",
+          message: `model-visible skills (${visible.map((skill) => skill.name).join(", ")}) cannot be loaded without the read coding tool; enable codingTools: ["read"] or remove/disable those skills`,
+          path: definition.dir,
+        },
+      ]
+    : [];
+}
+
 /** Stable identity of a definition's non-fatal findings — the dedup key below. */
-function findingsSignature(def: Findings): string {
+function findingsSignature(def: Findings, assembly: readonly AssemblyFinding[]): string {
   const collisions = def.collisions.map((c) => `c:${c.name}:${c.winnerPath}:${c.loserPath}`);
   const diagnostics = def.diagnostics.map((d) => `d:${d.code}:${d.path}`);
-  return [...collisions, ...diagnostics].sort().join("\n");
+  const assembled = assembly.map((d) => `a:${d.code}:${d.path}:${d.message}`);
+  return [...collisions, ...diagnostics, ...assembled].sort().join("\n");
 }
 
 /**
@@ -35,11 +61,12 @@ const lastFindings = new Map<string, string>();
  * `dir` must be the RESOLVED definition root (`LoadedDefinition.dir`), or two spellings of one path
  * become two memos and warn twice.
  */
-export function reportFindingsIfChanged(dir: string, def: Findings): void {
-  const sig = findingsSignature(def);
+export function reportFindingsIfChanged(dir: string, def: Findings, assembly: readonly AssemblyFinding[] = []): void {
+  const sig = findingsSignature(def, assembly);
   if (lastFindings.get(dir) === sig) return;
   lastFindings.set(dir, sig);
   reportDefinitionWarnings(def.collisions, def.diagnostics);
+  for (const finding of assembly) log.warn(`[fastagent] ${finding.code}: ${finding.message} (${finding.path})`);
 }
 
 export function reportDefinitionWarnings(collisions: SkillCollision[], diagnostics: SkillDiagnostic[]): void {

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -60,8 +60,13 @@ const lastFindings = new Map<string, string>();
  *
  * `dir` must be the RESOLVED definition root (`LoadedDefinition.dir`), or two spellings of one path
  * become two memos and warn twice.
+ *
+ * `assembly` is REQUIRED, with no default: an omitted argument writes a signature that does not
+ * include the assembly findings, so the next caller that does pass them re-warns and an earlier one
+ * suppresses them — the "record without printing" variant this module's single door exists to rule
+ * out. Callers with nothing to add pass `[]` and say so.
  */
-export function reportFindingsIfChanged(dir: string, def: Findings, assembly: readonly AssemblyFinding[] = []): void {
+export function reportFindingsIfChanged(dir: string, def: Findings, assembly: readonly AssemblyFinding[]): void {
   const sig = findingsSignature(def, assembly);
   if (lastFindings.get(dir) === sig) return;
   lastFindings.set(dir, sig);

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -11,7 +11,7 @@
  *   - prompt  → systemPromptOverride = base + instructions ONLY; pi appends the skill section and env
  *               (cwd) itself (including it here would duplicate it).
  *   - skills  → skillsOverride (fastagent's skills, for the section + invocation).
- *   - tools   → default coding tools by NAME (pi rebuilds them cwd-bound for rich rendering) +
+ *   - tools   → enabled default coding tools by NAME (pi rebuilds them cwd-bound for rich rendering) +
  *               fastagent's custom tools via pi's customTools path (so they survive /new, /resume, fork).
  *   - models  → a ModelRuntime with builtins only (`modelsPath: null`, no availability network), so
  *               the model surface equals serving's `createPiModels()` — pi's machine-global
@@ -54,7 +54,12 @@ import {
   agentSessionManager,
   turnContext,
 } from "./tool-context.ts";
-import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
+import {
+  definitionAssemblyFindings,
+  reportFindingsIfChanged,
+  reportModuleLoadFailures,
+  reportToolCollisions,
+} from "./report.ts";
 import { resolveAgentAssembly } from "./open.ts";
 
 export interface BuildSessionRuntimeOptions {
@@ -118,8 +123,18 @@ export async function buildAgentSessionRuntime(
     // on the session in createRuntime — pi's session starts all-active), and the activation bridge
     // above rides the same turn context, so the SAME search_tools works against pi's AgentSession
     // instead of the served one.
-    const { config, modelSpec, agentDir, authPath, stateRoot, tools, deferredToolNames, toolCollisions, toolFailures } =
-      await resolveAgentAssembly(cwd, options);
+    const {
+      config,
+      modelSpec,
+      agentDir,
+      authPath,
+      stateRoot,
+      tools,
+      codingToolNames,
+      deferredToolNames,
+      toolCollisions,
+      toolFailures,
+    } = await resolveAgentAssembly(cwd, options);
     reportToolCollisions(toolCollisions);
     reportModuleLoadFailures(toolFailures);
     // ONE hub owns model resolution AND per-request auth; see models.ts.
@@ -128,13 +143,19 @@ export async function buildAgentSessionRuntime(
     const modelRuntime = await createPiModelRuntime({ authPath, agentDir, stateRoot });
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(agentDir, { cwd, env });
-    reportFindingsIfChanged(definition.dir, definition);
+    reportFindingsIfChanged(
+      definition.dir,
+      definition,
+      definitionAssemblyFindings(definition, codingToolNames.includes("read")),
+    );
     // Assembly-time, like serving's: this whole function is memoized, so the scan and its warnings
     // happen once per runtime rather than per session rebuild (/new, /resume, fork).
     const extensionPaths = await loadExtensionPaths(agentDir, { cwd, env });
     // ALL of them, pi's four included: fastagent's `read` is `createReadTool({ imageProcessor })`
     // (create.ts), and letting pi mount its own instead would silently drop image reading in chat.
-    // Serving already does it this way.
+    // Serving already does it this way. And `tools` is ALREADY the configured surface —
+    // resolveTools() applied `codingTools` — so narrowing needs nothing here: what the definition
+    // disabled never reaches this list, and pi's own copies stay out via `noTools: "builtin"`.
     const customTools = tools;
     // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts
     // it). Each execute runs inside the turn context with the CURRENT session's activation bridge — the
@@ -167,7 +188,7 @@ export async function buildAgentSessionRuntime(
     // base + instructions ONLY — pi appends the skill section and env (cwd) itself (including
     // them here would duplicate them).
     const systemPrompt = assembleSystemPrompt({
-      base: piBasePrompt({ tools, persona: definition.persona }),
+      base: piBasePrompt({ tools, persona: definition.persona, codingToolNames }),
       contextFiles: definition.contextFiles,
     });
 

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -42,7 +42,7 @@ import {
   getAgentDir,
 } from "@earendil-works/pi-coding-agent";
 import { definitionResourceLoaderOptions, reportExtensionErrors } from "./agent-session-factory.ts";
-import { resolveModel } from "./config.ts";
+import { CODING_TOOL_NAMES, resolveModel } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt } from "./create.ts";
 import { canonicalPath, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
 import { createPiModelRuntime, probeAuthSource } from "./models.ts";
@@ -157,6 +157,8 @@ export async function buildAgentSessionRuntime(
     // resolveTools() applied `codingTools` — so narrowing needs nothing here: what the definition
     // disabled never reaches this list, and pi's own copies stay out via `noTools: "builtin"`.
     const customTools = tools;
+    // What the definition turned OFF, for pi to refuse rather than merely leave inactive.
+    const excludedCodingTools = CODING_TOOL_NAMES.filter((name) => !codingToolNames.includes(name));
     // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts
     // it). Each execute runs inside the turn context with the CURRENT session's activation bridge — the
     // assembly is memoized across /new//resume/fork rebuilds while the session changes, so the bridge
@@ -202,6 +204,7 @@ export async function buildAgentSessionRuntime(
       extensionPaths,
       customTools,
       customToolDefs,
+      excludedCodingTools,
       deferredToolNames,
       systemPrompt,
     };
@@ -247,6 +250,7 @@ export async function buildAgentSessionRuntime(
       definition,
       extensionPaths,
       customToolDefs,
+      excludedCodingTools,
       deferredToolNames,
       systemPrompt,
     } = await assemblyFor(cwd);
@@ -308,6 +312,10 @@ export async function buildAgentSessionRuntime(
       // was really there for (the machine's `defaultTools` setting cannot add pi's own copies on top
       // of ours) without freezing anything.
       noTools: "builtin",
+      // Disabled coding tools are refused at the REGISTRY, not just left inactive: chat has a TUI
+      // that can activate a tool by name, so "mounted but inactive" would make `codingTools` a
+      // default rather than a boundary.
+      ...(excludedCodingTools.length > 0 ? { excludeTools: excludedCodingTools } : {}),
       customTools: customToolDefs,
     });
     sessionRef.current = {

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -42,8 +42,8 @@ import {
   getAgentDir,
 } from "@earendil-works/pi-coding-agent";
 import { definitionResourceLoaderOptions, reportExtensionErrors } from "./agent-session-factory.ts";
-import { CODING_TOOL_NAMES, resolveModel } from "./config.ts";
-import { assembleSystemPrompt, piBasePrompt } from "./create.ts";
+import { resolveModel } from "./config.ts";
+import { assembleSystemPrompt, disabledBuiltinNames, piBasePrompt } from "./create.ts";
 import { canonicalPath, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
 import { createPiModelRuntime, probeAuthSource } from "./models.ts";
 import { log } from "../../log.ts";
@@ -157,8 +157,9 @@ export async function buildAgentSessionRuntime(
     // resolveTools() applied `codingTools` — so narrowing needs nothing here: what the definition
     // disabled never reaches this list, and pi's own copies stay out via `noTools: "builtin"`.
     const customTools = tools;
-    // What the definition turned OFF, for pi to refuse rather than merely leave inactive.
-    const excludedCodingTools = CODING_TOOL_NAMES.filter((name) => !codingToolNames.includes(name));
+    // What the definition turned OFF, for pi to refuse rather than merely leave inactive — minus any
+    // name an authored tool has taken (that name is the author's once the built-in is disabled).
+    const excludedCodingTools = disabledBuiltinNames(codingToolNames, tools);
     // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts
     // it). Each execute runs inside the turn context with the CURRENT session's activation bridge — the
     // assembly is memoized across /new//resume/fork rebuilds while the session changes, so the bridge

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -182,7 +182,7 @@ export async function loadTools(
 }
 
 /**
- * Merge resolved tools (pi defaults + `config.tools`) with discovered `tools/`, deduped by name.
+ * Merge resolved tools (enabled pi coding tools + `config.tools`) with discovered `tools/`, deduped by name.
  * Existing tools win; dropped discovered tools surface as collisions.
  */
 export function mergeDiscoveredTools(

--- a/src/host/node.ts
+++ b/src/host/node.ts
@@ -26,6 +26,9 @@ export type Routes = Record<string, ChannelHandler>;
 export interface ChannelContext {
   agent: Agent;
   stateRoot: string;
+  /** Whether the assembled agent can read absolute local attachment paths. Undefined preserves the
+   *  legacy embedder posture (assume available); standard directory serving always supplies a fact. */
+  canReadLocalFiles?: boolean;
   /** The serving session-control hub, when the serve wires one (`config.sessionControl`). Channels
    *  use it for DISPATCH only (the user-facing stop command); observation stays on the data plane. */
   control?: SessionControl;

--- a/src/host/node.ts
+++ b/src/host/node.ts
@@ -26,9 +26,15 @@ export type Routes = Record<string, ChannelHandler>;
 export interface ChannelContext {
   agent: Agent;
   stateRoot: string;
-  /** Whether the assembled agent can read absolute local attachment paths. Undefined preserves the
-   *  legacy embedder posture (assume available); standard directory serving always supplies a fact. */
-  canReadLocalFiles?: boolean;
+  /**
+   * Whether the assembled agent can read absolute local attachment paths.
+   *
+   * REQUIRED, and deliberately not optional: the unsafe answer would be the default. An absent
+   * value read as "assume it can" hands the model paths it cannot open — the failure this exists to
+   * prevent — and every transport would re-derive the rule (`x !== false`) on its own. One fact,
+   * stated by whoever assembles the agent.
+   */
+  canReadLocalFiles: boolean;
   /** The serving session-control hub, when the serve wires one (`config.sessionControl`). Channels
    *  use it for DISPATCH only (the user-facing stop command); observation stays on the data plane. */
   control?: SessionControl;

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -32,7 +32,13 @@ export {
 } from "./engines/pi/open.ts";
 export type { LoadedDefinition, SkillCollision } from "./engines/pi/definition.ts";
 
-export { defineConfig, listModels, resolveModel, type FastagentConfig } from "./engines/pi/config.ts";
+export {
+  type CodingToolName,
+  defineConfig,
+  listModels,
+  resolveModel,
+  type FastagentConfig,
+} from "./engines/pi/config.ts";
 export type { SessionObserver } from "./engines/pi/turn-kit.ts";
 export { inProcessLease, type Lease, type Release } from "./engines/pi/turn-kit.ts";
 export {

--- a/src/scaffold/templates/fastagent.config.mjs
+++ b/src/scaffold/templates/fastagent.config.mjs
@@ -10,6 +10,8 @@
 export default {
   // model: "openai-codex/gpt-5.5",
   // thinkingLevel: "high", // reasoning effort (off|minimal|low|medium|high|xhigh|max); default "medium" (pi TUI parity)
+  // codingTools: ["read"], // least privilege: keep skill/file reading, disable shell + file mutation
+  // codingTools: false,    // no coding tools; model-visible skills and non-image file attachments need `read`
   http: { port: 8787 },
   // selfSchedule: true, // mount the built-in `wake` tool: the agent schedules its own follow-up turns
   //                     // ("check the deploy in 10 min"). Cron jobs need no opt-in — drop a schedules/<name>.ts.

--- a/src/scaffold/templates/persona.md
+++ b/src/scaffold/templates/persona.md
@@ -2,11 +2,11 @@
 
 You are this workspace's agent. This file is your identity — it overrides the engine's default identity line, and it is re-read every turn along with the rest of your definition (`skills/` — capabilities you load when a task calls for them; `tools/` — code tools your author added, in the same directory as this file). An edit to any of them takes effect on your next message, no restart.
 
-Your definition is this directory: `persona.md`, `skills/`, `tools/`, and the config beside them. Your WORKSPACE is the directory you were started in — the project you work on. It may be this same directory, or the one containing it; `fastagent info` prints both. Use only the tools actually listed in your system prompt; `codingTools` may narrow or remove `read` / `write` / `edit` / `bash`. If the workspace has an `AGENTS.md`, it is project context — follow it without assuming a file tool is available.
+Your definition is this directory: `persona.md`, `skills/`, `tools/`, and the config beside them. Your WORKSPACE is the directory you were started in — the project you work on. It may be this same directory, or the one containing it; `fastagent info` prints both. Use only the tools actually listed in your system prompt. If the workspace has an `AGENTS.md`, it is project context — follow it without assuming a file tool is available.
 
 When your mounted tools allow it, you can improve yourself. When a task reveals something durable — a repeatable process, a standing preference, a hard-won fact — write it into your definition instead of losing it:
 
-- A repeatable process or capability → a new skill beside this file: `skills/<name>/SKILL.md`. Only the `skills/` next to this file is scanned. If `read` is mounted, read `skills/writing-great-skills/SKILL.md` first; it is the guide to authoring skills well.
-- A standing instruction or fact → edit this file when an editing tool is mounted.
+- A repeatable process or capability → a new skill beside this file: `skills/<name>/SKILL.md`. Only the `skills/` next to this file is scanned. Read `skills/writing-great-skills/SKILL.md` first; it is the guide to authoring skills well.
+- A standing instruction or fact → edit this file.
 
 Keep both lean: include only what changes your behavior, and delete what no longer earns its place.

--- a/src/scaffold/templates/persona.md
+++ b/src/scaffold/templates/persona.md
@@ -2,11 +2,11 @@
 
 You are this workspace's agent. This file is your identity — it overrides the engine's default identity line, and it is re-read every turn along with the rest of your definition (`skills/` — capabilities you load when a task calls for them; `tools/` — code tools your author added, in the same directory as this file). An edit to any of them takes effect on your next message, no restart.
 
-Your definition is this directory: `persona.md`, `skills/`, `tools/`, and the config beside them. Your WORKSPACE is the directory you were started in — the project you work on, and where your `read` / `write` / `edit` / `bash` tools operate. It may be this same directory, or the one containing it; `fastagent info` prints both. If the workspace has an `AGENTS.md`, it is project context — read it to learn the project's conventions.
+Your definition is this directory: `persona.md`, `skills/`, `tools/`, and the config beside them. Your WORKSPACE is the directory you were started in — the project you work on. It may be this same directory, or the one containing it; `fastagent info` prints both. Use only the tools actually listed in your system prompt; `codingTools` may narrow or remove `read` / `write` / `edit` / `bash`. If the workspace has an `AGENTS.md`, it is project context — follow it without assuming a file tool is available.
 
-You can improve yourself. When a task reveals something durable — a repeatable process, a standing preference, a hard-won fact — write it into your definition instead of losing it:
+When your mounted tools allow it, you can improve yourself. When a task reveals something durable — a repeatable process, a standing preference, a hard-won fact — write it into your definition instead of losing it:
 
-- A repeatable process or capability → a new skill beside this file: `skills/<name>/SKILL.md`. Only the `skills/` next to this file is scanned. Read `skills/writing-great-skills/SKILL.md` first; it is the guide to authoring skills well.
-- A standing instruction or fact → edit this file.
+- A repeatable process or capability → a new skill beside this file: `skills/<name>/SKILL.md`. Only the `skills/` next to this file is scanned. If `read` is mounted, read `skills/writing-great-skills/SKILL.md` first; it is the guide to authoring skills well.
+- A standing instruction or fact → edit this file when an editing tool is mounted.
 
 Keep both lean: include only what changes your behavior, and delete what no longer earns its place.

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -7,7 +7,7 @@ import { loadChannels } from "../src/index.ts";
 import { discoverChannelFiles, inspectChannels } from "../src/engines/pi/channel.ts";
 
 // loadChannels only forwards the ctx to the factory; these factories ignore it.
-const fakeCtx = { agent: {} as Agent, stateRoot: "/unused-in-tests" };
+const fakeCtx = { agent: {} as Agent, stateRoot: "/unused-in-tests", canReadLocalFiles: true };
 const freshDir = () => mkdtemp(join(tmpdir(), "fa-chan-"));
 
 describe("loadChannels (filesystem discovery)", () => {
@@ -172,9 +172,9 @@ describe("loadChannels (filesystem discovery)", () => {
 
   it("rejects a relative stateRoot at the mount boundary (the contract says absolute — fail visibly)", async () => {
     const dir = await freshDir();
-    await expect(loadChannels(dir, { agent: {} as Agent, stateRoot: "rel/state" })).rejects.toThrow(
-      /stateRoot must be absolute/,
-    );
+    await expect(
+      loadChannels(dir, { agent: {} as Agent, stateRoot: "rel/state", canReadLocalFiles: true }),
+    ).rejects.toThrow(/stateRoot must be absolute/);
   });
 
   it("isolates (surfaces, not fatal) a channel file that does not default-export a function", async () => {

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -10,11 +10,14 @@ import type { LoadedSchedule } from "../src/schedule/schedule.ts";
 describe("serving surface", () => {
   it("can suppress the fallback /invoke for AgentCore's publicly forwarded surface", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-agentcore-surface-"));
-    const ordinary = await routesFor(dir, {} as Agent, join(dir, ".state"));
+    const ordinary = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, { canReadLocalFiles: true });
     expect(Object.keys(ordinary.routes)).toContain("POST /invoke");
     expect(ordinary.builtinInvoke).toBe(true);
 
-    const agentcore = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, { builtinInvoke: false });
+    const agentcore = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, {
+      builtinInvoke: false,
+      canReadLocalFiles: true,
+    });
     expect(Object.keys(agentcore.routes)).toEqual(["GET /health"]);
     expect(agentcore.builtinInvoke).toBe(false);
   });
@@ -26,7 +29,7 @@ describe("serving surface", () => {
       join(dir, "channels", "socket.mjs"),
       `export default { name: "socket", connect: () => ({ ready: Promise.resolve(), closed: new Promise(() => {}) }) };\n`,
     );
-    const surface = await routesFor(dir, {} as Agent, join(dir, ".state"));
+    const surface = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, { canReadLocalFiles: true });
     expect(Object.keys(surface.routes)).toEqual(["GET /health"]);
     expect(surface.builtinInvoke).toBe(false);
     expect(surface.longConnections.map((connection) => connection.name)).toEqual(["socket"]);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -323,7 +323,11 @@ describe("cli papercuts", () => {
     expect(info.context.length).toBeGreaterThan(0); // the AGENTS.md is loaded as ② project context
     expect(info.skills.map((s: { name: string }) => s.name)).toEqual(["greet"]); // the malformed skill is skipped
     expect(JSON.stringify(info.diagnostics)).toMatch(/description/); // info SURFACES loader diagnostics
-    expect(JSON.stringify(info.diagnostics)).toMatch(/skills_require_file_reader/); // and assembled capability findings
+    // Its OWN key: a skill diagnostic points at a SKILL.md, an assembly finding at the definition
+    // dir with a code from a different vocabulary. One field holding both hands a machine consumer
+    // two shapes under one name.
+    expect(JSON.stringify(info.assemblyFindings)).toMatch(/skills_require_file_reader/);
+    expect(JSON.stringify(info.diagnostics)).not.toMatch(/skills_require_file_reader/);
     expect(info.channels).toEqual(["github"]);
     await expect(stat(join(dir, "fastagent", ".state"))).rejects.toThrow(); // read-only: never creates the state root
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -304,8 +304,11 @@ describe("cli papercuts", () => {
 
   it("info reports the assembled surface as JSON (incl. load diagnostics), read-only (no sessions dir)", async () => {
     const dir = await agentWorkspace("fa-info-", {
+      "fastagent.config.mjs": "export default { codingTools: false };\n",
       "skills/greet/SKILL.md": "---\nname: greet\ndescription: Greet warmly.\n---\nHi.\n",
       "skills/bad/SKILL.md": "---\nname: bad\n---\nno description.\n", // malformed
+      "tools/lookup.mjs":
+        'export default { description: "Lookup", parameters: { type: "object" }, async execute() { return "ok"; } };\n',
       "channels/github.ts": 'export default () => ({ "POST /x": () => new Response("ok") });\n',
     });
     await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
@@ -315,9 +318,12 @@ describe("cli papercuts", () => {
     expect(code).toBe(0); // an unset model is reported, not fatal
     const info = JSON.parse(stdout);
     expect(info.model).toBeNull();
+    expect(info.codingTools).toEqual([]);
+    expect(info.tools).toEqual(["lookup"]); // authored surface remains; coding defaults are disabled
     expect(info.context.length).toBeGreaterThan(0); // the AGENTS.md is loaded as ② project context
     expect(info.skills.map((s: { name: string }) => s.name)).toEqual(["greet"]); // the malformed skill is skipped
-    expect(JSON.stringify(info.diagnostics)).toMatch(/description/); // info SURFACES the loader diagnostic to the user
+    expect(JSON.stringify(info.diagnostics)).toMatch(/description/); // info SURFACES loader diagnostics
+    expect(JSON.stringify(info.diagnostics)).toMatch(/skills_require_file_reader/); // and assembled capability findings
     expect(info.channels).toEqual(["github"]);
     await expect(stat(join(dir, "fastagent", ".state"))).rejects.toThrow(); // read-only: never creates the state root
   });
@@ -397,6 +403,7 @@ describe("cli papercuts", () => {
     expect(info.schedules[0].next).toMatch(/T09:00:00\.000Z$/); // loaded → the next instant is printable
     expect(JSON.stringify(info.scheduleFailures)).toMatch(/bad\.mjs/); // the broken one is surfaced per-file
     expect(info.selfSchedule).toBe(false); // no config → wake tool won't mount
+    expect(info.codingTools).toEqual(["read", "bash", "edit", "write"]); // omitted keeps the compatible surface
 
     // text mode: next instant on the schedules line, the failure as a stderr warning
     const text = await run(["info", dir], undefined, env);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -64,6 +64,19 @@ describe("config: loadConfig validation", () => {
     await writeFile(join(bad, "fastagent.config.mjs"), `export default { selfSchedule: "yes" };\n`);
     await expect(loadConfig(bad)).rejects.toThrow(/selfSchedule.*must be a boolean/);
   });
+
+  it("codingTools: accepts booleans or a unique known-name array; rejects every other shape", async () => {
+    const load = async (value: string) => {
+      const dir = await mkdtemp(join(tmpdir(), "fa-coding-tools-"));
+      await writeFile(join(dir, "fastagent.config.mjs"), `export default { codingTools: ${value} };\n`);
+      return loadConfig(dir);
+    };
+    expect((await load("false")).config.codingTools).toBe(false);
+    expect((await load('["read"]')).config.codingTools).toEqual(["read"]);
+    await expect(load('"no"')).rejects.toThrow(/codingTools.*must be a boolean or an array/);
+    await expect(load('["cat"]')).rejects.toThrow(/codingTools\[0\].*read, bash, edit, write/);
+    await expect(load('["read", "read"]')).rejects.toThrow(/must not contain duplicate "read"/);
+  });
 });
 
 describe("config: resolveStateRoot / resolveSecretsDir (the machinery dirs)", () => {
@@ -284,14 +297,23 @@ describe("config: loadConfig", () => {
   });
 });
 
-describe("config: resolveTools (append-after-defaults semantics)", () => {
-  it("without config.tools returns pi defaults; with config.tools appends after defaults instead of replacing", () => {
+describe("config: resolveTools (coding defaults + authored tools)", () => {
+  it("enables pi coding tools by default and appends config.tools", () => {
     const defaults = resolveTools({});
-    expect(defaults.length).toBeGreaterThan(0);
+    expect(defaults.map((t) => t.name)).toEqual(["read", "bash", "edit", "write"]);
+    expect(resolveTools({ codingTools: true }).map((t) => t.name)).toEqual(defaults.map((t) => t.name));
 
     const extra = { name: "ping" } as unknown as FastagentTool;
     const merged = resolveTools({ tools: [extra] });
     expect(merged.map((t) => t.name)).toEqual([...defaults.map((t) => t.name), "ping"]);
+  });
+
+  it("codingTools false/[] remove all coding tools; an array selects names in canonical order", () => {
+    const extra = { name: "ping" } as unknown as FastagentTool;
+    expect(resolveTools({ codingTools: false }).map((t) => t.name)).toEqual([]);
+    expect(resolveTools({ codingTools: [] }).map((t) => t.name)).toEqual([]);
+    expect(resolveTools({ codingTools: ["write", "read"] }).map((t) => t.name)).toEqual(["read", "write"]);
+    expect(resolveTools({ codingTools: false, tools: [extra] }).map((t) => t.name)).toEqual(["ping"]);
   });
 });
 

--- a/test/definition.test.ts
+++ b/test/definition.test.ts
@@ -473,3 +473,31 @@ describe("definition: skills/ gets the same containment guard as tools/channels/
     await expect(loadAgentDefinition(agent)).rejects.toThrow(/resolves outside the agent dir/);
   });
 });
+
+describe("create L2: an explicit tools list states its own coding capabilities", () => {
+  it("does not claim a caller passing `read` lacks a file reader", async () => {
+    // `tools` is the caller stating the whole surface, which used to be read as "no coding tools at
+    // all" — so an L2 caller who passed a reader got the capability-neutral identity AND a warning
+    // that their model-visible skills had no way to read themselves.
+    const dir = await mkdtemp(join(tmpdir(), "fa-l2-caps-"));
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await mkdir(join(dir, "skills", "triage"), { recursive: true });
+    await writeFile(
+      join(dir, "skills", "triage", "SKILL.md"),
+      "---\nname: triage\ndescription: Triage things.\n---\n\nSteps.\n",
+    );
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const { faux } = makeFaux();
+    faux.setResponses([fauxAssistantMessage("ok")]);
+    try {
+      await createPiAgentFromDefinition(dir, {
+        model: "faux/faux-1",
+        providers: [faux.provider],
+        tools: piDefaultTools(),
+      });
+      expect(warn.mock.calls.flat().join("\n")).not.toMatch(/reader/i);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/test/feishu-websocket.test.ts
+++ b/test/feishu-websocket.test.ts
@@ -68,7 +68,7 @@ describe("Feishu/Lark WebSocket ingress", () => {
           yield { type: "completed" };
         },
       };
-      const run = module.connect({ agent, stateRoot: root }, new AbortController().signal);
+      const run = module.connect({ agent, stateRoot: root, canReadLocalFiles: true }, new AbortController().signal);
       await run.ready;
       expect(accepted).toBeTypeOf("function");
       await accepted?.(event);
@@ -103,7 +103,7 @@ describe("Feishu/Lark WebSocket ingress", () => {
         yield { type: "completed" };
       },
     };
-    module.connect({ agent, stateRoot: root }, new AbortController().signal);
+    module.connect({ agent, stateRoot: root, canReadLocalFiles: true }, new AbortController().signal);
     const home = join(root, "channels", "feishu");
     await mkdir(join(home, "turns.json.tmp")); // saveStateFile(writeFile) fails with EISDIR before the ACK
 

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -115,7 +115,7 @@ function buildChannel(
     verificationToken: TOKEN,
     apiBaseUrl: BASE,
     ...channelOpts,
-  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control, canReadLocalFiles });
+  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control, canReadLocalFiles: canReadLocalFiles ?? true });
   const handler = routes["POST /feishu"];
   if (!handler) throw new Error("expected POST /feishu");
   const maybeIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
@@ -190,6 +190,7 @@ describe("bot identity cache (the lazy-construction mention race)", () => {
     })({
       agent,
       stateRoot: root,
+      canReadLocalFiles: true,
     });
     const handler = routes["POST /feishu"];
     if (!handler) throw new Error("expected POST /feishu");
@@ -332,7 +333,7 @@ describe("bot identity cache (the lazy-construction mention race)", () => {
 
 describe("construction fails closed", () => {
   it("requires appId/appSecret/verificationToken at mount (metadata remains inspectable before secrets exist)", () => {
-    const ctx = { agent: {} as Agent, stateRoot: "/tmp/unused-feishu-construction" };
+    const ctx = { agent: {} as Agent, stateRoot: "/tmp/unused-feishu-construction", canReadLocalFiles: true };
     expect(() => buildFeishuChannel({ appId: "", appSecret: "s", verificationToken: "t" })(ctx)).toThrow(/appId/);
     expect(() => buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: "" })(ctx)).toThrow(
       /verificationToken/,
@@ -343,7 +344,11 @@ describe("construction fails closed", () => {
     feishuFetch();
     const { agent } = replyingAgent();
     expect(() =>
-      buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: "t" })({ agent, stateRoot: "rel" }),
+      buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: "t" })({
+        agent,
+        stateRoot: "rel",
+        canReadLocalFiles: true,
+      }),
     ).toThrow(/stateRoot/);
   });
 });
@@ -478,6 +483,7 @@ describe("upgrade from the session-mode model", () => {
 
     const { agent } = replyingAgent();
     buildFeishuChannel({ appId: "app", appSecret: "secret", verificationToken: TOKEN, apiBaseUrl: BASE })({
+      canReadLocalFiles: true,
       agent,
       stateRoot: root,
     });
@@ -557,7 +563,7 @@ describe("turn flow", () => {
       appSecret: "secret",
       verificationToken: TOKEN,
       apiBaseUrl: BASE,
-    })({ agent: restarted.agent, stateRoot: first.root });
+    })({ agent: restarted.agent, stateRoot: first.root, canReadLocalFiles: true });
     const again = routes["POST /feishu"];
     if (!again) throw new Error("expected POST /feishu");
     const idleAgain = (again as { turnsIdle?: () => Promise<void> }).turnsIdle ?? (async () => {});
@@ -2482,6 +2488,7 @@ describe("turn flow", () => {
     );
     const { agent, calls } = replyingAgent("recovered");
     const handler = buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: TOKEN, apiBaseUrl: BASE })({
+      canReadLocalFiles: true,
       agent,
       stateRoot: root,
     })["POST /feishu"];
@@ -2592,7 +2599,7 @@ describe("the Lark compatibility profile", () => {
       appSecret: "secret",
       verificationToken: TOKEN,
       apiBaseUrl: BASE,
-    })({ agent, stateRoot: root });
+    })({ agent, stateRoot: root, canReadLocalFiles: true });
     expect(routes["POST /feishu"]).toBeUndefined();
     const handler = routes["POST /lark"];
     if (!handler) throw new Error("expected POST /lark");
@@ -2615,7 +2622,7 @@ describe("the Lark compatibility profile", () => {
   });
 
   it("mount failures name each public factory", () => {
-    const ctx = { agent: {} as Agent, stateRoot: "/tmp/unused-feishu-factory-name" };
+    const ctx = { agent: {} as Agent, stateRoot: "/tmp/unused-feishu-factory-name", canReadLocalFiles: true };
     expect(() => buildFeishuChannel({ appId: "", appSecret: "s", verificationToken: "t" })(ctx)).toThrow(
       /feishuChannel/,
     );

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -102,10 +102,10 @@ function feishuFetch(
 
 /** Build a channel on a temp state root; returns the handler + the recorded agent + the state home. */
 function buildChannel(
-  opts: Partial<FeishuChannelOptions> & { control?: SessionControl } = {},
+  opts: Partial<FeishuChannelOptions> & { control?: SessionControl; canReadLocalFiles?: boolean } = {},
   agentReply = "the answer",
 ) {
-  const { control, ...channelOpts } = opts;
+  const { control, canReadLocalFiles, ...channelOpts } = opts;
   const root = mkdtempSync(join(tmpdir(), "feishu-state-"));
   tempRoots.push(root);
   const { agent, calls } = replyingAgent(agentReply);
@@ -115,7 +115,7 @@ function buildChannel(
     verificationToken: TOKEN,
     apiBaseUrl: BASE,
     ...channelOpts,
-  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control });
+  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control, canReadLocalFiles });
   const handler = routes["POST /feishu"];
   if (!handler) throw new Error("expected POST /feishu");
   const maybeIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
@@ -1680,6 +1680,38 @@ describe("turn flow", () => {
     expect(prompt).toContain("spec.pdf");
     expect(fx.calls("/im/v1/messages/om_parent/resources/fk1").length).toBe(1);
     expect(readFileSync(join(home, "files", "oc_1", "spec.pdf")).toString()).toBe("pdf-bytes");
+  });
+
+  it("rejects a primary non-image referent without a reader and does not download or invoke", async () => {
+    const fx = feishuFetch({
+      "/im/v1/messages/om_parent_no_reader": (url) =>
+        url.includes("/resources/")
+          ? new Response(Buffer.from("must-not-download"), { status: 200 })
+          : Response.json({
+              code: 0,
+              msg: "ok",
+              data: {
+                items: [
+                  {
+                    message_id: "om_parent_no_reader",
+                    msg_type: "file",
+                    body: { content: '{"file_key":"fk1","file_name":"spec.pdf"}' },
+                    sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
+                  },
+                ],
+              },
+            }),
+    });
+    const { handler, calls, idle } = buildChannel({
+      canReadLocalFiles: false,
+      onError: (failed) => failed.details,
+    });
+    await handler(
+      feishuRequest(messageEvent({ id: "om_no_reader", text: "summarize this", parentId: "om_parent_no_reader" })),
+    );
+    await idle();
+    expect(calls).toHaveLength(0);
+    expect(fx.calls("/im/v1/messages/om_parent_no_reader/resources/fk1")).toHaveLength(0);
   });
 
   it("a thread opened on the agent's own card reads that card AND the chain up to the ask", async () => {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -1688,7 +1688,11 @@ describe("turn flow", () => {
     expect(readFileSync(join(home, "files", "oc_1", "spec.pdf")).toString()).toBe("pdf-bytes");
   });
 
-  it("rejects a primary non-image referent without a reader and does not download or invoke", async () => {
+  it("a quoted file the agent cannot read costs the note, not the turn", async () => {
+    // A referent is CONTEXT, not the ask — this function's own policy. Every first message of a
+    // thread carries one, so hard-failing when the quoted message happens to be a file turns an
+    // ordinary platform edge into a lost turn, and tells the user to "send the content as text" for
+    // a file they never sent. Degrade like every other unreadable referent: skip it, say so.
     const fx = feishuFetch({
       "/im/v1/messages/om_parent_no_reader": (url) =>
         url.includes("/resources/")
@@ -1716,8 +1720,9 @@ describe("turn flow", () => {
       feishuRequest(messageEvent({ id: "om_no_reader", text: "summarize this", parentId: "om_parent_no_reader" })),
     );
     await idle();
-    expect(calls).toHaveLength(0);
-    expect(fx.calls("/im/v1/messages/om_parent_no_reader/resources/fk1")).toHaveLength(0);
+    expect(calls).toHaveLength(1); // the turn RAN
+    expect(fx.calls("/im/v1/messages/om_parent_no_reader/resources/fk1")).toHaveLength(0); // nothing downloaded
+    expect(String(calls[0]?.prompt.text)).toMatch(/no local-file reader/); // and the model was told
   });
 
   it("a thread opened on the agent's own card reads that card AND the chain up to the ask", async () => {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -41,7 +41,7 @@ const PR_OPENED = {
 
 /** The old two-arg shape over the ChannelModule contract, returning the mounted handler directly. */
 const githubChannel = (agent: Agent, opts: GithubChannelOptions) =>
-  buildGithubChannel(opts)({ agent, stateRoot: "/unused-in-tests" })["POST /webhook"]!;
+  buildGithubChannel(opts)({ agent, stateRoot: "/unused-in-tests", canReadLocalFiles: true })["POST /webhook"]!;
 
 describe("github channel", () => {
   it("a post-ACK turn counts as process-wide in-flight work (the AgentCore /ping depends on it)", async () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -103,6 +103,12 @@ describe("init: scaffoldAgent", () => {
     expect(await readFile(join(dir, "fastagent", "tools", "fetch-url.ts"), "utf8")).toContain(
       'from "@fastagent-sh/fastagent"',
     );
+    const persona = await readFile(join(dir, "fastagent", "persona.md"), "utf8");
+    expect(persona).toContain("Use only the tools actually listed in your system prompt");
+    expect(persona).not.toContain("where your `read` / `write` / `edit` / `bash` tools operate");
+    const configTemplate = await readFile(join(dir, "fastagent", "fastagent.config.mjs"), "utf8");
+    expect(configTemplate).toContain('codingTools: ["read"]');
+    expect(configTemplate).toContain("non-image file attachments need `read`");
 
     // The scaffolded agent ASSEMBLES: ① persona + tools from fastagent/, ② context walked from the workspace.
     const a = await createPiAgentFromDir(dir, { model: "openai-codex/gpt-5.5" });

--- a/test/invoke-turn-busy.test.ts
+++ b/test/invoke-turn-busy.test.ts
@@ -30,7 +30,13 @@ const FAST: BusyRetry = { delayMs: 10, maxWaitMs: 500 };
 const noAttachments = { primary: {}, buffered: { files: [], images: [], skipped: 0 } };
 
 async function run(agent: Agent, retry: BusyRetry = FAST): Promise<AgentEvent[]> {
-  const transport = { api: "http://t.test", botToken: "B", chatId: 1, filesDir: await mkdtemp(join(tmpdir(), "fa-")) };
+  const transport = {
+    api: "http://t.test",
+    botToken: "B",
+    chatId: 1,
+    filesDir: await mkdtemp(join(tmpdir(), "fa-")),
+    canReadLocalFiles: true,
+  };
   const out: AgentEvent[] = [];
   for await (const e of invokeTurn(agent, "s", "hi", transport, noAttachments, undefined, retry)) out.push(e);
   return out;

--- a/test/preview-kit.test.ts
+++ b/test/preview-kit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { ATTACHMENT_UNSUPPORTED_CODE } from "../src/agent.ts";
 import type { AgentEvent } from "../src/agent.ts";
 import {
   applyTurnEvent,
@@ -100,5 +101,20 @@ describe("turn-view reducer", () => {
   it("composeTurnBody skips empty parts and joins with blank lines", () => {
     expect(composeTurnBody(["a", "", "  ", "b"])).toBe("a\n\nb");
     expect(composeTurnBody(["", " "])).toBe("");
+  });
+});
+
+describe("defaultErrorMessage: a known limitation is named, not shrugged at", () => {
+  it("tells the user what cannot happen when the agent has no reader", () => {
+    // The generic non-retryable line asks the user to rephrase, which cannot help: only the operator
+    // can mount a tool. Naming it keeps the user from re-sending the file in five formats.
+    expect(defaultErrorMessage({ details: "…", retryable: false, code: ATTACHMENT_UNSUPPORTED_CODE })).toMatch(
+      /can't open file attachments/i,
+    );
+  });
+
+  it("keeps the neutral wording for a failure it cannot name", () => {
+    expect(defaultErrorMessage({ details: "…", retryable: false })).toMatch(/something went wrong/i);
+    expect(defaultErrorMessage({ details: "…", retryable: true })).toMatch(/try again/i);
   });
 });

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -33,20 +33,20 @@ describe("report", () => {
         { type: "warning", code: "invalid_metadata", message: "description is required", path: "/a/x/SKILL.md" },
       ] as SkillDiagnostic[],
     };
-    reportFindingsIfChanged("/agent", findings); // reader A (a turn)
+    reportFindingsIfChanged("/agent", findings, []); // reader A (a turn)
     expect(lines(err)).toMatch(/invalid_metadata/);
     err.mockClear();
-    reportFindingsIfChanged("/agent", findings); // reader B (commands()) — same finding, same dir
+    reportFindingsIfChanged("/agent", findings, []); // reader B (commands()) — same finding, same dir
     expect(err).not.toHaveBeenCalled();
     // A DIFFERENT definition keeps its own budget …
-    reportFindingsIfChanged("/other-agent", findings);
+    reportFindingsIfChanged("/other-agent", findings, []);
     expect(lines(err)).toMatch(/invalid_metadata/);
     err.mockClear();
     // There is no record-without-printing door: the boot report goes through this same function, so
     // a caller that never reports cannot silently consume the announcement for every later reader.
-    reportFindingsIfChanged("/third-agent", findings); // boot
+    reportFindingsIfChanged("/third-agent", findings, []); // boot
     err.mockClear();
-    reportFindingsIfChanged("/third-agent", findings); // a turn, then commands() — already said
+    reportFindingsIfChanged("/third-agent", findings, []); // a turn, then commands() — already said
     expect(err).not.toHaveBeenCalled();
   });
 

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -1,6 +1,11 @@
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { reportDefinitionWarnings, reportFindingsIfChanged, reportToolCollisions } from "../src/engines/pi/report.ts";
+import {
+  definitionAssemblyFindings,
+  reportDefinitionWarnings,
+  reportFindingsIfChanged,
+  reportToolCollisions,
+} from "../src/engines/pi/report.ts";
 
 // Locks the warning WORDING shared by the CLI runners and `chat` (the reason A1 deduped these into one
 // module: two copies could drift). Spies on console.error rather than going through a runner.
@@ -43,6 +48,34 @@ describe("report", () => {
     err.mockClear();
     reportFindingsIfChanged("/third-agent", findings); // a turn, then commands() — already said
     expect(err).not.toHaveBeenCalled();
+  });
+
+  it("finds and reports model-visible skills that have no local-file reader", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const definition = {
+      dir: "/skills-agent",
+      skills: [
+        {
+          name: "writing",
+          description: "Write well",
+          content: "Instructions",
+          filePath: "/skills-agent/skills/writing/SKILL.md",
+        },
+      ],
+      collisions: [],
+      diagnostics: [],
+    };
+    const findings = definitionAssemblyFindings(definition, false);
+    expect(findings).toHaveLength(1);
+    reportFindingsIfChanged(definition.dir, definition, findings);
+    expect(lines(err)).toMatch(/skills_require_file_reader.*codingTools: \["read"\]/);
+    expect(definitionAssemblyFindings(definition, true)).toEqual([]);
+    expect(
+      definitionAssemblyFindings(
+        { ...definition, skills: [{ ...definition.skills[0]!, disableModelInvocation: true }] },
+        false,
+      ),
+    ).toEqual([]);
   });
 
   it("renders tool collisions to stderr", () => {

--- a/test/session-builder.test.ts
+++ b/test/session-builder.test.ts
@@ -523,12 +523,15 @@ describe("session builder: codingTools narrows chat exactly as it narrows servin
     const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
     try {
       expect(rt.session.getActiveToolNames().sort()).toEqual(["read"]);
-      // What `codingTools` guarantees is that the model is not OFFERED them. pi still mounts its own
-      // read/bash/edit/write into the registry; `noTools: "builtin"` keeps them out of the active
-      // set. Worth stating, because for the security-shaped posture (`codingTools: false`, a
-      // public-facing agent) "mounted but inactive" is the whole distance between safe and not.
-      expect(rt.session.getAllTools().map((t) => t.name)).toContain("bash");
-      expect(rt.session.getActiveToolNames()).not.toContain("bash");
+      // A BOUNDARY, not a default: the disabled built-ins are refused at the registry, so nothing
+      // that activates by name — a TUI command, the control plane, a deferred-tool loader — can put
+      // one back. "Mounted but inactive" would be the whole distance between safe and not for a
+      // public-facing agent running `codingTools: false`.
+      const mounted = rt.session.getAllTools().map((tool) => tool.name);
+      expect(mounted).not.toContain("bash");
+      expect(mounted).not.toContain("write");
+      rt.session.setActiveToolsByName(["read", "bash"]);
+      expect(rt.session.getActiveToolNames()).not.toContain("bash"); // asking for it does not get it
     } finally {
       await rt.dispose?.();
     }

--- a/test/session-builder.test.ts
+++ b/test/session-builder.test.ts
@@ -537,3 +537,35 @@ describe("session builder: codingTools narrows chat exactly as it narrows servin
     }
   });
 });
+
+describe("session builder: disabling a built-in frees its name for an authored tool", () => {
+  it("mounts an authored `read` when codingTools is false", async () => {
+    // The denylist that makes `codingTools` a boundary matches by NAME, so excluding a name the
+    // author reused would delete THEIR tool instead of pi's — silently, and only for the four
+    // built-in names. Docs promise the opposite: with the built-in off, the name is theirs.
+    const dir = await mkdtemp(join(tmpdir(), "fa-authored-read-"));
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(
+      join(dir, "fastagent.config.mjs"),
+      'export default { model: "openai-codex/gpt-5.5", codingTools: false };\n',
+    );
+    await mkdir(join(dir, "tools"), { recursive: true });
+    await writeFile(
+      join(dir, "tools", "read.mjs"),
+      `export default {
+         description: "the author's own reader",
+         parameters: { type: "object", properties: {} },
+         execute: async () => ({ content: [{ type: "text", text: "mine" }], details: {} }),
+       };\n`,
+    );
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    try {
+      expect(rt.session.getAllTools().map((t) => t.name)).toContain("read");
+      expect(rt.session.getActiveToolNames()).toContain("read");
+      // ...and the built-ins the author did NOT take are still refused.
+      expect(rt.session.getAllTools().map((t) => t.name)).not.toContain("bash");
+    } finally {
+      await rt.dispose?.();
+    }
+  });
+});

--- a/test/session-builder.test.ts
+++ b/test/session-builder.test.ts
@@ -13,10 +13,10 @@ import { log } from "../src/log.ts";
 // AgentTool via `config.tools` lets the custom-tool path be tested without installing the package.
 /** A fresh AGENT dir (`<tmp>/fastagent/`). Passing it to the builder resolves to itself, with the
  *  temp dir as the workspace — the same placement `init` produces, entered from the inside. */
-async function freshAgentDir(prefix: string): Promise<string> {
+async function freshAgentDir(prefix: string, options: { persona?: boolean } = {}): Promise<string> {
   const dir = join(await mkdtemp(join(tmpdir(), prefix)), "fastagent");
   await mkdir(dir);
-  await writeFile(join(dir, "persona.md"), "You are terse.\n"); // an agent, not an empty dir
+  if (options.persona !== false) await writeFile(join(dir, "persona.md"), "You are terse.\n");
   return dir;
 }
 
@@ -134,6 +134,60 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
         const rebuilt = rt.session;
         expect(rebuilt.getActiveToolNames()).not.toContain("lookup_weather");
         expect(rebuilt.getActiveToolNames()).toContain("search_tools");
+      } finally {
+        await rt.dispose();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an empty codingTools false chat surface empty and uses a capability-neutral default identity", async () => {
+    const dir = await freshAgentDir("fa-chat-empty-", { persona: false });
+    try {
+      await writeFile(
+        join(dir, "fastagent.config.mjs"),
+        `export default { model: "openai-codex/gpt-5.5", codingTools: false };\n`,
+      );
+      const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+      try {
+        const state = rt.session.agent.state;
+        expect(state.tools).toEqual([]);
+        expect(state.systemPrompt).toContain("Available tools:\n(none)");
+        expect(state.systemPrompt).toContain("You are an AI assistant operating inside pi, an agent harness.");
+        expect(state.systemPrompt).not.toContain("You help users by reading files");
+      } finally {
+        await rt.dispose();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("honors codingTools false in chat's mounted surface and generated prompt", async () => {
+    const dir = await freshAgentDir("fa-chat-no-coding-");
+    try {
+      await writeFile(
+        join(dir, "fastagent.config.mjs"),
+        `export default {
+           model: "openai-codex/gpt-5.5",
+           codingTools: false,
+           tools: [{
+             name: "lookup",
+             description: "Look up a business record.",
+             parameters: { type: "object", properties: {} },
+             execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+           }],
+         };\n`,
+      );
+      const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+      try {
+        const state = rt.session.agent.state;
+        expect(state.tools.map((t) => t.name)).toEqual(["lookup"]);
+        expect(state.systemPrompt).toContain("- lookup: Look up a business record.");
+        for (const name of ["read", "bash", "edit", "write"]) {
+          expect(state.systemPrompt).not.toContain(`- ${name}:`);
+        }
       } finally {
         await rt.dispose();
       }
@@ -448,6 +502,33 @@ describe("session builder: chat offers the model the same tool set serving does"
       expect(active).toEqual(["bash", "edit", "read", "write"]);
       // ...and they ARE mounted, just not offered — so this is about activation, not discovery.
       expect(rt.session.getAllTools().map((t) => t.name)).toContain("grep");
+    } finally {
+      await rt.dispose?.();
+    }
+  });
+});
+
+describe("session builder: codingTools narrows chat exactly as it narrows serving", () => {
+  it("mounts and activates only the configured coding tools", async () => {
+    // Both assemblies take their tool list from resolveAgentAssembly, so a least-privilege posture
+    // needs no per-assembly narrowing: what the definition disabled never reaches either list, and
+    // pi's own copies stay out via `noTools: "builtin"`. Before the allowlist was dropped, chat
+    // narrowed a second time by NAME — a second place for the two paths to disagree.
+    const dir = await mkdtemp(join(tmpdir(), "fa-coding-narrow-"));
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(
+      join(dir, "fastagent.config.mjs"),
+      'export default { model: "openai-codex/gpt-5.5", codingTools: ["read"] };\n',
+    );
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    try {
+      expect(rt.session.getActiveToolNames().sort()).toEqual(["read"]);
+      // What `codingTools` guarantees is that the model is not OFFERED them. pi still mounts its own
+      // read/bash/edit/write into the registry; `noTools: "builtin"` keeps them out of the active
+      // set. Worth stating, because for the security-shaped posture (`codingTools: false`, a
+      // public-facing agent) "mounted but inactive" is the whole distance between safe and not.
+      expect(rt.session.getAllTools().map((t) => t.name)).toContain("bash");
+      expect(rt.session.getActiveToolNames()).not.toContain("bash");
     } finally {
       await rt.dispose?.();
     }

--- a/test/slack-invoke-turn.test.ts
+++ b/test/slack-invoke-turn.test.ts
@@ -56,7 +56,7 @@ describe("Slack turn attachment resolution", () => {
         agent,
         "s1",
         "read these",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+        { api, channelId: "C1", filesDir: "/state", label: "[slack]", canReadLocalFiles: true },
         { primaryFileIds: ["IMG", "DOC"], buffered: { files: [], skipped: 0 } },
         completed,
       ),
@@ -78,7 +78,7 @@ describe("Slack turn attachment resolution", () => {
         agent,
         "s1",
         "read it",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+        { api, channelId: "C1", filesDir: "/state", label: "[slack]", canReadLocalFiles: true },
         { primaryFileIds: ["F1"], buffered: { files: [], skipped: 0 } },
       ),
     );
@@ -107,7 +107,7 @@ describe("Slack turn attachment resolution", () => {
         agent,
         "s1",
         "answer",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+        { api, channelId: "C1", filesDir: "/state", label: "[slack]", canReadLocalFiles: true },
         {
           primaryFileIds: [],
           buffered: {

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -117,7 +117,7 @@ function mount(
     signingSecret: SECRET,
     apiBaseUrl: API,
     ...options,
-  })({ agent, stateRoot, control, canReadLocalFiles })["POST /slack"]!;
+  })({ agent, stateRoot, control, canReadLocalFiles: canReadLocalFiles ?? true })["POST /slack"]!;
   const turnsIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle ?? (async () => {});
   idles.add(turnsIdle);
   return { handler, stateRoot, turnsIdle };

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -105,13 +105,19 @@ function storedTurn(id: string, seq: number, extra: Record<string, unknown> = {}
   };
 }
 
-function mount(agent: Agent, options: Partial<SlackChannelOptions> = {}, stateRoot = root(), control?: SessionControl) {
+function mount(
+  agent: Agent,
+  options: Partial<SlackChannelOptions> = {},
+  stateRoot = root(),
+  control?: SessionControl,
+  canReadLocalFiles?: boolean,
+) {
   const handler = slackChannel({
     botToken: "xoxb-test",
     signingSecret: SECRET,
     apiBaseUrl: API,
     ...options,
-  })({ agent, stateRoot, control })["POST /slack"]!;
+  })({ agent, stateRoot, control, canReadLocalFiles })["POST /slack"]!;
   const turnsIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle ?? (async () => {});
   idles.add(turnsIdle);
   return { handler, stateRoot, turnsIdle };
@@ -128,6 +134,52 @@ afterEach(async () => {
   vi.unstubAllGlobals();
   idles.clear();
   for (const value of roots.splice(0)) rmSync(value, { recursive: true, force: true });
+});
+
+describe("Slack attachment capability", () => {
+  it("rejects a primary non-image file without a reader and never downloads or invokes", async () => {
+    let invoked = false;
+    const agent: Agent = {
+      async *invoke() {
+        invoked = true;
+        yield { type: "completed" as const };
+      },
+    };
+    const fetchMock = okFetch();
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+      if (url.endsWith("/auth.test")) return Response.json({ ok: true, team_id: "T1", user_id: "UBOT" });
+      if (url.endsWith("/files.info")) {
+        return Response.json({
+          ok: true,
+          file: {
+            id: "F1",
+            name: "report.pdf",
+            mimetype: "application/pdf",
+            url_private: "https://files.slack.test/F1",
+          },
+        });
+      }
+      if (url === "https://files.slack.test/F1") throw new Error("must not download");
+      if (url.endsWith("/chat.postMessage") || url.endsWith("/chat.startStream")) {
+        return Response.json({ ok: true, ts: "100" });
+      }
+      return Response.json({ ok: true });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { handler } = mount(agent, { onError: (failed) => failed.details }, root(), undefined, false);
+    await handler(
+      signedRequest(
+        message("1.0", {
+          subtype: "file_share",
+          files: [{ id: "F1", name: "report.pdf", mimetype: "application/pdf" }],
+        }),
+      ),
+    );
+    await settle();
+    expect(invoked).toBe(false);
+    expect(fetchMock.mock.calls.some(([input]) => String(input) === "https://files.slack.test/F1")).toBe(false);
+  });
 });
 
 describe("Slack reaction ack", () => {

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -113,12 +113,17 @@ const freshStateDir = (): string => {
  *  "restarts" and read files at the same paths. */
 const telegramChannel = (
   agent: Agent,
-  { stateDir, control, ...opts }: TelegramChannelOptions & { stateDir?: string; control?: SessionControl },
+  {
+    stateDir,
+    control,
+    canReadLocalFiles,
+    ...opts
+  }: TelegramChannelOptions & { stateDir?: string; control?: SessionControl; canReadLocalFiles?: boolean },
 ) => {
   const home = stateDir ?? freshStateDir();
   const root = rootOfHome.get(home);
   if (!root) throw new Error("test stateDir must come from freshStateDir()");
-  const handler = buildTelegramChannel(opts)({ agent, stateRoot: root, control })["POST /telegram"]!;
+  const handler = buildTelegramChannel(opts)({ agent, stateRoot: root, control, canReadLocalFiles })["POST /telegram"]!;
   // Register the turn-queue idle so flush() awaits this channel's fire-and-forget turns deterministically.
   const idle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
   if (idle) channelIdles.add(idle);
@@ -461,6 +466,25 @@ describe("buffered attachments (files/photos from un-summoned discussion)", () =
     const text = String(calls[0]?.text);
     expect(text).toMatch(/report\.pdf \(from @alice, msg 1, earlier discussion\)/); // attributed: "the file ALICE sent" resolves
     expect(text).toMatch(/attached files/);
+  });
+
+  it("does not download or render a buffered file path when the agent has no reader", async () => {
+    const got = attachFetch();
+    const { agent, calls } = replyingAgent("ok");
+    const ch = telegramChannel(agent, {
+      secretToken: SECRET,
+      botToken: "1:A",
+      route,
+      canReadLocalFiles: false,
+    });
+    await ch(tgRequest(doc(1, "report")));
+    await ch(tgRequest(summon(2, "@go summarize what you can")));
+    await until(() => calls.length > 0);
+    expect(got).toEqual([]);
+    const text = String(calls[0]?.text);
+    expect(text).toContain("no local-file reader");
+    expect(text).not.toContain("attached files — read them with your tools");
+    expect(text).not.toContain("report.pdf (");
   });
 
   it("a photo posted without summoning becomes a vision input on the next summon", async () => {
@@ -1538,6 +1562,43 @@ describe("telegram channel", () => {
     expect(existsSync(dest)).toBe(true);
     expect(calls[0]?.text).toMatch(/attached files/);
     expect(calls[0]?.text).toContain(dest);
+  });
+
+  it("fails a primary document clearly without a reader and never downloads or invokes", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    let invoked = false;
+    const agent: Agent = {
+      async *invoke(): AsyncIterable<AgentEvent> {
+        invoked = true;
+        yield { type: "completed" };
+      },
+    };
+    const ch = telegramChannel(agent, {
+      secretToken: SECRET,
+      botToken: "BOT",
+      route: act,
+      apiBaseUrl: API,
+      canReadLocalFiles: false,
+      onError: (f) => `ERR: ${f.details}`,
+    });
+    const doc: TelegramUpdate = {
+      update_id: 12,
+      message: {
+        message_id: 5,
+        caption: "summarize",
+        document: { file_id: "d1", file_name: "report.pdf" },
+        chat: { id: 77, type: "private" },
+      },
+    };
+    expect((await ch(tgRequest(doc))).status).toBe(200);
+    await flush();
+    expect(invoked).toBe(false);
+    expect(callsTo(fetchMock, "getFile")).toHaveLength(0);
+    const writes = [...callsTo(fetchMock, "sendMessage"), ...callsTo(fetchMock, "editMessageText")].map(
+      (c) => bodyOf(c).text as string,
+    );
+    expect(writes.some((text) => /cannot read local file attachments/.test(text))).toBe(true);
   });
 
   it("surfaces an attachment fetch failure to the user (not a silent skip) and does not run the agent", async () => {

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -123,7 +123,12 @@ const telegramChannel = (
   const home = stateDir ?? freshStateDir();
   const root = rootOfHome.get(home);
   if (!root) throw new Error("test stateDir must come from freshStateDir()");
-  const handler = buildTelegramChannel(opts)({ agent, stateRoot: root, control, canReadLocalFiles })["POST /telegram"]!;
+  const handler = buildTelegramChannel(opts)({
+    agent,
+    stateRoot: root,
+    control,
+    canReadLocalFiles: canReadLocalFiles ?? true,
+  })["POST /telegram"]!;
   // Register the turn-queue idle so flush() awaits this channel's fire-and-forget turns deterministically.
   const idle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
   if (idle) channelIdles.add(idle);
@@ -169,9 +174,11 @@ describe("durable group buffer (single-process restarts)", () => {
     const root = mkdtempSync(join(tmpdir(), "tg-root-"));
     stateDirs.push(root);
     const { agent } = replyingAgent("ok");
-    const ch = buildTelegramChannel({ secretToken: SECRET, botToken: "1:A", route })({ agent, stateRoot: root })[
-      "POST /telegram"
-    ]!;
+    const ch = buildTelegramChannel({ secretToken: SECRET, botToken: "1:A", route })({
+      agent,
+      stateRoot: root,
+      canReadLocalFiles: true,
+    })["POST /telegram"]!;
     expect((await ch(tgRequest(group(1, "hello state root")))).status).toBe(200);
     // The buffer landed under the DERIVED channel home, not the root itself and not process.cwd().
     const home = join(root, "channels", "telegram");
@@ -182,9 +189,13 @@ describe("durable group buffer (single-process restarts)", () => {
 
   it("rejects a relative ctx.stateRoot for embedders that mount without loadChannels (fail visibly)", () => {
     const { agent } = replyingAgent("ok");
-    expect(() => buildTelegramChannel({ secretToken: SECRET, botToken: "1:A" })({ agent, stateRoot: "rel" })).toThrow(
-      /stateRoot/,
-    );
+    expect(() =>
+      buildTelegramChannel({ secretToken: SECRET, botToken: "1:A" })({
+        agent,
+        stateRoot: "rel",
+        canReadLocalFiles: true,
+      }),
+    ).toThrow(/stateRoot/);
   });
 
   it("a FAILED turn keeps the folded discussion — the next summon re-folds it (commit on completed only)", async () => {

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -93,6 +93,43 @@ describe("loadTools (filesystem discovery)", () => {
     expect(toolNames).not.toContain("hostonly"); // cwd's own tools/ is the host's, not the agent's surface
   });
 
+  it("codingTools false with an empty definition stays empty instead of restoring pi defaults", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "fa-tools-empty-"));
+    const resolved = await resolveAgentTools({ codingTools: false }, agentDir);
+    expect(resolved.tools).toEqual([]);
+    expect(resolved.codingToolNames).toEqual([]);
+    expect(resolved.toolNames).toEqual([]);
+  });
+
+  it("codingTools false mounts and reports only authored tools, including a tool named like a coding default", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "fa-tools-no-coding-"));
+    await mkdir(join(agentDir, "tools"));
+    await writeFile(
+      join(agentDir, "tools", "read.mjs"),
+      `export default { description: "Business read", parameters: { type: "object" }, async execute() { return { content: [], details: "ok" }; } };`,
+    );
+
+    const { tools, toolNames, toolCollisions } = await resolveAgentTools({ codingTools: false }, agentDir);
+    expect(tools.map((t) => t.name)).toEqual(["read"]);
+    expect(toolNames).toEqual(["read"]);
+    expect(toolCollisions).toEqual([]);
+  });
+
+  it("codingTools false leaves the deferred search_tools policy unchanged", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "fa-tools-no-coding-deferred-"));
+    const deferred = defineTool({
+      name: "lookup",
+      description: "Look up a business record.",
+      input: z.object({}),
+      deferred: true,
+      execute: () => "ok",
+    });
+
+    const { tools, deferredToolNames } = await resolveAgentTools({ codingTools: false, tools: [deferred] }, agentDir);
+    expect(tools.map((t) => t.name).sort()).toEqual(["lookup", "search_tools"]);
+    expect(deferredToolNames).toEqual(["lookup"]);
+  });
+
   it("isolates (surfaces, not fatal) a tool file that does not default-export a tool", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-tools-"));
     await mkdir(join(dir, "tools"));

--- a/test/turn-kit.test.ts
+++ b/test/turn-kit.test.ts
@@ -2,8 +2,10 @@
  * `retryable` classification — the one bit every SPEC failure carries, and the reason a channel
  * either retries or reports. Structured status/code first, prose only as the last-resort ceiling.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { LocalFileAccessUnavailable } from "../src/channels/invoke-turn-kit.ts";
 import { classifyRetryable, errorToTerminal, toTerminal } from "../src/engines/pi/turn-kit.ts";
+import { log } from "../src/log.ts";
 
 describe("classifyRetryable (structured signal first, prose as the ceiling)", () => {
   it("a status decides, whatever the prose says", () => {
@@ -67,5 +69,25 @@ describe("terminals read the engine's own signal", () => {
       retryable: true,
     });
     expect(errorToTerminal(new Error("plain failure"))).toMatchObject({ retryable: false });
+  });
+});
+
+describe("LocalFileAccessUnavailable: the operator hears what the user cannot fix", () => {
+  it("logs the actionable fix when constructed", () => {
+    // The user-facing message deliberately does NOT say "mount the read coding tool" — that is not
+    // their lever. It has to reach the operator instead, and the throw site is the only place that
+    // knows. Before this, the sentence lived in an Error the default onError never rendered, so a
+    // misconfigured agent answered every attachment with a shrug and nobody learned why.
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      const err = new LocalFileAccessUnavailable("[telegram]");
+      expect(err.name).toBe("LocalFileAccessUnavailable");
+      const logged = warn.mock.calls.flat().join("\n");
+      expect(logged).toMatch(/\[telegram\]/);
+      expect(logged).toMatch(/no `read` tool/);
+      expect(logged).toMatch(/codingTools/);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Add `codingTools` so a directory agent can select which of pi's built-in `read`, `bash`, `edit` and
`write` it mounts: all-on (`true`/unset), all-off (`false`/`[]`), or a least-privilege subset such as
`["read"]`. One resolved posture applies across `dev`, `start`, `invoke`, `chat`, `tool` and `info`.

Original work by @Shuqian; rebased onto the single-engine `main` and continued here.

## Why a subset, not a switch

Capabilities are not interchangeable. Skills and downloaded non-image channel attachments are
file-backed and need `read`; they do not need a shell or mutation. Without the subset, a
public-facing agent has to choose between a full coding surface and none — and losing `read` quietly
breaks its own skills.

So the failures are made visible rather than left to surprise: model-visible skills that have no
reader are reported at assembly, and Telegram, Slack and Feishu refuse to hand the model a local
attachment path it cannot read instead of passing one that will fail.

## It is a boundary, not a default

`noTools: "builtin"` keeps pi's own copies out of the *active* set, but they remained in the session
registry — so anything that activates by name (a `chat` command, the control plane, the
deferred-tool loader) could put one back. A public-facing agent on `codingTools: false` was one
`/tools` away from a shell.

Disabled built-ins are now passed as pi's `excludeTools`, which filters inside
`_refreshToolRegistry`, so they are never mountable. The test asks for `bash` explicitly and does not
get it.

Two consequences that needed their own handling:

- **Disabling a name frees it.** The denylist matches by name, so it would have deleted an *authored*
  tool that reused one of the four — the opposite of what the docs promise. The exclusion now
  subtracts whatever the mounted set already provides.
- **An explicit `tools` list states its own capabilities.** L2 callers passing `piDefaultTools()`
  were treated as having no coding tools, which gave them a capability-neutral identity and a false
  "skills have no reader" warning. Capabilities are read from the built-in names present in the list.

## What the rebase simplified

The original narrowed chat a second time, by name, through pi's `tools` allowlist:

```ts
const defaultNames = codingToolNames;
const customTools = tools.filter((t) => !defaultNames.includes(t.name));
```

That allowlist is gone (#345 removed it — it froze the tool set against extensions registering from
a handler), and `resolveTools()` already applies `codingTools`. Both assemblies now take an
already-narrowed list from `resolveAgentAssembly`, so the posture lands in one place instead of two
that could disagree.

## Validation

- [x] `npm run lint`, `npm run typecheck`, `npm test` (108 files, 1379 tests)
- [x] Rebased onto the single-engine `main`; `invoke.ts`/`sessions.ts`/`harness.ts` no longer exist
- [x] `rv.sh local` — **No findings.** Each behavioural fix falsified by reverting it and confirming
      the test goes red

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated (`docs/configuration.md`, `docs/api-reference.md`, `docs/cli.md`, `docs/design/core.md`)
