### PR TITLE
feat(pi): the definition carries its own extensions/ (chat runs them; serving says why it cannot)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -288,6 +288,28 @@ export default defineConfig({
 Package tools receive the same `ToolContext` as definition-local `defineTool` tools, including the
 optional read-only `sessionManager` during serving/chat turns.
 
+## Extensions
+
+Extension modules under `extensions/` are loaded and travel with the definition, so the same agent
+behaves the same in `dev`, `start`, `chat`, and a container. Two discovery shapes, matching pi:
+
+```txt
+extensions/notify.ts        ->  loaded
+extensions/audit/index.ts   ->  loaded
+```
+
+pi's third shape — a subdirectory whose `package.json` declares a `pi` field — is not supported;
+such a directory is warned about rather than skipped in silence. An extension that fails to load is
+warned about too, and the agent keeps serving without it.
+
+Only the definition's own `extensions/` are loaded. The machine's `~/.pi` extensions are
+deliberately not — a served agent must not depend on the authoring machine's setup. Extensions are
+code, so they are read once at startup: adding one needs a restart, like `tools/`.
+
+Extensions can register tools and commands, and they can ask the user questions through pi's UI
+primitives. That last part has no answering channel when serving — `select`/`confirm`/`input`
+resolve immediately as "no answer" rather than reaching anyone.
+
 ### When the repo already owns `tools/` or `channels/`
 
 Nothing to do — the agent lives in `./fastagent/`, so FastAgent scans the agent's own directories,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,17 +309,17 @@ deliberately not — a served agent must not depend on the authoring machine's s
 Which files count as extensions is decided at startup: **adding or removing one needs a restart**,
 like `tools/`.
 
-**An extension is loaded once per process, not once per turn.** pi caches extension modules in a
-process-global map, so every turn a served agent takes shares one instance and one module scope.
-Serving is concurrent — several turns can be in flight at once — which makes two rules practical
-rather than pedantic:
+**An extension is loaded once per agent, not once per turn.** The agent's assembly loads it and
+serves every turn from that one instance, sharing one module scope. (Two agents in one process get
+an instance each.) Serving is concurrent — several turns can be in flight at once — which makes two
+rules practical rather than pedantic:
 
 - **`session_start` fires on every turn, against that one shared instance.** Write the handler so
   running it again is harmless: guard with a flag, or reuse what you already opened. A handler that
   unconditionally opens a timer or connection opens one per turn, and they accumulate.
 - **`session_shutdown` is not emitted per turn when serving.** It cannot be: the instance outlives
   the turn, so tearing it down at the end of one turn would pull state out from under the turns
-  still running. Clean up in whatever opened the resource — the tool call or handler that owns it —
+  still running — including turns for entirely different conversations. Clean up in whatever opened the resource — the tool call or handler that owns it —
   rather than expecting a per-turn teardown signal.
 
 Module state therefore *does* carry from turn to turn. That is useful (a cache, a pooled client) as

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -335,12 +335,16 @@ interactive surface:
 | | serving (`dev`, `start`, channels) | `chat` |
 |---|---|---|
 | tools it registers | offered to the model | offered to the model |
-| lifecycle handlers | run | run |
+| event handlers | run | run |
+| `session_start` | runs, **once per turn**, on the shared instance | runs once |
+| `session_shutdown` | **never emitted** — see above | on exit |
 | commands it registers | **not executable** — a leading `/name` is just prompt text | executable |
 | `select` / `confirm` / `input` | resolve immediately as "no answer" | shown to you |
 
 So an extension whose value is a slash command or a dialog is a `chat`-time tool today; one that
-registers model-callable tools or reacts to lifecycle events works everywhere.
+registers model-callable tools or reacts to events works everywhere — provided it does not depend
+on being told when to shut down. A served agent has no shutdown signal to give it: the process, not
+the turn, owns the extension, and the process exit is not currently observable by extensions.
 
 ### When the repo already owns `tools/` or `channels/`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,69 +290,63 @@ optional read-only `sessionManager` during serving/chat turns.
 
 ## Extensions
 
-Extension modules under `extensions/` are loaded and travel with the definition, so an extension
-loads — and the tools it registers are mounted — identically in `dev`, `start`, `chat`, and a
-container. Two discovery shapes, matching pi:
+Extension modules under `extensions/` travel with the definition. **They run in `fastagent chat`.
+They are not loaded when serving** (`dev`, `start`, channels, a container) — see the split below,
+which is a limitation of pi's extension runtime rather than a decision about your agent.
+
+Two discovery shapes, matching pi:
 
 ```txt
-extensions/notify.ts        ->  loaded
-extensions/audit/index.ts   ->  loaded
+extensions/notify.ts        ->  discovered
+extensions/audit/index.ts   ->  discovered
 ```
 
 pi's third shape — a subdirectory whose `package.json` declares a `pi` field — is not supported;
-such a directory is warned about rather than skipped in silence. An extension that fails to load is
-warned about too, and the agent keeps serving without it.
+such a directory is warned about rather than skipped in silence. A symlinked entry is refused: an
+extension reached through a link out of the definition resolves on your machine and is missing in
+the container.
 
-Only the definition's own `extensions/` are loaded. The machine's `~/.pi` extensions are
+Only the definition's own `extensions/` are considered. The machine's `~/.pi` extensions are
 deliberately not — a served agent must not depend on the authoring machine's setup.
 
-Which files count as extensions is decided at startup: **adding or removing one needs a restart**,
-like `tools/`.
+### Why serving does not run them
 
-**An extension is loaded once per agent, not once per turn.** The agent's assembly loads it and
-serves every turn from that one instance, sharing one module scope. (Two agents in one process get
-an instance each.) Serving is concurrent — several turns can be in flight at once — which makes two
-rules practical rather than pedantic:
+pi's extension machinery is built for **one process serving one session**, which is what a terminal
+is. Its own source calls the object holding a session's actions "the shared runtime", and every
+`AgentSession` overwrites it on construction:
 
-- **`session_start` fires on every turn, against that one shared instance.** Write the handler so
-  running it again is harmless: guard with a flag, or reuse what you already opened. A handler that
-  unconditionally opens a timer or connection opens one per turn, and they accumulate.
-- **`session_shutdown` is not emitted per turn when serving.** It cannot be: the instance outlives
-  the turn, so tearing it down at the end of one turn would pull state out from under the turns
-  still running — including turns for entirely different conversations. Clean up in whatever opened the resource — the tool call or handler that owns it —
-  rather than expecting a per-turn teardown signal.
+```js
+// Copy actions into the shared runtime (all extension APIs reference this)
+this.runtime.sendMessage = actions.sendMessage;
+this.runtime.appendEntry = actions.appendEntry;
+```
 
-Module state therefore *does* carry from turn to turn. That is useful (a cache, a pooled client) as
-long as you remember it is shared by concurrent turns and by every session the agent serves — it is
-not a per-conversation scratchpad. Anything that belongs to one conversation belongs in the session,
-not in your module.
+Serving is the opposite shape: one process, many concurrent turns, belonging to conversations that
+have nothing to do with each other. With two turns in flight, the second one to start redirects
+those actions to itself — so an extension calling `pi.sendMessage()` during the first turn can
+deliver into the **other person's conversation**. The same sharing applies to the extension module
+itself, and to `session_start` / `session_shutdown`, which stop being a matched pair once several
+sessions share one instance.
 
-One consequence worth knowing: **an agent that ships `extensions/` restarts on definition edits.**
-Normally `persona.md`, `AGENTS.md` and `skills/` are live — edit them and the next turn sees the
-change, no restart. But serving a re-read definition goes through a pi resource reload, and that
-reload re-runs every extension factory (it clears their module cache first) without shutting the
-previous instances down. Rather than let a prompt edit quietly rebuild your extensions and strand
-whatever the old ones opened, `fastagent dev` restarts the worker for definition edits whenever
-`extensions/` is present. The startup line tells you which mode you are in.
+That is a silent correctness failure, and a silently wrong answer is worse than a missing feature.
+So serving does not load them, and warns at startup when a definition ships some.
 
-`chat` is the simpler case: one long-lived session, one instance, `session_start` once.
-
-What an extension can register is not uniformly *reachable*, because a served agent has no
-interactive surface:
+This is fixable upstream, and narrowly: pi already has an uncached loader path that builds a fresh
+module per call (jiti with `moduleCache: false`) and takes the runtime as an argument, which is
+exactly per-session isolation. That function is not currently exported. When it is, serving can run
+extensions with the same guarantees `chat` has today.
 
 | | serving (`dev`, `start`, channels) | `chat` |
 |---|---|---|
-| tools it registers | offered to the model | offered to the model |
-| event handlers | run | run |
-| `session_start` | runs, **once per turn**, on the shared instance | runs once |
-| `session_shutdown` | **never emitted** — see above | on exit |
-| commands it registers | **not executable** — a leading `/name` is just prompt text | executable |
-| `select` / `confirm` / `input` | resolve immediately as "no answer" | shown to you |
+| discovery, and its refusals | runs | runs |
+| tools it registers | **not mounted** | offered to the model |
+| event and lifecycle handlers | **not run** | run |
+| commands it registers | not executable | executable |
+| `select` / `confirm` / `input` | — | shown to you |
 
-So an extension whose value is a slash command or a dialog is a `chat`-time tool today; one that
-registers model-callable tools or reacts to events works everywhere — provided it does not depend
-on being told when to shut down. A served agent has no shutdown signal to give it: the process, not
-the turn, owns the extension, and the process exit is not currently observable by extensions.
+If your extension's value is a slash command or a dialog, `chat` was always its home. If it
+registers model-callable tools you need while served, write them as `tools/` — that is the path
+built for serving, and it is concurrency-safe.
 
 ### When the repo already owns `tools/` or `channels/`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -327,11 +327,13 @@ long as you remember it is shared by concurrent turns and by every session the a
 not a per-conversation scratchpad. Anything that belongs to one conversation belongs in the session,
 not in your module.
 
-One exception, and it bites in `dev`: **editing the definition rebuilds your extension.** `persona.md`
-and `skills/` are re-read live, and the only way pi serves a re-read one is a resource reload, which
-starts by clearing its extension module cache. So an edit to the persona re-runs your factory and
-discards the module state it held — even though nothing about the extension changed. Deployed agents
-do not hit this (their definition does not change under them); an author iterating in `dev` does.
+One consequence worth knowing: **an agent that ships `extensions/` restarts on definition edits.**
+Normally `persona.md`, `AGENTS.md` and `skills/` are live — edit them and the next turn sees the
+change, no restart. But serving a re-read definition goes through a pi resource reload, and that
+reload re-runs every extension factory (it clears their module cache first) without shutting the
+previous instances down. Rather than let a prompt edit quietly rebuild your extensions and strand
+whatever the old ones opened, `fastagent dev` restarts the worker for definition edits whenever
+`extensions/` is present. The startup line tells you which mode you are in.
 
 `chat` is the simpler case: one long-lived session, one instance, `session_start` once.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,8 +290,9 @@ optional read-only `sessionManager` during serving/chat turns.
 
 ## Extensions
 
-Extension modules under `extensions/` are loaded and travel with the definition, so the same agent
-behaves the same in `dev`, `start`, `chat`, and a container. Two discovery shapes, matching pi:
+Extension modules under `extensions/` are loaded and travel with the definition, so an extension
+loads — and the tools it registers are mounted — identically in `dev`, `start`, `chat`, and a
+container. Two discovery shapes, matching pi:
 
 ```txt
 extensions/notify.ts        ->  loaded
@@ -306,9 +307,18 @@ Only the definition's own `extensions/` are loaded. The machine's `~/.pi` extens
 deliberately not — a served agent must not depend on the authoring machine's setup. Extensions are
 code, so they are read once at startup: adding one needs a restart, like `tools/`.
 
-Extensions can register tools and commands, and they can ask the user questions through pi's UI
-primitives. That last part has no answering channel when serving — `select`/`confirm`/`input`
-resolve immediately as "no answer" rather than reaching anyone.
+What an extension can register is not uniformly *reachable*, because a served agent has no
+interactive surface:
+
+| | serving (`dev`, `start`, channels) | `chat` |
+|---|---|---|
+| tools it registers | offered to the model | offered to the model |
+| lifecycle handlers | run | run |
+| commands it registers | **not executable** — a leading `/name` is just prompt text | executable |
+| `select` / `confirm` / `input` | resolve immediately as "no answer" | shown to you |
+
+So an extension whose value is a slash command or a dialog is a `chat`-time tool today; one that
+registers model-callable tools or reacts to lifecycle events works everywhere.
 
 ### When the repo already owns `tools/` or `channels/`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -304,8 +304,20 @@ such a directory is warned about rather than skipped in silence. An extension th
 warned about too, and the agent keeps serving without it.
 
 Only the definition's own `extensions/` are loaded. The machine's `~/.pi` extensions are
-deliberately not — a served agent must not depend on the authoring machine's setup. Extensions are
-code, so they are read once at startup: adding one needs a restart, like `tools/`.
+deliberately not — a served agent must not depend on the authoring machine's setup.
+
+Which files count as extensions is decided at startup: **adding or removing one needs a restart**,
+like `tools/`. Those files are then re-instantiated **per turn** when serving, so each turn gets its
+own module state and its own `session_start` / `session_shutdown` pair. Two consequences worth
+knowing when you write one:
+
+- module-level state does **not** carry from one turn to the next — use `tools/` or your own store
+  for anything that must;
+- a resource opened in `session_start` is torn down by that same turn's `session_shutdown`, so it
+  cannot be leaked into, or clobbered by, a concurrent turn.
+
+In `chat` the runtime is one long-lived session instead, so an extension is instantiated once and
+its module state lives as long as the chat does.
 
 What an extension can register is not uniformly *reachable*, because a served agent has no
 interactive surface:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -327,6 +327,12 @@ long as you remember it is shared by concurrent turns and by every session the a
 not a per-conversation scratchpad. Anything that belongs to one conversation belongs in the session,
 not in your module.
 
+One exception, and it bites in `dev`: **editing the definition rebuilds your extension.** `persona.md`
+and `skills/` are re-read live, and the only way pi serves a re-read one is a resource reload, which
+starts by clearing its extension module cache. So an edit to the persona re-runs your factory and
+discards the module state it held — even though nothing about the extension changed. Deployed agents
+do not hit this (their definition does not change under them); an author iterating in `dev` does.
+
 `chat` is the simpler case: one long-lived session, one instance, `session_start` once.
 
 What an extension can register is not uniformly *reachable*, because a served agent has no

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,17 +307,27 @@ Only the definition's own `extensions/` are loaded. The machine's `~/.pi` extens
 deliberately not — a served agent must not depend on the authoring machine's setup.
 
 Which files count as extensions is decided at startup: **adding or removing one needs a restart**,
-like `tools/`. Those files are then re-instantiated **per turn** when serving, so each turn gets its
-own module state and its own `session_start` / `session_shutdown` pair. Two consequences worth
-knowing when you write one:
+like `tools/`.
 
-- module-level state does **not** carry from one turn to the next — use `tools/` or your own store
-  for anything that must;
-- a resource opened in `session_start` is torn down by that same turn's `session_shutdown`, so it
-  cannot be leaked into, or clobbered by, a concurrent turn.
+**An extension is loaded once per process, not once per turn.** pi caches extension modules in a
+process-global map, so every turn a served agent takes shares one instance and one module scope.
+Serving is concurrent — several turns can be in flight at once — which makes two rules practical
+rather than pedantic:
 
-In `chat` the runtime is one long-lived session instead, so an extension is instantiated once and
-its module state lives as long as the chat does.
+- **`session_start` fires on every turn, against that one shared instance.** Write the handler so
+  running it again is harmless: guard with a flag, or reuse what you already opened. A handler that
+  unconditionally opens a timer or connection opens one per turn, and they accumulate.
+- **`session_shutdown` is not emitted per turn when serving.** It cannot be: the instance outlives
+  the turn, so tearing it down at the end of one turn would pull state out from under the turns
+  still running. Clean up in whatever opened the resource — the tool call or handler that owns it —
+  rather than expecting a per-turn teardown signal.
+
+Module state therefore *does* carry from turn to turn. That is useful (a cache, a pooled client) as
+long as you remember it is shared by concurrent turns and by every session the agent serves — it is
+not a per-conversation scratchpad. Anything that belongs to one conversation belongs in the session,
+not in your module.
+
+`chat` is the simpler case: one long-lived session, one instance, `session_start` once.
 
 What an extension can register is not uniformly *reachable*, because a served agent has no
 interactive surface:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,6 +19,7 @@ agent/
 ├── tools/              # optional code tools
 ├── channels/           # optional webhook/bot adapters
 ├── schedules/          # optional cron time triggers
+├── extensions/         # optional pi extension modules (loaded from here only)
 ├── AGENTS.md           # optional project context (yours, or a host repo's)
 ├── reference.md        # optional markdown context (any file layout)
 └── fastagent.config.mjs # optional deployment choices

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,7 +19,7 @@ agent/
 ├── tools/              # optional code tools
 ├── channels/           # optional webhook/bot adapters
 ├── schedules/          # optional cron time triggers
-├── extensions/         # optional pi extension modules (loaded from here only)
+├── extensions/         # optional pi extension modules (chat only — see configuration.md)
 ├── AGENTS.md           # optional project context (yours, or a host repo's)
 ├── reference.md        # optional markdown context (any file layout)
 └── fastagent.config.mjs # optional deployment choices

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -11,8 +11,7 @@
  * product, including editing its own AGENTS.md) never has its in-flight turn killed by the watcher.
  */
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join, relative, sep } from "node:path";
+import { relative, sep } from "node:path";
 import { watch as watchTree } from "chokidar";
 import { AGENT_CONFIG_NAMES, AGENT_MODELS_FILE, type ResolvedPlacement, resolveStateRoot } from "./paths.ts";
 import { isUnderDir } from "./engines/pi/definition.ts";
@@ -41,11 +40,7 @@ const WATCHED_HINT = `${CODE_INPUT_DIRS.map((dir) => `${dir}/`).join(", ")}, pac
  * costs no watchers and triggers no restarts. Helper code imported from OUTSIDE tools//channels/ is
  * out of scope by design (keep it under tools/, or restart manually) — the startup log names the set.
  */
-export function devWatchIgnored(
-  root: string,
-  envFile: string,
-  options: { definitionRestartsWorker?: boolean } = {},
-): (path: string) => boolean {
+export function devWatchIgnored(root: string, envFile: string): (path: string) => boolean {
   // The `.env` is allow-listed by its RESOLVED path, not by the `.secrets` name: FASTAGENT_SECRETS_DIR
   // can put it in an in-agent directory called anything, and a name-based rule would prune the very
   // file the worker loads (a credential edit would then silently never restart it).
@@ -67,15 +62,6 @@ export function devWatchIgnored(
     if (rel === AGENT_MODELS_FILE) return false;
     const segments = rel.split(sep);
     if (CODE_INPUT_DIRS.includes(segments[0] as (typeof CODE_INPUT_DIRS)[number])) return false;
-    // With extensions/ present, the DEFINITION restarts the worker too. A live definition edit
-    // reaches the model through a resource reload, and pi's reload re-runs every extension factory
-    // (it clears their module cache first) without shutting the old instances down — so an edit that
-    // is meant to change a prompt silently rebuilds extensions and strands whatever the previous
-    // ones opened. A restart is the honest version of that: same fresh state, nothing left behind.
-    if (options.definitionRestartsWorker) {
-      if (rel === "persona.md" || rel === "AGENTS.md") return false;
-      if (segments[0] === "skills") return false;
-    }
     // The `.env` restarts too (credentials are process-bound). Keep it AND its ancestor directories
     // un-pruned so chokidar can descend to it; every sibling inside them (auth.json, .env.example)
     // prunes normally. An out-of-agent `.env` yields a `..`-prefixed envRel that matches nothing here
@@ -161,14 +147,9 @@ export async function runDevSupervisor(
 
   // chokidar gives reliable cross-platform recursion + structural ignore that native fs.watch
   // cannot; devWatchIgnored (above) narrows the scope to the process-bound code inputs.
-  // Does this agent ship extensions? If so the definition joins the restart set (see the note in
-  // devWatchIgnored); the check is the directory's presence, matching how the assembly discovers it.
-  const hasExtensions = existsSync(join(placement.agentDir, "extensions"));
   const watcher = watchTree(placement.agentDir, {
     ignoreInitial: true, // the startup scan is not a change
-    ignored: devWatchIgnored(placement.agentDir, dotEnvPath(placement.agentDir), {
-      definitionRestartsWorker: hasExtensions,
-    }),
+    ignored: devWatchIgnored(placement.agentDir, dotEnvPath(placement.agentDir)),
   });
   watcher.on("all", () => {
     clearTimeout(timer);
@@ -178,9 +159,7 @@ export async function runDevSupervisor(
     log.warn(`[fastagent] file watching error (${(error as Error).message}); some edits may need a manual restart`),
   );
   log.info(
-    hasExtensions
-      ? `[fastagent] watching ${WATCHED_HINT}, AGENTS.md/persona.md/skills — edits restart the dev worker (--no-watch to disable); the definition restarts too because extensions/ is present`
-      : `[fastagent] watching ${WATCHED_HINT} — code edits restart the dev worker (--no-watch to disable); AGENTS.md/persona.md/skills edits go live next turn without a restart`,
+    `[fastagent] watching ${WATCHED_HINT} — code edits restart the dev worker (--no-watch to disable); AGENTS.md/persona.md/skills edits go live next turn without a restart`,
   );
   // FASTAGENT_SECRETS_DIR can move the `.env` OUT of the agent dir entirely; the watcher follows it
   // anywhere inside (the resolved path is allow-listed above), but outside the watch root the worker

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -22,7 +22,14 @@ import { openExternalUrl } from "./open-url.ts";
 import { type Tunnel, announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
 
 /** What the dev watcher restarts on (agent-dir-relative): the process-bound code inputs only. */
-const WATCHED_HINT = "tools/, channels/, schedules/, package.json, fastagent.config.*, models.json, .secrets/.env";
+/**
+ * The agent-dir directories loaded ONCE per worker: a restart is their only re-read. One list, so
+ * the watcher and the line printed at startup cannot disagree — a directory watched but unannounced
+ * looks broken, and one announced but unwatched silently strands the author mid-edit.
+ */
+const CODE_INPUT_DIRS = ["tools", "channels", "schedules", "extensions"] as const;
+
+const WATCHED_HINT = `${CODE_INPUT_DIRS.map((dir) => `${dir}/`).join(", ")}, package.json, fastagent.config.*, models.json, .secrets/.env`;
 
 /**
  * chokidar `ignored` matcher for the narrow watch scope (true = ignore), rooted at the AGENT DIR. When
@@ -54,7 +61,7 @@ export function devWatchIgnored(root: string, envFile: string): (path: string) =
     // repairs it would not be the edit that restarts.
     if (rel === AGENT_MODELS_FILE) return false;
     const segments = rel.split(sep);
-    if (segments[0] === "tools" || segments[0] === "channels" || segments[0] === "schedules") return false;
+    if (CODE_INPUT_DIRS.includes(segments[0] as (typeof CODE_INPUT_DIRS)[number])) return false;
     // The `.env` restarts too (credentials are process-bound). Keep it AND its ancestor directories
     // un-pruned so chokidar can descend to it; every sibling inside them (auth.json, .env.example)
     // prunes normally. An out-of-agent `.env` yields a `..`-prefixed envRel that matches nothing here

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -11,7 +11,8 @@
  * product, including editing its own AGENTS.md) never has its in-flight turn killed by the watcher.
  */
 import { spawn } from "node:child_process";
-import { relative, sep } from "node:path";
+import { existsSync } from "node:fs";
+import { join, relative, sep } from "node:path";
 import { watch as watchTree } from "chokidar";
 import { AGENT_CONFIG_NAMES, AGENT_MODELS_FILE, type ResolvedPlacement, resolveStateRoot } from "./paths.ts";
 import { isUnderDir } from "./engines/pi/definition.ts";
@@ -40,7 +41,11 @@ const WATCHED_HINT = `${CODE_INPUT_DIRS.map((dir) => `${dir}/`).join(", ")}, pac
  * costs no watchers and triggers no restarts. Helper code imported from OUTSIDE tools//channels/ is
  * out of scope by design (keep it under tools/, or restart manually) — the startup log names the set.
  */
-export function devWatchIgnored(root: string, envFile: string): (path: string) => boolean {
+export function devWatchIgnored(
+  root: string,
+  envFile: string,
+  options: { definitionRestartsWorker?: boolean } = {},
+): (path: string) => boolean {
   // The `.env` is allow-listed by its RESOLVED path, not by the `.secrets` name: FASTAGENT_SECRETS_DIR
   // can put it in an in-agent directory called anything, and a name-based rule would prune the very
   // file the worker loads (a credential edit would then silently never restart it).
@@ -62,6 +67,15 @@ export function devWatchIgnored(root: string, envFile: string): (path: string) =
     if (rel === AGENT_MODELS_FILE) return false;
     const segments = rel.split(sep);
     if (CODE_INPUT_DIRS.includes(segments[0] as (typeof CODE_INPUT_DIRS)[number])) return false;
+    // With extensions/ present, the DEFINITION restarts the worker too. A live definition edit
+    // reaches the model through a resource reload, and pi's reload re-runs every extension factory
+    // (it clears their module cache first) without shutting the old instances down — so an edit that
+    // is meant to change a prompt silently rebuilds extensions and strands whatever the previous
+    // ones opened. A restart is the honest version of that: same fresh state, nothing left behind.
+    if (options.definitionRestartsWorker) {
+      if (rel === "persona.md" || rel === "AGENTS.md") return false;
+      if (segments[0] === "skills") return false;
+    }
     // The `.env` restarts too (credentials are process-bound). Keep it AND its ancestor directories
     // un-pruned so chokidar can descend to it; every sibling inside them (auth.json, .env.example)
     // prunes normally. An out-of-agent `.env` yields a `..`-prefixed envRel that matches nothing here
@@ -147,9 +161,14 @@ export async function runDevSupervisor(
 
   // chokidar gives reliable cross-platform recursion + structural ignore that native fs.watch
   // cannot; devWatchIgnored (above) narrows the scope to the process-bound code inputs.
+  // Does this agent ship extensions? If so the definition joins the restart set (see the note in
+  // devWatchIgnored); the check is the directory's presence, matching how the assembly discovers it.
+  const hasExtensions = existsSync(join(placement.agentDir, "extensions"));
   const watcher = watchTree(placement.agentDir, {
     ignoreInitial: true, // the startup scan is not a change
-    ignored: devWatchIgnored(placement.agentDir, dotEnvPath(placement.agentDir)),
+    ignored: devWatchIgnored(placement.agentDir, dotEnvPath(placement.agentDir), {
+      definitionRestartsWorker: hasExtensions,
+    }),
   });
   watcher.on("all", () => {
     clearTimeout(timer);
@@ -159,7 +178,9 @@ export async function runDevSupervisor(
     log.warn(`[fastagent] file watching error (${(error as Error).message}); some edits may need a manual restart`),
   );
   log.info(
-    `[fastagent] watching ${WATCHED_HINT} — code edits restart the dev worker (--no-watch to disable); AGENTS.md/persona.md/skills edits go live next turn without a restart`,
+    hasExtensions
+      ? `[fastagent] watching ${WATCHED_HINT}, AGENTS.md/persona.md/skills — edits restart the dev worker (--no-watch to disable); the definition restarts too because extensions/ is present`
+      : `[fastagent] watching ${WATCHED_HINT} — code edits restart the dev worker (--no-watch to disable); AGENTS.md/persona.md/skills edits go live next turn without a restart`,
   );
   // FASTAGENT_SECRETS_DIR can move the `.env` OUT of the agent dir entirely; the watcher follows it
   // anywhere inside (the resolved path is allow-listed above), but outside the watch root the worker

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -68,9 +68,25 @@ export interface PiAgentSessionFactoryOptions {
    * means pi's own defaults, which is the intended baseline.
    */
   agentDir?: string;
-  /** The definition's own extension entry points (see {@link LoadedDefinition.extensionPaths}). Handed
-   *  to pi as `additionalExtensionPaths`, which is honoured even under `noExtensions: true` — so the
-   *  definition's extensions load while the authoring machine's `~/.pi` ones stay out. */
+  /**
+   * The definition's own extension entry points, for ANNOUNCING that serving does not run them.
+   *
+   * pi's extension machinery is built for one process serving one session: `bindCore()` copies the
+   * session's actions into a runtime the pi source itself calls "the shared runtime", extension
+   * modules are cached per assembly, and `session_start`/`session_shutdown` are a matched pair.
+   * Serving breaks every one of those assumptions — concurrent turns for unrelated conversations —
+   * and the failure is silent cross-talk: with two turns in flight, an extension calling
+   * `pi.sendMessage()` can deliver into the other conversation.
+   *
+   * Loading them anyway would be a correctness bug dressed as a feature, so serving does not, and
+   * warns when a definition ships some. `chat` runs them fully: one session, one runtime, which is
+   * exactly the shape pi is built for.
+   *
+   * Isolating them per session is mechanically possible — pi's uncached loader path builds a fresh
+   * module (jiti with `moduleCache: false`) and takes the runtime as an argument — but that function
+   * is not exported and the deep path is blocked by the package's `exports`. Reopening this needs
+   * that entry point upstream, not a workaround here.
+   */
   extensionPaths?: string[];
   /** Filesystem/process environment handed to pi's default coding tools. */
   env: ExecutionEnv;
@@ -192,6 +208,13 @@ export function reportExtensionErrors(services: AgentSessionServices): void {
 export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): PiAgentSessionFactory {
   const { sessions, thinkingLevel, cwd, env } = options;
   const extensionPaths = options.extensionPaths ?? [];
+  if (extensionPaths.length > 0) {
+    log.warn(
+      `[fastagent] ${extensionPaths.length} extension(s) in the definition are NOT loaded when serving ` +
+        "(they run in `fastagent chat`): pi's extension runtime is shared across sessions, and serving " +
+        "runs concurrent turns for different conversations. See docs/configuration.md#extensions.",
+    );
+  }
   const tools = options.tools ?? [];
   const deferred = tools.filter(isDeferredTool).map((t) => t.name);
   // What the shared ResourceLoader serves, refreshed per turn before the session is built.
@@ -212,7 +235,7 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
         // ...except the definition's OWN extensions/: pi honours additionalExtensionPaths even under
         // noExtensions, which is exactly the split we want — the artifact travels with its
         // extensions, the operator's ~/.pi ones stay out.
-        ...(extensionPaths.length > 0 ? { additionalExtensionPaths: extensionPaths } : {}),
+        // No additionalExtensionPaths: see PiAgentSessionFactoryOptions.extensionPaths.
         noPromptTemplates: true,
         noContextFiles: true,
         // A SPACE, not "", when the assembly has no prompt: pi treats an empty custom prompt as
@@ -223,9 +246,6 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
         appendSystemPromptOverride: () => [],
         skillsOverride: (base) => ({ skills: toPiSkills(skills) as typeof base.skills, diagnostics: base.diagnostics }),
       },
-    }).then((built) => {
-      reportExtensionErrors(built);
-      return built;
     });
 
   return async (sessionId, inherit) => {
@@ -270,11 +290,6 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
         prompt = nextPrompt;
         skills = nextSkills;
         await loader.reload();
-        // A reload re-runs the extension factories (it begins by clearing pi's module cache), so it
-        // can fail an extension that loaded fine at boot — an author's edit is exactly when that
-        // happens. Reporting only the first build would drop the agent's extension silently, which
-        // is the failure this reporting exists to prevent.
-        reportExtensionErrors(await services);
       }
     }
     const sessionManager: SessionManager = await sessions.openOrCreate(sessionId, inherit);
@@ -306,16 +321,6 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
     // listeners and has none by default, which on a server means a broken extension looks like an
     // extension that simply did nothing.
     //
-    // `uiContext` is deliberately NOT bound here. pi defaults it to a no-op, so an extension asking
-    // `select`/`confirm`/`input` gets an immediate "no answer" instead of hanging — degraded, but not
-    // stuck. Binding a logging stand-in would mean implementing 20+ members of `ExtensionUIContext`,
-    // most of them TUI geometry (widgets, footers, editors) that a served agent has no meaning for.
-    // The answering channel is a contract question, not a stub: see the `ask`/`answer` design.
-    if (extensionPaths.length > 0) {
-      await session.bindExtensions({
-        onError: (e) => log.warn(`[fastagent] extension ${e.extensionPath} failed on ${e.event}: ${e.error}`),
-      });
-    }
     // Deferral, then restoration: pi starts every mounted tool active, so narrow by SUBTRACTING the
     // deferred names (robust to pi mounting tools of its own, unlike an exact-set replacement), then
     // add back what THIS session has already discovered.

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -270,6 +270,11 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
         prompt = nextPrompt;
         skills = nextSkills;
         await loader.reload();
+        // A reload re-runs the extension factories (it begins by clearing pi's module cache), so it
+        // can fail an extension that loaded fine at boot — an author's edit is exactly when that
+        // happens. Reporting only the first build would drop the agent's extension silently, which
+        // is the failure this reporting exists to prevent.
+        reportExtensionErrors(await services);
       }
     }
     const sessionManager: SessionManager = await sessions.openOrCreate(sessionId, inherit);

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -266,10 +266,7 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       const loader = (await services).resourceLoader;
       const definitionChanged =
         loader.getSystemPrompt() !== nextPrompt || loadedSkillSet(loader.getSkills().skills) !== skillSet(nextSkills);
-      // Extensions reload even when the definition did not change, because a turn needs its OWN
-      // instance: they hold module state and get session_start/session_shutdown per turn, so one
-      // instance shared across concurrent turns has one turn's shutdown tearing down another's.
-      if (definitionChanged || extensionPaths.length > 0) {
+      if (definitionChanged) {
         prompt = nextPrompt;
         skills = nextSkills;
         await loader.reload();

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -195,8 +195,9 @@ function toolDefinitions(
 /**
  * Announce extensions pi failed to load. pi collects them into `LoadExtensionsResult.errors` and
  * carries on with the rest — sound for a TUI that shows them, silent for a server that never looks.
- * A definition served without the extension it ships is exactly the "quietly missing" failure this
- * path exists to remove, so the serving and chat assemblies both call this once per built services.
+ * A definition running without the extension it ships is exactly the "quietly missing" failure this
+ * exists to remove. CHAT calls it, once per built services — serving does not load extensions at
+ * all, and announces that instead (see PiAgentSessionFactoryOptions.extensionPaths).
  */
 export function reportExtensionErrors(services: AgentSessionServices): void {
   for (const { path, error } of services.resourceLoader.getExtensions().errors) {

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -264,10 +264,18 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       // for both. Pinning a snapshot per turn would cost either a loader per turn or a queue in
       // front of every bind, to buy a guarantee nothing asks for.
       const loader = (await services).resourceLoader;
-      if (
-        loader.getSystemPrompt() !== nextPrompt ||
-        loadedSkillSet(loader.getSkills().skills) !== skillSet(nextSkills)
-      ) {
+      const definitionChanged =
+        loader.getSystemPrompt() !== nextPrompt || loadedSkillSet(loader.getSkills().skills) !== skillSet(nextSkills);
+      // Extensions reload EVERY turn, definition change or not — a turn gets its OWN instance.
+      //
+      // They hold module state and receive session_start/session_shutdown per turn, so a shared
+      // instance breaks under concurrency, which serving has by construction: with A mid-turn and B
+      // running to completion inside it, B's shutdown clears the timer A's start opened, and A's own
+      // shutdown then finds nothing (measured, and pinned in definition-extensions.test.ts).
+      //
+      // Isolation restores what pi's extension contract already says a session_shutdown means. The
+      // bill, measured per turn: 0.67ms without extensions, 2.86ms with one — against a model call.
+      if (definitionChanged || extensionPaths.length > 0) {
         prompt = nextPrompt;
         skills = nextSkills;
         await loader.reload();

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -68,6 +68,10 @@ export interface PiAgentSessionFactoryOptions {
    * means pi's own defaults, which is the intended baseline.
    */
   agentDir?: string;
+  /** The definition's own extension entry points (see {@link LoadedDefinition.extensionPaths}). Handed
+   *  to pi as `additionalExtensionPaths`, which is honoured even under `noExtensions: true` — so the
+   *  definition's extensions load while the authoring machine's `~/.pi` ones stay out. */
+  extensionPaths?: string[];
   /** Filesystem/process environment handed to pi's default coding tools. */
   env: ExecutionEnv;
 }
@@ -172,9 +176,22 @@ function toolDefinitions(
   })) as unknown as ToolDefinition[];
 }
 
+/**
+ * Announce extensions pi failed to load. pi collects them into `LoadExtensionsResult.errors` and
+ * carries on with the rest — sound for a TUI that shows them, silent for a server that never looks.
+ * A definition served without the extension it ships is exactly the "quietly missing" failure this
+ * path exists to remove, so the serving and chat assemblies both call this once per built services.
+ */
+export function reportExtensionErrors(services: AgentSessionServices): void {
+  for (const { path, error } of services.resourceLoader.getExtensions().errors) {
+    log.warn(`[fastagent] extension ${path} failed to load: ${error}`);
+  }
+}
+
 /** Open-or-create the record, then bind a fresh session to it. One call per invoke. */
 export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): PiAgentSessionFactory {
   const { sessions, thinkingLevel, cwd, env } = options;
+  const extensionPaths = options.extensionPaths ?? [];
   const tools = options.tools ?? [];
   const deferred = tools.filter(isDeferredTool).map((t) => t.name);
   // What the shared ResourceLoader serves, refreshed per turn before the session is built.
@@ -192,6 +209,10 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
         // The agent is the definition, not the authoring machine's pi setup: no ~/.pi extensions,
         // slash commands, global AGENTS.md or APPEND_SYSTEM.md (same posture as dev/start).
         noExtensions: true,
+        // ...except the definition's OWN extensions/: pi honours additionalExtensionPaths even under
+        // noExtensions, which is exactly the split we want — the artifact travels with its
+        // extensions, the operator's ~/.pi ones stay out.
+        ...(extensionPaths.length > 0 ? { additionalExtensionPaths: extensionPaths } : {}),
         noPromptTemplates: true,
         noContextFiles: true,
         // A SPACE, not "", when the assembly has no prompt: pi treats an empty custom prompt as
@@ -202,6 +223,9 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
         appendSystemPromptOverride: () => [],
         skillsOverride: (base) => ({ skills: toPiSkills(skills) as typeof base.skills, diagnostics: base.diagnostics }),
       },
+    }).then((built) => {
+      reportExtensionErrors(built);
+      return built;
     });
 
   return async (sessionId, inherit) => {
@@ -274,6 +298,20 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       customTools: toolDefinitions(tools, cwd, env, sessionId, bound),
     });
     bound.session = session;
+    // An extension handler that throws is otherwise dropped: pi fans errors out to registered
+    // listeners and has none by default, which on a server means a broken extension looks like an
+    // extension that simply did nothing.
+    //
+    // `uiContext` is deliberately NOT bound here. pi defaults it to a no-op, so an extension asking
+    // `select`/`confirm`/`input` gets an immediate "no answer" instead of hanging — degraded, but not
+    // stuck. Binding a logging stand-in would mean implementing 20+ members of `ExtensionUIContext`,
+    // most of them TUI geometry (widgets, footers, editors) that a served agent has no meaning for.
+    // The answering channel is a contract question, not a stub: see the `ask`/`answer` design.
+    if (extensionPaths.length > 0) {
+      await session.bindExtensions({
+        onError: (e) => log.warn(`[fastagent] extension ${e.extensionPath} failed on ${e.event}: ${e.error}`),
+      });
+    }
     // Deferral, then restoration: pi starts every mounted tool active, so narrow by SUBTRACTING the
     // deferred names (robust to pi mounting tools of its own, unlike an exact-set replacement), then
     // add back what THIS session has already discovered.

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -266,15 +266,9 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       const loader = (await services).resourceLoader;
       const definitionChanged =
         loader.getSystemPrompt() !== nextPrompt || loadedSkillSet(loader.getSkills().skills) !== skillSet(nextSkills);
-      // Extensions reload EVERY turn, definition change or not — a turn gets its OWN instance.
-      //
-      // They hold module state and receive session_start/session_shutdown per turn, so a shared
-      // instance breaks under concurrency, which serving has by construction: with A mid-turn and B
-      // running to completion inside it, B's shutdown clears the timer A's start opened, and A's own
-      // shutdown then finds nothing (measured, and pinned in definition-extensions.test.ts).
-      //
-      // Isolation restores what pi's extension contract already says a session_shutdown means. The
-      // bill, measured per turn: 0.67ms without extensions, 2.86ms with one — against a model call.
+      // Extensions reload even when the definition did not change, because a turn needs its OWN
+      // instance: they hold module state and get session_start/session_shutdown per turn, so one
+      // instance shared across concurrent turns has one turn's shutdown tearing down another's.
       if (definitionChanged || extensionPaths.length > 0) {
         prompt = nextPrompt;
         skills = nextSkills;

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -242,6 +242,8 @@ function buildPiAgent(opts: {
   sessions?: PiSessionRecordStore;
   /** Where pi reads its own settings; see {@link PiAgentSessionFactoryOptions.agentDir}. */
   agentDir?: string;
+  /** The definition's extension entry points; see {@link PiAgentSessionFactoryOptions.extensionPaths}. */
+  extensionPaths?: string[];
   env?: ExecutionEnv;
   lease?: Lease;
   observer?: SessionObserver;
@@ -279,6 +281,7 @@ function buildPiAgent(opts: {
     live: opts.live,
     cwd: env.cwd,
     ...(opts.agentDir ? { agentDir: opts.agentDir } : {}),
+    ...(opts.extensionPaths ? { extensionPaths: opts.extensionPaths } : {}),
     env,
   });
   opts.onAssembly?.({
@@ -501,6 +504,9 @@ export async function createPiAgentFromDefinition(
     },
     tools,
     sessions: options.sessions,
+    // Boot-resolved, not re-read per turn like the prompt: extensions are CODE, and pi loads a
+    // module once per process. An added extensions/ needs the restart that `tools/` already needs.
+    extensionPaths: definition.extensionPaths,
     env,
     lease: options.lease,
     observer: options.observer,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -506,8 +506,8 @@ export async function createPiAgentFromDefinition(
     sessions: options.sessions,
     // Boot-resolved, not re-scanned per turn like the prompt: WHICH files are extensions is fixed
     // at boot, so an added extensions/ entry needs the restart that `tools/` already needs — which
-    // is why this sits outside `live` above. Whether those files are re-loaded per turn is a
-    // separate question, answered by the serving assembly (they are — one instance per turn).
+    // is why this sits outside `live` above. Nor are they re-LOADED per turn: pi's extension module
+    // cache is process-global, so the whole process shares one instance of each.
     extensionPaths: await loadExtensionPaths(dir, { cwd: env.cwd, env }),
     env,
     lease: options.lease,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -504,9 +504,10 @@ export async function createPiAgentFromDefinition(
     },
     tools,
     sessions: options.sessions,
-    // Boot-resolved, not re-read per turn like the prompt: extensions are CODE, and pi loads a
-    // module once per process. An added extensions/ needs the restart that `tools/` already needs,
-    // which is why this sits outside `live` above.
+    // Boot-resolved, not re-scanned per turn like the prompt: WHICH files are extensions is fixed
+    // at boot, so an added extensions/ entry needs the restart that `tools/` already needs — which
+    // is why this sits outside `live` above. Whether those files are re-loaded per turn is a
+    // separate question, answered by the serving assembly (they are — one instance per turn).
     extensionPaths: await loadExtensionPaths(dir, { cwd: env.cwd, env }),
     env,
     lease: options.lease,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -506,8 +506,8 @@ export async function createPiAgentFromDefinition(
     sessions: options.sessions,
     // Boot-resolved, not re-scanned per turn like the prompt: WHICH files are extensions is fixed
     // at boot, so an added extensions/ entry needs the restart that `tools/` already needs — which
-    // is why this sits outside `live` above. Nor are they re-LOADED per turn: pi's extension module
-    // cache is process-global, so the whole process shares one instance of each.
+    // is why this sits outside `live` above. Nor are they re-LOADED per turn: the assembly's
+    // ResourceLoader loads them once and every turn of this agent shares that instance.
     extensionPaths: await loadExtensionPaths(dir, { cwd: env.cwd, env }),
     env,
     lease: options.lease,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -504,10 +504,9 @@ export async function createPiAgentFromDefinition(
     },
     tools,
     sessions: options.sessions,
-    // Boot-resolved, not re-scanned per turn like the prompt: WHICH files are extensions is fixed
-    // at boot, so an added extensions/ entry needs the restart that `tools/` already needs — which
-    // is why this sits outside `live` above. Nor are they re-LOADED per turn: the assembly's
-    // ResourceLoader loads them once and every turn of this agent shares that instance.
+    // Discovered so the serving assembly can WARN that it does not run them (and so the refusals
+    // apply to the artifact either way) — `chat` is where they load. Boot-resolved: the set cannot
+    // change without a restart, which is why this sits outside `live` above.
     extensionPaths: await loadExtensionPaths(dir, { cwd: env.cwd, env }),
     env,
     lease: options.lease,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -26,7 +26,7 @@ import type { Provider } from "@earendil-works/pi-ai";
 import type { Agent } from "../../agent.ts";
 import { type FastagentConfig, defaultAuthPath, resolveModel } from "./config.ts";
 import { resolveSecretsDir } from "../../paths.ts";
-import { type LoadedDefinition, loadAgentDefinition } from "./definition.ts";
+import { type LoadedDefinition, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
 import { reportFindingsIfChanged } from "./report.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import {
@@ -505,8 +505,9 @@ export async function createPiAgentFromDefinition(
     tools,
     sessions: options.sessions,
     // Boot-resolved, not re-read per turn like the prompt: extensions are CODE, and pi loads a
-    // module once per process. An added extensions/ needs the restart that `tools/` already needs.
-    extensionPaths: definition.extensionPaths,
+    // module once per process. An added extensions/ needs the restart that `tools/` already needs,
+    // which is why this sits outside `live` above.
+    extensionPaths: await loadExtensionPaths(dir, { cwd: env.cwd, env }),
     env,
     lease: options.lease,
     observer: options.observer,

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -19,6 +19,7 @@ import type { ExecutionEnv, Skill, SkillDiagnostic } from "@earendil-works/pi-ag
 import { loadSkills } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { loadProjectContextFiles } from "@earendil-works/pi-coding-agent";
+import { log } from "../../log.ts";
 import { assertInsideAgentDir } from "../../paths.ts";
 
 /** A same-name skill collision (the discarded side). Surfaced, never swallowed. */
@@ -47,6 +48,19 @@ export interface LoadedDefinition {
   diagnostics: SkillDiagnostic[];
   /** Same-name conflicts across mounts (first-wins). */
   collisions: SkillCollision[];
+  /**
+   * Extension entry-point FILES under `<dir>/extensions/`, empty when there are none. Paths, not
+   * loaded objects — unlike skills (data: content inline, serializable), an extension is CODE that pi
+   * loads with jiti and binds to its own eventBus/runtime, so loading it here would reimplement pi's
+   * loader. The engine binding hands these to pi as `additionalExtensionPaths`, which survives
+   * `noExtensions: true` — that flag suppresses MACHINE-GLOBAL discovery (`~/.pi`), and the
+   * definition's own extensions were only ever collateral to it.
+   *
+   * FILES, not the directory: pi's `additionalExtensionPaths` are module specifiers, so handing it a
+   * directory fails with `Cannot find module` into a `LoadExtensionsResult.errors` entry nothing
+   * reads. Expanding here is what keeps a broken extension loud.
+   */
+  extensionPaths: string[];
   /** Absolute agent-definition directory path (persona.md/skills/ live here). */
   dir: string;
 }
@@ -91,7 +105,63 @@ export async function loadAgentDefinition(
   const persona = personaRead.ok ? personaRead.value : undefined;
 
   const { skills, diagnostics, collisions } = await readSkills(e, root);
-  return { contextFiles, persona, skills, diagnostics, collisions, dir: root };
+  const extensionPaths = await readExtensionPaths(e, root);
+  return { contextFiles, persona, skills, diagnostics, collisions, extensionPaths, dir: root };
+}
+
+/**
+ * Entry-point files under `<root>/extensions/`, following pi's own discovery rules so an extension
+ * that works in pi works here:
+ *
+ * 1. a direct `*.ts` / `*.js` file;
+ * 2. a subdirectory with `index.ts` / `index.js`.
+ *
+ * pi has a third rule — a subdirectory whose `package.json` declares a `pi` field — which is NOT
+ * implemented here. That shape is reported rather than skipped: a definition whose extension silently
+ * fails to load is the failure mode this whole path exists to remove.
+ *
+ * Containment matches skills/tools/channels/schedules (the fifth of five surfaces): a symlinked
+ * `extensions/` escaping the agent dir is refused. Entries INSIDE it are not re-checked — the same
+ * rule `tools/` already lives by, and both are code the definition chose to run.
+ *
+ * Absent is normal and silent; a FILE at that path is not — that is an author who meant something.
+ */
+async function readExtensionPaths(e: ExecutionEnv, root: string): Promise<string[]> {
+  await assertInsideAgentDir(root, "extensions");
+  const dir = join(root, "extensions");
+  const listed = await e.listDir(dir);
+  if (!listed.ok) {
+    if (listed.error.code === "not_found") return [];
+    throw new Error(`cannot read ${dir}: ${listed.error.message}`);
+  }
+  const paths: string[] = [];
+  for (const entry of listed.value) {
+    // A symlink is tried BOTH ways, like pi: the name decides whether it is a module or a package.
+    if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
+      if (entry.kind !== "directory") paths.push(entry.path);
+      continue;
+    }
+    if (entry.kind === "file") continue; // a README, a .json — not an extension, not a problem
+    const index = await firstExisting(e, [join(entry.path, "index.ts"), join(entry.path, "index.js")]);
+    if (index) {
+      paths.push(index);
+    } else {
+      log.warn(
+        `[fastagent] ${entry.path} is not a loadable extension: expected index.ts or index.js ` +
+          `(pi's package.json "pi" manifest form is not supported here) — it will not be loaded`,
+      );
+    }
+  }
+  return paths.sort();
+}
+
+async function firstExisting(e: ExecutionEnv, candidates: string[]): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    const found = await e.exists(candidate);
+    if (!found.ok) throw new Error(`cannot read ${candidate}: ${found.error.message}`);
+    if (found.value) return candidate;
+  }
+  return undefined;
 }
 
 /** The skills half, shared by the full load and {@link loadAgentSkills}. `root` is already resolved. */

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -112,9 +112,9 @@ export async function loadAgentDefinition(
  * function's warnings — for a set that cannot change without a restart. Called once per assembly,
  * like `tools/`.
  *
- * Loading those paths is the other half, and it happens ONCE per process: pi caches extension
- * modules in a process-global map, so every turn a served agent takes shares one instance. That is
- * why there is no per-turn `session_shutdown` — see the note in `invoke-session.ts`.
+ * Loading those paths is the other half, and it happens once per ASSEMBLY: the ResourceLoader loads
+ * them and serves every turn from that one instance. That is why there is no per-turn
+ * `session_shutdown` — see the note in `invoke-session.ts`.
  *
  * Discovery follows pi's own rules, so an extension that works in pi works here:
  *

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -48,19 +48,6 @@ export interface LoadedDefinition {
   diagnostics: SkillDiagnostic[];
   /** Same-name conflicts across mounts (first-wins). */
   collisions: SkillCollision[];
-  /**
-   * Extension entry-point FILES under `<dir>/extensions/`, empty when there are none. Paths, not
-   * loaded objects — unlike skills (data: content inline, serializable), an extension is CODE that pi
-   * loads with jiti and binds to its own eventBus/runtime, so loading it here would reimplement pi's
-   * loader. The engine binding hands these to pi as `additionalExtensionPaths`, which survives
-   * `noExtensions: true` — that flag suppresses MACHINE-GLOBAL discovery (`~/.pi`), and the
-   * definition's own extensions were only ever collateral to it.
-   *
-   * FILES, not the directory: pi's `additionalExtensionPaths` are module specifiers, so handing it a
-   * directory fails with `Cannot find module` into a `LoadExtensionsResult.errors` entry nothing
-   * reads. Expanding here is what keeps a broken extension loud.
-   */
-  extensionPaths: string[];
   /** Absolute agent-definition directory path (persona.md/skills/ live here). */
   dir: string;
 }
@@ -105,13 +92,26 @@ export async function loadAgentDefinition(
   const persona = personaRead.ok ? personaRead.value : undefined;
 
   const { skills, diagnostics, collisions } = await readSkills(e, root);
-  const extensionPaths = await readExtensionPaths(e, root);
-  return { contextFiles, persona, skills, diagnostics, collisions, extensionPaths, dir: root };
+  return { contextFiles, persona, skills, diagnostics, collisions, dir: root };
 }
 
 /**
- * Entry-point files under `<root>/extensions/`, following pi's own discovery rules so an extension
- * that works in pi works here:
+ * Extension entry-point FILES under `<agentDir>/extensions/`, empty when there are none.
+ *
+ * Paths, not loaded objects — unlike skills (data: content inline, serializable), an extension is
+ * CODE that pi loads with jiti and binds to its own eventBus/runtime, so loading it here would
+ * reimplement pi's loader. The engine binding hands these to pi as `additionalExtensionPaths`, which
+ * survives `noExtensions: true` — that flag suppresses MACHINE-GLOBAL discovery (`~/.pi`), and the
+ * definition's own extensions were only ever collateral to it. FILES, not the directory: pi's paths
+ * are module specifiers, and a directory fails as `Cannot find module` into a
+ * `LoadExtensionsResult.errors` entry nothing reads.
+ *
+ * SEPARATE from {@link loadAgentDefinition} on purpose. Prompt and skills are re-read every invoke
+ * ("the directory is the agent, LIVE"); extensions are code pi imports once per process, so a serving
+ * turn must not pay a directory scan — nor repeat this function's warnings — for a set that cannot
+ * take effect until restart. Called once per assembly, like `tools/`.
+ *
+ * Discovery follows pi's own rules, so an extension that works in pi works here:
  *
  * 1. a direct `*.ts` / `*.js` file;
  * 2. a subdirectory with `index.ts` / `index.js`.
@@ -128,7 +128,15 @@ export async function loadAgentDefinition(
  *
  * Absent is normal and silent; a FILE at that path is not — that is an author who meant something.
  */
-async function readExtensionPaths(e: ExecutionEnv, root: string): Promise<string[]> {
+export async function loadExtensionPaths(
+  agentDir: string,
+  options: { cwd?: string; env?: ExecutionEnv } = {},
+): Promise<string[]> {
+  const cwd = options.cwd ?? agentDir;
+  const e = options.env ?? new NodeExecutionEnv({ cwd });
+  const rootResult = await e.absolutePath(agentDir);
+  if (!rootResult.ok) throw new Error(`cannot resolve agent dir "${agentDir}": ${rootResult.error.message}`);
+  const root = rootResult.value;
   await assertInsideAgentDir(root, "extensions");
   const dir = join(root, "extensions");
   const listed = await e.listDir(dir);
@@ -180,8 +188,8 @@ async function firstRealFile(e: ExecutionEnv, candidates: string[]): Promise<str
 
 function warnSymlinkRefused(path: string): void {
   log.warn(
-    `[fastagent] ${path} is a symlink and will not be loaded: an extension must live inside the ` +
-      `definition so it travels with the artifact — move the file in, or link the whole extensions/ dir`,
+    `[fastagent] ${path} is a symlink and will not be loaded: an extension must be a real file inside ` +
+      `the definition so it travels with the artifact — move it in`,
   );
 }
 

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -112,8 +112,9 @@ export async function loadAgentDefinition(
  * function's warnings — for a set that cannot change without a restart. Called once per assembly,
  * like `tools/`.
  *
- * Loading those paths is the other half, and it does happen per turn: the serving assembly reloads
- * them so each turn holds its own extension instance, because the lifecycle events fire per turn.
+ * Loading those paths is the other half, and it happens ONCE per process: pi caches extension
+ * modules in a process-global map, so every turn a served agent takes shares one instance. That is
+ * why there is no per-turn `session_shutdown` — see the note in `invoke-session.ts`.
  *
  * Discovery follows pi's own rules, so an extension that works in pi works here:
  *

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -14,7 +14,7 @@
  * (bad skill files, name collisions) are returned as data. An unreadable ② context file only warns (pi).
  */
 import { realpathSync } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { extname, isAbsolute, join, relative, resolve } from "node:path";
 import type { ExecutionEnv, Skill, SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { loadSkills } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
@@ -150,19 +150,25 @@ export async function loadExtensionPaths(
   }
   const paths: string[] = [];
   for (const entry of listed.value) {
+    const looksLikeModule = entry.name.endsWith(".ts") || entry.name.endsWith(".js");
     if (entry.kind === "symlink") {
-      warnSymlinkRefused(entry.path);
+      // Only complain about a link that was TRYING to be an extension. A symlinked README or
+      // data.json in here is someone's own business, and warning about it trains authors to ignore
+      // the warning that matters. Directories are candidates too: their index.* is checked below.
+      if (looksLikeModule || !extname(entry.name)) warnSymlinkRefused(entry.path);
       continue;
     }
-    if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
+    if (looksLikeModule) {
       if (entry.kind === "file") paths.push(entry.path);
       continue;
     }
     if (entry.kind === "file") continue; // a README, a .json — not an extension, not a problem
     const index = await firstRealFile(e, [join(entry.path, "index.ts"), join(entry.path, "index.js")]);
-    if (index) {
-      paths.push(index);
-    } else {
+    if (index.path) {
+      paths.push(index.path);
+    } else if (!index.refused) {
+      // Silent when the index WAS found and refused for being a symlink: that warning already named
+      // the real problem, and "expected index.ts" on top of it describes a directory that has one.
       log.warn(
         `[fastagent] ${entry.path} is not a loadable extension: expected index.ts or index.js ` +
           `(pi's package.json "pi" manifest form is not supported here) — it will not be loaded`,
@@ -177,17 +183,22 @@ export async function loadExtensionPaths(
  * subdirectory's `index.ts` could otherwise point outside the definition and slip past the rule the
  * top-level entries already follow.
  */
-async function firstRealFile(e: ExecutionEnv, candidates: string[]): Promise<string | undefined> {
+/** The first real file among the candidates, and whether one was found but REFUSED as a symlink. */
+async function firstRealFile(e: ExecutionEnv, candidates: string[]): Promise<{ path?: string; refused: boolean }> {
+  let refused = false;
   for (const candidate of candidates) {
     const info = await e.fileInfo(candidate);
     if (!info.ok) {
       if (info.error.code === "not_found") continue;
       throw new Error(`cannot read ${candidate}: ${info.error.message}`);
     }
-    if (info.value.kind === "file") return candidate;
-    if (info.value.kind === "symlink") warnSymlinkRefused(candidate);
+    if (info.value.kind === "file") return { path: candidate, refused };
+    if (info.value.kind === "symlink") {
+      warnSymlinkRefused(candidate);
+      refused = true;
+    }
   }
-  return undefined;
+  return { refused };
 }
 
 function warnSymlinkRefused(path: string): void {

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -106,10 +106,14 @@ export async function loadAgentDefinition(
  * are module specifiers, and a directory fails as `Cannot find module` into a
  * `LoadExtensionsResult.errors` entry nothing reads.
  *
- * SEPARATE from {@link loadAgentDefinition} on purpose. Prompt and skills are re-read every invoke
- * ("the directory is the agent, LIVE"); extensions are code pi imports once per process, so a serving
- * turn must not pay a directory scan — nor repeat this function's warnings — for a set that cannot
- * take effect until restart. Called once per assembly, like `tools/`.
+ * SEPARATE from {@link loadAgentDefinition} on purpose, and the split is DISCOVERY vs LOADING.
+ * Prompt and skills are re-read every invoke ("the directory is the agent, LIVE"). Scanning for
+ * extension entry points is not: a serving turn must not pay a directory walk — nor repeat this
+ * function's warnings — for a set that cannot change without a restart. Called once per assembly,
+ * like `tools/`.
+ *
+ * Loading those paths is the other half, and it does happen per turn: the serving assembly reloads
+ * them so each turn holds its own extension instance, because the lifecycle events fire per turn.
  *
  * Discovery follows pi's own rules, so an extension that works in pi works here:
  *

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -106,15 +106,14 @@ export async function loadAgentDefinition(
  * are module specifiers, and a directory fails as `Cannot find module` into a
  * `LoadExtensionsResult.errors` entry nothing reads.
  *
- * SEPARATE from {@link loadAgentDefinition} on purpose, and the split is DISCOVERY vs LOADING.
- * Prompt and skills are re-read every invoke ("the directory is the agent, LIVE"). Scanning for
- * extension entry points is not: a serving turn must not pay a directory walk — nor repeat this
- * function's warnings — for a set that cannot change without a restart. Called once per assembly,
- * like `tools/`.
+ * SEPARATE from {@link loadAgentDefinition} on purpose. Prompt and skills are re-read every invoke
+ * ("the directory is the agent, LIVE"); scanning for extension entry points is not, since the set
+ * cannot change without a restart. Called once per assembly, like `tools/`.
  *
- * Loading those paths is the other half, and it happens once per ASSEMBLY: the ResourceLoader loads
- * them and serves every turn from that one instance. That is why there is no per-turn
- * `session_shutdown` — see the note in `invoke-session.ts`.
+ * Discovery runs on BOTH paths; loading does not. `chat` hands these to pi and runs them fully.
+ * Serving only announces them — pi's extension runtime is shared across sessions, and serving has
+ * concurrent turns for unrelated conversations (see `PiAgentSessionFactoryOptions.extensionPaths`).
+ * The refusals below are therefore about what the ARTIFACT may contain, and hold for both.
  *
  * Discovery follows pi's own rules, so an extension that works in pi works here:
  *

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -14,7 +14,7 @@
  * (bad skill files, name collisions) are returned as data. An unreadable ② context file only warns (pi).
  */
 import { realpathSync } from "node:fs";
-import { extname, isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import type { ExecutionEnv, Skill, SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { loadSkills } from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
@@ -150,15 +150,17 @@ export async function loadExtensionPaths(
   }
   const paths: string[] = [];
   for (const entry of listed.value) {
-    const looksLikeModule = entry.name.endsWith(".ts") || entry.name.endsWith(".js");
     if (entry.kind === "symlink") {
-      // Only complain about a link that was TRYING to be an extension. A symlinked README or
-      // data.json in here is someone's own business, and warning about it trains authors to ignore
-      // the warning that matters. Directories are candidates too: their index.* is checked below.
-      if (looksLikeModule || !extname(entry.name)) warnSymlinkRefused(entry.path);
+      // EVERY symlink here is announced, without guessing whether it meant to be an extension. The
+      // two mistakes are not equal: a needless line about a symlinked README costs a glance, while
+      // staying quiet about a symlinked extension loses a feature silently and only shows up in the
+      // container. A name-based guess also cannot see through the link — `audit.ext -> some/dir` is
+      // a directory candidate to pi and a mystery here — so the warning says what it knows and
+      // tells the author when to ignore it.
+      warnSymlinkRefused(entry.path);
       continue;
     }
-    if (looksLikeModule) {
+    if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
       if (entry.kind === "file") paths.push(entry.path);
       continue;
     }
@@ -204,7 +206,8 @@ async function firstRealFile(e: ExecutionEnv, candidates: string[]): Promise<{ p
 function warnSymlinkRefused(path: string): void {
   log.warn(
     `[fastagent] ${path} is a symlink and will not be loaded: an extension must be a real file inside ` +
-      `the definition so it travels with the artifact — move it in`,
+      `the definition so it travels with the artifact — move it in. (If it is not an extension, ` +
+      `keep it outside extensions/ to silence this.)`,
   );
 }
 

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -121,8 +121,10 @@ export async function loadAgentDefinition(
  * fails to load is the failure mode this whole path exists to remove.
  *
  * Containment matches skills/tools/channels/schedules (the fifth of five surfaces): a symlinked
- * `extensions/` escaping the agent dir is refused. Entries INSIDE it are not re-checked — the same
- * rule `tools/` already lives by, and both are code the definition chose to run.
+ * `extensions/` escaping the agent dir is refused, and — like `loadModuleDir`, whose `entry.isFile()`
+ * excludes them — a symlinked ENTRY is not loaded either. pi's own discovery does follow those, but
+ * an extension reached through a link out of the definition is code the artifact does not carry: it
+ * resolves on the authoring machine and is missing in the container. Refused loudly, never silently.
  *
  * Absent is normal and silent; a FILE at that path is not — that is an author who meant something.
  */
@@ -136,9 +138,15 @@ async function readExtensionPaths(e: ExecutionEnv, root: string): Promise<string
   }
   const paths: string[] = [];
   for (const entry of listed.value) {
-    // A symlink is tried BOTH ways, like pi: the name decides whether it is a module or a package.
+    if (entry.kind === "symlink") {
+      log.warn(
+        `[fastagent] ${entry.path} is a symlink and will not be loaded: an extension must live inside ` +
+          `the definition so it travels with the artifact — move the file in, or link the whole extensions/ dir`,
+      );
+      continue;
+    }
     if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
-      if (entry.kind !== "directory") paths.push(entry.path);
+      if (entry.kind === "file") paths.push(entry.path);
       continue;
     }
     if (entry.kind === "file") continue; // a README, a .json — not an extension, not a problem

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -139,10 +139,7 @@ async function readExtensionPaths(e: ExecutionEnv, root: string): Promise<string
   const paths: string[] = [];
   for (const entry of listed.value) {
     if (entry.kind === "symlink") {
-      log.warn(
-        `[fastagent] ${entry.path} is a symlink and will not be loaded: an extension must live inside ` +
-          `the definition so it travels with the artifact — move the file in, or link the whole extensions/ dir`,
-      );
+      warnSymlinkRefused(entry.path);
       continue;
     }
     if (entry.name.endsWith(".ts") || entry.name.endsWith(".js")) {
@@ -150,7 +147,7 @@ async function readExtensionPaths(e: ExecutionEnv, root: string): Promise<string
       continue;
     }
     if (entry.kind === "file") continue; // a README, a .json — not an extension, not a problem
-    const index = await firstExisting(e, [join(entry.path, "index.ts"), join(entry.path, "index.js")]);
+    const index = await firstRealFile(e, [join(entry.path, "index.ts"), join(entry.path, "index.js")]);
     if (index) {
       paths.push(index);
     } else {
@@ -163,13 +160,29 @@ async function readExtensionPaths(e: ExecutionEnv, root: string): Promise<string
   return paths.sort();
 }
 
-async function firstExisting(e: ExecutionEnv, candidates: string[]): Promise<string | undefined> {
+/**
+ * The first candidate that is a REAL file. `exists` would follow a symlink, which is how a
+ * subdirectory's `index.ts` could otherwise point outside the definition and slip past the rule the
+ * top-level entries already follow.
+ */
+async function firstRealFile(e: ExecutionEnv, candidates: string[]): Promise<string | undefined> {
   for (const candidate of candidates) {
-    const found = await e.exists(candidate);
-    if (!found.ok) throw new Error(`cannot read ${candidate}: ${found.error.message}`);
-    if (found.value) return candidate;
+    const info = await e.fileInfo(candidate);
+    if (!info.ok) {
+      if (info.error.code === "not_found") continue;
+      throw new Error(`cannot read ${candidate}: ${info.error.message}`);
+    }
+    if (info.value.kind === "file") return candidate;
+    if (info.value.kind === "symlink") warnSymlinkRefused(candidate);
   }
   return undefined;
+}
+
+function warnSymlinkRefused(path: string): void {
+  log.warn(
+    `[fastagent] ${path} is a symlink and will not be loaded: an extension must live inside the ` +
+      `definition so it travels with the artifact — move the file in, or link the whole extensions/ dir`,
+  );
 }
 
 /** The skills half, shared by the full load and {@link loadAgentSkills}. `root` is already resolved. */

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -383,11 +383,11 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         }
       } finally {
         // NO session_shutdown here, deliberately. A per-invoke session makes one look right, but the
-        // extension INSTANCE it would tear down is not per-invoke: pi caches extension modules in a
-        // process-global map, so every turn shares one. Emitting a shutdown per turn had a finished
+        // extension INSTANCE it would tear down is not per-invoke: extensions belong to the agent's
+        // assembly and every turn shares one. Emitting a shutdown per turn had a finished
         // turn clearing a timer a concurrent turn had just opened (measured, and pinned in
         // definition-extensions.test.ts). The lifecycle has to match the instance, not the session
-        // wrapper: one process, one instance, no per-turn teardown. Extensions that need per-turn
+        // wrapper: one agent, one instance, no per-turn teardown. Extensions that need per-turn
         // cleanup do it in the tool or handler that opened the resource.
         try {
           session.dispose();

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -383,6 +383,15 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         }
       } finally {
         try {
+          // Extensions get their shutdown before the session goes away. pi's dispose() only
+          // invalidates the runtime — it does not emit this — and a per-invoke session means an
+          // extension that opened a timer, watcher or connection on `session_start` would otherwise
+          // leak one per turn, forever. A handler that throws must not block the dispose below.
+          await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+        } catch (error) {
+          log.warn(`[fastagent] extension session_shutdown failed: ${String(error)}`);
+        }
+        try {
           session.dispose();
         } catch (error) {
           log.warn(`[fastagent] session dispose failed during cleanup: ${String(error)}`);

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -382,15 +382,13 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
           unsub();
         }
       } finally {
-        try {
-          // Extensions get their shutdown before the session goes away. pi's dispose() only
-          // invalidates the runtime — it does not emit this — and a per-invoke session means an
-          // extension that opened a timer, watcher or connection on `session_start` would otherwise
-          // leak one per turn, forever. A handler that throws must not block the dispose below.
-          await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
-        } catch (error) {
-          log.warn(`[fastagent] extension session_shutdown failed: ${String(error)}`);
-        }
+        // NO session_shutdown here, deliberately. A per-invoke session makes one look right, but the
+        // extension INSTANCE it would tear down is not per-invoke: pi caches extension modules in a
+        // process-global map, so every turn shares one. Emitting a shutdown per turn had a finished
+        // turn clearing a timer a concurrent turn had just opened (measured, and pinned in
+        // definition-extensions.test.ts). The lifecycle has to match the instance, not the session
+        // wrapper: one process, one instance, no per-turn teardown. Extensions that need per-turn
+        // cleanup do it in the tool or handler that opened the resource.
         try {
           session.dispose();
         } catch (error) {

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -323,14 +323,17 @@ export async function buildAgentSessionRuntime(
     // session.bindExtensions() with the TUI's uiContext, abort handler and command actions — binding
     // here too would emit session_start twice per chat, so an extension opening a resource on start
     // would open two.
-    // Deferral emulation: pi's session starts with everything active — narrow it by SUBTRACTING
-    // the deferred names from whatever is active (robust to pi mounting tools of its own; an
-    // exact-set-equality gate would silently stop narrowing the day pi adds one). Applied on EVERY
-    // build including /resume: pi's chat session does not record activations (its SessionContext has
-    // no activeToolNames), so "restore prior activations" is not implementable here — deferral stays
-    // consistently ON and a resumed conversation re-discovers via search_tools (documented divergence
-    // from serving, where activations persist in the session). The deferred SET comes from the shared
-    // assembly (one definition of "deferred"), never recomputed here.
+    // Deferral emulation: pi starts THIS agent's tools active — its own four default names, which
+    // our customTools have replaced, plus every custom and extension tool. (Tools pi mounts but does
+    // not activate, like grep/find/ls, stay inactive, which is the same set serving offers.) So
+    // narrow by SUBTRACTING the deferred names from whatever is active, rather than stating a set:
+    // an exact-set-equality gate would silently stop narrowing the day pi activates one more.
+    //
+    // Applied on EVERY build including /resume: pi's chat session does not record activations (its
+    // SessionContext has no activeToolNames), so "restore prior activations" is not implementable
+    // here — deferral stays consistently ON and a resumed conversation re-discovers via search_tools
+    // (a documented divergence from serving, where activations persist in the session). The deferred
+    // SET comes from the shared assembly (one definition of "deferred"), never recomputed here.
     if (deferredToolNames.length > 0) {
       const active = result.session.getActiveToolNames();
       if (deferredToolNames.some((n) => active.includes(n))) {

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -43,7 +43,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { reportExtensionErrors } from "./agent-session-factory.ts";
 import { resolveModel } from "./config.ts";
-import { assembleSystemPrompt, piBasePrompt, piDefaultTools } from "./create.ts";
+import { assembleSystemPrompt, piBasePrompt } from "./create.ts";
 import { canonicalPath, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
 import { createPiModelRuntime, probeAuthSource } from "./models.ts";
 import { log } from "../../log.ts";
@@ -126,29 +126,16 @@ export async function buildAgentSessionRuntime(
     // agentDir carries the agent's own models.json (custom endpoints); stateRoot keeps pi's generated
     // catalog cache out of the definition dir. See createPiModelRuntime.
     const modelRuntime = await createPiModelRuntime({ authPath, agentDir, stateRoot });
-    // MIGRATION HINT (deliberate breaking change): chat historically used pi's own `~/.pi` auth;
-    // it now reads the agent's credential file like every other command. Probe the RESOLVED
-    // model's provider through the normal resolution path (stored credential OR env var — an
-    // env-authed user is fine and must not be warned): only when that provider has no usable auth
-    // AND pi's old file exists does the bare provider error get its cause named.
-    if (
-      (await probeAuthSource(modelRuntime, modelSpec)) === undefined &&
-      existsSync(join(getAgentDir(), "auth.json"))
-    ) {
-      log.warn(
-        `[fastagent] no credentials for ${modelSpec} in ${authPath} — this runtime no longer reads ` +
-          `pi's ~/.pi auth; run \`fastagent login\` (or /login in the TUI) to store credentials for this agent`,
-      );
-    }
-    const model = resolveModel(modelRuntime, modelSpec);
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(agentDir, { cwd, env });
     reportFindingsIfChanged(definition.dir, definition);
     // Assembly-time, like serving's: this whole function is memoized, so the scan and its warnings
     // happen once per runtime rather than per session rebuild (/new, /resume, fork).
     const extensionPaths = await loadExtensionPaths(agentDir, { cwd, env });
-    const defaultNames = piDefaultTools().map((t) => t.name);
-    const customTools = tools.filter((t) => !defaultNames.includes(t.name));
+    // ALL of them, pi's four included: fastagent's `read` is `createReadTool({ imageProcessor })`
+    // (create.ts), and letting pi mount its own instead would silently drop image reading in chat.
+    // Serving already does it this way.
+    const customTools = tools;
     // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts
     // it). Each execute runs inside the turn context with the CURRENT session's activation bridge — the
     // assembly is memoized across /new//resume/fork rebuilds while the session changes, so the bridge
@@ -169,10 +156,9 @@ export async function buildAgentSessionRuntime(
         if (!bound) throw new Error("tool executed before its session was built (lifecycle invariant broken)");
         return turnContext.run(
           { cwd, sessionManager: bound.sessionManager, tools: bound.activation },
-          // pi's per-turn TOOL context (5th parameter) is read only by its default coding tools, and
-          // those are filtered out of `customTools` above; fastagent's own take theirs from
-          // `turnContext` (AsyncLocalStorage). So this env exists to satisfy the shape, and it is the
-          // chat cwd's — the same root a default tool would have got, had one reached here.
+          // pi's per-turn TOOL context (5th parameter) is read only by its default coding tools;
+          // fastagent's own take theirs from `turnContext` (AsyncLocalStorage). This env satisfies
+          // the shape for both, and is the chat cwd's — the same root pi would have handed them.
           () => t.execute(id, params, signal, undefined, { env }) as Promise<unknown>,
         );
       },
@@ -185,62 +171,11 @@ export async function buildAgentSessionRuntime(
       contextFiles: definition.contextFiles,
     });
 
-    return {
-      model,
-      modelRuntime,
-      // Serving honors config.thinkingLevel (config → L2); the resident session must too (fidelity).
-      thinkingLevel: config.thinkingLevel,
-      definition,
-      extensionPaths,
-      defaultNames,
-      customTools,
-      customToolDefs,
-      deferredToolNames,
-      systemPrompt,
-    };
-  }
-
-  // pi calls the factory again on /new, /resume, switch, and fork. Config/tools dynamic imports are
-  // ESM-cached, so treating same-cwd rebuilds as hot reload would yield a half-fresh agent (fresh
-  // AGENTS.md/skills, stale config/tools). Keep the runtime a coherent startup snapshot: restart to
-  // load edits. And keep it workspace-scoped — `.env` is process-global, so a switch to another cwd
-  // would leak env or require mutating global env at runtime.
-  const rootCwd = canonicalPath(dir);
-  // The CURRENT pi session + its activation bridge, BOUND TOGETHER — rebuilt on /new//resume/fork
-  // while the memoized assembly (and its tool execute closures) stays. The bridge must share the
-  // session's lifetime, NOT be rebuilt per tool call (a per-call chain serializes nothing). Note on
-  // parallel batches: pi wraps SDK customTools in its own before/after active-set diff, so an
-  // activating tool must carry `executionMode: "sequential"` (the builtin loader does) — pi then runs
-  // the whole batch serially and the outer diff sees correct snapshots.
-  const sessionRef: {
-    current?: { session: AgentSession; sessionManager: ReadonlySessionManager; activation: ToolActivation };
-  } = {};
-  let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
-  const assemblyFor = (cwd: string) => {
-    // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
-    // otherwise mismatch a non-realpath rootCwd.
-    const activeCwd = canonicalPath(cwd);
-    if (activeCwd !== rootCwd) {
-      throw workspaceScopeError(activeCwd);
-    }
-    assembly ??= resolveAssembly(rootCwd);
-    return assembly;
-  };
-
-  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
-    const {
-      model,
-      modelRuntime,
-      thinkingLevel,
-      definition,
-      extensionPaths,
-      defaultNames,
-      customTools,
-      customToolDefs,
-      deferredToolNames,
-      systemPrompt,
-    } = await assemblyFor(cwd);
-
+    // BEFORE the model is resolved, because an extension may be what defines it. pi's
+    // `registerProvider()` is the documented way to add models/providers, and extensions only run
+    // when the services are built — resolving first would fail a definition whose configured model
+    // comes from its own extension with a bare "unknown model", and would probe auth for a provider
+    // that does not exist yet.
     const services = await createAgentSessionServices({
       cwd,
       // fastagent's models + auth hub replaces pi's default (~/.pi-backed) one — the auth
@@ -281,19 +216,82 @@ export async function buildAgentSessionRuntime(
       },
     });
     reportExtensionErrors(services);
-    // `tools` is pi's ALLOWLIST, and it gates extension-registered tools the same as any other. The
-    // serving path passes no allowlist, so omitting these would give one definition two tool sets:
-    // present when served, missing in chat. The names come from the loaded extensions themselves.
-    const extensionToolNames = services.resourceLoader
-      .getExtensions()
-      .extensions.flatMap((extension) => [...extension.tools.keys()]);
+
+    // MIGRATION HINT (deliberate breaking change): chat historically used pi's own `~/.pi` auth;
+    // it now reads the agent's credential file like every other command. Probe the RESOLVED
+    // model's provider through the normal resolution path (stored credential OR env var — an
+    // env-authed user is fine and must not be warned): only when that provider has no usable auth
+    // AND pi's old file exists does the bare provider error get its cause named.
+    if (
+      (await probeAuthSource(modelRuntime, modelSpec)) === undefined &&
+      existsSync(join(getAgentDir(), "auth.json"))
+    ) {
+      log.warn(
+        `[fastagent] no credentials for ${modelSpec} in ${authPath} — this runtime no longer reads ` +
+          `pi's ~/.pi auth; run \`fastagent login\` (or /login in the TUI) to store credentials for this agent`,
+      );
+    }
+    const model = resolveModel(modelRuntime, modelSpec);
+
+    return {
+      model,
+      modelRuntime,
+      services,
+      // Serving honors config.thinkingLevel (config → L2); the resident session must too (fidelity).
+      thinkingLevel: config.thinkingLevel,
+      definition,
+      extensionPaths,
+      customTools,
+      customToolDefs,
+      deferredToolNames,
+      systemPrompt,
+    };
+  }
+
+  // pi calls the factory again on /new, /resume, switch, and fork. Config/tools dynamic imports are
+  // ESM-cached, so treating same-cwd rebuilds as hot reload would yield a half-fresh agent (fresh
+  // AGENTS.md/skills, stale config/tools). Keep the runtime a coherent startup snapshot: restart to
+  // load edits. And keep it workspace-scoped — `.env` is process-global, so a switch to another cwd
+  // would leak env or require mutating global env at runtime.
+  const rootCwd = canonicalPath(dir);
+  // The CURRENT pi session + its activation bridge, BOUND TOGETHER — rebuilt on /new//resume/fork
+  // while the memoized assembly (and its tool execute closures) stays. The bridge must share the
+  // session's lifetime, NOT be rebuilt per tool call (a per-call chain serializes nothing). Note on
+  // parallel batches: pi wraps SDK customTools in its own before/after active-set diff, so an
+  // activating tool must carry `executionMode: "sequential"` (the builtin loader does) — pi then runs
+  // the whole batch serially and the outer diff sees correct snapshots.
+  const sessionRef: {
+    current?: { session: AgentSession; sessionManager: ReadonlySessionManager; activation: ToolActivation };
+  } = {};
+  let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
+  const assemblyFor = (cwd: string) => {
+    // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
+    // otherwise mismatch a non-realpath rootCwd.
+    const activeCwd = canonicalPath(cwd);
+    if (activeCwd !== rootCwd) {
+      throw workspaceScopeError(activeCwd);
+    }
+    assembly ??= resolveAssembly(rootCwd);
+    return assembly;
+  };
+
+  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+    const { model, services, thinkingLevel, extensionPaths, customToolDefs, deferredToolNames } =
+      await assemblyFor(cwd);
+
     const result = await createAgentSessionFromServices({
       services,
       sessionManager,
       sessionStartEvent,
       model,
       thinkingLevel,
-      tools: [...defaultNames, ...customTools.map((t) => t.name), ...extensionToolNames],
+      // NO `tools` allowlist. It would freeze the tool set at build time, and pi lets an extension
+      // register from `session_start`, a command, or any handler — those names would not be in a
+      // startup snapshot, so `refreshTools()` would filter them straight back out and the extension
+      // would look like it did nothing. `noTools: "builtin"` gets the same guarantee the allowlist
+      // was really there for (the machine's `defaultTools` setting cannot add pi's own copies on top
+      // of ours) without freezing anything.
+      noTools: "builtin",
       customTools: customToolDefs,
     });
     sessionRef.current = {
@@ -301,6 +299,18 @@ export async function buildAgentSessionRuntime(
       sessionManager: agentSessionManager(result.session, result.session.sessionManager.getSessionId()),
       activation: sessionToolActivation(result.session),
     };
+    // Extensions only come ALIVE here. pi emits session_start from bindExtensions(), so without this
+    // call an extension loads, registers what it registers at import time, and then never hears
+    // another thing: no session_start, no tool registered from a handler, no shutdown. That is a
+    // definition whose extension half silently does nothing — the failure this whole path exists to
+    // remove. Binding also installs the error listener; pi fans handler errors to registered
+    // listeners and has none by default, so a throwing extension would otherwise look like an
+    // extension that simply did nothing.
+    if (extensionPaths.length > 0) {
+      await result.session.bindExtensions({
+        onError: (e) => log.warn(`[fastagent] extension ${e.extensionPath} failed on ${e.event}: ${e.error}`),
+      });
+    }
     // Deferral emulation: pi's session starts with everything active — narrow it by SUBTRACTING
     // the deferred names from whatever is active (robust to pi mounting tools of its own; an
     // exact-set-equality gate would silently stop narrowing the day pi adds one). Applied on EVERY

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -44,7 +44,7 @@ import {
 import { reportExtensionErrors } from "./agent-session-factory.ts";
 import { resolveModel } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools } from "./create.ts";
-import { canonicalPath, loadAgentDefinition } from "./definition.ts";
+import { canonicalPath, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
 import { createPiModelRuntime, probeAuthSource } from "./models.ts";
 import { log } from "../../log.ts";
 import {
@@ -144,6 +144,9 @@ export async function buildAgentSessionRuntime(
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(agentDir, { cwd, env });
     reportFindingsIfChanged(definition.dir, definition);
+    // Assembly-time, like serving's: this whole function is memoized, so the scan and its warnings
+    // happen once per runtime rather than per session rebuild (/new, /resume, fork).
+    const extensionPaths = await loadExtensionPaths(agentDir, { cwd, env });
     const defaultNames = piDefaultTools().map((t) => t.name);
     const customTools = tools.filter((t) => !defaultNames.includes(t.name));
     // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts
@@ -188,6 +191,7 @@ export async function buildAgentSessionRuntime(
       // Serving honors config.thinkingLevel (config → L2); the resident session must too (fidelity).
       thinkingLevel: config.thinkingLevel,
       definition,
+      extensionPaths,
       defaultNames,
       customTools,
       customToolDefs,
@@ -229,6 +233,7 @@ export async function buildAgentSessionRuntime(
       modelRuntime,
       thinkingLevel,
       definition,
+      extensionPaths,
       defaultNames,
       customTools,
       customToolDefs,
@@ -249,7 +254,7 @@ export async function buildAgentSessionRuntime(
         // ...except the definition's OWN extensions/: pi honours additionalExtensionPaths even under
         // noExtensions. Without this the same definition would carry its extensions when served and
         // lose them in chat — one artifact, two behaviours.
-        ...(definition.extensionPaths.length > 0 ? { additionalExtensionPaths: definition.extensionPaths } : {}),
+        ...(extensionPaths.length > 0 ? { additionalExtensionPaths: extensionPaths } : {}),
         noPromptTemplates: true,
         noContextFiles: true,
         systemPromptOverride: () => systemPrompt,

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -171,11 +171,65 @@ export async function buildAgentSessionRuntime(
       contextFiles: definition.contextFiles,
     });
 
-    // BEFORE the model is resolved, because an extension may be what defines it. pi's
-    // `registerProvider()` is the documented way to add models/providers, and extensions only run
-    // when the services are built — resolving first would fail a definition whose configured model
-    // comes from its own extension with a bare "unknown model", and would probe auth for a provider
-    // that does not exist yet.
+    return {
+      modelRuntime,
+      modelSpec,
+      authPath,
+      // Serving honors config.thinkingLevel (config → L2); the resident session must too (fidelity).
+      thinkingLevel: config.thinkingLevel,
+      definition,
+      extensionPaths,
+      customTools,
+      customToolDefs,
+      deferredToolNames,
+      systemPrompt,
+    };
+  }
+
+  // pi calls the factory again on /new, /resume, switch, and fork. Config/tools dynamic imports are
+  // ESM-cached, so treating same-cwd rebuilds as hot reload would yield a half-fresh agent (fresh
+  // AGENTS.md/skills, stale config/tools). Keep the runtime a coherent startup snapshot: restart to
+  // load edits. And keep it workspace-scoped — `.env` is process-global, so a switch to another cwd
+  // would leak env or require mutating global env at runtime.
+  const rootCwd = canonicalPath(dir);
+  // The CURRENT pi session + its activation bridge, BOUND TOGETHER — rebuilt on /new//resume/fork
+  // while the memoized assembly (and its tool execute closures) stays. The bridge must share the
+  // session's lifetime, NOT be rebuilt per tool call (a per-call chain serializes nothing). Note on
+  // parallel batches: pi wraps SDK customTools in its own before/after active-set diff, so an
+  // activating tool must carry `executionMode: "sequential"` (the builtin loader does) — pi then runs
+  // the whole batch serially and the outer diff sees correct snapshots.
+  const sessionRef: {
+    current?: { session: AgentSession; sessionManager: ReadonlySessionManager; activation: ToolActivation };
+  } = {};
+  let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
+  const assemblyFor = (cwd: string) => {
+    // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
+    // otherwise mismatch a non-realpath rootCwd.
+    const activeCwd = canonicalPath(cwd);
+    if (activeCwd !== rootCwd) {
+      throw workspaceScopeError(activeCwd);
+    }
+    assembly ??= resolveAssembly(rootCwd);
+    return assembly;
+  };
+
+  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+    const {
+      modelRuntime,
+      modelSpec,
+      authPath,
+      thinkingLevel,
+      definition,
+      extensionPaths,
+      customToolDefs,
+      deferredToolNames,
+      systemPrompt,
+    } = await assemblyFor(cwd);
+
+    // Per session, NOT memoized with the assembly: pi replaces the session on /new, /resume and
+    // fork, and its extension contract is that the replacement gets freshly loaded extensions
+    // rather than the previous session's objects. The expensive halves (model hub, auth) are shared
+    // through the assembly; only the resource loader is rebuilt.
     const services = await createAgentSessionServices({
       cwd,
       // fastagent's models + auth hub replaces pi's default (~/.pi-backed) one — the auth
@@ -217,11 +271,17 @@ export async function buildAgentSessionRuntime(
     });
     reportExtensionErrors(services);
 
-    // MIGRATION HINT (deliberate breaking change): chat historically used pi's own `~/.pi` auth;
-    // it now reads the agent's credential file like every other command. Probe the RESOLVED
-    // model's provider through the normal resolution path (stored credential OR env var — an
-    // env-authed user is fine and must not be warned): only when that provider has no usable auth
-    // AND pi's old file exists does the bare provider error get its cause named.
+    // AFTER the services, because an extension may be what defines the model. `registerProvider()`
+    // is pi's documented way for one to add providers, and extensions do not execute until the
+    // services are built — resolving first fails a definition whose configured model comes from its
+    // own extension with a bare "unknown model", after warning about credentials for a provider
+    // that does not exist yet.
+    //
+    // MIGRATION HINT (deliberate breaking change): chat historically used pi's own `~/.pi` auth; it
+    // now reads the agent's credential file like every other command. Probe the RESOLVED model's
+    // provider through the normal resolution path (stored credential OR env var — an env-authed
+    // user is fine and must not be warned): only when that provider has no usable auth AND pi's old
+    // file exists does the bare provider error get its cause named.
     if (
       (await probeAuthSource(modelRuntime, modelSpec)) === undefined &&
       existsSync(join(getAgentDir(), "auth.json"))
@@ -232,52 +292,6 @@ export async function buildAgentSessionRuntime(
       );
     }
     const model = resolveModel(modelRuntime, modelSpec);
-
-    return {
-      model,
-      modelRuntime,
-      services,
-      // Serving honors config.thinkingLevel (config → L2); the resident session must too (fidelity).
-      thinkingLevel: config.thinkingLevel,
-      definition,
-      extensionPaths,
-      customTools,
-      customToolDefs,
-      deferredToolNames,
-      systemPrompt,
-    };
-  }
-
-  // pi calls the factory again on /new, /resume, switch, and fork. Config/tools dynamic imports are
-  // ESM-cached, so treating same-cwd rebuilds as hot reload would yield a half-fresh agent (fresh
-  // AGENTS.md/skills, stale config/tools). Keep the runtime a coherent startup snapshot: restart to
-  // load edits. And keep it workspace-scoped — `.env` is process-global, so a switch to another cwd
-  // would leak env or require mutating global env at runtime.
-  const rootCwd = canonicalPath(dir);
-  // The CURRENT pi session + its activation bridge, BOUND TOGETHER — rebuilt on /new//resume/fork
-  // while the memoized assembly (and its tool execute closures) stays. The bridge must share the
-  // session's lifetime, NOT be rebuilt per tool call (a per-call chain serializes nothing). Note on
-  // parallel batches: pi wraps SDK customTools in its own before/after active-set diff, so an
-  // activating tool must carry `executionMode: "sequential"` (the builtin loader does) — pi then runs
-  // the whole batch serially and the outer diff sees correct snapshots.
-  const sessionRef: {
-    current?: { session: AgentSession; sessionManager: ReadonlySessionManager; activation: ToolActivation };
-  } = {};
-  let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
-  const assemblyFor = (cwd: string) => {
-    // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
-    // otherwise mismatch a non-realpath rootCwd.
-    const activeCwd = canonicalPath(cwd);
-    if (activeCwd !== rootCwd) {
-      throw workspaceScopeError(activeCwd);
-    }
-    assembly ??= resolveAssembly(rootCwd);
-    return assembly;
-  };
-
-  const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
-    const { model, services, thinkingLevel, extensionPaths, customToolDefs, deferredToolNames } =
-      await assemblyFor(cwd);
 
     const result = await createAgentSessionFromServices({
       services,
@@ -299,18 +313,10 @@ export async function buildAgentSessionRuntime(
       sessionManager: agentSessionManager(result.session, result.session.sessionManager.getSessionId()),
       activation: sessionToolActivation(result.session),
     };
-    // Extensions only come ALIVE here. pi emits session_start from bindExtensions(), so without this
-    // call an extension loads, registers what it registers at import time, and then never hears
-    // another thing: no session_start, no tool registered from a handler, no shutdown. That is a
-    // definition whose extension half silently does nothing — the failure this whole path exists to
-    // remove. Binding also installs the error listener; pi fans handler errors to registered
-    // listeners and has none by default, so a throwing extension would otherwise look like an
-    // extension that simply did nothing.
-    if (extensionPaths.length > 0) {
-      await result.session.bindExtensions({
-        onError: (e) => log.warn(`[fastagent] extension ${e.extensionPath} failed on ${e.event}: ${e.error}`),
-      });
-    }
+    // NOT bound here: the HOST does it. InteractiveMode.bindCurrentSessionExtensions() calls
+    // session.bindExtensions() with the TUI's uiContext, abort handler and command actions — binding
+    // here too would emit session_start twice per chat, so an extension opening a resource on start
+    // would open two.
     // Deferral emulation: pi's session starts with everything active — narrow it by SUBTRACTING
     // the deferred names from whatever is active (robust to pi mounting tools of its own; an
     // exact-set-equality gate would silently stop narrowing the day pi adds one). Applied on EVERY

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -41,6 +41,7 @@ import {
   createAgentSessionServices,
   getAgentDir,
 } from "@earendil-works/pi-coding-agent";
+import { reportExtensionErrors } from "./agent-session-factory.ts";
 import { resolveModel } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt, piDefaultTools } from "./create.ts";
 import { canonicalPath, loadAgentDefinition } from "./definition.ts";
@@ -245,6 +246,10 @@ export async function buildAgentSessionRuntime(
         // ~/.pi extensions, slash commands, global AGENTS.md, APPEND_SYSTEM.md) so this runtime runs
         // the same agent that gets served, not the authoring machine's pi setup on top.
         noExtensions: true,
+        // ...except the definition's OWN extensions/: pi honours additionalExtensionPaths even under
+        // noExtensions. Without this the same definition would carry its extensions when served and
+        // lose them in chat — one artifact, two behaviours.
+        ...(definition.extensionPaths.length > 0 ? { additionalExtensionPaths: definition.extensionPaths } : {}),
         noPromptTemplates: true,
         noContextFiles: true,
         systemPromptOverride: () => systemPrompt,
@@ -270,6 +275,7 @@ export async function buildAgentSessionRuntime(
         }),
       },
     });
+    reportExtensionErrors(services);
     const result = await createAgentSessionFromServices({
       services,
       sessionManager,

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -281,13 +281,19 @@ export async function buildAgentSessionRuntime(
       },
     });
     reportExtensionErrors(services);
+    // `tools` is pi's ALLOWLIST, and it gates extension-registered tools the same as any other. The
+    // serving path passes no allowlist, so omitting these would give one definition two tool sets:
+    // present when served, missing in chat. The names come from the loaded extensions themselves.
+    const extensionToolNames = services.resourceLoader
+      .getExtensions()
+      .extensions.flatMap((extension) => [...extension.tools.keys()]);
     const result = await createAgentSessionFromServices({
       services,
       sessionManager,
       sessionStartEvent,
       model,
       thinkingLevel,
-      tools: [...defaultNames, ...customTools.map((t) => t.name)],
+      tools: [...defaultNames, ...customTools.map((t) => t.name), ...extensionToolNames],
       customTools: customToolDefs,
     });
     sessionRef.current = {

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -213,6 +213,10 @@ export async function buildAgentSessionRuntime(
     return assembly;
   };
 
+  // The credential hint belongs to the RUNTIME, not to each session it builds: model resolution
+  // moved into createRuntime (extensions must load first), and repeating this on every /new,
+  // /resume and fork would nag about a setting that did not change.
+  let credentialHintShown = false;
   const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
     const {
       modelRuntime,
@@ -283,9 +287,11 @@ export async function buildAgentSessionRuntime(
     // user is fine and must not be warned): only when that provider has no usable auth AND pi's old
     // file exists does the bare provider error get its cause named.
     if (
+      !credentialHintShown &&
       (await probeAuthSource(modelRuntime, modelSpec)) === undefined &&
       existsSync(join(getAgentDir(), "auth.json"))
     ) {
+      credentialHintShown = true;
       log.warn(
         `[fastagent] no credentials for ${modelSpec} in ${authPath} — this runtime no longer reads ` +
           `pi's ~/.pi auth; run \`fastagent login\` (or /login in the TUI) to store credentials for this agent`,

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -2,7 +2,7 @@
  * The pi implementation of the session control plane: observation (`state`/`entries`/`events`,
  * design Phase 1) and run modulation (`dispatch`: steer/follow_up/abort, Phase 2a) over
  * invoke-driven runs. `createPiSessionControl` returns the neutral `SessionControl` plus the
- * {@link SessionObserver} to plug into the invoke pipeline (`createPiAgentFromSession({ observer })`)
+ * {@link SessionObserver} to plug into the invoke pipeline (`createPiAgent({ observer })`)
  * — the hub derives everything from the rich event stream (plus the {@link RunControls} the
  * run_started event carries), holds no durable state of its own, and never writes: durable truth
  * stays in the session repository (read via {@link PiSessionRecordStore}), live truth in the events the

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -80,6 +80,19 @@ describe("definition: extensions/ discovery", () => {
     warn.mockRestore();
   });
 
+  it("refuses a subdirectory whose index.ts is a symlink out of the definition", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "fa-ext-outside-"));
+    await writeFile(join(outside, "real.ts"), markerExtension("escape"));
+    const dir = await agentDirWith({ "extensions/keep.ts": markerExtension("keep") });
+    await mkdir(join(dir, "extensions", "pkg"), { recursive: true });
+    await symlink(join(outside, "real.ts"), join(dir, "extensions", "pkg", "index.ts"));
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([join(dir, "extensions", "keep.ts")]);
+    expect(warn.mock.calls.flat().join("\n")).toContain("is a symlink and will not be loaded");
+    warn.mockRestore();
+  });
+
   it("refuses an extensions/ symlinked outside the agent dir", async () => {
     const outside = await mkdtemp(join(tmpdir(), "fa-ext-outside-"));
     await writeFile(join(outside, "evil.ts"), markerExtension("evil"));

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -3,7 +3,7 @@
  * `additionalExtensionPaths`, and reaching the model through the SERVING path — while pi's
  * machine-global discovery stays suppressed.
  */
-import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
@@ -233,5 +233,62 @@ export default async function (api) {
     const counts = (globalThis as Record<string, unknown>)[counterKey] as { start: number; shutdown: number };
     expect(counts.start).toBe(2); // one session per invoke
     expect(counts.shutdown).toBe(counts.start); // and each one cleaned up
+  });
+});
+
+describe("extension lifecycle is per invoke, like the session it belongs to", () => {
+  /** Writes one line per lifecycle event into `<dir>/events.log`, from MODULE scope. */
+  const lifecycleExtension = `
+import { appendFileSync } from "node:fs";
+import { join } from "node:path";
+const logFile = join(import.meta.dirname, "..", "events.log");
+const instance = Math.random().toString(36).slice(2, 7);
+let live = new Set();
+export default async function (pi) {
+  pi.on("session_start", async () => {
+    const t = setInterval(() => {}, 1e6);
+    live.add(t);
+    appendFileSync(logFile, \`start instance=\${instance} live=\${live.size}\\n\`);
+  });
+  pi.on("session_shutdown", async () => {
+    for (const t of live) clearInterval(t);
+    appendFileSync(logFile, \`shutdown instance=\${instance} cleared=\${live.size}\\n\`);
+    live.clear();
+  });
+}
+`;
+
+  it("a turn's shutdown cleans up ITS OWN resources, not another turn's", async () => {
+    const dir = await agentDirWith({ "extensions/lifecycle.ts": lifecycleExtension });
+    const { faux } = makeFaux();
+    let releaseA!: () => void;
+    let aRunning!: () => void;
+    const held = new Promise<void>((r) => (releaseA = r));
+    const started = new Promise<void>((r) => (aRunning = r));
+    faux.setResponses([
+      async () => {
+        aRunning();
+        await held; // A's model call hangs, so A's session outlives B's entire turn
+        return fauxAssistantMessage("a");
+      },
+      fauxAssistantMessage("b"),
+    ]);
+    const { agent } = await createPiAgentFromDefinition(dir, {
+      model: `${faux.getModel().provider}/${faux.getModel().id}`,
+      providers: [faux.provider],
+    });
+
+    const a = collect(agent.invoke({ session: "room-a" }, { text: "x" }));
+    await started;
+    await collect(agent.invoke({ session: "room-b" }, { text: "y" })); // B runs to completion inside A
+    releaseA();
+    await a;
+
+    const events = (await readFile(join(dir, "events.log"), "utf8")).trim().split("\n");
+    // Each turn gets its own extension instance, so each shutdown clears exactly what its own start
+    // opened. Sharing one instance across turns makes B's shutdown clear A's live timer.
+    expect(events.every((line) => line.includes("live=1") || line.includes("cleared=1"))).toBe(true);
+    const instances = new Set(events.map((line) => line.match(/instance=(\w+)/)?.[1]));
+    expect(instances.size).toBe(2); // one per turn
   });
 });

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { collect, createPiAgentFromDefinition } from "../src/index.ts";
-import { loadAgentDefinition } from "../src/engines/pi/definition.ts";
+import { loadExtensionPaths } from "../src/engines/pi/definition.ts";
 import { log } from "../src/log.ts";
 import { makeFaux } from "./faux.ts";
 
@@ -40,7 +40,7 @@ async function agentDirWith(files: Record<string, string>): Promise<string> {
 describe("definition: extensions/ discovery", () => {
   it("has no extensions when the directory is absent", async () => {
     const dir = await agentDirWith({});
-    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([]);
+    expect(await loadExtensionPaths(dir)).toEqual([]);
   });
 
   it("finds direct .ts/.js files and subdirectory index files, ignoring non-extension files", async () => {
@@ -52,7 +52,7 @@ describe("definition: extensions/ discovery", () => {
       "extensions/data.json": "{}",
     });
 
-    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([
+    expect(await loadExtensionPaths(dir)).toEqual([
       join(dir, "extensions", "alpha.ts"),
       join(dir, "extensions", "beta.js"),
       join(dir, "extensions", "gamma", "index.ts"),
@@ -63,7 +63,7 @@ describe("definition: extensions/ discovery", () => {
     const dir = await agentDirWith({ "extensions/pkg/main.ts": markerExtension("pkg") });
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
 
-    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([]);
+    expect(await loadExtensionPaths(dir)).toEqual([]);
     expect(warn.mock.calls.flat().join("\n")).toContain("expected index.ts or index.js");
     warn.mockRestore();
   });
@@ -75,7 +75,7 @@ describe("definition: extensions/ discovery", () => {
     await symlink(join(outside, "escape.ts"), join(dir, "extensions", "escape.ts"));
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
 
-    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([join(dir, "extensions", "local.ts")]);
+    expect(await loadExtensionPaths(dir)).toEqual([join(dir, "extensions", "local.ts")]);
     expect(warn.mock.calls.flat().join("\n")).toContain("is a symlink and will not be loaded");
     warn.mockRestore();
   });
@@ -88,7 +88,7 @@ describe("definition: extensions/ discovery", () => {
     await symlink(join(outside, "real.ts"), join(dir, "extensions", "pkg", "index.ts"));
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
 
-    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([join(dir, "extensions", "keep.ts")]);
+    expect(await loadExtensionPaths(dir)).toEqual([join(dir, "extensions", "keep.ts")]);
     expect(warn.mock.calls.flat().join("\n")).toContain("is a symlink and will not be loaded");
     warn.mockRestore();
   });
@@ -99,7 +99,7 @@ describe("definition: extensions/ discovery", () => {
     const dir = await agentDirWith({});
     await symlink(outside, join(dir, "extensions"), "dir");
 
-    await expect(loadAgentDefinition(dir)).rejects.toThrow(/resolves outside the agent dir/);
+    await expect(loadExtensionPaths(dir)).rejects.toThrow(/resolves outside the agent dir/);
   });
 });
 
@@ -162,6 +162,26 @@ describe("definition: an extension that throws at runtime", () => {
     await collect(agent.invoke({ session: "s" }, { text: "hi" }));
 
     expect(warn.mock.calls.flat().join("\n")).toMatch(/extension .*boom\.ts failed on session_start/);
+    warn.mockRestore();
+  });
+});
+
+describe("definition: extension discovery is assembly-time, not per turn", () => {
+  it("does not repeat its warnings on every invoke", async () => {
+    const dir = await agentDirWith({ "extensions/pkg/main.ts": markerExtension("pkg") });
+    const { faux } = makeFaux();
+    faux.setResponses([() => fauxAssistantMessage("one"), () => fauxAssistantMessage("two")]);
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    const { agent } = await createPiAgentFromDefinition(dir, {
+      model: "faux/faux-1",
+      providers: [faux.provider],
+    });
+    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
+    await collect(agent.invoke({ session: "s" }, { text: "again" }));
+
+    const complaints = warn.mock.calls.flat().filter((c) => String(c).includes("expected index.ts"));
+    expect(complaints).toHaveLength(1); // the boot scan, not one per turn
     warn.mockRestore();
   });
 });

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -178,17 +178,17 @@ describe("definition: chat runs the definition's extensions in full", () => {
 });
 
 describe("definition: extensions/ discovery only complains about real candidates", () => {
-  it("ignores a symlinked non-module file instead of calling it a refused extension", async () => {
+  it("announces every symlink, including a directory-shaped one with a dotted name", async () => {
     const dir = await agentDirWith({ "extensions/real.ts": markerExtension("real") });
     const outside = await mkdtemp(join(tmpdir(), "fa-nonmod-"));
-    await writeFile(join(outside, "NOTES.md"), "notes\n");
-    await symlink(join(outside, "NOTES.md"), join(dir, "extensions", "NOTES.md"));
+    await writeFile(join(outside, "index.ts"), markerExtension("linked"));
+    // `audit.ext -> dir` is a directory candidate to pi, and from a listing it is indistinguishable
+    // from a symlinked data file. Guessing by name would drop this one in silence.
+    await symlink(outside, join(dir, "extensions", "audit.ext"), "dir");
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
 
-    expect(await loadExtensionPaths(dir)).toHaveLength(1);
-    // A symlinked README in extensions/ is the author's business. Warning about it teaches people to
-    // ignore the warning that matters — the one about a symlinked extension.
-    expect(warn.mock.calls.flat().join("\n")).not.toMatch(/NOTES\.md/);
+    expect(await loadExtensionPaths(dir)).toHaveLength(1); // only the real one
+    expect(warn.mock.calls.flat().join("\n")).toMatch(/audit\.ext is a symlink/);
     warn.mockRestore();
   });
 

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -303,3 +303,38 @@ export default async function (pi) {
     expect(events.filter((line) => line.startsWith("shutdown"))).toHaveLength(0);
   });
 });
+
+describe("a definition edit rebuilds the extension instance", () => {
+  it("editing persona.md re-runs the extension factory — pi's reload clears its module cache", async () => {
+    const key = `__fa_ext_rebuild_${Date.now()}__`;
+    const dir = await agentDirWith({
+      "extensions/counter.ts": `
+export default async function (api) {
+  const k = ${JSON.stringify(key)};
+  globalThis[k] = (globalThis[k] ?? 0) + 1;
+}
+`,
+    });
+    const { faux } = makeFaux();
+    faux.setResponses(Array.from({ length: 4 }, () => fauxAssistantMessage("ok")));
+    const { agent } = await createPiAgentFromDefinition(dir, {
+      model: "faux/faux-1",
+      providers: [faux.provider],
+    });
+
+    await collect(agent.invoke({ session: "s" }, { text: "one" }));
+    expect((globalThis as Record<string, unknown>)[key]).toBe(1);
+
+    await collect(agent.invoke({ session: "s" }, { text: "two" }));
+    expect((globalThis as Record<string, unknown>)[key]).toBe(1); // unchanged definition, same instance
+
+    // The definition is LIVE, and pi only serves a re-read one after ResourceLoader.reload() — which
+    // begins with clearExtensionCache(). Extensions are therefore rebuilt by an edit to persona.md,
+    // even though nothing about the extension changed. There is no narrower reload in pi's API and
+    // no session-level prompt setter, so this is a property to know, not a bug to fix here: state an
+    // extension holds does not survive an edit to the definition.
+    await writeFile(join(dir, "persona.md"), "You are extremely terse.\n");
+    await collect(agent.invoke({ session: "s" }, { text: "three" }));
+    expect((globalThis as Record<string, unknown>)[key]).toBe(2);
+  });
+});

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -207,3 +207,96 @@ describe("definition: extensions/ discovery only complains about real candidates
     warn.mockRestore();
   });
 });
+
+describe("definition: chat brings extensions to life, not just into memory", () => {
+  /** Registers at import time AND from session_start — pi supports both; only one used to survive. */
+  const twoMoments = `
+export default async function (pi) {
+  pi.registerTool({
+    name: "at_load", label: "a", description: "d",
+    parameters: { type: "object", properties: {} },
+    execute: async () => ({ output: "ok" }),
+  });
+  pi.on("session_start", async () => {
+    pi.registerTool({
+      name: "at_session_start", label: "b", description: "d",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ output: "ok" }),
+    });
+  });
+}
+`;
+
+  async function chatToolNames(files: Record<string, string>): Promise<string[]> {
+    const workspace = await mkdtemp(join(tmpdir(), "fa-chat-live-"));
+    const dir = join(workspace, "fastagent");
+    await mkdir(join(dir, "extensions"), { recursive: true });
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    for (const [rel, content] of Object.entries(files)) await writeFile(join(dir, rel), content);
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    try {
+      return rt.session.getAllTools().map((t) => t.name);
+    } finally {
+      await rt.dispose?.();
+    }
+  }
+
+  it("fires session_start, so a tool registered from a handler reaches the session", async () => {
+    // pi emits session_start from bindExtensions(). Without that call an extension loads and is
+    // then never spoken to again: no lifecycle events, nothing registered from a handler, and no
+    // error listener either — it looks like an extension that chose to do nothing.
+    const names = await chatToolNames({ "extensions/two.ts": twoMoments });
+    expect(names).toContain("at_load");
+    expect(names).toContain("at_session_start");
+  });
+
+  it("uses fastagent's own read tool, not pi's copy of it", async () => {
+    // fastagent's `read` is createReadTool({ imageProcessor }) (create.ts). Chat used to allow-list
+    // the NAME "read", which mounted pi's own — silently dropping image reading in chat only.
+    const names = await chatToolNames({});
+    expect(names).toContain("read");
+    expect(names.filter((n) => n === "read")).toHaveLength(1); // and exactly one of them
+  });
+});
+
+describe("definition: an extension can define the model chat runs on", () => {
+  it("resolves a model registered by an extension's registerProvider()", async () => {
+    // pi documents registerProvider() as the way an extension adds providers/models, and extensions
+    // only execute when the services are built. Resolving the configured model before that failed
+    // with a bare "unknown model" — and probed auth for a provider that did not exist yet.
+    const workspace = await mkdtemp(join(tmpdir(), "fa-prov-"));
+    const dir = join(workspace, "fastagent");
+    await mkdir(join(dir, "extensions"), { recursive: true });
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "acme-proxy/acme-1" };\n');
+    await writeFile(
+      join(dir, "extensions", "provider.ts"),
+      `
+export default async function (pi) {
+  pi.registerProvider("acme-proxy", {
+    baseUrl: "https://proxy.example.com",
+    apiKey: "$ACME_KEY",
+    api: "anthropic-messages",
+    models: [{
+      id: "acme-1",
+      name: "Acme 1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 16384,
+    }],
+  });
+}
+`,
+    );
+
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    try {
+      expect(rt.session.model?.id).toBe("acme-1");
+    } finally {
+      await rt.dispose?.();
+    }
+  });
+});

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -208,6 +208,33 @@ describe("definition: chat loads the same extensions serving does", () => {
 });
 
 describe("definition: extension lifecycle across per-invoke sessions", () => {
+  it("two agents in one process get an instance each — the boundary is the assembly, not the process", async () => {
+    const key = `__fa_ext_perassembly_${Date.now()}__`;
+    const mk = async () =>
+      await agentDirWith({
+        "extensions/c.ts": `
+export default async function (api) {
+  const k = ${JSON.stringify(key)};
+  globalThis[k] = (globalThis[k] ?? 0) + 1;
+}
+`,
+      });
+    const [d1, d2] = [await mk(), await mk()];
+    const { faux } = makeFaux();
+    faux.setResponses(Array.from({ length: 8 }, () => fauxAssistantMessage("ok")));
+    const opts = { model: "faux/faux-1", providers: [faux.provider] };
+    const a1 = (await createPiAgentFromDefinition(d1, opts)).agent;
+    const a2 = (await createPiAgentFromDefinition(d2, opts)).agent;
+    const g = globalThis as unknown as Record<string, number>;
+
+    await collect(a1.invoke({ session: "s" }, { text: "1" }));
+    expect(g[key]).toBe(1);
+    await collect(a2.invoke({ session: "s" }, { text: "2" }));
+    expect(g[key]).toBe(2); // a second agent loads its own
+    await collect(a1.invoke({ session: "s" }, { text: "3" }));
+    expect(g[key]).toBe(2); // and the first one keeps the instance it had
+  });
+
   it("one extension instance serves every turn, and session_start repeats on each", async () => {
     const counterKey = `__fa_ext_lifecycle_${Date.now()}__`;
     const dir = await agentDirWith({
@@ -236,8 +263,8 @@ export default async function (api) {
       shutdown: number;
       factories: number;
     };
-    // ONE instance for the process: pi caches extension modules in a process-global map, so a served
-    // agent cannot hand a turn its own copy however the loader is driven.
+    // ONE instance for this agent: the extensions belong to the assembly's ResourceLoader, which
+    // loads them once and serves every turn from that. A turn cannot be given its own copy.
     expect(counts.factories).toBe(1);
     // session_start still fires per turn, because a session must be bound for its errors to surface
     // at all — which is why the docs require start handlers to be idempotent.

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The definition carries its own `extensions/`: discovered as entry-point FILES, handed to pi as
+ * `additionalExtensionPaths`, and reaching the model through the SERVING path — while pi's
+ * machine-global discovery stays suppressed.
+ */
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { collect, createPiAgentFromDefinition } from "../src/index.ts";
+import { loadAgentDefinition } from "../src/engines/pi/definition.ts";
+import { log } from "../src/log.ts";
+import { makeFaux } from "./faux.ts";
+
+/** An extension registering one tool whose presence proves the module was loaded and bound. */
+const markerExtension = (toolName: string) => `
+export default async function (api) {
+  api.registerTool({
+    name: ${JSON.stringify(toolName)},
+    label: ${JSON.stringify(toolName)},
+    description: "proves the extension loaded",
+    parameters: { type: "object", properties: {} },
+    execute: async () => ({ output: "ok" }),
+  });
+}
+`;
+
+async function agentDirWith(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "fa-ext-"));
+  await writeFile(join(dir, "persona.md"), "You are terse.\n");
+  for (const [rel, content] of Object.entries(files)) {
+    const path = join(dir, rel);
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, content);
+  }
+  return dir;
+}
+
+describe("definition: extensions/ discovery", () => {
+  it("has no extensions when the directory is absent", async () => {
+    const dir = await agentDirWith({});
+    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([]);
+  });
+
+  it("finds direct .ts/.js files and subdirectory index files, ignoring non-extension files", async () => {
+    const dir = await agentDirWith({
+      "extensions/alpha.ts": markerExtension("alpha"),
+      "extensions/beta.js": markerExtension("beta"),
+      "extensions/gamma/index.ts": markerExtension("gamma"),
+      "extensions/README.md": "not an extension",
+      "extensions/data.json": "{}",
+    });
+
+    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([
+      join(dir, "extensions", "alpha.ts"),
+      join(dir, "extensions", "beta.js"),
+      join(dir, "extensions", "gamma", "index.ts"),
+    ]);
+  });
+
+  it("warns about a subdirectory with no index rather than skipping it silently", async () => {
+    const dir = await agentDirWith({ "extensions/pkg/main.ts": markerExtension("pkg") });
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([]);
+    expect(warn.mock.calls.flat().join("\n")).toContain("expected index.ts or index.js");
+    warn.mockRestore();
+  });
+
+  it("refuses an extensions/ symlinked outside the agent dir", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "fa-ext-outside-"));
+    await writeFile(join(outside, "evil.ts"), markerExtension("evil"));
+    const dir = await agentDirWith({});
+    await symlink(outside, join(dir, "extensions"), "dir");
+
+    await expect(loadAgentDefinition(dir)).rejects.toThrow(/resolves outside the agent dir/);
+  });
+});
+
+describe("definition: extensions reach the served agent", () => {
+  /** Build a served agent on a faux model and report the tool names the model was offered. */
+  async function toolNamesOfferedBy(dir: string): Promise<string[]> {
+    const { faux } = makeFaux();
+    let offered: string[] = [];
+    faux.setResponses([
+      (context) => {
+        offered = (context.tools ?? []).map((t) => t.name);
+        return fauxAssistantMessage("ok");
+      },
+    ]);
+    const { agent } = await createPiAgentFromDefinition(dir, {
+      model: "faux/faux-1",
+      providers: [faux.provider],
+    });
+    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
+    return offered;
+  }
+
+  it("an extension-registered tool is offered to the model on the serving path", async () => {
+    const dir = await agentDirWith({ "extensions/marker.ts": markerExtension("extension_marker") });
+    expect(await toolNamesOfferedBy(dir)).toContain("extension_marker");
+  });
+
+  it("a broken extension is warned about, not swallowed, and the agent still serves", async () => {
+    const dir = await agentDirWith({ "extensions/broken.ts": "throw new Error('boom at import');\n" });
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    const offered = await toolNamesOfferedBy(dir);
+
+    expect(warn.mock.calls.flat().join("\n")).toMatch(/extension .*broken\.ts failed to load/);
+    expect(offered.length).toBeGreaterThan(0); // the turn still ran
+    warn.mockRestore();
+  });
+});
+
+describe("definition: an extension that throws at runtime", () => {
+  it("is warned about rather than dropped", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-ext-"));
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await mkdir(join(dir, "extensions"), { recursive: true });
+    await writeFile(
+      join(dir, "extensions", "boom.ts"),
+      `export default async function (api) {
+         api.on("session_start", () => { throw new Error("handler exploded"); });
+       }\n`,
+    );
+
+    const { faux } = makeFaux();
+    faux.setResponses([() => fauxAssistantMessage("ok")]);
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    const { agent } = await createPiAgentFromDefinition(dir, {
+      model: "faux/faux-1",
+      providers: [faux.provider],
+    });
+    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
+
+    expect(warn.mock.calls.flat().join("\n")).toMatch(/extension .*boom\.ts failed on session_start/);
+    warn.mockRestore();
+  });
+});

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -3,7 +3,7 @@
  * `additionalExtensionPaths`, and reaching the model through the SERVING path — while pi's
  * machine-global discovery stays suppressed.
  */
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
@@ -105,7 +105,7 @@ describe("definition: extensions/ discovery", () => {
   });
 });
 
-describe("definition: extensions reach the served agent", () => {
+describe("definition: serving does NOT run extensions, and says so", () => {
   /** Build a served agent on a faux model and report the tool names the model was offered. */
   async function toolNamesOfferedBy(dir: string): Promise<string[]> {
     const { faux } = makeFaux();
@@ -124,71 +124,37 @@ describe("definition: extensions reach the served agent", () => {
     return offered;
   }
 
-  it("an extension-registered tool is offered to the model on the serving path", async () => {
+  it("does not offer an extension-registered tool to the model", async () => {
+    // pi's extension runtime is shared across sessions (its own source calls it "the shared
+    // runtime"), and serving runs concurrent turns for unrelated conversations. Loading them would
+    // let one turn's `pi.sendMessage()` land in another conversation - a silent correctness bug,
+    // which is worse than the missing feature. `chat` runs them fully; see the block below.
     const dir = await agentDirWith({ "extensions/marker.ts": markerExtension("extension_marker") });
-    expect(await toolNamesOfferedBy(dir)).toContain("extension_marker");
-  });
-
-  it("a broken extension is warned about, not swallowed, and the agent still serves", async () => {
-    const dir = await agentDirWith({ "extensions/broken.ts": "throw new Error('boom at import');\n" });
-    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
-
     const offered = await toolNamesOfferedBy(dir);
-
-    expect(warn.mock.calls.flat().join("\n")).toMatch(/extension .*broken\.ts failed to load/);
-    expect(offered.length).toBeGreaterThan(0); // the turn still ran
-    warn.mockRestore();
+    expect(offered).not.toContain("extension_marker");
+    expect(offered.length).toBeGreaterThan(0); // the agent still serves, with its own tools
   });
-});
 
-describe("definition: an extension that throws at runtime", () => {
-  it("is warned about rather than dropped", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-ext-"));
-    await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await mkdir(join(dir, "extensions"), { recursive: true });
-    await writeFile(
-      join(dir, "extensions", "boom.ts"),
-      `export default async function (api) {
-         api.on("session_start", () => { throw new Error("handler exploded"); });
-       }\n`,
-    );
-
-    const { faux } = makeFaux();
-    faux.setResponses([() => fauxAssistantMessage("ok")]);
+  it("warns that they were skipped, rather than dropping them in silence", async () => {
+    const dir = await agentDirWith({ "extensions/marker.ts": markerExtension("extension_marker") });
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
-
-    const { agent } = await createPiAgentFromDefinition(dir, {
-      model: "faux/faux-1",
-      providers: [faux.provider],
-    });
-    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
-
-    expect(warn.mock.calls.flat().join("\n")).toMatch(/extension .*boom\.ts failed on session_start/);
+    await toolNamesOfferedBy(dir);
+    expect(warn.mock.calls.flat().join("\n")).toMatch(/NOT loaded when serving/);
     warn.mockRestore();
+  });
+
+  it("keeps refusing an extensions/ that escapes the agent dir", async () => {
+    // Discovery keeps running even though serving does not load: the refusals are about what the
+    // artifact may contain, and chat consumes the same list.
+    const outside = await mkdtemp(join(tmpdir(), "fa-outside-"));
+    await writeFile(join(outside, "eee.ts"), markerExtension("nope"));
+    const dir = await agentDirWith({});
+    await symlink(outside, join(dir, "extensions"), "dir");
+    await expect(loadExtensionPaths(dir)).rejects.toThrow(/resolves outside the agent dir/);
   });
 });
 
-describe("definition: extension discovery is assembly-time, not per turn", () => {
-  it("does not repeat its warnings on every invoke", async () => {
-    const dir = await agentDirWith({ "extensions/pkg/main.ts": markerExtension("pkg") });
-    const { faux } = makeFaux();
-    faux.setResponses([() => fauxAssistantMessage("one"), () => fauxAssistantMessage("two")]);
-    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
-
-    const { agent } = await createPiAgentFromDefinition(dir, {
-      model: "faux/faux-1",
-      providers: [faux.provider],
-    });
-    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
-    await collect(agent.invoke({ session: "s" }, { text: "again" }));
-
-    const complaints = warn.mock.calls.flat().filter((c) => String(c).includes("expected index.ts"));
-    expect(complaints).toHaveLength(1); // the boot scan, not one per turn
-    warn.mockRestore();
-  });
-});
-
-describe("definition: chat loads the same extensions serving does", () => {
+describe("definition: chat runs the definition's extensions in full", () => {
   it("mounts an extension-registered tool on the resident chat session", async () => {
     // The chat placement: the agent dir is `<workspace>/fastagent/`, entered from the inside.
     const workspace = await mkdtemp(join(tmpdir(), "fa-chat-ext-"));
@@ -204,164 +170,5 @@ describe("definition: chat loads the same extensions serving does", () => {
     } finally {
       await rt.dispose?.();
     }
-  });
-});
-
-describe("definition: extension lifecycle across per-invoke sessions", () => {
-  it("two agents in one process get an instance each — the boundary is the assembly, not the process", async () => {
-    const key = `__fa_ext_perassembly_${Date.now()}__`;
-    const mk = async () =>
-      await agentDirWith({
-        "extensions/c.ts": `
-export default async function (api) {
-  const k = ${JSON.stringify(key)};
-  globalThis[k] = (globalThis[k] ?? 0) + 1;
-}
-`,
-      });
-    const [d1, d2] = [await mk(), await mk()];
-    const { faux } = makeFaux();
-    faux.setResponses(Array.from({ length: 8 }, () => fauxAssistantMessage("ok")));
-    const opts = { model: "faux/faux-1", providers: [faux.provider] };
-    const a1 = (await createPiAgentFromDefinition(d1, opts)).agent;
-    const a2 = (await createPiAgentFromDefinition(d2, opts)).agent;
-    const g = globalThis as unknown as Record<string, number>;
-
-    await collect(a1.invoke({ session: "s" }, { text: "1" }));
-    expect(g[key]).toBe(1);
-    await collect(a2.invoke({ session: "s" }, { text: "2" }));
-    expect(g[key]).toBe(2); // a second agent loads its own
-    await collect(a1.invoke({ session: "s" }, { text: "3" }));
-    expect(g[key]).toBe(2); // and the first one keeps the instance it had
-  });
-
-  it("one extension instance serves every turn, and session_start repeats on each", async () => {
-    const counterKey = `__fa_ext_lifecycle_${Date.now()}__`;
-    const dir = await agentDirWith({
-      "extensions/lifecycle.ts": `
-export default async function (api) {
-  const key = ${JSON.stringify(counterKey)};
-  globalThis[key] ??= { start: 0, shutdown: 0, factories: 0 };
-  globalThis[key].factories++;
-  api.on("session_start", () => { globalThis[key].start++; });
-  api.on("session_shutdown", () => { globalThis[key].shutdown++; });
-}
-`,
-    });
-    const { faux } = makeFaux();
-    faux.setResponses([() => fauxAssistantMessage("one"), () => fauxAssistantMessage("two")]);
-
-    const { agent } = await createPiAgentFromDefinition(dir, {
-      model: "faux/faux-1",
-      providers: [faux.provider],
-    });
-    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
-    await collect(agent.invoke({ session: "s" }, { text: "again" }));
-
-    const counts = (globalThis as Record<string, unknown>)[counterKey] as {
-      start: number;
-      shutdown: number;
-      factories: number;
-    };
-    // ONE instance for this agent: the extensions belong to the assembly's ResourceLoader, which
-    // loads them once and serves every turn from that. A turn cannot be given its own copy.
-    expect(counts.factories).toBe(1);
-    // session_start still fires per turn, because a session must be bound for its errors to surface
-    // at all — which is why the docs require start handlers to be idempotent.
-    expect(counts.start).toBe(2);
-    // No per-turn shutdown. Emitting one would tear down state the NEXT turn (or a concurrent one)
-    // is still using, since they are all the same instance.
-    expect(counts.shutdown).toBe(0);
-  });
-});
-
-describe("extension lifecycle under concurrency", () => {
-  /** Writes one line per lifecycle event into `<dir>/events.log`, from MODULE scope. */
-  const lifecycleExtension = `
-import { appendFileSync } from "node:fs";
-import { join } from "node:path";
-const logFile = join(import.meta.dirname, "..", "events.log");
-let live = new Set();
-export default async function (pi) {
-  pi.on("session_start", async () => {
-    const t = setInterval(() => {}, 1e6);
-    live.add(t);
-    appendFileSync(logFile, \`start live=\${live.size}\\n\`);
-  });
-  pi.on("session_shutdown", async () => {
-    for (const t of live) clearInterval(t);
-    appendFileSync(logFile, \`shutdown cleared=\${live.size}\\n\`);
-    live.clear();
-  });
-}
-`;
-
-  it("a turn never tears down a resource another turn is using", async () => {
-    const dir = await agentDirWith({ "extensions/lifecycle.ts": lifecycleExtension });
-    const { faux } = makeFaux();
-    let releaseA!: () => void;
-    let aRunning!: () => void;
-    const held = new Promise<void>((r) => (releaseA = r));
-    const started = new Promise<void>((r) => (aRunning = r));
-    faux.setResponses([
-      async () => {
-        aRunning();
-        await held; // A's model call hangs, so A's session outlives B's entire turn
-        return fauxAssistantMessage("a");
-      },
-      fauxAssistantMessage("b"),
-    ]);
-    const { agent } = await createPiAgentFromDefinition(dir, {
-      model: `${faux.getModel().provider}/${faux.getModel().id}`,
-      providers: [faux.provider],
-    });
-
-    const a = collect(agent.invoke({ session: "room-a" }, { text: "x" }));
-    await started;
-    await collect(agent.invoke({ session: "room-b" }, { text: "y" })); // B runs to completion inside A
-    releaseA();
-    await a;
-
-    const events = (await readFile(join(dir, "events.log"), "utf8")).trim().split("\n");
-    // The instance is shared (pi's module cache is process-global), so a per-turn shutdown would
-    // clear the timer A is still using — B's cleanup destroying A's resource. Not emitting one is
-    // what keeps concurrent turns from interfering.
-    expect(events.filter((line) => line.startsWith("start"))).toHaveLength(2);
-    expect(events.filter((line) => line.startsWith("shutdown"))).toHaveLength(0);
-  });
-});
-
-describe("a definition edit rebuilds the extension instance", () => {
-  it("editing persona.md re-runs the extension factory — pi's reload clears its module cache", async () => {
-    const key = `__fa_ext_rebuild_${Date.now()}__`;
-    const dir = await agentDirWith({
-      "extensions/counter.ts": `
-export default async function (api) {
-  const k = ${JSON.stringify(key)};
-  globalThis[k] = (globalThis[k] ?? 0) + 1;
-}
-`,
-    });
-    const { faux } = makeFaux();
-    faux.setResponses(Array.from({ length: 4 }, () => fauxAssistantMessage("ok")));
-    const { agent } = await createPiAgentFromDefinition(dir, {
-      model: "faux/faux-1",
-      providers: [faux.provider],
-    });
-
-    await collect(agent.invoke({ session: "s" }, { text: "one" }));
-    expect((globalThis as Record<string, unknown>)[key]).toBe(1);
-
-    await collect(agent.invoke({ session: "s" }, { text: "two" }));
-    expect((globalThis as Record<string, unknown>)[key]).toBe(1); // unchanged definition, same instance
-
-    // The definition is LIVE, and pi only serves a re-read one after ResourceLoader.reload() — which
-    // begins with clearExtensionCache(). Extensions are therefore rebuilt by an edit to persona.md,
-    // even though nothing about the extension changed. There is no narrower reload in pi's API and
-    // no session-level prompt setter, so this is a property to know, not a bug to fix here: state an
-    // extension holds does not survive an edit to the definition.
-    await writeFile(join(dir, "persona.md"), "You are extremely terse.\n");
-    await collect(agent.invoke({ session: "s" }, { text: "three" }));
-    expect((globalThis as Record<string, unknown>)[key]).toBe(2);
   });
 });

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -6,10 +6,12 @@
 import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { collect, createPiAgentFromDefinition } from "../src/index.ts";
 import { loadExtensionPaths } from "../src/engines/pi/definition.ts";
+import { buildAgentSessionRuntime } from "../src/engines/pi/session-builder.ts";
 import { log } from "../src/log.ts";
 import { makeFaux } from "./faux.ts";
 
@@ -183,5 +185,24 @@ describe("definition: extension discovery is assembly-time, not per turn", () =>
     const complaints = warn.mock.calls.flat().filter((c) => String(c).includes("expected index.ts"));
     expect(complaints).toHaveLength(1); // the boot scan, not one per turn
     warn.mockRestore();
+  });
+});
+
+describe("definition: chat loads the same extensions serving does", () => {
+  it("mounts an extension-registered tool on the resident chat session", async () => {
+    // The chat placement: the agent dir is `<workspace>/fastagent/`, entered from the inside.
+    const workspace = await mkdtemp(join(tmpdir(), "fa-chat-ext-"));
+    const dir = join(workspace, "fastagent");
+    await mkdir(join(dir, "extensions"), { recursive: true });
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    await writeFile(join(dir, "extensions", "marker.ts"), markerExtension("chat_extension_marker"));
+
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    try {
+      expect(rt.session.getAllTools().map((t) => t.name)).toContain("chat_extension_marker");
+    } finally {
+      await rt.dispose?.();
+    }
   });
 });

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -68,6 +68,18 @@ describe("definition: extensions/ discovery", () => {
     warn.mockRestore();
   });
 
+  it("refuses a symlinked entry, which would not survive the trip into a container", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "fa-ext-outside-"));
+    await writeFile(join(outside, "escape.ts"), markerExtension("escape"));
+    const dir = await agentDirWith({ "extensions/local.ts": markerExtension("local") });
+    await symlink(join(outside, "escape.ts"), join(dir, "extensions", "escape.ts"));
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    expect((await loadAgentDefinition(dir)).extensionPaths).toEqual([join(dir, "extensions", "local.ts")]);
+    expect(warn.mock.calls.flat().join("\n")).toContain("is a symlink and will not be loaded");
+    warn.mockRestore();
+  });
+
   it("refuses an extensions/ symlinked outside the agent dir", async () => {
     const outside = await mkdtemp(join(tmpdir(), "fa-ext-outside-"));
     await writeFile(join(outside, "evil.ts"), markerExtension("evil"));

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -1,7 +1,11 @@
 /**
- * The definition carries its own `extensions/`: discovered as entry-point FILES, handed to pi as
- * `additionalExtensionPaths`, and reaching the model through the SERVING path — while pi's
- * machine-global discovery stays suppressed.
+ * The definition carries its own `extensions/`: discovered as entry-point FILES with pi's own rules,
+ * refused when they would not survive the trip into a container, and loaded by `fastagent chat`.
+ *
+ * SERVING does not load them, and warns that it did not — pi's extension runtime is shared across
+ * sessions, which a concurrent server cannot use safely. These tests pin both halves: discovery and
+ * its refusals apply either way, tools reach the model in chat, and serving stays quiet-free about
+ * skipping them.
  */
 import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -170,5 +174,36 @@ describe("definition: chat runs the definition's extensions in full", () => {
     } finally {
       await rt.dispose?.();
     }
+  });
+});
+
+describe("definition: extensions/ discovery only complains about real candidates", () => {
+  it("ignores a symlinked non-module file instead of calling it a refused extension", async () => {
+    const dir = await agentDirWith({ "extensions/real.ts": markerExtension("real") });
+    const outside = await mkdtemp(join(tmpdir(), "fa-nonmod-"));
+    await writeFile(join(outside, "NOTES.md"), "notes\n");
+    await symlink(join(outside, "NOTES.md"), join(dir, "extensions", "NOTES.md"));
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    expect(await loadExtensionPaths(dir)).toHaveLength(1);
+    // A symlinked README in extensions/ is the author's business. Warning about it teaches people to
+    // ignore the warning that matters — the one about a symlinked extension.
+    expect(warn.mock.calls.flat().join("\n")).not.toMatch(/NOTES\.md/);
+    warn.mockRestore();
+  });
+
+  it("does not claim a directory lacks an index when its index was refused as a symlink", async () => {
+    const dir = await agentDirWith({});
+    await mkdir(join(dir, "extensions", "audit"), { recursive: true });
+    const outside = await mkdtemp(join(tmpdir(), "fa-idx-"));
+    await writeFile(join(outside, "index.ts"), markerExtension("audit"));
+    await symlink(join(outside, "index.ts"), join(dir, "extensions", "audit", "index.ts"));
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    expect(await loadExtensionPaths(dir)).toHaveLength(0);
+    const warnings = warn.mock.calls.flat().join("\n");
+    expect(warnings).toMatch(/symlink/i); // the real reason
+    expect(warnings).not.toMatch(/expected index\.ts/); // not a contradicting second story
+    warn.mockRestore();
   });
 });

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -322,11 +322,12 @@ export default async function (pi) {
 });
 
 describe("definition: chat rebuilds extensions when pi replaces the session", () => {
-  it("re-runs the extension factory on a session replacement, not once for the runtime", async () => {
+  it("re-runs the extension factory on newSession(), not once for the runtime", async () => {
     // pi replaces the session on /new, /resume and fork, and its extension contract is that the
-    // replacement gets freshly loaded extensions. Memoizing the services with the assembly (they
-    // are memoized: prompt, tools and definition all are) would carry one session's extension
-    // objects into the next.
+    // replacement gets freshly loaded extensions. The assembly is memoized (prompt, tools and
+    // definition all are); memoizing the services with it would carry one session's extension
+    // objects into the next. Driving runtime.newSession() is the only way to prove that — two
+    // separate runtimes would each load once and pass either way.
     const key = `__fa_ext_rebuild_on_new_${Date.now()}__`;
     const workspace = await mkdtemp(join(tmpdir(), "fa-newsess-"));
     const dir = join(workspace, "fastagent");
@@ -343,13 +344,16 @@ export default async function (pi) {
 `,
     );
 
-    const first = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
-    await first.dispose?.();
-    const afterFirst = (globalThis as unknown as Record<string, number>)[key] ?? 0;
-    // A second runtime over the same directory stands in for the replacement pi performs: what
-    // matters is that building a session loads extensions rather than reusing a memoized set.
-    const second = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
-    await second.dispose?.();
-    expect((globalThis as unknown as Record<string, number>)[key]).toBeGreaterThan(afterFirst);
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    try {
+      const counts = globalThis as unknown as Record<string, number>;
+      const afterBuild = counts[key] ?? 0;
+      expect(afterBuild).toBeGreaterThan(0);
+      const { cancelled } = await rt.newSession();
+      expect(cancelled).toBe(false);
+      expect(counts[key]).toBeGreaterThan(afterBuild);
+    } finally {
+      await rt.dispose?.();
+    }
   });
 });

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -208,13 +208,14 @@ describe("definition: chat loads the same extensions serving does", () => {
 });
 
 describe("definition: extension lifecycle across per-invoke sessions", () => {
-  it("pairs every session_start with a session_shutdown", async () => {
+  it("one extension instance serves every turn, and session_start repeats on each", async () => {
     const counterKey = `__fa_ext_lifecycle_${Date.now()}__`;
     const dir = await agentDirWith({
       "extensions/lifecycle.ts": `
 export default async function (api) {
   const key = ${JSON.stringify(counterKey)};
-  globalThis[key] ??= { start: 0, shutdown: 0 };
+  globalThis[key] ??= { start: 0, shutdown: 0, factories: 0 };
+  globalThis[key].factories++;
   api.on("session_start", () => { globalThis[key].start++; });
   api.on("session_shutdown", () => { globalThis[key].shutdown++; });
 }
@@ -230,35 +231,45 @@ export default async function (api) {
     await collect(agent.invoke({ session: "s" }, { text: "hi" }));
     await collect(agent.invoke({ session: "s" }, { text: "again" }));
 
-    const counts = (globalThis as Record<string, unknown>)[counterKey] as { start: number; shutdown: number };
-    expect(counts.start).toBe(2); // one session per invoke
-    expect(counts.shutdown).toBe(counts.start); // and each one cleaned up
+    const counts = (globalThis as Record<string, unknown>)[counterKey] as {
+      start: number;
+      shutdown: number;
+      factories: number;
+    };
+    // ONE instance for the process: pi caches extension modules in a process-global map, so a served
+    // agent cannot hand a turn its own copy however the loader is driven.
+    expect(counts.factories).toBe(1);
+    // session_start still fires per turn, because a session must be bound for its errors to surface
+    // at all — which is why the docs require start handlers to be idempotent.
+    expect(counts.start).toBe(2);
+    // No per-turn shutdown. Emitting one would tear down state the NEXT turn (or a concurrent one)
+    // is still using, since they are all the same instance.
+    expect(counts.shutdown).toBe(0);
   });
 });
 
-describe("extension lifecycle is per invoke, like the session it belongs to", () => {
+describe("extension lifecycle under concurrency", () => {
   /** Writes one line per lifecycle event into `<dir>/events.log`, from MODULE scope. */
   const lifecycleExtension = `
 import { appendFileSync } from "node:fs";
 import { join } from "node:path";
 const logFile = join(import.meta.dirname, "..", "events.log");
-const instance = Math.random().toString(36).slice(2, 7);
 let live = new Set();
 export default async function (pi) {
   pi.on("session_start", async () => {
     const t = setInterval(() => {}, 1e6);
     live.add(t);
-    appendFileSync(logFile, \`start instance=\${instance} live=\${live.size}\\n\`);
+    appendFileSync(logFile, \`start live=\${live.size}\\n\`);
   });
   pi.on("session_shutdown", async () => {
     for (const t of live) clearInterval(t);
-    appendFileSync(logFile, \`shutdown instance=\${instance} cleared=\${live.size}\\n\`);
+    appendFileSync(logFile, \`shutdown cleared=\${live.size}\\n\`);
     live.clear();
   });
 }
 `;
 
-  it("a turn's shutdown cleans up ITS OWN resources, not another turn's", async () => {
+  it("a turn never tears down a resource another turn is using", async () => {
     const dir = await agentDirWith({ "extensions/lifecycle.ts": lifecycleExtension });
     const { faux } = makeFaux();
     let releaseA!: () => void;
@@ -285,10 +296,10 @@ export default async function (pi) {
     await a;
 
     const events = (await readFile(join(dir, "events.log"), "utf8")).trim().split("\n");
-    // Each turn gets its own extension instance, so each shutdown clears exactly what its own start
-    // opened. Sharing one instance across turns makes B's shutdown clear A's live timer.
-    expect(events.every((line) => line.includes("live=1") || line.includes("cleared=1"))).toBe(true);
-    const instances = new Set(events.map((line) => line.match(/instance=(\w+)/)?.[1]));
-    expect(instances.size).toBe(2); // one per turn
+    // The instance is shared (pi's module cache is process-global), so a per-turn shutdown would
+    // clear the timer A is still using — B's cleanup destroying A's resource. Not emitting one is
+    // what keeps concurrent turns from interfering.
+    expect(events.filter((line) => line.startsWith("start"))).toHaveLength(2);
+    expect(events.filter((line) => line.startsWith("shutdown"))).toHaveLength(0);
   });
 });

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -206,3 +206,32 @@ describe("definition: chat loads the same extensions serving does", () => {
     }
   });
 });
+
+describe("definition: extension lifecycle across per-invoke sessions", () => {
+  it("pairs every session_start with a session_shutdown", async () => {
+    const counterKey = `__fa_ext_lifecycle_${Date.now()}__`;
+    const dir = await agentDirWith({
+      "extensions/lifecycle.ts": `
+export default async function (api) {
+  const key = ${JSON.stringify(counterKey)};
+  globalThis[key] ??= { start: 0, shutdown: 0 };
+  api.on("session_start", () => { globalThis[key].start++; });
+  api.on("session_shutdown", () => { globalThis[key].shutdown++; });
+}
+`,
+    });
+    const { faux } = makeFaux();
+    faux.setResponses([() => fauxAssistantMessage("one"), () => fauxAssistantMessage("two")]);
+
+    const { agent } = await createPiAgentFromDefinition(dir, {
+      model: "faux/faux-1",
+      providers: [faux.provider],
+    });
+    await collect(agent.invoke({ session: "s" }, { text: "hi" }));
+    await collect(agent.invoke({ session: "s" }, { text: "again" }));
+
+    const counts = (globalThis as Record<string, unknown>)[counterKey] as { start: number; shutdown: number };
+    expect(counts.start).toBe(2); // one session per invoke
+    expect(counts.shutdown).toBe(counts.start); // and each one cleaned up
+  });
+});

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -227,6 +227,18 @@ export default async function (pi) {
 }
 `;
 
+  async function runtimeFor(files: Record<string, string>): Promise<unknown> {
+    const workspace = await mkdtemp(join(tmpdir(), "fa-chat-live-"));
+    const dir = join(workspace, "fastagent");
+    await mkdir(join(dir, "extensions"), { recursive: true });
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    for (const [rel, content] of Object.entries(files)) await writeFile(join(dir, rel), content);
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    await rt.dispose?.();
+    return rt.session;
+  }
+
   async function chatToolNames(files: Record<string, string>): Promise<string[]> {
     const workspace = await mkdtemp(join(tmpdir(), "fa-chat-live-"));
     const dir = join(workspace, "fastagent");
@@ -242,13 +254,21 @@ export default async function (pi) {
     }
   }
 
-  it("fires session_start, so a tool registered from a handler reaches the session", async () => {
-    // pi emits session_start from bindExtensions(). Without that call an extension loads and is
-    // then never spoken to again: no lifecycle events, nothing registered from a handler, and no
-    // error listener either — it looks like an extension that chose to do nothing.
+  it("does not freeze the tool set, so a host-bound session_start can still add to it", async () => {
+    // The tool NAMES are not allow-listed. pi lets an extension register from session_start, a
+    // command or any handler, and those names cannot be in a build-time snapshot — an allowlist
+    // would have refreshTools() filter them straight back out.
+    //
+    // session_start itself is emitted by the HOST (InteractiveMode.bindCurrentSessionExtensions),
+    // which is why this asserts the absence of the freeze rather than the arrival of a late tool:
+    // buildAgentSessionRuntime is the assembly, not the host, and a test that bound extensions
+    // itself would be testing its own call.
     const names = await chatToolNames({ "extensions/two.ts": twoMoments });
     expect(names).toContain("at_load");
-    expect(names).toContain("at_session_start");
+    const session = (await runtimeFor({ "extensions/two.ts": twoMoments })) as unknown as {
+      _allowedToolNames?: Set<string>;
+    };
+    expect(session._allowedToolNames).toBeUndefined();
   });
 
   it("uses fastagent's own read tool, not pi's copy of it", async () => {
@@ -298,5 +318,38 @@ export default async function (pi) {
     } finally {
       await rt.dispose?.();
     }
+  });
+});
+
+describe("definition: chat rebuilds extensions when pi replaces the session", () => {
+  it("re-runs the extension factory on a session replacement, not once for the runtime", async () => {
+    // pi replaces the session on /new, /resume and fork, and its extension contract is that the
+    // replacement gets freshly loaded extensions. Memoizing the services with the assembly (they
+    // are memoized: prompt, tools and definition all are) would carry one session's extension
+    // objects into the next.
+    const key = `__fa_ext_rebuild_on_new_${Date.now()}__`;
+    const workspace = await mkdtemp(join(tmpdir(), "fa-newsess-"));
+    const dir = join(workspace, "fastagent");
+    await mkdir(join(dir, "extensions"), { recursive: true });
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    await writeFile(
+      join(dir, "extensions", "count.ts"),
+      `
+export default async function (pi) {
+  const k = ${JSON.stringify(key)};
+  globalThis[k] = (globalThis[k] ?? 0) + 1;
+}
+`,
+    );
+
+    const first = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    await first.dispose?.();
+    const afterFirst = (globalThis as unknown as Record<string, number>)[key] ?? 0;
+    // A second runtime over the same directory stands in for the replacement pi performs: what
+    // matters is that building a session loads extensions rather than reusing a memoized set.
+    const second = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    await second.dispose?.();
+    expect((globalThis as unknown as Record<string, number>)[key]).toBeGreaterThan(afterFirst);
   });
 });

--- a/test/dev-supervisor.test.ts
+++ b/test/dev-supervisor.test.ts
@@ -78,3 +78,29 @@ describe("dev-supervisor: the watched .env follows FASTAGENT_SECRETS_DIR", () =>
     expect(ig("/agent/tools/x.ts")).toBe(false); // code inputs unaffected
   });
 });
+
+describe("dev-supervisor: an agent with extensions/ restarts on definition edits too", () => {
+  const root = "/agent";
+  const plain = devWatchIgnored(root, join(root, ".secrets", ".env"));
+  const withExtensions = devWatchIgnored(root, join(root, ".secrets", ".env"), {
+    definitionRestartsWorker: true,
+  });
+
+  it("leaves the definition live-read when the agent ships no extensions", () => {
+    expect(plain(join(root, "persona.md"))).toBe(true); // pruned: live-read, no restart
+    expect(plain(join(root, "AGENTS.md"))).toBe(true);
+    expect(plain(join(root, "skills", "triage.md"))).toBe(true);
+  });
+
+  it("restarts on a definition edit when extensions/ is present", () => {
+    // pi's resource reload - how a live edit reaches the model - re-runs every extension factory
+    // without shutting the previous instances down. Restarting is what keeps that from stranding
+    // whatever they opened.
+    expect(withExtensions(join(root, "persona.md"))).toBe(false);
+    expect(withExtensions(join(root, "AGENTS.md"))).toBe(false);
+    expect(withExtensions(join(root, "skills", "triage.md"))).toBe(false);
+    // and the code inputs are unchanged
+    expect(withExtensions(join(root, "extensions", "notify.ts"))).toBe(false);
+    expect(withExtensions(join(root, "notes", "scratch.md"))).toBe(true);
+  });
+});

--- a/test/dev-supervisor.test.ts
+++ b/test/dev-supervisor.test.ts
@@ -13,6 +13,11 @@ describe("dev-supervisor: devWatchIgnored (the narrow watch scope)", () => {
     expect(ignored(join(root, "tools", "lib", "helper.ts"))).toBe(false); // nested under tools/
     expect(ignored(join(root, "channels", "telegram.ts"))).toBe(false);
     expect(ignored(join(root, "schedules", "daily.ts"))).toBe(false); // loaded once per worker — restart is the re-read
+    // Which FILES are extensions is decided at boot, so an added or removed entry needs the restart
+    // this watcher exists to give. (Their per-turn reload is a different thing and does not help:
+    // it re-instantiates the set discovered at boot.)
+    expect(ignored(join(root, "extensions", "notify.ts"))).toBe(false);
+    expect(ignored(join(root, "extensions", "notify", "index.ts"))).toBe(false);
     expect(ignored(join(root, "package.json"))).toBe(false);
     expect(ignored(join(root, "fastagent.config.mjs"))).toBe(false);
     expect(ignored(join(root, "fastagent.config.ts"))).toBe(false);

--- a/test/dev-supervisor.test.ts
+++ b/test/dev-supervisor.test.ts
@@ -78,29 +78,3 @@ describe("dev-supervisor: the watched .env follows FASTAGENT_SECRETS_DIR", () =>
     expect(ig("/agent/tools/x.ts")).toBe(false); // code inputs unaffected
   });
 });
-
-describe("dev-supervisor: an agent with extensions/ restarts on definition edits too", () => {
-  const root = "/agent";
-  const plain = devWatchIgnored(root, join(root, ".secrets", ".env"));
-  const withExtensions = devWatchIgnored(root, join(root, ".secrets", ".env"), {
-    definitionRestartsWorker: true,
-  });
-
-  it("leaves the definition live-read when the agent ships no extensions", () => {
-    expect(plain(join(root, "persona.md"))).toBe(true); // pruned: live-read, no restart
-    expect(plain(join(root, "AGENTS.md"))).toBe(true);
-    expect(plain(join(root, "skills", "triage.md"))).toBe(true);
-  });
-
-  it("restarts on a definition edit when extensions/ is present", () => {
-    // pi's resource reload - how a live edit reaches the model - re-runs every extension factory
-    // without shutting the previous instances down. Restarting is what keeps that from stranding
-    // whatever they opened.
-    expect(withExtensions(join(root, "persona.md"))).toBe(false);
-    expect(withExtensions(join(root, "AGENTS.md"))).toBe(false);
-    expect(withExtensions(join(root, "skills", "triage.md"))).toBe(false);
-    // and the code inputs are unchanged
-    expect(withExtensions(join(root, "extensions", "notify.ts"))).toBe(false);
-    expect(withExtensions(join(root, "notes", "scratch.md"))).toBe(true);
-  });
-});

--- a/test/session-builder.test.ts
+++ b/test/session-builder.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import { buildAgentSessionRuntime } from "../src/engines/pi/session-builder.ts";
+import { log } from "../src/log.ts";
 
 // `chat` must run the SAME agent dev/start serve, presented in pi's TUI — NOT pi's vanilla
 // discovery. buildAgentSessionRuntime is split out precisely so that injection is inspectable without a
@@ -398,6 +399,35 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
     } finally {
       process.chdir(originalCwd);
       await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("session builder: the credential hint belongs to the runtime, not to each session", () => {
+  it("warns once, not again on every newSession()", async () => {
+    // Model resolution moved into createRuntime (extensions must load before a model they register
+    // can resolve), which put this warning on a per-session path. Credentials do not change between
+    // /new and /resume, so repeating it is nagging about a setting the user did not touch.
+    const workspace = await mkdtemp(join(tmpdir(), "fa-hint-"));
+    const dir = join(workspace, "fastagent");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    try {
+      const hintsAfterBuild = warn.mock.calls
+        .flat()
+        .filter((c: unknown) => String(c).includes("no credentials for")).length;
+      await rt.newSession();
+      await rt.newSession();
+      const hintsAfterReplacements = warn.mock.calls
+        .flat()
+        .filter((c: unknown) => String(c).includes("no credentials for")).length;
+      expect(hintsAfterReplacements).toBe(hintsAfterBuild);
+    } finally {
+      warn.mockRestore();
+      await rt.dispose?.();
     }
   });
 });

--- a/test/session-builder.test.ts
+++ b/test/session-builder.test.ts
@@ -431,3 +431,25 @@ describe("session builder: the credential hint belongs to the runtime, not to ea
     }
   });
 });
+
+describe("session builder: chat offers the model the same tool set serving does", () => {
+  it("activates fastagent's tools without pi's extra ones", async () => {
+    // Dropping the `tools` allowlist (it froze the set against extensions registering from a
+    // handler) put this at risk: pi mounts read-only helpers of its own — grep, find, ls — that
+    // fastagent's tool set does not include. It mounts them without activating them, which is why
+    // the allowlist was removable; a version of this that stated the active set explicitly offered
+    // the model all three and was caught by the assertion above.
+    const dir = await mkdtemp(join(tmpdir(), "fa-active-"));
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
+    try {
+      const active = rt.session.getActiveToolNames().sort();
+      expect(active).toEqual(["bash", "edit", "read", "write"]);
+      // ...and they ARE mounted, just not offered — so this is about activation, not discovery.
+      expect(rt.session.getAllTools().map((t) => t.name)).toContain("grep");
+    } finally {
+      await rt.dispose?.();
+    }
+  });
+});


### PR DESCRIPTION
Closes #285.

Load `<agentDir>/extensions/` as part of the definition and run them in **`fastagent chat`**.
Serving discovers them, warns, and runs without them — because pi's extension runtime cannot
currently be shared safely by concurrent sessions. That split is the substance of this PR.

## The split the flag was really making

`noExtensions` protects reproducibility — a served agent must not inherit the authoring machine's
`~/.pi` extensions and slash commands. That is worth keeping. But the flag was suppressing two
different things at once:

| | before | after |
|---|---|---|
| machine-global `~/.pi/extensions` | suppressed | suppressed |
| the definition's own `extensions/` | suppressed (collateral) | **loaded in `chat`** |

pi honours `additionalExtensionPaths` even under `noExtensions`, so `chat` gets both properties at
once without a host-kind branch or a "local mode".

## Why serving does not run them

This is what most of the review on this PR was about, and it took six rounds to see whole.

pi's extension machinery is built for **one process serving one session** — a terminal. Its own
source calls the object holding a session's actions "the shared runtime", and every `AgentSession`
overwrites it on construction:

```js
// Copy actions into the shared runtime (all extension APIs reference this)
this.runtime.sendMessage = actions.sendMessage;
this.runtime.appendEntry = actions.appendEntry;
```

Serving is the opposite shape: one process, concurrent turns, conversations with nothing to do with
each other. With two turns in flight, the second to start redirects those actions to itself — so an
extension calling `pi.sendMessage()` during the first turn can deliver **into someone else's
conversation**.

The same sharing shows up from other angles, and each one was found separately before the pattern
was clear:

| symptom found | what it actually was |
|---|---|
| a turn's `session_shutdown` cleared a timer a concurrent turn had just opened | one module instance, per-turn lifecycle events |
| reloading per turn "for isolation" — three concurrent turns still shared one instance | reload mutates shared state; it cannot isolate |
| building a loader per turn didn't help either | the module cache is process-global |
| editing `persona.md` rebuilt every extension | `reload()` starts with `clearExtensionCache()` |

Six defects, one cause: a single-session extension model wired into a multi-session server. Serving
therefore discovers, warns, and continues — a missing feature that says so beats a silent wrong
answer.

**This is narrowly fixable upstream.** pi already has an uncached loader path that builds a fresh
module per call (jiti with `moduleCache: false`) and takes the runtime as an argument — that *is*
per-session isolation. It is not exported, and the deep path is blocked by the package `exports`.
When that entry point exists, serving can run extensions with the guarantees `chat` has today. The
options type and `docs/configuration.md` both record what is needed.

## Not the shape the issue proposed

The issue suggested `AgentDefinition.extensions: Extension[]`, by analogy with `skills`. The analogy
breaks: a skill is **data** (content inline, serializable), an extension is **code** that pi loads
with jiti and binds to its own eventBus and runtime. The definition carries *paths*; pi does the
loading.

They are entry-point **files**, not the directory — handing pi a directory fails with
`Cannot find module` into a `LoadExtensionsResult.errors` entry nothing was reading. Discovery
follows pi's own rules (direct `*.ts`/`*.js`, or a subdirectory `index.*`); the `package.json` `pi`
manifest form is warned about rather than skipped in silence.

## Failures are read now, not dropped

- a load error (`LoadExtensionsResult.errors`) — pi collects and carries on, sound for a TUI that
  displays them, silent for a host that never looks;
- a throwing handler — pi fans errors to registered listeners and has none by default;
- a subdirectory in the unsupported manifest shape;
- **every symlink**, announced without guessing whether it meant to be an extension. A symlinked
  entry is refused (it resolves on the authoring machine and is missing in the container), and the
  message says how to silence it when the file was never an extension. Guessing by name looked
  tidier until `audit.ext -> some/dir` — a directory candidate to pi — got dropped in silence.

## Two things deliberately not done

**No `uiContext`.** pi defaults it to a no-op, so an extension calling `select`/`confirm`/`input`
gets an immediate "no answer" rather than hanging. (This also corrects the premise of #289.) Binding
a stand-in would mean implementing 20+ members of `ExtensionUIContext`, most of them TUI geometry.

**A throwing extension handler does not fail the turn.** It warns and the turn continues, which is
pi's own fan-out-and-continue semantics. Making it terminal would let one buggy handler take a chat
session down.

## What on-PR review changed

Review found two ways "chat runs them fully" was not yet true, and fixing them uncovered a third
bug nobody had reported:

- **An extension could not define the model.** `registerProvider()` is pi's documented way to add
  providers, but extensions do not execute until the services are built — and the model was resolved
  before that. A definition whose configured model came from its own extension failed with a bare
  `unknown model`, after warning about credentials for a provider that did not exist yet. The model
  is now resolved per session, after the services.
- **The `tools` allowlist froze the tool set at build time.** pi lets an extension register from
  `session_start`, a command, or any handler; those names cannot be in a startup snapshot, so
  `refreshTools()` filtered them straight back out. `noTools: "builtin"` gives the guarantee the
  allowlist was really there for — the machine's `defaultTools` setting cannot add pi's own copies
  on top of ours — without freezing anything.
- **(unreported) Chat was running pi's `read`, not ours.** Allow-listing the default tool *names*
  mounts pi's own implementations; fastagent's is `createReadTool({ imageProcessor })`. Chat had
  been running without image reading. Every fastagent tool is now passed as a `customTool`, exactly
  as serving does.

Two of my own fixes were wrong and are recorded here because the mistake is instructive:

- I added a `bindExtensions()` call, having measured that `session_start` never fired. It fires:
  `InteractiveMode.bindCurrentSessionExtensions()` does it. The measurement drove
  `buildAgentSessionRuntime` — the assembly, not the host — so it proved something true of the test's
  own call path and false of `fastagent chat`. The call would have emitted `session_start` twice per
  chat.
- I then stated the active tool set explicitly, on the theory that `noTools: "builtin"` left tools
  inactive. It does not; pi activates this agent's tools and leaves only its own extra helpers
  (`grep`, `find`, `ls`) inactive — the same set serving offers. Stating it explicitly handed the
  model all three. The existing session-builder assertion caught it.

Both properties now have tests that fail if the behaviour regresses.

## Validation

- [x] `npm run lint`, `npm run typecheck`, `npm test` (108 files, 1364 tests)
- [x] Rebased onto pi 0.84.2 + the single-engine `main`
- [x] `rv.sh local` — **No findings.** Ten rounds local plus one on-PR pass; each behavioural fix
      was falsified by reverting it and confirming the test goes red

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated (`docs/configuration.md`, `docs/overview.md`)

