### PR TITLE
refactor(surface): the public API is the product, not the parts that build it

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,15 +157,19 @@ const agent = createPiAgent({
 
 The root export intentionally contains the supported surface only.
 
+`Provider` and `ProviderAuth` are exported as types because our options name them; the factory that
+builds one, `createProvider`, comes from `@earendil-works/pi-ai` — add it as a direct dependency when
+you register a custom provider.
+
 | Area | Examples | Stability |
 |---|---|---|
 | Contract | `Agent`, `AgentEvent`, `collect` | Stable within SPEC v0.1 |
 | Directory → service | `createAgentService`, `AgentService` | The supported way to mount an agent directory in an app |
 | Mounting | `createInvokeHandler`, `nodeListener`, `serveNode`, `Routes` | Reference implementation, pre-1.0 |
 | pi assembly | `createPiAgentFromDir`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
-| Tool/channel authoring | `defineTool`, `z`, `loadTools`, `loadChannels`, `ChannelModule` | Usable now, may tighten before 1.0 |
-| Injection ports | `PiSessionRecordStore`, `piSessionRecordStore`, `piInMemorySessionRecordStore`, `Lease`, `Provider`, `createProvider` | Public because options reference them |
-| Not exported | Assembly parts (`router`, `createControlPlane`), prompt/config internals | Internal modules; no compatibility promise |
+| Tool/channel authoring | `defineTool`, `z`, `defineSchedule`, `ChannelModule` | Usable now, may tighten before 1.0 |
+| Injection ports | `PiSessionRecordStore`, `piSessionRecordStore`, `piInMemorySessionRecordStore`, `Lease`, `Provider` | Public because options reference them |
+| Not exported | The assembly's parts — `router`, `createControlPlane`, `loadTools`/`loadChannels`/`loadSchedules`, `createScheduler` — and prompt/config internals | `createAgentService` does this; no compatibility promise |
 
 Subpath entry points (`./package.json` is also exported, for tools that read the version):
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -250,7 +250,7 @@ export default defineTool({
 });
 ```
 
-`tools/<name>.ts` files are discovered with `loadTools(dir)`, and the filename becomes the tool name.
+`tools/<name>.ts` files are discovered by the assembly, and the filename becomes the tool name.
 
 The second `execute` argument is a `ToolContext`:
 
@@ -332,17 +332,6 @@ interface LongConnectionChannelModule {
   name: string;
   connect(ctx: ChannelContext, signal: AbortSignal): LongConnection;
 }
-function loadChannels(
-  dir: string,
-  ctx: ChannelContext,
-): Promise<{
-  routes: Routes;
-  longConnections: LoadedLongConnectionChannel[];
-  routeChannels: string[];
-  longConnectionChannels: string[];
-  collisions: ChannelCollision[];
-  failures: ModuleLoadFailure[];
-}>;
 ```
 
 An agent channel default-exports either a route `ChannelModule` or a
@@ -373,11 +362,6 @@ interface Schedule {
   prompt: string; // the turn's text = the job's instruction
 }
 function defineSchedule(schedule: Schedule): Schedule;
-function loadSchedules(dir: string): Promise<{ schedules: LoadedSchedule[]; failures: ModuleLoadFailure[] }>;
-function discoverScheduleFiles(dir: string): Promise<string[]>; // existence probe: file basenames, no import
-// (deploy preflight's time-trigger detection; prefer loadSchedules to also surface broken files)
-function createScheduler(opts: SchedulerOptions): Scheduler; // { start(): void; stop(): void }
-function scheduleSession(name: string): string; // the derived stable session id
 ```
 
 An agent declares time-triggers by dropping `schedules/<name>.ts`, mirroring `tools/`/`channels/`;
@@ -398,7 +382,7 @@ The scheduler is a time-trigger (the N axis, clock form): on each cron instant i
 with `prompt` — borrowing the same `Agent` contract as channels, adding none. It:
 
 - **carries no `session` field** — a session id is runtime conversational context, not a build-time
-  value. It derives a stable per-schedule session (`scheduleSession(name)` = `schedule:<name>`), so a
+  value. It derives a stable per-schedule session (`schedule:<name>`), so a
   schedule's turns share one continuing conversation persisted by the core session store (zero-touch on
   storage, like the telegram channel deriving a session from `chat.id`);
 - **delivers nothing** — output is the agent's tools' job; the scheduler only fires and logs the outcome;
@@ -406,7 +390,7 @@ with `prompt` — borrowing the same `Agent` contract as channels, adding none. 
   last fire; a run missed while the process was down fires once on the next start (not per missed slot),
   claimed before the invoke (at-most-once per slot).
 
-Single-process (like all state today). `createScheduler({ agent, stateRoot, schedules })` is started by
+Single-process (like all state today). The scheduler is started by
 the serve path (`dev`/`start`); `fastagent fire <name>` runs one schedule's turn immediately for authoring.
 
 **Self-scheduling.** Opt in with `selfSchedule: true` in `fastagent.config` (off by default — an autonomy
@@ -445,11 +429,9 @@ to read the project's credential (the `createPiAgentFrom*` openers already do).
 
 Provider injection:
 
-```ts
-function createProvider(...): Provider;
-```
-
-`createProvider`, `Provider`, `ProviderAuth`, and `Model` are re-exported from pi's model layer so callers do not need to depend on FastAgent internals.
+`Provider`, `ProviderAuth` and `Model` are re-exported as TYPES because they appear in our options —
+a caller must be able to name them. The factory that builds one is pi's own: import `createProvider`
+from `@earendil-works/pi-ai` directly, so its API answers to its own package.
 
 ## Sessions and leases
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -214,8 +214,9 @@ Static keys belong in the login file or the environment, not in code — there i
 When your model source needs per-request logic — minting or rotating a token, calling an auth service — register it as a provider; a `model` spec then selects it by id. This is the one case that touches the engine's provider layer — built-in providers cover everything else.
 
 ```ts
-import { createPiAgent, createProvider } from "@fastagent-sh/fastagent";
-// the wire-protocol impl comes from pi-ai's api subpath (reuse, don't reimplement)
+import { createPiAgent } from "@fastagent-sh/fastagent";
+// Both come from pi-ai: the provider factory and the wire-protocol impl (reuse, don't reimplement).
+import { createProvider } from "@earendil-works/pi-ai";
 import { /* the matching api impl */ } from "@earendil-works/pi-ai/api/openai-responses";
 
 const myGateway = createProvider({

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-// Engine-neutral Agent Handler contract, consumption helpers, host/channel kit, and time triggers.
+// Engine-neutral Agent Handler contract, consumption helpers, channel kit, and time triggers.
 // Import this subpath from channel packages or contract-only integrations to avoid loading the pi runtime.
 // Session-control layering (design §1): the CONTRACT (SessionControl types, error codes) lives
 // behind the `/session` subpath so interactive serving does not grow the minimal handler contract,
@@ -34,6 +34,6 @@ export type {
 // `createAgentService` assembles a service — not something a caller has to reproduce.
 export { nodeListener, serveNode } from "./channels/serve.ts";
 
+// `defineSchedule` is what a `schedules/*.ts` file is written against. Discovering those files and
+// running the clock is what `createAgentService` does with them — parts a caller does not reproduce.
 export { defineSchedule, type LoadedSchedule, type Schedule } from "./schedule/schedule.ts";
-export { discoverScheduleFiles, loadSchedules } from "./schedule/discover.ts";
-export { createScheduler, scheduleSession, type Scheduler, type SchedulerOptions } from "./schedule/scheduler.ts";

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -24,9 +24,6 @@ export type { AgentTool, ExecutionEnv, Skill, SkillDiagnostic } from "@earendil-
  */
 export type { SessionManager, SessionEntry as PiSessionEntry } from "@earendil-works/pi-coding-agent";
 
-// The collision TYPES surface in a service's diagnostics; the loaders that produce them are the
-// assembly's, not a caller's.
-export type { ChannelCollision } from "./engines/pi/channel.ts";
 export {
   createPiAgentFromDir,
   type CreatePiAgentFromDirOptions,

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -8,7 +8,6 @@ export {
 
 export {
   defineTool,
-  loadTools,
   type DefineToolOptions,
   type FastagentTool,
   type MountedTool,
@@ -25,7 +24,9 @@ export type { AgentTool, ExecutionEnv, Skill, SkillDiagnostic } from "@earendil-
  */
 export type { SessionManager, SessionEntry as PiSessionEntry } from "@earendil-works/pi-coding-agent";
 
-export { loadChannels, type ChannelCollision } from "./engines/pi/channel.ts";
+// The collision TYPES surface in a service's diagnostics; the loaders that produce them are the
+// assembly's, not a caller's.
+export type { ChannelCollision } from "./engines/pi/channel.ts";
 export {
   createPiAgentFromDir,
   type CreatePiAgentFromDirOptions,
@@ -54,7 +55,10 @@ export type { SessionInheritance } from "./engines/pi/session-inheritance.ts";
 export { GLOBAL_AUTH_PATH, fastagentCredentialStore, type FastagentAuthOptions } from "./engines/pi/auth.ts";
 export { createPiModels, probeAuthSource, type CreatePiModelsOptions } from "./engines/pi/models.ts";
 export type { Models } from "@earendil-works/pi-ai";
-export { createProvider, type Provider, type ProviderAuth } from "@earendil-works/pi-ai";
+// Types only: they appear in our signatures, so a caller must be able to name them. `createProvider`
+// is pi-ai's own runtime function — forwarding it would make us answerable for its API without
+// adding anything; import it from `@earendil-works/pi-ai` directly.
+export type { Provider, ProviderAuth } from "@earendil-works/pi-ai";
 export type { Model } from "@earendil-works/pi-ai";
 
 // The product's one-call assembly: a directory becomes a live service. On the pi surface because

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Agent } from "../src/index.ts";
-import { loadChannels } from "../src/index.ts";
+import { loadChannels } from "../src/engines/pi/channel.ts";
 import { discoverChannelFiles, inspectChannels } from "../src/engines/pi/channel.ts";
 
 // loadChannels only forwards the ctx to the factory; these factories ignore it.

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -148,6 +148,19 @@ describe("the assembly's parts stay out of the public surface", () => {
   // exporting one is a promise with no caller.
   const ORPHAN_TYPES = ["ChannelCollision", "Scheduler", "SchedulerOptions"];
 
+  it("the curated entries name every export, so nothing rides in behind a wildcard", () => {
+    // This is what makes the two checks below sufficient. A `export *` — or `export type *`, which
+    // leaves no runtime trace at all — would re-export whatever its target grows next, and neither a
+    // name list nor a module import can see that coming.
+    for (const entry of ["core.ts", "pi.ts", "session.ts"]) {
+      expect(readFileSync(resolve(srcDir, entry), "utf8"), entry).not.toMatch(/export\s+(?:type\s+)?\*/);
+    }
+    // The root is the all-in-one, and may forward the curated three — but only those.
+    const index = readFileSync(resolve(srcDir, "index.ts"), "utf8");
+    const targets = [...index.matchAll(/export\s+(?:type\s+)?\*\s+from\s+"([^"]+)"/g)].map((m) => m[1]);
+    expect(targets.sort()).toEqual(["./core.ts", "./pi.ts", "./session.ts"]);
+  });
+
   for (const entry of ["core.ts", "pi.ts", "index.ts"]) {
     it(`${entry} exports no assembly part`, async () => {
       // The MODULE, so a later `export *` cannot smuggle one past a regex over the text.

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -144,12 +144,32 @@ describe("the assembly's parts stay out of the public surface", () => {
     "createProvider",
   ];
 
+  // Types the parts drag along: nothing public references them once their producer is internal, so
+  // exporting one is a promise with no caller.
+  const ORPHAN_TYPES = ["ChannelCollision", "Scheduler", "SchedulerOptions"];
+
   for (const entry of ["core.ts", "pi.ts", "index.ts"]) {
     it(`${entry} exports no assembly part`, async () => {
-      // The MODULE, not its source: a `export *` added later would satisfy a regex over the text
-      // while re-exporting everything behind it.
+      // The MODULE, so a later `export *` cannot smuggle one past a regex over the text.
       const mod = (await import(resolve(srcDir, entry))) as Record<string, unknown>;
       expect(PARTS.filter((p) => p in mod)).toEqual([]);
+    });
+
+    it(`${entry} exports no orphaned type`, () => {
+      // The SOURCE, because a type export leaves no runtime trace for the check above to see.
+      const source = readFileSync(resolve(srcDir, entry), "utf8");
+      const named = [...source.matchAll(/export (?:type )?\{([^}]*)\}/g)]
+        .flatMap((m) => m[1]!.split(","))
+        .map((raw) =>
+          raw
+            .trim()
+            .replace(/^type\s+/, "")
+            .split(/\s+as\s+/)
+            .pop()!
+            .trim(),
+        )
+        .filter(Boolean);
+      expect(named.filter((n) => ORPHAN_TYPES.includes(n))).toEqual([]);
     });
   }
 });

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -128,6 +128,41 @@ describe("the public subpaths do not reach into the CLI", () => {
   }
 });
 
+describe("the assembly's parts stay out of the public surface", () => {
+  // Each of these was public once. They are how `createAgentService` builds a service, not something
+  // a caller reproduces — and every one of them re-exported is a promise we then have to keep.
+  const PARTS = [
+    "router",
+    "createControlPlane",
+    "loadTools",
+    "loadChannels",
+    "loadSchedules",
+    "discoverScheduleFiles",
+    "createScheduler",
+    "scheduleSession",
+    // pi-ai's own runtime function: forwarding it makes us answerable for an API we do not own.
+    "createProvider",
+  ];
+
+  for (const entry of ["core.ts", "pi.ts", "index.ts"]) {
+    it(`${entry} exports no assembly part`, () => {
+      const source = readFileSync(resolve(srcDir, entry), "utf8");
+      // Value exports only — a TYPE of the same name may legitimately surface in a signature.
+      const values = [...source.matchAll(/export \{([^}]*)\}/g)]
+        .flatMap((m) => m[1]!.split(","))
+        .map((raw) => raw.trim())
+        .filter((raw) => raw !== "" && !raw.startsWith("type "))
+        .map((raw) =>
+          raw
+            .split(/\s+as\s+/)
+            .pop()!
+            .trim(),
+        );
+      expect(values.filter((v) => PARTS.includes(v))).toEqual([]);
+    });
+  }
+});
+
 describe("the contracts depend on nothing", () => {
   // agent.ts (what an engine implements), channel.ts (what a trigger implements) and session.ts (the
   // serving control plane) are the three product contracts — pure types, zero packages. The bar is

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -145,7 +145,10 @@ describe("the assembly's parts stay out of the public surface", () => {
   ];
 
   // Types the parts drag along: nothing public references them once their producer is internal, so
-  // exporting one is a promise with no caller.
+  // exporting one is a promise with no caller. This list guards against RE-EXPORTING them, which is
+  // how each left. It does not — and is not meant to — stop someone declaring a fresh type of the
+  // same name at an entry: the wildcard check above already removes every path by which something
+  // arrives here unnoticed, and what remains is a line somebody wrote on purpose.
   const ORPHAN_TYPES = ["ChannelCollision", "Scheduler", "SchedulerOptions"];
 
   it("the curated entries name every export, so nothing rides in behind a wildcard", () => {

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -130,7 +130,7 @@ describe("the public subpaths do not reach into the CLI", () => {
 
 describe("the assembly's parts stay out of the public surface", () => {
   // Each of these was public once. They are how `createAgentService` builds a service, not something
-  // a caller reproduces — and every one of them re-exported is a promise we then have to keep.
+  // a caller reproduces — and every one re-exported is a promise we then have to keep.
   const PARTS = [
     "router",
     "createControlPlane",
@@ -145,20 +145,11 @@ describe("the assembly's parts stay out of the public surface", () => {
   ];
 
   for (const entry of ["core.ts", "pi.ts", "index.ts"]) {
-    it(`${entry} exports no assembly part`, () => {
-      const source = readFileSync(resolve(srcDir, entry), "utf8");
-      // Value exports only — a TYPE of the same name may legitimately surface in a signature.
-      const values = [...source.matchAll(/export \{([^}]*)\}/g)]
-        .flatMap((m) => m[1]!.split(","))
-        .map((raw) => raw.trim())
-        .filter((raw) => raw !== "" && !raw.startsWith("type "))
-        .map((raw) =>
-          raw
-            .split(/\s+as\s+/)
-            .pop()!
-            .trim(),
-        );
-      expect(values.filter((v) => PARTS.includes(v))).toEqual([]);
+    it(`${entry} exports no assembly part`, async () => {
+      // The MODULE, not its source: a `export *` added later would satisfy a regex over the text
+      // while re-exporting everything behind it.
+      const mod = (await import(resolve(srcDir, entry))) as Record<string, unknown>;
+      expect(PARTS.filter((p) => p in mod)).toEqual([]);
     });
   }
 });

--- a/test/tool.test.ts
+++ b/test/tool.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { defineTool, loadTools, z } from "../src/index.ts";
+import { defineTool, z } from "../src/index.ts";
+import { loadTools } from "../src/engines/pi/tool.ts";
 import { CODING_TOOL_NAMES, resolveAgentTools } from "../src/engines/pi/create.ts";
 
 describe("defineTool", () => {


### PR DESCRIPTION
Four findings from the pre-release audit of the published surface. Each is the same question — does a caller who is not reimplementing `createAgentService` have a reason to reach for this?

## 1. Assembly parts left the surface

`createAgentService` (#355) discovers channels, tools and schedules, and owns the scheduler's lifetime. The functions that do those things were still exported:

| Removed | Why it was there |
|---|---|
| `loadTools`, `loadChannels` | Filesystem discovery — the service already did it |
| `loadSchedules`, `discoverScheduleFiles` | Same, for `schedules/*.ts` |
| `createScheduler`, `scheduleSession` | The service starts and stops the clock |

None appeared in a scaffold template, and the docs referenced them only as reference entries — no tutorial taught them. `defineSchedule` stays: it is what a `schedules/*.ts` file is written against.

## 2. `createProvider` goes back to its own package

`Provider` and `ProviderAuth` stay as TYPES because our options name them, so a caller must be able to write them down. The factory is pi-ai's own function, and forwarding it made us answerable for an API we do not own without adding anything. `docs/embedding.md` now imports it from `@earendil-works/pi-ai`, where it lives.

## 3. `ChannelCollision` had no reachable caller

Its only appearance in the public types was `loadChannels`' return. With that internal, the type was a promise nobody could use. `ToolCollision` and `SkillCollision` stay — they surface in what `createPiAgent*` returns.

## 4. `core.ts` still said "host/channel kit"

`src/host/` was deleted in #355.

## The guard this needed

`test/package-boundary.test.ts` had nothing pinning any of it, so a re-export would silently undo the lot. Three checks now, because each catches what the others cannot:

| Check | Catches |
|---|---|
| The curated entries (`core`/`pi`/`session`) contain no `export *` or `export type *`; `index.ts` may wildcard only those three | Anything arriving unnoticed behind a wildcard — including `export type *`, which leaves no runtime trace |
| Importing each entry and asserting the parts are absent | A value re-export, however it is spelled |
| Scanning the source for orphaned type names | A type re-export, which the runtime check cannot see |

Verified by attempting each smuggling route — `export *`, `export type *`, a wildcard into an internal module from `index.ts`, an explicit value re-export, and a type-only re-export. All five go red.

The orphan list guards against re-exporting; it deliberately does not try to stop someone declaring a fresh type of the same name at an entry, which the wildcard check makes a deliberate act rather than an accident.
