### PR TITLE
fix(deploy): docker registers webhooks in its driver, so it can gate like every other host

### DIFF
--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -658,7 +658,7 @@ function withCursor(error: unknown, cursor: string | undefined): Error {
 }
 
 /** The cursor a failed round reached, if it recorded one. */
-export function roundCursor(error: unknown): string | undefined {
+function roundCursor(error: unknown): string | undefined {
   return (error as { attachCursor?: string }).attachCursor;
 }
 

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -585,35 +585,45 @@ async function runDeployDocker(
     extraSecrets,
     env: deployEnvironment(agentDir, channels),
   });
-  // Docker Desktop commonly injects a host proxy. The Quick Tunnel hostname may be resolvable only
-  // through it, exactly like provider/channel APIs; use the same Node dispatcher as dev/start/login.
-  // Installed BEFORE the driver, which is what reaches the registrars now.
-  installProxyFetch();
   const outcome = await deployDockerRun(
-    { composeFile, port, secrets, missingSecrets, needsModelCredential, requireTunnel },
+    {
+      composeFile,
+      port,
+      secrets,
+      missingSecrets,
+      needsModelCredential,
+      requireTunnel,
+      announce: (tunnelUrl) =>
+        announceWebhooks(agentDir, tunnelUrl, {
+          openUrl: openExternalUrl,
+          routeChannels: channels.filter((kind) => !longConnectionChannels.includes(kind)),
+          stateRoot: resolveStateRoot(agentDir),
+        }),
+    },
     spawnRunner("docker", workspace),
     (message) => console.error(`[fastagent] ${message}`),
-    undefined,
-    undefined,
-    (tunnelUrl) =>
-      announceWebhooks(agentDir, tunnelUrl, {
-        openUrl: openExternalUrl,
-        routeChannels: channels.filter((kind) => !longConnectionChannels.includes(kind)),
-        stateRoot: resolveStateRoot(agentDir),
-      }),
   );
   const compose = `docker compose -f ${composeFile}`;
+  // Compose reached "up" iff the driver could report where it is. The gates before that point
+  // (no Docker CLI, no daemon, missing secrets) must not be preceded by `docker compose logs`
+  // instructions for containers that do not exist; the health-check gate names its own logs command.
+  const isUp = outcome.ok || outcome.url !== undefined || outcome.tunnelUrl !== undefined;
   if (outcome.url) console.error(`[fastagent] running → ${outcome.url}`);
-  console.error(`[fastagent] logs: ${compose} logs -f agent`);
-  console.error(`[fastagent] stop: ${compose} down (state volume is kept)`);
-  if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
+  if (isUp) {
+    console.error(`[fastagent] logs: ${compose} logs -f agent`);
+    console.error(`[fastagent] stop: ${compose} down (state volume is kept)`);
+  }
+  // BEFORE failStartup: a registration gate says "re-run this deploy", and a re-run rebuilds the
+  // tunnel service — the operator needs to know the URL will be a different one, or they will read
+  // the retry as re-registering the same address.
   if (outcome.tunnelUrl) {
     console.error(
       `[fastagent] note: Quick Tunnel URLs are ephemeral — after the tunnel container/Docker daemon ` +
         `restarts, re-run this deploy so webhooks receive the new URL`,
     );
-    return;
   }
