### PR TITLE
refactor(pi): one definition of what pi may discover

### DIFF
--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -12,12 +12,13 @@
  * - the `AgentSession` and its tool bindings are per turn, because a tool's `execute` closes over the
  *   session it runs in and this posture has several in flight at once.
  */
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { ExecutionEnv, Skill, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Model } from "@earendil-works/pi-ai";
 import {
   type AgentSession,
   type AgentSessionServices,
+  type CreateAgentSessionServicesOptions,
   type ModelRuntime,
   type SessionManager,
   type ToolDefinition,
@@ -205,6 +206,53 @@ export function reportExtensionErrors(services: AgentSessionServices): void {
   }
 }
 
+/** What pi is allowed to discover, minus the parts each assembly fills in itself. */
+type DefinitionLoaderOptions = NonNullable<CreateAgentSessionServicesOptions["resourceLoaderOptions"]>;
+
+/**
+ * The resource posture a fastagent definition asks pi for — ONE definition of it, for both
+ * assemblies. Serving (`piAgentSessionFactory`) and chat (`buildAgentSessionRuntime`) build
+ * different sessions on top, but what pi is allowed to DISCOVER is not one of the differences:
+ * everything comes from the definition, nothing from the machine that happens to be running it.
+ *
+ * Two copies of this drifted once already: `additionalExtensionPaths` was added to both, and only
+ * one of them also passed the resulting tool names through pi's `tools` allowlist — so extensions
+ * worked when served and vanished in chat. A difference between the two has to be visible AS a
+ * difference, which is what the parameters are for: serving reads a prompt and skills that change
+ * per turn and passes NO extension paths (it does not run them — see
+ * {@link PiAgentSessionFactoryOptions.extensionPaths}); chat reads a fixed assembly and passes its
+ * own. Both are arguments now, rather than two files that happen to disagree.
+ */
+export function definitionResourceLoaderOptions(source: {
+  systemPrompt: () => string | undefined;
+  skills: () => Skill[];
+  /** Omitted by serving, which does not run them. */
+  extensionPaths?: readonly string[];
+}): DefinitionLoaderOptions {
+  return {
+    // Definition-only, like dev/start: pi's machine-global discovery (the operator's own ~/.pi
+    // extensions, slash commands, global AGENTS.md, APPEND_SYSTEM.md) stays out, so the agent that
+    // runs is the artifact, not the artifact plus whoever's laptop it is.
+    noExtensions: true,
+    // ...except the definition's OWN extensions/: pi honours additionalExtensionPaths even under
+    // noExtensions, which is exactly the split wanted here — the artifact travels with its
+    // extensions, the machine's stay out.
+    ...(source.extensionPaths?.length ? { additionalExtensionPaths: [...source.extensionPaths] } : {}),
+    noPromptTemplates: true,
+    noContextFiles: true,
+    // A SPACE, not "", when the assembly has no prompt: pi treats an empty custom prompt as absent
+    // and substitutes its own coding-assistant identity, which an L1 agent
+    // (`createPiAgent({ model, tools })`) never asked for. pi appends its own working-directory line
+    // either way — that is engine behaviour this binding does not fight.
+    systemPromptOverride: () => source.systemPrompt() ?? " ",
+    appendSystemPromptOverride: () => [],
+    skillsOverride: (base) => ({
+      skills: toPiSkills(source.skills()) as typeof base.skills,
+      diagnostics: base.diagnostics,
+    }),
+  };
+}
+
 /** Open-or-create the record, then bind a fresh session to it. One call per invoke. */
 export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): PiAgentSessionFactory {
   const { sessions, thinkingLevel, cwd, env } = options;
@@ -229,24 +277,14 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       cwd,
       agentDir: options.agentDir ?? join(cwd, ".fastagent", "pi"),
       modelRuntime,
-      resourceLoaderOptions: {
-        // The agent is the definition, not the authoring machine's pi setup: no ~/.pi extensions,
-        // slash commands, global AGENTS.md or APPEND_SYSTEM.md (same posture as dev/start).
-        noExtensions: true,
-        // ...except the definition's OWN extensions/: pi honours additionalExtensionPaths even under
-        // noExtensions, which is exactly the split we want — the artifact travels with its
-        // extensions, the operator's ~/.pi ones stay out.
-        // No additionalExtensionPaths: see PiAgentSessionFactoryOptions.extensionPaths.
-        noPromptTemplates: true,
-        noContextFiles: true,
-        // A SPACE, not "", when the assembly has no prompt: pi treats an empty custom prompt as
-        // absent and substitutes its own coding-assistant identity, which an L1 agent
-        // (`createPiAgent({ model, tools })`) never asked for. pi appends its own working-directory
-        // line either way — that is engine behaviour this binding does not fight.
-        systemPromptOverride: () => prompt ?? " ",
-        appendSystemPromptOverride: () => [],
-        skillsOverride: (base) => ({ skills: toPiSkills(skills) as typeof base.skills, diagnostics: base.diagnostics }),
-      },
+      // No extensionPaths: serving does not run them (see PiAgentSessionFactoryOptions), which is
+      // the one resource question the two assemblies answer differently. The accessors read the
+      // CURRENT prompt/skills — serving refreshes both per turn, so a snapshot taken here would
+      // serve a stale definition after the first edit.
+      resourceLoaderOptions: definitionResourceLoaderOptions({
+        systemPrompt: () => prompt,
+        skills: () => skills,
+      }),
     });
 
   return async (sessionId, inherit) => {
@@ -362,18 +400,21 @@ function loadedSkillSet(skills: readonly { name: string; filePath?: string; desc
 
 /** fastagent's Skill (content inline) as pi's (read from filePath at invocation time). */
 function toPiSkills(skills: Skill[]) {
-  return skills.map((skill) => ({
-    name: skill.name,
-    description: skill.description,
-    filePath: skill.filePath,
-    baseDir: skill.filePath.slice(0, skill.filePath.lastIndexOf("/")),
-    sourceInfo: {
-      path: skill.filePath,
-      source: "fastagent",
-      scope: "project",
-      origin: "top-level",
-      baseDir: skill.filePath.slice(0, skill.filePath.lastIndexOf("/")),
-    },
-    disableModelInvocation: skill.disableModelInvocation ?? false,
-  }));
+  return skills.map((skill) => {
+    const baseDir = dirname(skill.filePath);
+    return {
+      name: skill.name,
+      description: skill.description,
+      filePath: skill.filePath,
+      baseDir,
+      sourceInfo: {
+        path: skill.filePath,
+        source: "fastagent",
+        scope: "project",
+        origin: "top-level",
+        baseDir,
+      },
+      disableModelInvocation: skill.disableModelInvocation ?? false,
+    };
+  });
 }

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -28,7 +28,7 @@
  * workspace.
  */
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   type AgentSession,
@@ -41,7 +41,7 @@ import {
   createAgentSessionServices,
   getAgentDir,
 } from "@earendil-works/pi-coding-agent";
-import { reportExtensionErrors } from "./agent-session-factory.ts";
+import { definitionResourceLoaderOptions, reportExtensionErrors } from "./agent-session-factory.ts";
 import { resolveModel } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt } from "./create.ts";
 import { canonicalPath, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
@@ -239,39 +239,14 @@ export async function buildAgentSessionRuntime(
       // fastagent's models + auth hub replaces pi's default (~/.pi-backed) one — the auth
       // unification point; see the header.
       modelRuntime,
-      resourceLoaderOptions: {
-        // Definition-only, like dev/start: suppress pi's machine-global discovery (the developer's own
-        // ~/.pi extensions, slash commands, global AGENTS.md, APPEND_SYSTEM.md) so this runtime runs
-        // the same agent that gets served, not the authoring machine's pi setup on top.
-        noExtensions: true,
-        // ...except the definition's OWN extensions/: pi honours additionalExtensionPaths even under
-        // noExtensions. Without this the same definition would carry its extensions when served and
-        // lose them in chat — one artifact, two behaviours.
-        ...(extensionPaths.length > 0 ? { additionalExtensionPaths: extensionPaths } : {}),
-        noPromptTemplates: true,
-        noContextFiles: true,
-        systemPromptOverride: () => systemPrompt,
-        appendSystemPromptOverride: () => [],
-        // Replace pi's discovered skills with fastagent's. fastagent's Skill (content inline) is
-        // reshaped to pi-coding-agent's (read from filePath/baseDir at invocation time).
-        skillsOverride: (base) => ({
-          skills: definition.skills.map((s) => ({
-            name: s.name,
-            description: s.description,
-            filePath: s.filePath,
-            baseDir: dirname(s.filePath),
-            sourceInfo: {
-              path: s.filePath,
-              source: "fastagent",
-              scope: "project",
-              origin: "top-level",
-              baseDir: dirname(s.filePath),
-            },
-            disableModelInvocation: s.disableModelInvocation ?? false,
-          })) as typeof base.skills,
-          diagnostics: base.diagnostics,
-        }),
-      },
+      // Chat's assembly is fixed for the life of the runtime (a rebuild makes a new one), so these
+      // read constants — where serving passes accessors that change per turn — and it DOES pass its
+      // extension paths: chat runs them.
+      resourceLoaderOptions: definitionResourceLoaderOptions({
+        systemPrompt: () => systemPrompt,
+        skills: () => definition.skills,
+        extensionPaths,
+      }),
     });
     reportExtensionErrors(services);
 


### PR DESCRIPTION
Stacked on #345 — merge that first, then this rebases onto `main` on its own.

## The defect this removes

Serving (`agent-session-factory.ts`) and chat (`session-builder.ts`) each built their own
`resourceLoaderOptions`: the same settings twice, two copies of the comment explaining them, and two
implementations of the fastagent-Skill to pi-Skill reshape.

Nothing structural said the two had to agree, and they had already stopped agreeing.

## #345 paid the bill for it

`additionalExtensionPaths` was added to both copies. Only chat also had to pass the resulting tool
names through pi's `tools` allowlist — a step that is invisible when you are looking at the serving
copy. Result: extensions worked when served and silently vanished in `fastagent chat`.

That was caught by review, not by a test. A test would have had to know to look.

## The shape now

`definitionResourceLoaderOptions` is the single answer to *what pi may discover*. The real
differences become arguments instead of accidents:

| | serving | chat |
|---|---|---|
| `systemPrompt` / `skills` | accessors — the definition is re-read per turn | constants — one fixed assembly |
| `extensionPaths` | **omitted** — serving does not run extensions (#345) | its own |
| everything else | one definition, shared | one definition, shared |

Both differences are now visible in the call, which is the point: the next person can tell a
deliberate difference from an omission without diffing two files.

Adding a loader setting is one edit, and it cannot land on one path only.

## A second disagreement, found on the way

The two skill reshapes computed `baseDir` differently: chat used `dirname()`, serving used
`slice(0, lastIndexOf("/"))`. Identical on POSIX, wrong on Windows separators. There is one now, and
it uses `dirname()`.

## What deliberately stays split

The `tools` allowlist. Chat gates the tool set, serving does not — a genuine difference, not an
omission. The function header names it, so the next reader can tell which kind it is.

## Validation

- [x] `npm run lint`, `npm run typecheck`, `npm test` (108 files, 1358 tests) — no test changes: the
      existing suite is the safety net, and a pure refactor that needed new tests would not be one
- [x] `rv.sh local feature/definition-extensions` — **No findings.**

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
