### PR TITLE
fix(feishu): a signature says who, not when — bound the replay window

### DIFF
--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -189,7 +189,7 @@ and resolves `closed`. There is deliberately no second public `close()` path. Se
 WebSocket authentication happens once while establishing the official-SDK connection. Webhook has two
 security modes, decided by the console's Encrypt Key setting and mirrored by `encryptKey`:
 
-- **Encrypt Key set (recommended):** ordinary events arrive AES-256-CBC encrypted with `X-Lark-Signature` headers. The channel verifies the signature over the raw body, decrypts, and **refuses plaintext events entirely** — accepting both would let a forger skip the stronger check.
+- **Encrypt Key set (recommended):** ordinary events arrive AES-256-CBC encrypted with `X-Lark-Signature` headers. The channel verifies the signature over the raw body, decrypts, and **refuses plaintext events entirely** — accepting both would let a forger skip the stronger check. A signature stays valid forever, so `X-Lark-Request-Timestamp` must also be within ±5 minutes of the server's clock; outside it the request is refused as a replay. Keep the host's clock in NTP sync.
 - **No Encrypt Key:** events arrive in plaintext and are authenticated by the Verification Token (constant-time compare).
 
 Request URL verification is the platform-documented narrow exception to event signatures. With an

--- a/src/channels/feishu/crypto.ts
+++ b/src/channels/feishu/crypto.ts
@@ -10,6 +10,11 @@
  *  - Signature: `X-Lark-Signature = sha256(timestamp + nonce + encryptKey + rawBody)` hex, where
  *    rawBody is the VERBATIM request body (the encrypted form) — computed over bytes, so the caller
  *    must pass the raw text, never a re-serialization.
+ *  - Freshness: the signature covers the timestamp but says nothing about WHEN, so a valid one stays
+ *    valid forever — {@link signatureFresh} bounds it. Kept separate from {@link verifySignature}
+ *    rather than folded in, because the two failures need two diagnoses: a wrong key and a skewed
+ *    clock are different things to go fix, and one message covering both sends the operator after
+ *    the wrong one.
  *
  * Comparisons are constant-time (timingSafeEqual) so neither the signature check nor the verification-
  * token check leaks a timing signal.
@@ -40,7 +45,22 @@ export function eventSignature(encryptKey: string, timestamp: string, nonce: str
   return createHash("sha256").update(`${timestamp}${nonce}${encryptKey}${rawBody}`, "utf8").digest("hex");
 }
 
