### PR TITLE
docs(control): the multi-tenant facade, and the two ids it must not miss

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -673,6 +673,8 @@ included — within the action body cap (1 MiB, with base64 inflation counted; o
 The wire is RESTful and mechanical, so a non-TypeScript client is a `curl` away:
 
 ```
+GET    /control/capabilities                   what this deployment allows
+GET    /control/commands                       the agent's skills
 GET    /control/sessions                       list
 PUT    /control/sessions/{id}                  {from, at} — fork (idempotent)
 GET    /control/sessions/{id}                  state
@@ -681,6 +683,7 @@ DELETE /control/sessions/{id}
 GET    /control/sessions/{id}/entries          ?since=
 GET    /control/sessions/{id}/events           SSE
 POST   /control/sessions/{id}/actions          {type: "steer"|"follow_up"|"abort"|"compact"}
+POST   /control/invoke                         the DATA plane: {session, text} — SSE, starts a run
 ```
 
 `{id}` is percent-encoded, so a Telegram group is `/control/sessions/tg%3A-1001234567890` — session

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -642,11 +642,12 @@ the plane does.
 Four properties make the pass-through safe. Each is load-bearing — remove one and the pattern needs
 the facade to understand what it forwards:
 
-- **Every call that touches user data names its session, and names it in the URL** — one path
-  segment, percent-encoded (§13). The facade routes on a prefix instead of parsing bodies.
+- **Every CONTROL call names its session in the URL** — one path segment, percent-encoded (§13), so
+  the facade routes on a prefix. The DATA plane is the exception that costs the most to learn late:
+  `POST /control/invoke` names its session in the BODY (see the trap below).
 - **`events` subscribes per session** rather than filtering a global stream, so a tenant cannot
   observe another's run by holding a connection open.
-- **The lease is per session** (§5.2), so a busy tenant answers `session_busy` to itself alone.
+- **The lease is per session** (§9), so a busy tenant answers `session_busy` to itself alone.
 - **Authentication and extraction are separate in the plane itself.** The bearer guard authenticates;
   taking the id out of the path is extraction and enforces nothing. There is no per-session
   permission inside to half-configure and get wrong — the facade owns that question whole.
@@ -670,7 +671,10 @@ through as-is. `GET /control/sessions` must NOT be exposed — it returns every 
 deployment (§5), and a facade already holds the per-user mapping that a filtered list would return,
 so it should answer from that instead of forwarding. And the deployment's own port must not be
 reachable by end users: the bearer token is deployment-wide, so a user who can reach past the facade
-holds every session. A same-host facade wants `--bind 127.0.0.1`.
+holds every session. A same-host facade wants `--bind 127.0.0.1` — with one consequence to plan for:
+the plane and the channel webhooks share one server and one bind, so loopback takes Telegram/Feishu/
+Slack ingress off the network too (and is refused outright with `--tunnel`). Either proxy those paths
+through the facade as well, or keep the port public and put the facade in front of it elsewhere.
 
 A remotely exposed control plane MUST be wrapped by a host that enforces: an authenticated
 principal and per-session authorization; separated observe and write permissions; allowed model

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -643,7 +643,9 @@ Four properties make the pass-through safe. Each is load-bearing — remove one 
 the facade to understand what it forwards:
 
 - **Every CONTROL call names its session in the URL** — one path segment, percent-encoded (§13), so
-  the facade routes on a prefix. The DATA plane is the exception that costs the most to learn late:
+  the facade routes on a prefix. It must compare the DECODED segment against its own mapping, because
+  that is what the plane addresses: `%61bc` and `abc` are one session, and a Feishu id containing `/`
+  never matches raw. The DATA plane is the exception that costs the most to learn late:
   `POST /control/invoke` names its session in the BODY (see the trap below).
 - **`events` subscribes per session** rather than filtering a global stream, so a tenant cannot
   observe another's run by holding a connection open.
@@ -671,10 +673,13 @@ through as-is. `GET /control/sessions` must NOT be exposed — it returns every 
 deployment (§5), and a facade already holds the per-user mapping that a filtered list would return,
 so it should answer from that instead of forwarding. And the deployment's own port must not be
 reachable by end users: the bearer token is deployment-wide, so a user who can reach past the facade
-holds every session. A same-host facade wants `--bind 127.0.0.1` — with one consequence to plan for:
-the plane and the channel webhooks share one server and one bind, so loopback takes Telegram/Feishu/
-Slack ingress off the network too (and is refused outright with `--tunnel`). Either proxy those paths
-through the facade as well, or keep the port public and put the facade in front of it elsewhere.
+holds every session. A same-host facade wants `--bind 127.0.0.1`, with two consequences to plan for.
+The plane and the channel webhooks share one server and one bind, so loopback takes Telegram/Feishu/
+Slack ingress off the network too — either proxy those paths through the facade as well, or keep the
+port public and put the facade in front of it elsewhere. And `--tunnel` is ALLOWED with that bind
+(cloudflared dials the name `localhost`, which `127.0.0.1` answers), so nothing stops the two being
+combined — but the tunnel republishes the port on a public URL, which is precisely what the loopback
+bind was for. A facade deployment does not use both.
 
 A remotely exposed control plane MUST be wrapped by a host that enforces: an authenticated
 principal and per-session authorization; separated observe and write permissions; allowed model

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -632,6 +632,46 @@ every entry and abort every run; `delete` adds that the loss is permanent. A dep
 per-principal destructive policy owes it at the wrapping host, which is where this section already
 puts authorisation.
 
+**The multi-tenant facade.** That wrapping host has one shape worth naming, because the plane was
+built to make it possible and none of it is visible from the route list. N users behind one
+deployment, each reaching only their own sessions: the facade authenticates its user, reads the
+session id out of the request, checks it against its OWN user→session mapping, and forwards to the
+deployment with the deployment token. It never parses a command, and it gains no new capability when
+the plane does.
+
+Four properties make the pass-through safe. Each is load-bearing — remove one and the pattern needs
+the facade to understand what it forwards:
+
+- **Every call that touches user data names its session, and names it in the URL** — one path
+  segment, percent-encoded (§13). The facade routes on a prefix instead of parsing bodies.
+- **`events` subscribes per session** rather than filtering a global stream, so a tenant cannot
+  observe another's run by holding a connection open.
+- **The lease is per session** (§5.2), so a busy tenant answers `session_busy` to itself alone.
+- **Authentication and extraction are separate in the plane itself.** The bearer guard authenticates;
+  taking the id out of the path is extraction and enforces nothing. There is no per-session
+  permission inside to half-configure and get wrong — the facade owns that question whole.
+
+**The trap: the path says where a call WRITES, the body says where it READS.** Two calls take a
+second session id, and neither one is in the URL:
+
+| Call | Checked by a facade reading the path | Also needs checking |
+|---|---|---|
+| `POST /control/invoke` | — (the session is in the BODY, not the path) | `session` AND `parentSession` — the latter inherits the parent's history into the new session |
+| `PUT /control/sessions/{id}` | `{id}`, the fork's destination | `from` in the body — the history's SOURCE |
+
+A facade that authorises only what it finds in the path lets a user read any conversation on the
+deployment by naming it as a `parentSession` or a fork `from`. Both are extension fields on a call
+whose primary id checks out, which is exactly where an ownership check is not looked for. `invoke` is
+doubly easy to miss: it is the DATA plane, so a facade written around "the control routes" may not
+guard it at all — and it is the one that WRITES.
+
+The rest sorts cleanly: `capabilities` and `commands` are agent-level with no user data and pass
+through as-is. `GET /control/sessions` must NOT be exposed — it returns every session on the
+deployment (§5), and a facade already holds the per-user mapping that a filtered list would return,
+so it should answer from that instead of forwarding. And the deployment's own port must not be
+reachable by end users: the bearer token is deployment-wide, so a user who can reach past the facade
+holds every session. A same-host facade wants `--bind 127.0.0.1`.
+
 A remotely exposed control plane MUST be wrapped by a host that enforces: an authenticated
 principal and per-session authorization; separated observe and write permissions; allowed model
 and thinking-level policy; prompt and attachment size limits; opaque artifact references instead of

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -7,6 +7,7 @@
  */
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type, type FauxResponseStep, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { readFileSync } from "node:fs";
 import { afterAll, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
 import { controlPlaneRoutes, createControlPlane, mountControlPlane } from "../src/channels/control.ts";
@@ -86,7 +87,7 @@ describe("session control over HTTP (Phase 3)", () => {
       // DERIVED from the routes this server actually MOUNTS — not a hand-kept list, and not a second
       // createControlPlane() call that could drift from it: "every control route requires the token" has
       // to fail when a NEW route forgets `guard`, which a literal array cannot do.
-      expect(served.routeKeys).toContain("GET /control/commands"); // the route this PR adds is in the sweep
+      expect(served.routeKeys).toContain("GET /control/commands"); // the sweep sees the whole table
       for (const key of served.routeKeys) {
         const [method, path] = key.split(" ") as [string, string];
         // OPTIONS is the ONE unauthenticated method here, and deliberately so: a preflight cannot
@@ -290,6 +291,29 @@ describe("session control over HTTP (Phase 3)", () => {
     } finally {
       errors.mockRestore();
       server.close();
+    }
+  });
+
+  it("\u00a713's route table lists every route the plane mounts", async () => {
+    // The design doc's table is a hand-kept copy, and the multi-tenant facade in \u00a714 is written
+    // AGAINST it: a facade author reads that table to decide what to authorise and what to pass
+    // through, so a route missing from it is a route nobody guards. Derived from the mount, so
+    // adding one without documenting it fails here.
+    const doc = readFileSync(new URL("../docs/design/session-control.md", import.meta.url), "utf8");
+    const table = doc.slice(doc.indexOf("## 13."), doc.indexOf("## 14."));
+    const documented = new Set(
+      [...table.matchAll(/^(GET|POST|PUT|PATCH|DELETE)\s+(\/control\/\S*)/gm)].map(
+        ([, method, path]) => `${method} ${(path as string).replace("{id}", "{session}")}`,
+      ),
+    );
+    const served = await serveControl();
+    try {
+      for (const key of served.routeKeys) {
+        if (key.startsWith("OPTIONS ")) continue; // CORS preflight, not a call a facade forwards
+        expect(documented, `${key} is mounted but missing from \u00a713`).toContain(key);
+      }
+    } finally {
+      await served.close();
     }
   });
 

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -294,27 +294,35 @@ describe("session control over HTTP (Phase 3)", () => {
     }
   });
 
-  it("\u00a713's route table lists every route the plane mounts", () => {
-    // The design doc's table is a hand-kept copy, and the multi-tenant facade in \u00a714 is written
-    // AGAINST it: a facade author reads that table to decide what to authorise and what to pass
-    // through, so a route missing from it is a route nobody guards. Derived from the mount, so
-    // adding one without documenting it fails here.
-    const doc = readFileSync(new URL("../docs/design/session-control.md", import.meta.url), "utf8");
-    const start = doc.indexOf("## 13.");
-    const end = doc.indexOf("## 14.");
-    // Renumbering either heading would leave `slice(start, -1)` scanning the whole document, turning
-    // this into a check that passes on a table it never read.
-    expect([start, end]).not.toContain(-1);
-    const documented = new Set(
-      [...doc.slice(start, end).matchAll(/^(GET|POST|PUT|PATCH|DELETE)\s+(\/control\/\S*)/gm)].map(
-        ([, method, path]) => `${method} ${(path as string).replace("{id}", "{session}")}`,
-      ),
-    );
-    // No server: the route table is what `controlPlaneRoutes` returns, and it is synchronous.
+  it("both hand-kept route tables list every route the plane mounts", () => {
+    // TWO copies of the route list exist outside the code: \u00a713, which the multi-tenant facade in
+    // \u00a714 is written against (a route missing there is a route nobody guards), and the curl table in
+    // api-reference, which is what a non-TypeScript client builds from. Both are derived from the
+    // mount here, so adding a route without documenting it fails in whichever copy forgot it.
+    const section = (file: string, from: string, to: string): string => {
+      const doc = readFileSync(new URL(`../docs/${file}`, import.meta.url), "utf8");
+      const start = doc.indexOf(from);
+      const end = doc.indexOf(to, start + 1);
+      // Renumbering or retitling either bound would leave `slice` scanning past the table, turning
+      // this into a check that passes on text it never read.
+      expect([start, end], `${file}: could not locate the table between ${from} and ${to}`).not.toContain(-1);
+      return doc.slice(start, end);
+    };
+    const documented = (text: string): Set<string> =>
+      new Set(
+        [...text.matchAll(/^(GET|POST|PUT|PATCH|DELETE)\s+(\/control\/\S*)/gm)].map(
+          ([, method, path]) => `${method} ${(path as string).replace("{id}", "{session}")}`,
+        ),
+      );
+    const tables = {
+      "design/session-control.md \u00a713": documented(section("design/session-control.md", "## 13.", "## 14.")),
+      "api-reference.md (curl)": documented(section("api-reference.md", "a `curl` away", "```\n\n")),
+    };
     // `agent` is what mounts the data-plane route, so the table must be built WITH one.
     const agent: Agent = { invoke: () => (async function* () {})() };
     const mounted = Object.keys(controlPlaneRoutes(handleControl({}), { token: TOKEN, agent }));
-    for (const key of mounted) expect(documented, `${key} is mounted but missing from \u00a713`).toContain(key);
+    for (const [where, listed] of Object.entries(tables))
+      for (const key of mounted) expect(listed, `${key} is mounted but missing from ${where}`).toContain(key);
   });
 
   it("local and remote are isomorphic: capabilities/state/entries/dispatch answer identically", async () => {

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -9,7 +9,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type, type FauxResponseStep, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { readFileSync } from "node:fs";
 import { afterAll, describe, expect, it, vi } from "vitest";
-import type { AgentEvent } from "../src/agent.ts";
+import type { Agent, AgentEvent } from "../src/agent.ts";
 import { controlPlaneRoutes, createControlPlane, mountControlPlane } from "../src/channels/control.ts";
 import { log } from "../src/log.ts";
 import { inProcessLease } from "../src/engines/pi/turn-kit.ts";
@@ -294,27 +294,27 @@ describe("session control over HTTP (Phase 3)", () => {
     }
   });
 
-  it("\u00a713's route table lists every route the plane mounts", async () => {
+  it("\u00a713's route table lists every route the plane mounts", () => {
     // The design doc's table is a hand-kept copy, and the multi-tenant facade in \u00a714 is written
     // AGAINST it: a facade author reads that table to decide what to authorise and what to pass
     // through, so a route missing from it is a route nobody guards. Derived from the mount, so
     // adding one without documenting it fails here.
     const doc = readFileSync(new URL("../docs/design/session-control.md", import.meta.url), "utf8");
-    const table = doc.slice(doc.indexOf("## 13."), doc.indexOf("## 14."));
+    const start = doc.indexOf("## 13.");
+    const end = doc.indexOf("## 14.");
+    // Renumbering either heading would leave `slice(start, -1)` scanning the whole document, turning
+    // this into a check that passes on a table it never read.
+    expect([start, end]).not.toContain(-1);
     const documented = new Set(
-      [...table.matchAll(/^(GET|POST|PUT|PATCH|DELETE)\s+(\/control\/\S*)/gm)].map(
+      [...doc.slice(start, end).matchAll(/^(GET|POST|PUT|PATCH|DELETE)\s+(\/control\/\S*)/gm)].map(
         ([, method, path]) => `${method} ${(path as string).replace("{id}", "{session}")}`,
       ),
     );
-    const served = await serveControl();
-    try {
-      for (const key of served.routeKeys) {
-        if (key.startsWith("OPTIONS ")) continue; // CORS preflight, not a call a facade forwards
-        expect(documented, `${key} is mounted but missing from \u00a713`).toContain(key);
-      }
-    } finally {
-      await served.close();
-    }
+    // No server: the route table is what `controlPlaneRoutes` returns, and it is synchronous.
+    // `agent` is what mounts the data-plane route, so the table must be built WITH one.
+    const agent: Agent = { invoke: () => (async function* () {})() };
+    const mounted = Object.keys(controlPlaneRoutes(handleControl({}), { token: TOKEN, agent }));
+    for (const key of mounted) expect(documented, `${key} is mounted but missing from \u00a713`).toContain(key);
   });
 
   it("local and remote are isomorphic: capabilities/state/entries/dispatch answer identically", async () => {


### PR DESCRIPTION
Closes #353.

N users behind one deployment, each reaching only their own sessions, works today and is invisible
from the route list. The issue named four properties that make the pass-through safe; writing it up
against the shipped plane changed one and added a trap that outweighs the rest.

**What the reshape improved.** #353 was written when every call carried its session in the body
(`?session=`, or a `dispatch` payload). The id is a path segment now, so a facade routes on a prefix
and never parses a body to authorise — comparing the DECODED segment, which is what the plane
addresses: raw, `%61bc` and `abc` are one session under two strings and a Feishu id containing `/`
never matches at all. The other three properties hold as written: `events`
subscribes per session rather than filtering a global stream, the lease is per session, and the
plane's own guard authenticates without pretending to authorise.

**The trap.**

> The path says where a call WRITES. The body says where it READS.

| Call | What a path-reading facade checks | What it misses |
|---|---|---|
| `POST /control/invoke` | nothing — the session is in the body | `session` **and** `parentSession` |
| `PUT /control/sessions/{id}` | `{id}`, the fork's destination | `from`, the history's source |

Both extension fields inherit another session's history. Both ride a call whose primary id checks
out, which is exactly where an ownership check is not looked for. `invoke` is the easier miss: it is
the DATA plane, so a facade built around "the control routes" may not guard it at all — and it is
the one that writes.

This is not a new hole. `parentSession` and `fork.from` are both doing what they are for; the plane
has one deployment-wide key and §14 has always put authorisation at the wrapping host. What was
missing is that the host cannot derive this from the route list, because neither id appears there.

**Also stated:** `GET /control/sessions` must not be forwarded (it returns every session on the
deployment, and a facade already holds the per-user mapping a filtered list would return);
`capabilities`/`commands` pass through as-is; and the deployment port must not be user-reachable,
since reaching past the facade means holding every session — with the two costs of `--bind
127.0.0.1` named, because neither is enforced. The plane and the channel webhooks share one server
and one bind, so loopback takes Telegram/Feishu/Slack ingress off the network too. And `--tunnel` is
ALLOWED alongside that bind (cloudflared dials the name `localhost`, which `127.0.0.1` answers), so
nothing stops the two being combined — but the tunnel republishes the port publicly, which is what
the loopback bind was for.

## Verification

Two hand-kept route tables exist outside the code: §13, which this section is written against (a
route missing there is a route nobody guards), and api-reference's curl table, which a
non-TypeScript client builds from. The latter was missing `capabilities`, `commands` and `invoke`;
it lists them now. A test derives the list from what the plane MOUNTS and checks both, failing on a
missing row and on a heading it can no longer locate — the second matters because an unanchored
slice scans past the table and passes on text it never read. Both verified red:

```
× both hand-kept route tables list every route the plane mounts
AssertionError: GET /control/commands is mounted but missing from api-reference.md (curl)
AssertionError: api-reference.md: could not locate the table between a `curl` away and ```
```

1536 tests pass; docs-only otherwise.

