### PR TITLE
feat(models): custom model endpoints via the agent's own models.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,8 @@ src/
     ├── definition.ts        # AGENTS.md + skills loading and bundling
     ├── config.ts            # fastagent.config.ts loading + model/precedence (placement lives in paths.ts)
     ├── auth.ts, login.ts    # credential store/resolution (project-level auth.json default) + `login` flow
-    ├── models.ts            # Models collection wiring
+    ├── models.ts            # Models collection wiring + the agent's OWN models.json (custom endpoints:
+    │                         # definition-local so it travels; the machine-global ~/.pi one stays unread)
     ├── report.ts            # startup report (auth/model/skills/tools surface)
     └── sessions.ts          # PiSessionStore port + in-memory/jsonl backends
 test/                        # vitest; faux models by default + reusable SPEC conformance

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,84 @@ fastagent dev --model openai-codex/gpt-5.5
 FASTAGENT_MODEL=openai-codex/gpt-5.5 fastagent start
 ```
 
+## Custom model endpoints
+
+To run against something the built-in catalog does not know — a self-hosted model (vLLM, SGLang,
+Ollama, LM Studio) or your own gateway/proxy — declare it in `models.json` **next to the config
+file**, in the agent dir:
+
+```txt
+my-agent/
+├── fastagent.config.ts
+├── models.json        ← custom endpoints
+└── persona.md
+```
+
+The file's existence is the switch; there is no config key for it. An endpoint needs a URL, an API
+shape, a key, and the model ids it serves — everything else has a default:
+
+```json
+{
+  "providers": {
+    "mygw": {
+      "baseUrl": "http://vllm.internal:8000/v1",
+      "api": "openai-completions",
+      "apiKey": "$MYGW_API_KEY",
+      "models": [{ "id": "deepseek-v3", "contextWindow": 65536 }]
+    }
+  }
+}
+```
+
+The provider id joins the model id into a normal spec, usable everywhere a spec is:
+
+```ts
+export default defineConfig({
+  model: "mygw/deepseek-v3",
+  deploy: { secrets: ["MYGW_API_KEY"] },
+});
+```
+
+Custom endpoints are **additive** — built-in providers stay available alongside them.
+
+### Keys stay out of the file
+
+`apiKey` (and any `headers` value) resolves at request time: `"$MYGW_API_KEY"` reads an environment
+variable, `"!cmd"` runs a command and uses its stdout, anything else is a literal. Use the env form
+and list the NAME in `deploy.secrets` (above), so `deploy` carries the value to the host — the file
+itself stays safe to commit and to bake into an image.
+
+### Routing a built-in provider through a proxy
+
+Give an existing provider a new `baseUrl` and nothing else. Its full model list, pricing metadata and
+compatibility flags are kept, and existing OAuth / API-key auth keeps working:
+
+```json
+{
+  "providers": {
+    "deepseek": { "baseUrl": "https://llm-proxy.internal/v1" }
+  }
+}
+```
+
+### Compatibility flags
+
+OpenAI-compatible servers differ in the details. `compat` (per provider, or per model to override)
+carries the switches — e.g. `supportsDeveloperRole: false` for servers that reject the `developer`
+role, or `thinkingFormat` for reasoning models behind a chat template.
+
+The schema is pi's own; its full field reference, including every `compat` flag and per-model
+override, is in pi's `docs/models.md` (`@earendil-works/pi-coding-agent`). Two things are specific to
+FastAgent:
+
+| Behavior | Why |
+|---|---|
+| pi's machine-global `~/.pi/agent/models.json` is **not** read | Deployment behavior must come from the bundled definition, not the builder machine — a globally-defined endpoint would work locally and vanish on deploy. |
+| A malformed `models.json` fails startup | Upstream degrades silently to the built-ins; FastAgent surfaces the parse error instead of letting it resurface later as `unknown model`. |
+
+`fastagent models` lists the built-in catalog only — it answers "what does FastAgent support", not
+"what does this agent use". To confirm what an agent resolved, run `fastagent info`.
+
 ## Auth and secrets
 
 FastAgent resolves model credentials through the model provider layer. Common options:
@@ -251,7 +329,11 @@ The following are library API injection points rather than config keys:
 - custom session stores,
 - custom execution environments (a complete sandbox adapter remains future work),
 - distributed leases,
-- custom model providers,
 - base prompt overrides.
 
 Use the library API in [Embedding](embedding.md) when you need those ports.
+
+Custom model providers are the exception that proves the rule: a *declarative* endpoint is definition
+data, so it lives in the agent's own [`models.json`](#custom-model-endpoints). A provider that needs
+CODE — minting a token per request, say — is still an injection point (`providers`, see
+[Embedding](embedding.md)).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,6 @@ The provider id joins the model id into a normal spec, usable everywhere a spec 
 ```ts
 export default defineConfig({
   model: "mygw/deepseek-v3",
-  deploy: { secrets: ["MYGW_API_KEY"] },
 });
 ```
 
@@ -127,9 +126,23 @@ Custom endpoints are **additive** — built-in providers stay available alongsid
 ### Keys stay out of the file
 
 `apiKey` (and any `headers` value) resolves at request time: `"$MYGW_API_KEY"` reads an environment
-variable, `"!cmd"` runs a command and uses its stdout, anything else is a literal. Use the env form
-and list the NAME in `deploy.secrets` (above), so `deploy` carries the value to the host — the file
-itself stays safe to commit and to bake into an image.
+variable, `"!cmd"` runs a command and uses its stdout, anything else is a literal. Prefer the env
+form — the file then stays safe to commit and to bake into an image.
+
+`deploy` recognizes the variable backing the selected model and carries its value to the host like any
+provider key, listing it in the runbook and refusing `--run` when it has no local value. You do not
+need to declare it. `deploy.secrets` remains for the variables `deploy` cannot infer — a key used only
+in `headers`, or a value assembled from several variables (`"${A}_${B}"`):
+
+```ts
+export default defineConfig({
+  model: "mygw/deepseek-v3",
+  deploy: { secrets: ["MYGW_PORTKEY_KEY"] },
+});
+```
+
+A key written INTO `models.json` (a literal, or a `!command` resolved on the host) travels with the
+file itself, so there is nothing to carry — and `deploy` does not ask for one.
 
 ### Routing a built-in provider through a proxy
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -45,6 +45,8 @@ There is ONE agent shape and ONE marker. The shape:
 ├── channels/
 ├── schedules/
 ├── fastagent.config.mjs    # THE marker
+├── models.json             # optional: custom model endpoints (pi's schema, definition-LOCAL so it
+│                           # travels into the image — pi's machine-global ~/.pi one stays unread)
 ├── .gitignore              # scaffolded ONCE by init, yours after: node_modules, .state, a stray .env
 ├── .secrets/               # secrets: .env + auth.json; only tracked .env.example + .gitignore travel
 └── .state/                 # mutable machine state: sessions, channel state, schedule state

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -194,7 +194,9 @@ const myGateway = createProvider({
 const agent = createPiAgent({ model: "acme/gpt-x", providers: [myGateway] });
 ```
 
-`providers` are registered on top of the built-ins and the agent's `models.json` (a matching id overrides). An "auth service" is modeled as a provider — its per-request credential logic lives in the provider's `auth.…resolve()`, not as a separate credential option.
+`providers` are registered on top of the built-ins (a matching id overrides a built-in). Against the agent's own `models.json` the precedence is the other way round: an injected provider is the BASE and a same-id `models.json` entry composes over it, so the file wins. That is deliberate — where a deployed agent's traffic goes is a property of the definition, not of the program that embedded it — but it does mean a same-id entry silently replaces the endpoint you injected. Use a distinct id when you mean both to exist.
+
+An "auth service" is modeled as a provider — its per-request credential logic lives in the provider's `auth.…resolve()`, not as a separate credential option.
 
 ## How embed and CLI relate
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -165,7 +165,12 @@ Static keys belong in the login file or the environment, not in code — there i
 
 ## 5. Your own model source: `providers`
 
