### PR TITLE
docs: catch the docs up to four rounds of refactoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ src/
 │                           # channel author must not pull node:http in behind a type import.
 ├── collect.ts               # caller-side stream helpers: collect (buffered consumption) + abortFirstIterator (shared cancellation protocol)
 ├── core.ts, node.ts,        # THE THREE LAYERS, split by what each costs to import: core (+session)
-│   pi.ts                 # is engine- AND runtime-neutral with ZERO packages; node adds what needs
+│   pi.ts                    # is engine- AND runtime-neutral with ZERO packages; node adds what needs
 │                           # a Node runtime (the assembly, the http binding); pi names an engine.
 │                           # Every layer's dependency list is asserted in package-boundary.test.ts.
 ├── index.ts                 # supported all-in-one entry (re-exports core + node + session + pi)
@@ -101,6 +101,8 @@ src/
 │   ├── http.ts              # HTTP/SSE channel (consumes only the Agent contract). Serving it is
 │   │                     # serve.ts's job — this file knows only the contract and one stream's shape
 │   ├── control.ts           # session-control transport: bearer-token /control/* routes (dispatch + SSE events with wire envelope + /control/invoke)
+│   ├── discover.ts          # channels/ filesystem discovery (ChannelModule → Routes) — engine-neutral,
+│   │                     # so it lives here and not under engines/ (#365)
 │   ├── body.ts, respond.ts  # channel-authoring kit (body cap, responses)
 │   ├── wait-health.ts       # SHARED readiness probe — channels AND deploy use it, so NOT in kit/
 │   ├── registration.ts      # SHARED registrar outcome (registered|manual|failed) — same reason
@@ -197,7 +199,7 @@ src/
     │                         # definition-local so it travels; the machine-global ~/.pi one stays unread)
     └── report.ts            # startup report (auth/model/skills/tools surface)
 test/                        # vitest; faux models by default + reusable SPEC conformance.
-  embedding.test.ts          # the docs/embedding.md snippets, run against REAL express/fastify (the
+└── embedding.test.ts       # the docs/embedding.md snippets, run against REAL express/fastify (the
                              # only reason they are devDeps): that path crosses the Node/Fetch seam
                              # through code we do not own, so a swap underneath can keep every unit
                              # test green while breaking the paste-this-in promise
@@ -212,7 +214,7 @@ fastagent *is* a developer-experience product: its whole promise is turning an e
 2. **Incremental migration.** Both directions. For users: adoption is incremental (existing definition → service, a few rough edges acceptable if the path forward is viable). For us: migrate systems in place; a full rewrite pauses maintenance and usually loses. If you *must* rewrite, say so explicitly and own the risk.
 3. **Clarity.** Surface the *right* level of complexity at the best interaction point — do not mask it in the name of "getting out of the way." The `docs/SPEC.md` contract is the narrative; keep plans, APIs, and names plain. It's never too early to share a draft (this is what the PR loop is for) — test changes with whoever has the most context before building.
 4. **Re-evaluate assumptions, constraints, trade-offs.** Engine-/model-/cloud-neutrality exists *because* these change. Old code wasn't bad — its constraints differed; gain that context before reshaping it. Be honest that most solutions carry negative trade-offs; refuse the ones that put us in a worse future position, and don't stack complex abstractions on complex systems.
-5. **Maximize option value.** Every change should unlock more future options, not fewer. This is the architecture's design center: a neutral contract, clear API boundaries, swappable implementations (the `PiSessionStore` port, `engines/pi/`), and carefully chosen dependencies. Prefer modular seams that let a piece be replaced over monoliths that must move as one.
+5. **Maximize option value.** Every change should unlock more future options, not fewer. This is the architecture's design center: a neutral contract, clear API boundaries, swappable implementations (the `PiSessionRecordStore` port, `engines/pi/`), and carefully chosen dependencies. Prefer modular seams that let a piece be replaced over monoliths that must move as one.
 
 ## Working rules specific to this repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,11 +38,16 @@ src/
 │                           # a WebSocket ingress needs LongConnection and has no HTTP in it, and a
 │                           # channel author must not pull node:http in behind a type import.
 ├── collect.ts               # caller-side stream helpers: collect (buffered consumption) + abortFirstIterator (shared cancellation protocol)
