### PR TITLE
feat(pi): prove the SPEC MUSTs on pi's own AgentSession class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,14 @@ src/
 │   └── state.ts            # atomic schedule state under <stateRoot>/schedule/ (fires.json + wakeups.json)
 └── engines/pi/              # the pi reference implementation
     ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
-    ├── invoke.ts            # L0 + the request-time turn mechanism (lease, translate, queue)
+    ├── turn-kit.ts          # the engine-NEUTRAL half of the turn mechanism, shared by every pi L0:
+    │                         # lease (single-writer floor), terminals (settled message/thrown error →
+    │                         # SPEC terminal + retryable), EventQueue (push→pull), prompt image prep
+    ├── invoke.ts            # the harness L0: AgentHarness's two ports → one stream, plus what only it
+    │                         # has — its event vocabulary translated ONCE into the rich SessionEvent
+    │                         # layer, and the observation plane that layer feeds
+    ├── invoke-session.ts    # the AgentSession L0 (per-invoke): SPEC-conformance proof that pi's own
+    │                         # session class serves a turn. Not wired into serving — see its header
     ├── session-control.ts   # the pi session-control hub: observation projections + dispatch (run modulation, boundary mutations, abortable compaction)
     ├── session-builder.ts   # definition-aware session builder: agent assembly → resident pi AgentSessionRuntime (chat TUI consumes it)
     ├── open.ts              # shared opener: directory → agent for dev/start/invoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,8 @@ src/
 │   └── state.ts            # atomic schedule state under <stateRoot>/schedule/ (fires.json + wakeups.json)
 └── engines/pi/              # the pi reference implementation
     ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
-    ├── turn-kit.ts          # the engine-NEUTRAL half of the turn mechanism, shared by every pi L0:
+    ├── turn-kit.ts          # the turn mechanism's pi-CLASS-neutral half, shared by every pi L0 (it
+    │                         # speaks pi's types, so NOT engine-neutral in this repo's sense):
     │                         # lease (single-writer floor), terminals (settled message/thrown error →
     │                         # SPEC terminal + retryable), EventQueue (push→pull), prompt image prep
     ├── invoke.ts            # the harness L0: AgentHarness's two ports → one stream, plus what only it

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -227,8 +227,8 @@ never resident process state as the source of continuity.
 ## 4. Event translation and terminal discipline
 
 Pi exposes a promise for the final assistant message and a subscription side channel for streaming
-events. `src/engines/pi/invoke.ts` combines them into one async iterable (over the engine-neutral
-lease/terminal/queue parts in `turn-kit.ts`):
+events. `src/engines/pi/invoke.ts` combines them into one async iterable (over the lease/terminal/
+queue parts shared by both pi L0s in `turn-kit.ts`):
 
 1. acquire the per-session lease;
 2. open/create the session and harness;

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -227,7 +227,8 @@ never resident process state as the source of continuity.
 ## 4. Event translation and terminal discipline
 
 Pi exposes a promise for the final assistant message and a subscription side channel for streaming
-events. `src/engines/pi/invoke.ts` combines them into one async iterable:
+events. `src/engines/pi/invoke.ts` combines them into one async iterable (over the engine-neutral
+lease/terminal/queue parts in `turn-kit.ts`):
 
 1. acquire the per-session lease;
 2. open/create the session and harness;

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -349,7 +349,7 @@ deliberately excludes editor replacement, themes, widgets, and all other TUI pre
 ## 9. Concurrency and residency
 
 - **Single writer, run-scoped.** All writers — channel invoke, scheduler fire, desktop invoke —
-  take the same `Lease` (the existing injectable port in `engines/pi/invoke.ts`) for the run's
+  take the same `Lease` (the existing injectable port in `engines/pi/turn-kit.ts`) for the run's
   activity window. A scheduler firing into a session mid-run gets `session_busy` and defers, the
   same mechanism and behavior as today.
 - **Boundary mutations take the lease.** `compact`, `set_model`, `set_thinking` and `navigate` are the

--- a/src/collect.ts
+++ b/src/collect.ts
@@ -1,8 +1,13 @@
 /**
- * Caller-side stream helpers: `collect` (buffered consumption, SPEC §7) reduces an AgentEvent
- * stream to a final value, encoding the terminal discipline (failed → throw, missing terminal →
- * error) — streaming consumers for-await themselves. `abortFirstIterator` is the shared
- * cancellation protocol for generator-backed streams.
+ * Stream helpers around the SPEC's two stream disciplines.
+ *
+ * Caller side: `collect` (buffered consumption, SPEC §7) reduces an AgentEvent stream to a final
+ * value, encoding the terminal discipline (failed → throw, missing terminal → error) — streaming
+ * consumers for-await themselves.
+ *
+ * Agent side: the cancellation protocol (SPEC MUST 3), in two halves that only work together —
+ * `abortFirstIterator` delivers the consumer's knock, `cancellableStream` is what an engine wraps
+ * its turn in to receive it.
  */
 import type { AgentEvent, Json } from "./agent.ts";
 
@@ -29,6 +34,38 @@ export function abortFirstIterator<T>(gen: AsyncGenerator<T>, cancel: () => void
       throw error;
     },
   };