-When you run your own **gateway** or a **self-hosted / OpenAI-compatible** endpoint, register it as a provider; a `model` spec then selects it by id. This is the one case that touches the engine's provider layer — built-in providers cover everything else.
+> Reach for this only when the provider needs **code**. An endpoint that is just a URL, a key and some
+> model ids is data: declare it in the agent's own `models.json` and every path — `dev`, `start`,
+> `invoke`, `chat`, `deploy`, and L2 embedding — picks it up with no wiring. See
+> [Custom model endpoints](configuration.md#custom-model-endpoints).
+
+When your model source needs per-request logic — minting or rotating a token, calling an auth service — register it as a provider; a `model` spec then selects it by id. This is the one case that touches the engine's provider layer — built-in providers cover everything else.
 
 ```ts
 import { createPiAgent, createProvider } from "@fastagent-sh/fastagent";
@@ -189,7 +194,7 @@ const myGateway = createProvider({
 const agent = createPiAgent({ model: "acme/gpt-x", providers: [myGateway] });
 ```
 
-`providers` are registered on top of the built-ins (a matching id overrides a built-in). An "auth service" is modeled as a provider — its per-request credential logic lives in the provider's `auth.…resolve()`, not as a separate credential option.
+`providers` are registered on top of the built-ins and the agent's `models.json` (a matching id overrides). An "auth service" is modeled as a provider — its per-request credential logic lives in the provider's `auth.…resolve()`, not as a separate credential option.
 
 ## How embed and CLI relate
 

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -118,6 +118,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
     longConnectionChannels,
     hasTimeTriggers,
     modelAuth,
+    modelKeyInDefinition,
     authPath,
     container,
     port,
@@ -174,6 +175,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
         port,
         requireTunnel: requestedTunnel,
         modelAuth,
+        modelKeyInDefinition,
         authPath,
         channels,
         longConnectionChannels,
@@ -232,6 +234,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
         workspace,
         name: serviceName,
         modelAuth,
+        modelKeyInDefinition,
         authPath,
         channels,
         longConnectionChannels,
@@ -346,6 +349,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
         agentPrefix: container.agentPrefix,
         name: acName,
         modelAuth,
+        modelKeyInDefinition,
         authPath,
         channels,
         extraSecrets,
@@ -445,6 +449,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
       agentPrefix: container.agentPrefix,
       appName,
       modelAuth,
+      modelKeyInDefinition,
       authPath,
       channels,
       longConnectionChannels,
@@ -552,6 +557,7 @@ async function runDeployDocker(
     port: number;
     requireTunnel: boolean;
     modelAuth: string | undefined;
+    modelKeyInDefinition: boolean;
     authPath: string;
     channels: ChannelKind[];
     longConnectionChannels: string[];
@@ -565,6 +571,7 @@ async function runDeployDocker(
     port,
     requireTunnel,
     modelAuth,
+    modelKeyInDefinition,
     authPath,
     channels,
     longConnectionChannels,
@@ -572,6 +579,7 @@ async function runDeployDocker(
   } = params;
   const { secrets, missingSecrets, needsModelCredential } = assembleSecrets({
     modelAuth,
+    modelKeyInDefinition,
     authFile: (await exists(authPath)) ? await readFile(authPath) : undefined,
     channels,
     longConnectionChannels,
@@ -626,6 +634,7 @@ async function runDeployFly(
     agentPrefix: string;
     appName: string;
     modelAuth: string | undefined;
+    modelKeyInDefinition: boolean;
     authPath: string;
     channels: ChannelKind[];
     longConnectionChannels: string[];
@@ -639,6 +648,7 @@ async function runDeployFly(
     agentPrefix,
     appName,
     modelAuth,
+    modelKeyInDefinition,
     authPath,
     channels,
     longConnectionChannels,
@@ -654,6 +664,7 @@ async function runDeployFly(
   const region = parseFlyRegion(await readFile(flyTomlPath, "utf8")) ?? "iad";
   const { secrets, missingSecrets, needsModelCredential } = assembleSecrets({
     modelAuth,
+    modelKeyInDefinition,
     authFile: (await exists(authPath)) ? await readFile(authPath) : undefined,
     channels,
     longConnectionChannels,
@@ -703,6 +714,7 @@ async function runDeployAgentcore(
     agentPrefix: string;
     name: string;
     modelAuth: string | undefined;
+    modelKeyInDefinition: boolean;
     authPath: string;
     channels: ChannelKind[];
     extraSecrets: string[];
@@ -710,9 +722,21 @@ async function runDeployAgentcore(
     needsForwarder: boolean;
   },
 ): Promise<void> {
-  const { agentDir, workspace, agentPrefix, name, modelAuth, authPath, channels, extraSecrets, selfSchedule } = params;
+  const {
+    agentDir,
+    workspace,
+    agentPrefix,
+    name,
+    modelAuth,
+    modelKeyInDefinition,
+    authPath,
+    channels,
+    extraSecrets,
+    selfSchedule,
+  } = params;
   const { secrets, missingSecrets, needsModelCredential } = assembleSecrets({
     modelAuth,
+    modelKeyInDefinition,
     authFile: (await exists(authPath)) ? await readFile(authPath) : undefined,
     channels,
     extraSecrets,
@@ -799,6 +823,7 @@ async function runDeployRailway(
   params: ResolvedPlacement & {
     name: string;
     modelAuth: string | undefined;
+    modelKeyInDefinition: boolean;
     authPath: string;
     channels: ChannelKind[];
     longConnectionChannels: string[];
@@ -813,6 +838,7 @@ async function runDeployRailway(
     workspace,
     name,
     modelAuth,
+    modelKeyInDefinition,
     authPath,
     channels,
     longConnectionChannels,
@@ -828,6 +854,7 @@ async function runDeployRailway(
 
   const { secrets, missingSecrets, needsModelCredential } = assembleSecrets({
     modelAuth,
+    modelKeyInDefinition,
     authFile: (await exists(authPath)) ? await readFile(authPath) : undefined,
     channels,
     longConnectionChannels,

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -72,7 +72,7 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   reportWorkspaceHint(workspaceHint(a));
   reportLine("config", a.configPath ?? "(none)");
   reportLine("model", `${a.modelSpec}${a.config.thinkingLevel ? ` (thinking: ${a.config.thinkingLevel})` : ""}`);
-  await reportAuth(a.modelSpec, a.authPath);
+  await reportAuth(a.agentDir, a.modelSpec, a.authPath);
   reportAgentsSkillsTools(a);
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.

--- a/src/cli/commands/fire.ts
+++ b/src/cli/commands/fire.ts
@@ -49,7 +49,7 @@ export async function runFire(name: string, dirArg: string, opts: FireOptions): 
     authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
   }).catch(failStartup);
   console.error(`[fastagent] fire: ${name} (${modelSpec})`);
-  await reportAuth(modelSpec, authPath);
+  await reportAuth(placement.agentDir, modelSpec, authPath);
   const exitCode = await runInvokeStream(
     agent.invoke({ session: scheduleSession(name) }, { text: schedule.prompt }),
     (text) => process.stdout.write(text),

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -6,9 +6,11 @@ import {
   defaultSessionsDir,
   loadConfig,
   resolveAuthPath,
+  resolveModel,
   resolveModelSpec,
   resolveSessionsDirOverride,
 } from "../../engines/pi/config.ts";
+import { createPiModelRuntime } from "../../engines/pi/models.ts";
 import { resolveStateRoot, workspaceHint } from "../../paths.ts";
 import { resolveAgentTools } from "../../engines/pi/create.ts";
 import { loadAgentDefinition } from "../../engines/pi/definition.ts";
@@ -70,6 +72,21 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   const sessionsDir = resolveSessionsDirOverride(opts.sessionsDir) ?? defaultSessionsDir(stateRoot);
   const authPath = resolveAuthPath(agentDir, opts.authPath); // flag > FASTAGENT_AUTH_PATH > default — the one owner
 
+  // RESOLVE the spec, do not just echo it: a spec is only real once its provider/model exist in the
+  // agent's own surface (built-ins + its models.json), which is exactly what a custom endpoint changes.
+  // Reporting a healthy-looking spec that `dev`/`start` then reject is the failure this pre-empts.
+  // Reported as DATA rather than thrown — a broken agent is what `info` is for — and read-only: the
+  // runtime reads models.json without creating anything (its catalog cache is written on refresh, and
+  // there is none here).
+  const modelError = modelSpec
+    ? await createPiModelRuntime({ agentDir, authPath })
+        .then((models) => {
+          resolveModel(models, modelSpec);
+          return undefined as string | undefined;
+        })
+        .catch((error: unknown) => (error as Error).message)
+    : undefined;
+
   if (opts.json) {
     console.log(
       JSON.stringify(
@@ -78,6 +95,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
           workspace,
           configPath: configPath ?? null,
           model: modelSpec ?? null,
+          modelError: modelError ?? null,
           thinkingLevel: config.thinkingLevel ?? null,
           context: definition.contextFiles.map((f) => f.path),
           persona: definition.persona !== undefined,
@@ -106,12 +124,15 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   // One padded label writer: hand-spaced labels drifted out of alignment the moment a longer one
   // (agent/workspace/selfSchedule) joined the report.
   const line = (label: string, value: string): void => console.log(`${`${label}:`.padEnd(13)} ${value}`);
+  /** A continuation under the previous line, aligned to the same column (no label, so no bare colon). */
+  const cont = (value: string): void => console.log(`${"".padEnd(13)} ${value}`);
   line("agent", agentDir);
   line("workspace", workspace);
   const hint = workspaceHint({ agentDir, workspace });
   if (hint) line("hint", hint);
   line("config", configPath ?? "(none)");
   line("model", modelSpec ?? "(not set — pass --model, set FASTAGENT_MODEL, or config.model)");
+  if (modelError) cont(`⚠ does not resolve: ${modelError}`);
   if (config.thinkingLevel) line("thinking", config.thinkingLevel);
   line("context", definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
   line("persona", definition.persona ? "persona.md" : "(none)");

--- a/src/cli/commands/invoke.ts
+++ b/src/cli/commands/invoke.ts
@@ -29,7 +29,7 @@ export async function runInvoke(message: string, dirArg: string, opts: InvokeOpt
   // BOTH directories, like dev/start: from the workspace, `placement.workspace` alone equals the dir you
   // typed, so it cannot tell you which agent actually ran.
   console.error(`[fastagent] invoke: ${placement.agentDir} (workspace ${placement.workspace}, ${modelSpec})`);
-  await reportAuth(modelSpec, authPath);
+  await reportAuth(placement.agentDir, modelSpec, authPath);
   // Fresh session per invoke (one-shot, no resume). runInvokeStream maps events→IO: reply→stdout,
   // tool/failure→stderr, exit 1 iff the turn failed (so CI can gate on it).
   const exitCode = await runInvokeStream(

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -87,7 +87,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   reportLine("workspace", workspace);
   reportWorkspaceHint(workspaceHint({ agentDir, workspace }));
   reportLine("model", `${modelSpec}${config.thinkingLevel ? ` (thinking: ${config.thinkingLevel})` : ""}`);
-  await reportAuth(modelSpec, authPath);
+  await reportAuth(agentDir, modelSpec, authPath);
   reportLine("context", definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
   if (definition.persona) reportLine("persona", "persona.md");
   reportLine("skills", definition.skills.map((s) => s.name).join(", ") || "(none)");

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -20,7 +20,13 @@ import {
   rewriteConfigModel,
 } from "../engines/pi/config.ts";
 import { LoginCancelled, type LoginIO, type LoginMethod, type LoginResult, loginFlow } from "../engines/pi/login.ts";
-import { createPiModels, probeApiKey, probeAuthSource, providerAuthStatuses } from "../engines/pi/models.ts";
+import {
+  createPiModelRuntime,
+  createPiModels,
+  probeApiKey,
+  probeAuthSource,
+  providerAuthStatuses,
+} from "../engines/pi/models.ts";
 import { formatAuthReport } from "./auth-view.ts";
 import { log } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
@@ -80,10 +86,13 @@ export function parseBind(value: string | undefined): string | undefined {
   return bindAddress(trimmed); // a name never travels past this point — see bind.ts
 }
 
-/** Report which source provides the model's credentials, surfacing a remediation hint at startup. Non-blocking. */
-export async function reportAuth(modelSpec: string, authPath: string): Promise<void> {
+/** Report which source provides the model's credentials, surfacing a remediation hint at startup. Non-blocking.
+ *  Probes through the AGENT's model surface (`agentDir` carries its models.json), so a custom endpoint is
+ *  reported like any built-in rather than as an unknown provider. */
+export async function reportAuth(agentDir: string, modelSpec: string, authPath: string): Promise<void> {
   const provider = providerOf(modelSpec);
-  const source = await probeAuthSource(createPiModels({ authPath }), modelSpec);
+  const models = await createPiModelRuntime({ agentDir, authPath }).catch(failStartup);
+  const source = await probeAuthSource(models, modelSpec);
   // Only when nothing satisfies auth do we read the store (refresh-FREE) to tell "nothing stored" from
   // "stored but unusable" — see formatAuthReport for why. store.read warns on a corrupt file itself.
   const stored =
@@ -119,7 +128,9 @@ export async function resolveFirstRunModel(
   if (!isInteractive()) return; // CI/deploy: the opener throws the actionable missing-model error
 
   const authPath = resolveAuthPath(agentDir, options.authPath);
-  const models = createPiModels({ authPath });
+  // The picker lists the AGENT's surface: built-ins plus whatever its models.json declares, so a
+  // self-hosted endpoint is pickable on first run instead of being invisible until hand-set.
+  const models = await createPiModelRuntime({ agentDir, authPath }).catch(failStartup);
   const chosen = await pickWithCredentials(models, authPath);
   if (chosen === undefined) return; // cancelled (or auth probe failed): the caller raises its clear missing-model error
   process.env.FASTAGENT_MODEL = chosen; // this process + any spawned dev worker inherits it
@@ -234,6 +245,8 @@ async function verifyApiKeyLogin(
   authPath: string,
   spec?: string,
 ): Promise<"ok" | "rejected" | "unknown"> {
+  // Built-ins only: `login` itself offers built-in providers (login.ts), and a models.json endpoint
+  // authenticates from its own `apiKey` (env/command), so there is no stored credential to verify here.
   const models = createPiModels({ authPath });
   const model = spec ? resolveModel(models, spec) : models.getProvider(provider)?.getModels()[0];
   if (!model) {

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -18,7 +18,7 @@ import { resolveAuthPath } from "../engines/pi/config.ts";
 import { type ResolvedPlacement, resolveSecretsDir, resolveStateRoot } from "../paths.ts";
 import { inspectChannels } from "../engines/pi/channel.ts";
 import { discoverScheduleFiles } from "../schedule/discover.ts";
-import { createPiModels, probeAuthSource } from "../engines/pi/models.ts";
+import { createPiModelRuntime, probeAuthSource } from "../engines/pi/models.ts";
 import { CHANNEL_KINDS, type ChannelKind } from "../scaffold/add-channel.ts";
 import { exists } from "../paths.ts";
 import { detectRuntime, readPackageJson } from "../runtime.ts";
@@ -194,9 +194,13 @@ export async function preflightDeploy(input: {
   }
 
   // Probe auth from the SAME project-level file the opener/login use — not the global default, which would
-  // miss a `fastagent login` credential and falsely report "none configured".
+  // miss a `fastagent login` credential and falsely report "none configured". Through the AGENT's model
+  // surface too (its models.json travels into the image), so a custom endpoint is not read as an unknown
+  // provider — this probe feeds the gate that decides whether `--run` may proceed.
   const authPath = resolveAuthPath(agentDir, authPathFlag);
-  const modelAuth = modelSpec ? await probeAuthSource(createPiModels({ authPath }), modelSpec) : undefined;
+  const modelAuth = modelSpec
+    ? await probeAuthSource(await createPiModelRuntime({ agentDir, authPath }), modelSpec)
+    : undefined;
 
   // Container facts (shared by every host) + the warnings that follow. The facts describe the AGENT —
   // its package.json/runtime/lockfile drive the image's install step — never the workspace's (the bake

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -18,12 +18,13 @@ import { resolveAuthPath } from "../engines/pi/config.ts";
 import { type ResolvedPlacement, resolveSecretsDir, resolveStateRoot } from "../paths.ts";
 import { inspectChannels } from "../engines/pi/channel.ts";
 import { discoverScheduleFiles } from "../schedule/discover.ts";
-import { createPiModelRuntime, probeAuthSource } from "../engines/pi/models.ts";
+import { createPiModelRuntime, modelCredentialCarry, probeAuthSource } from "../engines/pi/models.ts";
 import { CHANNEL_KINDS, type ChannelKind } from "../scaffold/add-channel.ts";
 import { exists } from "../paths.ts";
 import { detectRuntime, readPackageJson } from "../runtime.ts";
 import { fastagentVersion } from "../version.ts";
 import { type ContainerInput, isGeneratedDockerfile, isGeneratedDockerignore } from "./container.ts";
+import { isEnvKey } from "./secrets.ts";
 
 /** A stderr line the CLI prints (`[fastagent] warn: …` / `[fastagent] note: …`). Host-neutral advisories. */
 interface DeployMessage {
@@ -43,9 +44,15 @@ interface DeployFacts {
    *  has no external wake-up, so the deployment must keep one machine running: the fly plan forces
    *  `min_machines_running=1`, the railway runbook forbids App Sleeping. */
   hasTimeTriggers: boolean;
-  /** What satisfies model auth locally ({@link probeAuthSource}) — an env-var name, an OAuth/stored label,
-   *  or undefined. Drives the runbook's secret guidance and `--run`'s credential carry. */
+  /** What satisfies model auth locally — an env-var name, an OAuth/stored label, or undefined. Drives the
+   *  runbook's secret guidance and `--run`'s credential carry. For a models.json endpoint keyed from the
+   *  environment this is the VARIABLE NAME (see {@link modelCredentialCarry}), not the display label, so
+   *  the value carries like any provider key. */
   modelAuth: string | undefined;
+  /** The definition itself carries the model key (a models.json literal `apiKey`, or a `!command` run on
+   *  the host), so there is nothing for `--run` to carry AND nothing to gate: `fastagent login` cannot
+   *  serve a custom provider, so gating on it would strand a correctly configured agent. */
+  modelKeyInDefinition: boolean;
   /** The project-level auth file `--run` reads to carry the credential (probed with the same path). */
   authPath: string;
   /** Container facts shared by the plan and the generated Dockerfile — ONE source, so they can't drift. */
@@ -198,9 +205,19 @@ export async function preflightDeploy(input: {
   // surface too (its models.json travels into the image), so a custom endpoint is not read as an unknown
   // provider — this probe feeds the gate that decides whether `--run` may proceed.
   const authPath = resolveAuthPath(agentDir, authPathFlag);
-  const modelAuth = modelSpec
-    ? await probeAuthSource(await createPiModelRuntime({ agentDir, authPath }), modelSpec)
-    : undefined;
+  const models = await createPiModelRuntime({ agentDir, authPath });
+  let modelAuth = modelSpec ? await probeAuthSource(models, modelSpec) : undefined;
+  let modelKeyInDefinition = false;
+  // probeAuthSource answers "is it authenticated here", which is not the deploy question ("how does the
+  // credential REACH the host"). It reports every models.json endpoint as "configured API key" — not an
+  // env-var name — so without this the gate below sees no credential and stops the deploy with two
+  // remedies that are both wrong for such an agent: `fastagent login` cannot serve a custom provider,
+  // and the key is already in the environment.
+  if (modelSpec && !isEnvKey(modelAuth)) {
+    const carry = modelCredentialCarry(models, modelSpec);
+    if (carry.envVar) modelAuth = carry.envVar;
+    else modelKeyInDefinition = carry.inDefinition;
+  }
 
   // Container facts (shared by every host) + the warnings that follow. The facts describe the AGENT —
   // its package.json/runtime/lockfile drive the image's install step — never the workspace's (the bake
@@ -488,6 +505,7 @@ export async function preflightDeploy(input: {
     longConnectionChannels,
     hasTimeTriggers,
     modelAuth,
+    modelKeyInDefinition,
     authPath,
     container,
     port,

--- a/src/deploy/secrets.ts
+++ b/src/deploy/secrets.ts
@@ -60,6 +60,9 @@ export function deploymentSecrets(
  */
 export function assembleSecrets(input: {
   modelAuth: string | undefined;
+  /** The definition carries the model key itself (a models.json literal `apiKey` / `!command`): there is
+   *  no value to carry and no gate to raise — see {@link modelCredentialCarry}. */
+  modelKeyInDefinition?: boolean;
   authFile: Buffer | undefined;
   channels: ChannelKind[];
   longConnectionChannels?: string[];
@@ -81,6 +84,11 @@ export function assembleSecrets(input: {
     else missingSecrets.push(input.modelAuth); // an env-key name with no value — `.env` remediation fits
   } else if (input.authFile) {
     secrets.FASTAGENT_AUTH_SEED = input.authFile.toString("base64");
+  } else if (input.modelKeyInDefinition) {
+    // The definition authenticates itself (models.json literal key, or a command run on the host), so it
+    // travels in the image with everything else. Gating here would be the worst kind of wrong: both
+    // remedies we print are impossible for such an agent — `fastagent login` has no flow for a custom
+    // provider, and there is no provider env key to set.
   } else {
     needsModelCredential = true; // no env key, no auth.json — `fastagent login` remediation
   }

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -13,7 +13,7 @@
 import { spawn } from "node:child_process";
 import { relative, sep } from "node:path";
 import { watch as watchTree } from "chokidar";
-import { AGENT_CONFIG_NAMES, type ResolvedPlacement, resolveStateRoot } from "./paths.ts";
+import { AGENT_CONFIG_NAMES, AGENT_MODELS_FILE, type ResolvedPlacement, resolveStateRoot } from "./paths.ts";
 import { isUnderDir } from "./engines/pi/definition.ts";
 import { dotEnvPath } from "./env.ts";
 import { log } from "./log.ts";
@@ -22,7 +22,7 @@ import { openExternalUrl } from "./open-url.ts";
 import { type Tunnel, announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
 
 /** What the dev watcher restarts on (agent-dir-relative): the process-bound code inputs only. */
-const WATCHED_HINT = "tools/, channels/, schedules/, package.json, fastagent.config.*, .secrets/.env";
+const WATCHED_HINT = "tools/, channels/, schedules/, package.json, fastagent.config.*, models.json, .secrets/.env";
 
 /**
  * chokidar `ignored` matcher for the narrow watch scope (true = ignore), rooted at the AGENT DIR. When
@@ -48,6 +48,11 @@ export function devWatchIgnored(root: string, envFile: string): (path: string) =
     // silently stop `dev` restarting on edits to it.
     if ((AGENT_CONFIG_NAMES as readonly string[]).includes(rel)) return false;
     if (rel === "package.json") return false;
+    // models.json is read ONCE per worker (the model hub is built during assembly), so an edit needs a
+    // restart like any other code input. It is also the one input whose breakage KILLS the worker — a
+    // malformed file fails assembly — so leaving it unwatched would strand the author: the fix that
+    // repairs it would not be the edit that restarts.
+    if (rel === AGENT_MODELS_FILE) return false;
     const segments = rel.split(sep);
     if (segments[0] === "tools" || segments[0] === "channels" || segments[0] === "schedules") return false;
     // The `.env` restarts too (credentials are process-bound). Keep it AND its ancestor directories

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -28,7 +28,7 @@ import { type FastagentConfig, defaultAuthPath, resolveModel } from "./config.ts
 import { resolveSecretsDir } from "../../paths.ts";
 import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
 import { type AnyModel, DEFAULT_THINKING_LEVEL, piHarnessFactory } from "./harness.ts";
-import { createPiModels } from "./models.ts";
+import { createPiModelRuntime, createPiModels } from "./models.ts";
 import { reportFindingsIfChanged } from "./report.ts";
 import { type PiSessionStore, inMemorySessionStore } from "./sessions.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
@@ -225,6 +225,10 @@ function buildPiAgent(opts: {
   thinkingLevel?: ThinkingLevel;
   providers?: Provider[];
   authPath?: string;
+  /** A pre-built collection, used verbatim. The DIRECTORY rungs pass one so the agent's own
+   *  models.json is in scope (see createPiModelRuntime); building it is async, which is why it
+   *  happens in the caller — L1 has no directory, so it keeps the synchronous built-ins path. */
+  models?: Models;
   systemPrompt?: string | (() => string);
   tools?: MountedTool[];
   skills?: Skill[];
@@ -236,7 +240,7 @@ function buildPiAgent(opts: {
   observer?: SessionObserver;
   onAssembly?: OnAssembly;
 }): Agent {
-  const models = createPiModels({ providers: opts.providers, authPath: opts.authPath });
+  const models = opts.models ?? createPiModels({ providers: opts.providers, authPath: opts.authPath });
   const env = opts.env ?? new NodeExecutionEnv({ cwd: process.cwd() });
   // Materialized here (not defaulted inside createPiAgentFromHarness) so the exposed parts carry
   // the SAME lease instance the agent runs under — boundary mutations must contend on it.
@@ -423,13 +427,17 @@ export async function createPiAgentFromDefinition(
   // Deferred tools need their loader on every rung (idempotent — the workspace opener already applied
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());
+  // Dir-aware default: the same secrets-dir-derived file the opener uses for this dir (the opener
+  // passes an explicit authPath, so this only affects direct L2 callers).
+  const authPath = options.authPath ?? defaultAuthPath(resolveSecretsDir(dir));
   const agent = buildPiAgent({
     model: options.model,
     thinkingLevel: options.thinkingLevel,
-    providers: options.providers,
-    // Dir-aware default: the same secrets-dir-derived file the opener uses for this dir (the opener
-    // passes an explicit authPath, so this only affects direct L2 callers).
-    authPath: options.authPath ?? defaultAuthPath(resolveSecretsDir(dir)),
+    // THE directory rung's model surface: built-ins + the agent's own models.json (custom endpoints,
+    // which are definition data and travel with the artifact) + any injected Provider instance. This
+    // is what makes `dev`/`start`/`invoke` and an embedded L2 caller resolve the same specs.
+    models: await createPiModelRuntime({ agentDir: dir, authPath, providers: options.providers }),
+    authPath,
     // The directory is the agent, LIVE: re-read the definition on every invoke, so AGENTS.md/skills
     // edits (the author's, or the agent's own self-modification) take effect on the next turn with
     // no process restart — restarts are reserved for code (tools/channels/config, module cache).

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -63,6 +63,10 @@ export async function createPiModelRuntime(
     agentDir?: string;
     /** Where the dynamic model-catalog cache goes; defaults to the agent's resolved state root. */
     stateRoot?: string;
+    /** Extra providers registered on top of the built-ins and models.json (same id overrides). The
+     *  CODE-shaped sibling of models.json: embedding callers that build a `Provider` (per-request
+     *  token minting, a test fake) inject it here. */
+    providers?: Provider[];
   } = {},
 ): Promise<ModelRuntime> {
   const { agentDir } = options;
@@ -83,6 +87,7 @@ export async function createPiModelRuntime(
   // message already names both the reason and the file, so it is surfaced verbatim.
   const error = runtime.getError();
   if (error) throw new Error(error);
+  for (const provider of options.providers ?? []) runtime.registerNativeProvider(provider);
   return runtime;
 }
 

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -10,7 +10,7 @@ import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { type FastagentAuthOptions, fastagentCredentialStore } from "./auth.ts";
 import { type InteractiveLoginKind, interactiveLoginKind } from "./login.ts";
-import { resolveStateRoot } from "../../paths.ts";
+import { AGENT_MODELS_FILE, resolveStateRoot } from "../../paths.ts";
 
 /** The DEFINITION-LOCAL custom-endpoint file, in pi's own models.json schema (see pi's docs/models.md):
  *  declare a self-hosted / gateway endpoint as `{ providers: { <id>: { baseUrl, api, apiKey, models } } }`
@@ -19,8 +19,8 @@ import { resolveStateRoot } from "../../paths.ts";
  *  travels to the host. Living in the agent dir is the whole point: it is part of the definition, so it
  *  is baked into the deployed image. pi's MACHINE-GLOBAL `~/.pi/agent/models.json` stays unread — that
  *  one is builder-machine state, and reading it would make an agent work locally and lose its model on
- *  deploy. */
-const AGENT_MODELS_JSON = "models.json";
+ *  deploy. The NAME itself lives in the neutral paths.ts — `dev`'s watcher needs the same one, and a
+ *  second spelling would let the restart scope drift from what the worker loads. */
 
 export interface CreatePiModelsOptions extends FastagentAuthOptions {
   /** Credentials file path. Defaults to the global `~/.fastagent/.secrets/auth.json`; the directory opener passes
@@ -50,7 +50,7 @@ export function createPiModels(options: CreatePiModelsOptions = {}): Models {
  * The `ModelRuntime`-shaped sibling of {@link createPiModels} — the SAME hub semantics (built-in
  * providers + fastagent's credential store at `authPath`) in the type pi's session services require
  * (`createAgentSessionServices({ modelRuntime })`). Built-ins PLUS the agent's own
- * {@link AGENT_MODELS_JSON} when `agentDir` is given (a dir-less caller gets built-ins only), and no
+ * {@link AGENT_MODELS_FILE} when `agentDir` is given (a dir-less caller gets built-ins only), and no
  * availability network, so the model surface equals serving's.
  *
  * `ModelRuntime` also takes `Provider` INSTANCES via `registerNativeProvider` (pi 0.83); the
@@ -59,20 +59,24 @@ export function createPiModels(options: CreatePiModelsOptions = {}): Models {
 export async function createPiModelRuntime(
   options: FastagentAuthOptions & {
     authPath?: string;
-    /** The agent dir, whose {@link AGENT_MODELS_JSON} declares custom endpoints. Omit for built-ins only. */
+    /** The agent dir, whose {@link AGENT_MODELS_FILE} declares custom endpoints. Omit for built-ins only. */
     agentDir?: string;
     /** Where the dynamic model-catalog cache goes; defaults to the agent's resolved state root. */
     stateRoot?: string;
-    /** Extra providers registered on top of the built-ins and models.json (same id overrides). The
-     *  CODE-shaped sibling of models.json: embedding callers that build a `Provider` (per-request
-     *  token minting, a test fake) inject it here. */
+    /** Extra providers for the ids the built-ins do not cover — the CODE-shaped sibling of models.json,
+     *  for what a file cannot express (minting a token per request, a test fake).
+     *
+     *  On an id COLLISION the file wins, not this: upstream installs a native provider as the BASE and
+     *  composes the models.json entry over it. Right way round — where a deployed agent's traffic goes
+     *  is a property of the definition, not of the program that embedded it — but it does mean a same-id
+     *  file entry silently replaces the endpoint injected here. Use a distinct id to keep both. */
     providers?: Provider[];
   } = {},
 ): Promise<ModelRuntime> {
   const { agentDir } = options;
   const runtime = await ModelRuntime.create({
     credentials: fastagentCredentialStore(options.authPath, { warn: options.warn }),
-    modelsPath: agentDir ? join(agentDir, AGENT_MODELS_JSON) : null,
+    modelsPath: agentDir ? join(agentDir, AGENT_MODELS_FILE) : null,
     // MUST be set whenever modelsPath is: pi defaults this to `<dirname(modelsPath)>/models-store.json`,
     // which would write a generated cache INTO the author's agent dir — and `deploy` bakes the whole
     // tree, so it would travel into the image as stale state. Machinery belongs under the state root.

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -9,6 +9,7 @@ import { type Api, type Model, type Models, type Provider, defaultProviderAuthCo
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { type FastagentAuthOptions, fastagentCredentialStore } from "./auth.ts";
+import { providerOf } from "./config.ts";
 import { type InteractiveLoginKind, interactiveLoginKind } from "./login.ts";
 import { AGENT_MODELS_FILE, resolveStateRoot } from "../../paths.ts";
 
@@ -93,6 +94,32 @@ export async function createPiModelRuntime(
   if (error) throw new Error(error);
   for (const provider of options.providers ?? []) runtime.registerNativeProvider(provider);
   return runtime;
+}
+
+/**
+ * How a model's credential will REACH a deployed agent — the question `deploy` asks, which
+ * {@link probeAuthSource} cannot answer: it flattens every models.json endpoint to the display label
+ * "configured API key", so a self-hosted endpoint looks credential-less to the deploy gate even when
+ * its key is sitting in an env var.
+ *
+ * - `envVar`: an environment variable backs it, BY NAME — the shape `deploy` already understands, so
+ *   the value carries as a host secret with no extra declaration from the author.
+ * - `inDefinition`: the definition itself carries it (a literal `apiKey`, or a `!command` run on the
+ *   host). Nothing for `deploy` to carry — and nothing to gate on either, which is the point: the
+ *   `fastagent login` remedy is meaningless for a provider login cannot serve.
+ *
+ * Neither set = a stored credential or nothing at all; the existing auth.json / gate paths decide.
+ */
+export function modelCredentialCarry(runtime: ModelRuntime, spec: string): { envVar?: string; inDefinition: boolean } {
+  const status = runtime.getProviderAuthStatus(providerOf(spec));
+  if (!status.configured) return { inDefinition: false };
+  // An env-var name is only useful downstream if it IS one: `"${A}_${B}"` interpolation resolves from
+  // the environment but has no single name to carry, so it falls through to the definition-carried
+  // branch, where the author's `deploy.secrets` is the mechanism.
+  if (status.source === "environment" && status.label && /^[A-Z][A-Z0-9_]*$/.test(status.label)) {
+    return { envVar: status.label, inDefinition: false };
+  }
+  return { inDefinition: status.source !== "stored" };
 }
 
 /** Per-provider auth status for the first-run model picker: usable now (with the source label), not

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -4,11 +4,23 @@
  * it into the harness alongside the selected `model`; the two must come from the same collection so
  * the model's provider auth is in scope.
  */
+import { join } from "node:path";
 import { type Api, type Model, type Models, type Provider, defaultProviderAuthContext } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { type FastagentAuthOptions, fastagentCredentialStore } from "./auth.ts";
 import { type InteractiveLoginKind, interactiveLoginKind } from "./login.ts";
+import { resolveStateRoot } from "../../paths.ts";
+
+/** The DEFINITION-LOCAL custom-endpoint file, in pi's own models.json schema (see pi's docs/models.md):
+ *  declare a self-hosted / gateway endpoint as `{ providers: { <id>: { baseUrl, api, apiKey, models } } }`
+ *  and select it with a `<id>/<modelId>` model spec. Keys belong in the environment — `apiKey` supports
+ *  `"$ENV_VAR"` interpolation and `"!command"` — with the NAME listed in `deploy.secrets` so the value
+ *  travels to the host. Living in the agent dir is the whole point: it is part of the definition, so it
+ *  is baked into the deployed image. pi's MACHINE-GLOBAL `~/.pi/agent/models.json` stays unread — that
+ *  one is builder-machine state, and reading it would make an agent work locally and lose its model on
+ *  deploy. */
+const AGENT_MODELS_JSON = "models.json";
 
 export interface CreatePiModelsOptions extends FastagentAuthOptions {
   /** Credentials file path. Defaults to the global `~/.fastagent/.secrets/auth.json`; the directory opener passes
@@ -37,20 +49,41 @@ export function createPiModels(options: CreatePiModelsOptions = {}): Models {
 /**
  * The `ModelRuntime`-shaped sibling of {@link createPiModels} — the SAME hub semantics (built-in
  * providers + fastagent's credential store at `authPath`) in the type pi's session services require
- * (`createAgentSessionServices({ modelRuntime })`). Builtins only (`modelsPath: null` — pi's
- * machine-global models.json is definition-foreign) and no availability network, so the model
- * surface equals serving's. No `providers` option: `ModelRuntime` registers providers by config
- * record, not `Provider` instance — accepting the option and dropping it would be a silent no-op;
- * add the mapping when a consumer actually needs it.
+ * (`createAgentSessionServices({ modelRuntime })`). Built-ins PLUS the agent's own
+ * {@link AGENT_MODELS_JSON} when `agentDir` is given (a dir-less caller gets built-ins only), and no
+ * availability network, so the model surface equals serving's.
+ *
+ * `ModelRuntime` also takes `Provider` INSTANCES via `registerNativeProvider` (pi 0.83); the
+ * declarative file is what this rung wires because it is data that travels with the definition.
  */
-export function createPiModelRuntime(
-  options: FastagentAuthOptions & { authPath?: string } = {},
+export async function createPiModelRuntime(
+  options: FastagentAuthOptions & {
+    authPath?: string;
+    /** The agent dir, whose {@link AGENT_MODELS_JSON} declares custom endpoints. Omit for built-ins only. */
+    agentDir?: string;
+    /** Where the dynamic model-catalog cache goes; defaults to the agent's resolved state root. */
+    stateRoot?: string;
+  } = {},
 ): Promise<ModelRuntime> {
-  return ModelRuntime.create({
+  const { agentDir } = options;
+  const runtime = await ModelRuntime.create({
     credentials: fastagentCredentialStore(options.authPath, { warn: options.warn }),
-    modelsPath: null,
+    modelsPath: agentDir ? join(agentDir, AGENT_MODELS_JSON) : null,
+    // MUST be set whenever modelsPath is: pi defaults this to `<dirname(modelsPath)>/models-store.json`,
+    // which would write a generated cache INTO the author's agent dir — and `deploy` bakes the whole
+    // tree, so it would travel into the image as stale state. Machinery belongs under the state root.
+    ...(agentDir
+      ? { modelsStorePath: join(options.stateRoot ?? resolveStateRoot(agentDir), "models-store.json") }
+      : {}),
     allowModelNetwork: false,
   });
+  // A malformed models.json does NOT throw upstream — `create` resolves with the built-ins and parks the
+  // reason in getError(). Left unread, a typo'd endpoint would silently degrade to "provider not in
+  // registry" at model-resolution time, i.e. the silent fallback this codebase forbids. The upstream
+  // message already names both the reason and the file, so it is surfaced verbatim.
+  const error = runtime.getError();
+  if (error) throw new Error(error);
+  return runtime;
 }
 
 /** Per-provider auth status for the first-run model picker: usable now (with the source label), not

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -127,13 +127,15 @@ export async function buildAgentSessionRuntime(
     // on the session in createRuntime — pi's session starts all-active), and the activation bridge
     // above rides the same turn context, so the SAME search_tools works against pi's AgentSession
     // instead of fastagent's harness.
-    const { config, modelSpec, agentDir, authPath, tools, deferredToolNames, toolCollisions, toolFailures } =
+    const { config, modelSpec, agentDir, authPath, stateRoot, tools, deferredToolNames, toolCollisions, toolFailures } =
       await resolveAgentAssembly(cwd, options);
     reportToolCollisions(toolCollisions);
     reportModuleLoadFailures(toolFailures);
     // ONE hub owns model resolution AND per-request auth — the ModelRuntime-shaped sibling of
     // serving's createPiModels; see models.ts.
-    const modelRuntime = await createPiModelRuntime({ authPath });
+    // agentDir carries the agent's own models.json (custom endpoints); stateRoot keeps pi's generated
+    // catalog cache out of the definition dir. See createPiModelRuntime.
+    const modelRuntime = await createPiModelRuntime({ authPath, agentDir, stateRoot });
     // MIGRATION HINT (deliberate breaking change): chat historically used pi's own `~/.pi` auth;
     // it now reads the agent's credential file like every other command. Probe the RESOLVED
     // model's provider through the normal resolution path (stored credential OR env var — an

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -52,6 +52,13 @@ export const STATE_DIRNAME = ".state";
  *  already-an-agent refusal both read this, so "is there a config?" can't diverge between them. */
 export const AGENT_CONFIG_NAMES = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"] as const;
 
+/** The optional custom-model-endpoint file inside an agent dir (pi's models.json schema). Definition
+ *  data, not machinery: it declares WHICH endpoint the agent talks to, so it belongs beside the config
+ *  and travels into the deployed image. The name lives HERE, with the other placement facts, because
+ *  two neutral readers need it — the loader in engines/pi/models.ts and `dev`'s watcher, whose restart
+ *  scope must not silently drift from what the worker actually loads. */
+export const AGENT_MODELS_FILE = "models.json";
+
 export interface ResolvedPlacement {
   /** The AGENT directory — where the definition (persona.md/skills/tools/channels/schedules), the
    *  config, and the machinery dirs (`.secrets/`, `.state/`) live. Absolute. */

--- a/src/scaffold/templates/fastagent.config.mjs
+++ b/src/scaffold/templates/fastagent.config.mjs
@@ -5,6 +5,8 @@
 // No model is preset: `fastagent dev` shows the full model catalog (models you already have
 // credentials for come first; picking one that needs auth logs you in inline) and writes your choice
 // below. Or set it by hand to a "provider/modelId" (`fastagent models` lists them).
+// Self-hosted model (vLLM/Ollama/…) or your own gateway? Declare it in a models.json next to this
+// file and select it like any other spec — see docs/configuration.md "Custom model endpoints".
 export default {
   // model: "openai-codex/gpt-5.5",
   // thinkingLevel: "high", // reasoning effort (off|minimal|low|medium|high|xhigh|max); default "medium" (pi TUI parity)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -322,6 +322,35 @@ describe("cli papercuts", () => {
     await expect(stat(join(dir, "fastagent", ".state"))).rejects.toThrow(); // read-only: never creates the state root
   });
 
+  it("info RESOLVES the model spec against the agent's own models.json, and says so when it does not", async () => {
+    // The docs point at `info` to confirm what an agent resolved, so it must not merely echo the spec:
+    // a custom endpoint changes which specs exist, and reporting a healthy-looking one that `dev`/`start`
+    // then reject is the failure this pre-empts. Read-only and non-fatal — diagnosing a broken agent is
+    // the job, so the verdict is DATA (exit 0), not a throw.
+    const dir = await agentWorkspace("fa-info-models-", {
+      "models.json": JSON.stringify({
+        providers: {
+          mygw: {
+            baseUrl: "http://vllm.internal:8000/v1",
+            api: "openai-completions",
+            apiKey: "$FA_TEST_KEY",
+            models: [{ id: "deepseek-v3" }],
+          },
+        },
+      }),
+    });
+    const env = { ...process.env };
+    delete env.FASTAGENT_MODEL;
+
+    const ok = JSON.parse((await run(["info", dir, "--json", "--model", "mygw/deepseek-v3"], undefined, env)).stdout);
+    expect(ok.model).toBe("mygw/deepseek-v3");
+    expect(ok.modelError).toBeNull(); // declared in models.json — it resolves
+
+    const bad = await run(["info", dir, "--json", "--model", "mygw/not-declared"], undefined, env);
+    expect(bad.code).toBe(0);
+    expect(JSON.parse(bad.stdout).modelError).toMatch(/not in registry/);
+  });
+
   it("info degrades when a tool can't load (missing dep) — reports it, still shows the surface, exits 0", async () => {
     // The scaffold ships tools/ that import @fastagent-sh/fastagent; before `npm install` the import fails.
     // A broken tool file is ISOLATED (skipped + reported, not thrown) so it can't crash the load — info

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -276,6 +276,23 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
     expect(r.missingSecrets).toEqual([]);
   });
 
+  it("a definition-carried model key (models.json) satisfies the gate without carrying a secret", () => {
+    // The regression this pins: a models.json endpoint has no env-key name and no auth.json, so it fell
+    // into needsModelCredential and `--run` stopped with two impossible remedies — `fastagent login`
+    // has no flow for a custom provider, and there is no provider env key to set. The key is already
+    // inside the definition, which the image ships.
+    const r = assembleSecrets({
+      modelAuth: "configured API key",
+      modelKeyInDefinition: true,
+      authFile: undefined,
+      channels: [],
+      env: {},
+    });
+    expect(r.needsModelCredential).toBe(false);
+    expect(r.secrets).toEqual({}); // nothing to carry — and nothing invented
+    expect(r.missingSecrets).toEqual([]);
+  });
+
   it("channel secrets come from env; never minted (a re-run is stable; a human-shared secret stays known)", () => {
     const env = { OPENAI_API_KEY: "k", TELEGRAM_BOT_TOKEN: "bot", TELEGRAM_SECRET_TOKEN: "sec" };
     const r = assembleSecrets({ modelAuth: "OPENAI_API_KEY", authFile: undefined, channels: ["telegram"], env });

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -434,3 +434,37 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     expect(pre.messages.some((m) => /does not list @fastagent-sh\/fastagent/.test(m.text))).toBe(true);
   });
 });
+
+describe("preflight: how a models.json endpoint's credential reaches the host", () => {
+  const GATEWAY = (apiKey: string) =>
+    JSON.stringify({
+      providers: {
+        mygw: { baseUrl: "http://vllm.internal:8000/v1", api: "openai-completions", apiKey, models: [{ id: "m1" }] },
+      },
+    });
+
+  it("an env-keyed endpoint reports the VARIABLE NAME, so the value carries like any provider key", async () => {
+    // What made this wrong: probeAuthSource answers "is it authenticated here" ("configured API key"),
+    // not "how does the credential reach the host". Reporting the display label left `--run` seeing no
+    // credential at all, and it stopped a correctly configured agent with two impossible remedies.
+    const dir = await workspace({ "models.json": GATEWAY("$FA_PREFLIGHT_GW_KEY") });
+    process.env.FA_PREFLIGHT_GW_KEY = "sk-x";
+    try {
+      const pre = await call(dir, { model: "mygw/m1" });
+      expect(pre.ok).toBe(true);
+      if (pre.ok) {
+        expect(pre.modelAuth).toBe("FA_PREFLIGHT_GW_KEY"); // the name, not "configured API key"
+        expect(pre.modelKeyInDefinition).toBe(false);
+      }
+    } finally {
+      delete process.env.FA_PREFLIGHT_GW_KEY;
+    }
+  });
+
+  it("a key written into the file is reported as definition-carried (nothing to carry, nothing to gate)", async () => {
+    const dir = await workspace({ "models.json": GATEWAY("sk-literal-in-file") });
+    const pre = await call(dir, { model: "mygw/m1" });
+    expect(pre.ok).toBe(true);
+    if (pre.ok) expect(pre.modelKeyInDefinition).toBe(true);
+  });
+});

--- a/test/dev-supervisor.test.ts
+++ b/test/dev-supervisor.test.ts
@@ -16,6 +16,10 @@ describe("dev-supervisor: devWatchIgnored (the narrow watch scope)", () => {
     expect(ignored(join(root, "package.json"))).toBe(false);
     expect(ignored(join(root, "fastagent.config.mjs"))).toBe(false);
     expect(ignored(join(root, "fastagent.config.ts"))).toBe(false);
+    // models.json is loaded once per worker (the model hub is built during assembly) AND a malformed one
+    // fails that assembly — unwatched, the edit that repairs a dead worker would not be the edit that
+    // restarts it, so the author would be stranded with a correct file and a broken serve.
+    expect(ignored(join(root, "models.json"))).toBe(false);
   });
 
   it(".secrets/.env is a code input (credentials are process-bound); the rest of .secrets is not", () => {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -4,7 +4,13 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Api, type Model, type Models, createProvider } from "@earendil-works/pi-ai";
-import { createPiModelRuntime, probeApiKey, probeAuthSource, providerAuthStatuses } from "../src/engines/pi/models.ts";
+import {
+  createPiModelRuntime,
+  modelCredentialCarry,
+  probeApiKey,
+  probeAuthSource,
+  providerAuthStatuses,
+} from "../src/engines/pi/models.ts";
 import { resolveModel } from "../src/engines/pi/config.ts";
 import { createPiAgentFromDir } from "../src/engines/pi/open.ts";
 
@@ -139,9 +145,34 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
     // stays out of the file, which is what lets models.json be committed and baked into an image.
     process.env.FASTAGENT_TEST_GW_KEY = "sk-from-env";
     try {
-      expect(await probeAuthSource(runtime, "mygw/deepseek-v3")).toBeDefined();
+      // Assert the SHAPE, not just presence: probeAuthSource flattens every models.json endpoint to this
+      // display label, which is why `deploy` cannot branch on it (see modelCredentialCarry below).
+      expect(await probeAuthSource(runtime, "mygw/deepseek-v3")).toBe("configured API key");
+      // The deploy-facing question — how does the credential REACH the host — answers with the env-var
+      // NAME, the shape assembleSecrets already carries.
+      expect(modelCredentialCarry(runtime, "mygw/deepseek-v3")).toEqual({
+        envVar: "FASTAGENT_TEST_GW_KEY",
+        inDefinition: false,
+      });
     } finally {
       delete process.env.FASTAGENT_TEST_GW_KEY;
+    }
+  });
+
+  it("a key written into models.json (literal or command) is carried BY the definition, not by deploy", async () => {
+    // These travel inside the image with the file itself. Reported as such so the deploy gate does not
+    // demand a credential that is already there — its remedies (`fastagent login`, a provider env key)
+    // are both impossible for a custom provider.
+    for (const apiKey of ["sk-literal-in-file", "!echo sk-from-command"]) {
+      const dir = await agentWith(
+        JSON.stringify({
+          providers: {
+            mygw: { baseUrl: "http://x/v1", api: "openai-completions", apiKey, models: [{ id: "m1" }] },
+          },
+        }),
+      );
+      const runtime = await createPiModelRuntime({ agentDir: dir, authPath: join(dir, "auth.json") });
+      expect(modelCredentialCarry(runtime, "mygw/m1")).toEqual({ inDefinition: true });
     }
   });
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import type { Api, Model, Models } from "@earendil-works/pi-ai";
 import { createPiModelRuntime, probeApiKey, probeAuthSource, providerAuthStatuses } from "../src/engines/pi/models.ts";
 import { resolveModel } from "../src/engines/pi/config.ts";
+import { createPiAgentFromDir } from "../src/engines/pi/open.ts";
 
 type FakeProvider = {
   id: string;
@@ -168,5 +169,37 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
     await mkdir(stateRoot, { recursive: true });
     await createPiModelRuntime({ agentDir: dir, authPath: join(dir, "auth.json"), stateRoot });
     expect(existsSync(join(dir, "models-store.json"))).toBe(false);
+  });
+});
+
+describe("models.json on the serving path (createPiAgentFromDir)", () => {
+  it("dev/start/invoke assemble against a models.json endpoint, and leave no generated file in the agent dir", async () => {
+    // The Phase-2 claim: the SERVING opener — not just `chat` — resolves a custom endpoint. Before this,
+    // the opener ran on pi-ai's builtinModels(), which cannot see models.json, so assembly died with
+    // `unknown model "mygw/deepseek-v3"` no matter what the file said.
+    const dir = await mkdtemp(join(tmpdir(), "fastagent-serving-modelsjson-"));
+    await writeFile(join(dir, "fastagent.config.ts"), `export default { model: "mygw/deepseek-v3" };`);
+    await writeFile(
+      join(dir, "models.json"),
+      JSON.stringify({
+        providers: {
+          mygw: {
+            baseUrl: "http://vllm.internal:8000/v1",
+            api: "openai-completions",
+            apiKey: "$FASTAGENT_TEST_GW_KEY",
+            models: [{ id: "deepseek-v3" }],
+          },
+        },
+      }),
+    );
+
+    const { agent, modelSpec, stateRoot } = await createPiAgentFromDir(dir);
+    expect(agent).toBeDefined();
+    expect(modelSpec).toBe("mygw/deepseek-v3");
+
+    // The agent dir holds AUTHORED files only. L2 does not pass stateRoot explicitly, so this also pins
+    // that its default derivation keeps pi's catalog cache out of what `deploy` bakes into the image.
+    expect(existsSync(join(dir, "models-store.json"))).toBe(false);
+    expect(stateRoot.startsWith(dir)).toBe(true);
   });
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Api, Model, Models } from "@earendil-works/pi-ai";
+import { type Api, type Model, type Models, createProvider } from "@earendil-works/pi-ai";
 import { createPiModelRuntime, probeApiKey, probeAuthSource, providerAuthStatuses } from "../src/engines/pi/models.ts";
 import { resolveModel } from "../src/engines/pi/config.ts";
 import { createPiAgentFromDir } from "../src/engines/pi/open.ts";
@@ -143,6 +143,43 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
     } finally {
       delete process.env.FASTAGENT_TEST_GW_KEY;
     }
+  });
+
+  it("on an id collision the file wins over an injected Provider (models.json composes over the native base)", async () => {
+    // Upstream installs a registerNativeProvider() provider as the BASE and composes the models.json
+    // entry over it — the opposite of the built-in case, where an injected provider overrides. Pinned
+    // because the docs promise it and because it is the direction that keeps a DEPLOYED agent's traffic
+    // decided by its definition rather than by the program that embedded it.
+    const dir = await agentWith(GATEWAY); // declares "mygw" at http://vllm.internal:8000/v1
+    const injected = createProvider({
+      id: "mygw",
+      baseUrl: "https://from-injected-code/v1",
+      auth: { apiKey: { name: "k", resolve: async () => ({ auth: { apiKey: "x" }, source: "code" }) } },
+      models: [
+        {
+          id: "deepseek-v3",
+          name: "injected",
+          api: "openai-completions",
+          provider: "mygw",
+          baseUrl: "https://from-injected-code/v1",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 111,
+          maxTokens: 222,
+        },
+      ],
+      api: { stream: () => undefined, streamSimple: () => undefined } as never,
+    });
+
+    const runtime = await createPiModelRuntime({
+      agentDir: dir,
+      authPath: join(dir, "auth.json"),
+      providers: [injected],
+    });
+    const model = resolveModel(runtime, "mygw/deepseek-v3");
+    expect(model.baseUrl).toBe("http://vllm.internal:8000/v1"); // the file, not the injected code
+    expect(model.contextWindow).toBe(65536); // the file's value, not the injected 111
   });
 
   it("a malformed models.json fails visibly instead of degrading to the built-ins", async () => {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Api, Model, Models } from "@earendil-works/pi-ai";
-import { probeApiKey, providerAuthStatuses } from "../src/engines/pi/models.ts";
+import { createPiModelRuntime, probeApiKey, probeAuthSource, providerAuthStatuses } from "../src/engines/pi/models.ts";
+import { resolveModel } from "../src/engines/pi/config.ts";
 
 type FakeProvider = {
   id: string;
@@ -92,5 +97,76 @@ describe("probeApiKey (the post-login quick-fail check)", () => {
       message: "forbidden",
     });
     expect(await probeApiKey(stub("throw"), model)).toEqual({ state: "unknown", message: "store unreadable" });
+  });
+});
+
+describe("models.json: definition-local custom endpoints (createPiModelRuntime)", () => {
+  /** An agent dir with `models.json` — the file that declares a self-hosted / gateway endpoint. */
+  async function agentWith(modelsJson: string | undefined): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "fastagent-modelsjson-"));
+    await writeFile(join(dir, "fastagent.config.ts"), "export default {};");
+    if (modelsJson !== undefined) await writeFile(join(dir, "models.json"), modelsJson);
+    return dir;
+  }
+
+  const GATEWAY = JSON.stringify({
+    providers: {
+      mygw: {
+        baseUrl: "http://vllm.internal:8000/v1",
+        api: "openai-completions",
+        apiKey: "$FASTAGENT_TEST_GW_KEY",
+        models: [{ id: "deepseek-v3", contextWindow: 65536 }],
+      },
+    },
+  });
+
+  it("a declared endpoint becomes a resolvable model, and its key comes from the environment", async () => {
+    const dir = await agentWith(GATEWAY);
+    const runtime = await createPiModelRuntime({ agentDir: dir, authPath: join(dir, "auth.json") });
+
+    // The point of the feature: `<id>/<modelId>` resolves, carrying the AUTHOR's endpoint — not a
+    // built-in's. contextWindow is the declared one; maxTokens is pi's documented default (16384),
+    // which is what makes "endpoint + key + model name" a complete config.
+    const model = resolveModel(runtime, "mygw/deepseek-v3");
+    expect(model.baseUrl).toBe("http://vllm.internal:8000/v1");
+    expect(model.contextWindow).toBe(65536);
+    expect(model.maxTokens).toBe(16384);
+    // Built-ins are kept alongside, so a custom endpoint is additive, never a replacement.
+    expect(runtime.getProvider("anthropic")).toBeDefined();
+
+    // `apiKey: "$ENV"` must interpolate on the SERVING path too (pi documents it for the TUI): the key
+    // stays out of the file, which is what lets models.json be committed and baked into an image.
+    process.env.FASTAGENT_TEST_GW_KEY = "sk-from-env";
+    try {
+      expect(await probeAuthSource(runtime, "mygw/deepseek-v3")).toBeDefined();
+    } finally {
+      delete process.env.FASTAGENT_TEST_GW_KEY;
+    }
+  });
+
+  it("a malformed models.json fails visibly instead of degrading to the built-ins", async () => {
+    // Upstream `ModelRuntime.create` RESOLVES on a parse error and parks the reason in getError(),
+    // so an unread error would surface later as a bare "unknown model" — the silent fallback this
+    // codebase forbids. The throw must name the file so the typo is findable.
+    const dir = await agentWith("{ not json");
+    await expect(createPiModelRuntime({ agentDir: dir, authPath: join(dir, "auth.json") })).rejects.toThrow(
+      /models\.json/,
+    );
+  });
+
+  it("no models.json is the normal case: built-ins load, nothing throws", async () => {
+    const dir = await agentWith(undefined);
+    const runtime = await createPiModelRuntime({ agentDir: dir, authPath: join(dir, "auth.json") });
+    expect(runtime.getProvider("anthropic")).toBeDefined();
+  });
+
+  it("pi's generated catalog cache lands in the state root, never in the agent dir", async () => {
+    // pi defaults modelsStorePath to `<dirname(modelsPath)>/models-store.json` — i.e. inside the agent
+    // dir, which `deploy` bakes wholesale into the image. The definition dir holds authored files only.
+    const dir = await agentWith(GATEWAY);
+    const stateRoot = join(dir, ".state");
+    await mkdir(stateRoot, { recursive: true });
+    await createPiModelRuntime({ agentDir: dir, authPath: join(dir, "auth.json"), stateRoot });
+    expect(existsSync(join(dir, "models-store.json"))).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Point an agent at a self-hosted model or your own gateway by declaring the endpoint in a
`models.json` next to `fastagent.config.*`:

```json
{
  "providers": {
    "mygw": {
      "baseUrl": "https://llm-proxy.internal/v1",
      "api": "openai-completions",
      "apiKey": "$MYGW_API_KEY",
      "models": [{ "id": "deepseek-v4-pro" }]
    }
  }
}
```

```ts
export default defineConfig({ model: "mygw/deepseek-v4-pro", deploy: { secrets: ["MYGW_API_KEY"] } });
```

Works on every path: `dev`, `start`, `invoke`, `chat`, `deploy`'s pre-flight, and L2 embedding.
Custom endpoints are additive — built-in providers stay available. Giving an existing provider a new
`baseUrl` retargets it through a proxy while keeping its models, pricing and compat metadata.

## Why this shape

**The capability is pi's, not new.** The schema is pi's own `models.json` (`docs/models.md`),
unchanged — so the full field reference, every `compat` flag and per-model override transfer, and the
docs point there instead of duplicating it.

**What was actually rejected was the file's LOCATION, not its format.** `createPiModelRuntime` pinned
`modelsPath: null` because pi's file lives at `~/.pi/agent/models.json` — builder-machine state that
`deploy` does not bake, so an endpoint defined there would work locally and vanish on deploy. A
`models.json` inside the agent dir is definition data: it travels with the artifact. The
machine-global file stays unread, with no fallback — a fallback is exactly the "works here, breaks
there" failure the original decision was protecting against.

`docs/configuration.md` listed custom model providers under "deliberately not config" alongside
custom session stores and distributed leases. That grouping was wrong: those are *code*, an endpoint
is *data*. Declarative endpoints now live in `models.json`; `providers` (embedding) remains the
injection point for a provider that needs code, e.g. minting a token per request.

## Two upstream behaviors this must not pass through

| Behavior | Why it cannot be transparent |
|---|---|
| `modelsStorePath` defaults to `<dirname(modelsPath)>/models-store.json` | With the file in the agent dir, pi's generated catalog cache lands in the author's definition dir — and `deploy` bakes that tree into the image. Pinned to the state root. |
| A malformed `models.json` does not throw | `ModelRuntime.create` resolves with the built-ins and parks the reason in `getError()`. Unread, a typo resurfaces later as a bare `unknown model`. Surfaced as a throw, which matches `preflight`'s documented "throws on a real fault" contract. |

## Structure

`createPiModels` (pi-ai `builtinModels`) and `createPiModelRuntime` (`ModelRuntime`) were two model
hubs, and only the second can see `models.json`. The directory rungs now assemble against
`ModelRuntime`, which `implements Models`, so this removes a duplicate hub rather than adding an
abstraction.

`models.json` is a DIRECTORY concept, so the split follows placement: L1 `createPiAgent` — assembly
from typed parts, no directory to read — keeps the synchronous built-ins path and its public
signature; L2 `createPiAgentFromDefinition`, already async, builds the runtime and hands it down.
Verified before switching: `ModelRuntime`'s built-in provider set is identical to `builtinModels()`
(38 each, no difference either way), so no model spec changes meaning, and its default auth context
is the same function fastagent passed explicitly.

Two callers stay on the built-ins by design: `fastagent models` answers "what does FastAgent
support", not "what does this agent use" (`fastagent info` answers that), and login verification only
checks stored credentials, which a `models.json` endpoint does not use.

## Verification

`npm run lint && npm run typecheck && npm test` green (1337 tests).

Four assumptions about upstream were probed before implementing, not inferred from types: loading
from a non-default `modelsPath`, `$ENV_VAR` interpolation outside the TUI, the `modelsStorePath`
default, and built-in provider set equality. The serving-path test was checked to fail without the
change (`unknown model "mygw/deepseek-v3"`).

Also run end to end against a real OpenAI-compatible gateway: single turn, a tool-calling turn, and
`start` + `/invoke` SSE — including `thinking` deltas, which is the only way to confirm a `compat`
flag is right.

## Not included

- `fastagent models` is not directory-aware (documented).
- `fastagent login` does not offer custom providers — such an endpoint authenticates from its own
  `apiKey` (`$ENV` / `!command`), so there is no credential to store.
- No dedicated tests for the `deploy` pre-flight and `reportAuth` dir-awareness; both are pass-the-
  runtime changes covered by the end-to-end run.
