### PR TITLE
fix(telegram): a /stop must address the bot it stops

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -82,7 +82,7 @@ By default, `telegramChannel` uses `defaultTelegramRoute`:
 - groups answer when the message replies to THIS bot — matched by the bot id parsed from the token, so a reply to another bot in a multi-bot group stays silent, precisely from the first update (no getMe race),
 - groups answer on an `@botname` mention when the bot username is known — detected from Telegram's own `mention` entities, not a text scan, so `@fast` never matches `@fastagent`, and an `@botname` inside a code block or a URL does not summon (it is not a mention entity).
 
-A slash command does **not** summon in a group (bare or directed like `/cmd@botname`) — it was noise; a bot that wants commands adds a custom `route`. Override `route` to decide whether and where to answer; a custom route owns its own group-summon policy. When reusing `defaultTelegramRoute`, pass your bot's identity (`botUsername` and/or `botId`) — group summon needs it, and a bare call answers only private chats (fail-closed: "is this a reply to me?" cannot be yes without knowing who "me" is).
+A slash command does **not** summon in a group (bare or directed like `/cmd@botname`) — it was noise; a bot that wants commands adds a custom `route`. The one exception is a `/stop` [addressed to this bot](#stopping-a-running-turn): refusing it would leave the stop buffered as ordinary discussion while the run it meant to stop kept going. Override `route` to decide whether and where to answer; a custom route owns its own group-summon policy — including `/stop`, which is gated by the route like any other message and aborts the session the route returns. Reuse `defaultTelegramRoute` (as below) or the exported `telegramStop(update, { botUsername, botId })` to keep the command working. When reusing `defaultTelegramRoute`, pass your bot's identity (`botUsername` and/or `botId`) — group summon needs it, and a bare call answers only private chats (fail-closed: "is this addressed to me?" cannot be yes without knowing who "me" is).
 
 ## Group chats
 
@@ -103,6 +103,7 @@ const botUsername = "my_bot";
 telegramChannel({
   secretToken: process.env.TELEGRAM_SECRET_TOKEN ?? "",
   botToken: process.env.TELEGRAM_BOT_TOKEN ?? "",
+  botUsername,
   route(update) {
     const base = defaultTelegramRoute(update, { botUsername });
     if (!base) return null;
@@ -168,10 +169,30 @@ For development bots, surfacing `failed.details` is useful. For public bots, pre
 
 ## Stopping a running turn
 
-When the serve runs with `sessionControl: true` (fastagent.config), `/stop` aborts the chat's active
-turn (queued asks are independent and keep running — send `/stop` again when one starts). Without
-session control the command answers with a visible "not enabled" notice. `/stop@<bot>` addressed to
-another bot is ignored.
+When the serve runs with `sessionControl: true` (fastagent.config), a `/stop` **addressed to this bot**
+aborts the chat's active turn (queued asks are independent and keep running — send `/stop` again when
+one starts). Without session control the command answers with a visible "not enabled" notice.
+
+Four ways to address it, all equivalent: a bare `/stop` in a private chat, `/stop@<thisbot>`,
+`@<thisbot> /stop`, and a bare `/stop` replying to one of the bot's own messages.
+
+**In a group, a bare `/stop` is not the command** — it stays ordinary discussion and lands in the
+context buffer like any other message. Telegram hands a bare command to every bot in the group, and
+only promises to deliver it when this bot spoke last, so it addresses no one: acting on it would let a
+bystander's ask for a different bot abort this bot's run. Say `@<thisbot> /stop`, or reply to the bot
+with `/stop`, instead. `/stop@<otherbot>` is likewise not this bot's.
+
+"Stays discussion" is what `defaultTelegramRoute` does with it. A permissive custom `route` that
+answers every group message will instead run the bare `/stop` as an ordinary turn — queued behind the
+run it meant to stop. If your route is that permissive, decide what to do with an unaddressed stop
+yourself: `telegramStop(update, { botUsername, botId })` tells you whether a stop is addressed to this
+bot, and returning `null` for the rest keeps them out of the queue.
+
+`/stop` runs through `route` like any other message: it aborts the session the route resolves (so a
+route that remaps `session` stops the session it actually runs), and a route that returns `null` for
+the chat silences the command there too. Pass `botUsername` to `telegramChannel` whenever you also
+pass a custom `route` (as the example above does) — the channel matches an addressed stop against its
+OWN identity, which it otherwise only learns from `getMe`, and not at all if that call fails.
 
 ## Files and images
 

--- a/src/channels/telegram/parse.ts
+++ b/src/channels/telegram/parse.ts
@@ -168,21 +168,67 @@ function botName(botUsername: string | undefined): string | undefined {
 }
 
 /**
- * Whether the message @mentions the bot — read from the `mention` ENTITIES Telegram's server already
- * parsed, not a regex over the raw text. The entity type excludes by construction what a text scan
- * false-matches: `@bot` inside a code block or a URL is not a `mention` entity, a glued `/cmd@bot` is a
- * `bot_command` — and slicing the exact offset/length range makes `@fast` vs `@fastagent` confusion
- * impossible. (Offsets are UTF-16 code units = native JS string indexing.) No text fallback: mention
- * entities are produced server-side, so their absence means there is no mention.
+ * The `mention` ENTITIES naming THIS bot — read from what Telegram's server already parsed, not a
+ * regex over the raw text. The entity type excludes by construction what a text scan false-matches:
+ * `@bot` inside a code block or a URL is not a `mention` entity, a glued `/cmd@bot` is a `bot_command`
+ * — and slicing the exact offset/length range makes `@fast` vs `@fastagent` confusion impossible.
+ * (Offsets are UTF-16 code units = native JS string indexing.) No text fallback: mention entities are
+ * produced server-side, so their absence means there is no mention. Empty when the bot does not know
+ * its own username — "which of these names me?" has no answer then, and guessing would mis-summon.
  */
-function mentionsBot(m: TelegramMessage, botUsername: string | undefined): boolean {
+function botMentions(m: TelegramMessage, botUsername: string | undefined): { offset: number; length: number }[] {
   const name = botName(botUsername);
-  if (!name) return false;
+  if (!name) return [];
   const text = m.text ?? m.caption ?? "";
   const entities = (m.text !== undefined ? m.entities : m.caption_entities) ?? [];
-  return entities.some(
+  return entities.filter(
     (e) => e.type === "mention" && text.slice(e.offset, e.offset + e.length).toLowerCase() === `@${name}`,
   );
+}
+
+/** Whether the message @mentions the bot. */
+function mentionsBot(m: TelegramMessage, botUsername: string | undefined): boolean {
+  return botMentions(m, botUsername).length > 0;
+}
+
+/** The message text with THIS bot's mentions cut out, so a command addressed to it reads as the bare
+ *  command. Only its own: a message that names someone else (`@otherbot /stop`) must keep that name,
+ *  or cutting it would turn an ask aimed elsewhere into this bot's command. Cut from the end so the
+ *  earlier offsets stay valid (they are UTF-16 code units = native JS indexing). */
+function textWithoutBotMentions(m: TelegramMessage, botUsername: string | undefined): string {
+  const text = m.text ?? m.caption ?? "";
+  return botMentions(m, botUsername)
+    .sort((a, b) => b.offset - a.offset)
+    .reduce((out, e) => out.slice(0, e.offset) + out.slice(e.offset + e.length), text)
+    .trim();
+}
+
+/**
+ * Whether the update is a `/stop` ADDRESSED TO THIS BOT — the one question the channel asks about a
+ * stop, because an unaddressed one is not a command it may act on. Four ways to address it, all
+ * equivalent: a bare `/stop` in a private chat (no one else is there), `/stop@thisbot`, an `@thisbot`
+ * mention beside the command, and a bare `/stop` replying to one of this bot's messages.
+ *
+ * A BARE `/stop` in a group is deliberately NOT one of them. Telegram hands it to every bot in the
+ * chat — and only promises to deliver it at all when this bot spoke last — so it names no one: acting
+ * on it lets a bystander's ask for a different bot abort this bot's run, and answering it lets that
+ * bystander make this bot talk. It stays ordinary discussion, which is what the group sees anyway.
+ *
+ * Takes the UPDATE, like `route` itself, so a custom route can ask it directly — that route is the
+ * gate a stop must pass, and one that refuses this update silences the command.
+ */
+export function telegramStop(update: TelegramUpdate, options?: { botUsername?: string; botId?: number }): boolean {
+  const m = pickMessage(update);
+  if (!m) return false;
+  // This bot's own mentions are cut out before matching: `@thisbot /stop` is the same command as
+  // `/stop@thisbot`. Anyone else's stays in the text, so `@otherbot /stop` never reduces to a command
+  // here — not even when it also replies to this bot.
+  const match = /^\/stop(?:@([A-Za-z0-9_]+))?$/i.exec(textWithoutBotMentions(m, options?.botUsername));
+  if (!match) return false;
+  // `/stop@name` states its addressee: ours only when the name is ours, and never when this bot does
+  // not know its own username (fail closed — the same rule reply/mention summon follows).
+  if (match[1] !== undefined) return match[1].toLowerCase() === botName(options?.botUsername);
+  return m.chat.type === "private" || mentionsBot(m, options?.botUsername) || repliesToBot(m, options);
 }
 
 /** Whether the message replies to THIS bot — not just any bot: in a multi-bot group, replying to
@@ -204,7 +250,9 @@ function repliesToBot(m: TelegramMessage, options?: { botUsername?: string; botI
  * answer private chats always; a group only on a reply to THIS bot (by `botId`) or a `mention` entity
  * naming it (when `botUsername` is supplied — telegramChannel parses the id from the token and resolves
  * the username via getMe). A bare or directed slash command does NOT summon in a group (that was noisy;
- * a bot author who wants commands adds a custom route). Returns `{}` (act; the channel fills
+ * a bot author who wants commands adds a custom route) — except a `/stop` ADDRESSED to this bot, which
+ * must reach the run it stops rather than sit in the buffer behind it (see {@link telegramStop}; a
+ * bare group `/stop` addresses no one and stays ordinary discussion). Returns `{}` (act; the channel fills
  * session/target/prompt from the message) or `null` (ignore).
  */
 export function defaultTelegramRoute(
@@ -213,6 +261,13 @@ export function defaultTelegramRoute(
 ): TelegramRoute | null {
   const m = pickMessage(update);
   if (!m) return null;
-  const summoned = m.chat.type === "private" || repliesToBot(m, options) || mentionsBot(m, options?.botUsername);
+  const summoned =
+    m.chat.type === "private" ||
+    repliesToBot(m, options) ||
+    mentionsBot(m, options?.botUsername) ||
+    // Adds exactly ONE case to the three above: the `/stop@thisbot` suffix form. Every other way to
+    // address a stop (private, mention, reply) is already a summon on its own — telegramStop repeats
+    // those three by design, since it must answer "addressed to me?" without a route to lean on.
+    telegramStop(update, options);
   return summoned ? {} : null;
 }

--- a/src/channels/telegram/scaffold/channel.ts
+++ b/src/channels/telegram/scaffold/channel.ts
@@ -15,11 +15,15 @@ export default telegramChannel({
   // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
   // full details always go to the server log regardless.
   onError: (failed) => `⚠️ ${failed.details}`,
+  // Your bot's @username. Optional — resolved via getMe when omitted — but set it if you pass a `route`
+  // below: the channel needs its own copy to recognise a `/stop` addressed to it.
+  // botUsername: "your_bot",
   // The channel owns transport + format (HTML) + attachments (photo→vision, file→disk) + streaming.
   // `route` (POLICY) is OPTIONAL — omitted, it uses defaultTelegramRoute: private chats always answer,
-  // groups only on a reply to THIS bot or an @mention of it. Override to customise, reusing the
-  // export — but pass your bot's identity: group summon needs it (the omitted default gets it from
-  // the channel; a bare `defaultTelegramRoute(u)` answers only private chats):
+  // groups only on a reply to THIS bot, an @mention of it, or a `/stop` addressed to it. Override to
+  // customise, reusing the export — but pass your bot's identity BOTH here and as `botUsername` above
+  // (the omitted default gets it from the channel; a bare `defaultTelegramRoute(u)` answers only
+  // private chats):
   //   route: (u) => defaultTelegramRoute(u, { botUsername: "my_bot" }) && { session: `user:${u.message?.from?.id}` },
   //   route: (u) => defaultTelegramRoute(u, { botUsername: "my_bot" }) && { text: `${telegramEnvelope(u.message!)}\n[extra]` },
 });

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -44,6 +44,7 @@ import {
   ownImages,
   pickMessage,
   telegramEnvelope,
+  telegramStop,
 } from "./parse.ts";
 import { type TelegramFailure, defaultErrorMessage, streamReply } from "./preview.ts";
 import { ensureStateHome } from "../kit/state.ts";
@@ -53,7 +54,7 @@ import { createTurnQueue } from "../kit/turn-queue.ts";
 import { type StoredTurn, createTurnStore } from "./turn-store.ts";
 
 // Re-export the public surface authored elsewhere, so `@fastagent-sh/fastagent/telegram` keeps one entry point.
-export { defaultTelegramRoute, telegramEnvelope };
+export { defaultTelegramRoute, telegramEnvelope, telegramStop };
 export type { TelegramFailure, TelegramMessage, TelegramRoute, TelegramUpdate };
 
 /** Execution ceiling: a turn that has STARTED running this many times without finishing is dropped
@@ -136,9 +137,10 @@ export function telegramChannel({
       throw new Error("telegramChannel requires a non-empty botToken (used to send the agent's reply)");
     }
     const formatError = onError ?? defaultErrorMessage;
-    // One getMe at startup: the bot's @username (for the default route's group @mention summon, only when
-    // not supplied) and the group-privacy flag — privacy mode off is required to receive the un-summoned
-    // group messages that feed the context buffer, so warn if it is on.
+    // One getMe at startup: the bot's @username (for the default route's group @mention summon and for
+    // recognising an addressed `/stop`, only when not supplied) and the group-privacy flag — privacy
+    // mode off is required to receive the un-summoned group messages that feed the context buffer, so
+    // warn if it is on.
     let mentionName = botUsername;
     void callApi(apiBaseUrl, botToken, "getMe", {}).then(
       (me) => {
@@ -150,7 +152,13 @@ export function telegramChannel({
           );
         }
       },
-      (e) => log.warn(`[telegram] getMe failed; @mention summon + privacy check skipped: ${String(e)}`),
+      // Name every capability the missing username costs, so "the bot ignores /stop@name" is
+      // diagnosable from this ONE line — the alternative, a warn per undecidable message, repeats a
+      // single startup fact on every update.
+      (e) =>
+        log.warn(
+          `[telegram] getMe failed; @mention summon, addressed /stop, and the privacy check are skipped: ${String(e)}`,
+        ),
     );
     // A bot token is "<bot_id>:<secret>" — the bot's own id is knowable synchronously, so reply-to-bot
     // targeting is precise from the first update (no getMe race; getMe only resolves the @username).
@@ -372,35 +380,6 @@ export function telegramChannel({
       if (!m) return new Response(null, { status: 200 });
       const placeKey = m.message_thread_id ? `${m.chat.id}:${m.message_thread_id}` : `${m.chat.id}`;
       const r = decide(update);
-      // Target + session resolution, read from the route when there is one and from the message
-      // otherwise. Hoisted above the summon check because `/stop` below needs them for a message the
-      // route did NOT summon.
-      const session = r?.session ?? placeKey;
-      const chatId = r?.chatId ?? m.chat.id;
-      // Reply to the summoning message in groups (threads the answer under the asker); a 1:1 DM needs no
-      // reply-quote. Only when the RESOLVED target is the message's own chat+thread: a route that
-      // redirects elsewhere must not carry a reply_parameters that resolves in the wrong place (fail, or
-      // quote a same-id message there). Compare VALUES, not whether the route touched the field — a route
-      // that explicitly returns the same chat/thread still quotes.
-      const threadId = r?.threadId ?? m.message_thread_id;
-      const sameTarget = String(chatId) === String(m.chat.id) && threadId === m.message_thread_id;
-      const replyTo = m.chat.type !== "private" && sameTarget ? m.message_id : undefined;
-      // Explicit user stop (`/stop`): a control action, never a turn — it must not queue behind the
-      // run it stops. `/stop@otherbot` is not ours; a bare `/stop` always is. Awaited before the ACK:
-      // dispatch + one sendMessage is fast, and a delivery failure logs instead of failing the webhook.
-      //
-      // Deliberately NOT gated on the route: the default route refuses slash commands in a group
-      // (parse.ts), so asking it first left a group's `/stop` buffered as ordinary discussion while the
-      // run it meant to stop kept going. A stop names the bot by construction, so the summon question
-      // does not apply to it.
-      const stopMatch = /^\/stop(?:@([A-Za-z0-9_]+))?$/i.exec(messageText(m).trim());
-      if (stopMatch && (!stopMatch[1] || stopMatch[1].toLowerCase() === mentionName?.toLowerCase())) {
-        const feedback = await dispatchStop(control, session, "[telegram]");
-        await sendMessage(apiBaseUrl, botToken, { chatId, threadId, replyTo }, feedback, { html: false }).catch((e) =>
-          log.warn(`[telegram] stop feedback failed: ${String(e)}`),
-        );
-        return new Response(null, { status: 200 });
-      }
       if (!r) {
         // Not summoned: in a group, record the message so a later summon has the discussion (needs privacy
         // off to be delivered here at all). Empty/service messages and non-group chats keep no buffer.
@@ -425,6 +404,31 @@ export function telegramChannel({
             imageIds: imageIds.length ? imageIds : undefined,
           });
         }
+        return new Response(null, { status: 200 });
+      }
+      const session = r.session ?? placeKey;
+      const chatId = r.chatId ?? m.chat.id;
+      // Reply to the summoning message in groups (threads the answer under the asker); a 1:1 DM needs no
+      // reply-quote. Only when the RESOLVED target is the message's own chat+thread: a route that
+      // redirects elsewhere must not carry a reply_parameters that resolves in the wrong place (fail, or
+      // quote a same-id message there). Compare VALUES, not whether the route touched the field — a route
+      // that explicitly returns the same chat/thread still quotes.
+      const threadId = r.threadId ?? m.message_thread_id;
+      const sameTarget = String(chatId) === String(m.chat.id) && threadId === m.message_thread_id;
+      const replyTo = m.chat.type !== "private" && sameTarget ? m.message_id : undefined;
+      // Explicit user stop (`/stop`): a control action, never a turn — it must not queue behind the
+      // run it stops. Awaited before the ACK: dispatch + one sendMessage is fast, and a delivery failure
+      // logs instead of failing the webhook. Read AFTER the route, on the route's own session: the route
+      // is both the gate (a route that ignores this chat must not have the bot abort or answer in it) and
+      // the session authority (a route that remaps `session` would otherwise have its stop abort a
+      // session nobody runs). The default route summons an ADDRESSED `/stop` in a group for this reason:
+      // the general slash-command refusal would leave it buffered as discussion while the run kept going.
+      // An unaddressed one is not a command at all (see telegramStop) and never reaches here.
+      if (telegramStop(update, { botUsername: mentionName, botId })) {
+        const feedback = await dispatchStop(control, session, "[telegram]");
+        await sendMessage(apiBaseUrl, botToken, { chatId, threadId, replyTo }, feedback, { html: false }).catch((e) =>
+          log.warn(`[telegram] stop feedback failed: ${String(e)}`),
+        );
         return new Response(null, { status: 200 });
       }
       const baseText = r.text ?? telegramEnvelope(m);

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -372,6 +372,35 @@ export function telegramChannel({
       if (!m) return new Response(null, { status: 200 });
       const placeKey = m.message_thread_id ? `${m.chat.id}:${m.message_thread_id}` : `${m.chat.id}`;
       const r = decide(update);
+      // Target + session resolution, read from the route when there is one and from the message
+      // otherwise. Hoisted above the summon check because `/stop` below needs them for a message the
+      // route did NOT summon.
+      const session = r?.session ?? placeKey;
+      const chatId = r?.chatId ?? m.chat.id;
+      // Reply to the summoning message in groups (threads the answer under the asker); a 1:1 DM needs no
+      // reply-quote. Only when the RESOLVED target is the message's own chat+thread: a route that
+      // redirects elsewhere must not carry a reply_parameters that resolves in the wrong place (fail, or
+      // quote a same-id message there). Compare VALUES, not whether the route touched the field — a route
+      // that explicitly returns the same chat/thread still quotes.
+      const threadId = r?.threadId ?? m.message_thread_id;
+      const sameTarget = String(chatId) === String(m.chat.id) && threadId === m.message_thread_id;
+      const replyTo = m.chat.type !== "private" && sameTarget ? m.message_id : undefined;
+      // Explicit user stop (`/stop`): a control action, never a turn — it must not queue behind the
+      // run it stops. `/stop@otherbot` is not ours; a bare `/stop` always is. Awaited before the ACK:
+      // dispatch + one sendMessage is fast, and a delivery failure logs instead of failing the webhook.
+      //
+      // Deliberately NOT gated on the route: the default route refuses slash commands in a group
+      // (parse.ts), so asking it first left a group's `/stop` buffered as ordinary discussion while the
+      // run it meant to stop kept going. A stop names the bot by construction, so the summon question
+      // does not apply to it.
+      const stopMatch = /^\/stop(?:@([A-Za-z0-9_]+))?$/i.exec(messageText(m).trim());
+      if (stopMatch && (!stopMatch[1] || stopMatch[1].toLowerCase() === mentionName?.toLowerCase())) {
+        const feedback = await dispatchStop(control, session, "[telegram]");
+        await sendMessage(apiBaseUrl, botToken, { chatId, threadId, replyTo }, feedback, { html: false }).catch((e) =>
+          log.warn(`[telegram] stop feedback failed: ${String(e)}`),
+        );
+        return new Response(null, { status: 200 });
+      }
       if (!r) {
         // Not summoned: in a group, record the message so a later summon has the discussion (needs privacy
         // off to be delivered here at all). Empty/service messages and non-group chats keep no buffer.
@@ -398,52 +427,25 @@ export function telegramChannel({
         }
         return new Response(null, { status: 200 });
       }
-      {
-        const session = r.session ?? placeKey;
-        const chatId = r.chatId ?? m.chat.id;
-        // Reply to the summoning message in groups (threads the answer under the asker); a 1:1 DM needs no
-        // reply-quote. Only when the RESOLVED target is the message's own chat+thread: a route that
-        // redirects elsewhere must not carry a reply_parameters that resolves in the wrong place (fail, or
-        // quote a same-id message there). Compare VALUES, not whether the route touched the field — a route
-        // that explicitly returns the same chat/thread still quotes.
-        const threadId = r.threadId ?? m.message_thread_id;
-        const sameTarget = String(chatId) === String(m.chat.id) && threadId === m.message_thread_id;
-        // Explicit user stop (`/stop`): a control action, never a turn — it must not queue behind the
-        // run it stops. `/stop@otherbot` is not ours; a bare `/stop` always is. Awaited before the ACK:
-        // dispatch + one sendMessage is fast, and a delivery failure logs instead of failing the webhook.
-        const stopMatch = /^\/stop(?:@([A-Za-z0-9_]+))?$/i.exec(messageText(m).trim());
-        if (stopMatch && (!stopMatch[1] || stopMatch[1].toLowerCase() === mentionName?.toLowerCase())) {
-          const feedback = await dispatchStop(control, session, "[telegram]");
-          const target: Target = {
+      const baseText = r.text ?? telegramEnvelope(m);
+      const imageFileIds = extractImages(m);
+      const fileIds = extractFiles(m);
+      if (baseText.trim() !== "" || imageFileIds.length > 0 || fileIds.length > 0) {
+        // Everything the turn needs, as a plain record; persisted pre-ACK then run serially per session.
+        submit(
+          {
+            id: `${update.update_id}`,
+            session,
+            placeKey,
+            baseText,
             chatId,
             threadId,
-            replyTo: m.chat.type !== "private" && sameTarget ? m.message_id : undefined,
-          };
-          await sendMessage(apiBaseUrl, botToken, target, feedback, { html: false }).catch((e) =>
-            log.warn(`[telegram] stop feedback failed: ${String(e)}`),
-          );
-          return new Response(null, { status: 200 });
-        }
-        const baseText = r.text ?? telegramEnvelope(m);
-        const imageFileIds = extractImages(m);
-        const fileIds = extractFiles(m);
-        if (baseText.trim() !== "" || imageFileIds.length > 0 || fileIds.length > 0) {
-          // Everything the turn needs, as a plain record; persisted pre-ACK then run serially per session.
-          submit(
-            {
-              id: `${update.update_id}`,
-              session,
-              placeKey,
-              baseText,
-              chatId,
-              threadId,
-              replyTo: m.chat.type !== "private" && sameTarget ? m.message_id : undefined,
-              imageFileIds,
-              fileIds,
-            },
-            true,
-          );
-        }
+            replyTo,
+            imageFileIds,
+            fileIds,
+          },
+          true,
+        );
       }
       return new Response(null, { status: 200 });
     };

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -3,6 +3,7 @@ export {
   telegramChannel,
   defaultTelegramRoute,
   telegramEnvelope,
+  telegramStop,
   type TelegramChannelOptions,
   type TelegramUpdate,
   type TelegramMessage,

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1884,4 +1884,44 @@ describe("telegram /stop command", () => {
     expect(sent.some((b) => b.text === "Nothing is running.")).toBe(true);
     expect(sent.some((b) => String(b.text).includes("Stop isn't enabled"))).toBe(true);
   });
+
+  // The default route refuses slash commands in a group, so a route-gated stop was buffered as
+  // ordinary discussion while the run it meant to stop kept going.
+  const groupStop = (text: string): TelegramUpdate => ({
+    update_id: 78,
+    message: {
+      message_id: 4,
+      text,
+      chat: { id: -100123, type: "supergroup" },
+      from: { id: 7, username: "alice" },
+    },
+  });
+
+  it.each(["/stop", "/stop@mybot"])("%s in a group aborts instead of becoming buffered context", async (text) => {
+    invoked.length = 0;
+    vi.stubGlobal("fetch", okFetch());
+    const { control, aborted } = fakeControl({ ok: true });
+    const stateDir = freshStateDir();
+    const ch = telegramChannel(agent, {
+      secretToken: SECRET,
+      botToken: "BOT",
+      botUsername: "mybot",
+      control,
+      stateDir,
+    });
+    expect((await ch(tgRequest(groupStop(text)))).status).toBe(200);
+    await flush();
+    expect(aborted).toEqual(["-100123"]);
+    expect(invoked).toEqual([]);
+    expect(existsSync(join(stateDir, "buffers.json"))).toBe(false);
+  });
+
+  it("/stop@otherbot in a group is still not ours", async () => {
+    vi.stubGlobal("fetch", okFetch());
+    const { control, aborted } = fakeControl({ ok: true });
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", botUsername: "mybot", control });
+    await ch(tgRequest(groupStop("/stop@otherbot")));
+    await flush();
+    expect(aborted).toEqual([]);
+  });
 });

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1885,21 +1885,32 @@ describe("telegram /stop command", () => {
     expect(sent.some((b) => String(b.text).includes("Stop isn't enabled"))).toBe(true);
   });
 
-  // The default route refuses slash commands in a group, so a route-gated stop was buffered as
-  // ordinary discussion while the run it meant to stop kept going.
-  const groupStop = (text: string): TelegramUpdate => ({
+  // A `/stop` ADDRESSED to this bot is the command; an unaddressed one in a group is not (see
+  // telegramStop). Everything below is that one rule, in a group — the ambiguous place.
+  const groupStop = (text: string, extra: Record<string, unknown> = {}): TelegramUpdate => ({
     update_id: 78,
     message: {
       message_id: 4,
       text,
       chat: { id: -100123, type: "supergroup" },
       from: { id: 7, username: "alice" },
+      ...extra,
     },
   });
 
-  it.each(["/stop", "/stop@mybot"])("%s in a group aborts instead of becoming buffered context", async (text) => {
+  const stopFeedback = (fetchMock: ReturnType<typeof okFetch>): (string | undefined)[] =>
+    callsTo(fetchMock, "sendMessage").map(([, init]) => (JSON.parse(String(init.body)) as { text?: string }).text);
+
+  // The four addressing forms are equivalent, and each must abort rather than become a turn — a turn
+  // would queue behind the very run it means to stop. (The private-chat form is the first test above.)
+  it.each([
+    ["/stop@mybot", {}],
+    ["@mybot /stop", { entities: [{ type: "mention", offset: 0, length: 6 }] }],
+    ["/stop", { reply_to_message: { message_id: 1, from: { id: 9, is_bot: true, username: "mybot" } } }],
+  ])("aborts on an addressed group stop: %s", async (text, extra) => {
     invoked.length = 0;
-    vi.stubGlobal("fetch", okFetch());
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
     const { control, aborted } = fakeControl({ ok: true });
     const stateDir = freshStateDir();
     const ch = telegramChannel(agent, {
@@ -1909,19 +1920,112 @@ describe("telegram /stop command", () => {
       control,
       stateDir,
     });
-    expect((await ch(tgRequest(groupStop(text)))).status).toBe(200);
+    expect((await ch(tgRequest(groupStop(text, extra)))).status).toBe(200);
     await flush();
     expect(aborted).toEqual(["-100123"]);
     expect(invoked).toEqual([]);
     expect(existsSync(join(stateDir, "buffers.json"))).toBe(false);
+    expect(stopFeedback(fetchMock)).toEqual(["\u23f9 Stopped."]);
   });
 
-  it("/stop@otherbot in a group is still not ours", async () => {
-    vi.stubGlobal("fetch", okFetch());
+  // An addressed stop reports whatever happened — the asker named this bot and must not be left
+  // guessing while the run continues.
+  it.each([
+    ["nothing is running", { code: NO_ACTIVE_RUN_CODE } as const, "Nothing is running."],
+    [
+      "the hub rejects the abort",
+      { code: "run_command_failed" } as const,
+      "\u26a0\ufe0f Could not stop (run_command_failed).",
+    ],
+  ])("answers an addressed group stop when %s", async (_case, result, expected) => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control } = fakeControl(result);
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", botUsername: "mybot", control });
+    await ch(tgRequest(groupStop("/stop@mybot")));
+    await flush();
+    expect(stopFeedback(fetchMock)).toEqual([expected]);
+  });
+
+  // Cutting mentions must not cut SOMEONE ELSE'S: `@otherbot /stop` names another addressee, and a
+  // reply to this bot alongside it does not transfer the command — the reply is context, the mention
+  // is the address.
+  it.each([
+    ["alone", {}, 0],
+    [
+      "while replying to this bot",
+      { reply_to_message: { message_id: 1, from: { id: 9, is_bot: true, username: "mybot" } } },
+      1,
+    ],
+  ] as const)("never acts on `@otherbot /stop` %s", async (_case, extra, turns) => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
     const { control, aborted } = fakeControl({ ok: true });
     const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", botUsername: "mybot", control });
-    await ch(tgRequest(groupStop("/stop@otherbot")));
+    const mention = { entities: [{ type: "mention", offset: 0, length: 9 }] };
+    await ch(tgRequest(groupStop("@otherbot /stop", { ...mention, ...extra })));
     await flush();
     expect(aborted).toEqual([]);
+    expect(stopFeedback(fetchMock)).not.toContain("⏹ Stopped.");
+    // The reply still SUMMONS this bot — it just answers as an ordinary turn instead of stopping.
+    expect(invoked).toHaveLength(turns);
+  });
+
+  // Unaddressed: Telegram hands a bare group command to EVERY bot in the chat, so acting on it would
+  // let a bystander's ask for another bot abort this one's run — and answering it would let them make
+  // this bot talk. It is not the command: it stays ordinary discussion, buffered like any message.
+  it.each(["/stop", "/stop@otherbot"])("leaves an unaddressed group stop as discussion: %s", async (text) => {
+    invoked.length = 0;
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control, aborted } = fakeControl({ ok: true });
+    const stateDir = freshStateDir();
+    const ch = telegramChannel(agent, {
+      secretToken: SECRET,
+      botToken: "BOT",
+      botUsername: "mybot",
+      control,
+      stateDir,
+    });
+    await ch(tgRequest(groupStop(text)));
+    await flush();
+    expect(aborted).toEqual([]);
+    expect(invoked).toEqual([]);
+    expect(stopFeedback(fetchMock)).toEqual([]);
+    expect(readFileSync(join(stateDir, "buffers.json"), "utf8")).toContain(text);
+  });
+
+  // The route is the session authority: a custom route that remaps `session` (the shape docs/telegram.md
+  // shows) must have its stop abort the session its turns actually run on, not the message's place key.
+  it("aborts the session a custom route remaps to", async () => {
+    vi.stubGlobal("fetch", okFetch());
+    const { control, aborted } = fakeControl({ ok: true });
+    const ch = telegramChannel(agent, {
+      secretToken: SECRET,
+      botToken: "BOT",
+      botUsername: "mybot",
+      control,
+      route: (update) => {
+        const base = defaultTelegramRoute(update, { botUsername: "mybot" });
+        return base && { ...base, session: `telegram:${update.message?.chat.id}` };
+      },
+    });
+    await ch(tgRequest(groupStop("/stop@mybot")));
+    await flush();
+    expect(aborted).toEqual(["telegram:-100123"]);
+  });
+
+  // The route is also the gate: a route that ignores a chat (a whitelist) must not have the bot abort
+  // there — nor post the feedback line into a conversation it was told to stay out of.
+  it("a route that ignores the chat silences /stop there", async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    const { control, aborted } = fakeControl({ ok: true });
+    const ch = telegramChannel(agent, { secretToken: SECRET, botToken: "BOT", control, route: ignore });
+    await ch(tgRequest(groupStop("/stop@mybot")));
+    await flush();
+    expect(aborted).toEqual([]);
+    expect(callsTo(fetchMock, "sendMessage")).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Problem

The default route refuses every group slash command, so a group `/stop` was buffered as ordinary discussion while the run it meant to stop kept going. `stop-command.ts` states a stop is "a control action, never a turn" — in a group it was neither.

## Rule

**A `/stop` is this bot's command when it addresses this bot.** Four equivalent forms:

| Form | Where |
|---|---|
| bare `/stop` | private chat |
| `/stop@thisbot` | anywhere |
| `@thisbot /stop` | anywhere (mention entity) |
| bare `/stop` replying to one of this bot's messages | anywhere |

**A bare group `/stop` is deliberately not the command.** Telegram hands a bare command to every bot in the chat, and only promises to deliver it when this bot spoke last — it addresses no one. Acting on it would let a bystander's ask for a different bot abort this bot's run; it stays ordinary discussion and lands in the context buffer like any other message.

Only this bot's own mentions are cut before matching, so `@otherbot /stop` never reduces to a command here — including alongside a reply to this bot, where the reply is context and the mention is the address.

## Placement

The check runs **after** the route, on the route's own session. The route is both:

- the **gate** — a route that returns `null` for a chat must not have the bot abort or answer there;
- the **session authority** — a route that remaps `session` must stop the session its turns actually run on, not the message's place key.

`defaultTelegramRoute` therefore summons an addressed stop; that adds exactly one case to its existing three (the `/stop@thisbot` suffix form — private/mention/reply already summon on their own).

## Surface

- `telegramStop(update, { botUsername, botId })` is exported from `@fastagent-sh/fastagent/telegram` so a custom route can apply the same rule.
- `botMentions()` now backs both `mentionsBot` and the mention-stripping, replacing two copies of the same entity match.

## Behavior change

A group's bare `/stop` no longer aborts. Under a permissive custom `route` (one that answers every group message) it becomes an ordinary turn rather than a stop — documented, with `telegramStop` offered as the opt-in for such routes.

## Verification

`npm run lint`, `npm run typecheck`, `npx vitest run` (114 files / 1556 tests) all green. New cases cover the four addressing forms, `@otherbot /stop` alone and with a reply, both unaddressed forms falling through to the buffer, plus the two route boundaries (session remap, ignored chat).