### PR TITLE
chore(deps): hold @earendil-works/pi-* until the serving path leaves AgentHarness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,19 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    ignore:
+      # pi 0.84 promoted the unfinished lane-based AgentHarness to pi-agent-core's default export
+      # and removed the working one: prompt/compact/abort/events.on all throw HarnessNotImplemented.
+      # The serving path (src/engines/pi/invoke.ts) runs on that class, so it cannot move yet.
+      #
+      # The condition is OURS, not upstream's. pi does not consume AgentHarness itself - its TUI,
+      # RPC and SDK all run on AgentSession - so waiting for someone else to finish it is waiting
+      # on work with no owner. The serving path moves to AgentSession instead (invoke-session.ts is
+      # the proof it holds the SPEC); drop this entry when the harness L0 is gone, not when an
+      # upstream release implements it. Hence the open-ended range: every version from 0.84 on
+      # breaks the same class, and 0.85 will not be different.
+      - dependency-name: "@earendil-works/pi-*"
+        versions: [">=0.84"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
`pi` 0.84 promoted the unfinished lane-based `AgentHarness` to pi-agent-core's default export and removed the working one:

```
prompt -> HarnessNotImplemented: AgentHarness.prompt is not implemented yet
events.on -> AgentHarness.events.on is not implemented yet
```

`prompt()`, `compact()`, `abort()`, `navigateTree()`, `resume()` and `events.on()` all reject; `create()` throws for any session that already holds a record. There is no other entrypoint — 0.84's `exports` map is `.`, `./node`, `./session/testing`. The serving path (`src/engines/pi/invoke.ts`) runs on that class, so the ~40 type errors the grouped bump produced are not a migration cost: the API is gone with a skeleton behind it.

**The release condition is ours, not upstream's.** pi does not consume `AgentHarness` itself — its TUI, RPC and SDK all run on `AgentSession` — so waiting for someone else to finish it is waiting on work with no owner. The serving path moves to `AgentSession` instead; #338 is the executable proof that the SPEC's Agent-side MUSTs hold there, in the `per-invoke` posture that keeps portability.

So this entry goes when the harness L0 goes, not when an upstream release implements the harness.

`>=0.84` rather than `0.84.x` for the same reason: every version from 0.84 on breaks the same class, so pinning to one minor would just reopen the same red PR at 0.85.

Config-only change; no source touched.