### PR TITLE
chore: release 0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, Telegram, Slack, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Version bump only. The changelog goes in the GitHub Release.

Verified against the packed tarball installed in a clean project:

```
root 37 exports | core 10 | node 3 | session 7
createAgentService / mountAgentService / serveNode / nodeListener / collect / defineTool / defineSchedule  callable
router / createProvider / loadTools / loadChannels / createScheduler / scheduleSession                     absent
core does not carry the node binding
fastagent --version → 0.19.0
@earendil-works/pi-coding-agent → ^0.84.3
```

20 commits since v0.18.0. Breaking changes are listed in the release notes.