### PR TITLE
refactor(core): the neutral entry costs nothing to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ you register a custom provider.
 |---|---|---|
 | Contract | `Agent`, `AgentEvent`, `collect` | Stable within SPEC v0.1 |
 | Directory → service | `createAgentService`, `AgentService` | The supported way to mount an agent directory in an app |
-| Mounting | `createInvokeHandler`, `nodeListener`, `serveNode`, `Routes` | Reference implementation, pre-1.0 |
+| Mounting | `createInvokeHandler`, `Routes`, `ChannelHandler` | Reference implementation, pre-1.0 |
+| Node binding | `nodeListener`, `serveNode` (from `/node`) | The one runtime-specific piece; see below |
 | pi assembly | `createPiAgentFromDir`, `createPiAgentFromDefinition`, `createPiAgent` | Usable now, may tighten before 1.0 |
 | Tool/channel authoring | `defineTool`, `z`, `defineSchedule`, `ChannelModule` | Usable now, may tighten before 1.0 |
 | Injection ports | `PiSessionRecordStore`, `piSessionRecordStore`, `piInMemorySessionRecordStore`, `Lease`, `Provider` | Public because options reference them |
@@ -173,7 +174,8 @@ you register a custom provider.
 
 Subpath entry points (`./package.json` is also exported, for tools that read the version):
 
