### PR TITLE
fix(channels): a side task that rejects must not fail the whole drain

### DIFF
--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -369,7 +369,7 @@ function createFeishuRuntimeFactory(
     });
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
     // Side tasks (stop feedback) run off the ingress path but drain in turnsIdle.
-    const sideTasks = createTaskTracker();
+    const sideTasks = createTaskTracker(label);
     const toStored = (r: PendingFeishuTurn): StoredFeishuTurn => {
       const { preview: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
       return { ...intent, attempts: 0 };

--- a/src/channels/kit/tasks.ts
+++ b/src/channels/kit/tasks.ts
@@ -4,10 +4,13 @@
  * (`turnsIdle`) — otherwise a reply in flight when the process exits is silently dropped. Error
  * handling stays with the caller: track() only guarantees the drain sees the task SETTLE, and settle
  * includes reject. A caller that handles its error on a separate branch (`p.catch(log); track(p)`)
- * still hands us a promise that rejects, and a drain that propagated it would turn one channel's side
- * task into a failed `turnsIdle` for the whole serve.
+ * still hands us a promise that rejects, and a drain that propagated it would fail the channel's whole
+ * `turnsIdle` over one side task. A rejection that reaches us is logged — we
+ * cannot tell a missing `.catch` from one on a separate branch, so the line is a visibility floor
+ * rather than a diagnosis, and without it a dropped side task leaves no trace anywhere.
  */
 import { beginWork } from "../busy.ts";
+import { log } from "../../log.ts";
 
 export interface TaskTracker {
   /** Track one task. The caller keeps its own `.catch` — rejections must already be handled. */
@@ -16,7 +19,7 @@ export interface TaskTracker {
   drain(): Promise<void>;
 }
 
-export function createTaskTracker(): TaskTracker {
+export function createTaskTracker(label: string): TaskTracker {
   const tasks = new Set<Promise<unknown>>();
   return {
     track(task) {
@@ -29,7 +32,7 @@ export function createTaskTracker(): TaskTracker {
           workDone();
           tasks.delete(task);
         })
-        .catch(() => {}); // the caller's chain owns the error
+        .catch((error) => log.warn(`${label} side task rejected: ${String(error)}`));
     },
     drain: () => Promise.allSettled(tasks).then(() => undefined),
   };

--- a/src/channels/kit/tasks.ts
+++ b/src/channels/kit/tasks.ts
@@ -2,7 +2,10 @@
  * SHARED fire-and-forget side-task tracking. Channels launch work off the request path (stop
  * feedback, DM welcomes) that must not block the transport ACK but MUST be drained on shutdown
  * (`turnsIdle`) — otherwise a reply in flight when the process exits is silently dropped. Error
- * handling stays with the caller: track() only guarantees the drain sees the task settle.
+ * handling stays with the caller: track() only guarantees the drain sees the task SETTLE, and settle
+ * includes reject. A caller that handles its error on a separate branch (`p.catch(log); track(p)`)
+ * still hands us a promise that rejects, and a drain that propagated it would turn one channel's side
+ * task into a failed `turnsIdle` for the whole serve.
  */
 import { beginWork } from "../busy.ts";
 
@@ -28,6 +31,6 @@ export function createTaskTracker(): TaskTracker {
         })
         .catch(() => {}); // the caller's chain owns the error
     },
-    drain: () => Promise.all(tasks).then(() => undefined),
+    drain: () => Promise.allSettled(tasks).then(() => undefined),
   };
 }

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -265,6 +265,11 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
       });
     };
 
