### PR TITLE
docs(agents): the PR is the design asset, and the language rule needs no exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,4 +184,4 @@ Full version: `CONTRIBUTING.md`. The essentials:
 
 The reader is a senior engineer with full project context. Lead with the conclusion, use tables for structured comparisons, skip obvious reasoning, do not restate, and do not add decorative formatting or meta-narration. Density check: if cutting half the text loses no information, cut it.
 
-优先使用中文回答；面向仓库的产物（代码、注释、文档、commit/PR）一律英文。
+Direct chat with the user may be in Chinese. Everything that lands in or on the repository is English — code, comments, documentation, commit messages, PR titles and bodies, code reviews and review replies, issue discussion, and release notes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Full version: `CONTRIBUTING.md`. The essentials:
    npm run lint && npm run typecheck && npm test
    ```
 2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`.
-3. **Squash merge only** (repo settings enforce it): one PR = one commit on `main`; curate the PR title/body — they become the commit message. `main` enforces linear history; force-push is forbidden.
+3. **Squash merge only** (repo settings enforce it): one PR = one commit on `main`; curate the PR title/body — they become the commit message. Branch commits are working state, the PR is the design asset: put the durable *why* there, not in per-commit narration. `main` enforces linear history; force-push is forbidden.
 4. **Review policy.** Merging is an explicit maintainer decision — agents never merge. Green CI makes a PR eligible; report "ready to merge" and stop. External-contributor PRs are reviewed and merged by a maintainer.
 5. **After merge:**
    ```bash
@@ -184,4 +184,4 @@ Full version: `CONTRIBUTING.md`. The essentials:
 
 The reader is a senior engineer with full project context. Lead with the conclusion, use tables for structured comparisons, skip obvious reasoning, do not restate, and do not add decorative formatting or meta-narration. Density check: if cutting half the text loses no information, cut it.
 
-Direct chat with the user may be in Chinese. Everything that lands in or on the repository is English — code, comments, documentation, commit messages, PR titles and bodies, code reviews and review replies, issue discussion, and release notes.
+Everything that lands in or on the repository is English — code, comments, documentation, commit messages, PR titles and bodies, code reviews and review replies, issue discussion, and release notes.


### PR DESCRIPTION
Two edits to `AGENTS.md`, both in the section an agent reads before it touches the repository.

## The language rule

`优先使用中文回答；面向仓库的产物（代码、注释、文档、commit/PR）一律英文。` becomes:

> Everything that lands in or on the repository is English — code, comments, documentation, commit messages, PR titles and bodies, code reviews and review replies, issue discussion, and release notes.

Two things change. The rule was written in the language it was making an exception for, and its list stopped at "commit/PR" — leaving review comments, review replies, issue discussion and release notes unclaimed, which is exactly where non-English text kept appearing. The enumeration is now explicit.

The clause about chat language is dropped rather than translated: what language a conversation happens in is not a property of this repository, so it has no place in a rule about what lands in it. This file governs the artifacts; how an agent and its user talk is between them.

## The squash rule gains its consequence

Item 3 stated the mechanism — *curate the PR title/body, they become the commit message* — without what follows from it:

> Branch commits are working state, the PR is the design asset: put the durable *why* there, not in per-commit narration.

`CONTRIBUTING.md` has said this all along; `AGENTS.md` is what an agent actually reads, and the gap has a cost on record. #330 landed with five branch commits each written as a permanent account of itself — what an earlier revision attempted, what a later pass sharpened — and the repository's squash setting was `COMMIT_MESSAGES` at the time, so all of it is now in `main`'s history, including a description of a design that was reverted before merge. (The setting has since been corrected to `PR_BODY`; this makes the guidance and the machinery agree.)