-- `@fastagent-sh/fastagent/core` — engine-neutral contract, consumption helpers, channel kit, schedules, and the session-control clients (`connectSessionControl`, `connectAgent`);
+- `@fastagent-sh/fastagent/core` — engine-neutral contract, consumption helpers, channel kit, schedules, and the session-control clients (`connectSessionControl`, `connectAgent`). **Zero third-party dependencies**, enforced by test;
+- `@fastagent-sh/fastagent/node` — `serveNode` / `nodeListener`, the `node:http` ↔ Fetch binding. Separate because it is the only runtime-specific piece, and the only one that costs a package;
 - `@fastagent-sh/fastagent/session` — the engine-neutral session-control contract (types and error codes);
 - `@fastagent-sh/fastagent/pi` — the pi reference implementation;
 - `@fastagent-sh/fastagent/github` — GitHub webhook channel;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -84,6 +84,8 @@ a dead connection — parse per the SSE spec (only `data:` lines carry events), 
 JSON.
 
 ```ts
+// From `@fastagent-sh/fastagent/node` — the only runtime-specific entry, and the only one that
+// costs a third-party package (the node:http ↔ Fetch bridge).
 function nodeListener(handler: ChannelHandler): (req, res) => void;
 // `host` is the bind address; unset binds all interfaces (what containers need).
 function serveNode(handler: ChannelHandler, options: { port: number; host?: string }): {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/core.d.ts",
       "default": "./dist/core.js"
     },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "default": "./dist/node.js"
+    },
     "./session": {
       "types": "./dist/session.d.ts",
       "default": "./dist/session.js"

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,5 @@
 // Engine-neutral Agent Handler contract, consumption helpers, channel kit, and time triggers.
+// ZERO third-party dependencies, enforced by test — the Node HTTP binding lives at `/node`.
 // Import this subpath from channel packages or contract-only integrations to avoid loading the pi runtime.
 // Session-control layering (design §1): the CONTRACT (SessionControl types, error codes) lives
 // behind the `/session` subpath so interactive serving does not grow the minimal handler contract,
@@ -32,7 +33,8 @@ export type {
 } from "./channel.ts";
 // Mounting only. Composing a route table (`router`) and owning a prefix (`PrefixMount`) are how
 // `createAgentService` assembles a service — not something a caller has to reproduce.
-export { nodeListener, serveNode } from "./channels/serve.ts";
+// Binding to a Node server lives at `/node`: it is the only runtime-specific piece here, and the
+// only one that costs a third-party package.
 
 // `defineSchedule` is what a `schedules/*.ts` file is written against. Discovering those files and
 // running the clock is what `createAgentService` does with them — parts a caller does not reproduce.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@
 // Contract/channel-only consumers should prefer `@fastagent-sh/fastagent/core`; pi-specific consumers
 // may use `@fastagent-sh/fastagent/pi`. The root remains the supported all-in-one surface.
 export * from "./core.ts";
+export * from "./node.ts";
 export * from "./session.ts";
 export * from "./pi.ts";

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,0 +1,13 @@
+/**
+ * Binding a Fetch handler to a Node HTTP server.
+ *
+ * Its own entry point because it is the one piece of the neutral surface that is RUNTIME-specific:
+ * `@hono/node-server` bridges `node:http` ↔ Fetch, and that package is the only third-party weight
+ * anywhere behind `/core`. Keeping it here lets a channel package or another engine import the
+ * contract without pulling a Node HTTP bridge it will never call — and lets a non-Node runtime
+ * (Workers, Deno, Bun's own server) consume `/core` unchanged.
+ *
+ * Engine-neutral is not the same as runtime-neutral; `/core` is both, and this is where the second
+ * one is spent.
+ */
+export { nodeListener, serveNode } from "./channels/serve.ts";

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -17,7 +17,9 @@ const srcDir = resolve(dirname(fileURLToPath(import.meta.url)), "../src");
 function staticPackageGraph(entryRel: string): Set<string> {
   const visited = new Set<string>();
   const packages = new Set<string>();
-  const fromRe = /^\s*(?:import|export)\b[^;]*?\bfrom\s*["']([^"']+)["']/gm;
+  // `import type` / `export type` are erased at compile time, so they cost a consumer nothing. A
+  // graph that counted them would report a dependency the published .js does not have.
+  const fromRe = /^\s*(?:import|export)\s+(?!type\b)[^;]*?\bfrom\s*["']([^"']+)["']/gm;
   const bareRe = /^\s*import\s+["']([^"']+)["']/gm;
 
   const visit = (fileAbs: string): void => {
@@ -155,13 +157,13 @@ describe("the assembly's parts stay out of the public surface", () => {
     // This is what makes the two checks below sufficient. A `export *` — or `export type *`, which
     // leaves no runtime trace at all — would re-export whatever its target grows next, and neither a
     // name list nor a module import can see that coming.
-    for (const entry of ["core.ts", "pi.ts", "session.ts"]) {
+    for (const entry of ["core.ts", "node.ts", "pi.ts", "session.ts"]) {
       expect(readFileSync(resolve(srcDir, entry), "utf8"), entry).not.toMatch(/export\s+(?:type\s+)?\*/);
     }
     // The root is the all-in-one, and may forward the curated three — but only those.
     const index = readFileSync(resolve(srcDir, "index.ts"), "utf8");
     const targets = [...index.matchAll(/export\s+(?:type\s+)?\*\s+from\s+"([^"]+)"/g)].map((m) => m[1]);
-    expect(targets.sort()).toEqual(["./core.ts", "./pi.ts", "./session.ts"]);
+    expect(targets.sort()).toEqual(["./core.ts", "./node.ts", "./pi.ts", "./session.ts"]);
   });
 
   for (const entry of ["core.ts", "pi.ts", "index.ts"]) {
@@ -201,6 +203,14 @@ describe("the contracts depend on nothing", () => {
       expect([...staticPackageGraph(contract)]).toEqual([]);
     });
   }
+
+  it("the /core entry costs nothing to import — the Node binding is at /node", () => {
+    // A channel package or a second engine takes `/core` for the contract and the fetch-shaped kit.
+    // Before `/node` existed, that import also pulled a node:http bridge it would never call (and,
+    // earlier still, a cron library). ZERO is the property; `/node` is where the cost is paid.
+    expect([...staticPackageGraph("core.ts")]).toEqual([]);
+    expect([...staticPackageGraph("node.ts")]).toEqual(["@hono/node-server"]);
+  });
 
   it("...and the mechanism that serves them depends on one, for the node bridge only", () => {
     // The guard has teeth: serving pulls a package, contracts pull none. What it pulls is the


### PR DESCRIPTION
Depends on #362 (branched from it).

`/core` exists so a channel package or a second engine can take the contract without the pi runtime. It was not free to take: importing it pulled `@hono/node-server` and `croner`.

#362 removes the scheduler parts, which takes `croner` with them. That leaves one package, from two functions:

```
/core            @hono/node-server        ← serve.js
  └ serve.js     @hono/node-server        ← nodeListener / serveNode
  └ everything else                        zero
```

So `serveNode` and `nodeListener` move to `@fastagent-sh/fastagent/node`, and `/core` becomes **zero third-party dependencies** — asserted, not claimed.

## Why a separate entry rather than a smaller /core

Engine-neutral and runtime-neutral are different properties. `/core` is both; the Node HTTP binding is the one place the second is spent, and `@hono/node-server` exists precisely to bridge `node:http` ↔ Fetch. A consumer on Workers, Deno, or Bun's own server now takes `/core` unchanged, and a channel package importing `ChannelModule` no longer inherits a server it will never start.

The root entry re-exports `/node`, so `import { serveNode } from "@fastagent-sh/fastagent"` is unchanged — which is what every doc example uses.

## A guard that was quietly wrong

`staticPackageGraph` counted `import type` as a dependency. Type imports are erased at compile time, so it was reporting packages the published `.js` does not load — the three "contracts depend on nothing" tests passed while being stricter than the property they describe. Now the graph matches the emitted output, which is what a consumer actually installs.

Verified: putting the Node binding back into `core.ts` goes red, and reverting the type-import fix goes red too (it reports a dependency the build does not have).

Also checked against a packed tarball installed in a clean project: `/core` exports 10 names and no `serveNode`; `/node` exports the two; the root still has both.