+    // Side tasks (stop feedback, DM welcomes) run off the ACK path but drain in turnsIdle. Declared
+    // before its consumers, not beside them: `acceptEvent` reaches for it on the stop path, and a
+    // caller that ever runs during construction rather than from the handler would hit the temporal
+    // dead zone and throw at ACK time — which Slack answers with endless redelivery.
+    const sideTasks = createTaskTracker();
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
     const threadParticipants = createThreadParticipants(join(stateHome, "thread-participants.json"), label);
     /** A thread's participation is keyed by the SESSION it describes — "the agent answered here" is a
@@ -577,9 +582,6 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
         });
       }
     };
-
-    // Side tasks (stop feedback, DM welcomes) run off the ACK path but drain in turnsIdle.
-    const sideTasks = createTaskTracker();
 
     // First-run DM welcome: app_home_opened(tab="messages") signals a DM open. Post once per user.
     const welcomeInFlight = new Set<string>();

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -266,10 +266,8 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
     };
 
     // Side tasks (stop feedback, DM welcomes) run off the ACK path but drain in turnsIdle. Declared
-    // before its consumers, not beside them: `acceptEvent` reaches for it on the stop path, and a
-    // caller that ever runs during construction rather than from the handler would hit the temporal
-    // dead zone and throw at ACK time — which Slack answers with endless redelivery.
-    const sideTasks = createTaskTracker();
+    // ahead of its consumers so no construction-time path can reach it in the temporal dead zone.
+    const sideTasks = createTaskTracker(label);
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
     const threadParticipants = createThreadParticipants(join(stateHome, "thread-participants.json"), label);
     /** A thread's participation is keyed by the SESSION it describes — "the agent answered here" is a

--- a/test/busy.test.ts
+++ b/test/busy.test.ts
@@ -52,7 +52,7 @@ describe("channels/busy: the process-wide in-flight signal", () => {
 
   it("a tracked side task counts until it settles — rejection included", async () => {
     const base = activeWork();
-    const tracker = createTaskTracker();
+    const tracker = createTaskTracker("[test]");
     let reject: (e: Error) => void = () => {};
     const task = new Promise<void>((_r, rj) => {
       reject = rj;

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTaskTracker } from "../src/channels/kit/tasks.ts";
 
 describe("createTaskTracker", () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it("drain waits for tracked tasks; settled tasks drop out", async () => {
-    const tracker = createTaskTracker();
+    const tracker = createTaskTracker("[test]");
     let done = false;
     let release!: () => void;
     tracker.track(
@@ -21,15 +23,16 @@ describe("createTaskTracker", () => {
   });
 
   it("a rejected (caller-handled) task still settles the drain", async () => {
-    const tracker = createTaskTracker();
+    const tracker = createTaskTracker("[test]");
     tracker.track(Promise.reject(new Error("boom")).catch(() => "handled"));
     await expect(tracker.drain()).resolves.toBeUndefined();
   });
 
-  it("drain SETTLES a task that rejects — a caller handling its error on a separate branch still", async () => {
+  it("drain SETTLES a task that rejects, and the rejection is logged rather than swallowed", async () => {
     // `p.catch(log); track(p)` handles the error but hands us a promise that still rejects. Draining
-    // must not turn that into a failed turnsIdle for the whole serve.
-    const tracker = createTaskTracker();
+    // must not turn that into a failed turnsIdle for the whole serve — and must still leave a trace.
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const tracker = createTaskTracker("[test]");
     const task = Promise.reject(new Error("boom"));
     let handled: string | undefined;
     task.catch((error: Error) => {
@@ -38,5 +41,6 @@ describe("createTaskTracker", () => {
     tracker.track(task);
     await expect(tracker.drain()).resolves.toBeUndefined();
     expect(handled).toBe("boom");
+    expect(stderr.mock.calls.flat().join("\n")).toContain("[test] side task rejected: Error: boom");
   });
 });

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -25,4 +25,18 @@ describe("createTaskTracker", () => {
     tracker.track(Promise.reject(new Error("boom")).catch(() => "handled"));
     await expect(tracker.drain()).resolves.toBeUndefined();
   });
+
+  it("drain SETTLES a task that rejects — a caller handling its error on a separate branch still", async () => {
+    // `p.catch(log); track(p)` handles the error but hands us a promise that still rejects. Draining
+    // must not turn that into a failed turnsIdle for the whole serve.
+    const tracker = createTaskTracker();
+    const task = Promise.reject(new Error("boom"));
+    let handled: string | undefined;
+    task.catch((error: Error) => {
+      handled = error.message;
+    });
+    tracker.track(task);
+    await expect(tracker.drain()).resolves.toBeUndefined();
+    expect(handled).toBe("boom");
+  });
 });


### PR DESCRIPTION
## Summary

Two faults in the shared side-task tracker and its Slack consumer.

**`drain()` could reject, and a dropped task left no trace.** `TaskTracker` stores the caller's
original promise and attaches its `.catch` to a *derived* chain, so what `drain()` awaited via
`Promise.all` was still the rejecting promise. A caller that handles its error on a separate branch
— `p.catch(log); track(p)`, which is exactly what the tracker's own docstring invites — would fail
the channel's whole `turnsIdle()` over one side task. Every current caller happens to chain instead,
so this never fired; the safety was a convention no type enforced. `Promise.allSettled` makes the
docstring ("resolves when every currently-tracked task has settled") true.

That alone would have traded one fault for a quieter one: with `drain()` no longer propagating, the
`.catch(() => {})` in `track()` was the *only* thing holding a rejection, so a caller that missed its
`.catch` produced no unhandled rejection, no log, and no failed drain. `track()` now logs the
rejection it absorbs. It cannot tell a missing handler from one on a separate branch, so the line is
a visibility floor rather than a diagnosis — and it carries the channel label, because with Slack and
Feishu in one process a bare `[fastagent]` prefix cannot say which channel dropped the task.

**A temporal-dead-zone landmine in `slackChannel`.** `acceptEvent` reaches for `sideTasks` on the
stop path, and `const sideTasks` was declared ~160 lines below it. It works only because
`acceptEvent` is called from the HTTP handler, long after construction — but the recovery path
already has the shape (`store.recover()` runs during construction) that would reach a consumer in the
dead zone and fail the mount. Moved the declaration above its consumers; no behaviour change.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (114 files, 1546 tests)
- [x] Added or updated the smallest relevant tests

The existing "a rejected (caller-handled) task still settles the drain" case passed a promise the
caller had already turned into a resolution, so it never exercised the reject path. The new case
tracks a genuinely rejecting promise and asserts the warning reaches stderr; reverting either half of
`tasks.ts` alone turns it red.

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (no public surface changed)