+}
+
+/** What a turn generator gets so a consumer walking away can stop it. */
+export interface CancelHooks {
+  /** Publish the door: how to abort the engine work, once there is engine work to abort. */
+  onCancelReady: (cancel: () => void) => void;
+  /** The latch, for the window where the door is armed but the engine is still idle — knocking then
+   *  does nothing, so a turn must read this before committing to work no one is waiting for. */
+  wasCancelled: () => boolean;
+}
+
+/**
+ * Wrap a turn generator in the cancellation protocol: cancelling the returned stream latches the
+ * intent AND knocks on whatever door the generator published, in that order (the latch must be set
+ * before the knock, or a turn checking it mid-flight could miss the cancel it just received).
+ */
+export function cancellableStream<T>(start: (hooks: CancelHooks) => AsyncGenerator<T>): AsyncIterable<T> {
+  let door: (() => void) | undefined;
+  let cancelled = false;
+  const iterator = abortFirstIterator(
+    start({
+      onCancelReady: (cancel) => {
+        door = cancel;
+      },
+      wasCancelled: () => cancelled,
+    }),
+    () => {
+      cancelled = true;
+      door?.();
+    },
+  );
+  return { [Symbol.asyncIterator]: () => iterator };
 }
 
 /** Exception form of a failed event (thrown by collect). Carries the failed event's fields verbatim, so

--- a/src/collect.ts
+++ b/src/collect.ts
@@ -19,18 +19,32 @@ import type { AgentEvent, Json } from "./agent.ts";
  * settles the suspension), then delegates to `gen.return`, swallowing its rejection (the
  * generator's own catch/finally already surfaced the outcome). `throw()` tears down identically
  * and rethrows the caller's error deterministically instead of poking a completed generator.
+ *
+ * Cancellation also SILENCES the stream, and that belongs here rather than in each producer: a
+ * generator parked in an await can still reach a `yield` on its way out (an error path that
+ * yields a terminal, say), and that yield satisfies the pending `next()` — handing a terminal
+ * event to a consumer that already walked away, which SPEC MUST 3 forbids. Deciding it once, at
+ * the protocol boundary, is what keeps every producer from having to re-ask "is anyone still
+ * listening?" before each yield.
  */
 export function abortFirstIterator<T>(gen: AsyncGenerator<T>, cancel: () => void): AsyncIterator<T> {
+  let cancelled = false;
+  const teardown = async () => {
+    cancelled = true;
+    cancel();
+    await gen.return(undefined as never).catch(() => {});
+  };
   return {
-    next: () => gen.next(),
-    async return(value?: unknown) {
-      cancel();
-      await gen.return(value as never).catch(() => {});
+    async next() {
+      const result = await gen.next();
+      return cancelled ? { done: true as const, value: undefined } : result;
+    },
+    async return() {
+      await teardown();
       return { done: true as const, value: undefined };
     },
     async throw(error?: unknown): Promise<IteratorResult<T>> {
-      cancel();
-      await gen.return(undefined as never).catch(() => {});
+      await teardown();
       throw error;
     },
   };

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -41,7 +41,8 @@ import {
   type MountedTool,
 } from "./tool.ts";
 import { withSearchTool } from "./search-tools.ts";
-import { type Lease, type SessionObserver, createPiAgentFromHarness, inProcessLease } from "./invoke.ts";
+import { type SessionObserver, createPiAgentFromHarness } from "./invoke.ts";
+import { type Lease, inProcessLease } from "./turn-kit.ts";
 
 // ── §1 tools ─────────────────────────────────────────────────────────────────
 //

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -10,10 +10,14 @@
  *
  * SCOPE, deliberately narrow: the concurrency floor, the event stream, and cancellation. The
  * observation plane (SessionObserver / RunControls / the rich `SessionEvent` vocabulary), the tool
- * activation bridge and auto-compaction are NOT wired — this translates pi events straight to SPEC
- * `AgentEvent`s, which is the second parallel translation design §6 forbids. That is the price of a
- * throwaway proof; the harness L0 remains the one true path until this one grows the observation
- * plane and replaces it.
+ * activation bridge, auto-compaction and session inheritance are NOT wired.
+ *
+ * WHICH L0 SERVES: {@link createPiAgentFromHarness}, still — this one is reachable only from its
+ * conformance test (deliberately absent from `src/pi.ts`), because a serving path needs the pieces
+ * above. Its one known debt is {@link toAgentEvent}: translating pi events straight to SPEC
+ * `AgentEvent`s is the second parallel translation `docs/design/session-control.md` §6 forbids. It
+ * retires the moment this L0 grows the observation plane — the rich `SessionEvent` layer comes back
+ * with it, and the harness L0 goes away.
  */
 import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
@@ -71,7 +75,16 @@ function terminalFromState(session: AgentSession): AgentEvent {
     const message = messages[i];
     if (message?.role === "assistant") return toTerminal(message as AssistantMessage);
   }
-  return { type: "failed", details: "the turn produced no assistant message", retryable: false };
+  // Unreachable on a settled run: pi records an assistant message for every outcome, error and abort
+  // included. Reaching it means the engine broke its own contract — say so with what the state held,
+  // so the report names the engine rather than the turn.
+  return {
+    type: "failed",
+    details:
+      `the engine settled the run without an assistant message ` +
+      `(${messages.length} message(s), last role: ${messages.at(-1)?.role ?? "none"})`,
+    retryable: false,
+  };
 }
 
 export function createPiAgentFromSession(options: CreatePiAgentFromSessionOptions): Agent {

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -42,9 +42,11 @@ export interface CreatePiAgentFromSessionOptions {
 function toAgentEvent(event: AgentSessionEvent): AgentEvent | null {
   switch (event.type) {
     case "message_update": {
+      // An empty delta is not output: it moves no consumer's state, and treating it as output would
+      // spend the silent window that auto-retry is allowed to use (see runOnSession).
       const ev = event.assistantMessageEvent;
-      if (ev.type === "text_delta") return { type: "text", delta: ev.delta };
-      if (ev.type === "thinking_delta") return { type: "thinking", delta: ev.delta };
+      if (ev.type === "text_delta") return ev.delta === "" ? null : { type: "text", delta: ev.delta };
+      if (ev.type === "thinking_delta") return ev.delta === "" ? null : { type: "thinking", delta: ev.delta };
       return null;
     }
     case "tool_execution_start":
@@ -66,27 +68,22 @@ function toAgentEvent(event: AgentSessionEvent): AgentEvent | null {
 
 /**
  * The turn's outcome. `prompt()` resolves void and never throws for an engine-side failure (measured:
- * a provider error and an abort both resolve normally), so the terminal comes from the last assistant
- * message's `stopReason` — the same read {@link toTerminal} performs on the harness path.
+ * a provider error and an abort both resolve normally), so the terminal comes from the assistant
+ * message the run ended on — the same read {@link toTerminal} performs on the harness path.
  *
- * Bounded to THIS turn (`from` = the message count before `prompt()`): the session is durable and
- * carries every previous turn, so an unbounded reverse scan would answer a run that produced nothing
- * with the PREVIOUS turn's assistant message — reporting `completed` for a turn that never ran.
+ * That message is taken from the EVENT STREAM, not from `session.state.messages`. Session state is
+ * mutable mid-turn: compaction replaces the array, and overflow recovery splices the last assistant
+ * message out of it outright (`state.messages = messages.slice(0, -1)`). Any index into it is a
+ * turn boundary that the engine is free to invalidate, while a `message_end` payload is a fact that
+ * already happened. Auto-compaction runs its own model call outside the agent's event stream, so it
+ * cannot masquerade as the turn's answer here.
  */
-function turnTerminal(session: AgentSession, from: number): AgentEvent {
-  const messages = session.state.messages;
-  for (let i = messages.length - 1; i >= from; i--) {
-    const message = messages[i];
-    if (message?.role === "assistant") return toTerminal(message as AssistantMessage);
-  }
-  // Unreachable on a settled run: pi records an assistant message for every outcome, error and abort
-  // included. Reaching it means the engine broke its own contract — say so with what the state held,
-  // so the report names the engine rather than the turn.
+function engineProducedNothing(): AgentEvent {
+  // Unreachable on a settled run: pi ends every outcome, error and abort included, with an assistant
+  // message. Reaching it means the engine broke its own contract — name the engine, not the turn.
   return {
     type: "failed",
-    details:
-      `the engine settled the run without an assistant message ` +
-      `(${messages.length - from} message(s) this turn, last role: ${messages.at(-1)?.role ?? "none"})`,
+    details: "the engine settled the run without ending an assistant message",
     retryable: false,
   };
 }
@@ -140,9 +137,32 @@ async function* runOnSession(
   const abort = () => session.abort().catch(() => {});
   onCancelReady(() => void abort());
   const queue = new EventQueue<AgentEvent>();
+  let finalAssistant: AssistantMessage | undefined;
+  let emittedOutput = false;
+  /** Set when a retry is refused because output already left — carries the error that ends the turn. */
+  let retriedAfterOutput: string | undefined;
   const unsub = session.subscribe((event) => {
+    if (retriedAfterOutput !== undefined) return; // the turn is decided; the retry's output is not ours
+    if (event.type === "message_end" && event.message.role === "assistant") {
+      finalAssistant = event.message as AssistantMessage;
+    }
+    // pi retries a failed assistant request by discarding the attempt and running another one. That
+    // is free resilience while the turn is still silent, and corruption once it is not: SPEC deltas
+    // are append-only and `retrying` cannot retract them, so the second attempt's answer would
+    // arrive concatenated onto the failed one's half-sentence. Take the resilience in the silent
+    // window; end the turn honestly outside it.
+    if (event.type === "auto_retry_start" && emittedOutput) {
+      retriedAfterOutput = event.errorMessage;
+      // Not synchronously: pi emits this event BEFORE creating the controller that makes its backoff
+      // abortable, so an abort from inside the listener would find nothing to cancel and the turn
+      // would still pay the full delay and burn a provider call on an answer we must discard.
+      queueMicrotask(() => void abort());
+      return;
+    }
     const projected = toAgentEvent(event);
-    if (projected) queue.push(projected);
+    if (!projected) return;
+    if (projected.type !== "retrying") emittedOutput = true;
+    queue.push(projected);
   });
   try {
     // Resolving prompt options lazy-loads the image pipeline and re-encodes every attachment, so it
@@ -162,12 +182,15 @@ async function* runOnSession(
       await abort();
       return;
     }
-    const before = session.state.messages.length;
     const run = session.prompt(prompt.text, options);
     yield* queue.drainUntil(run);
     try {
       await run;
-      yield turnTerminal(session, before);
+      yield retriedAfterOutput !== undefined
+        ? { type: "failed", details: retriedAfterOutput, retryable: true }
+        : finalAssistant
+          ? toTerminal(finalAssistant)
+          : engineProducedNothing();
     } catch (error) {
       yield errorToTerminal(error);
     }

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -78,15 +78,13 @@ function toAgentEvent(event: AgentSessionEvent): AgentEvent | null {
  * already happened. Auto-compaction runs its own model call outside the agent's event stream, so it
  * cannot masquerade as the turn's answer here.
  */
-function engineProducedNothing(): AgentEvent {
+const ENGINE_PRODUCED_NOTHING: AgentEvent = {
   // Unreachable on a settled run: pi ends every outcome, error and abort included, with an assistant
   // message. Reaching it means the engine broke its own contract — name the engine, not the turn.
-  return {
-    type: "failed",
-    details: "the engine settled the run without ending an assistant message",
-    retryable: false,
-  };
-}
+  type: "failed",
+  details: "the engine settled the run without ending an assistant message",
+  retryable: false,
+};
 
 export function createPiAgentFromSession(options: CreatePiAgentFromSessionOptions): Agent {
   const { sessionFactory, lease = inProcessLease() } = options;
@@ -138,21 +136,23 @@ async function* runOnSession(
   onCancelReady(() => void abort());
   const queue = new EventQueue<AgentEvent>();
   let finalAssistant: AssistantMessage | undefined;
-  let emittedOutput = false;
-  /** Set when a retry is refused because output already left — carries the error that ends the turn. */
-  let retriedAfterOutput: string | undefined;
+  /** Whether any of THIS attempt's answer has been streamed — the only output a retry would duplicate. */
+  let streamedAnswer = false;
+  /** Set when a retry is refused because the answer already streamed — carries the error that ends it. */
+  let retriedAfterAnswer: string | undefined;
   const unsub = session.subscribe((event) => {
-    if (retriedAfterOutput !== undefined) return; // the turn is decided; the retry's output is not ours
+    if (retriedAfterAnswer !== undefined) return; // the turn is decided; the retry's output is not ours
     if (event.type === "message_end" && event.message.role === "assistant") {
       finalAssistant = event.message as AssistantMessage;
     }
-    // pi retries a failed assistant request by discarding the attempt and running another one. That
-    // is free resilience while the turn is still silent, and corruption once it is not: SPEC deltas
-    // are append-only and `retrying` cannot retract them, so the second attempt's answer would
-    // arrive concatenated onto the failed one's half-sentence. Take the resilience in the silent
-    // window; end the turn honestly outside it.
-    if (event.type === "auto_retry_start" && emittedOutput) {
-      retriedAfterOutput = event.errorMessage;
+    // pi retries a failed assistant request by DISCARDING that attempt's assistant message and asking
+    // again. Everything the turn achieved before it survives - executed tools keep their persisted
+    // results, and the retry resumes from them - so the only thing a retry can duplicate is answer
+    // text this L0 already streamed, which SPEC deltas cannot retract. Refuse it exactly there:
+    // refusing on tool events instead would push the retry out to the CALLER, who can only re-run the
+    // whole prompt and execute the tool a second time.
+    if (event.type === "auto_retry_start" && streamedAnswer) {
+      retriedAfterAnswer = event.errorMessage;
       // Not synchronously: pi emits this event BEFORE creating the controller that makes its backoff
       // abortable, so an abort from inside the listener would find nothing to cancel and the turn
       // would still pay the full delay and burn a provider call on an answer we must discard.
@@ -161,7 +161,7 @@ async function* runOnSession(
     }
     const projected = toAgentEvent(event);
     if (!projected) return;
-    if (projected.type !== "retrying") emittedOutput = true;
+    if (projected.type === "text" || projected.type === "thinking") streamedAnswer = true;
     queue.push(projected);
   });
   try {
@@ -186,11 +186,11 @@ async function* runOnSession(
     yield* queue.drainUntil(run);
     try {
       await run;
-      yield retriedAfterOutput !== undefined
-        ? { type: "failed", details: retriedAfterOutput, retryable: true }
-        : finalAssistant
-          ? toTerminal(finalAssistant)
-          : engineProducedNothing();
+      if (retriedAfterAnswer !== undefined) {
+        yield { type: "failed", details: retriedAfterAnswer, retryable: true };
+      } else {
+        yield finalAssistant ? toTerminal(finalAssistant) : ENGINE_PRODUCED_NOTHING;
+      }
     } catch (error) {
       yield errorToTerminal(error);
     }

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -68,10 +68,14 @@ function toAgentEvent(event: AgentSessionEvent): AgentEvent | null {
  * The turn's outcome. `prompt()` resolves void and never throws for an engine-side failure (measured:
  * a provider error and an abort both resolve normally), so the terminal comes from the last assistant
  * message's `stopReason` — the same read {@link toTerminal} performs on the harness path.
+ *
+ * Bounded to THIS turn (`from` = the message count before `prompt()`): the session is durable and
+ * carries every previous turn, so an unbounded reverse scan would answer a run that produced nothing
+ * with the PREVIOUS turn's assistant message — reporting `completed` for a turn that never ran.
  */
-function terminalFromState(session: AgentSession): AgentEvent {
+function terminalFromState(session: AgentSession, from: number): AgentEvent {
   const messages = session.state.messages;
-  for (let i = messages.length - 1; i >= 0; i--) {
+  for (let i = messages.length - 1; i >= from; i--) {
     const message = messages[i];
     if (message?.role === "assistant") return toTerminal(message as AssistantMessage);
   }
@@ -82,7 +86,7 @@ function terminalFromState(session: AgentSession): AgentEvent {
     type: "failed",
     details:
       `the engine settled the run without an assistant message ` +
-      `(${messages.length} message(s), last role: ${messages.at(-1)?.role ?? "none"})`,
+      `(${messages.length - from} message(s) this turn, last role: ${messages.at(-1)?.role ?? "none"})`,
     retryable: false,
   };
 }
@@ -150,12 +154,13 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
           if (projected) queue.push(projected);
         });
         try {
+          const before = session.state.messages.length;
           const run = session.prompt(prompt.text, await toPiPromptOptions(prompt));
           yield* queue.drainUntil(run);
           let terminal: AgentEvent;
           try {
             await run;
-            terminal = terminalFromState(session);
+            terminal = terminalFromState(session, before);
           } catch (error) {
             terminal = errorToTerminal(error);
           }

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -154,7 +154,17 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
           // only stops a RUNNING session, so a consumer who walks away while the session is being
           // built or its images resized would knock on an idle one and then have the turn start
           // anyway. One gate, placed after the last await before the call, covers both windows.
-          const options = await toPiPromptOptions(prompt);
+          //
+          // Its own failure is a turn failure, not an iteration failure (MUST 2): resolving options
+          // lazy-loads the image pipeline and re-encodes every attachment, so it can throw before any
+          // engine work exists to fail.
+          let options: Awaited<ReturnType<typeof toPiPromptOptions>>;
+          try {
+            options = await toPiPromptOptions(prompt);
+          } catch (error) {
+            yield errorToTerminal(error);
+            return;
+          }
           if (wasCancelled()) {
             await session.abort().catch(() => {});
             return;

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -144,18 +144,23 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         onCancelReady(() => {
           void session.abort().catch(() => {});
         });
-        if (wasCancelled()) {
-          await session.abort().catch(() => {});
-          return;
-        }
         const queue = new EventQueue<AgentEvent>();
         const unsub = session.subscribe((event) => {
           const projected = toAgentEvent(event);
           if (projected) queue.push(projected);
         });
         try {
+          // Everything the model call needs, resolved BEFORE the latch is read: the door armed above
+          // only stops a RUNNING session, so a consumer who walks away while the session is being
+          // built or its images resized would knock on an idle one and then have the turn start
+          // anyway. One gate, placed after the last await before the call, covers both windows.
+          const options = await toPiPromptOptions(prompt);
+          if (wasCancelled()) {
+            await session.abort().catch(() => {});
+            return;
+          }
           const before = session.state.messages.length;
-          const run = session.prompt(prompt.text, await toPiPromptOptions(prompt));
+          const run = session.prompt(prompt.text, options);
           yield* queue.drainUntil(run);
           let terminal: AgentEvent;
           try {

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -22,9 +22,9 @@
 import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { SESSION_BUSY_CODE, type Agent, type AgentEvent, type Json, type Prompt, type Scope } from "../../agent.ts";
-import { abortFirstIterator } from "../../collect.ts";
+import { type CancelHooks, cancellableStream } from "../../collect.ts";
 import { log } from "../../log.ts";
-import { EventQueue, type Lease, errorToTerminal, inProcessLease, toPiPromptOptions, toTerminal } from "./invoke.ts";
+import { EventQueue, type Lease, errorToTerminal, inProcessLease, toPiPromptOptions, toTerminal } from "./turn-kit.ts";
 
 /** Open-or-create the session behind `sessionId` and bind an `AgentSession` to it, per invoke. */
 export type PiAgentSessionFactory = (sessionId: string) => Promise<AgentSession>;
@@ -73,7 +73,7 @@ function toAgentEvent(event: AgentSessionEvent): AgentEvent | null {
  * carries every previous turn, so an unbounded reverse scan would answer a run that produced nothing
  * with the PREVIOUS turn's assistant message — reporting `completed` for a turn that never ran.
  */
-function terminalFromState(session: AgentSession, from: number): AgentEvent {
+function turnTerminal(session: AgentSession, from: number): AgentEvent {
   const messages = session.state.messages;
   for (let i = messages.length - 1; i >= from; i--) {
     const message = messages[i];
@@ -94,34 +94,8 @@ function terminalFromState(session: AgentSession, from: number): AgentEvent {
 export function createPiAgentFromSession(options: CreatePiAgentFromSessionOptions): Agent {
   const { sessionFactory, lease = inProcessLease() } = options;
 
-  function invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
-    // The cancellation door (SPEC MUST 3), armed once the session exists; the latch covers a consumer
-    // that walks away while the session is still being built. Same protocol as the harness L0.
-    let externalCancel: (() => void) | undefined;
-    let cancelled = false;
-    const iterator = abortFirstIterator(
-      turn(
-        scope,
-        prompt,
-        (cancel) => {
-          externalCancel = cancel;
-        },
-        () => cancelled,
-      ),
-      () => {
-        cancelled = true;
-        externalCancel?.();
-      },
-    );
-    return { [Symbol.asyncIterator]: () => iterator };
-  }
-
-  async function* turn(
-    scope: Scope,
-    prompt: Prompt,
-    onCancelReady: (cancel: () => void) => void,
-    wasCancelled: () => boolean,
-  ): AsyncGenerator<AgentEvent> {
+  /** Own the session's lifetime: one writer, built here, disposed here whatever the turn did. */
+  async function* turn(scope: Scope, prompt: Prompt, hooks: CancelHooks): AsyncGenerator<AgentEvent> {
     const release = lease.tryAcquire(scope.session);
     if (!release) {
       yield {
@@ -141,48 +115,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         return;
       }
       try {
-        onCancelReady(() => {
-          void session.abort().catch(() => {});
-        });
-        const queue = new EventQueue<AgentEvent>();
-        const unsub = session.subscribe((event) => {
-          const projected = toAgentEvent(event);
-          if (projected) queue.push(projected);
-        });
-        try {
-          // Everything the model call needs, resolved BEFORE the latch is read: the door armed above
-          // only stops a RUNNING session, so a consumer who walks away while the session is being
-          // built or its images resized would knock on an idle one and then have the turn start
-          // anyway. One gate, placed after the last await before the call, covers both windows.
-          //
-          // Its own failure is a turn failure, not an iteration failure (MUST 2): resolving options
-          // lazy-loads the image pipeline and re-encodes every attachment, so it can throw before any
-          // engine work exists to fail.
-          let options: Awaited<ReturnType<typeof toPiPromptOptions>>;
-          try {
-            options = await toPiPromptOptions(prompt);
-          } catch (error) {
-            yield errorToTerminal(error);
-            return;
-          }
-          if (wasCancelled()) {
-            await session.abort().catch(() => {});
-            return;
-          }
-          const before = session.state.messages.length;
-          const run = session.prompt(prompt.text, options);
-          yield* queue.drainUntil(run);
-          let terminal: AgentEvent;
-          try {
-            await run;
-            terminal = terminalFromState(session, before);
-          } catch (error) {
-            terminal = errorToTerminal(error);
-          }
-          yield terminal;
-        } finally {
-          unsub();
-        }
+        yield* runOnSession(session, prompt, hooks);
       } finally {
         try {
           session.dispose();
@@ -195,5 +128,50 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
     }
   }
 
-  return { invoke };
+  return { invoke: (scope, prompt) => cancellableStream((hooks) => turn(scope, prompt, hooks)) };
+}
+
+/** One turn on a session someone else owns: subscribe, prompt, stream, terminal. */
+async function* runOnSession(
+  session: AgentSession,
+  prompt: Prompt,
+  { onCancelReady, wasCancelled }: CancelHooks,
+): AsyncGenerator<AgentEvent> {
+  const abort = () => session.abort().catch(() => {});
+  onCancelReady(() => void abort());
+  const queue = new EventQueue<AgentEvent>();
+  const unsub = session.subscribe((event) => {
+    const projected = toAgentEvent(event);
+    if (projected) queue.push(projected);
+  });
+  try {
+    // Resolving prompt options lazy-loads the image pipeline and re-encodes every attachment, so it
+    // both takes time and can throw before any engine work exists to fail. Hence the two guards, in
+    // this order and no earlier: its failure is a turn failure (MUST 2), and the latch has to be read
+    // after the LAST await before the call — the door armed above only stops a RUNNING session, so a
+    // consumer who walked away during the build or the resize would knock on an idle one and have
+    // the turn start anyway.
+    let options: Awaited<ReturnType<typeof toPiPromptOptions>>;
+    try {
+      options = await toPiPromptOptions(prompt);
+    } catch (error) {
+      yield errorToTerminal(error);
+      return;
+    }
+    if (wasCancelled()) {
+      await abort();
+      return;
+    }
+    const before = session.state.messages.length;
+    const run = session.prompt(prompt.text, options);
+    yield* queue.drainUntil(run);
+    try {
+      await run;
+      yield turnTerminal(session, before);
+    } catch (error) {
+      yield errorToTerminal(error);
+    }
+  } finally {
+    unsub();
+  }
 }

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -1,0 +1,166 @@
+/**
+ * L0 over pi-coding-agent's `AgentSession`, in the `per-invoke` state locality
+ * ([conformance-levels.md](../../../docs/design/conformance-levels.md) §2, top-right cell): build a
+ * session per invoke over the SAME durable jsonl, run one turn, dispose.
+ *
+ * Why this exists next to {@link createPiAgentFromHarness}: pi 0.84 replaced `AgentHarness` with an
+ * unimplemented lane-based skeleton, and pi does not consume that class itself — its TUI, RPC and SDK
+ * all run on `AgentSession`. This is the executable proof that the SPEC's four Agent-side MUSTs hold
+ * on the class pi actually maintains (test/conformance-session.test.ts).
+ *
+ * SCOPE, deliberately narrow: the concurrency floor, the event stream, and cancellation. The
+ * observation plane (SessionObserver / RunControls / the rich `SessionEvent` vocabulary), the tool
+ * activation bridge and auto-compaction are NOT wired — this translates pi events straight to SPEC
+ * `AgentEvent`s, which is the second parallel translation design §6 forbids. That is the price of a
+ * throwaway proof; the harness L0 remains the one true path until this one grows the observation
+ * plane and replaces it.
+ */
+import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { SESSION_BUSY_CODE, type Agent, type AgentEvent, type Json, type Prompt, type Scope } from "../../agent.ts";
+import { abortFirstIterator } from "../../collect.ts";
+import { log } from "../../log.ts";
+import { EventQueue, type Lease, errorToTerminal, inProcessLease, toPiPromptOptions, toTerminal } from "./invoke.ts";
+
+/** Open-or-create the session behind `sessionId` and bind an `AgentSession` to it, per invoke. */
+export type PiAgentSessionFactory = (sessionId: string) => Promise<AgentSession>;
+
+export interface CreatePiAgentFromSessionOptions {
+  sessionFactory: PiAgentSessionFactory;
+  /** Single-writer lease. Defaults to the in-process per-session fail-fast lease. */
+  lease?: Lease;
+}
+
+/**
+ * SPEC events from pi's session stream. `auto_retry_start` has no harness counterpart: an
+ * `AgentSession` retries a failed assistant request itself, which the SPEC already has a word for.
+ */
+function toAgentEvent(event: AgentSessionEvent): AgentEvent | null {
+  switch (event.type) {
+    case "message_update": {
+      const ev = event.assistantMessageEvent;
+      if (ev.type === "text_delta") return { type: "text", delta: ev.delta };
+      if (ev.type === "thinking_delta") return { type: "thinking", delta: ev.delta };
+      return null;
+    }
+    case "tool_execution_start":
+      return { type: "tool_started", id: event.toolCallId, name: event.toolName, args: event.args as Json };
+    case "tool_execution_end":
+      return { type: "tool_ended", id: event.toolCallId, isError: event.isError, content: event.result as Json };
+    case "auto_retry_start":
+      return {
+        type: "retrying",
+        attempt: event.attempt,
+        maxAttempts: event.maxAttempts,
+        delayMs: event.delayMs,
+        reason: event.errorMessage,
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * The turn's outcome. `prompt()` resolves void and never throws for an engine-side failure (measured:
+ * a provider error and an abort both resolve normally), so the terminal comes from the last assistant
+ * message's `stopReason` — the same read {@link toTerminal} performs on the harness path.
+ */
+function terminalFromState(session: AgentSession): AgentEvent {
+  const messages = session.state.messages;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role === "assistant") return toTerminal(message as AssistantMessage);
+  }
+  return { type: "failed", details: "the turn produced no assistant message", retryable: false };
+}
+
+export function createPiAgentFromSession(options: CreatePiAgentFromSessionOptions): Agent {
+  const { sessionFactory, lease = inProcessLease() } = options;
+
+  function invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
+    // The cancellation door (SPEC MUST 3), armed once the session exists; the latch covers a consumer
+    // that walks away while the session is still being built. Same protocol as the harness L0.
+    let externalCancel: (() => void) | undefined;
+    let cancelled = false;
+    const iterator = abortFirstIterator(
+      turn(
+        scope,
+        prompt,
+        (cancel) => {
+          externalCancel = cancel;
+        },
+        () => cancelled,
+      ),
+      () => {
+        cancelled = true;
+        externalCancel?.();
+      },
+    );
+    return { [Symbol.asyncIterator]: () => iterator };
+  }
+
+  async function* turn(
+    scope: Scope,
+    prompt: Prompt,
+    onCancelReady: (cancel: () => void) => void,
+    wasCancelled: () => boolean,
+  ): AsyncGenerator<AgentEvent> {
+    const release = lease.tryAcquire(scope.session);
+    if (!release) {
+      yield {
+        type: "failed",
+        details: "session busy: a turn is already in flight for this session",
+        retryable: true,
+        code: SESSION_BUSY_CODE,
+      };
+      return;
+    }
+    try {
+      let session: AgentSession;
+      try {
+        session = await sessionFactory(scope.session);
+      } catch (error) {
+        yield errorToTerminal(error); // setup failures are events, never throws (MUST 2)
+        return;
+      }
+      try {
+        onCancelReady(() => {
+          void session.abort().catch(() => {});
+        });
+        if (wasCancelled()) {
+          await session.abort().catch(() => {});
+          return;
+        }
+        const queue = new EventQueue<AgentEvent>();
+        const unsub = session.subscribe((event) => {
+          const projected = toAgentEvent(event);
+          if (projected) queue.push(projected);
+        });
+        try {
+          const run = session.prompt(prompt.text, await toPiPromptOptions(prompt));
+          yield* queue.drainUntil(run);
+          let terminal: AgentEvent;
+          try {
+            await run;
+            terminal = terminalFromState(session);
+          } catch (error) {
+            terminal = errorToTerminal(error);
+          }
+          yield terminal;
+        } finally {
+          unsub();
+        }
+      } finally {
+        try {
+          session.dispose();
+        } catch (error) {
+          log.warn(`[fastagent] session dispose failed during cleanup: ${String(error)}`);
+        }
+      }
+    } finally {
+      release();
+    }
+  }
+
+  return { invoke };
+}

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -1,11 +1,10 @@
 /**
- * The turn mechanism (request-time): fan pi AgentHarness's two ports (subscribe event side-channel
- * + prompt final value) into SPEC's single event stream, under a single-writer-per-session lease.
+ * The harness L0: fan pi AgentHarness's two ports (subscribe event side-channel + prompt final
+ * value) into SPEC's single event stream, under a single-writer-per-session lease.
  *
- *   §1 Lease       — single-writer concurrency floor (injectable port + in-process default)
- *   §2 translate   — the single pi↔SPEC translation point (both directions)
- *   §3 EventQueue  — push→pull plumbing for pi's two-port shape
- *   §4 createPiAgentFromHarness — composes §1–§3 into Agent.invoke
+ * The engine-neutral half of that mechanism — lease, terminals, event queue, prompt prep — is
+ * turn-kit.ts. What lives here is what only the harness has: its event vocabulary, translated ONCE
+ * into the rich `SessionEvent` layer, and the observation plane that layer feeds.
  *
  * Concurrency: at most one in-flight turn per session; a second invoke fails fast with
  * `failed{retryable}` ("session busy"), leaving dedupe/queueing/steering to the channel. Each
@@ -13,7 +12,7 @@
  */
 import type { AgentHarnessEvent } from "@earendil-works/pi-agent-core";
 import { DEFAULT_COMPACTION_SETTINGS, calculateContextTokens, shouldCompact } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import {
   ABORTED_CODE,
   type Agent,
@@ -23,43 +22,14 @@ import {
   type Scope,
   SESSION_BUSY_CODE,
 } from "../../agent.ts";
-import { abortFirstIterator } from "../../collect.ts";
+import { type CancelHooks, cancellableStream } from "../../collect.ts";
 import type { RetryScheduledEvent, RunSettledEvent, SessionEvent } from "../../session.ts";
 import { log } from "../../log.ts";
 import { TOOL_ACTIVATION_ENTRY, harnessSession, type PiHarnessFactory } from "./harness.ts";
+import { EventQueue, type Lease, errorToTerminal, inProcessLease, toPiPromptOptions, toTerminal } from "./turn-kit.ts";
 import { type ReadonlySessionManager, type ToolActivation, additiveActivation, turnContext } from "./tool-context.ts";
 
-// ── §1 Lease: single-writer concurrency floor ───────────────────────────────
-//
-// Corruption-prevention floor only: it does not pick a UX. Fail-fast over queueing because real
-// same-session concurrency is mostly duplicate intent or a user firing follow-ups, not two real
-// turns; a queue would also leak a slot when a waiter is cancelled. Synchronous (no awaits) so
-// nothing interleaves between acquire and entering try — cancellation always releases in finally.
-
-export type Release = () => void;
-
-export interface Lease {
-  /** Try to acquire exclusive write access for the session (fail-fast). Returns null if held. */
-  tryAcquire(session: string): Release | null;
-}
-
-export function inProcessLease(): Lease {
-  const busy = new Set<string>();
-  return {
-    tryAcquire(session: string): Release | null {
-      if (busy.has(session)) return null;
-      busy.add(session);
-      let released = false;
-      return () => {
-        if (released) return;
-        released = true;
-        busy.delete(session);
-      };
-    },
-  };
-}
-
-// ── §2 translate: the single pi↔SPEC translation point ───────────────────────
+// ── Event translation: the single pi↔SPEC translation point ─────────────────
 //
 // `retryable` = worth re-sending with the same session (SPEC §6: advisory, not a session-atomicity
 // guarantee). Classify from the STRUCTURED signal first, prose only as the last-resort ceiling. What
@@ -75,67 +45,6 @@ export function inProcessLease(): Lease {
 // already exhausted the cleanly-retryable cases. The regex is the narrow ceiling, not the classifier.
 // Upstream ask: a first-class `retryable`/`kind` on pi's terminal error would retire the prose path
 // entirely (mirrors the §11 "the deeper fix is upstream in pi" pattern).
-
-/** Clearly-transient network error codes (Node/undici), decisive on their own. */
-const RETRYABLE_CODES = new Set([
-  "ECONNRESET",
-  "ETIMEDOUT",
-  "ENETUNREACH",
-  "ENETDOWN",
-  "EAI_AGAIN",
-  "EPIPE",
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_SOCKET",
-]);
-
-/** 429 (rate limit) and 5xx (server) are worth retrying; other statuses are decisive NON-retryable. */
-const statusIsRetryable = (status: number): boolean => status === 429 || (status >= 500 && status < 600);
-
-/** Last-resort prose match, used only when no structured status/code is available. */
-const RETRYABLE_MESSAGE =
-  /\b(429|5\d\d|timeout|timed out|rate.?limit|overloaded|ECONNRESET|ETIMEDOUT|ENETUNREACH|EAI_AGAIN|socket hang up)\b/i;
-
-/** A structured status/code decision, or `null` when the signal is absent/undecisive → fall to prose. */
-function retryableFromSignal(signal: { status?: number; code?: unknown }): boolean | null {
-  if (typeof signal.status === "number") return statusIsRetryable(signal.status);
-  const { code } = signal;
-  if (typeof code === "number") return statusIsRetryable(code);
-  if (typeof code === "string") {
-    if (RETRYABLE_CODES.has(code)) return true;
-    if (/^\d{3}$/.test(code)) return statusIsRetryable(Number(code)); // a status carried as a string
-  }
-  return null; // no code, or an unknown one — not decisive on its own
-}
-
-/** Classify `retryable`: structured status/code first, message prose only as the last-resort ceiling. */
-export function classifyRetryable(details: string, signal: { status?: number; code?: unknown }): boolean {
-  return retryableFromSignal(signal) ?? RETRYABLE_MESSAGE.test(details);
-}
-
-/** Pull a structured status/code off a thrown error (HTTP status or a network code, incl. its cause). */
-function errorSignal(error: unknown): { status?: number; code?: unknown } {
-  if (!error || typeof error !== "object") return {};
-  const e = error as { status?: unknown; statusCode?: unknown; code?: unknown; cause?: unknown };
-  const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
-  const causeCode = e.cause && typeof e.cause === "object" ? (e.cause as { code?: unknown }).code : undefined;
-  return { status, code: e.code ?? causeCode };
-}
-
-/**
- * Pull the structured error `code` pi records on a failed message's diagnostics. `diagnostics`
- * accumulates across attempts (`appendAssistantMessageDiagnostic`), so the terminal cause is the LAST
- * code-bearing entry — `findLast`, not `find`: an earlier attempt's transient 503 must not classify a
- * terminal 400/auth failure as retryable. (Reverse scan rather than `findLast` — the tsconfig lib is
- * ES2022.)
- */
-function messageSignal(message: AssistantMessage): { status?: number; code?: unknown } {
-  const diagnostics = message.diagnostics ?? [];
-  for (let i = diagnostics.length - 1; i >= 0; i--) {
-    const code = diagnostics[i]?.error?.code;
-    if (code !== undefined) return { code };
-  }
-  return {};
-}
 
 /**
  * In-stream event mapping — pi events are translated ONCE into the rich `SessionEvent` vocabulary;
@@ -266,30 +175,6 @@ export interface RunControls {
  *  untrusted taps here; give third parties the read-only `events()` stream instead. */
 export type SessionObserver = (session: string, event: SessionEvent, run?: RunControls) => void;
 
-/**
- * Terminal mapping, decided by the resolved message's stopReason: pi's prompt() resolves a message
- * with stopReason "error"/"aborted" rather than throwing, so relying on catch alone would miss this
- * entire failure class (violating SPEC MUST 1).
- */
-export function toTerminal(message: AssistantMessage): AgentEvent {
-  if (message.stopReason === "aborted") {
-    // A deliberate stop (control-plane abort / harness abort), not an error — see {@link ABORTED_CODE}
-    // for the consumer contract (design §6).
-    const details = message.errorMessage ?? "run aborted";
-    return { type: "failed", details, retryable: false, code: ABORTED_CODE };
-  }
-  if (message.stopReason === "error") {
-    const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
-    return { type: "failed", details, retryable: classifyRetryable(details, messageSignal(message)) };
-  }
-  return { type: "completed" };
-}
-
-export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "failed" }> {
-  const details = error instanceof Error ? error.message : String(error);
-  return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
-}
-
 type PiHarness = Awaited<ReturnType<PiHarnessFactory>>;
 
 /** Bind the concrete pi-agent-core Session behind FastAgent's tool-runtime manager port. */
@@ -360,77 +245,7 @@ async function maybeCompact(harness: PiHarness, message: AssistantMessage): Prom
   }
 }
 
-/**
- * Map prompt images to pi ImageContent, resizing each to model-friendly dimensions/size with pi's
- * Photon resizer (reused from pi-coding-agent, lazy-imported so the common no-image headless path never
- * loads the TUI module graph). A null resize (unresizable / Photon unavailable) keeps the original
- * bytes — the provider then applies its own limit.
- */
-// Exported for the AgentSession L0 (invoke-session.ts), which drives the same pi prompt surface.
-export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
-  if (!prompt.images || prompt.images.length === 0) return undefined;
-  const { resizeImage } = await import("@earendil-works/pi-coding-agent");
-  const images = await Promise.all(
-    prompt.images.map(async (img): Promise<ImageContent> => {
-      const resized = await resizeImage(Buffer.from(img.data, "base64"), img.mimeType, {
-        maxWidth: 1568,
-        maxHeight: 1568,
-        maxBytes: 5 * 1024 * 1024,
-      }).catch(() => null);
-      return resized
-        ? { type: "image", data: resized.data, mimeType: resized.mimeType }
-        : { type: "image", data: img.data, mimeType: img.mimeType };
-    }),
-  );
-  return { images };
-}
-
-// ── §3 EventQueue: push→pull plumbing for pi's two-port shape ────────────────
-//
-// Single-consumer async queue; single-threaded JS means no await interleaves between push and
-// drain, so no locking. Engines that are natively async-iterable would not need it.
-
-// Exported for the AgentSession L0 (invoke-session.ts): the same push→pull shape, same engine port.
-export class EventQueue<T> {
-  private buffer: T[] = [];
-  private wake?: () => void;
-
-  push(item: T): void {
-    this.buffer.push(item);
-    const wake = this.wake;
-    this.wake = undefined;
-    wake?.();
-  }
-
-  /**
-   * Yield pushed events in order until `done` settles AND the buffer is drained. The terminal is
-   * produced separately (toTerminal); rejections of `done` are swallowed here (the caller awaits
-   * `run` itself) to avoid unhandled rejections.
-   */
-  async *drainUntil(done: Promise<unknown>): AsyncGenerator<T> {
-    let settled = false;
-    const onSettle = () => {
-      settled = true;
-      const wake = this.wake;
-      this.wake = undefined;
-      wake?.();
-    };
-    const finished = done.then(onSettle, onSettle);
-
-    while (true) {
-      while (this.buffer.length > 0) {
-        yield this.buffer.shift() as T;
-      }
-      if (settled) break;
-      await new Promise<void>((resolve) => {
-        this.wake = resolve;
-      });
-    }
-    await finished;
-  }
-}
-
-// ── §4 createPiAgentFromHarness ──────────────────────────────────────────────
+// ── createPiAgentFromHarness ────────────────────────────────────────────────
 
 export interface CreatePiAgentFromHarnessOptions {
   harnessFactory: PiHarnessFactory;
@@ -447,44 +262,18 @@ export interface CreatePiAgentFromHarnessOptions {
 export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOptions): Agent {
   const { harnessFactory, lease = inProcessLease(), observer } = options;
 
-  function invoke(scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> {
-    // The cancellation DOOR (SPEC MUST 3), via the shared abort-first protocol (see
-    // abortFirstIterator): cancel aborts the engine work, which settles the run and releases a
-    // generator suspended on a quiet stream (a tool mid-execution). The local for-await pattern
-    // never hit the underlying deadlock (it breaks at a yield boundary); pull-driven consumers
-    // (the SSE handler's eager reads) do.
-    // The cancel intent is LATCHED: a consumer may cancel while the generator is still inside
-    // the harness build (the door not yet armed) — abortFirstIterator knocks exactly once, and a
-    // knock before prompt() starts would be a no-op on an idle harness (the LATER run would
-    // ignore it). So turn consults the latch right after arming and, when the consumer already
-    // walked away, never starts the model call at all.
-    let externalCancel: (() => void) | undefined;
-    let cancelled = false;
-    const gen = turn(
-      scope,
-      prompt,
-      (cancel) => {
-        externalCancel = cancel;
-      },
-      () => cancelled,
-    );
-    const iterator = abortFirstIterator(gen, () => {
-      cancelled = true;
-      externalCancel?.();
-    });
-    return {
-      [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
-        return iterator;
-      },
-    };
-  }
+  // The cancellation protocol (SPEC MUST 3) lives in cancellableStream. Both halves matter here:
+  // the DOOR settles a generator suspended on a quiet stream (a tool mid-execution) — the local
+  // for-await pattern never hit that deadlock, but pull-driven consumers (the SSE handler's eager
+  // reads) do — and the LATCH covers the window where the harness is still being built, where a
+  // knock would land on an idle harness and the LATER run would ignore it.
+  const invoke = (scope: Scope, prompt: Prompt): AsyncIterable<AgentEvent> =>
+    cancellableStream((hooks) => turn(scope, prompt, hooks));
 
   async function* turn(
     scope: Scope,
     prompt: Prompt,
-    onCancelReady: (cancel: () => void) => void,
-    /** The consumer's cancel latch (see invoke's wrapper) — checked once at arming. */
-    wasCancelled: () => boolean,
+    { onCancelReady, wasCancelled }: CancelHooks,
   ): AsyncGenerator<AgentEvent> {
     const release = lease.tryAcquire(scope.session);
     if (!release) {

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -2,8 +2,8 @@
  * The harness L0: fan pi AgentHarness's two ports (subscribe event side-channel + prompt final
  * value) into SPEC's single event stream, under a single-writer-per-session lease.
  *
- * The engine-neutral half of that mechanism — lease, terminals, event queue, prompt prep — is
- * turn-kit.ts. What lives here is what only the harness has: its event vocabulary, translated ONCE
+ * The half that does not care which pi class runs the turn — lease, terminals, event queue, prompt
+ * prep — is turn-kit.ts. What lives here is what only the harness has: its event vocabulary, translated ONCE
  * into the rich `SessionEvent` layer, and the observation plane that layer feeds.
  *
  * Concurrency: at most one in-flight turn per session; a second invoke fails fast with

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -366,7 +366,7 @@ async function maybeCompact(harness: PiHarness, message: AssistantMessage): Prom
  * loads the TUI module graph). A null resize (unresizable / Photon unavailable) keeps the original
  * bytes — the provider then applies its own limit.
  */
-async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
+export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
   if (!prompt.images || prompt.images.length === 0) return undefined;
   const { resizeImage } = await import("@earendil-works/pi-coding-agent");
   const images = await Promise.all(
@@ -389,7 +389,7 @@ async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageConten
 // Single-consumer async queue; single-threaded JS means no await interleaves between push and
 // drain, so no locking. Engines that are natively async-iterable would not need it.
 
-class EventQueue<T> {
+export class EventQueue<T> {
   private buffer: T[] = [];
   private wake?: () => void;
 

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -366,6 +366,7 @@ async function maybeCompact(harness: PiHarness, message: AssistantMessage): Prom
  * loads the TUI module graph). A null resize (unresizable / Photon unavailable) keeps the original
  * bytes — the provider then applies its own limit.
  */
+// Exported for the AgentSession L0 (invoke-session.ts), which drives the same pi prompt surface.
 export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
   if (!prompt.images || prompt.images.length === 0) return undefined;
   const { resizeImage } = await import("@earendil-works/pi-coding-agent");
@@ -389,6 +390,7 @@ export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: Imag
 // Single-consumer async queue; single-threaded JS means no await interleaves between push and
 // drain, so no locking. Engines that are natively async-iterable would not need it.
 
+// Exported for the AgentSession L0 (invoke-session.ts): the same push→pull shape, same engine port.
 export class EventQueue<T> {
   private buffer: T[] = [];
   private wake?: () => void;

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -36,7 +36,8 @@ import {
   UNSUPPORTED_CAPABILITY_CODE,
 } from "../../session.ts";
 import { listModels } from "./config.ts";
-import type { Lease, RunControls, SessionObserver } from "./invoke.ts";
+import type { RunControls, SessionObserver } from "./invoke.ts";
+import type { Lease } from "./turn-kit.ts";
 import { type AnyModel, SUMMARIZATION_RETRY_POLICY, type PiHarnessFactory, harnessSession } from "./harness.ts";
 import { THINKING_LEVELS, resolveSessionSettings } from "./session-settings.ts";
 import { log } from "../../log.ts";

--- a/src/engines/pi/turn-kit.ts
+++ b/src/engines/pi/turn-kit.ts
@@ -1,14 +1,16 @@
 /**
- * The engine-facing half of the turn mechanism, shared by every pi L0.
+ * The turn mechanism's pi-CLASS-neutral half, shared by every pi L0. Not "engine-neutral" in this
+ * repo's sense — that term is reserved for code with no engine import at all (src/agent.ts), and
+ * everything here speaks pi's message and image types. What it is neutral about is which pi class
+ * runs the turn.
  *
  *   Lease       — single-writer concurrency floor (injectable port + in-process default)
  *   Terminals   — a settled pi message or a thrown error → the SPEC terminal, `retryable` included
  *   EventQueue  — push→pull plumbing for engines that emit events beside their result
  *   Prompt prep — SPEC images → pi's ImageContent
  *
- * These are the parts that do not care WHICH pi class runs the turn. What does — the harness's
- * event vocabulary and its observation plane — stays in invoke.ts, and the AgentSession's in
- * invoke-session.ts.
+ * What is NOT neutral — the harness's event vocabulary and its observation plane — stays in
+ * invoke.ts, and the AgentSession's in invoke-session.ts.
  */
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import { ABORTED_CODE, type AgentEvent, type Prompt } from "../../agent.ts";

--- a/src/engines/pi/turn-kit.ts
+++ b/src/engines/pi/turn-kit.ts
@@ -1,0 +1,193 @@
+/**
+ * The engine-facing half of the turn mechanism, shared by every pi L0.
+ *
+ *   Lease       — single-writer concurrency floor (injectable port + in-process default)
+ *   Terminals   — a settled pi message or a thrown error → the SPEC terminal, `retryable` included
+ *   EventQueue  — push→pull plumbing for engines that emit events beside their result
+ *   Prompt prep — SPEC images → pi's ImageContent
+ *
+ * These are the parts that do not care WHICH pi class runs the turn. What does — the harness's
+ * event vocabulary and its observation plane — stays in invoke.ts, and the AgentSession's in
+ * invoke-session.ts.
+ */
+import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
+import { ABORTED_CODE, type AgentEvent, type Prompt } from "../../agent.ts";
+
+// ── Lease: single-writer concurrency floor ──────────────────────────────────
+//
+// Corruption-prevention floor only: it does not pick a UX. Fail-fast over queueing because real
+// same-session concurrency is mostly duplicate intent or a user firing follow-ups, not two real
+// turns; a queue would also leak a slot when a waiter is cancelled. Synchronous (no awaits) so
+// nothing interleaves between acquire and entering try — cancellation always releases in finally.
+
+export type Release = () => void;
+
+export interface Lease {
+  /** Try to acquire exclusive write access for the session (fail-fast). Returns null if held. */
+  tryAcquire(session: string): Release | null;
+}
+
+export function inProcessLease(): Lease {
+  const busy = new Set<string>();
+  return {
+    tryAcquire(session: string): Release | null {
+      if (busy.has(session)) return null;
+      busy.add(session);
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        busy.delete(session);
+      };
+    },
+  };
+}
+/** Clearly-transient network error codes (Node/undici), decisive on their own. */
+const RETRYABLE_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EAI_AGAIN",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/** 429 (rate limit) and 5xx (server) are worth retrying; other statuses are decisive NON-retryable. */
+const statusIsRetryable = (status: number): boolean => status === 429 || (status >= 500 && status < 600);
+
+/** Last-resort prose match, used only when no structured status/code is available. */
+const RETRYABLE_MESSAGE =
+  /\b(429|5\d\d|timeout|timed out|rate.?limit|overloaded|ECONNRESET|ETIMEDOUT|ENETUNREACH|EAI_AGAIN|socket hang up)\b/i;
+
+/** A structured status/code decision, or `null` when the signal is absent/undecisive → fall to prose. */
+function retryableFromSignal(signal: { status?: number; code?: unknown }): boolean | null {
+  if (typeof signal.status === "number") return statusIsRetryable(signal.status);
+  const { code } = signal;
+  if (typeof code === "number") return statusIsRetryable(code);
+  if (typeof code === "string") {
+    if (RETRYABLE_CODES.has(code)) return true;
+    if (/^\d{3}$/.test(code)) return statusIsRetryable(Number(code)); // a status carried as a string
+  }
+  return null; // no code, or an unknown one — not decisive on its own
+}
+
+/** Classify `retryable`: structured status/code first, message prose only as the last-resort ceiling. */
+export function classifyRetryable(details: string, signal: { status?: number; code?: unknown }): boolean {
+  return retryableFromSignal(signal) ?? RETRYABLE_MESSAGE.test(details);
+}
+
+/** Pull a structured status/code off a thrown error (HTTP status or a network code, incl. its cause). */
+function errorSignal(error: unknown): { status?: number; code?: unknown } {
+  if (!error || typeof error !== "object") return {};
+  const e = error as { status?: unknown; statusCode?: unknown; code?: unknown; cause?: unknown };
+  const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
+  const causeCode = e.cause && typeof e.cause === "object" ? (e.cause as { code?: unknown }).code : undefined;
+  return { status, code: e.code ?? causeCode };
+}
+
+/**
+ * Pull the structured error `code` pi records on a failed message's diagnostics. `diagnostics`
+ * accumulates across attempts (`appendAssistantMessageDiagnostic`), so the terminal cause is the LAST
+ * code-bearing entry — `findLast`, not `find`: an earlier attempt's transient 503 must not classify a
+ * terminal 400/auth failure as retryable. (Reverse scan rather than `findLast` — the tsconfig lib is
+ * ES2022.)
+ */
+function messageSignal(message: AssistantMessage): { status?: number; code?: unknown } {
+  const diagnostics = message.diagnostics ?? [];
+  for (let i = diagnostics.length - 1; i >= 0; i--) {
+    const code = diagnostics[i]?.error?.code;
+    if (code !== undefined) return { code };
+  }
+  return {};
+}
+/**
+ * Terminal mapping, decided by the resolved message's stopReason: pi's prompt() resolves a message
+ * with stopReason "error"/"aborted" rather than throwing, so relying on catch alone would miss this
+ * entire failure class (violating SPEC MUST 1).
+ */
+export function toTerminal(message: AssistantMessage): AgentEvent {
+  if (message.stopReason === "aborted") {
+    // A deliberate stop (control-plane abort / harness abort), not an error — see {@link ABORTED_CODE}
+    // for the consumer contract (design §6).
+    const details = message.errorMessage ?? "run aborted";
+    return { type: "failed", details, retryable: false, code: ABORTED_CODE };
+  }
+  if (message.stopReason === "error") {
+    const details = message.errorMessage ?? `model stopped: ${message.stopReason}`;
+    return { type: "failed", details, retryable: classifyRetryable(details, messageSignal(message)) };
+  }
+  return { type: "completed" };
+}
+
+export function errorToTerminal(error: unknown): Extract<AgentEvent, { type: "failed" }> {
+  const details = error instanceof Error ? error.message : String(error);
+  return { type: "failed", details, retryable: classifyRetryable(details, errorSignal(error)) };
+}
+/**
+ * Map prompt images to pi ImageContent, resizing each to model-friendly dimensions/size with pi's
+ * Photon resizer (reused from pi-coding-agent, lazy-imported so the common no-image headless path never
+ * loads the TUI module graph). A null resize (unresizable / Photon unavailable) keeps the original
+ * bytes — the provider then applies its own limit.
+ */
+export async function toPiPromptOptions(prompt: Prompt): Promise<{ images?: ImageContent[] } | undefined> {
+  if (!prompt.images || prompt.images.length === 0) return undefined;
+  const { resizeImage } = await import("@earendil-works/pi-coding-agent");
+  const images = await Promise.all(
+    prompt.images.map(async (img): Promise<ImageContent> => {
+      const resized = await resizeImage(Buffer.from(img.data, "base64"), img.mimeType, {
+        maxWidth: 1568,
+        maxHeight: 1568,
+        maxBytes: 5 * 1024 * 1024,
+      }).catch(() => null);
+      return resized
+        ? { type: "image", data: resized.data, mimeType: resized.mimeType }
+        : { type: "image", data: img.data, mimeType: img.mimeType };
+    }),
+  );
+  return { images };
+}
+// ── EventQueue: push→pull plumbing for a two-port engine ────────────────────
+//
+// Single-consumer async queue; single-threaded JS means no await interleaves between push and
+// drain, so no locking. Engines that are natively async-iterable would not need it.
+
+export class EventQueue<T> {
+  private buffer: T[] = [];
+  private wake?: () => void;
+
+  push(item: T): void {
+    this.buffer.push(item);
+    const wake = this.wake;
+    this.wake = undefined;
+    wake?.();
+  }
+
+  /**
+   * Yield pushed events in order until `done` settles AND the buffer is drained. The terminal is
+   * produced separately (toTerminal); rejections of `done` are swallowed here (the caller awaits
+   * `run` itself) to avoid unhandled rejections.
+   */
+  async *drainUntil(done: Promise<unknown>): AsyncGenerator<T> {
+    let settled = false;
+    const onSettle = () => {
+      settled = true;
+      const wake = this.wake;
+      this.wake = undefined;
+      wake?.();
+    };
+    const finished = done.then(onSettle, onSettle);
+
+    while (true) {
+      while (this.buffer.length > 0) {
+        yield this.buffer.shift() as T;
+      }
+      if (settled) break;
+      await new Promise<void>((resolve) => {
+        this.wake = resolve;
+      });
+    }
+    await finished;
+  }
+}

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -34,7 +34,8 @@ export {
 export type { LoadedDefinition, SkillCollision } from "./engines/pi/definition.ts";
 
 export { defineConfig, listModels, resolveModel, type FastagentConfig } from "./engines/pi/config.ts";
-export { inProcessLease, type Lease, type Release, type SessionObserver } from "./engines/pi/invoke.ts";
+export type { SessionObserver } from "./engines/pi/invoke.ts";
+export { inProcessLease, type Lease, type Release } from "./engines/pi/turn-kit.ts";
 export {
   createPiSessionControl,
   type CreatePiSessionControlOptions,

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -7,11 +7,12 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { type FauxResponseStep, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { type FauxResponseStep, Type, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import {
   type AgentSession,
   ModelRuntime,
   SessionManager,
+  type ToolDefinition,
   createAgentSessionFromServices,
   createAgentSessionServices,
 } from "@earendil-works/pi-coding-agent";
@@ -32,11 +33,13 @@ import { describeSpecConformance } from "./spec-conformance.ts";
 interface SubjectOptions {
   /** Where the record lives. Omitted — a fresh in-memory session per turn (no continuity needed). */
   dir?: string;
+  /** Mounted on the session, for the paths where a turn has to do something before it answers. */
+  customTools?: ToolDefinition[];
 }
 
 async function sessionFactory(
   responses: FauxResponseStep[],
-  { dir }: SubjectOptions = {},
+  { dir, customTools }: SubjectOptions = {},
 ): Promise<PiAgentSessionFactory> {
   const { faux } = makeFaux();
   faux.setResponses(responses);
@@ -70,7 +73,10 @@ async function sessionFactory(
       services,
       sessionManager,
       model: faux.getModel(),
-      noTools: "all",
+      // "builtin" not "all": the coding tools stay off (this is a protocol subject, not an agent),
+      // while a subject that mounts its own tool keeps it.
+      noTools: "builtin",
+      customTools,
     });
     return session;
   };
@@ -144,5 +150,40 @@ describe("AgentSession L0: pi's auto-retry vs. append-only deltas", () => {
     ]);
     const { text } = await collect(agent.invoke({ session: "silent-then-retried" }, { text: "go" }));
     expect(text).toBe("the answer, second attempt");
+  });
+
+  it("an executed tool does not close the window — the retry resumes from it instead of re-running it", async () => {
+    let toolRuns = 0;
+    const agent = await piSessionAgent(
+      [
+        fauxAssistantMessage(fauxToolCall("ping", {}, { id: "call-1" })),
+        // The request that follows the tool fails before saying anything. pi retries it against the
+        // PERSISTED tool result; refusing here would hand the retry to the caller, who has no way to
+        // re-ask without running the tool again.
+        fauxAssistantMessage("", { stopReason: "error", errorMessage: "boom 500" }),
+        fauxAssistantMessage("pong, once"),
+      ],
+      {
+        // The cast is the same one session-builder.ts makes: pi types `parameters` per-tool, so a
+        // literal only satisfies ToolDefinition after erasure.
+        customTools: [
+          {
+            name: "ping",
+            label: "ping",
+            description: "A tool with a side effect worth not repeating.",
+            parameters: Type.Object({}),
+            execute: async () => {
+              toolRuns++;
+              return { content: [{ type: "text", text: "pong" }] };
+            },
+          } as unknown as ToolDefinition,
+        ],
+      },
+    );
+
+    const { text } = await collect(agent.invoke({ session: "tool-then-retried" }, { text: "go" }));
+
+    expect(text).toBe("pong, once");
+    expect(toolRuns).toBe(1);
   });
 });

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -16,6 +16,9 @@ import {
   createAgentSessionServices,
 } from "@earendil-works/pi-coding-agent";
 import { createPiAgentFromSession, type PiAgentSessionFactory } from "../src/engines/pi/invoke-session.ts";
+import { collect } from "../src/collect.ts";
+import { AgentFailure } from "../src/collect.ts";
+import { describe, expect, it } from "vitest";
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
 
@@ -29,14 +32,11 @@ import { describeSpecConformance } from "./spec-conformance.ts";
 interface SubjectOptions {
   /** Where the record lives. Omitted — a fresh in-memory session per turn (no continuity needed). */
   dir?: string;
-  /** pi's own assistant-level auto-retry. Off in the failure subject so its backoff (~14s) does not
-   *  pace the suite; whether serving keeps it on is a phase-2 policy call. */
-  autoRetry?: boolean;
 }
 
 async function sessionFactory(
   responses: FauxResponseStep[],
-  { dir, autoRetry = true }: SubjectOptions = {},
+  { dir }: SubjectOptions = {},
 ): Promise<PiAgentSessionFactory> {
   const { faux } = makeFaux();
   faux.setResponses(responses);
@@ -72,7 +72,6 @@ async function sessionFactory(
       model: faux.getModel(),
       noTools: "all",
     });
-    if (!autoRetry) session.setAutoRetryEnabled(false);
     return session;
   };
 }
@@ -84,10 +83,9 @@ async function piSessionAgent(responses: FauxResponseStep[], options?: SubjectOp
 describeSpecConformance("pi AgentSession (faux model, per-invoke L0)", {
   completing: () => piSessionAgent([fauxAssistantMessage("hello world")]),
 
-  failing: () =>
-    piSessionAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })], {
-      autoRetry: false,
-    }),
+  // The answer streams a token before it fails, so the L0 refuses pi's retry and the subject stays
+  // failed - no backoff, and the refusal itself is exercised by every conformance run.
+  failing: () => piSessionAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })]),
 
   hanging: async (onCleanup) => {
     const factory = await sessionFactory([fauxAssistantMessage("a long answer that streams out slowly")]);
@@ -122,4 +120,29 @@ describeSpecConformance("pi AgentSession (faux model, per-invoke L0)", {
     );
     return { a, b, sawHistory: () => saw };
   },
+});
+
+describe("AgentSession L0: pi's auto-retry vs. append-only deltas", () => {
+  it("a failure AFTER output was streamed is final — a retry would concatenate two answers", async () => {
+    const agent = await piSessionAgent([
+      fauxAssistantMessage("the first half of a wrong", { stopReason: "error", errorMessage: "boom 500" }),
+      fauxAssistantMessage("a complete replacement answer"),
+    ]);
+    const started = Date.now();
+    await expect(collect(agent.invoke({ session: "streamed-then-failed" }, { text: "go" }))).rejects.toBeInstanceOf(
+      AgentFailure,
+    );
+    // Refusing the retry must also CANCEL it: pi's first backoff is 2s, and letting it run would
+    // both delay the failure and spend a provider call on an answer this turn can never use.
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it("a failure BEFORE any output still retries — that window is free resilience", async () => {
+    const agent = await piSessionAgent([
+      fauxAssistantMessage("", { stopReason: "error", errorMessage: "boom 500" }),
+      fauxAssistantMessage("the answer, second attempt"),
+    ]);
+    const { text } = await collect(agent.invoke({ session: "silent-then-retried" }, { text: "go" }));
+    expect(text).toBe("the answer, second attempt");
+  });
 });

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The SPEC conformance suite (spec-conformance.ts) against the `AgentSession` L0 — the proof that
+ * pi's own session class satisfies the four Agent-side MUSTs in the `per-invoke` posture, MUST 6
+ * (portability) included: every turn builds a fresh `AgentSession` over the same jsonl on disk, with
+ * nothing shared in-process but the directory.
+ */
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type FauxResponseStep, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import {
+  type AgentSession,
+  ModelRuntime,
+  SessionManager,
+  createAgentSessionFromServices,
+  createAgentSessionServices,
+} from "@earendil-works/pi-coding-agent";
+import { createPiAgentFromSession, type PiAgentSessionFactory } from "../src/engines/pi/invoke-session.ts";
+import { makeFaux } from "./faux.ts";
+import { describeSpecConformance } from "./spec-conformance.ts";
+
+/**
+ * A per-invoke `AgentSession` factory over one faux model. `dir` makes the record durable (the
+ * portability subject); without it each turn gets a fresh in-memory session.
+ *
+ * `services` is built ONCE and shared across turns — the per-turn cost is the session binding only,
+ * which is what makes this posture affordable.
+ */
+async function sessionFactory(
+  responses: FauxResponseStep[],
+  dir?: string,
+  /** pi's own assistant-level auto-retry. Off in the failure subject so its backoff (~14s) does not
+   *  pace the suite; whether serving keeps it on is a phase-2 policy call. */
+  autoRetry = true,
+): Promise<PiAgentSessionFactory> {
+  const { faux } = makeFaux();
+  faux.setResponses(responses);
+  const modelRuntime = await ModelRuntime.create({ modelsPath: null, allowModelNetwork: false });
+  modelRuntime.registerNativeProvider(faux.provider);
+  const cwd = process.cwd();
+  const services = await createAgentSessionServices({
+    cwd,
+    modelRuntime,
+    resourceLoaderOptions: {
+      // The agent is the definition, not the authoring machine's pi setup (same posture as serving).
+      noExtensions: true,
+      noPromptTemplates: true,
+      noContextFiles: true,
+      systemPromptOverride: () => "test",
+      appendSystemPromptOverride: () => [],
+      skillsOverride: (base) => ({ skills: [], diagnostics: base.diagnostics }),
+    },
+  });
+  return async (sessionId) => {
+    let sessionManager: SessionManager;
+    if (dir === undefined) {
+      sessionManager = SessionManager.inMemory(cwd, { id: sessionId });
+    } else {
+      const existing = (await SessionManager.list(cwd, dir)).find((info) => info.id === sessionId);
+      sessionManager = existing
+        ? SessionManager.open(existing.path, dir)
+        : SessionManager.create(cwd, dir, { id: sessionId });
+    }
+    const { session } = await createAgentSessionFromServices({
+      services,
+      sessionManager,
+      model: faux.getModel(),
+      noTools: "all",
+    });
+    if (!autoRetry) session.setAutoRetryEnabled(false);
+    return session;
+  };
+}
+
+async function piSessionAgent(responses: FauxResponseStep[], dir?: string, autoRetry = true) {
+  return createPiAgentFromSession({ sessionFactory: await sessionFactory(responses, dir, autoRetry) });
+}
+
+describeSpecConformance("pi AgentSession (faux model, per-invoke L0)", {
+  completing: () => piSessionAgent([fauxAssistantMessage("hello world")]),
+
+  failing: () =>
+    piSessionAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })], undefined, false),
+
+  hanging: async (onCleanup) => {
+    const factory = await sessionFactory([fauxAssistantMessage("a long answer that streams out slowly")]);
+    // The engine's cancel cleanup is session.abort() — intercept it as the probe.
+    return createPiAgentFromSession({
+      sessionFactory: async (sessionId) => {
+        const session = await factory(sessionId);
+        const abort = session.abort.bind(session);
+        (session as { abort: AgentSession["abort"] }).abort = async () => {
+          onCleanup();
+          return abort();
+        };
+        return session;
+      },
+    });
+  },
+
+  // Portable conformance: two agent instances, each building its own SessionManager over the same
+  // directory — nothing shared in-process, the disk is the only common state.
+  pair: async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-session-conformance-"));
+    let saw = false;
+    const a = await piSessionAgent([fauxAssistantMessage("the code is 47")], dir);
+    const b = await piSessionAgent(
+      [
+        (context) => {
+          saw = JSON.stringify(context.messages).includes("the code is 47");
+          return fauxAssistantMessage("ok");
+        },
+      ],
+      dir,
+    );
+    return { a, b, sawHistory: () => saw };
+  },
+});

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -26,12 +26,17 @@ import { describeSpecConformance } from "./spec-conformance.ts";
  * `services` is built ONCE and shared across turns — the per-turn cost is the session binding only,
  * which is what makes this posture affordable.
  */
-async function sessionFactory(
-  responses: FauxResponseStep[],
-  dir?: string,
+interface SubjectOptions {
+  /** Where the record lives. Omitted — a fresh in-memory session per turn (no continuity needed). */
+  dir?: string;
   /** pi's own assistant-level auto-retry. Off in the failure subject so its backoff (~14s) does not
    *  pace the suite; whether serving keeps it on is a phase-2 policy call. */
-  autoRetry = true,
+  autoRetry?: boolean;
+}
+
+async function sessionFactory(
+  responses: FauxResponseStep[],
+  { dir, autoRetry = true }: SubjectOptions = {},
 ): Promise<PiAgentSessionFactory> {
   const { faux } = makeFaux();
   faux.setResponses(responses);
@@ -72,15 +77,17 @@ async function sessionFactory(
   };
 }
 
-async function piSessionAgent(responses: FauxResponseStep[], dir?: string, autoRetry = true) {
-  return createPiAgentFromSession({ sessionFactory: await sessionFactory(responses, dir, autoRetry) });
+async function piSessionAgent(responses: FauxResponseStep[], options?: SubjectOptions) {
+  return createPiAgentFromSession({ sessionFactory: await sessionFactory(responses, options) });
 }
 
 describeSpecConformance("pi AgentSession (faux model, per-invoke L0)", {
   completing: () => piSessionAgent([fauxAssistantMessage("hello world")]),
 
   failing: () =>
-    piSessionAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })], undefined, false),
+    piSessionAgent([fauxAssistantMessage("x", { stopReason: "error", errorMessage: "boom 500" })], {
+      autoRetry: false,
+    }),
 
   hanging: async (onCleanup) => {
     const factory = await sessionFactory([fauxAssistantMessage("a long answer that streams out slowly")]);
@@ -103,7 +110,7 @@ describeSpecConformance("pi AgentSession (faux model, per-invoke L0)", {
   pair: async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-session-conformance-"));
     let saw = false;
-    const a = await piSessionAgent([fauxAssistantMessage("the code is 47")], dir);
+    const a = await piSessionAgent([fauxAssistantMessage("the code is 47")], { dir });
     const b = await piSessionAgent(
       [
         (context) => {
@@ -111,7 +118,7 @@ describeSpecConformance("pi AgentSession (faux model, per-invoke L0)", {
           return fauxAssistantMessage("ok");
         },
       ],
-      dir,
+      { dir },
     );
     return { a, b, sawHistory: () => saw };
   },

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -10,7 +10,8 @@ import { Type, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai"
 import { afterAll, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
 import { controlRoutes } from "../src/channels/control.ts";
-import { createPiAgentFromHarness, inProcessLease } from "../src/engines/pi/invoke.ts";
+import { createPiAgentFromHarness } from "../src/engines/pi/invoke.ts";
+import { inProcessLease } from "../src/engines/pi/turn-kit.ts";
 import { piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { createPiSessionControl } from "../src/engines/pi/session-control.ts";
 import { inMemorySessionStore } from "../src/engines/pi/sessions.ts";

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -121,7 +121,9 @@ describe("AgentSession L0: cancelling before the model call", () => {
     const inTheWindow = new Promise<void>((resolve) => (entered = resolve));
     duringPromptPrep.value = () => {
       entered();
-      return new Promise<void>((_, reject) => (failPreparation = () => reject(new Error("image pipeline unavailable"))));
+      return new Promise<void>(
+        (_, reject) => (failPreparation = () => reject(new Error("image pipeline unavailable"))),
+      );
     };
 
     const iterator = agent.invoke({ session: "cancel-then-fail" }, { text: "go" })[Symbol.asyncIterator]();

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -64,14 +64,15 @@ afterEach(() => {
 });
 
 describe("AgentSession L0: the terminal describes THIS turn", () => {
-  it("a run that produces no assistant message fails, even when the session holds a completed one", async () => {
+  it("a run that ends no assistant message fails, however complete the session's history looks", async () => {
     const agent = createPiAgentFromSession({ sessionFactory: async () => silentSessionAfterHistory() });
     const events = await drain(agent.invoke({ session: "durable" }, { text: "turn two" }));
-    // The durable session's previous turn ended `completed`; reading it here would report success for
-    // a turn that never ran.
+    // The session state holds a previous turn that ended `completed`. Deriving the terminal from that
+    // state - at any index, since compaction and overflow recovery both rewrite the array mid-turn -
+    // would report success for a turn that produced nothing.
     expect(events.at(-1)?.type).toBe("failed");
     const last = events.at(-1);
-    if (last?.type === "failed") expect(last.details).toContain("without an assistant message");
+    if (last?.type === "failed") expect(last.details).toContain("without ending an assistant message");
   });
 });
 

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -4,9 +4,29 @@
  * is exactly what a healthy engine never does.
  */
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
 import { createPiAgentFromSession } from "../src/engines/pi/invoke-session.ts";
+
+/** Holds prompt-option resolution open, so a cancellation can land in that exact window. */
+const optionsGate = vi.hoisted(() => {
+  let open!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { gate, open: () => open(), enabled: { value: false } };
+});
+
+vi.mock("../src/engines/pi/invoke.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/engines/pi/invoke.ts")>();
+  return {
+    ...actual,
+    toPiPromptOptions: async (prompt: unknown) => {
+      if (optionsGate.enabled.value) await optionsGate.gate;
+      return actual.toPiPromptOptions(prompt as Parameters<typeof actual.toPiPromptOptions>[0]);
+    },
+  };
+});
 
 /** A session carrying one COMPLETED turn of history whose next `prompt()` produces nothing. */
 function silentSessionAfterHistory(): AgentSession {
@@ -21,6 +41,21 @@ function silentSessionAfterHistory(): AgentSession {
     abort: async () => {},
     dispose: () => {},
   } as unknown as AgentSession;
+}
+
+/** Records whether the model call was ever started. */
+function promptRecordingSession(): { session: AgentSession; prompted: () => boolean } {
+  let prompted = false;
+  const session = {
+    state: { messages: [] },
+    subscribe: () => () => {},
+    prompt: async () => {
+      prompted = true;
+    },
+    abort: async () => {},
+    dispose: () => {},
+  } as unknown as AgentSession;
+  return { session, prompted: () => prompted };
 }
 
 async function drain(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
@@ -38,5 +73,40 @@ describe("AgentSession L0: the terminal describes THIS turn", () => {
     expect(events.at(-1)?.type).toBe("failed");
     const last = events.at(-1);
     if (last?.type === "failed") expect(last.details).toContain("without an assistant message");
+  });
+});
+
+describe("AgentSession L0: cancelling before the model call", () => {
+  it("never starts the turn when the consumer walks away while the session is being prepared", async () => {
+    const { session, prompted } = promptRecordingSession();
+    const agent = createPiAgentFromSession({ sessionFactory: async () => session });
+    const iterator = agent.invoke({ session: "early-cancel" }, { text: "go" })[Symbol.asyncIterator]();
+    // The consumer leaves before the first event exists — the window where the cancellation door is
+    // armed but the session is still idle, so knocking on it does nothing.
+    const first = iterator.next();
+    await iterator.return?.(undefined);
+    const settled = await first;
+    expect(prompted()).toBe(false);
+    expect(settled.done).toBe(true); // cancellation has no terminal event (SPEC MUST 3)
+  });
+
+  it("never starts the turn when the consumer walks away while the prompt's images are resized", async () => {
+    const { session, prompted } = promptRecordingSession();
+    const agent = createPiAgentFromSession({ sessionFactory: async () => session });
+    optionsGate.enabled.value = true;
+    try {
+      const iterator = agent.invoke({ session: "resize-cancel" }, { text: "go" })[Symbol.asyncIterator]();
+      const first = iterator.next();
+      // Park the generator INSIDE prompt-option resolution: the session exists and is idle, so the
+      // armed door has nothing to abort — only a latch read after this await can stop the turn.
+      await Promise.resolve();
+      const cancelled = iterator.return?.(undefined);
+      optionsGate.open();
+      await cancelled;
+      expect((await first).done).toBe(true);
+      expect(prompted()).toBe(false);
+    } finally {
+      optionsGate.enabled.value = false;
+    }
   });
 });

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -14,7 +14,7 @@ const optionsGate = vi.hoisted(() => {
   const gate = new Promise<void>((resolve) => {
     open = resolve;
   });
-  return { gate, open: () => open(), enabled: { value: false } };
+  return { gate, open: () => open(), enabled: { value: false }, failure: { value: null as Error | null } };
 });
 
 vi.mock("../src/engines/pi/invoke.ts", async (importOriginal) => {
@@ -23,6 +23,7 @@ vi.mock("../src/engines/pi/invoke.ts", async (importOriginal) => {
     ...actual,
     toPiPromptOptions: async (prompt: unknown) => {
       if (optionsGate.enabled.value) await optionsGate.gate;
+      if (optionsGate.failure.value) throw optionsGate.failure.value;
       return actual.toPiPromptOptions(prompt as Parameters<typeof actual.toPiPromptOptions>[0]);
     },
   };
@@ -107,6 +108,20 @@ describe("AgentSession L0: cancelling before the model call", () => {
       expect(prompted()).toBe(false);
     } finally {
       optionsGate.enabled.value = false;
+    }
+  });
+
+  it("a failure while preparing the prompt is one failed terminal, not a thrown iteration", async () => {
+    const { session, prompted } = promptRecordingSession();
+    const agent = createPiAgentFromSession({ sessionFactory: async () => session });
+    optionsGate.failure.value = new Error("image pipeline unavailable");
+    try {
+      const events = await drain(agent.invoke({ session: "prep-failure" }, { text: "go" }));
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ type: "failed", details: "image pipeline unavailable" });
+      expect(prompted()).toBe(false);
+    } finally {
+      optionsGate.failure.value = null;
     }
   });
 });

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -108,6 +108,24 @@ describe("AgentSession L0: cancelling before the model call", () => {
     expect(prompted()).toBe(false);
   });
 
+  it("a cancelled consumer gets no terminal, even when preparing the prompt then fails", async () => {
+    const { session, prompted } = promptRecordingSession();
+    const agent = createPiAgentFromSession({ sessionFactory: async () => session });
+    let failPreparation!: () => void;
+    duringPromptPrep.value = () =>
+      new Promise<void>((_, reject) => (failPreparation = () => reject(new Error("image pipeline unavailable"))));
+
+    const iterator = agent.invoke({ session: "cancel-then-fail" }, { text: "go" })[Symbol.asyncIterator]();
+    const first = iterator.next();
+    await Promise.resolve();
+    const cancelled = iterator.return?.(undefined);
+    failPreparation(); // the failure races the cancellation, and loses: nobody is listening
+    await cancelled;
+
+    expect((await first).done).toBe(true);
+    expect(prompted()).toBe(false);
+  });
+
   it("a failure while preparing the prompt is one failed terminal, not a thrown iteration", async () => {
     const { session, prompted } = promptRecordingSession();
     const agent = createPiAgentFromSession({ sessionFactory: async () => session });

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The AgentSession L0's own turn-boundary discipline. The conformance suite drives a real engine;
+ * this drives a stub, because the case that matters — a run that settles without producing anything —
+ * is exactly what a healthy engine never does.
+ */
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../src/agent.ts";
+import { createPiAgentFromSession } from "../src/engines/pi/invoke-session.ts";
+
+/** A session carrying one COMPLETED turn of history whose next `prompt()` produces nothing. */
+function silentSessionAfterHistory(): AgentSession {
+  const messages = [
+    { role: "user", content: "turn one", timestamp: 1 },
+    { role: "assistant", content: [{ type: "text", text: "the code is 47" }], stopReason: "stop", timestamp: 2 },
+  ];
+  return {
+    state: { messages },
+    subscribe: () => () => {},
+    prompt: async () => {},
+    abort: async () => {},
+    dispose: () => {},
+  } as unknown as AgentSession;
+}
+
+async function drain(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+describe("AgentSession L0: the terminal describes THIS turn", () => {
+  it("a run that produces no assistant message fails, even when the session holds a completed one", async () => {
+    const agent = createPiAgentFromSession({ sessionFactory: async () => silentSessionAfterHistory() });
+    const events = await drain(agent.invoke({ session: "durable" }, { text: "turn two" }));
+    // The durable session's previous turn ended `completed`; reading it here would report success for
+    // a turn that never ran.
+    expect(events.at(-1)?.type).toBe("failed");
+    const last = events.at(-1);
+    if (last?.type === "failed") expect(last.details).toContain("without an assistant message");
+  });
+});

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -4,27 +4,21 @@
  * is exactly what a healthy engine never does.
  */
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
 import { createPiAgentFromSession } from "../src/engines/pi/invoke-session.ts";
 
-/** Holds prompt-option resolution open, so a cancellation can land in that exact window. */
-const optionsGate = vi.hoisted(() => {
-  let open!: () => void;
-  const gate = new Promise<void>((resolve) => {
-    open = resolve;
-  });
-  return { gate, open: () => open(), enabled: { value: false }, failure: { value: null as Error | null } };
-});
+/** Runs inside prompt-option resolution — the window between "the session exists" and "the model
+ *  call starts", which a test cannot otherwise reach. */
+const duringPromptPrep = vi.hoisted(() => ({ value: null as null | (() => Promise<void>) }));
 
-vi.mock("../src/engines/pi/invoke.ts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../src/engines/pi/invoke.ts")>();
+vi.mock("../src/engines/pi/turn-kit.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/engines/pi/turn-kit.ts")>();
   return {
     ...actual,
-    toPiPromptOptions: async (prompt: unknown) => {
-      if (optionsGate.enabled.value) await optionsGate.gate;
-      if (optionsGate.failure.value) throw optionsGate.failure.value;
-      return actual.toPiPromptOptions(prompt as Parameters<typeof actual.toPiPromptOptions>[0]);
+    toPiPromptOptions: async (prompt: Parameters<typeof actual.toPiPromptOptions>[0]) => {
+      await duringPromptPrep.value?.();
+      return actual.toPiPromptOptions(prompt);
     },
   };
 });
@@ -65,6 +59,10 @@ async function drain(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   return out;
 }
 
+afterEach(() => {
+  duringPromptPrep.value = null;
+});
+
 describe("AgentSession L0: the terminal describes THIS turn", () => {
   it("a run that produces no assistant message fails, even when the session holds a completed one", async () => {
     const agent = createPiAgentFromSession({ sessionFactory: async () => silentSessionAfterHistory() });
@@ -94,34 +92,31 @@ describe("AgentSession L0: cancelling before the model call", () => {
   it("never starts the turn when the consumer walks away while the prompt's images are resized", async () => {
     const { session, prompted } = promptRecordingSession();
     const agent = createPiAgentFromSession({ sessionFactory: async () => session });
-    optionsGate.enabled.value = true;
-    try {
-      const iterator = agent.invoke({ session: "resize-cancel" }, { text: "go" })[Symbol.asyncIterator]();
-      const first = iterator.next();
-      // Park the generator INSIDE prompt-option resolution: the session exists and is idle, so the
-      // armed door has nothing to abort — only a latch read after this await can stop the turn.
-      await Promise.resolve();
-      const cancelled = iterator.return?.(undefined);
-      optionsGate.open();
-      await cancelled;
-      expect((await first).done).toBe(true);
-      expect(prompted()).toBe(false);
-    } finally {
-      optionsGate.enabled.value = false;
-    }
+    // Park the generator INSIDE prompt-option resolution: the session exists and is idle, so the
+    // armed door has nothing to abort — only a latch read after this await can stop the turn.
+    let leaveTheWindow!: () => void;
+    duringPromptPrep.value = () => new Promise<void>((resolve) => (leaveTheWindow = resolve));
+
+    const iterator = agent.invoke({ session: "resize-cancel" }, { text: "go" })[Symbol.asyncIterator]();
+    const first = iterator.next();
+    await Promise.resolve();
+    const cancelled = iterator.return?.(undefined);
+    leaveTheWindow();
+    await cancelled;
+
+    expect((await first).done).toBe(true);
+    expect(prompted()).toBe(false);
   });
 
   it("a failure while preparing the prompt is one failed terminal, not a thrown iteration", async () => {
     const { session, prompted } = promptRecordingSession();
     const agent = createPiAgentFromSession({ sessionFactory: async () => session });
-    optionsGate.failure.value = new Error("image pipeline unavailable");
-    try {
-      const events = await drain(agent.invoke({ session: "prep-failure" }, { text: "go" }));
-      expect(events).toHaveLength(1);
-      expect(events[0]).toMatchObject({ type: "failed", details: "image pipeline unavailable" });
-      expect(prompted()).toBe(false);
-    } finally {
-      optionsGate.failure.value = null;
-    }
+    duringPromptPrep.value = () => Promise.reject(new Error("image pipeline unavailable"));
+
+    const events = await drain(agent.invoke({ session: "prep-failure" }, { text: "go" }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "failed", details: "image pipeline unavailable" });
+    expect(prompted()).toBe(false);
   });
 });

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -95,11 +95,16 @@ describe("AgentSession L0: cancelling before the model call", () => {
     // Park the generator INSIDE prompt-option resolution: the session exists and is idle, so the
     // armed door has nothing to abort — only a latch read after this await can stop the turn.
     let leaveTheWindow!: () => void;
-    duringPromptPrep.value = () => new Promise<void>((resolve) => (leaveTheWindow = resolve));
+    let entered!: () => void;
+    const inTheWindow = new Promise<void>((resolve) => (entered = resolve));
+    duringPromptPrep.value = () => {
+      entered();
+      return new Promise<void>((resolve) => (leaveTheWindow = resolve));
+    };
 
     const iterator = agent.invoke({ session: "resize-cancel" }, { text: "go" })[Symbol.asyncIterator]();
     const first = iterator.next();
-    await Promise.resolve();
+    await inTheWindow;
     const cancelled = iterator.return?.(undefined);
     leaveTheWindow();
     await cancelled;
@@ -112,12 +117,16 @@ describe("AgentSession L0: cancelling before the model call", () => {
     const { session, prompted } = promptRecordingSession();
     const agent = createPiAgentFromSession({ sessionFactory: async () => session });
     let failPreparation!: () => void;
-    duringPromptPrep.value = () =>
-      new Promise<void>((_, reject) => (failPreparation = () => reject(new Error("image pipeline unavailable"))));
+    let entered!: () => void;
+    const inTheWindow = new Promise<void>((resolve) => (entered = resolve));
+    duringPromptPrep.value = () => {
+      entered();
+      return new Promise<void>((_, reject) => (failPreparation = () => reject(new Error("image pipeline unavailable"))));
+    };
 
     const iterator = agent.invoke({ session: "cancel-then-fail" }, { text: "go" })[Symbol.asyncIterator]();
     const first = iterator.next();
-    await Promise.resolve();
+    await inTheWindow;
     const cancelled = iterator.return?.(undefined);
     failPreparation(); // the failure races the cancellation, and loses: nobody is listening
     await cancelled;

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -10,14 +10,8 @@ import { fauxAssistantMessage, fauxThinking, fauxToolCall, Type, type FauxRespon
 import type { AssistantMessage, StopReason, Usage } from "@earendil-works/pi-ai";
 import { defineTool, inMemorySessionStore, inProcessLease, type AgentEvent, z } from "../src/index.ts";
 import { SESSION_BUSY_CODE } from "../src/agent.ts";
-import {
-  classifyRetryable,
-  createPiAgentFromHarness,
-  errorToTerminal,
-  projectAgentEvent,
-  toSessionEvent,
-  toTerminal,
-} from "../src/engines/pi/invoke.ts";
+import { createPiAgentFromHarness, projectAgentEvent, toSessionEvent } from "../src/engines/pi/invoke.ts";
+import { classifyRetryable, errorToTerminal, toTerminal } from "../src/engines/pi/turn-kit.ts";
 import { type PiHarnessFactory, piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AgentHarness,
   InMemorySessionRepo,
@@ -15,6 +15,25 @@ import { classifyRetryable, errorToTerminal, toTerminal } from "../src/engines/p
 import { type PiHarnessFactory, piHarnessFactory } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+
+/** Runs inside prompt preparation — the window between "the harness exists" and "the model call
+ *  starts", which a test cannot otherwise reach. Inert unless a test sets it. */
+const duringPromptPrep = vi.hoisted(() => ({ value: null as null | (() => Promise<void>) }));
+
+vi.mock("../src/engines/pi/turn-kit.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/engines/pi/turn-kit.ts")>();
+  return {
+    ...actual,
+    toPiPromptOptions: async (prompt: Parameters<typeof actual.toPiPromptOptions>[0]) => {
+      await duringPromptPrep.value?.();
+      return actual.toPiPromptOptions(prompt);
+    },
+  };
+});
+
+afterEach(() => {
+  duringPromptPrep.value = null;
+});
 
 /** An echo tool for the tool-call path. */
 const echoTool: AgentTool = {
@@ -261,6 +280,49 @@ describe("prompt.images passthrough (SPEC §4)", () => {
     const dump = JSON.stringify(seen);
     expect(dump).toContain("aGVsbG8="); // base64 payload reached the context
     expect(dump).toContain('"image"');
+  });
+
+  it("never starts the model call when the consumer walks away while the prompt is prepared", async () => {
+    const { faux, models } = makeFaux();
+    faux.setResponses([fauxAssistantMessage("never reached")]);
+    let prompted = false;
+    const inner = piHarnessFactory({
+      env: new NodeExecutionEnv({ cwd: process.cwd() }),
+      sessions: inMemorySessionStore(),
+      models,
+      model: faux.getModel(),
+      systemPrompt: "test",
+    });
+    const agent = createPiAgentFromHarness({
+      harnessFactory: async (sessionId) => {
+        const harness = await inner(sessionId);
+        const prompt = harness.prompt.bind(harness);
+        harness.prompt = async (...args: Parameters<typeof prompt>) => {
+          prompted = true;
+          return prompt(...args);
+        };
+        return harness;
+      },
+    });
+    // Park the generator INSIDE prompt preparation: the harness exists and is idle, so the armed
+    // door has nothing to abort — only a latch read after this await can stop the turn.
+    let leaveTheWindow!: () => void;
+    let entered!: () => void;
+    const inTheWindow = new Promise<void>((resolve) => (entered = resolve));
+    duringPromptPrep.value = () => {
+      entered();
+      return new Promise<void>((resolve) => (leaveTheWindow = resolve));
+    };
+
+    const iterator = agent.invoke({ session: "resize-cancel" }, { text: "go" })[Symbol.asyncIterator]();
+    const first = iterator.next();
+    await inTheWindow;
+    const cancelled = iterator.return?.(undefined);
+    leaveTheWindow();
+    await cancelled;
+
+    expect((await first).done).toBe(true);
+    expect(prompted).toBe(false);
   });
 
   it("a prompt that cannot be prepared fails the turn instead of throwing at the caller", async () => {

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../src/session.ts";
 import { SESSION_BUSY_CODE } from "../src/agent.ts";
 import type { PiBoundaryWiring } from "../src/engines/pi/session-control.ts";
-import { inProcessLease } from "../src/engines/pi/invoke.ts";
+import { inProcessLease } from "../src/engines/pi/turn-kit.ts";
 import type { PiSessionReader } from "../src/engines/pi/sessions.ts";
 import { resolveHarnessOverrides } from "../src/engines/pi/harness.ts";
 import { makeFaux } from "./faux.ts";
@@ -588,7 +588,7 @@ describe("session control (Phase 2a): run modulation", () => {
   });
 
   it("toTerminal attributes pi's own stopReason 'aborted' without any control-plane intent", async () => {
-    const { toTerminal } = await import("../src/engines/pi/invoke.ts");
+    const { toTerminal } = await import("../src/engines/pi/turn-kit.ts");
     const terminal = toTerminal({
       role: "assistant",
       content: [],


### PR DESCRIPTION
Phase 1 of moving the serving path off `AgentHarness`. This is a **proof, not a migration**: it adds a second L0 next to `createPiAgentFromHarness` and runs the existing SPEC conformance suite against it. Nothing serves on it yet.

## Why

pi 0.84 promoted an unimplemented lane-based `AgentHarness` to pi-agent-core's default export and removed the working one (`prompt`/`compact`/`abort`/`events.on` all throw `HarnessNotImplemented`; see #337, which holds us at 0.83). The deeper problem it exposed: **pi does not consume `AgentHarness` itself** — its TUI, RPC and SDK all run on `AgentSession`. We were the only consumer of a surface with no dogfooding pressure behind it.

`docs/design/conformance-levels.md` §2 already named the destination — `per-invoke × session`, the "portable AND extension-hosting" cell. This PR makes it executable.

## What it proves

All four Agent-side MUSTs hold on `AgentSession` in the `per-invoke` posture, MUST 6 (portability) included — every turn builds a fresh session over the same jsonl, with nothing shared in-process but the directory:

```
✓ MUST 1 single terminal                     25ms
✓ MUST 1+2 failures are events               10ms
✓ MUST 3 cancel + cleanup                    10ms
✓ §5 JSON-serializable                       17ms
✓ MUST 6 portable across instances           22ms
```

Measured behaviour behind the implementation (probed before writing it):

| Question | Answer |
|---|---|
| Event stream | `agent_start → turn_start → message_start/update/end → turn_end → agent_end → agent_settled`; `message_update` / `tool_execution_*` fields are identical to the harness ones |
| Does `prompt()` throw? | No — a provider error and an abort both resolve normally, so the terminal comes from the last assistant message's `stopReason`, exactly as on the harness path |
| Abort | `stopReason: "aborted"`, content truncated at the interruption point |
| Cross-instance history | `SessionManager.create(cwd, dir, {id})` / `list` / `open(path)` is sufficient |

Per-turn cost on a 20-turn session (directory scan + jsonl read included): services build once at 16ms, then **p50 0.59ms / p95 2.08ms** to bind a session — confirming the "~1 ms" figure in conformance-levels.md §2.

One free upgrade: `AgentSession` retries a failed assistant request itself (`auto_retry_start`), which the harness never did. It maps onto SPEC's existing `retrying` event. Whether serving keeps it enabled is a phase-2 policy call — the failure subject turns it off so its ~14s backoff does not pace the suite.

## Scope

Wired: the concurrency floor, the event stream, cancellation.

Not wired: observation plane (`SessionObserver` / `RunControls` / rich `SessionEvent`), tool activation bridge, auto-compaction, session inheritance. The fastagent assembly (definition, tools, prompt) is not connected either — the test supplies a bare `services`.

So `createPiAgentFromHarness` remains the only serving path, and the new module is deliberately absent from `src/pi.ts`.

Known debt, stated in the module header with its retirement condition: `toAgentEvent` translates pi events straight to SPEC `AgentEvent`s, which is the second parallel translation `docs/design/session-control.md` §6 forbids. It goes away when this L0 grows the observation plane — which is also when the harness L0 goes away.

## Verification

`npm run lint && npm run typecheck && npm test` — 106 files, 1368 tests, all green.
