### PR TITLE
docs(readme): the public-surface table matches what the package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The root export intentionally contains the supported surface only.
 | Area | Examples | Stability |
 |---|---|---|
 | Contract | `Agent`, `AgentEvent`, `collect` | Stable within SPEC v0.1 |
-| The whole agent | `createAgentService`, `AgentService` | The supported way to mount a directory in an app |
+| Directory → service | `createAgentService`, `AgentService` | The supported way to mount an agent directory in an app |
 | Mounting | `createInvokeHandler`, `nodeListener`, `serveNode`, `Routes` | Reference implementation, pre-1.0 |
 | pi assembly | `createPiAgentFromDir`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
 | Tool/channel authoring | `defineTool`, `z`, `loadTools`, `loadChannels`, `ChannelModule` | Usable now, may tighten before 1.0 |

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ The root export intentionally contains the supported surface only.
 
 Subpath entry points (`./package.json` is also exported, for tools that read the version):
 
-- `@fastagent-sh/fastagent/core` — engine-neutral contract, consumption helpers, channel kit, schedules;
-- `@fastagent-sh/fastagent/session` — the engine-neutral session-control contract and its remote clients;
+- `@fastagent-sh/fastagent/core` — engine-neutral contract, consumption helpers, channel kit, schedules, and the session-control clients (`connectSessionControl`, `connectAgent`);
+- `@fastagent-sh/fastagent/session` — the engine-neutral session-control contract (types and error codes);
 - `@fastagent-sh/fastagent/pi` — the pi reference implementation;
 - `@fastagent-sh/fastagent/github` — GitHub webhook channel;
 - `@fastagent-sh/fastagent/telegram` — Telegram bot channel;

--- a/README.md
+++ b/README.md
@@ -165,14 +165,16 @@ The root export intentionally contains the supported surface only.
 | pi assembly | `createPiAgentFromDir`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
 | Tool/channel authoring | `defineTool`, `z`, `loadTools`, `loadChannels`, `ChannelModule` | Usable now, may tighten before 1.0 |
 | Injection ports | `PiSessionRecordStore`, `piSessionRecordStore`, `piInMemorySessionRecordStore`, `Lease`, `Provider`, `createProvider` | Public because options reference them |
-| Not exported | Assembly parts (`router`, the control plane), prompt/config internals | Internal modules; no compatibility promise |
+| Not exported | Assembly parts (`router`, `createControlPlane`), prompt/config internals | Internal modules; no compatibility promise |
 
 Subpath exports:
 
-- `@fastagent-sh/fastagent/core` — engine-neutral contract, consumption helpers, channel/host kit, schedules;
+- `@fastagent-sh/fastagent/core` — engine-neutral contract, consumption helpers, channel kit, schedules;
+- `@fastagent-sh/fastagent/session` — the engine-neutral session-control contract and its remote clients;
 - `@fastagent-sh/fastagent/pi` — the pi reference implementation;
 - `@fastagent-sh/fastagent/github` — GitHub webhook channel;
 - `@fastagent-sh/fastagent/telegram` — Telegram bot channel;
+- `@fastagent-sh/fastagent/slack` — Slack Events API bot channel;
 - `@fastagent-sh/fastagent/feishu` — canonical Feishu bot channel (飞书, open.feishu.cn);
 - `@fastagent-sh/fastagent/lark` — Lark-international compatibility profile over the Feishu engine.
 

--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ The root export intentionally contains the supported surface only.
 | Area | Examples | Stability |
 |---|---|---|
 | Contract | `Agent`, `AgentEvent`, `collect` | Stable within SPEC v0.1 |
-| Channels/host | `createInvokeHandler`, `nodeListener`, `serveNode`, `router`, `Routes` | Reference implementation, pre-1.0 |
+| The whole agent | `createAgentService`, `AgentService` | The supported way to mount a directory in an app |
+| Mounting | `createInvokeHandler`, `nodeListener`, `serveNode`, `Routes` | Reference implementation, pre-1.0 |
 | pi assembly | `createPiAgentFromDir`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
 | Tool/channel authoring | `defineTool`, `z`, `loadTools`, `loadChannels`, `ChannelModule` | Usable now, may tighten before 1.0 |
-| Injection ports | `PiSessionStore`, `inMemorySessionStore`, `jsonlSessionStore`, `Lease`, `Provider`, `createProvider` | Public because options reference them |
-| Not exported | L0 harness adapter, pi harness factory, prompt/config internals | Internal modules; no compatibility promise |
+| Injection ports | `PiSessionRecordStore`, `piSessionRecordStore`, `piInMemorySessionRecordStore`, `Lease`, `Provider`, `createProvider` | Public because options reference them |
+| Not exported | Assembly parts (`router`, the control plane), prompt/config internals | Internal modules; no compatibility promise |
 
 Subpath exports:
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The root export intentionally contains the supported surface only.
 | Injection ports | `PiSessionRecordStore`, `piSessionRecordStore`, `piInMemorySessionRecordStore`, `Lease`, `Provider`, `createProvider` | Public because options reference them |
 | Not exported | Assembly parts (`router`, `createControlPlane`), prompt/config internals | Internal modules; no compatibility promise |
 
-Subpath exports:
+Subpath entry points (`./package.json` is also exported, for tools that read the version):
 
 - `@fastagent-sh/fastagent/core` — engine-neutral contract, consumption helpers, channel kit, schedules;
 - `@fastagent-sh/fastagent/session` — the engine-neutral session-control contract and its remote clients;


### PR DESCRIPTION
Pre-release audit of the published package found the README's surface section describing a shape two releases old.

Verified by installing the packed tarball into a clean project and importing every documented name.

| Claim | Reality |
|---|---|
| `PiSessionStore`, `inMemorySessionStore`, `jsonlSessionStore` listed as injection ports | Removed in #341; the replacements are `PiSessionRecordStore` / `piSessionRecordStore` / `piInMemorySessionRecordStore` |
| `router` listed under Channels/host | Made internal in #355 |
| "L0 harness adapter, pi harness factory" listed as not-exported | The harness path was deleted entirely in #341 |
| Subpath list | Missing `/session` and `/slack` |
| `/session` described as carrying the remote clients | `connectSessionControl` / `connectAgent` are exported by `/core` — the description pointed at the wrong import |

Also adds the row for `createAgentService` (#355), which the table never gained.

The rest of the pre-release audit came back clean: lint/typecheck/1454 tests, knip, `npm pack` → install → CLI, `init`, and `deploy agentcore` end to end (the generated `lambda/index.js` is byte-identical to the packaged source), every production dependency has real importers, no dev dependency reaches `src/`, and no documented function name is missing from the package.