-├── core.ts, pi.ts           # lightweight neutral subpath + pi reference-implementation subpath
-├── index.ts                 # supported all-in-one public surface (re-exports core + pi)
+├── core.ts, node.ts,        # THE THREE LAYERS, split by what each costs to import: core (+session)
+│   pi.ts                 # is engine- AND runtime-neutral with ZERO packages; node adds what needs
+│                           # a Node runtime (the assembly, the http binding); pi names an engine.
+│                           # Every layer's dependency list is asserted in package-boundary.test.ts.
+├── index.ts                 # supported all-in-one entry (re-exports core + node + session + pi)
 ├── cli.ts                   # the THIN entry (import-free; lazy-loads cli/program.ts)
 ├── cli/                     # the CLI, built on clig.dev: kernel.ts (CommandSpec-as-data + the commander adapter — commander appears ONLY here; help/suggestions/exit-code policy: 0 ok, 1 runtime, 2 usage), program.ts (the spec registry — the CLI surface's single source of truth; lazy per-command imports), presenters (invoke-stream.ts `invoke` stream → exit code; models-view.ts/auth-view.ts `models`/auth-report output; add-feishu.ts `add feishu|lark` app onboarding), shared.ts/serve.ts (cross-command helpers: serve/bind reporting, tunnel — the ASSEMBLY lives in service.ts and the agentcore one in channels/agentcore-service.ts, since a public entry may not reach into cli/), fail.ts, commands/ (one module per command)
-├── telegram.ts, github.ts   # subpath-export shims (@fastagent-sh/fastagent/telegram etc. — the supported surface)
+├── telegram.ts, github.ts,  # subpath-export shims (@fastagent-sh/fastagent/telegram etc.)
+│   slack.ts, feishu.ts,
+│   lark.ts
 ├── bind.ts                  # THE reading of a bind address, as the six DIFFERENT questions it is:
 │                           # bindable (isBindAddress) / an address not a name (bindAddress, applied
 │                           # where a value enters) / reach (classifyBind) / dialable by the NAME
@@ -185,16 +190,14 @@ src/
     ├── tool-context.ts      # ToolContext.session + tool-activation bridge via AsyncLocalStorage (set around the turn; read in execute — the wake/search_tools seam)
     ├── search-tools.ts      # built-in search_tools loader for deferred tools (auto-mounted when any tool is deferred; author's wins)
     ├── wake-tool.ts         # the built-in `wake` tool (pi-coupled: defineTool): writes a wake-up into ToolContext.session; withWakeTool mounts it (serving path only)
-    ├── channel.ts           # channels/ filesystem discovery (ChannelModule → Routes)
     ├── definition.ts        # AGENTS.md + skills loading and bundling
     ├── config.ts            # fastagent.config.ts loading + model/precedence (placement lives in paths.ts)
     ├── auth.ts, login.ts    # credential store/resolution (project-level auth.json default) + `login` flow
     ├── models.ts            # Models collection wiring + the agent's OWN models.json (custom endpoints:
     │                         # definition-local so it travels; the machine-global ~/.pi one stays unread)
-    ├── report.ts            # startup report (auth/model/skills/tools surface)
-    └── sessions.ts          # PiSessionStore port + in-memory/jsonl backends
+    └── report.ts            # startup report (auth/model/skills/tools surface)
 test/                        # vitest; faux models by default + reusable SPEC conformance.
