### PR TITLE
refactor(channels): an attachment is a fact, not an assumption about the reader

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -283,7 +283,6 @@ Costs and behavior to know:
 interface ChannelContext {
   agent: Agent;
   stateRoot: string; // resolved state root (FASTAGENT_STATE_DIR > <root>/.state), absolute
-  canReadLocalFiles: boolean; // required: whether the agent has a reader for absolute local paths
 }
 type ChannelModule = (ctx: ChannelContext) => Routes;
 interface LongConnection {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,7 +75,7 @@ Prints the assembled surface without starting a server:
 - model source,
 - config path,
 - persona presence and context files (`AGENTS.md`),
-- skills, their diagnostics, and any assembly findings (`assemblyFindings` — definition-wide, e.g. skills with no reader),
+- skills and their diagnostics,
 - the resolved coding-tool names (`read`/`bash`/`edit`/`write`), plus authored tools and collisions,
 - channel files,
 - schedules (name + next fire instant; a broken schedule file is reported here, not first at `dev`),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,10 +294,14 @@ export default defineConfig({
 ```
 
 Model-visible skills are loaded on demand from their `SKILL.md` paths, and chat-channel non-image
-attachments are downloaded to local paths. Both need the built-in `read` tool; FastAgent warns when
-model-visible skills have no reader, and channels reject an explicitly attached file rather than hand
-the model an unreadable path. Use `false` only when the agent needs neither capability (images still
-travel inline through vision).
+attachments are downloaded to local paths. Both are read with the built-in `read` tool.
+
+Skills get a startup warning when they are listed to the model but `read` is absent — an assembly
+that advertises a capability it cannot deliver is contradicting itself, and only the assembly can
+see that. Attachments do not: a channel states what it attached (name, size, path) and the agent
+answers for itself. Without `read` it will say it cannot open the file — the direct, visible
+consequence of the posture you configured, and images still travel inline through vision either
+way.
 
 A disabled built-in is **refused, not merely hidden**: it never enters the session's tool registry,
 so nothing that activates a tool by name — a `chat` command, the control plane, the deferred-tool

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,14 +294,13 @@ export default defineConfig({
 ```
 
 Model-visible skills are loaded on demand from their `SKILL.md` paths, and chat-channel non-image
-attachments are downloaded to local paths. Both are read with the built-in `read` tool.
+attachments are downloaded to local paths. Both are read with a file tool.
 
-Skills get a startup warning when they are listed to the model but `read` is absent — an assembly
-that advertises a capability it cannot deliver is contradicting itself, and only the assembly can
-see that. Attachments do not: a channel states what it attached (name, size, path) and the agent
-answers for itself. Without `read` it will say it cannot open the file — the direct, visible
-consequence of the posture you configured, and images still travel inline through vision either
-way.
+Neither is checked ahead of time. A channel states what it attached (name, size, path) and the agent
+answers for itself; a skill listing is loaded when the model reaches for it. Without a reader the
+agent says it cannot open the file — the direct, visible consequence of the posture you configured,
+and images still travel inline through vision either way. (A pre-flight check would also have to
+guess: `codingTools: false` plus an authored `tools/read.ts` is a perfectly readable agent.)
 
 A disabled built-in is **refused, not merely hidden**: it never enters the session's tool registry,
 so nothing that activates a tool by name — a `chat` command, the control plane, the deferred-tool

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -73,16 +73,6 @@ export const SESSION_BUSY_CODE = "session_busy";
 export const ABORTED_CODE = "aborted";
 
 /**
- * The `failed.code` set when a turn carried an attachment the agent has no way to open — a local
- * file with no `read` tool mounted. A CONFIGURATION limitation, not an unknown failure: the channel
- * knows exactly what is wrong and can say so, where the generic "something went wrong" would leave
- * the user guessing at a problem only the operator can fix. Exported for the same reason as
- * {@link SESSION_BUSY_CODE}: its consumer (`defaultErrorMessage`, and any channel's own `onError`)
- * must branch on it rather than string-match the message.
- */
-export const ATTACHMENT_UNSUPPORTED_CODE = "attachment_unsupported";
-
-/**
  * One turn = one invoke, returning a single async event stream. The stream MUST terminate with
  * exactly one of completed / failed, or be cancelled by the caller (no terminal event). Any
  * AsyncIterable producer that implements this conforms (interface, not base class).

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -218,7 +218,7 @@ function createFeishuRuntimeFactory(
   const baseUrl = opts.apiBaseUrl ?? profile.apiBase;
   const { kind } = profile;
   const label = `[${kind}]`;
-  return ({ agent, stateRoot, canReadLocalFiles, control }) => {
+  return ({ agent, stateRoot, control }) => {
     // Credential checks run when serving starts, not while the authored module is imported: deployment
     // can inspect the module shape before secrets exist, while serving still fails before ready.
     if (!appId || !appSecret) {
@@ -489,7 +489,6 @@ function createFeishuRuntimeFactory(
                 filesDir: join(stateHome, "files"),
                 label,
                 appId,
-                canReadLocalFiles,
                 ...(parentSession !== undefined ? { parentSession } : {}),
               },
               { primary: { images: rec.images, files: rec.files, parentId: rec.parentId }, buffered },

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -12,18 +12,16 @@
  * ancestors, and degrade per attachment: one expired background file must not block the current ask
  * or hide its still-readable siblings.
  */
-import { type Agent, type AgentEvent, ATTACHMENT_UNSUPPORTED_CODE, type ImageRef, type Scope } from "../../agent.ts";
+import type { Agent, AgentEvent, ImageRef, Scope } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
   DEFAULT_BUSY_RETRY,
-  LocalFileAccessUnavailable,
   attachedFilesManifest,
   attributedFileName,
   backgroundImagesManifest,
   missingAttachmentsNote,
   streamTurnWithBusyRetry,
-  unreadableAttachmentsNote,
 } from "../invoke-turn-kit.ts";
 import { BUFFER_ATTACH_MAX } from "../context-buffer.ts";
 import type { FeishuBufferedRef } from "./context-buffer.ts";
@@ -56,8 +54,6 @@ export interface FeishuTurnTransport {
    *  (participant-model.md §5). The engine reads it once, at session creation; every later turn
    *  carries it inertly. */
   parentSession?: string;
-  /** Whether the agent has a reader for absolute local paths; see ChannelContext. */
-  canReadLocalFiles: boolean;
 }
 
 /** An attachment reference: the resource key inside its CARRYING message (the resource API addresses
@@ -224,14 +220,8 @@ async function walkReplyChain(
  * degrade independently.
  */
 async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurnAttachments): Promise<ResolvedInputs> {
-  const { canReadLocalFiles } = t;
   const images = [...attachments.primary.images];
   const files = [...attachments.primary.files];
-  // The ASK's own files, before a referent's join them. Fail-fast applies to these only: the user
-  // pointed at them, so silently dropping them would answer a question they did not ask.
-  if (!canReadLocalFiles && files.length > 0) throw new LocalFileAccessUnavailable(t.label);
-  // A referent's unreadable files degrade instead (see below); counted for the note.
-  let unreadableReferentFiles = 0;
   let referentBlock = "";
   let chain: ReplyChain = { block: "", images: [], files: [], ids: [] };
   if (attachments.primary.parentId !== undefined) {
@@ -262,14 +252,8 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
         mentions: parent.mentions as FeishuMention[] | undefined,
       });
       // The referent's own resources join the turn as primary inputs, carried by the PARENT message id.
-      // Images always: vision needs no reader. Files only if there IS one — a quoted file must not
-      // cost the user their turn, which is what this function's own policy says two paragraphs up.
       for (const key of parsed.imageKeys) images.push({ msg: parentId, key });
-      if (canReadLocalFiles) {
-        for (const ref of parsed.fileRefs) files.push({ msg: parentId, key: ref.key, name: ref.name });
-      } else {
-        unreadableReferentFiles += parsed.fileRefs.length;
-      }
+      for (const ref of parsed.fileRefs) files.push({ msg: parentId, key: ref.key, name: ref.name });
       const from = fetchedSenderLabel(parent.sender, t.appId);
       referentBlock = `\n\n[replied-to message (msg ${parentId}${from ? `, from ${from}` : ""}): ${truncateCodePointPrefix(parsed.text, REFERENT_MAX_CODE_POINTS) || "(empty)"}]`;
       // The referent's own parent starts the chain walk; the referent id seeds the cycle guard.
@@ -322,17 +306,12 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
       log.warn(`${t.label} could not load an earlier (buffered) image: ${String(result.reason)}`);
     }
   }
