### PR TITLE
chore: release 0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, Telegram, Slack, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Release v0.18.0

Bump @fastagent-sh/fastagent from 0.17.1 to 0.18.0.

Minor, not patch: `v0.17.1..main` carries five features — custom model endpoints via the agent's own `models.json` (#333), the SPEC MUSTs proven on pi's own AgentSession (#338), and three Feishu participation/threading changes (#330, #328, #327).

### Verification

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm pack --dry-run --json`

### After merge

Create and publish the GitHub Release `v0.18.0`. The protected publish workflow will verify and publish the package to npm via Trusted Publishing.