-└── embedding.test.ts         # the docs/embedding.md snippets, run against REAL express/fastify (the
+  embedding.test.ts          # the docs/embedding.md snippets, run against REAL express/fastify (the
                              # only reason they are devDeps): that path crosses the Node/Fetch seam
                              # through code we do not own, so a swap underneath can keep every unit
                              # test green while breaking the paste-this-in promise
@@ -216,7 +219,7 @@ fastagent *is* a developer-experience product: its whole promise is turning an e
 - **The contract is engine-neutral.** `src/agent.ts` must not import any engine (`@earendil-works/pi-*` only under `src/engines/`).
 - **Fail visibly.** Errors must surface; no swallowed exceptions, no silent fallbacks. On the invoke path, failures become `failed` events (SPEC MUST 2), never thrown iteration errors.
 - **Per-invoke state is the DEFAULT level, not an axiom.** The serving path binds a fresh `AgentSession` per invoke and disposes it; durable state lives behind `PiSessionRecordStore`. Do not introduce in-process session state *into that path* — it is what satisfies SPEC MUST 6 (no location dependence), which AgentCore and every horizontally-scaled channel host require. The SPEC permits a resident Agent at the cost of portable conformance; if a deployment posture wants one, that is a deliberate level choice with its own bill ([conformance-levels.md](docs/design/conformance-levels.md)), never a quiet drift in this one.
-- **Public surface is scoped on purpose.** `src/core.ts` is engine-neutral, `src/pi.ts` is the pi reference surface, and `src/index.ts` combines them. Pi-coupled internals (L0 `createPiAgentFromSession`, `piAgentSessionFactory`, assembly helpers) remain unexported — import them from their modules for tests/custom wiring, do not re-export them.
+- **Public surface is scoped on purpose.** `src/core.ts` is engine- and runtime-neutral (zero packages), `src/node.ts` is engine-neutral but needs a Node runtime, `src/pi.ts` names the engine, and `src/index.ts` combines all of them. Pi-coupled internals (L0 `createPiAgentFromSession`, `piAgentSessionFactory`, assembly helpers) remain unexported — import them from their modules for tests/custom wiring, do not re-export them.
 - **The artifact is the truth.** Deployment behavior must come from the bundled definition, not the builder machine's global state. Engines have their own opinion about this: pi reads its settings (retry budget, compaction thresholds, default thinking level) from `~/.pi/agent` unless pointed elsewhere, so the binding points it at a definition-scoped path. Any new engine surface that reads "the user's config" gets the same treatment.
 - **A session id belongs to the Caller.** `scope.session` is opaque and arbitrary — a telegram group is `-1001234567890`, a feishu thread carries `:` and `/`. What an engine needs to store it (pi rejects all of those as record names, so they are encoded) is storage detail and must not leak back out: a tool asking which conversation it is in gets the id the channel minted, not the record's name.
 - **The run plane and the observation plane read the same state, through the same function.** They answer different questions about one session — what will execute, and what to report — so deriving them separately is how they come to disagree. The concrete failures this rule is made of: a turn running on assembly defaults while `state()` reported the recorded override, and one plane refusing a record with a cut parent chain while the other silently ran on the truncated path.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,12 +1,19 @@
 ---
 title: API reference
-description: "The public TypeScript surface of @fastagent-sh/fastagent: the Agent contract, assembly functions, channel and host kit, typed tools, sessions, and providers."
+description: "The public TypeScript surface of @fastagent-sh/fastagent: the Agent contract, the service assembly, the channel kit, typed tools, sessions, and providers."
 status: current
 ---
 
 # API reference
 
-This is a compact reference for the all-in-one `@fastagent-sh/fastagent` surface. The same exports are grouped into `@fastagent-sh/fastagent/core` (engine-neutral) and `@fastagent-sh/fastagent/pi` (the pi reference implementation).
+This is a compact reference for the all-in-one `@fastagent-sh/fastagent` entry. The same exports are
+layered across subpaths by what each costs to import:
+
+| | engine-neutral | runtime-neutral | pulls |
+|---|---|---|---|
+| `/core`, `/session` | yes | yes | nothing |
+| `/node` | yes | no | the Node HTTP bridge and a cron |
+| `/pi` | no | no | the pi runtime |
 
 FastAgent is pre-1.0. The Agent Handler contract is the stable design center; implementation-specific APIs may still tighten before 1.0.
 
