### PR TITLE
fix(pi): a failure preparing the prompt fails the turn, not the iteration

### DIFF
--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -634,8 +634,21 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       });
       let completed: AssistantMessage | undefined; // the assistant message of a cleanly completed turn
       try {
+        // Preparing the prompt lazy-loads the image pipeline and re-encodes every attachment, so it
+        // can throw BEFORE any engine work exists to fail — and a throw here would escape the
+        // generator and break iteration for the caller, which MUST 2 forbids. It settles the run the
+        // same way a setup failure does.
+        let opts: Awaited<ReturnType<typeof toPiPromptOptions>>;
+        try {
+          opts = await toPiPromptOptions(prompt);
+        } catch (error) {
+          const terminal = errorToTerminal(error);
+          outcome = { status: "failed", error: { message: terminal.details, retryable: terminal.retryable } };
+          runSettled = true;
+          yield terminal;
+          return; // → outer finally emits the settlement
+        }
         // Bind current cwd/session/activation capabilities for every FastAgent-defined tool.
-        const opts = await toPiPromptOptions(prompt);
         const run = turnContext.run(
           {
             cwd: options.cwd ?? process.cwd(),

--- a/src/engines/pi/invoke.ts
+++ b/src/engines/pi/invoke.ts
@@ -603,20 +603,6 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       onCancelReady(() => {
         void harness.abort().catch(() => {});
       });
-      // The consumer cancelled DURING the build (latched — the door above came too late to be
-      // knocked): never start the model call; settle as aborted and let the queued return()
-      // finish the generator. Same synchronous tick as the arming — a cancel from here on
-      // reaches the armed door instead.
-      if (wasCancelled()) {
-        outcome = { status: "aborted" };
-        runSettled = true;
-        try {
-          await harness.abort(); // teardown — fresh-harness discipline
-        } catch (error) {
-          log.warn(`[fastagent] harness abort failed during cleanup: ${String(error)}`);
-        }
-        return; // → outer finally emits the settlement
-      }
       const queue = new EventQueue<AgentEvent>();
       const unsub = harness.subscribe((pe) => {
         // Summarization retries also warn to server logs: the session `retry_scheduled` event only
@@ -635,9 +621,9 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
       let completed: AssistantMessage | undefined; // the assistant message of a cleanly completed turn
       try {
         // Preparing the prompt lazy-loads the image pipeline and re-encodes every attachment, so it
-        // can throw BEFORE any engine work exists to fail — and a throw here would escape the
-        // generator and break iteration for the caller, which MUST 2 forbids. It settles the run the
-        // same way a setup failure does.
+        // both takes time and can throw BEFORE any engine work exists to fail — and a throw here
+        // would escape the generator and break iteration for the caller, which MUST 2 forbids. It
+        // settles the run the same way a setup failure does.
         let opts: Awaited<ReturnType<typeof toPiPromptOptions>>;
         try {
           opts = await toPiPromptOptions(prompt);
@@ -646,6 +632,21 @@ export function createPiAgentFromHarness(options: CreatePiAgentFromHarnessOption
           outcome = { status: "failed", error: { message: terminal.details, retryable: terminal.retryable } };
           runSettled = true;
           yield terminal;
+          return; // → outer finally emits the settlement
+        }
+        // The consumer walked away while the harness was built or the prompt prepared (latched — the
+        // door armed above only stops a RUNNING harness, so a knock in that window is a no-op the
+        // LATER run would ignore): never start the model call. Read AFTER the last await before it,
+        // so both windows are covered; settle as aborted and let the queued return() finish the
+        // generator.
+        if (wasCancelled()) {
+          outcome = { status: "aborted" };
+          runSettled = true;
+          try {
+            await harness.abort(); // teardown — fresh-harness discipline
+          } catch (error) {
+            log.warn(`[fastagent] harness abort failed during cleanup: ${String(error)}`);
+          }
           return; // → outer finally emits the settlement
         }
         // Bind current cwd/session/activation capabilities for every FastAgent-defined tool.

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -268,6 +268,20 @@ describe("prompt.images passthrough (SPEC §4)", () => {
     expect(dump).toContain("aGVsbG8="); // base64 payload reached the context
     expect(dump).toContain('"image"');
   });
+
+  it("a prompt that cannot be prepared fails the turn instead of throwing at the caller", async () => {
+    const { agent } = makeAgent([fauxAssistantMessage("never reached")]);
+    // Preparing images decodes and re-encodes every attachment; a payload that is not a string kills
+    // that step before any engine work exists to fail. MUST 2 makes it an event, not a throw.
+    const events = await drain(
+      agent.invoke(
+        { session: "bad-image" },
+        { text: "what is this?", images: [{ mimeType: "image/png", data: 42 as unknown as string }] },
+      ),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("failed");
+  });
 });
 
 describe("session continuity (open instead of create)", () => {


### PR DESCRIPTION
A malformed or unpreparable prompt broke iteration for the caller instead of failing the turn.

`toPiPromptOptions()` lazy-loads the image pipeline and re-encodes every attachment, so it can throw *before* any engine work exists to fail. On the serving path the call sat outside every catch, so the throw escaped the generator:

```
TypeError: The first argument must be of type string or an instance of Buffer... Received type number
```

SPEC MUST 1/2 require exactly one terminal event and no thrown iteration. A channel handing us an image whose `data` is not a string (anything crossing a wire boundary can) took down the turn's consumer rather than getting a `failed` event.

It now settles the run the way a setup failure already does: one `failed` event, the `run_settled` the observation plane expects, and the lease released.

Found by review while proving the `AgentSession` L0 (#338) — that PR carries the same fix for its own path, and deliberately left this one alone because it is the serving path and deserves its own change.

## Verification

New test in `test/invoke.test.ts` (fails on the parent commit with the `TypeError` above). `npm run lint && npm run typecheck && npm test` — 1364 tests, all green.
