### PR TITLE
fix(deploy): a host CLI that refuses stdin must not crash — or pass — the deploy

### DIFF
--- a/src/deploy/runner.ts
+++ b/src/deploy/runner.ts
@@ -4,6 +4,7 @@
  * binary and the command sequence differ. Tests inject a fake recorder; production spawns the real CLI.
  */
 import { spawn } from "node:child_process";
+import { log } from "../log.ts";
 
 interface RunResult {
   code: number;
@@ -42,10 +43,30 @@ export function spawnRunner(bin: string, cwd: string): CliRunner {
       });
       let out = "";
       let err = "";
+      let stdinError: Error | undefined;
       child.stdout?.on("data", (d) => (out += String(d)));
       child.stderr?.on("data", (d) => (err += String(d)));
-      if (opts?.input) child.stdin?.end(opts.input);
-      child.on("close", (code) => res({ code: code ?? 1, stdout: out, stderr: opts?.captureStderr ? err : undefined }));
+      if (opts?.input) {
+        // A host CLI that rejects before reading (bad auth, a refused command) closes stdin under us:
+        // the write then emits `error` on a stream with no listener, which Node turns into an uncaught
+        // exception — crashing the deploy and losing the gate message the exit code was about to carry.
+        // HELD, not dropped: the exit code says it only when the CLI exits non-zero (see below).
+        child.stdin?.on("error", (error) => (stdinError ??= error));
+        child.stdin?.end(opts.input);
+      }
+      child.on("close", (code) => {
+        // A CLI that exits 0 having refused part of its stdin took TRUNCATED input — an auth seed runs
+        // well past the 64KB pipe buffer, so "success" here would deploy a half-written secret and say
+        // nothing. The exit code is what callers read, so the failure has to reach them as one.
+        const truncated = stdinError !== undefined && (code ?? 1) === 0;
+        if (truncated) {
+          // `error`, not `warn`: this line is the ONLY evidence of the failure — the caller's gate says
+          // "see the output above", and above it the host CLI printed success. A log level that mutes
+          // it (CI often sets `error`) leaves a stopped deploy with no diagnosable cause.
+          log.error(`[fastagent] ${bin} exited 0 without reading all of its input — ${stdinError?.message}`);
+        }
+        res({ code: truncated ? 1 : (code ?? 1), stdout: out, stderr: opts?.captureStderr ? err : undefined });
+      });
       child.on("error", () => res({ code: 127, stdout: "", stderr: opts?.captureStderr ? "" : undefined })); // ENOENT
     });
 }

--- a/test/deploy-runner.test.ts
+++ b/test/deploy-runner.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { spawnRunner } from "../src/deploy/runner.ts";
+
+/** Real child processes: the seam under test is the spawn wiring itself, which a fake would erase. */
+describe("spawnRunner", () => {
+  it("resolves 127 when the binary is not on PATH, so callers gate with an install hint", async () => {
+    const run = spawnRunner("fastagent-no-such-binary-xyz", process.cwd());
+    expect((await run(["--version"], { capture: true })).code).toBe(127);
+  });
+
+  it("captures stdout and the exit code", async () => {
+    const run = spawnRunner("sh", process.cwd());
+    const result = await run(["-c", "printf hello; exit 0"], { capture: true });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("hello");
+  });
+
+  it("still reports the exit code when the child exits WITHOUT reading stdin", async () => {
+    // The host-CLI failure shape: `fly secrets import` / `railway variables set` rejects before
+    // draining stdin, so the write lands on a closed pipe. Unhandled, that EPIPE is an uncaught
+    // exception mid-deploy and the gate message the exit code carries is lost.
+    const run = spawnRunner("sh", process.cwd());
+    const result = await run(["-c", "exit 3"], { input: "x".repeat(1 << 20) });
+    expect(result.code).toBe(3);
+  });
+
+  it("fails a child that exits 0 without reading all of its stdin — the input was truncated", async () => {
+    // The hole a swallowed EPIPE leaves: the secrets a deploy feeds over stdin outrun the 64KB pipe
+    // buffer, so a CLI that reports success having read a prefix would deploy half a credential and
+    // the caller (which reads the exit code) would call it done.
+    const run = spawnRunner("sh", process.cwd());
+    const result = await run(["-c", "exit 0"], { input: "x".repeat(1 << 20) });
+    expect(result.code).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Secrets reach the host CLI over stdin, never argv (`fly secrets import`, `railway variables set
--stdin`). `spawnRunner` wrote to `child.stdin` with no `error` listener, so a CLI that rejects
before draining — bad auth, a refused command, anything that exits early — produced an uncaught
`write EPIPE`: the deploy died mid-run and the gate message the exit code was about to carry was
lost, which is the opposite of what the gate exists for.

The error is now **held, not dropped**. A non-zero exit already tells the caller what happened. An
exit **0** does not: it means the CLI read a prefix and stopped, and the payload here is secrets —
a `FASTAGENT_AUTH_SEED` runs well past the 64KB pipe buffer — so that combination would deploy a
half-written credential and report success. The runner resolves code 1 for it, which is the signal
every caller reads (fly, railway, docker and agentcore drivers all gate on a non-zero code).

The cause is logged at `error`, not `warn`: it is the only evidence of this failure. The caller's
gate says "see the output above", and above it the host CLI printed success — a level that mutes the
line (CI commonly sets `error`) would leave a stopped deploy with nothing to diagnose it by.

Scope is deliberately one thing. The long-connection webhook filter this branch also carried has a
structural cause — the same "which channels have a webhook" rule is hand-written in six places across
four host directories — and lands separately as a `channel-ingress` kernel rather than as a fifth
copy of the predicate.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Added or updated the smallest relevant tests

`spawnRunner` had no test at all. The new file drives real child processes, because the wiring under
test is the spawn itself and a fake would erase it: ENOENT to 127, stdout capture, and a child that
exits without reading a 1 MiB stdin write — once exiting 3 (the code must survive), once exiting 0
(the truncation must not pass). Reverting the listener turns the first into an unhandled EPIPE that
fails the run; reverting the truncation check turns the second green-but-wrong (verified: it reports
0).

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (no public surface changed)