-/** Whether a request's signature headers verify against the raw body (constant-time). */
+/** How far a signed request's timestamp may sit from ours before it is refused — the replay bound,
+ *  the same ±5 minutes the Slack ingress applies. Without it the `seen` ring is the only defence,
+ *  and that ring is bounded: once it rolls over, a captured body plus its headers replays and re-runs
+ *  the turn. Two-sided because a skewed clock is a real deployment, and a future timestamp is as
+ *  unverifiable as an ancient one. */
+export const MAX_SIGNATURE_AGE_S = 5 * 60;
+
+/** Whether a signed request's `X-Lark-Request-Timestamp` (Unix SECONDS) is inside the replay window. */
+export function signatureFresh(timestamp: string, nowMs: number = Date.now()): boolean {
+  if (!/^\d+$/.test(timestamp)) return false;
+  const seconds = Number(timestamp);
+  return Number.isSafeInteger(seconds) && Math.abs(Math.floor(nowMs / 1000) - seconds) <= MAX_SIGNATURE_AGE_S;
+}
+
+/** Whether a request's signature headers verify against the raw body (constant-time). Says nothing
+ *  about freshness — see {@link signatureFresh}. */
 export function verifySignature(
   encryptKey: string,
   headers: { timestamp: string; nonce: string; signature: string },

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -26,7 +26,7 @@ import {
   feishuBufferPlaceKey,
   feishuBufferText,
 } from "./context-buffer.ts";
-import { decryptEvent, timingSafeEqualStr, verifySignature } from "./crypto.ts";
+import { MAX_SIGNATURE_AGE_S, decryptEvent, signatureFresh, timingSafeEqualStr, verifySignature } from "./crypto.ts";
 import { invokeFeishuTurn } from "./invoke-turn.ts";
 import { type FeishuApi, type FeishuTarget, createFeishuApi } from "./feishu-api.ts";
 import type { FeishuEventHeader } from "./model.ts";
@@ -803,6 +803,17 @@ function createFeishuWebhookRoutes(
       if (sig.signature && !verifySignature(encryptKey, sig, body.text)) {
         log.warn(`${label} rejected an event: invalid X-Lark-Signature (encrypt key mismatch, or a forgery)`);
         return text("invalid signature\n", 401);
+      }
+      // A signature covers the timestamp but not the moment: without a window a captured body plus
+      // its headers stays valid forever, and the `seen` ring — bounded, so it rolls over — is the only
+      // thing between that and a re-run turn. Its own branch, and its own message: a skewed clock and
+      // a wrong encrypt key are different things to go fix.
+      if (sig.signature && !signatureFresh(sig.timestamp)) {
+        log.warn(
+          `${label} rejected an event: X-Lark-Request-Timestamp ${sig.timestamp || "(missing)"} is outside the ` +
+            `±${MAX_SIGNATURE_AGE_S}s replay window — a replayed request, or this box's clock has drifted`,
+        );
+        return text("stale signature\n", 401);
       }
       try {
         envelope = JSON.parse(decryptEvent(encryptKey, outer.encrypt)) as Record<string, unknown>;

--- a/test/feishu-crypto.test.ts
+++ b/test/feishu-crypto.test.ts
@@ -1,6 +1,13 @@
 import { createCipheriv, createHash, randomBytes } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { decryptEvent, eventSignature, timingSafeEqualStr, verifySignature } from "../src/channels/feishu/crypto.ts";
+import {
+  MAX_SIGNATURE_AGE_S,
+  decryptEvent,
+  eventSignature,
+  signatureFresh,
+  timingSafeEqualStr,
+  verifySignature,
+} from "../src/channels/feishu/crypto.ts";
 
 /** The INVERSE of the channel's decryption, built independently here from the platform's documented
  *  construction (key = sha256(encryptKey), payload = base64(IV ‖ AES-256-CBC ciphertext)) — so the test
@@ -39,6 +46,28 @@ describe("eventSignature / verifySignature", () => {
     expect(verifySignature("K", headers, "body")).toBe(true);
     expect(verifySignature("K", headers, "tampered")).toBe(false);
     expect(verifySignature("K", { ...headers, nonce: "n2" }, "body")).toBe(false);
+  });
+});
+
+describe("signatureFresh", () => {
+  const now = 1_700_000_000_000; // ms
+  const at = (offsetSeconds: number): string => String(Math.floor(now / 1000) + offsetSeconds);
+
+  it("accepts a timestamp inside the window in BOTH directions (a skewed clock runs either way)", () => {
+    expect(signatureFresh(at(0), now)).toBe(true);
+    expect(signatureFresh(at(-MAX_SIGNATURE_AGE_S), now)).toBe(true);
+    expect(signatureFresh(at(MAX_SIGNATURE_AGE_S), now)).toBe(true);
+  });
+
+  it("refuses a timestamp outside the window — the replay bound a valid-forever signature lacks", () => {
+    expect(signatureFresh(at(-MAX_SIGNATURE_AGE_S - 1), now)).toBe(false);
+    expect(signatureFresh(at(MAX_SIGNATURE_AGE_S + 1), now)).toBe(false);
+  });
+
+  it("refuses anything that is not a plain integer second count", () => {
+    for (const bad of ["", " ", "abc", "-1", "1.5", "1e9", "99999999999999999999"]) {
+      expect(signatureFresh(bad, now)).toBe(false);
+    }
   });
 });
 

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -395,8 +395,10 @@ describe("ingress verification", () => {
     };
     const encryptedBody = (plain: Record<string, unknown>): string =>
       JSON.stringify({ encrypt: encrypt(JSON.stringify(plain)) });
-    const headers = (sig: string) => ({
-      "x-lark-request-timestamp": "170",
+    // A live timestamp: the ingress bounds the replay window, so a fixed one would age out.
+    const ts = String(Math.floor(Date.now() / 1000));
+    const headers = (sig: string, timestamp = ts) => ({
+      "x-lark-request-timestamp": timestamp,
       "x-lark-request-nonce": "n1",
       "x-lark-signature": sig,
     });
@@ -427,7 +429,7 @@ describe("ingress verification", () => {
       new Request("http://app/feishu", {
         method: "POST",
         body: eventBody,
-        headers: headers(eventSignature(KEY, "170", "n1", eventBody)),
+        headers: headers(eventSignature(KEY, ts, "n1", eventBody)),
       }),
     );
     expect(signedEvent.status).toBe(200);
@@ -436,6 +438,20 @@ describe("ingress verification", () => {
         .status,
     ).toBe(401);
     expect((await handler(new Request("http://app/feishu", { method: "POST", body: eventBody }))).status).toBe(401);
+    // A correctly signed but STALE request is refused: a signature stays valid forever, so this
+    // window is the only thing bounding a replay once the bounded `seen` ring rolls over.
+    const stale = String(Math.floor(Date.now() / 1000) - 6 * 60);
+    expect(
+      (
+        await handler(
+          new Request("http://app/feishu", {
+            method: "POST",
+            body: eventBody,
+            headers: headers(eventSignature(KEY, stale, "n1", eventBody), stale),
+          }),
+        )
+      ).status,
+    ).toBe(401);
     // Encrypt Key mode remains modal: plaintext events are never accepted.
     expect((await handler(feishuRequest(messageEvent({})))).status).toBe(401);
   });


### PR DESCRIPTION
## Summary

A Feishu/Lark webhook signature was valid forever.

`verifySignature` hashes `timestamp + nonce + encryptKey + rawBody` and compares constant-time, but
nothing checked that the timestamp was recent — so a captured `{encrypt: …}` body plus its three
`x-lark-*` headers stayed a valid request indefinitely. The only thing standing between that and a
re-run turn (a re-sent message, a re-fired tool) was the `seen` ring, which is bounded at 2000 ids
and rolls over. The Slack ingress in this same repo has had a ±5 minute window since it landed; the
asymmetry was not deliberate and was not written down anywhere.

`signatureFresh` now bounds it with the same ±5 minutes. It is a separate predicate rather than a
branch inside `verifySignature` because the two failures need two diagnoses: a wrong encrypt key and
a clock that has drifted are different things to go fix, and one message covering both sends the
operator after the wrong one. The window is two-sided for the same reason — a skewed clock runs
either way, and a future timestamp is exactly as unverifiable as an ancient one.

Unaffected: `url_verification` (the platform sends it without signature headers, and that exception
is unchanged) and the plaintext no-Encrypt-Key mode (no signature to age).

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (114 files, 1548 tests)
- [x] Added or updated the smallest relevant tests

The ingress test used a hardcoded `"170"` timestamp, which is why nothing caught this; it now signs
with a live one and adds a correctly-signed-but-6-minutes-old request that must be refused. Reverting
`feishu.ts` alone turns that case red. `signatureFresh` gets its own unit coverage for both window
edges and for non-integer input.

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (`docs/feishu.md` security section)