+  if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
+  if (outcome.tunnelUrl) return;
   const paths = dockerWebhookPaths(channels.filter((kind) => !longConnectionChannels.includes(kind)));
   if (paths.length > 0) {
     console.error(

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -585,26 +585,29 @@ async function runDeployDocker(
     extraSecrets,
     env: deployEnvironment(agentDir, channels),
   });
+  // Docker Desktop commonly injects a host proxy. The Quick Tunnel hostname may be resolvable only
+  // through it, exactly like provider/channel APIs; use the same Node dispatcher as dev/start/login.
+  // Installed BEFORE the driver, which is what reaches the registrars now.
+  installProxyFetch();
   const outcome = await deployDockerRun(
     { composeFile, port, secrets, missingSecrets, needsModelCredential, requireTunnel },
     spawnRunner("docker", workspace),
     (message) => console.error(`[fastagent] ${message}`),
+    undefined,
+    undefined,
+    (tunnelUrl) =>
+      announceWebhooks(agentDir, tunnelUrl, {
+        openUrl: openExternalUrl,
+        routeChannels: channels.filter((kind) => !longConnectionChannels.includes(kind)),
+        stateRoot: resolveStateRoot(agentDir),
+      }),
   );
-  if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
-
   const compose = `docker compose -f ${composeFile}`;
-  console.error(`[fastagent] running${outcome.url ? ` → ${outcome.url}` : ""}`);
+  if (outcome.url) console.error(`[fastagent] running → ${outcome.url}`);
   console.error(`[fastagent] logs: ${compose} logs -f agent`);
   console.error(`[fastagent] stop: ${compose} down (state volume is kept)`);
+  if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
   if (outcome.tunnelUrl) {
-    // Docker Desktop commonly injects a host proxy. The Quick Tunnel hostname may be resolvable only
-    // through it, exactly like provider/channel APIs; use the same Node dispatcher as dev/start/login.
-    installProxyFetch();
-    await announceWebhooks(agentDir, outcome.tunnelUrl, {
-      openUrl: openExternalUrl,
-      routeChannels: channels.filter((kind) => !longConnectionChannels.includes(kind)),
-      stateRoot: resolveStateRoot(agentDir),
-    });
     console.error(
       `[fastagent] note: Quick Tunnel URLs are ephemeral — after the tunnel container/Docker daemon ` +
         `restarts, re-run this deploy so webhooks receive the new URL`,

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -5,6 +5,8 @@
  */
 import { waitForHealth } from "../../channels/wait-health.ts";
 import { parseTunnelUrl } from "../../tunnel.ts";
+import type { RegistrationOutcome } from "../../channels/registration.ts";
+import { registrationGate } from "../registration-gate.ts";
 import { MIN_DOCKER_COMPOSE_VERSION } from "./plan.ts";
 import type { CliRunner } from "../runner.ts";
 
@@ -23,7 +25,15 @@ export interface DockerRunPlan {
   requireTunnel: boolean;
 }
 
-export type DockerRunOutcome = { ok: true; url?: string; tunnelUrl?: string } | { ok: false; gate: string };
+export type DockerRunOutcome =
+  | { ok: true; url?: string; tunnelUrl?: string }
+  /** `url`/`tunnelUrl` travel with a gate too: Compose is up, so the operator still needs to know
+   *  where it is and what to re-run. */
+  | { ok: false; gate: string; url?: string; tunnelUrl?: string };
+
+/** Register the deployment's webhooks against its public URL, reporting what each registrar
+ *  answered. Injected so the driver stays free of channel specifics — and so a test can fail one. */
+export type DockerAnnounce = (baseUrl: string) => Promise<{ kind: string; outcome: RegistrationOutcome }[]>;
 
 export type DockerHealthProbe = (healthUrl: string) => Promise<boolean>;
 export type DockerTunnelUrlProbe = (
@@ -78,6 +88,7 @@ export async function deployDockerRun(
   log: (message: string) => void,
   healthProbe: DockerHealthProbe = defaultHealthProbe,
   tunnelUrlProbe: DockerTunnelUrlProbe = defaultTunnelUrlProbe,
+  announce?: DockerAnnounce,
 ): Promise<DockerRunOutcome> {
   const gate = (message: string): DockerRunOutcome => ({ ok: false, gate: message });
   const compose = ["compose", "-f", plan.composeFile];
@@ -182,6 +193,15 @@ export async function deployDockerRun(
     return gate(
       `tunnel did not publish a Quick Tunnel URL — inspect \`docker compose -f ${plan.composeFile} logs tunnel\``,
     );
+  }
+  // Registration lives HERE, like every other host's driver, and not at the CLI: this is the layer
+  // that owns the outcome, so it is the layer that can gate on one. While it sat above, docker was
+  // the one target whose `--run` could exit 0 with a webhook that never registered.
+  if (announce) {
+    const reg = registrationGate(log, `re-run this deploy to retry registration (Compose is already up)`);
+    for (const { kind, outcome } of await announce(tunnelUrl)) reg.track(kind, outcome);
+    const blocked = reg.gate();
+    if (blocked) return { ok: false, gate: blocked, url, tunnelUrl };
   }
   return { ok: true, url, tunnelUrl };
 }

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -21,6 +21,10 @@ export interface DockerRunPlan {
   missingSecrets: string[];
   /** Neither an env-key credential nor a readable auth.json is available. */
   needsModelCredential: boolean;
+  /** Register the deployment's webhooks against the tunnel URL, reporting what each registrar
+   *  answered. REQUIRED, not optional: an absent one would delete this whole step in silence, which
+   *  is the failure this driver's gate exists to end. A topology with no tunnel never calls it. */
+  announce: DockerAnnounce;
   /** `--tunnel` was requested for this run; a kept Compose file must actually contain that service. */
   requireTunnel: boolean;
 }
@@ -33,7 +37,7 @@ export type DockerRunOutcome =
 
 /** Register the deployment's webhooks against its public URL, reporting what each registrar
  *  answered. Injected so the driver stays free of channel specifics — and so a test can fail one. */
-export type DockerAnnounce = (baseUrl: string) => Promise<{ kind: string; outcome: RegistrationOutcome }[]>;
+type DockerAnnounce = (baseUrl: string) => Promise<{ kind: string; outcome: RegistrationOutcome }[]>;
 
 export type DockerHealthProbe = (healthUrl: string) => Promise<boolean>;
 export type DockerTunnelUrlProbe = (
@@ -88,7 +92,6 @@ export async function deployDockerRun(
   log: (message: string) => void,
   healthProbe: DockerHealthProbe = defaultHealthProbe,
   tunnelUrlProbe: DockerTunnelUrlProbe = defaultTunnelUrlProbe,
-  announce?: DockerAnnounce,
 ): Promise<DockerRunOutcome> {
   const gate = (message: string): DockerRunOutcome => ({ ok: false, gate: message });
   const compose = ["compose", "-f", plan.composeFile];
@@ -197,11 +200,9 @@ export async function deployDockerRun(
   // Registration lives HERE, like every other host's driver, and not at the CLI: this is the layer
   // that owns the outcome, so it is the layer that can gate on one. While it sat above, docker was
   // the one target whose `--run` could exit 0 with a webhook that never registered.
-  if (announce) {
-    const reg = registrationGate(log, `re-run this deploy to retry registration (Compose is already up)`);
-    for (const { kind, outcome } of await announce(tunnelUrl)) reg.track(kind, outcome);
-    const blocked = reg.gate();
-    if (blocked) return { ok: false, gate: blocked, url, tunnelUrl };
-  }
+  const reg = registrationGate(log, `re-run this deploy to retry registration (Compose is already up)`);
+  for (const { kind, outcome } of await plan.announce(tunnelUrl)) reg.track(kind, outcome);
+  const blocked = reg.gate();
+  if (blocked) return { ok: false, gate: blocked, url, tunnelUrl };
   return { ok: true, url, tunnelUrl };
 }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -9,6 +9,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { join } from "node:path";
 import { moduleInventory } from "./loader.ts";
+import type { RegistrationOutcome } from "./channels/registration.ts";
 import { registerFeishuWebhook } from "./channels/feishu/register-webhook.ts";
 import { registerSlackWebhook } from "./channels/slack/register-webhook.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
@@ -151,12 +152,20 @@ async function channelBasenames(dir: string): Promise<string[]> {
  * Print the public URL and wire up first-party webhook channels found under `dir` (the agent
  * ROOT): Telegram and Feishu/Lark use runtime credentials; onboarded Slack uses its owner-local config
  * token; GitHub and a manually scaffolded Slack app receive explicit console URLs.
+ *
+ * Returns what each registrar ANSWERED, because two kinds of caller need different things from a
+ * failure. `dev`/`start` are long-running: a webhook that did not register is a logged problem, not
+ * a reason to stop serving, and they void this. `deploy … --run` is a command that exits, and an
+ * exit 0 there tells its caller the deployment is reachable — so it feeds these through
+ * `registrationGate`, exactly as the fly/railway/agentcore runners feed their own registrar calls
+ * (docker used to be the one host that could not, because this returned nothing).
  */
 export async function announceWebhooks(
   dir: string,
   baseUrl: string,
   opts: { openUrl?: (url: string) => void; routeChannels?: string[]; stateRoot?: string } = {},
-): Promise<void> {
+): Promise<{ kind: string; outcome: RegistrationOutcome }[]> {
+  const registrations: { kind: string; outcome: RegistrationOutcome }[] = [];
   log.info(`[fastagent] public URL: ${baseUrl}`);
   try {
     loadDotEnv(dir); // webhook registrars read channel credentials from .env
@@ -171,21 +180,28 @@ export async function announceWebhooks(
   // Serving passes the validated route-channel subset. The basename fallback preserves the public
   // helper's behavior for callers that did not assemble channels first.
   const routeChannels = opts.routeChannels ?? (await channelBasenames(dir));
-  if (routeChannels.length === 0) return;
+  if (routeChannels.length === 0) return registrations;
   // Readiness is the registrar's job now: a fresh quick tunnel returns Cloudflare 530 for ~20-30s before
   // its origin connects, and the automatic registrars poll /health before configuring the platform (the
   // same wait the deploy runners rely on). GitHub needs no wait — the operator adds that webhook by hand.
-  if (routeChannels.includes("telegram")) await registerTelegramWebhook(baseUrl);
+  const track = (kind: string, outcome: RegistrationOutcome): void => {
+    registrations.push({ kind, outcome });
+  };
+  if (routeChannels.includes("telegram")) track("telegram", await registerTelegramWebhook(baseUrl));
   if (routeChannels.includes("github")) {
     log.info(
       `[fastagent] github: add a webhook in your repo (Settings → Webhooks): Payload URL = ${baseUrl}/webhook, content type application/json, secret = GITHUB_WEBHOOK_SECRET`,
     );
+    track("github", "manual"); // always a human step — the console line above IS the instruction
   }
   if (routeChannels.includes("slack")) {
-    await registerSlackWebhook(baseUrl, {
-      stateRoot: opts.stateRoot ?? resolveStateRoot(dir),
-      log: (message) => log.info(message),
-    });
+    track(
+      "slack",
+      await registerSlackWebhook(baseUrl, {
+        stateRoot: opts.stateRoot ?? resolveStateRoot(dir),
+        log: (message) => log.info(message),
+      }),
+    );
   }
   // feishu/lark register programmatically too (application-v7 config PATCH — telegram-setWebhook
   // parity), once per mounted kind (each kind is its own app with its own credentials); the registrar
@@ -193,6 +209,7 @@ export async function announceWebhooks(
   const feishuOptions = {
     onManualRegistration: ({ consoleUrl }: { consoleUrl: string }) => opts.openUrl?.(consoleUrl),
   };
-  if (routeChannels.includes("feishu")) await registerFeishuWebhook(baseUrl, "feishu", feishuOptions);
-  if (routeChannels.includes("lark")) await registerFeishuWebhook(baseUrl, "lark", feishuOptions);
+  if (routeChannels.includes("feishu")) track("feishu", await registerFeishuWebhook(baseUrl, "feishu", feishuOptions));
+  if (routeChannels.includes("lark")) track("lark", await registerFeishuWebhook(baseUrl, "lark", feishuOptions));
+  return registrations;
 }

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -24,6 +24,7 @@ const plan = (override: Partial<DockerRunPlan> = {}): DockerRunPlan => ({
   missingSecrets: [],
   needsModelCredential: false,
   requireTunnel: false,
+  announce: async () => [],
   ...override,
 });
 
@@ -97,15 +98,17 @@ describe("deploy/docker/run: local Compose journey", () => {
       return {};
     });
     const gated = await deployDockerRun(
-      plan({ requireTunnel: true }),
+      plan({
+        requireTunnel: true,
+        announce: async () => [
+          { kind: "telegram", outcome: "failed" },
+          { kind: "github", outcome: "manual" },
+        ],
+      }),
       docker,
       () => {},
       healthy,
       async () => "https://blue-cat.trycloudflare.com",
-      async () => [
-        { kind: "telegram", outcome: "failed" },
-        { kind: "github", outcome: "manual" },
-      ],
     );
     expect(gated.ok).toBe(false);
     if (!gated.ok) {
@@ -121,14 +124,13 @@ describe("deploy/docker/run: local Compose journey", () => {
       return {};
     });
     const out = await deployDockerRun(
-      plan({ requireTunnel: true }),
+      // `manual` must NOT gate: re-running can never clear it, so an unclearable gate would spin a
+      // coding agent forever (registration-gate.ts states this).
+      plan({ requireTunnel: true, announce: async () => [{ kind: "github", outcome: "manual" }] }),
       docker,
       () => {},
       healthy,
       async () => "https://blue-cat.trycloudflare.com",
-      // `manual` must NOT gate: re-running can never clear it, so an unclearable gate would spin a
-      // coding agent forever (registration-gate.ts states this).
-      async () => [{ kind: "github", outcome: "manual" }],
     );
     expect(out.ok).toBe(true);
   });

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -86,6 +86,53 @@ describe("deploy/docker/run: local Compose journey", () => {
     expect(withoutTunnel.commands()).not.toContain("compose -f fastagent.compose.yml up -d --build");
   });
 
+  it("gates when a webhook registration terminally fails, and still reports where Compose is", async () => {
+    // The parity fix: fly/railway/agentcore all gate on their registrars, and docker could not,
+    // because registration happened above this layer — where no outcome was available to gate on.
+    // exit 0 there tells a caller the deployment is reachable while a channel cannot receive a
+    // message. The URLs ride along with the gate: Compose IS up, so the operator needs both.
+    const { docker } = fakeDocker((args) => {
+      if (args.includes("--services")) return { stdout: "agent\ntunnel\n" };
+      if (args.includes("port")) return { stdout: "127.0.0.1:8787\n" };
+      return {};
+    });
+    const gated = await deployDockerRun(
+      plan({ requireTunnel: true }),
+      docker,
+      () => {},
+      healthy,
+      async () => "https://blue-cat.trycloudflare.com",
+      async () => [
+        { kind: "telegram", outcome: "failed" },
+        { kind: "github", outcome: "manual" },
+      ],
+    );
+    expect(gated.ok).toBe(false);
+    if (!gated.ok) {
+      expect(gated.gate).toMatch(/telegram/);
+      expect(gated.tunnelUrl).toBe("https://blue-cat.trycloudflare.com");
+    }
+  });
+
+  it("does not gate when every registrar succeeded or needs a human", async () => {
+    const { docker } = fakeDocker((args) => {
+      if (args.includes("--services")) return { stdout: "agent\ntunnel\n" };
+      if (args.includes("port")) return { stdout: "127.0.0.1:8787\n" };
+      return {};
+    });
+    const out = await deployDockerRun(
+      plan({ requireTunnel: true }),
+      docker,
+      () => {},
+      healthy,
+      async () => "https://blue-cat.trycloudflare.com",
+      // `manual` must NOT gate: re-running can never clear it, so an unclearable gate would spin a
+      // coding agent forever (registration-gate.ts states this).
+      async () => [{ kind: "github", outcome: "manual" }],
+    );
+    expect(out.ok).toBe(true);
+  });
+
   it("passes secret values through the child environment, never argv", async () => {
     const { docker, calls } = fakeDocker((args) => {
       if (args.includes("--services")) return { stdout: "agent\n" };

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -323,7 +323,8 @@ describe("tunnel: announceWebhooks", () => {
     const dir = await workspace([]); // no channels → returns right after the .env read
     await mkdir(join(dir, ".secrets", ".env"), { recursive: true }); // a directory at the .env path → loadDotEnv throws EISDIR, not ENOENT
 
-    await expect(announceWebhooks(dir, "https://x.trycloudflare.com")).resolves.toBeUndefined(); // no crash
+    // No channels, so nothing to register — the point is that it RESOLVES rather than throwing.
+    await expect(announceWebhooks(dir, "https://x.trycloudflare.com")).resolves.toEqual([]);
     expect(errs.some((e) => /could not read/.test(e) && /\.env/.test(e))).toBe(true); // surfaced, not silent
   });
 


### PR DESCRIPTION

`deploy docker --run` exited 0 when a webhook registration failed. registration-
gate.ts exists for exactly that ("exit 0 would tell a coding agent 'done' while
the deployed agent cannot receive messages"), and fly/railway/agentcore all
apply it — docker could not.

The reason was structural, not a missing call: docker was the one host whose
DRIVER did no registration. It happened a layer up, in the CLI, where no outcome
was available to gate on and no test could reach it. Counting registrar calls
per driver: fly 8, railway 8, agentcore 8, docker 0.

So registration moves into deployDockerRun, injected like its health and tunnel
probes. The driver already had a gate channel (`{ok: false, gate}`) and the CLI
already failed on it, so the fix is mostly deletion at the call site. URLs now
ride out with a gate too — Compose IS up, and the operator needs to know where
it is and what to re-run.

`announceWebhooks` returns what each registrar answered. Three of its four
callers are long-running serves that void it: a webhook that did not register is
a logged problem there, not a reason to stop serving. Only the command that
EXITS turns it into an exit code.

Verified by reverting each half: dropping the gate reddens the failure test, and
making `manual` gate reddens the one that pins github's human step as
non-blocking (an unclearable gate would spin a coding agent forever).

Also drops an `export` from `roundCursor` in attach.ts — same file-local-only
finding as the one knip caught in loader.ts, left over from an earlier PR.