-  // Everything skipped for want of a reader: this turn's buffered files, plus any the referent
-  // carried. One number, one note — the model is told what it did not get.
-  const unreadable = canReadLocalFiles ? 0 : bufferedFiles.length + unreadableReferentFiles;
-  const fileResults = canReadLocalFiles
-    ? await Promise.allSettled(
-        bufferedFiles.map(async (ref) => ({
-          ref,
-          file: await t.api.fetchFile(ref.messageId, ref.key, ref.name ?? ref.key, t.chatId, t.filesDir),
-        })),
-      )
-    : [];
+  const fileResults = await Promise.allSettled(
+    bufferedFiles.map(async (ref) => ({
+      ref,
+      file: await t.api.fetchFile(ref.messageId, ref.key, ref.name ?? ref.key, t.chatId, t.filesDir),
+    })),
+  );
   for (const result of fileResults) {
     if (result.status === "fulfilled") backgroundFiles.push(result.value);
     else {
@@ -343,7 +322,6 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   const missingNote = missingAttachmentsNote(
     lost + attachments.buffered.skipped + mergedImages.dropped + mergedFiles.dropped,
   );
-  const unreadableNote = unreadableAttachmentsNote(unreadable);
   const backgroundImageManifest = backgroundImagesManifest(
     imageRefs.length,
     backgroundImages.map(({ ref }) => ref),
@@ -358,7 +336,7 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
   const allImages = [...imageRefs, ...backgroundImages.map(({ image }) => image)];
   return {
     images: allImages.length ? allImages : undefined,
-    promptSuffix: `${referentBlock}${missingNote}${unreadableNote}${backgroundImageManifest}${attachedFilesManifest(allFiles)}`,
+    promptSuffix: `${referentBlock}${missingNote}${backgroundImageManifest}${attachedFilesManifest(allFiles)}`,
     referentIds: [...(attachments.primary.parentId !== undefined ? [attachments.primary.parentId] : []), ...chain.ids],
   };
 }
@@ -381,13 +359,7 @@ export async function* invokeFeishuTurn(
   try {
     resolved = await resolveTurnInputs(transport, attachments);
   } catch (e) {
-    const unavailable = e instanceof LocalFileAccessUnavailable;
-    yield {
-      type: "failed",
-      details: unavailable ? e.message : `could not load attachment: ${String(e)}`,
-      retryable: !unavailable,
-      ...(unavailable ? { code: ATTACHMENT_UNSUPPORTED_CODE } : {}),
-    };
+    yield { type: "failed", details: `could not load attachment: ${String(e)}`, retryable: true };
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${REPLY_INSTRUCTION}`, images: resolved.images };

--- a/src/channels/invoke-turn-kit.ts
+++ b/src/channels/invoke-turn-kit.ts
@@ -7,6 +7,10 @@
  *   - the prompt-suffix wording: {@link attachedFilesManifest}, {@link backgroundImagesManifest},
  *     {@link missingAttachmentsNote}, {@link attributedFileName}.
  *
+ * None of it asks what the agent can DO with an attachment. A channel resolves platform resources
+ * and states what it found; deciding whether to open a file is the agent's, and an agent without a
+ * file tool answers that it cannot — visibly, and as the direct consequence of its own `codingTools`.
+ *
  * Attachment RESOLUTION stays per channel — the platform resource models (Bot API file_ids,
  * message-scoped Feishu keys, Slack file objects) are real differences.
  */
@@ -72,25 +76,6 @@ export async function* streamTurnWithBusyRetry(
   }
 }
 
-/**
- * A primary local-file attachment cannot be represented faithfully for an agent without a reader.
- *
- * Constructing this LOGS, because the fix belongs to the operator and nothing else would tell them:
- * the user gets a customer-facing line (see `defaultErrorMessage`), which by design does not carry
- * "mount the read coding tool". Without this, a misconfigured agent answers every attachment with a
- * shrug and no one learns why.
- */
-export class LocalFileAccessUnavailable extends Error {
-  constructor(label = "[fastagent]") {
-    super("this agent cannot read local file attachments; mount the read coding tool or send the content as text");
-    this.name = "LocalFileAccessUnavailable";
-    log.warn(
-      `${label} an attachment arrived but this agent has no \`read\` tool — the turn was refused. ` +
-        `Enable it with \`codingTools\` (or \`codingTools: ["read"]\` for least privilege).`,
-    );
-  }
-}
-
 /** What the attached-files manifest renders per file: display name, byte size, absolute local path. */
 export interface ManifestFile {
   name: string;
@@ -98,11 +83,18 @@ export interface ManifestFile {
   path: string;
 }
 
-/** The downloaded-file manifest appended to the prompt — the agent reads the paths with its tools.
- *  Empty input renders nothing. */
+/**
+ * The downloaded-file manifest appended to the prompt: name, size, path. Empty input renders nothing.
+ *
+ * It STATES, it does not instruct. The earlier wording ("read them with your tools") was an
+ * assumption about the reader, and an assumption has to be verified — which is where a capability
+ * flag threaded through eight files came from. An agent with a file tool decides for itself whether
+ * to open one, and how much of it; an agent without one says so. Neither needs this line to have
+ * guessed first.
+ */
 export function attachedFilesManifest(files: readonly ManifestFile[]): string {
   return files.length
-    ? `\n\n[attached files — read them with your tools:\n${files.map((f) => `- ${f.name} (${f.size} bytes) → ${f.path}`).join("\n")}\n]`
+    ? `\n\n[attached files:\n${files.map((f) => `- ${f.name} (${f.size} bytes) → ${f.path}`).join("\n")}\n]`
     : "";
 }
 
@@ -132,13 +124,5 @@ export function backgroundImagesManifest(
 export function missingAttachmentsNote(missing: number): string {
   return missing > 0
     ? `\n[note: ${missing} attachment(s) from the earlier discussion are not loaded (no longer available, or older than the most recent few)]`
-    : "";
-}
-
-/** Background files omitted because this agent has no declared local-file reader. Never render their
- *  dead paths: tell the model exactly which context it does not have instead. */
-export function unreadableAttachmentsNote(unreadable: number): string {
-  return unreadable > 0
-    ? `\n[note: ${unreadable} non-image attachment(s) from the earlier discussion are not loaded because this agent has no local-file reader]`
     : "";
 }

--- a/src/channels/preview-kit.ts
+++ b/src/channels/preview-kit.ts
@@ -8,14 +8,14 @@
  * everything platform-independent lives here, so a new event type or a wording change lands in ONE
  * place instead of one hunk per channel.
  */
-import { type AgentEvent, ATTACHMENT_UNSUPPORTED_CODE, type Json } from "../agent.ts";
+import type { AgentEvent, Json } from "../agent.ts";
 import { truncateCodePointPrefix, truncateCodePointSuffix } from "./text.ts";
 
 /** A terminal failure, as a channel hands it to its `onError`. */
 export interface ChannelFailure {
   details: string;
   retryable: boolean;
-  /** The engine's failure code, when it set one — see `ATTACHMENT_UNSUPPORTED_CODE`. */
+  /** The engine's failure code, when it set one. */
   code?: string;
 }
 
@@ -24,12 +24,6 @@ export interface ChannelFailure {
  *  The non-retryable branch keeps the "something went wrong" phrase deliberately — it is neutral (we only
  *  know a boolean, never the specific limitation) and shared verbatim across channels. */
 export function defaultErrorMessage(failed: ChannelFailure): string {
-  // A known limitation gets named. The generic line asks the user to rephrase, which cannot help
-  // when the agent simply has no reader — only the operator can fix that, and the user deserves to
-  // know it is not their message.
-  if (failed.code === ATTACHMENT_UNSUPPORTED_CODE) {
-    return "⚠️ I can't open file attachments — please paste the content as text.";
-  }
   return failed.retryable
     ? "⚠️ Temporary problem — please try again in a moment."
     : "⚠️ Sorry, something went wrong. Try rephrasing, or check I have access to what you need.";

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -1,16 +1,14 @@
 /** Resolve Slack file IDs at dequeue, then stream one engine-neutral Agent turn. */
-import { type Agent, type AgentEvent, ATTACHMENT_UNSUPPORTED_CODE, type ImageRef } from "../../agent.ts";
+import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
   DEFAULT_BUSY_RETRY,
-  LocalFileAccessUnavailable,
   attachedFilesManifest,
   attributedFileName,
   backgroundImagesManifest,
   missingAttachmentsNote,
   streamTurnWithBusyRetry,
-  unreadableAttachmentsNote,
 } from "../invoke-turn-kit.ts";
 import type { SlackBufferedFileRef } from "./context-buffer.ts";
 import type { DownloadedSlackFile, SlackApi } from "./slack-api.ts";
@@ -23,8 +21,6 @@ export interface SlackTurnTransport {
   channelId: string;
   filesDir: string;
   label: string;
-  /** Whether the agent has a reader for absolute local paths; see ChannelContext. */
-  canReadLocalFiles: boolean;
 }
 
 export interface SlackTurnAttachments {
@@ -40,27 +36,22 @@ interface ResolvedInputs {
 async function resolveFile(
   transport: SlackTurnTransport,
   fileId: string,
-  canReadLocalFiles: boolean,
-): Promise<{ image?: ImageRef; file?: DownloadedSlackFile; unreadableFile?: true }> {
+): Promise<{ image?: ImageRef; file?: DownloadedSlackFile }> {
   const info = await transport.api.fileInfo(fileId);
   if (info.mimetype?.toLowerCase().startsWith("image/")) return { image: await transport.api.fetchImage(info) };
-  return canReadLocalFiles
-    ? { file: await transport.api.fetchFile(info, transport.channelId, transport.filesDir) }
-    : { unreadableFile: true };
+  return { file: await transport.api.fetchFile(info, transport.channelId, transport.filesDir) };
 }
 
 async function resolveInputs(
   transport: SlackTurnTransport,
   attachments: SlackTurnAttachments,
 ): Promise<ResolvedInputs> {
-  const { canReadLocalFiles } = transport;
   const images: ImageRef[] = [];
   const files: DownloadedSlackFile[] = [];
   for (const id of attachments.primaryFileIds) {
-    const resolved = await resolveFile(transport, id, canReadLocalFiles);
+    const resolved = await resolveFile(transport, id);
     if (resolved.image) images.push(resolved.image);
     if (resolved.file) files.push(resolved.file);
-    if (resolved.unreadableFile) throw new LocalFileAccessUnavailable(transport.label);
   }
 
   const backgroundImages: { image: ImageRef; ref: SlackBufferedFileRef }[] = [];
@@ -69,16 +60,14 @@ async function resolveInputs(
   const results = await Promise.allSettled(
     attachments.buffered.files.map(async (ref) => ({
       ref,
-      resolved: await resolveFile(transport, ref.id, canReadLocalFiles),
+      resolved: await resolveFile(transport, ref.id),
     })),
   );
-  let unreadable = 0;
   for (const result of results) {
     if (result.status === "fulfilled") {
       const { ref, resolved } = result.value;
       if (resolved.image) backgroundImages.push({ image: resolved.image, ref });
       if (resolved.file) backgroundFiles.push({ file: resolved.file, ref });
-      if (resolved.unreadableFile) unreadable++;
     } else {
       lost++;
       log.warn(`${transport.label} could not load an earlier (buffered) Slack file: ${String(result.reason)}`);
@@ -86,7 +75,6 @@ async function resolveInputs(
   }
 
   const missingNote = missingAttachmentsNote(lost + attachments.buffered.skipped);
-  const unreadableNote = unreadableAttachmentsNote(unreadable);
   const imageManifest = backgroundImagesManifest(
     images.length,
     backgroundImages.map(({ ref }) => ref),
@@ -101,7 +89,7 @@ async function resolveInputs(
   const allImages = [...images, ...backgroundImages.map(({ image }) => image)];
   return {
     images: allImages.length ? allImages : undefined,
-    promptSuffix: `${missingNote}${unreadableNote}${imageManifest}${attachedFilesManifest(allFiles)}`,
+    promptSuffix: `${missingNote}${imageManifest}${attachedFilesManifest(allFiles)}`,
   };
 }
 
@@ -118,13 +106,7 @@ export async function* invokeSlackTurn(
   try {
     resolved = await resolveInputs(transport, attachments);
   } catch (error) {
-    const unavailable = error instanceof LocalFileAccessUnavailable;
-    yield {
-      type: "failed",
-      details: unavailable ? error.message : `could not load Slack attachment: ${String(error)}`,
-      retryable: !unavailable,
-      ...(unavailable ? { code: ATTACHMENT_UNSUPPORTED_CODE } : {}),
-    };
+    yield { type: "failed", details: `could not load Slack attachment: ${String(error)}`, retryable: true };
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${MARKDOWN_INSTRUCTION}`, images: resolved.images };

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -205,7 +205,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
   }
   const reactionEmojis = resolveReactionEmojis(reactionAck);
 
-  return ({ agent, stateRoot, canReadLocalFiles, control }) => {
+  return ({ agent, stateRoot, control }) => {
     if (!botToken) throw new Error("slackChannel requires a non-empty botToken (Bot User OAuth Token)");
     if (!signingSecret)
       throw new Error("slackChannel requires a non-empty signingSecret (Basic Information → App Credentials)");
@@ -362,7 +362,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
               agent,
               turn.session,
               prompt,
-              { api, channelId: turn.channelId, filesDir: join(stateHome, "files"), label, canReadLocalFiles },
+              { api, channelId: turn.channelId, filesDir: join(stateHome, "files"), label },
               { primaryFileIds: turn.fileIds, buffered },
               () => {
                 store.remove(turn.id);

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -5,17 +5,15 @@
  * pure) because this half touches the Bot API + disk; split from telegram.ts so the factory keeps only
  * wiring and the per-turn lifecycle.
  */
-import { type Agent, type AgentEvent, ATTACHMENT_UNSUPPORTED_CODE, type ImageRef } from "../../agent.ts";
+import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
   DEFAULT_BUSY_RETRY,
-  LocalFileAccessUnavailable,
   attachedFilesManifest,
   attributedFileName,
   missingAttachmentsNote,
   streamTurnWithBusyRetry,
-  unreadableAttachmentsNote,
 } from "../invoke-turn-kit.ts";
 import type { BufferedRef } from "./context-buffer.ts";
 import { type DownloadedFile, resolveFiles, resolveImages } from "./telegram-api.ts";
@@ -30,8 +28,6 @@ export interface TurnTransport {
   botToken: string;
   chatId: number | string;
   filesDir: string;
-  /** Whether the agent has a reader for absolute local paths; see ChannelContext. */
-  canReadLocalFiles: boolean;
 }
 
 /** A turn's attachment inputs: the summoning message's own file_ids (primary) and the ones folded in
@@ -62,11 +58,7 @@ interface ResolvedAttachments {
 async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachments): Promise<ResolvedAttachments> {
   const { api, botToken, chatId, filesDir } = t;
   const { primary, buffered } = attachments;
-  const { canReadLocalFiles } = t;
-  if (!canReadLocalFiles && (primary.fileIds?.length ?? 0) > 0) throw new LocalFileAccessUnavailable("[telegram]");
   const images = await resolveImages(api, botToken, primary.imageFileIds);
-  // No reader-check here: the guard above already refused a non-empty list, and an empty one resolves
-  // to nothing either way. Two readings of one rule, two lines apart, is one too many.
   const files = await resolveFiles(api, botToken, primary.fileIds, chatId, filesDir);
   const bufferedImages: ImageRef[] = [];
   const bufferedFiles: { file: DownloadedFile; ref: BufferedRef }[] = [];
@@ -79,15 +71,12 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
       log.warn(`[telegram] could not load an earlier (buffered) photo: ${String(r.reason)}`);
     }
   }
-  const unreadable = canReadLocalFiles ? 0 : buffered.files.length;
-  const fileResults = canReadLocalFiles
-    ? await Promise.allSettled(
-        buffered.files.map(async (ref) => ({
-          ref,
-          files: (await resolveFiles(api, botToken, [ref.id], chatId, filesDir)) ?? [],
-        })),
-      )
-    : [];
+  const fileResults = await Promise.allSettled(
+    buffered.files.map(async (ref) => ({
+      ref,
+      files: (await resolveFiles(api, botToken, [ref.id], chatId, filesDir)) ?? [],
+    })),
+  );
   for (const r of fileResults) {
     if (r.status === "fulfilled") {
       for (const file of r.value.files) bufferedFiles.push({ file, ref: r.value.ref });
@@ -97,7 +86,6 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
     }
   }
   const missingNote = missingAttachmentsNote(lost + buffered.skipped);
-  const unreadableNote = unreadableAttachmentsNote(unreadable);
   // PRIMARY first, background after — consistent with "primary wins": what the user pointed at this
   // turn leads. Buffered file entries are attributed like the fold's text lines ("the file Bob sent"
   // resolves); buffered PHOTOS cannot be (ImageRef carries no label), so their attribution stops at
@@ -110,7 +98,7 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
   const allImages = [...(images ?? []), ...bufferedImages];
   return {
     images: allImages.length ? allImages : undefined,
-    promptSuffix: `${missingNote}${unreadableNote}${attachedFilesManifest(allFiles)}`,
+    promptSuffix: `${missingNote}${attachedFilesManifest(allFiles)}`,
   };
 }
 
@@ -132,13 +120,7 @@ export async function* invokeTurn(
   try {
     resolved = await resolveTurnAttachments(transport, attachments);
   } catch (e) {
-    const unavailable = e instanceof LocalFileAccessUnavailable;
-    yield {
-      type: "failed",
-      details: unavailable ? e.message : `could not load attachment: ${String(e)}`,
-      retryable: !unavailable,
-      ...(unavailable ? { code: ATTACHMENT_UNSUPPORTED_CODE } : {}),
-    };
+    yield { type: "failed", details: `could not load attachment: ${String(e)}`, retryable: true };
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${HTML_INSTRUCTION}`, images: resolved.images };

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -125,7 +125,7 @@ export function telegramChannel({
   botUsername,
   apiBaseUrl = "https://api.telegram.org",
 }: TelegramChannelOptions): ChannelModule {
-  return ({ agent, stateRoot, canReadLocalFiles, control }) => {
+  return ({ agent, stateRoot, control }) => {
     // Validate at activation so deploy may inspect the module shape before secrets are provisioned.
     if (!secretToken) {
       throw new Error(
@@ -273,7 +273,6 @@ export function telegramChannel({
                 botToken,
                 chatId: rec.chatId,
                 filesDir: join(stateHome, "files"),
-                canReadLocalFiles,
               },
               {
                 primary: {

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -7,12 +7,7 @@ import { resolve } from "node:path";
 import { runDevSupervisor } from "../../dev-supervisor.ts";
 import { loadDotEnv } from "../../env.ts";
 
-import {
-  definitionAssemblyFindings,
-  reportFindingsIfChanged,
-  reportModuleLoadFailures,
-  reportToolCollisions,
-} from "../../engines/pi/report.ts";
+import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { setLogLevel } from "../../log.ts";
 import { logAgentLoop } from "../../observe.ts";
@@ -122,5 +117,5 @@ function reportAgentsSkillsTools(a: Assembled): void {
   }
   reportToolCollisions(a.toolCollisions);
   reportModuleLoadFailures(a.toolFailures);
-  reportFindingsIfChanged(a.definition.dir, a.definition, definitionAssemblyFindings(a.definition, a.codingToolNames));
+  reportFindingsIfChanged(a.definition.dir, a.definition);
 }

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -90,9 +90,7 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
   // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
   // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
   const traced = logAgentLoop(a.agent);
-  const routed = await routesFor(a.agentDir, traced, a.stateRoot, a.sessionControl, {
-    canReadLocalFiles: a.codingToolNames.includes("read"),
-  }).catch(failStartup);
+  const routed = await routesFor(a.agentDir, traced, a.stateRoot, a.sessionControl).catch(failStartup);
   // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
   // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
   const configured = a.config.http?.host;
@@ -124,9 +122,5 @@ function reportAgentsSkillsTools(a: Assembled): void {
   }
   reportToolCollisions(a.toolCollisions);
   reportModuleLoadFailures(a.toolFailures);
-  reportFindingsIfChanged(
-    a.definition.dir,
-    a.definition,
-    definitionAssemblyFindings(a.definition, a.codingToolNames.includes("read")),
-  );
+  reportFindingsIfChanged(a.definition.dir, a.definition, definitionAssemblyFindings(a.definition, a.codingToolNames));
 }

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -64,7 +64,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
       failures: [],
       error: (e as Error).message,
     }));
-  const assemblyFindings = definitionAssemblyFindings(definition, tools.coding.includes("read"));
+  const assemblyFindings = definitionAssemblyFindings(definition, tools.coding);
   const channels = await discoverChannelFiles(agentDir).catch(failStartup);
   // Loaded (imported + validated), not just discovered: info's job is "fix only what it reports", so a
   // broken schedule file (bad cron/tz, failed import) must show up HERE, not first at dev/start — and

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -14,12 +14,7 @@ import { createPiModelRuntime } from "../../engines/pi/models.ts";
 import { resolveStateRoot, workspaceHint } from "../../paths.ts";
 import { resolveAgentTools, resolveCodingTools } from "../../engines/pi/create.ts";
 import { loadAgentDefinition } from "../../engines/pi/definition.ts";
-import {
-  definitionAssemblyFindings,
-  reportFindingsIfChanged,
-  reportModuleLoadFailures,
-  reportToolCollisions,
-} from "../../engines/pi/report.ts";
+import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
 import { log } from "../../log.ts";
 import { nextRun } from "../../schedule/cron.ts";
 import { loadSchedules } from "../../schedule/discover.ts";
@@ -64,7 +59,6 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
       failures: [],
       error: (e as Error).message,
     }));
-  const assemblyFindings = definitionAssemblyFindings(definition, tools.coding);
   const channels = await discoverChannelFiles(agentDir).catch(failStartup);
   // Loaded (imported + validated), not just discovered: info's job is "fix only what it reports", so a
   // broken schedule file (bad cron/tz, failed import) must show up HERE, not first at dev/start — and
@@ -121,12 +115,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
           stateRoot,
           sessionsDir,
           authPath,
-          // Two entities, two keys: `diagnostics` is per-skill parse problems (path = the SKILL.md),
-          // while an assembly finding describes the definition as a whole (path = the definition dir,
-          // code outside the skill vocabulary). Merged, a machine consumer branching on `code` or
-          // resolving `path` gets a second shape without warning.
           diagnostics: definition.diagnostics,
-          assemblyFindings,
           skillCollisions: definition.collisions,
           toolCollisions: tools.collisions,
           toolFailures: tools.failures,
@@ -166,5 +155,5 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   reportModuleLoadFailures(tools.failures);
   reportModuleLoadFailures(sched.failures);
   if (tools.error) log.warn(`[fastagent] ${tools.error}`);
-  reportFindingsIfChanged(definition.dir, definition, assemblyFindings);
+  reportFindingsIfChanged(definition.dir, definition);
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -136,11 +136,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
         `FASTAGENT_SECRETS_DIR at a persistent volume so a redeploy that replaces the dir does not wipe them.`,
     );
   }
-  reportFindingsIfChanged(
-    definition.dir,
-    definition,
-    definitionAssemblyFindings(definition, codingToolNames.includes("read")),
-  );
+  reportFindingsIfChanged(definition.dir, definition, definitionAssemblyFindings(definition, codingToolNames));
 
   // AgentCore Runtime posture (FASTAGENT_AGENTCORE=1, set by the generated deploy artifacts): the
   // adapter (POST /invocations + GET /ping) is the container's only reachable surface, and cron
@@ -158,10 +154,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   // so channels mount eagerly and a broken channel fails startup.
   const routed = agentcore
     ? undefined
-    : await routesFor(agentDir, traced, stateRoot, sessionControl, {
-        builtinInvoke: true,
-        canReadLocalFiles: codingToolNames.includes("read"),
-      }).catch(failStartup);
+    : await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: true }).catch(failStartup);
   // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
   // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
   const configured = config.http?.host;
@@ -205,10 +198,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
     // re-establishes it — so their presence is a configuration error, surfaced per envelope and by
     // the deploy driver's health probe (there is no boot to fail on this host).
     const lazyChannels = async (): Promise<Routes> => {
-      const surface = await routesFor(agentDir, traced, stateRoot, sessionControl, {
-        builtinInvoke: false,
-        canReadLocalFiles: codingToolNames.includes("read"),
-      });
+      const surface = await routesFor(agentDir, traced, stateRoot, sessionControl, { builtinInvoke: false });
       if (surface.longConnections.length > 0) {
         throw new Error(
           `long-connection channel(s) ${surface.longConnections.map((c) => c.name).join(", ")} cannot serve on ` +

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -9,12 +9,7 @@ import { loadDotEnv } from "../../env.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
 import { resolveSecretsDir, workspaceHint } from "../../paths.ts";
 import { isUnderDir } from "../../engines/pi/definition.ts";
-import {
-  definitionAssemblyFindings,
-  reportFindingsIfChanged,
-  reportModuleLoadFailures,
-  reportToolCollisions,
-} from "../../engines/pi/report.ts";
+import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "../../engines/pi/report.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { log, setLogLevel } from "../../log.ts";
 import { createWakeAlarmSink, reconcileWakeAlarms } from "../../schedule/wake-alarm.ts";
@@ -136,7 +131,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
         `FASTAGENT_SECRETS_DIR at a persistent volume so a redeploy that replaces the dir does not wipe them.`,
     );
   }
-  reportFindingsIfChanged(definition.dir, definition, definitionAssemblyFindings(definition, codingToolNames));
+  reportFindingsIfChanged(definition.dir, definition);
 
   // AgentCore Runtime posture (FASTAGENT_AGENTCORE=1, set by the generated deploy artifacts): the
   // adapter (POST /invocations + GET /ping) is the container's only reachable surface, and cron

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -43,12 +43,11 @@ export async function routesFor(
   agent: Agent,
   stateRoot: string,
   control: SessionControl | undefined,
-  options: { builtinInvoke?: boolean; canReadLocalFiles: boolean },
+  options: { builtinInvoke?: boolean } = {},
 ): Promise<ServingSurface> {
   const { routes, longConnections, routeChannels, collisions, failures } = await loadChannels(agentDir, {
     agent,
     stateRoot,
-    canReadLocalFiles: options.canReadLocalFiles,
     control,
   });
   for (const c of collisions) {

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -33,7 +33,7 @@ import {
 } from "./config.ts";
 import { resolveSecretsDir } from "../../paths.ts";
 import { type LoadedDefinition, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
-import { definitionAssemblyFindings, reportFindingsIfChanged } from "./report.ts";
+import { reportFindingsIfChanged } from "./report.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import {
   type DefineToolOptions,
@@ -533,7 +533,7 @@ export async function createPiAgentFromDefinition(
   // the resolved dir): announced once here, and re-announced by a turn or by the control plane's
   // command list only when the set CHANGES — a runtime-written bad skill surfaces the moment it
   // appears, a static one does not spam. Log dedup, not session state (stateless invoke holds).
-  reportFindingsIfChanged(definition.dir, definition, definitionAssemblyFindings(definition, codingToolNames));
+  reportFindingsIfChanged(definition.dir, definition);
   // Dir-aware default: the same secrets-dir-derived file the opener uses for this dir (the opener
   // passes an explicit authPath, so this only affects direct L2 callers).
   const authPath = options.authPath ?? defaultAuthPath(resolveSecretsDir(dir));
@@ -557,7 +557,7 @@ export async function createPiAgentFromDefinition(
     // next good edit heals both.
     live: async () => {
       const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
-      reportFindingsIfChanged(def.dir, def, definitionAssemblyFindings(def, codingToolNames));
+      reportFindingsIfChanged(def.dir, def);
       return {
         systemPrompt: assembleSystemPrompt({
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -470,8 +470,9 @@ export interface CreatePiAgentFromDefinitionOptions {
   /** Override tools. Defaults to {@link piDefaultTools} (lock down with a custom list). An authored
    *  `FastagentTool[]` (AgentTool plus the optional `deferred` marker) widens into {@link MountedTool}. */
   tools?: MountedTool[];
-  /** INTERNAL directory-opener fact: which mounted tools are pi's coding tools. Keeps prompt identity,
-   *  skill findings and chat parity tied to the resolver instead of inferring semantics from authored names. */
+  /** INTERNAL directory-opener fact: which mounted tools are pi's coding tools. Keeps prompt identity
+   *  and the disabled-built-in exclusion tied to the resolver instead of inferring semantics from
+   *  authored names. */
   codingToolNames?: readonly CodingToolName[];
   /**
    * The agent's working directory: where the default tools operate AND whose ancestors are walked for
@@ -521,11 +522,11 @@ export async function createPiAgentFromDefinition(
   // it; a caller's own search_tools wins).
   const tools = withSearchTool(options.tools ?? piDefaultTools());
   // An explicit `tools` list is the caller stating the whole surface, so the coding capabilities are
-  // whichever built-in NAMES appear in it — not none. A caller passing `piDefaultTools()` has a
-  // reader; telling them otherwise would give the model a capability-neutral identity and warn that
-  // their skills have no reader. Name-based, exactly like the exclusion below, and for the same
-  // reason: the name is the only thing either side can observe. `codingTools` stays a definition
-  // property — the directory opener passes the resolved set explicitly.
+  // whichever built-in NAMES appear in it — not none. A caller passing `piDefaultTools()` gets the
+  // identity that matches what they mounted, rather than the capability-neutral one. Name-based,
+  // exactly like the exclusion below, and for the same reason: the name is the only thing either
+  // side can observe. `codingTools` stays a definition property — the directory opener passes the
+  // resolved set explicitly.
   const codingToolNames =
     options.codingToolNames ??
     (options.tools === undefined ? [...CODING_TOOL_NAMES] : codingToolNamesIn(options.tools));

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -533,11 +533,7 @@ export async function createPiAgentFromDefinition(
   // the resolved dir): announced once here, and re-announced by a turn or by the control plane's
   // command list only when the set CHANGES — a runtime-written bad skill surfaces the moment it
   // appears, a static one does not spam. Log dedup, not session state (stateless invoke holds).
-  reportFindingsIfChanged(
-    definition.dir,
-    definition,
-    definitionAssemblyFindings(definition, codingToolNames.includes("read")),
-  );
+  reportFindingsIfChanged(definition.dir, definition, definitionAssemblyFindings(definition, codingToolNames));
   // Dir-aware default: the same secrets-dir-derived file the opener uses for this dir (the opener
   // passes an explicit authPath, so this only affects direct L2 callers).
   const authPath = options.authPath ?? defaultAuthPath(resolveSecretsDir(dir));
@@ -561,7 +557,7 @@ export async function createPiAgentFromDefinition(
     // next good edit heals both.
     live: async () => {
       const def = await loadAgentDefinition(dir, { cwd: env.cwd, env });
-      reportFindingsIfChanged(def.dir, def, definitionAssemblyFindings(def, codingToolNames.includes("read")));
+      reportFindingsIfChanged(def.dir, def, definitionAssemblyFindings(def, codingToolNames));
       return {
         systemPrompt: assembleSystemPrompt({
           // Segment ①: an authored persona (persona.md, def.persona) overrides the engine identity,

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -227,11 +227,7 @@ export async function createPiAgentFromDir(
           // A skill whose frontmatter broke simply is not in `skills` — it would disappear from the
           // author's composer with no signal anywhere. The memo is SHARED with the turn path (keyed
           // by dir), so a finding is warned when it appears, not once per reader that notices it.
-          reportFindingsIfChanged(
-            loaded.dir,
-            loaded,
-            definitionAssemblyFindings(loaded, codingToolNames.includes("read")),
-          );
+          reportFindingsIfChanged(loaded.dir, loaded, definitionAssemblyFindings(loaded, codingToolNames));
           return loaded.skills.map((skill) => ({
             name: skill.name,
             description: skill.description,

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -28,7 +28,7 @@ import { type PiBoundaryWiring, createPiSessionControl } from "./session-control
 import { withWakeTool } from "./wake-tool.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import { type LoadedDefinition, loadAgentSkills } from "./definition.ts";
-import { definitionAssemblyFindings, reportFindingsIfChanged } from "./report.ts";
+import { reportFindingsIfChanged } from "./report.ts";
 import { type PiSessionRecordStore, piSessionRecordStore } from "./session-store.ts";
 import type { ToolCollision } from "./tool.ts";
 import type { MountedTool } from "./tool.ts";
@@ -227,7 +227,7 @@ export async function createPiAgentFromDir(
           // A skill whose frontmatter broke simply is not in `skills` — it would disappear from the
           // author's composer with no signal anywhere. The memo is SHARED with the turn path (keyed
           // by dir), so a finding is warned when it appears, not once per reader that notices it.
-          reportFindingsIfChanged(loaded.dir, loaded, definitionAssemblyFindings(loaded, codingToolNames));
+          reportFindingsIfChanged(loaded.dir, loaded);
           return loaded.skills.map((skill) => ({
             name: skill.name,
             description: skill.description,

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -4,51 +4,17 @@
  */
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { log } from "../../log.ts";
-import type { LoadedDefinition, SkillCollision } from "./definition.ts";
+import type { SkillCollision } from "./definition.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import type { ToolCollision } from "./tool.ts";
 
 type Findings = { collisions: SkillCollision[]; diagnostics: SkillDiagnostic[] };
 
-/** A non-fatal problem created by the assembled capability surface rather than by parsing one skill. */
-export interface AssemblyFinding {
-  code: "skills_require_file_reader";
-  message: string;
-  path: string;
-}
-
-/**
- * A model-visible skill is a path-based capability: pi tells the model to read SKILL.md on demand.
- * Without a `read` tool that listing is a dead instruction, so surface the mismatch.
- *
- * Takes the tool NAMES rather than a pre-computed boolean: six callers were each deriving
- * `.includes("read")` on the way in, which is one reading of one rule copied six times. This is the
- * only place in the codebase that still asks what the agent can do with a file — a channel states
- * what it attached and lets the agent answer, but an assembly that lists skills it cannot open is
- * contradicting itself, and only the assembly can see that.
- */
-export function definitionAssemblyFindings(
-  definition: Pick<LoadedDefinition, "dir" | "skills">,
-  codingToolNames: readonly string[],
-): AssemblyFinding[] {
-  const visible = definition.skills.filter((skill) => !skill.disableModelInvocation);
-  return !codingToolNames.includes("read") && visible.length > 0
-    ? [
-        {
-          code: "skills_require_file_reader",
-          message: `model-visible skills (${visible.map((skill) => skill.name).join(", ")}) cannot be loaded without the read coding tool; enable codingTools: ["read"] or remove/disable those skills`,
-          path: definition.dir,
-        },
-      ]
-    : [];
-}
-
 /** Stable identity of a definition's non-fatal findings — the dedup key below. */
-function findingsSignature(def: Findings, assembly: readonly AssemblyFinding[]): string {
+function findingsSignature(def: Findings): string {
   const collisions = def.collisions.map((c) => `c:${c.name}:${c.winnerPath}:${c.loserPath}`);
   const diagnostics = def.diagnostics.map((d) => `d:${d.code}:${d.path}`);
-  const assembled = assembly.map((d) => `a:${d.code}:${d.path}:${d.message}`);
-  return [...collisions, ...diagnostics, ...assembled].sort().join("\n");
+  return [...collisions, ...diagnostics].sort().join("\n");
 }
 
 /**
@@ -68,18 +34,12 @@ const lastFindings = new Map<string, string>();
  *
  * `dir` must be the RESOLVED definition root (`LoadedDefinition.dir`), or two spellings of one path
  * become two memos and warn twice.
- *
- * `assembly` is REQUIRED, with no default: an omitted argument writes a signature that does not
- * include the assembly findings, so the next caller that does pass them re-warns and an earlier one
- * suppresses them — the "record without printing" variant this module's single door exists to rule
- * out. Callers with nothing to add pass `[]` and say so.
  */
-export function reportFindingsIfChanged(dir: string, def: Findings, assembly: readonly AssemblyFinding[]): void {
-  const sig = findingsSignature(def, assembly);
+export function reportFindingsIfChanged(dir: string, def: Findings): void {
+  const sig = findingsSignature(def);
   if (lastFindings.get(dir) === sig) return;
   lastFindings.set(dir, sig);
   reportDefinitionWarnings(def.collisions, def.diagnostics);
-  for (const finding of assembly) log.warn(`[fastagent] ${finding.code}: ${finding.message} (${finding.path})`);
 }
 
 export function reportDefinitionWarnings(collisions: SkillCollision[], diagnostics: SkillDiagnostic[]): void {

--- a/src/engines/pi/report.ts
+++ b/src/engines/pi/report.ts
@@ -17,14 +17,22 @@ export interface AssemblyFinding {
   path: string;
 }
 
-/** A model-visible skill is a path-based capability: pi tells the model to read SKILL.md on demand.
- *  Without the built-in local reader that listing is a dead instruction, so surface the mismatch. */
+/**
+ * A model-visible skill is a path-based capability: pi tells the model to read SKILL.md on demand.
+ * Without a `read` tool that listing is a dead instruction, so surface the mismatch.
+ *
+ * Takes the tool NAMES rather than a pre-computed boolean: six callers were each deriving
+ * `.includes("read")` on the way in, which is one reading of one rule copied six times. This is the
+ * only place in the codebase that still asks what the agent can do with a file — a channel states
+ * what it attached and lets the agent answer, but an assembly that lists skills it cannot open is
+ * contradicting itself, and only the assembly can see that.
+ */
 export function definitionAssemblyFindings(
   definition: Pick<LoadedDefinition, "dir" | "skills">,
-  canReadLocalFiles: boolean,
+  codingToolNames: readonly string[],
 ): AssemblyFinding[] {
   const visible = definition.skills.filter((skill) => !skill.disableModelInvocation);
-  return !canReadLocalFiles && visible.length > 0
+  return !codingToolNames.includes("read") && visible.length > 0
     ? [
         {
           code: "skills_require_file_reader",

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -143,11 +143,7 @@ export async function buildAgentSessionRuntime(
     const modelRuntime = await createPiModelRuntime({ authPath, agentDir, stateRoot });
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(agentDir, { cwd, env });
-    reportFindingsIfChanged(
-      definition.dir,
-      definition,
-      definitionAssemblyFindings(definition, codingToolNames.includes("read")),
-    );
+    reportFindingsIfChanged(definition.dir, definition, definitionAssemblyFindings(definition, codingToolNames));
     // Assembly-time, like serving's: this whole function is memoized, so the scan and its warnings
     // happen once per runtime rather than per session rebuild (/new, /resume, fork).
     const extensionPaths = await loadExtensionPaths(agentDir, { cwd, env });

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -54,12 +54,7 @@ import {
   agentSessionManager,
   turnContext,
 } from "./tool-context.ts";
-import {
-  definitionAssemblyFindings,
-  reportFindingsIfChanged,
-  reportModuleLoadFailures,
-  reportToolCollisions,
-} from "./report.ts";
+import { reportFindingsIfChanged, reportModuleLoadFailures, reportToolCollisions } from "./report.ts";
 import { resolveAgentAssembly } from "./open.ts";
 
 export interface BuildSessionRuntimeOptions {
@@ -143,7 +138,7 @@ export async function buildAgentSessionRuntime(
     const modelRuntime = await createPiModelRuntime({ authPath, agentDir, stateRoot });
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(agentDir, { cwd, env });
-    reportFindingsIfChanged(definition.dir, definition, definitionAssemblyFindings(definition, codingToolNames));
+    reportFindingsIfChanged(definition.dir, definition);
     // Assembly-time, like serving's: this whole function is memoized, so the scan and its warnings
     // happen once per runtime rather than per session rebuild (/new, /resume, fork).
     const extensionPaths = await loadExtensionPaths(agentDir, { cwd, env });

--- a/src/host/node.ts
+++ b/src/host/node.ts
@@ -26,15 +26,6 @@ export type Routes = Record<string, ChannelHandler>;
 export interface ChannelContext {
   agent: Agent;
   stateRoot: string;
-  /**
-   * Whether the assembled agent can read absolute local attachment paths.
-   *
-   * REQUIRED, and deliberately not optional: the unsafe answer would be the default. An absent
-   * value read as "assume it can" hands the model paths it cannot open — the failure this exists to
-   * prevent — and every transport would re-derive the rule (`x !== false`) on its own. One fact,
-   * stated by whoever assembles the agent.
-   */
-  canReadLocalFiles: boolean;
   /** The serving session-control hub, when the serve wires one (`config.sessionControl`). Channels
    *  use it for DISPATCH only (the user-facing stop command); observation stays on the data plane. */
   control?: SessionControl;

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -7,7 +7,7 @@ import { loadChannels } from "../src/index.ts";
 import { discoverChannelFiles, inspectChannels } from "../src/engines/pi/channel.ts";
 
 // loadChannels only forwards the ctx to the factory; these factories ignore it.
-const fakeCtx = { agent: {} as Agent, stateRoot: "/unused-in-tests", canReadLocalFiles: true };
+const fakeCtx = { agent: {} as Agent, stateRoot: "/unused-in-tests" };
 const freshDir = () => mkdtemp(join(tmpdir(), "fa-chan-"));
 
 describe("loadChannels (filesystem discovery)", () => {
@@ -172,9 +172,9 @@ describe("loadChannels (filesystem discovery)", () => {
 
   it("rejects a relative stateRoot at the mount boundary (the contract says absolute — fail visibly)", async () => {
     const dir = await freshDir();
-    await expect(
-      loadChannels(dir, { agent: {} as Agent, stateRoot: "rel/state", canReadLocalFiles: true }),
-    ).rejects.toThrow(/stateRoot must be absolute/);
+    await expect(loadChannels(dir, { agent: {} as Agent, stateRoot: "rel/state" })).rejects.toThrow(
+      /stateRoot must be absolute/,
+    );
   });
 
   it("isolates (surfaces, not fatal) a channel file that does not default-export a function", async () => {

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -10,13 +10,12 @@ import type { LoadedSchedule } from "../src/schedule/schedule.ts";
 describe("serving surface", () => {
   it("can suppress the fallback /invoke for AgentCore's publicly forwarded surface", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-agentcore-surface-"));
-    const ordinary = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, { canReadLocalFiles: true });
+    const ordinary = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, {});
     expect(Object.keys(ordinary.routes)).toContain("POST /invoke");
     expect(ordinary.builtinInvoke).toBe(true);
 
     const agentcore = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, {
       builtinInvoke: false,
-      canReadLocalFiles: true,
     });
     expect(Object.keys(agentcore.routes)).toEqual(["GET /health"]);
     expect(agentcore.builtinInvoke).toBe(false);
@@ -29,7 +28,7 @@ describe("serving surface", () => {
       join(dir, "channels", "socket.mjs"),
       `export default { name: "socket", connect: () => ({ ready: Promise.resolve(), closed: new Promise(() => {}) }) };\n`,
     );
-    const surface = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, { canReadLocalFiles: true });
+    const surface = await routesFor(dir, {} as Agent, join(dir, ".state"), undefined, {});
     expect(Object.keys(surface.routes)).toEqual(["GET /health"]);
     expect(surface.builtinInvoke).toBe(false);
     expect(surface.longConnections.map((connection) => connection.name)).toEqual(["socket"]);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -323,11 +323,6 @@ describe("cli papercuts", () => {
     expect(info.context.length).toBeGreaterThan(0); // the AGENTS.md is loaded as ② project context
     expect(info.skills.map((s: { name: string }) => s.name)).toEqual(["greet"]); // the malformed skill is skipped
     expect(JSON.stringify(info.diagnostics)).toMatch(/description/); // info SURFACES loader diagnostics
-    // Its OWN key: a skill diagnostic points at a SKILL.md, an assembly finding at the definition
-    // dir with a code from a different vocabulary. One field holding both hands a machine consumer
-    // two shapes under one name.
-    expect(JSON.stringify(info.assemblyFindings)).toMatch(/skills_require_file_reader/);
-    expect(JSON.stringify(info.diagnostics)).not.toMatch(/skills_require_file_reader/);
     expect(info.channels).toEqual(["github"]);
     await expect(stat(join(dir, "fastagent", ".state"))).rejects.toThrow(); // read-only: never creates the state root
   });

--- a/test/feishu-websocket.test.ts
+++ b/test/feishu-websocket.test.ts
@@ -68,7 +68,7 @@ describe("Feishu/Lark WebSocket ingress", () => {
           yield { type: "completed" };
         },
       };
-      const run = module.connect({ agent, stateRoot: root, canReadLocalFiles: true }, new AbortController().signal);
+      const run = module.connect({ agent, stateRoot: root }, new AbortController().signal);
       await run.ready;
       expect(accepted).toBeTypeOf("function");
       await accepted?.(event);
@@ -103,7 +103,7 @@ describe("Feishu/Lark WebSocket ingress", () => {
         yield { type: "completed" };
       },
     };
-    module.connect({ agent, stateRoot: root, canReadLocalFiles: true }, new AbortController().signal);
+    module.connect({ agent, stateRoot: root }, new AbortController().signal);
     const home = join(root, "channels", "feishu");
     await mkdir(join(home, "turns.json.tmp")); // saveStateFile(writeFile) fails with EISDIR before the ACK
 

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -102,10 +102,10 @@ function feishuFetch(
 
 /** Build a channel on a temp state root; returns the handler + the recorded agent + the state home. */
 function buildChannel(
-  opts: Partial<FeishuChannelOptions> & { control?: SessionControl; canReadLocalFiles?: boolean } = {},
+  opts: Partial<FeishuChannelOptions> & { control?: SessionControl } = {},
   agentReply = "the answer",
 ) {
-  const { control, canReadLocalFiles, ...channelOpts } = opts;
+  const { control, ...channelOpts } = opts;
   const root = mkdtempSync(join(tmpdir(), "feishu-state-"));
   tempRoots.push(root);
   const { agent, calls } = replyingAgent(agentReply);
@@ -115,7 +115,7 @@ function buildChannel(
     verificationToken: TOKEN,
     apiBaseUrl: BASE,
     ...channelOpts,
-  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control, canReadLocalFiles: canReadLocalFiles ?? true });
+  })({ agent: opts2Agent(opts) ?? agent, stateRoot: root, control });
   const handler = routes["POST /feishu"];
   if (!handler) throw new Error("expected POST /feishu");
   const maybeIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
@@ -190,7 +190,6 @@ describe("bot identity cache (the lazy-construction mention race)", () => {
     })({
       agent,
       stateRoot: root,
-      canReadLocalFiles: true,
     });
     const handler = routes["POST /feishu"];
     if (!handler) throw new Error("expected POST /feishu");
@@ -333,7 +332,7 @@ describe("bot identity cache (the lazy-construction mention race)", () => {
 
 describe("construction fails closed", () => {
   it("requires appId/appSecret/verificationToken at mount (metadata remains inspectable before secrets exist)", () => {
-    const ctx = { agent: {} as Agent, stateRoot: "/tmp/unused-feishu-construction", canReadLocalFiles: true };
+    const ctx = { agent: {} as Agent, stateRoot: "/tmp/unused-feishu-construction" };
     expect(() => buildFeishuChannel({ appId: "", appSecret: "s", verificationToken: "t" })(ctx)).toThrow(/appId/);
     expect(() => buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: "" })(ctx)).toThrow(
       /verificationToken/,
@@ -347,7 +346,6 @@ describe("construction fails closed", () => {
       buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: "t" })({
         agent,
         stateRoot: "rel",
-        canReadLocalFiles: true,
       }),
     ).toThrow(/stateRoot/);
   });
@@ -483,7 +481,6 @@ describe("upgrade from the session-mode model", () => {
 
     const { agent } = replyingAgent();
     buildFeishuChannel({ appId: "app", appSecret: "secret", verificationToken: TOKEN, apiBaseUrl: BASE })({
-      canReadLocalFiles: true,
       agent,
       stateRoot: root,
     });
@@ -563,7 +560,7 @@ describe("turn flow", () => {
       appSecret: "secret",
       verificationToken: TOKEN,
       apiBaseUrl: BASE,
-    })({ agent: restarted.agent, stateRoot: first.root, canReadLocalFiles: true });
+    })({ agent: restarted.agent, stateRoot: first.root });
     const again = routes["POST /feishu"];
     if (!again) throw new Error("expected POST /feishu");
     const idleAgain = (again as { turnsIdle?: () => Promise<void> }).turnsIdle ?? (async () => {});
@@ -1682,47 +1679,10 @@ describe("turn flow", () => {
     expect(calls).toHaveLength(1);
     const prompt = calls[0]?.prompt.text ?? "";
     expect(prompt).toContain("[replied-to message (msg om_parent, from user ou_bob): [file: spec.pdf]]");
-    expect(prompt).toContain("attached files — read them with your tools");
+    expect(prompt).toContain("attached files:");
     expect(prompt).toContain("spec.pdf");
     expect(fx.calls("/im/v1/messages/om_parent/resources/fk1").length).toBe(1);
     expect(readFileSync(join(home, "files", "oc_1", "spec.pdf")).toString()).toBe("pdf-bytes");
-  });
-
-  it("a quoted file the agent cannot read costs the note, not the turn", async () => {
-    // A referent is CONTEXT, not the ask — this function's own policy. Every first message of a
-    // thread carries one, so hard-failing when the quoted message happens to be a file turns an
-    // ordinary platform edge into a lost turn, and tells the user to "send the content as text" for
-    // a file they never sent. Degrade like every other unreadable referent: skip it, say so.
-    const fx = feishuFetch({
-      "/im/v1/messages/om_parent_no_reader": (url) =>
-        url.includes("/resources/")
-          ? new Response(Buffer.from("must-not-download"), { status: 200 })
-          : Response.json({
-              code: 0,
-              msg: "ok",
-              data: {
-                items: [
-                  {
-                    message_id: "om_parent_no_reader",
-                    msg_type: "file",
-                    body: { content: '{"file_key":"fk1","file_name":"spec.pdf"}' },
-                    sender: { id: "ou_bob", id_type: "open_id", sender_type: "user" },
-                  },
-                ],
-              },
-            }),
-    });
-    const { handler, calls, idle } = buildChannel({
-      canReadLocalFiles: false,
-      onError: (failed) => failed.details,
-    });
-    await handler(
-      feishuRequest(messageEvent({ id: "om_no_reader", text: "summarize this", parentId: "om_parent_no_reader" })),
-    );
-    await idle();
-    expect(calls).toHaveLength(1); // the turn RAN
-    expect(fx.calls("/im/v1/messages/om_parent_no_reader/resources/fk1")).toHaveLength(0); // nothing downloaded
-    expect(String(calls[0]?.prompt.text)).toMatch(/no local-file reader/); // and the model was told
   });
 
   it("a thread opened on the agent's own card reads that card AND the chain up to the ask", async () => {
@@ -2493,7 +2453,6 @@ describe("turn flow", () => {
     );
     const { agent, calls } = replyingAgent("recovered");
     const handler = buildFeishuChannel({ appId: "a", appSecret: "s", verificationToken: TOKEN, apiBaseUrl: BASE })({
-      canReadLocalFiles: true,
       agent,
       stateRoot: root,
     })["POST /feishu"];
@@ -2604,7 +2563,7 @@ describe("the Lark compatibility profile", () => {
       appSecret: "secret",
       verificationToken: TOKEN,
       apiBaseUrl: BASE,
-    })({ agent, stateRoot: root, canReadLocalFiles: true });
+    })({ agent, stateRoot: root });
     expect(routes["POST /feishu"]).toBeUndefined();
     const handler = routes["POST /lark"];
     if (!handler) throw new Error("expected POST /lark");
@@ -2627,7 +2586,7 @@ describe("the Lark compatibility profile", () => {
   });
 
   it("mount failures name each public factory", () => {
-    const ctx = { agent: {} as Agent, stateRoot: "/tmp/unused-feishu-factory-name", canReadLocalFiles: true };
+    const ctx = { agent: {} as Agent, stateRoot: "/tmp/unused-feishu-factory-name" };
     expect(() => buildFeishuChannel({ appId: "", appSecret: "s", verificationToken: "t" })(ctx)).toThrow(
       /feishuChannel/,
     );

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -41,7 +41,7 @@ const PR_OPENED = {
 
 /** The old two-arg shape over the ChannelModule contract, returning the mounted handler directly. */
 const githubChannel = (agent: Agent, opts: GithubChannelOptions) =>
-  buildGithubChannel(opts)({ agent, stateRoot: "/unused-in-tests", canReadLocalFiles: true })["POST /webhook"]!;
+  buildGithubChannel(opts)({ agent, stateRoot: "/unused-in-tests" })["POST /webhook"]!;
 
 describe("github channel", () => {
   it("a post-ACK turn counts as process-wide in-flight work (the AgentCore /ping depends on it)", async () => {

--- a/test/invoke-turn-busy.test.ts
+++ b/test/invoke-turn-busy.test.ts
@@ -35,7 +35,6 @@ async function run(agent: Agent, retry: BusyRetry = FAST): Promise<AgentEvent[]>
     botToken: "B",
     chatId: 1,
     filesDir: await mkdtemp(join(tmpdir(), "fa-")),
-    canReadLocalFiles: true,
   };
   const out: AgentEvent[] = [];
   for await (const e of invokeTurn(agent, "s", "hi", transport, noAttachments, undefined, retry)) out.push(e);

--- a/test/preview-kit.test.ts
+++ b/test/preview-kit.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { ATTACHMENT_UNSUPPORTED_CODE } from "../src/agent.ts";
 import type { AgentEvent } from "../src/agent.ts";
 import {
   applyTurnEvent,
@@ -101,20 +100,5 @@ describe("turn-view reducer", () => {
   it("composeTurnBody skips empty parts and joins with blank lines", () => {
     expect(composeTurnBody(["a", "", "  ", "b"])).toBe("a\n\nb");
     expect(composeTurnBody(["", " "])).toBe("");
-  });
-});
-
-describe("defaultErrorMessage: a known limitation is named, not shrugged at", () => {
-  it("tells the user what cannot happen when the agent has no reader", () => {
-    // The generic non-retryable line asks the user to rephrase, which cannot help: only the operator
-    // can mount a tool. Naming it keeps the user from re-sending the file in five formats.
-    expect(defaultErrorMessage({ details: "…", retryable: false, code: ATTACHMENT_UNSUPPORTED_CODE })).toMatch(
-      /can't open file attachments/i,
-    );
-  });
-
-  it("keeps the neutral wording for a failure it cannot name", () => {
-    expect(defaultErrorMessage({ details: "…", retryable: false })).toMatch(/something went wrong/i);
-    expect(defaultErrorMessage({ details: "…", retryable: true })).toMatch(/try again/i);
   });
 });

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -65,15 +65,15 @@ describe("report", () => {
       collisions: [],
       diagnostics: [],
     };
-    const findings = definitionAssemblyFindings(definition, false);
+    const findings = definitionAssemblyFindings(definition, []);
     expect(findings).toHaveLength(1);
     reportFindingsIfChanged(definition.dir, definition, findings);
     expect(lines(err)).toMatch(/skills_require_file_reader.*codingTools: \["read"\]/);
-    expect(definitionAssemblyFindings(definition, true)).toEqual([]);
+    expect(definitionAssemblyFindings(definition, ["read"])).toEqual([]);
     expect(
       definitionAssemblyFindings(
         { ...definition, skills: [{ ...definition.skills[0]!, disableModelInvocation: true }] },
-        false,
+        [],
       ),
     ).toEqual([]);
   });

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -1,11 +1,6 @@
 import type { SkillDiagnostic } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  definitionAssemblyFindings,
-  reportDefinitionWarnings,
-  reportFindingsIfChanged,
-  reportToolCollisions,
-} from "../src/engines/pi/report.ts";
+import { reportDefinitionWarnings, reportFindingsIfChanged, reportToolCollisions } from "../src/engines/pi/report.ts";
 
 // Locks the warning WORDING shared by the CLI runners and `chat` (the reason A1 deduped these into one
 // module: two copies could drift). Spies on console.error rather than going through a runner.
@@ -33,49 +28,21 @@ describe("report", () => {
         { type: "warning", code: "invalid_metadata", message: "description is required", path: "/a/x/SKILL.md" },
       ] as SkillDiagnostic[],
     };
-    reportFindingsIfChanged("/agent", findings, []); // reader A (a turn)
+    reportFindingsIfChanged("/agent", findings); // reader A (a turn)
     expect(lines(err)).toMatch(/invalid_metadata/);
     err.mockClear();
-    reportFindingsIfChanged("/agent", findings, []); // reader B (commands()) — same finding, same dir
+    reportFindingsIfChanged("/agent", findings); // reader B (commands()) — same finding, same dir
     expect(err).not.toHaveBeenCalled();
     // A DIFFERENT definition keeps its own budget …
-    reportFindingsIfChanged("/other-agent", findings, []);
+    reportFindingsIfChanged("/other-agent", findings);
     expect(lines(err)).toMatch(/invalid_metadata/);
     err.mockClear();
     // There is no record-without-printing door: the boot report goes through this same function, so
     // a caller that never reports cannot silently consume the announcement for every later reader.
-    reportFindingsIfChanged("/third-agent", findings, []); // boot
+    reportFindingsIfChanged("/third-agent", findings); // boot
     err.mockClear();
-    reportFindingsIfChanged("/third-agent", findings, []); // a turn, then commands() — already said
+    reportFindingsIfChanged("/third-agent", findings); // a turn, then commands() — already said
     expect(err).not.toHaveBeenCalled();
-  });
-
-  it("finds and reports model-visible skills that have no local-file reader", () => {
-    const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    const definition = {
-      dir: "/skills-agent",
-      skills: [
-        {
-          name: "writing",
-          description: "Write well",
-          content: "Instructions",
-          filePath: "/skills-agent/skills/writing/SKILL.md",
-        },
-      ],
-      collisions: [],
-      diagnostics: [],
-    };
-    const findings = definitionAssemblyFindings(definition, []);
-    expect(findings).toHaveLength(1);
-    reportFindingsIfChanged(definition.dir, definition, findings);
-    expect(lines(err)).toMatch(/skills_require_file_reader.*codingTools: \["read"\]/);
-    expect(definitionAssemblyFindings(definition, ["read"])).toEqual([]);
-    expect(
-      definitionAssemblyFindings(
-        { ...definition, skills: [{ ...definition.skills[0]!, disableModelInvocation: true }] },
-        [],
-      ),
-    ).toEqual([]);
   });
 
   it("renders tool collisions to stderr", () => {

--- a/test/slack-invoke-turn.test.ts
+++ b/test/slack-invoke-turn.test.ts
@@ -56,7 +56,7 @@ describe("Slack turn attachment resolution", () => {
         agent,
         "s1",
         "read these",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]", canReadLocalFiles: true },
+        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
         { primaryFileIds: ["IMG", "DOC"], buffered: { files: [], skipped: 0 } },
         completed,
       ),
@@ -78,7 +78,7 @@ describe("Slack turn attachment resolution", () => {
         agent,
         "s1",
         "read it",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]", canReadLocalFiles: true },
+        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
         { primaryFileIds: ["F1"], buffered: { files: [], skipped: 0 } },
       ),
     );
@@ -107,7 +107,7 @@ describe("Slack turn attachment resolution", () => {
         agent,
         "s1",
         "answer",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]", canReadLocalFiles: true },
+        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
         {
           primaryFileIds: [],
           buffered: {

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -105,19 +105,13 @@ function storedTurn(id: string, seq: number, extra: Record<string, unknown> = {}
   };
 }
 
-function mount(
-  agent: Agent,
-  options: Partial<SlackChannelOptions> = {},
-  stateRoot = root(),
-  control?: SessionControl,
-  canReadLocalFiles?: boolean,
-) {
+function mount(agent: Agent, options: Partial<SlackChannelOptions> = {}, stateRoot = root(), control?: SessionControl) {
   const handler = slackChannel({
     botToken: "xoxb-test",
     signingSecret: SECRET,
     apiBaseUrl: API,
     ...options,
-  })({ agent, stateRoot, control, canReadLocalFiles: canReadLocalFiles ?? true })["POST /slack"]!;
+  })({ agent, stateRoot, control })["POST /slack"]!;
   const turnsIdle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle ?? (async () => {});
   idles.add(turnsIdle);
   return { handler, stateRoot, turnsIdle };
@@ -167,7 +161,7 @@ describe("Slack attachment capability", () => {
       return Response.json({ ok: true });
     });
     vi.stubGlobal("fetch", fetchMock);
-    const { handler } = mount(agent, { onError: (failed) => failed.details }, root(), undefined, false);
+    const { handler } = mount(agent, { onError: (failed) => failed.details }, root(), undefined);
     await handler(
       signedRequest(
         message("1.0", {

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -130,52 +130,6 @@ afterEach(async () => {
   for (const value of roots.splice(0)) rmSync(value, { recursive: true, force: true });
 });
 
-describe("Slack attachment capability", () => {
-  it("rejects a primary non-image file without a reader and never downloads or invokes", async () => {
-    let invoked = false;
-    const agent: Agent = {
-      async *invoke() {
-        invoked = true;
-        yield { type: "completed" as const };
-      },
-    };
-    const fetchMock = okFetch();
-    fetchMock.mockImplementation(async (input: string | URL) => {
-      const url = String(input);
-      if (url.endsWith("/auth.test")) return Response.json({ ok: true, team_id: "T1", user_id: "UBOT" });
-      if (url.endsWith("/files.info")) {
-        return Response.json({
-          ok: true,
-          file: {
-            id: "F1",
-            name: "report.pdf",
-            mimetype: "application/pdf",
-            url_private: "https://files.slack.test/F1",
-          },
-        });
-      }
-      if (url === "https://files.slack.test/F1") throw new Error("must not download");
-      if (url.endsWith("/chat.postMessage") || url.endsWith("/chat.startStream")) {
-        return Response.json({ ok: true, ts: "100" });
-      }
-      return Response.json({ ok: true });
-    });
-    vi.stubGlobal("fetch", fetchMock);
-    const { handler } = mount(agent, { onError: (failed) => failed.details }, root(), undefined);
-    await handler(
-      signedRequest(
-        message("1.0", {
-          subtype: "file_share",
-          files: [{ id: "F1", name: "report.pdf", mimetype: "application/pdf" }],
-        }),
-      ),
-    );
-    await settle();
-    expect(invoked).toBe(false);
-    expect(fetchMock.mock.calls.some(([input]) => String(input) === "https://files.slack.test/F1")).toBe(false);
-  });
-});
-
 describe("Slack reaction ack", () => {
   const reactionCalls = (
     fetchMock: ReturnType<typeof okFetch>,

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -116,7 +116,6 @@ const telegramChannel = (
   {
     stateDir,
     control,
-    canReadLocalFiles,
     ...opts
   }: TelegramChannelOptions & { stateDir?: string; control?: SessionControl; canReadLocalFiles?: boolean },
 ) => {
@@ -127,7 +126,6 @@ const telegramChannel = (
     agent,
     stateRoot: root,
     control,
-    canReadLocalFiles: canReadLocalFiles ?? true,
   })["POST /telegram"]!;
   // Register the turn-queue idle so flush() awaits this channel's fire-and-forget turns deterministically.
   const idle = (handler as { turnsIdle?: () => Promise<void> }).turnsIdle;
@@ -177,7 +175,6 @@ describe("durable group buffer (single-process restarts)", () => {
     const ch = buildTelegramChannel({ secretToken: SECRET, botToken: "1:A", route })({
       agent,
       stateRoot: root,
-      canReadLocalFiles: true,
     })["POST /telegram"]!;
     expect((await ch(tgRequest(group(1, "hello state root")))).status).toBe(200);
     // The buffer landed under the DERIVED channel home, not the root itself and not process.cwd().
@@ -193,7 +190,6 @@ describe("durable group buffer (single-process restarts)", () => {
       buildTelegramChannel({ secretToken: SECRET, botToken: "1:A" })({
         agent,
         stateRoot: "rel",
-        canReadLocalFiles: true,
       }),
     ).toThrow(/stateRoot/);
   });
@@ -477,25 +473,6 @@ describe("buffered attachments (files/photos from un-summoned discussion)", () =
     const text = String(calls[0]?.text);
     expect(text).toMatch(/report\.pdf \(from @alice, msg 1, earlier discussion\)/); // attributed: "the file ALICE sent" resolves
     expect(text).toMatch(/attached files/);
-  });
-
-  it("does not download or render a buffered file path when the agent has no reader", async () => {
-    const got = attachFetch();
-    const { agent, calls } = replyingAgent("ok");
-    const ch = telegramChannel(agent, {
-      secretToken: SECRET,
-      botToken: "1:A",
-      route,
-      canReadLocalFiles: false,
-    });
-    await ch(tgRequest(doc(1, "report")));
-    await ch(tgRequest(summon(2, "@go summarize what you can")));
-    await until(() => calls.length > 0);
-    expect(got).toEqual([]);
-    const text = String(calls[0]?.text);
-    expect(text).toContain("no local-file reader");
-    expect(text).not.toContain("attached files — read them with your tools");
-    expect(text).not.toContain("report.pdf (");
   });
 
   it("a photo posted without summoning becomes a vision input on the next summon", async () => {
@@ -1573,43 +1550,6 @@ describe("telegram channel", () => {
     expect(existsSync(dest)).toBe(true);
     expect(calls[0]?.text).toMatch(/attached files/);
     expect(calls[0]?.text).toContain(dest);
-  });
-
-  it("fails a primary document clearly without a reader and never downloads or invokes", async () => {
-    const fetchMock = okFetch();
-    vi.stubGlobal("fetch", fetchMock);
-    let invoked = false;
-    const agent: Agent = {
-      async *invoke(): AsyncIterable<AgentEvent> {
-        invoked = true;
-        yield { type: "completed" };
-      },
-    };
-    const ch = telegramChannel(agent, {
-      secretToken: SECRET,
-      botToken: "BOT",
-      route: act,
-      apiBaseUrl: API,
-      canReadLocalFiles: false,
-      onError: (f) => `ERR: ${f.details}`,
-    });
-    const doc: TelegramUpdate = {
-      update_id: 12,
-      message: {
-        message_id: 5,
-        caption: "summarize",
-        document: { file_id: "d1", file_name: "report.pdf" },
-        chat: { id: 77, type: "private" },
-      },
-    };
-    expect((await ch(tgRequest(doc))).status).toBe(200);
-    await flush();
-    expect(invoked).toBe(false);
-    expect(callsTo(fetchMock, "getFile")).toHaveLength(0);
-    const writes = [...callsTo(fetchMock, "sendMessage"), ...callsTo(fetchMock, "editMessageText")].map(
-      (c) => bodyOf(c).text as string,
-    );
-    expect(writes.some((text) => /cannot read local file attachments/.test(text))).toBe(true);
   });
 
   it("surfaces an attachment fetch failure to the user (not a silent skip) and does not run the agent", async () => {

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -113,11 +113,7 @@ const freshStateDir = (): string => {
  *  "restarts" and read files at the same paths. */
 const telegramChannel = (
   agent: Agent,
-  {
-    stateDir,
-    control,
-    ...opts
-  }: TelegramChannelOptions & { stateDir?: string; control?: SessionControl; canReadLocalFiles?: boolean },
+  { stateDir, control, ...opts }: TelegramChannelOptions & { stateDir?: string; control?: SessionControl },
 ) => {
   const home = stateDir ?? freshStateDir();
   const root = rootOfHome.get(home);

--- a/test/turn-kit.test.ts
+++ b/test/turn-kit.test.ts
@@ -2,10 +2,9 @@
  * `retryable` classification — the one bit every SPEC failure carries, and the reason a channel
  * either retries or reports. Structured status/code first, prose only as the last-resort ceiling.
  */
-import { describe, expect, it, vi } from "vitest";
-import { LocalFileAccessUnavailable } from "../src/channels/invoke-turn-kit.ts";
+import { describe, expect, it } from "vitest";
+import { attachedFilesManifest } from "../src/channels/invoke-turn-kit.ts";
 import { classifyRetryable, errorToTerminal, toTerminal } from "../src/engines/pi/turn-kit.ts";
-import { log } from "../src/log.ts";
 
 describe("classifyRetryable (structured signal first, prose as the ceiling)", () => {
   it("a status decides, whatever the prose says", () => {
@@ -72,22 +71,20 @@ describe("terminals read the engine's own signal", () => {
   });
 });
 
-describe("LocalFileAccessUnavailable: the operator hears what the user cannot fix", () => {
-  it("logs the actionable fix when constructed", () => {
-    // The user-facing message deliberately does NOT say "mount the read coding tool" — that is not
-    // their lever. It has to reach the operator instead, and the throw site is the only place that
-    // knows. Before this, the sentence lived in an Error the default onError never rendered, so a
-    // misconfigured agent answered every attachment with a shrug and nobody learned why.
-    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
-    try {
-      const err = new LocalFileAccessUnavailable("[telegram]");
-      expect(err.name).toBe("LocalFileAccessUnavailable");
-      const logged = warn.mock.calls.flat().join("\n");
-      expect(logged).toMatch(/\[telegram\]/);
-      expect(logged).toMatch(/no `read` tool/);
-      expect(logged).toMatch(/codingTools/);
-    } finally {
-      warn.mockRestore();
-    }
+describe("attachedFilesManifest: states, does not instruct", () => {
+  it("gives name, size and path without telling the agent what to do with them", () => {
+    const rendered = attachedFilesManifest([{ name: "spec.pdf", size: 1234, path: "/state/files/spec.pdf" }]);
+    expect(rendered).toContain("spec.pdf");
+    expect(rendered).toContain("1234");
+    expect(rendered).toContain("/state/files/spec.pdf");
+    // The earlier wording was "read them with your tools" — an assumption about the reader. An
+    // assumption has to be verified, which is where a capability flag threaded through eight files
+    // came from. An agent with a file tool decides for itself; one without says it cannot. Neither
+    // needs this line to have guessed first.
+    expect(rendered).not.toMatch(/your tools|read them/i);
+  });
+
+  it("renders nothing for no files", () => {
+    expect(attachedFilesManifest([])).toBe("");
   });
 });


### PR DESCRIPTION
Removes the capability flag that #331 threaded through eight files, by removing the assumption that
made it necessary.

## One half-sentence

The attachment manifest said:

```
[attached files — read them with your tools: …]
```

"read them with your tools" is an assumption about the reader, and an assumption has to be verified.
That verification is where all of this came from:

| | |
|---|---|
| `canReadLocalFiles` | threaded config → CLI → serve → `ChannelContext` → 3 transports → invoke-turn |
| `codingToolNames.includes("read")` | the same derivation, written **9 times** |
| `LocalFileAccessUnavailable`, `ATTACHMENT_UNSUPPORTED_CODE`, `unreadableAttachmentsNote`, a `defaultErrorMessage` branch | the machinery for refusing when the assumption failed |

## Images never needed any of it

```ts
interface ImageRef { mimeType: string; data: string; }   // a value
interface DownloadedFile { path: string; name: string; size: number; }   // a reference
```

`ImageRef` carries `data`, so a channel hands over a value and the engine decides what to do with
it. **No channel anywhere asks whether the model has vision** — zero occurrences of any such check.

A file carried a path — a reference, which only means something if the holder can dereference it.
That is the entire difference, and it is why the agent's tool configuration leaked into every
channel.

## What replaces it

The manifest states name, size and path. Nothing else changes hands.

An agent with a file tool decides for itself whether to open one and how much of it to read (`read`
takes offset/limit — better than any threshold we could have picked). An agent without one answers
that it cannot: visible, and the direct consequence of its own `codingTools`, which is what
configuring a capability means.

A considered and rejected middle: inlining small text files below some size threshold, so a
tool-less agent could still read them. It trades one guess for another — the channel would be
deciding *whether the agent needs the content* instead of *whether it can read it* — and the number
would have been mine, not measured. If usage later shows tool-free attachment reading matters, it
can be added against evidence.

## The same assumption, one size smaller

`report.ts` had a pre-flight version of it: at assembly, warn when a definition lists model-visible
skills while mounting no `read`. Removed too, along with `AssemblyFinding`, the `assemblyFindings`
key in `info --json`, and `reportFindingsIfChanged`'s third parameter.

Its answer was already wrong in a case #331 itself established. Authors may define their own tool
named `read` — `disabledBuiltinNames` subtracts exactly that name from the exclusion list — so
`codingTools: false` plus `tools/read.ts` is a perfectly readable agent that this check warned about
anyway. Every new way to have a reader is another way for a pre-flight guess to be wrong.

What it bought was hearing at startup rather than at first use, and it only ever warned, so nothing
was gated on it. An agent asked to use a skill it cannot open says so — same visibility, one turn
later, no guess.

**Public surface note:** `info --json` no longer emits `assemblyFindings`. `diagnostics` keeps its
original meaning (per-skill parse problems), and `docs/cli.md` is updated.

## Validation

- [x] `npm run lint`, `npm run typecheck`, `npm test` (108 files, 1376 tests)
- [x] `rv.sh local` — **No findings.** It caught two tests that asserted removed behaviour, one of
      which had been passing for an unrelated reason
- [x] Net **−408 lines**

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs updated (`docs/configuration.md`, `docs/api-reference.md`)

