### PR TITLE
fix(channels): one answer to "is this a channel file", for all three readers

### DIFF
--- a/src/channels/discover.ts
+++ b/src/channels/discover.ts
@@ -5,12 +5,10 @@
  * Engine-neutral, and living here rather than under `engines/` because of it: reading `channels/*.ts`
  * is the Channel contract plus a directory, with no engine in sight.
  */
-import type { Dirent } from "node:fs";
-import { readdir } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 import type { ChannelContext, ChannelModule, LongConnection, LongConnectionChannelModule, Routes } from "../channel.ts";
 import { assertRouteKey, routeKeysConflict } from "./serve.ts";
-import { type ModuleLoadFailure, isMissingDir, isModuleEntry, loadModuleDir, moduleName } from "../loader.ts";
+import { type ModuleLoadFailure, loadModuleDir, moduleInventory } from "../loader.ts";
 import { assertInsideAgentDir } from "../paths.ts";
 
 /** A dropped route: two channels claim the same key. Surfaced, never silent. */
@@ -78,17 +76,8 @@ export async function inspectChannels(dir: string): Promise<{
  */
 export async function discoverChannelFiles(dir: string): Promise<string[]> {
   await assertInsideAgentDir(dir, "channels");
-  let entries: Dirent[];
-  try {
-    entries = await readdir(join(dir, "channels"), { withFileTypes: true });
-  } catch (error) {
-    if (isMissingDir(error)) return [];
-    throw error;
-  }
-  return entries
-    .filter(isModuleEntry)
-    .map((entry) => moduleName(entry.name))
-    .sort();
+  const { entries } = await moduleInventory(join(dir, "channels"));
+  return entries.map((entry) => entry.name).sort();
 }
 
 function validateRoutes(value: unknown, label: string): [string, (req: Request) => Response | Promise<Response>][] {

--- a/src/channels/discover.ts
+++ b/src/channels/discover.ts
@@ -77,7 +77,7 @@ export async function inspectChannels(dir: string): Promise<{
 export async function discoverChannelFiles(dir: string): Promise<string[]> {
   await assertInsideAgentDir(dir, "channels");
   const { entries } = await moduleInventory(join(dir, "channels"));
-  return entries.map((entry) => entry.name).sort();
+  return entries.map((entry) => entry.name);
 }
 
 function validateRoutes(value: unknown, label: string): [string, (req: Request) => Response | Promise<Response>][] {

--- a/src/channels/discover.ts
+++ b/src/channels/discover.ts
@@ -5,11 +5,12 @@
  * Engine-neutral, and living here rather than under `engines/` because of it: reading `channels/*.ts`
  * is the Channel contract plus a directory, with no engine in sight.
  */
+import type { Dirent } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 import type { ChannelContext, ChannelModule, LongConnection, LongConnectionChannelModule, Routes } from "../channel.ts";
 import { assertRouteKey, routeKeysConflict } from "./serve.ts";
-import { type ModuleLoadFailure, isModuleFile, loadModuleDir } from "../loader.ts";
+import { type ModuleLoadFailure, isModuleEntry, loadModuleDir, moduleName } from "../loader.ts";
 import { assertInsideAgentDir } from "../paths.ts";
 
 /** A dropped route: two channels claim the same key. Surfaced, never silent. */
@@ -77,16 +78,16 @@ export async function inspectChannels(dir: string): Promise<{
  */
 export async function discoverChannelFiles(dir: string): Promise<string[]> {
   await assertInsideAgentDir(dir, "channels");
-  let names: string[];
+  let entries: Dirent[];
   try {
-    names = await readdir(join(dir, "channels"));
+    entries = await readdir(join(dir, "channels"), { withFileTypes: true });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
     throw error;
   }
-  return names
-    .filter(isModuleFile)
-    .map((name) => name.replace(/\.(ts|js|mjs)$/, ""))
+  return entries
+    .filter(isModuleEntry)
+    .map((entry) => moduleName(entry.name))
     .sort();
 }
 

--- a/src/channels/discover.ts
+++ b/src/channels/discover.ts
@@ -10,7 +10,7 @@ import { readdir } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 import type { ChannelContext, ChannelModule, LongConnection, LongConnectionChannelModule, Routes } from "../channel.ts";
 import { assertRouteKey, routeKeysConflict } from "./serve.ts";
-import { type ModuleLoadFailure, isModuleEntry, loadModuleDir, moduleName } from "../loader.ts";
+import { type ModuleLoadFailure, isMissingDir, isModuleEntry, loadModuleDir, moduleName } from "../loader.ts";
 import { assertInsideAgentDir } from "../paths.ts";
 
 /** A dropped route: two channels claim the same key. Surfaced, never silent. */
@@ -82,7 +82,7 @@ export async function discoverChannelFiles(dir: string): Promise<string[]> {
   try {
     entries = await readdir(join(dir, "channels"), { withFileTypes: true });
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    if (isMissingDir(error)) return [];
     throw error;
   }
   return entries

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -7,6 +7,7 @@ import type { Dirent } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { log } from "./log.ts";
 
 const MODULE_EXTS = new Set([".ts", ".js", ".mjs"]);
 
@@ -20,9 +21,27 @@ export function isModuleFile(name: string): boolean {
  * DIRECTORY called `telegram.ts` passes the name alone, and every reader of `channels/` has to
  * reach the same verdict or they disagree about what the deployment serves (the loader would skip
  * it, `info` would list it, `--tunnel` would register a webhook for it).
+ *
+ * `isFile()` is false for a SYMLINK, and that is load-bearing rather than incidental:
+ * `assertInsideAgentDir` guards the code-input DIRECTORY (`channels`, `tools`, `skills`) against
+ * escaping the definition, and nothing guards the entries inside it. A symlinked
+ * `channels/telegram.ts` would import code from anywhere on the box, past the containment check
+ * that exists to prevent exactly that. Do not "fix" this by following links — skipping is the
+ * boundary; {@link describeSkipped} is what keeps it from being silent.
  */
 export function isModuleEntry(entry: Dirent): boolean {
   return entry.isFile() && isModuleFile(entry.name);
+}
+
+/** Why a module-looking entry was skipped, or undefined when it was not one to begin with. An
+ *  author who names a file like a channel and gets nothing needs the reason at the moment it is
+ *  ignored — the alternative is a channel that silently does not exist. */
+function describeSkipped(entry: Dirent): string | undefined {
+  if (isModuleEntry(entry) || !isModuleFile(entry.name)) return undefined;
+  if (entry.isSymbolicLink()) {
+    return "a symlink — code inputs must be real files inside the agent dir (a link could import from anywhere)";
+  }
+  return entry.isDirectory() ? "a directory, not a file" : "not a regular file";
 }
 
 /** The name a discovered module is known by: the basename without its extension. Derived from the
@@ -89,7 +108,11 @@ export async function loadModuleDir(
   const modules: DiscoveredModule[] = [];
   const failures: ModuleLoadFailure[] = [];
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!isModuleEntry(entry)) continue;
+    if (!isModuleEntry(entry)) {
+      const why = describeSkipped(entry);
+      if (why) log.warn(`[fastagent] ${sub}/${entry.name} is ${why} — not loaded`);
+      continue;
+    }
     const file = join(subDir, entry.name);
     const label = `${sub}/${entry.name}`;
     try {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -15,6 +15,22 @@ export function isModuleFile(name: string): boolean {
   return MODULE_EXTS.has(extname(name)) && !name.endsWith(".d.ts");
 }
 
+/**
+ * Whether a directory entry IS one — the name test plus `isFile()`, which travel together: a
+ * DIRECTORY called `telegram.ts` passes the name alone, and every reader of `channels/` has to
+ * reach the same verdict or they disagree about what the deployment serves (the loader would skip
+ * it, `info` would list it, `--tunnel` would register a webhook for it).
+ */
+export function isModuleEntry(entry: Dirent): boolean {
+  return entry.isFile() && isModuleFile(entry.name);
+}
+
+/** The name a discovered module is known by: the basename without its extension. Derived from the
+ *  filename rather than a second copy of {@link MODULE_EXTS} as a regex. */
+export function moduleName(fileName: string): string {
+  return basename(fileName, extname(fileName));
+}
+
 export interface DiscoveredModule {
   /** Basename without extension — the authoritative name for tools/channels. */
   name: string;
@@ -57,12 +73,12 @@ export async function loadModuleDir(
   const modules: DiscoveredModule[] = [];
   const failures: ModuleLoadFailure[] = [];
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!entry.isFile() || !isModuleFile(entry.name)) continue;
+    if (!isModuleEntry(entry)) continue;
     const file = join(subDir, entry.name);
     const label = `${sub}/${entry.name}`;
     try {
       const mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
-      modules.push({ name: basename(entry.name, extname(entry.name)), label, file, mod });
+      modules.push({ name: moduleName(entry.name), label, file, mod });
     } catch (error) {
       failures.push({
         label,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -12,59 +12,77 @@ import { log } from "./log.ts";
 const MODULE_EXTS = new Set([".ts", ".js", ".mjs"]);
 
 /** Whether `name` is an importable agent module (a discovery candidate, not a type declaration). */
-export function isModuleFile(name: string): boolean {
+function isModuleFile(name: string): boolean {
   return MODULE_EXTS.has(extname(name)) && !name.endsWith(".d.ts");
 }
 
-/**
- * Whether a directory entry IS one — the name test plus `isFile()`, which travel together: a
- * DIRECTORY called `telegram.ts` passes the name alone, and every reader of `channels/` has to
- * reach the same verdict or they disagree about what the deployment serves (the loader would skip
- * it, `info` would list it, `--tunnel` would register a webhook for it).
- *
- * `isFile()` is false for a SYMLINK, and that is load-bearing rather than incidental:
- * `assertInsideAgentDir` guards the code-input DIRECTORY (`channels`, `tools`, `skills`) against
- * escaping the definition, and nothing guards the entries inside it. A symlinked
- * `channels/telegram.ts` would import code from anywhere on the box, past the containment check
- * that exists to prevent exactly that. Do not "fix" this by following links — skipping is the
- * boundary; {@link describeSkipped} is what keeps it from being silent.
- */
-export function isModuleEntry(entry: Dirent): boolean {
-  return entry.isFile() && isModuleFile(entry.name);
+/** One module file a directory declares. `name` is what the domain knows it by; nothing is imported
+ *  to produce this. */
+export interface InventoryEntry {
+  /** Basename without extension — the authoritative name for tools/channels/schedules. */
+  name: string;
+  /** "tools/foo.ts"-style label for errors and collisions. */
+  label: string;
+  file: string;
 }
 
-/** Why a module-looking entry was skipped, or undefined when it was not one to begin with. An
- *  author who names a file like a channel and gets nothing needs the reason at the moment it is
- *  ignored — the alternative is a channel that silently does not exist. */
-function describeSkipped(entry: Dirent): string | undefined {
-  if (isModuleEntry(entry) || !isModuleFile(entry.name)) return undefined;
-  if (entry.isSymbolicLink()) {
-    return "a symlink — code inputs must be real files inside the agent dir (a link could import from anywhere)";
+/** An entry whose NAME says module and whose kind says otherwise. Data, not a log line: the loader
+ *  warns, `info` could show it, and a test can assert it. */
+export interface SkippedEntry {
+  label: string;
+  /** Why it is not loadable, in words an author can act on. */
+  why: string;
+}
+
+/**
+ * WHAT A CODE-INPUT DIRECTORY DECLARES — the single answer to "which files here are modules",
+ * without importing any of them.
+ *
+ * It exists because three consumers need that answer and only one of them may import: the loader
+ * below, `fastagent info`'s listing, and `--tunnel`'s webhook registration. When they each read the
+ * directory themselves they disagreed — on what counts as a module file, on how to strip the
+ * extension, on which errno means "no such directory" — and every fix had to be applied three
+ * times. There is one reading now; what to DO with a failure stays with the caller, because that
+ * genuinely differs (the loader throws, the tunnel cannot).
+ *
+ * A missing directory is an empty inventory. Everything else throws, ENOTDIR included: `channels`
+ * and `schedules` are named directories, so the path existing as a FILE is a mistake in the agent
+ * rather than an agent without one (`service.test.ts` pins that for `schedules`). `paths.ts` folds
+ * ENOTDIR into its empty scan for the opposite reason — it asks which children HAPPEN to be agent
+ * dirs, where a file simply is not one. `not_found` is a non-Node runtime's ENOENT.
+ *
+ * SYMLINKS ARE SKIPPED, and that is a boundary rather than an oversight: `assertInsideAgentDir`
+ * guards the code-input DIRECTORY against escaping the definition, and nothing guards the entries
+ * inside it, so following a link would import from anywhere on the box past the very check meant to
+ * prevent it. Do not "fix" this by following them — report them, which is what `skipped` is for.
+ */
+export async function moduleInventory(subDir: string): Promise<{
+  entries: InventoryEntry[];
+  skipped: SkippedEntry[];
+}> {
+  let dirents: Dirent[];
+  try {
+    dirents = await readdir(subDir, { withFileTypes: true });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "not_found") return { entries: [], skipped: [] };
+    throw new Error(`cannot read ${subDir}: ${(error as Error).message}`);
   }
-  return entry.isDirectory() ? "a directory, not a file" : "not a regular file";
-}
-
-/** The name a discovered module is known by: the basename without its extension. Derived from the
- *  filename rather than a second copy of {@link MODULE_EXTS} as a regex. */
-export function moduleName(fileName: string): string {
-  return basename(fileName, extname(fileName));
-}
-
-/**
- * Whether a read failure means "there is no such directory" — the ordinary case for an agent that
- * ships no `channels/`. Every reader agrees on THIS half; what to do with everything else is theirs
- * (the loader and `info` throw, the tunnel warns — it is void-called, so a throw takes the serve
- * down).
- *
- * ENOTDIR is deliberately NOT here. `channels`/`schedules` are named directories; the path existing
- * as a FILE is a mistake in the agent, not an agent without one, and `service.test.ts` pins that a
- * `schedules` file must reject rather than serve as if nothing was declared. (`paths.ts` folds
- * ENOTDIR into its empty scan for the opposite reason: it is asking which children happen to be
- * agent dirs, where a file is simply not one.) `not_found` is a non-Node runtime's ENOENT.
- */
-export function isMissingDir(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException).code;
-  return code === "ENOENT" || code === "not_found";
+  const sub = basename(subDir);
+  const entries: InventoryEntry[] = [];
+  const skipped: SkippedEntry[] = [];
+  for (const dirent of dirents.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!isModuleFile(dirent.name)) continue;
+    const label = `${sub}/${dirent.name}`;
+    if (dirent.isFile()) {
+      entries.push({ name: basename(dirent.name, extname(dirent.name)), label, file: join(subDir, dirent.name) });
+    } else if (dirent.isSymbolicLink()) {
+      skipped.push({ label, why: "a symlink — code inputs must be real files inside the agent dir" });
+    } else {
+      skipped.push({ label, why: dirent.isDirectory() ? "a directory, not a file" : "not a regular file" });
+    }
+  }
+  return { entries, skipped };
 }
 
 export interface DiscoveredModule {
@@ -88,36 +106,25 @@ export interface ModuleLoadFailure {
 }
 
 /**
- * Import every module file in `subDir`, sorted by name. Missing dir returns none. A file that fails to
- * IMPORT is collected into `failures` (with {@link moduleLoadHint}) rather than thrown, so the caller can
- * report every bad file and apply domain policy; `loadTools`/`loadChannels` add validation failures the
- * same way. (A missing DIRECTORY still returns empty; an unreadable directory still throws
- * — that's not a per-file problem.)
+ * Import every module the directory declares ({@link moduleInventory}). A file that fails to IMPORT
+ * is collected into `failures` (with {@link moduleLoadHint}) rather than thrown, so the caller can
+ * report every bad file and apply domain policy; `loadTools`/`loadChannels` add validation failures
+ * the same way.
+ *
+ * Skipped entries are warned HERE rather than returned: this is the path where an author finds out
+ * their channel does not exist, and the inventory's other two consumers only list names.
  */
 export async function loadModuleDir(
   subDir: string,
 ): Promise<{ modules: DiscoveredModule[]; failures: ModuleLoadFailure[] }> {
-  let entries: Dirent[];
-  try {
-    entries = await readdir(subDir, { withFileTypes: true });
-  } catch (error) {
-    if (isMissingDir(error)) return { modules: [], failures: [] };
-    throw new Error(`cannot read ${subDir}: ${(error as Error).message}`);
-  }
-  const sub = basename(subDir);
+  const { entries, skipped } = await moduleInventory(subDir);
+  for (const { label, why } of skipped) log.warn(`[fastagent] ${label} is ${why} — not loaded`);
   const modules: DiscoveredModule[] = [];
   const failures: ModuleLoadFailure[] = [];
-  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!isModuleEntry(entry)) {
-      const why = describeSkipped(entry);
-      if (why) log.warn(`[fastagent] ${sub}/${entry.name} is ${why} — not loaded`);
-      continue;
-    }
-    const file = join(subDir, entry.name);
-    const label = `${sub}/${entry.name}`;
+  for (const { name, label, file } of entries) {
     try {
       const mod = (await import(pathToFileURL(file).href)) as { default?: unknown };
-      modules.push({ name: moduleName(entry.name), label, file, mod });
+      modules.push({ name, label, file, mod });
     } catch (error) {
       failures.push({
         label,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -31,6 +31,23 @@ export function moduleName(fileName: string): string {
   return basename(fileName, extname(fileName));
 }
 
+/**
+ * Whether a read failure means "there is no such directory" — the ordinary case for an agent that
+ * ships no `channels/`. Every reader agrees on THIS half; what to do with everything else is theirs
+ * (the loader and `info` throw, the tunnel warns — it is void-called, so a throw takes the serve
+ * down).
+ *
+ * ENOTDIR is deliberately NOT here. `channels`/`schedules` are named directories; the path existing
+ * as a FILE is a mistake in the agent, not an agent without one, and `service.test.ts` pins that a
+ * `schedules` file must reject rather than serve as if nothing was declared. (`paths.ts` folds
+ * ENOTDIR into its empty scan for the opposite reason: it is asking which children happen to be
+ * agent dirs, where a file is simply not one.) `not_found` is a non-Node runtime's ENOENT.
+ */
+export function isMissingDir(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT" || code === "not_found";
+}
+
 export interface DiscoveredModule {
   /** Basename without extension — the authoritative name for tools/channels. */
   name: string;
@@ -65,8 +82,7 @@ export async function loadModuleDir(
   try {
     entries = await readdir(subDir, { withFileTypes: true });
   } catch (error) {
-    const e = error as NodeJS.ErrnoException;
-    if (e.code === "ENOENT" || e.code === "not_found") return { modules: [], failures: [] };
+    if (isMissingDir(error)) return { modules: [], failures: [] };
     throw new Error(`cannot read ${subDir}: ${(error as Error).message}`);
   }
   const sub = basename(subDir);

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,7 +1,8 @@
 /**
  * Generic ESM module discovery + loading for the agent's code-input dirs (`tools/`, `channels/`,
- * `schedules/`, config). Pure node stdlib — engine-neutral, so it lives at the top level: the schedule
- * discovery (src/schedule/) must not reach into `engines/` for what is plain filesystem/import plumbing.
+ * `schedules/`, config). Node stdlib plus the logger — engine-neutral, so it lives at the top level:
+ * the schedule discovery (src/schedule/) must not reach into `engines/` for what is plain
+ * filesystem/import plumbing.
  */
 import type { Dirent } from "node:fs";
 import { readdir } from "node:fs/promises";
@@ -14,6 +15,11 @@ const MODULE_EXTS = new Set([".ts", ".js", ".mjs"]);
 /** Whether `name` is an importable agent module (a discovery candidate, not a type declaration). */
 function isModuleFile(name: string): boolean {
   return MODULE_EXTS.has(extname(name)) && !name.endsWith(".d.ts");
+}
+
+/** The name a module is known by: its basename without the extension. */
+function moduleName(fileName: string): string {
+  return basename(fileName, extname(fileName));
 }
 
 /** One module file a directory declares. `name` is what the domain knows it by; nothing is imported
@@ -38,11 +44,12 @@ export interface SkippedEntry {
  * WHAT A CODE-INPUT DIRECTORY DECLARES — the single answer to "which files here are modules",
  * without importing any of them.
  *
- * It exists because three consumers need that answer and only one of them may import: the loader
- * below, `fastagent info`'s listing, and `--tunnel`'s webhook registration. When they each read the
- * directory themselves they disagreed — on what counts as a module file, on how to strip the
- * extension, on which errno means "no such directory" — and every fix had to be applied three
- * times. There is one reading now; what to DO with a failure stays with the caller, because that
+ * It exists because four consumers need that answer and only one of them may import: the loader
+ * below, `fastagent info`'s channel listing, `--tunnel`'s webhook registration, and the deploy
+ * pre-flight's schedule probe. When they each read the directory themselves they disagreed — on
+ * what counts as a module file, on how to strip the extension, on which errno means "no such
+ * directory" — and a fix had to be applied in four places, which is why the fourth kept being
+ * missed. There is one reading now; what to DO with a failure stays with the caller, because that
  * genuinely differs (the loader throws, the tunnel cannot).
  *
  * A missing directory is an empty inventory. Everything else throws, ENOTDIR included: `channels`
@@ -71,11 +78,16 @@ export async function moduleInventory(subDir: string): Promise<{
   const sub = basename(subDir);
   const entries: InventoryEntry[] = [];
   const skipped: SkippedEntry[] = [];
-  for (const dirent of dirents.sort((a, b) => a.name.localeCompare(b.name))) {
+  // Sorted by the NAME a consumer sees, so none of them re-sorts and none can disagree about order.
+  // Filename breaks a tie: `foo.js` and `foo.ts` both read as `foo`, and the domain loaders document
+  // that the FIRST wins — deciding that here keeps it from depending on readdir's order.
+  const byName = (a: Dirent, b: Dirent): number =>
+    moduleName(a.name).localeCompare(moduleName(b.name)) || a.name.localeCompare(b.name);
+  for (const dirent of dirents.sort(byName)) {
     if (!isModuleFile(dirent.name)) continue;
     const label = `${sub}/${dirent.name}`;
     if (dirent.isFile()) {
-      entries.push({ name: basename(dirent.name, extname(dirent.name)), label, file: join(subDir, dirent.name) });
+      entries.push({ name: moduleName(dirent.name), label, file: join(subDir, dirent.name) });
     } else if (dirent.isSymbolicLink()) {
       skipped.push({ label, why: "a symlink — code inputs must be real files inside the agent dir" });
     } else {

--- a/src/schedule/discover.ts
+++ b/src/schedule/discover.ts
@@ -16,7 +16,7 @@ import type { LoadedSchedule, Schedule } from "./schedule.ts";
 export async function discoverScheduleFiles(dir: string): Promise<string[]> {
   await assertInsideAgentDir(dir, "schedules");
   const { entries } = await moduleInventory(join(dir, "schedules"));
-  return entries.map((entry) => entry.name).sort();
+  return entries.map((entry) => entry.name);
 }
 
 /**

--- a/src/schedule/discover.ts
+++ b/src/schedule/discover.ts
@@ -4,9 +4,8 @@
  * named from its filename. This is the FILE producer of scheduled invocations (the author's, declarative,
  * git-tracked, deploy-guaranteed); the agent's `wake` tool is the second producer.
  */
-import { readdir } from "node:fs/promises";
 import { join } from "node:path";
-import { type ModuleLoadFailure, isModuleFile, loadModuleDir } from "../loader.ts";
+import { type ModuleLoadFailure, loadModuleDir, moduleInventory } from "../loader.ts";
 import { assertInsideAgentDir } from "../paths.ts";
 import { cronError } from "./cron.ts";
 import type { LoadedSchedule, Schedule } from "./schedule.ts";
@@ -16,17 +15,8 @@ import type { LoadedSchedule, Schedule } from "./schedule.ts";
  *  since it also reports broken files and next instants). */
 export async function discoverScheduleFiles(dir: string): Promise<string[]> {
   await assertInsideAgentDir(dir, "schedules");
-  let names: string[];
-  try {
-    names = await readdir(join(dir, "schedules"));
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-    throw error;
-  }
-  return names
-    .filter(isModuleFile)
-    .map((n) => n.replace(/\.(ts|js|mjs)$/, ""))
-    .sort();
+  const { entries } = await moduleInventory(join(dir, "schedules"));
+  return entries.map((entry) => entry.name).sort();
 }
 
 /**

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -8,8 +8,8 @@
  */
 import { type ChildProcess, spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
-import { basename, extname, join } from "node:path";
-import { isModuleFile } from "./loader.ts";
+import { join } from "node:path";
+import { isModuleEntry, moduleName } from "./loader.ts";
 import { registerFeishuWebhook } from "./channels/feishu/register-webhook.ts";
 import { registerSlackWebhook } from "./channels/slack/register-webhook.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
@@ -138,8 +138,8 @@ function channelBasenames(dir: string): string[] {
   const channels = join(dir, "channels");
   try {
     return readdirSync(channels, { withFileTypes: true })
-      .filter((entry) => entry.isFile() && isModuleFile(entry.name))
-      .map((entry) => basename(entry.name, extname(entry.name)));
+      .filter(isModuleEntry)
+      .map((entry) => moduleName(entry.name));
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     // No channels/ is the ordinary case. Anything else is a directory we cannot read, and returning

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -7,9 +7,8 @@
  * Process orchestration, not assembly — lives outside the engine, beside dev-supervisor.ts.
  */
 import { type ChildProcess, spawn } from "node:child_process";
-import { readdirSync } from "node:fs";
 import { join } from "node:path";
-import { isMissingDir, isModuleEntry, moduleName } from "./loader.ts";
+import { moduleInventory } from "./loader.ts";
 import { registerFeishuWebhook } from "./channels/feishu/register-webhook.ts";
 import { registerSlackWebhook } from "./channels/slack/register-webhook.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
@@ -130,24 +129,20 @@ function lastErrorLine(tail: string): string {
   return ([...lines].reverse().find((l) => /err|error|failed/i.test(l)) ?? lines.at(-1) ?? "").slice(0, 200);
 }
 
-/** Channel basenames present in `<dir>/channels/`. Both halves of the test match what actually
- *  LOADS a channel (`loadModuleDir`): {@link isModuleEntry}, both halves. `isFile()` is not
- *  pedantry here — a directory named `telegram.ts` passes the name test, and registering a webhook
- *  for a channel the serve never mounted is the same wrong answer as missing one. */
-function channelBasenames(dir: string): string[] {
+/** Channel basenames present in `<dir>/channels/` — {@link moduleInventory}, the same reading the
+ *  serve loads from, so the tunnel cannot register a set the deployment does not have.
+ *
+ *  The one thing it does differently is the FAILURE: `announceWebhooks` is void-called with no
+ *  unhandledRejection handler, so a throw here would take the serve down. It reports and continues
+ *  — silence would hide exactly the fault this scan exists to feed (a `channels/` that cannot be
+ *  read registers nothing while the tunnel announces its public URL). */
+async function channelBasenames(dir: string): Promise<string[]> {
   const channels = join(dir, "channels");
   try {
-    return readdirSync(channels, { withFileTypes: true })
-      .filter(isModuleEntry)
-      .map((entry) => moduleName(entry.name));
+    const { entries } = await moduleInventory(channels);
+    return entries.map((entry) => entry.name);
   } catch (error) {
-    // No channels/ is the ordinary case. Anything else is a directory we cannot read, and returning
-    // "no channels" for it registers no webhooks while the tunnel reports itself up — the failure
-    // this function exists to feed, hidden. It cannot THROW (announceWebhooks is void-called with no
-    // unhandledRejection handler, so it would take the serve down), so it says so and continues.
-    if (!isMissingDir(error)) {
-      log.warn(`[fastagent] --tunnel: cannot read ${channels}: ${(error as Error).message} — no webhooks registered`);
-    }
+    log.warn(`[fastagent] --tunnel: cannot read ${channels}: ${(error as Error).message} — no webhooks registered`);
     return [];
   }
 }
@@ -175,7 +170,7 @@ export async function announceWebhooks(
   }
   // Serving passes the validated route-channel subset. The basename fallback preserves the public
   // helper's behavior for callers that did not assemble channels first.
-  const routeChannels = opts.routeChannels ?? channelBasenames(dir);
+  const routeChannels = opts.routeChannels ?? (await channelBasenames(dir));
   if (routeChannels.length === 0) return;
   // Readiness is the registrar's job now: a fresh quick tunnel returns Cloudflare 530 for ~20-30s before
   // its origin connects, and the automatic registrars poll /health before configuring the platform (the

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -9,7 +9,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
-import { isModuleEntry, moduleName } from "./loader.ts";
+import { isMissingDir, isModuleEntry, moduleName } from "./loader.ts";
 import { registerFeishuWebhook } from "./channels/feishu/register-webhook.ts";
 import { registerSlackWebhook } from "./channels/slack/register-webhook.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
@@ -131,7 +131,7 @@ function lastErrorLine(tail: string): string {
 }
 
 /** Channel basenames present in `<dir>/channels/`. Both halves of the test match what actually
- *  LOADS a channel (`loadModuleDir`): a real file, and {@link isModuleFile}. `isFile()` is not
+ *  LOADS a channel (`loadModuleDir`): {@link isModuleEntry}, both halves. `isFile()` is not
  *  pedantry here — a directory named `telegram.ts` passes the name test, and registering a webhook
  *  for a channel the serve never mounted is the same wrong answer as missing one. */
 function channelBasenames(dir: string): string[] {
@@ -141,12 +141,11 @@ function channelBasenames(dir: string): string[] {
       .filter(isModuleEntry)
       .map((entry) => moduleName(entry.name));
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
     // No channels/ is the ordinary case. Anything else is a directory we cannot read, and returning
     // "no channels" for it registers no webhooks while the tunnel reports itself up — the failure
     // this function exists to feed, hidden. It cannot THROW (announceWebhooks is void-called with no
     // unhandledRejection handler, so it would take the serve down), so it says so and continues.
-    if (code !== "ENOENT" && code !== "ENOTDIR") {
+    if (!isMissingDir(error)) {
       log.warn(`[fastagent] --tunnel: cannot read ${channels}: ${(error as Error).message} — no webhooks registered`);
     }
     return [];

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -130,14 +130,16 @@ function lastErrorLine(tail: string): string {
   return ([...lines].reverse().find((l) => /err|error|failed/i.test(l)) ?? lines.at(-1) ?? "").slice(0, 200);
 }
 
-/** Channel basenames present in `<dir>/channels/`. What counts as a module file is {@link isModuleFile}
- *  — the same predicate discovery uses, so the tunnel cannot register a set the serve did not mount. */
+/** Channel basenames present in `<dir>/channels/`. Both halves of the test match what actually
+ *  LOADS a channel (`loadModuleDir`): a real file, and {@link isModuleFile}. `isFile()` is not
+ *  pedantry here — a directory named `telegram.ts` passes the name test, and registering a webhook
+ *  for a channel the serve never mounted is the same wrong answer as missing one. */
 function channelBasenames(dir: string): string[] {
   const channels = join(dir, "channels");
   try {
-    return readdirSync(channels)
-      .filter(isModuleFile)
-      .map((n) => basename(n, extname(n)));
+    return readdirSync(channels, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && isModuleFile(entry.name))
+      .map((entry) => basename(entry.name, extname(entry.name)));
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     // No channels/ is the ordinary case. Anything else is a directory we cannot read, and returning

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -274,6 +274,15 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     expect(await discoverChannelFiles(dir)).toEqual(["github", "telegram"]);
   });
 
+  it("a channels/ that is a FILE is a mistake, not an agent without channels", async () => {
+    // ENOENT means "this agent declares no channels". ENOTDIR means the author put a FILE where the
+    // directory goes — reading that as "no channels" serves a deployment that silently ignores what
+    // they wrote. service.test.ts pins the same verdict for `schedules`.
+    const dir = await freshDir();
+    await writeFile(join(dir, "channels"), "not a directory\n");
+    await expect(discoverChannelFiles(dir)).rejects.toThrow(/ENOTDIR|not a directory/i);
+  });
+
   it("enforces containment on its OWN path: rejects a channels/ symlink escaping the workspace", async () => {
     // info goes through this, not loadChannels — the boundary guard must hold here independently.
     const dir = await freshDir();

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -268,6 +268,9 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     await writeFile(join(dir, "channels", "telegram.ts"), "export default () => ({});\n");
     await writeFile(join(dir, "channels", "github.ts"), "export default () => ({});\n");
     await writeFile(join(dir, "channels", "slack.ts.disabled"), "not imported\n");
+    // A DIRECTORY passes the name test on its own. Every reader of channels/ has to answer this the
+    // same way loadModuleDir does, or `info` lists a channel the serve never mounts.
+    await mkdir(join(dir, "channels", "feishu.ts"));
     expect(await discoverChannelFiles(dir)).toEqual(["github", "telegram"]);
   });
 

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Agent } from "../src/index.ts";
 import { loadChannels, discoverChannelFiles, inspectChannels } from "../src/channels/discover.ts";
+import { log } from "../src/log.ts";
 
 // loadChannels only forwards the ctx to the factory; these factories ignore it.
 const fakeCtx = { agent: {} as Agent, stateRoot: "/unused-in-tests" };
@@ -272,6 +273,27 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     // same way loadModuleDir does, or `info` lists a channel the serve never mounts.
     await mkdir(join(dir, "channels", "feishu.ts"));
     expect(await discoverChannelFiles(dir)).toEqual(["github", "telegram"]);
+  });
+
+  it("a SYMLINKED channel file is skipped, and says why", async () => {
+    // Not a gap to close: assertInsideAgentDir guards the channels DIRECTORY, nothing guards the
+    // entries in it, so following a link would import code from anywhere on the box past the very
+    // check that exists to stop that. Skipping is the boundary — the warning is what keeps an
+    // author from staring at a channel that silently does not exist.
+    const dir = await freshDir();
+    const outside = await freshDir();
+    await writeFile(join(outside, "telegram.ts"), "export default () => ({});\n");
+    await mkdir(join(dir, "channels"));
+    await symlink(join(outside, "telegram.ts"), join(dir, "channels", "telegram.ts"));
+    const said: string[] = [];
+    const warn = vi.spyOn(log, "warn").mockImplementation((message: string) => void said.push(message));
+    try {
+      const loaded = await loadChannels(dir, { agent: {} as never, stateRoot: dir });
+      expect(loaded.routeChannels).toEqual([]);
+      expect(said.join("\n")).toContain("symlink");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("a channels/ that is a FILE is a mistake, not an agent without channels", async () => {

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -275,6 +275,17 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     expect(await discoverChannelFiles(dir)).toEqual(["github", "telegram"]);
   });
 
+  it("orders by the NAME a consumer sees, not by filename", async () => {
+    // `-` sorts before `.`, so filename order gives ["a-b", "a"] while name order gives ["a", "a-b"].
+    // The inventory sorts by name so no consumer re-sorts; a github/telegram pair cannot tell the
+    // two apart, which is why this pair exists.
+    const dir = await freshDir();
+    await mkdir(join(dir, "channels"));
+    await writeFile(join(dir, "channels", "a.ts"), "export default () => ({});\n");
+    await writeFile(join(dir, "channels", "a-b.ts"), "export default () => ({});\n");
+    expect(await discoverChannelFiles(dir)).toEqual(["a", "a-b"]);
+  });
+
   it("a SYMLINKED channel file is skipped, and says why", async () => {
     // Not a gap to close: assertInsideAgentDir guards the channels DIRECTORY, nothing guards the
     // entries in it, so following a link would import code from anywhere on the box past the very

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -352,6 +352,23 @@ describe("tunnel: announceWebhooks", () => {
   // chmod is the only way to reach this branch, and it does not bite as root (root reads any
   // directory) or on Windows. Skipped rather than faked there: a guard that cannot run its own case
   // should say so instead of passing quietly.
+  it("a DIRECTORY named like a channel file is not a channel", async () => {
+    // The name test alone passes for `github.ts/` — and announcing a webhook for a channel the serve
+    // never mounted is the same wrong answer as missing one. `loadModuleDir` checks isFile(); so does
+    // this, or the two disagree about what the deployment serves.
+    const dir = await mkdtemp(join(tmpdir(), "fa-tunnel-dirch-"));
+    await mkdir(join(dir, "channels", "github.ts"), { recursive: true });
+    const said: string[] = [];
+    const info = vi.spyOn(log, "info").mockImplementation((message) => void said.push(message));
+    try {
+      await announceWebhooks(dir, "https://x.trycloudflare.com");
+      expect(said.join("\n")).not.toContain("github:");
+    } finally {
+      info.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   const canDenyRead = process.platform !== "win32" && process.getuid?.() !== 0;
   it.skipIf(!canDenyRead)("reports an unreadable channels/ instead of reading it as 'no channels'", async () => {
     // Returning [] for a directory it could not read registers no webhooks while the tunnel reports

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -360,8 +360,32 @@ describe("tunnel: announceWebhooks", () => {
     try {
       await announceWebhooks(dir, "https://x.trycloudflare.com");
       expect(said.join("\n")).not.toContain("github:");
+      // The positive half, in the same test: without it the assertion above passes for any reason
+      // the announcement never happens — including github's line moving off `log.info`, which would
+      // retire this guard silently.
+      said.length = 0;
+      await rm(join(dir, "channels", "github.ts"), { recursive: true });
+      await writeFile(join(dir, "channels", "github.ts"), "export default () => ({});\n");
+      await announceWebhooks(dir, "https://x.trycloudflare.com");
+      expect(said.join("\n")).toContain("github:");
     } finally {
       info.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a channels/ that is a FILE is reported, not read as 'no channels'", async () => {
+    // ENOTDIR is the author putting a file where the directory goes. #381 folded it in with ENOENT
+    // and said nothing — the same silence this scan exists to break, for a case that IS a mistake.
+    const dir = await mkdtemp(join(tmpdir(), "fa-tunnel-notdir-"));
+    await writeFile(join(dir, "channels"), "not a directory\n");
+    const said: string[] = [];
+    const warn = vi.spyOn(log, "warn").mockImplementation((message) => void said.push(message));
+    try {
+      await announceWebhooks(dir, "https://x.trycloudflare.com");
+      expect(said.join("\n")).toContain("cannot read");
+    } finally {
+      warn.mockRestore();
       await rm(dir, { recursive: true, force: true });
     }
   });

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -349,9 +349,6 @@ describe("tunnel: announceWebhooks", () => {
     expect(errs.some((e) => /Register manually/.test(e))).toBe(true);
   });
 
-  // chmod is the only way to reach this branch, and it does not bite as root (root reads any
-  // directory) or on Windows. Skipped rather than faked there: a guard that cannot run its own case
-  // should say so instead of passing quietly.
   it("a DIRECTORY named like a channel file is not a channel", async () => {
     // The name test alone passes for `github.ts/` — and announcing a webhook for a channel the serve
     // never mounted is the same wrong answer as missing one. `loadModuleDir` checks isFile(); so does
@@ -369,6 +366,9 @@ describe("tunnel: announceWebhooks", () => {
     }
   });
 
+  // chmod is the only way to reach this branch, and it does not bite as root (root reads any
+  // directory) or on Windows. Skipped rather than faked there: a guard that cannot run its own case
+  // should say so instead of passing quietly.
   const canDenyRead = process.platform !== "win32" && process.getuid?.() !== 0;
   it.skipIf(!canDenyRead)("reports an unreadable channels/ instead of reading it as 'no channels'", async () => {
     // Returning [] for a directory it could not read registers no webhooks while the tunnel reports


### PR DESCRIPTION
Post-merge review of #381 found its own comment overclaiming, and pulling that thread found the
disagreement was three-way.

`channels/` has three readers, and they answered "is this a channel file?" differently:

| reader | test | consequence of the gap |
|---|---|---|
| `loadModuleDir` — what actually LOADS a channel | `entry.isFile() && isModuleFile(name)` | correct |
| `discoverChannelFiles` — `fastagent info` | name only | lists a channel that is not one |
| `channelBasenames` — `--tunnel` webhook scan | name only | registers a webhook for a channel the serve never mounted |

A directory named `github.ts` passes the name test. Nobody creates one on purpose, which is why
this sat unnoticed — but #381's comment claimed the tunnel "cannot register a set the serve did not
mount", and that was not true when it was written.

## The change

`isModuleEntry(entry)` and `moduleName(fileName)` in `loader.ts`; all three readers call them.
The second helper also removes a copy of `MODULE_EXTS` that lived in `discover.ts` as the regex
`/\.(ts|js|mjs)$/`.

## Verification

Dropping `isFile()` from the shared helper turns BOTH the info listing test and the tunnel test red
from that single edit — which is what makes them one rule rather than three copies that agree
today. The tunnel's unreadable-`channels/` guard (from #381) was re-verified too: restoring the
bare `catch` still reddens it.

`npm run lint`, `npx tsc --noEmit`, 1539 tests pass.