@@ -641,6 +648,6 @@ import { feishuChannel } from "@fastagent-sh/fastagent/feishu";
 import { larkChannel } from "@fastagent-sh/fastagent/lark";
 ```
 
-`core` avoids loading the pi reference runtime and is the preferred dependency for engine-neutral
-channels. The root entry remains the supported convenience surface. See [GitHub channel](github.md),
+`/core` loads no third-party package at all, which is what makes it the right dependency for a
+channel package or a second engine. The root entry remains the supported all-in-one. See [GitHub channel](github.md),
 [Telegram channel](telegram.md), [Slack channel](slack.md), and the canonical [Feishu channel with Lark compatibility](feishu.md).

--- a/docs/channel-development.md
+++ b/docs/channel-development.md
@@ -86,7 +86,7 @@ A channel adapter should depend on the engine-neutral `@fastagent-sh/fastagent/c
 | `readBodyCapped` | read a request body with a byte cap |
 | `text`, `textHeaders` | build plain status/error responses |
 
-Do not import from `src/engines/*`, `@earendil-works/*`, or the pi subpath in a channel package. Channels consume the neutral Agent contract; `/core` also avoids loading the reference runtime.
+Do not import from `src/engines/*`, `@earendil-works/*`, or the pi subpath in a channel package. Channels consume the neutral Agent contract, and `/core` loads no third-party package at all — which is what makes it the right dependency for a channel package.
 
 ## Minimal adapter
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -66,7 +66,7 @@ const agent = createPiAgent({
 });
 ```
 
-Author tool schemas with the `z` re-exported from `@fastagent-sh/fastagent` (as above), not a separately installed `zod` — `defineTool` converts the schema with its own zod, so a single shared copy avoids version-skew surprises. Every type on this surface (`AgentTool`, `Skill`, `Session`, `Model`, …) is re-exported too, so you never import from `@earendil-works/*` (the one exception is a provider's wire-protocol `api`, see §5).
+Author tool schemas with the `z` re-exported from `@fastagent-sh/fastagent` (as above), not a separately installed `zod` — `defineTool` converts the schema with its own zod, so a single shared copy avoids version-skew surprises. Every type our signatures name (`AgentTool`, `Skill`, `Model`, `PiSessionEntry`, …) is re-exported too, so you rarely import from `@earendil-works/*`. Two things stay there on purpose: `createProvider` and a provider's wire-protocol `api` (see §5) — both are pi-ai's own runtime, and forwarding them would make us answerable for an API we do not own.
 
 `model` is always a spec string; `fastagent models` (or `listModels`) lists the available ones. `instructions` IS the system prompt — verbatim, no engine persona prepended. The directory path instead assembles the pi base (optionally customized by `persona.md`), `AGENTS.md` project context, skills, and environment context. See [core design §2](design/core.md).
 
@@ -91,7 +91,7 @@ const handler = createInvokeHandler(agent);   // (Request) => Promise<Response>;
 ### The whole agent, as a service
 
 The handler above serves `invoke` only. To mount the **whole** agent — every channel it declares,
-its control plane, health — open the directory as a surface:
+its control plane, health — open the directory as a service:
 
 ```ts
 import { nodeListener, createAgentService } from "@fastagent-sh/fastagent";
@@ -244,8 +244,10 @@ An "auth service" is modeled as a provider — its per-request credential logic 
 
 `fastagent dev` / `start` wrap the pi reference implementation's `createPiAgentFromDir` plus process side effects (`.env`, proxy, watch, serve). The agent the CLI serves is the **same** one `createPiAgentFromDefinition` hands you when embedding — single assembly source. What you iterate under `dev`, what `start` serves, and what you embed are identical.
 
-For contract-only or channel code, import `@fastagent-sh/fastagent/core`; it does not load the pi
-reference runtime. Pi-specific assembly is also available explicitly from `@fastagent-sh/fastagent/pi`.
+For contract-only or channel code, import `@fastagent-sh/fastagent/core` — it loads no third-party
+package at all. `@fastagent-sh/fastagent/node` adds what needs a Node runtime (`mountAgentService`,
+`serveNode`, `nodeListener`); `@fastagent-sh/fastagent/pi` is the engine-specific assembly. The root
+entry re-exports all three, which is what every example above uses.
 
 ## Where next
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -246,8 +246,9 @@ An "auth service" is modeled as a provider — its per-request credential logic 
 
 For contract-only or channel code, import `@fastagent-sh/fastagent/core` — it loads no third-party
 package at all. `@fastagent-sh/fastagent/node` adds what needs a Node runtime (`mountAgentService`,
-`serveNode`, `nodeListener`); `@fastagent-sh/fastagent/pi` is the engine-specific assembly. The root
-entry re-exports all three, which is what every example above uses.
+`serveNode`, `nodeListener`); `@fastagent-sh/fastagent/session` is the control-plane contract; and
+`@fastagent-sh/fastagent/pi` is the engine-specific assembly. The root entry re-exports every one of
+them, which is what every example above uses.
 
 ## Where next
 


### PR DESCRIPTION
A file-by-file audit of all 26 documents before the release, checking every claim a reader could act on against the code.

## Found and fixed

| Where | Claim | Reality |
|---|---|---|
| `api-reference.md` header | Subpaths are `/core` and `/pi` | Four now, layered by import cost |
| `api-reference.md` footer | "core avoids loading the pi runtime" | It loads **nothing** — that is the point of #363 |
| `embedding.md` | `Session` is among the re-exported types | Removed in #341 |
| `embedding.md` | "you never import from `@earendil-works/*`" | `createProvider` moved back there in #362 |
| `embedding.md` | "open the directory as a surface" | Renamed to service in #355 |
| `embedding.md` footer | Two subpaths described | Three, with what each costs |
| `AGENTS.md` repo map | `engines/pi/channel.ts` | Moved to `channels/discover.ts` (#365) |
| `AGENTS.md` repo map | `engines/pi/sessions.ts` | Renamed `session-store.ts` (#341) |
| `AGENTS.md` repo map | `core.ts, pi.ts` as the layering | `node.ts` was missing entirely (#363) |
| `AGENTS.md` working rules | "core is engine-neutral, pi is the reference surface" | Three layers, two properties |

## How it was checked

Four scripted passes, plus reading the four most-affected documents end to end:

1. **Every documented import resolves** — parse each `import { … } from "@fastagent-sh/fastagent…"` in the docs against the emitted `.d.ts` per subpath. This is what caught `Session`.
2. **Every `src/…` path mentioned exists** — and, in reverse, every path in the `AGENTS.md` tree is on disk. This caught the three stale map entries; the reverse direction caught the missing `node.ts`.
3. **Every documented function/interface signature exists** in the build output.
4. **Every `FASTAGENT_*` env var** in the docs is read by the code, and every one the code reads is either documented or deliberately internal (`FASTAGENT_INGRESS_SECRET`, `FASTAGENT_DEV_WORKER`, `FASTAGENT_WAKE_SECRET` are injected by generated deploy artifacts and the dev supervisor — verified, correctly absent).

## Checked and correct

`AgentHarness` still appears in `design/conformance-levels.md`, as history ("there used to be a second axis") — accurate, kept. `host/` in four places means the deployment host, not the deleted `src/host/`. `fastagent depoly` in `cli.md` is a deliberate typo demonstrating command suggestion — verified the CLI answers "Did you mean deploy?". No subpath is referenced that does not exist, and none exists that no document mentions.