### PR TITLE
refactor(slack): the fifth atomic write becomes the first one again

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,10 @@ src/
 │                           # path helpers the CLI/deploy share (displayPath, exists). Engine-neutral,
 │                           # so the scaffold/deploy/watcher/env consume it without touching engines/pi.
 ├── atomic-write.ts         # writeFileAtomic: the ONE synchronous "whole file or none of it" write
-│                           # (temp + rename + mode), after four copies drifted apart. The fixed
-│                           # `<path>.tmp` rests on a stated assumption — no two processes write one
-│                           # state root — and is the seam channel tests use to inject a write failure.
+│                           # (temp + rename + mode), after five copies drifted apart. The fixed
+│                           # `<path>.tmp` rests on one-writer-per-state-root, with slack onboarding
+│                           # state as the documented exception, and is the seam channel tests use to
+│                           # inject a write failure.
 ├── version.ts              # package version (deploy pins it into the image)
 ├── scaffold/                # `init` / `add <channel>` / `add skill` + templates/ (real files)
 ├── channels/

--- a/src/atomic-write.ts
+++ b/src/atomic-write.ts
@@ -4,8 +4,8 @@
  *
  * Synchronous, and there is no async sibling: every caller either sits on a path where a KB-sized
  * write must complete BEFORE a transport ACK (channel state — an ACKed delivery is not redelivered)
- * or on an interactive CLI flow where the cost is not observable. An async spelling would buy one of
- * them nothing and cost this module a second set of rules to keep true.
+ * or on a CLI/startup path where the cost is not observable. An async spelling would buy one of them
+ * nothing and cost this module a second set of rules to keep true.
  */
 import { chmodSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
@@ -13,12 +13,16 @@ import { dirname } from "node:path";
 /**
  * Write a file so a reader sees the whole thing or nothing: same-directory temp, then rename.
  *
- * The temp name is fixed (`<path>.tmp`). That is safe here because no two processes write one state
- * root: a deployment runs one container, `dev`'s supervisor respawns its worker only after the old
- * one has EXITED (dev-supervisor.ts), and the onboarding flows are one interactive command — and
- * these writes are synchronous, so an exited process has none in flight. The fixed name is also the seam several channel tests use to inject a write
- * failure, by occupying that path with a directory. A unique name would trade that seam for a race
- * this codebase does not have; revisit it if a second writer ever becomes real.
+ * The temp name is fixed (`<path>.tmp`). It holds wherever one process writes one state root: a
+ * deployment runs one container, `dev`'s supervisor respawns its worker only after the old one has
+ * EXITED (dev-supervisor.ts), and these writes are synchronous, so an exited process has none in
+ * flight. Slack's onboarding state is the one file with two writers — `add slack`, and the
+ * config-token rotation inside `--tunnel` webhook registration — so a second terminal running
+ * `add slack --replace-config` can overlap a live `dev --tunnel`. Kept fixed anyway: that window is
+ * a single write at tunnel startup, its repair is the `add slack --replace-config` the registration
+ * failure already prints, and the fixed name is the seam several channel tests use to inject a write
+ * failure by occupying that path with a directory. Revisit for a writer that is neither rare nor
+ * self-repairing.
  *
  * `mode` is applied to the temp first, so the content is never briefly world-readable.
  *

--- a/src/atomic-write.ts
+++ b/src/atomic-write.ts
@@ -1,10 +1,11 @@
 /**
- * One spelling of "a reader sees the whole file or none of it" for SYNCHRONOUS writes, after four
- * copies of it drifted apart: two identical, two with different temp names and different permission
- * handling.
+ * One spelling of "a reader sees the whole file or none of it", after five copies of it drifted
+ * apart: two identical, three with different temp names and different permission handling.
  *
- * Slack's onboarding state stays on its own async path — this is deliberately not an async API, and
- * converting that caller is a separate question from de-duplicating these four.
+ * Synchronous, and there is no async sibling: every caller either sits on a path where a KB-sized
+ * write must complete BEFORE a transport ACK (channel state — an ACKed delivery is not redelivered)
+ * or on an interactive CLI flow where the cost is not observable. An async spelling would buy one of
+ * them nothing and cost this module a second set of rules to keep true.
  */
 import { chmodSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
@@ -13,9 +14,9 @@ import { dirname } from "node:path";
  * Write a file so a reader sees the whole thing or nothing: same-directory temp, then rename.
  *
  * The temp name is fixed (`<path>.tmp`). That is safe here because no two processes write one state
- * root: a deployment runs one container, and `dev`'s supervisor respawns its worker only after the
- * old one has EXITED (dev-supervisor.ts) — and these writes are synchronous, so an exited process
- * has none in flight. The fixed name is also the seam several channel tests use to inject a write
+ * root: a deployment runs one container, `dev`'s supervisor respawns its worker only after the old
+ * one has EXITED (dev-supervisor.ts), and the onboarding flows are one interactive command — and
+ * these writes are synchronous, so an exited process has none in flight. The fixed name is also the seam several channel tests use to inject a write
  * failure, by occupying that path with a directory. A unique name would trade that seam for a race
  * this codebase does not have; revisit it if a second writer ever becomes real.
  *

--- a/src/channels/slack/onboard.ts
+++ b/src/channels/slack/onboard.ts
@@ -57,7 +57,7 @@ export async function onboardSlackApp(
     // Record BEFORE the non-idempotent API call. A transport/internal failure may have created the app;
     // refusing a blind retry is safer than silently producing duplicates.
     state = { ...state, createAttemptedAt: new Date().toISOString() };
-    await writeSlackOnboardingState(input.stateRoot, state);
+    writeSlackOnboardingState(input.stateRoot, state);
     let created: Awaited<ReturnType<typeof createSlackApp>>;
     try {
       created = await (deps.createApp ?? createSlackApp)(current.token, manifest);
@@ -69,7 +69,7 @@ export async function onboardSlackApp(
         );
       if (!ambiguous) {
         state = { ...state, createAttemptedAt: undefined };
-        await writeSlackOnboardingState(input.stateRoot, state);
+        writeSlackOnboardingState(input.stateRoot, state);
       }
       throw error;
     }
@@ -82,7 +82,7 @@ export async function onboardSlackApp(
       signingSecret: created.signingSecret,
     };
     // Irreversible boundary first: a cancellation or .env write failure can resume without creating a duplicate.
-    await writeSlackOnboardingState(input.stateRoot, state);
+    writeSlackOnboardingState(input.stateRoot, state);
     io.note(`Created Slack app ${created.appId}; credentials captured locally.`);
   } else {
     if (!state.clientId || !state.clientSecret) {
@@ -98,7 +98,7 @@ export async function onboardSlackApp(
   if (state.signingSecret) {
     await io.writeRuntimeSecrets({ signingSecret: state.signingSecret });
     state = { ...state, signingSecret: undefined };
-    await writeSlackOnboardingState(input.stateRoot, state);
+    writeSlackOnboardingState(input.stateRoot, state);
   }
   if (!state.appId || !state.clientId || !state.clientSecret) {
     throw new Error("Slack onboarding state lost app OAuth credentials before installation");
@@ -142,7 +142,7 @@ export async function onboardSlackApp(
     teamName: oauth.teamName,
     installedAt: new Date().toISOString(),
   };
-  await writeSlackOnboardingState(input.stateRoot, state);
+  writeSlackOnboardingState(input.stateRoot, state);
   return state;
 }
 

--- a/src/channels/slack/onboarding-state.ts
+++ b/src/channels/slack/onboarding-state.ts
@@ -1,5 +1,6 @@
-import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { writeFileAtomic } from "../../atomic-write.ts";
 import { rotateSlackConfigToken } from "./config-api.ts";
 import type { SlackGroupBehavior } from "./manifest.ts";
 
@@ -59,20 +60,12 @@ export async function readSlackOnboardingState(stateRoot: string): Promise<Slack
   }
 }
 
-/** Atomic replacement with owner-only permissions: this file carries a workspace-wide config refresh token. */
-export async function writeSlackOnboardingState(stateRoot: string, state: SlackOnboardingState): Promise<void> {
-  const file = slackOnboardingStatePath(stateRoot);
-  await mkdir(dirname(file), { recursive: true });
-  const temp = `${file}.${process.pid}.${Date.now()}.tmp`;
-  try {
-    await writeFile(temp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
-    await chmod(temp, 0o600);
-    await rename(temp, file);
-    await chmod(file, 0o600);
-  } catch (error) {
-    await rm(temp, { force: true }).catch(() => {});
-    throw error;
-  }
+/** Atomic replacement with owner-only permissions: this file carries a workspace-wide config refresh
+ *  token. Synchronous, through the shared writer, like every other piece of state this repo keeps: the
+ *  file is ~1 KB and this runs on an interactive `fastagent add slack`, so the async spelling bought
+ *  nothing and cost a fifth set of temp-name and permission rules to keep true. */
+export function writeSlackOnboardingState(stateRoot: string, state: SlackOnboardingState): void {
+  writeFileAtomic(slackOnboardingStatePath(stateRoot), `${JSON.stringify(state, null, 2)}\n`, 0o600);
 }
 
 export async function currentSlackConfigToken(
@@ -90,6 +83,6 @@ export async function currentSlackConfigToken(
     configTokenExpiresAt: rotated.expiresAt,
     teamId: state.teamId ?? rotated.teamId,
   };
-  await writeSlackOnboardingState(stateRoot, next);
+  writeSlackOnboardingState(stateRoot, next);
   return { token: next.configToken, state: next };
 }

--- a/src/channels/slack/onboarding-state.ts
+++ b/src/channels/slack/onboarding-state.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { writeFileAtomic } from "../../atomic-write.ts";
 import { rotateSlackConfigToken } from "./config-api.ts";
@@ -42,11 +42,11 @@ function validState(value: unknown): value is SlackOnboardingState {
   );
 }
 
-export async function readSlackOnboardingState(stateRoot: string): Promise<SlackOnboardingState | undefined> {
+export function readSlackOnboardingState(stateRoot: string): SlackOnboardingState | undefined {
   const file = slackOnboardingStatePath(stateRoot);
   let raw: string;
   try {
-    raw = await readFile(file, "utf8");
+    raw = readFileSync(file, "utf8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     throw new Error(`cannot read Slack onboarding state ${file}: ${(error as Error).message}`);
@@ -61,9 +61,10 @@ export async function readSlackOnboardingState(stateRoot: string): Promise<Slack
 }
 
 /** Atomic replacement with owner-only permissions: this file carries a workspace-wide config refresh
- *  token. Synchronous, through the shared writer, like every other piece of state this repo keeps: the
- *  file is ~1 KB and this runs on an interactive `fastagent add slack`, so the async spelling bought
- *  nothing and cost a fifth set of temp-name and permission rules to keep true. */
+ *  token. Synchronous, through the shared writer, like every other piece of state this repo keeps
+ *  (kit/state.ts): the file is ~1 KB and its writers are `fastagent add slack` and one config-token
+ *  rotation at tunnel startup, so the async spelling bought nothing and cost a fifth set of temp-name
+ *  and permission rules to keep true. */
 export function writeSlackOnboardingState(stateRoot: string, state: SlackOnboardingState): void {
   writeFileAtomic(slackOnboardingStatePath(stateRoot), `${JSON.stringify(state, null, 2)}\n`, 0o600);
 }

--- a/src/channels/slack/register-webhook.ts
+++ b/src/channels/slack/register-webhook.ts
@@ -19,9 +19,9 @@ export async function registerSlackWebhook(
 ): Promise<RegistrationOutcome> {
   const note = options.log ?? ((message: string) => console.error(message));
   const publicBaseUrl = baseUrl.replace(/\/$/, "");
-  let state: Awaited<ReturnType<typeof readSlackOnboardingState>>;
+  let state: ReturnType<typeof readSlackOnboardingState>;
   try {
-    state = await readSlackOnboardingState(options.stateRoot);
+    state = readSlackOnboardingState(options.stateRoot);
   } catch (error) {
     note(`[fastagent] slack: cannot read local onboarding state: ${String(error)}`);
     return "failed";

--- a/src/cli/add-slack.ts
+++ b/src/cli/add-slack.ts
@@ -39,7 +39,7 @@ export async function onboardSlackInternalApp(input: {
     );
   }
 
-  let state = await readSlackOnboardingState(input.stateRoot);
+  let state = readSlackOnboardingState(input.stateRoot);
   const resumed = state !== undefined;
   if (input.replaceConfig && !state) {
     throw new Error(
@@ -100,7 +100,7 @@ export async function onboardSlackInternalApp(input: {
       if (!configToken.startsWith("xoxe.") || !configRefreshToken.startsWith("xoxe-")) {
         throw new Error("invalid Slack configuration token prefix (expected xoxe. access + xoxe- refresh)");
       }
-      await writeSlackOnboardingState(input.stateRoot, {
+      writeSlackOnboardingState(input.stateRoot, {
         ...state,
         configToken,
         configRefreshToken,
@@ -133,10 +133,10 @@ export async function onboardSlackInternalApp(input: {
       configToken,
       configRefreshToken,
     });
-    await writeSlackOnboardingState(input.stateRoot, state);
+    writeSlackOnboardingState(input.stateRoot, state);
   } else if (input.groupBehavior.explicit && !state.appId) {
     state = { ...state, groupBehavior: input.groupBehavior.behavior };
-    await writeSlackOnboardingState(input.stateRoot, state);
+    writeSlackOnboardingState(input.stateRoot, state);
   }
   if (state.createAttemptedAt && !state.appId) {
     throw new Error(
@@ -172,7 +172,7 @@ export async function onboardSlackInternalApp(input: {
       if (!state.configToken.startsWith("xoxe.") || !state.configRefreshToken.startsWith("xoxe-")) {
         throw new Error("invalid Slack configuration token prefix (expected xoxe. access + xoxe- refresh)");
       }
-      await writeSlackOnboardingState(input.stateRoot, state);
+      writeSlackOnboardingState(input.stateRoot, state);
     }
   }
 

--- a/test/add-slack-replace-config.test.ts
+++ b/test/add-slack-replace-config.test.ts
@@ -88,7 +88,7 @@ describe("add slack --replace-config", () => {
 
   it("installed app: skips the menu, replaces only the config token pair, leaves runtime credentials alone", async () => {
     await writeFile(join(target, ".secrets", ".env"), RUNTIME_ENV);
-    await writeSlackOnboardingState(stateRoot, {
+    writeSlackOnboardingState(stateRoot, {
       version: 1,
       appName: "App",
       groupBehavior: "context",
@@ -112,7 +112,7 @@ describe("add slack --replace-config", () => {
 
   it("installed app: rejects a token pair with the wrong prefixes", async () => {
     await writeFile(join(target, ".secrets", ".env"), RUNTIME_ENV);
-    await writeSlackOnboardingState(stateRoot, {
+    writeSlackOnboardingState(stateRoot, {
       version: 1,
       appName: "App",
       groupBehavior: "context",
@@ -128,7 +128,7 @@ describe("add slack --replace-config", () => {
   });
 
   it("created-but-not-installed app: replaces tokens without a menu, then resumes installation", async () => {
-    await writeSlackOnboardingState(stateRoot, {
+    writeSlackOnboardingState(stateRoot, {
       version: 1,
       appName: "App",
       groupBehavior: "context",

--- a/test/atomic-write.test.ts
+++ b/test/atomic-write.test.ts
@@ -1,6 +1,6 @@
 /**
- * `writeFileAtomic` — the one spelling of "a reader sees the whole file or none of it", after four
- * copies of it drifted apart across the codebase (two identical, two with different temp names and
+ * `writeFileAtomic` — the one spelling of "a reader sees the whole file or none of it", after five
+ * copies of it drifted apart across the codebase (two identical, three with different temp names and
  * different permission handling).
  */
 import { chmodSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync, mkdtempSync } from "node:fs";

--- a/test/slack-onboard.test.ts
+++ b/test/slack-onboard.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -149,7 +149,7 @@ describe("Slack internal-app onboarding", () => {
       configToken: "xoxe.config",
       configRefreshToken: "xoxe-refresh",
     });
-    await writeSlackOnboardingState(stateRoot, initial);
+    writeSlackOnboardingState(stateRoot, initial);
     let oauthState = "";
     const secrets: { botToken?: string; signingSecret?: string }[] = [];
 
@@ -210,6 +210,22 @@ describe("Slack internal-app onboarding", () => {
     );
   });
 
+  it("a failed write leaves the previous state intact and surfaces, never a half-file", async () => {
+    // The shared writer's fixed `<path>.tmp` is the injection seam every other state test uses:
+    // occupying it with a directory makes the temp write fail with EISDIR, before the rename.
+    const stateRoot = await root();
+    const initial = newSlackOnboardingState({
+      appName: "Agent",
+      groupBehavior: "mentions",
+      configToken: "xoxe.config",
+      configRefreshToken: "xoxe-refresh",
+    });
+    writeSlackOnboardingState(stateRoot, initial);
+    await mkdir(join(stateRoot, "channels", "slack", "onboarding.json.tmp"));
+    expect(() => writeSlackOnboardingState(stateRoot, { ...initial, appName: "Renamed" })).toThrow();
+    expect((await readSlackOnboardingState(stateRoot))?.appName).toBe("Agent");
+  });
+
   it("blocks a blind duplicate create after an ambiguous create response", async () => {
     const stateRoot = await root();
     const initial = newSlackOnboardingState({
@@ -218,7 +234,7 @@ describe("Slack internal-app onboarding", () => {
       configToken: "xoxe.config",
       configRefreshToken: "xoxe-refresh",
     });
-    await writeSlackOnboardingState(stateRoot, initial);
+    writeSlackOnboardingState(stateRoot, initial);
     const createApp = vi.fn(async () => {
       throw new Error("connection reset after request");
     });
@@ -254,7 +270,7 @@ describe("Slack internal-app onboarding", () => {
       }),
       configTokenExpiresAt: 0,
     };
-    await writeSlackOnboardingState(stateRoot, state);
+    writeSlackOnboardingState(stateRoot, state);
     const fetchMock = vi.fn<typeof fetch>(async () =>
       Response.json({
         ok: true,
@@ -284,7 +300,7 @@ describe("Slack internal-app onboarding", () => {
       clientId: "C1",
       clientSecret: "secret",
     };
-    await writeSlackOnboardingState(stateRoot, state);
+    writeSlackOnboardingState(stateRoot, state);
     const exchangeCode = vi.fn();
     await expect(
       onboardSlackApp(
@@ -331,7 +347,7 @@ describe("Slack Request URL registration", () => {
 
   it("updates an onboarded app from the local machine without deploying the config token", async () => {
     const stateRoot = await root();
-    await writeSlackOnboardingState(stateRoot, {
+    writeSlackOnboardingState(stateRoot, {
       ...newSlackOnboardingState({
         appName: "Agent",
         groupBehavior: "context",

--- a/test/slack-onboard.test.ts
+++ b/test/slack-onboard.test.ts
@@ -201,7 +201,7 @@ describe("Slack internal-app onboarding", () => {
     ]);
     expect(result).toMatchObject({ appId: "A1", teamId: "T1", teamName: "Acme" });
     expect(result.clientSecret).toBeUndefined();
-    const persisted = await readSlackOnboardingState(stateRoot);
+    const persisted = readSlackOnboardingState(stateRoot);
     expect(persisted?.clientSecret).toBeUndefined();
     expect(persisted?.installedAt).toBeTruthy();
     expect((await stat(join(stateRoot, "channels", "slack", "onboarding.json"))).mode & 0o777).toBe(0o600);
@@ -222,8 +222,10 @@ describe("Slack internal-app onboarding", () => {
     });
     writeSlackOnboardingState(stateRoot, initial);
     await mkdir(join(stateRoot, "channels", "slack", "onboarding.json.tmp"));
-    expect(() => writeSlackOnboardingState(stateRoot, { ...initial, appName: "Renamed" })).toThrow();
-    expect((await readSlackOnboardingState(stateRoot))?.appName).toBe("Agent");
+    expect(() => writeSlackOnboardingState(stateRoot, { ...initial, appName: "Renamed" })).toThrow(
+      expect.objectContaining({ syscall: "open", code: "EISDIR" }),
+    );
+    expect(readSlackOnboardingState(stateRoot)?.appName).toBe("Agent");
   });
 
   it("blocks a blind duplicate create after an ambiguous create response", async () => {
@@ -251,7 +253,7 @@ describe("Slack internal-app onboarding", () => {
       redirectUrl: "https://setup.test/oauth",
     };
     await expect(onboardSlackApp(input, io, { createApp })).rejects.toThrow(/connection reset/);
-    const attempted = await readSlackOnboardingState(stateRoot);
+    const attempted = readSlackOnboardingState(stateRoot);
     expect(attempted?.createAttemptedAt).toBeTruthy();
     await expect(onboardSlackApp({ ...input, state: attempted! }, io, { createApp })).rejects.toThrow(
       /Inspect https:\/\/api.slack.com\/apps/,
@@ -284,7 +286,7 @@ describe("Slack internal-app onboarding", () => {
       token: "xoxe.new",
       state: { configRefreshToken: "xoxe-new-refresh", teamId: "T1" },
     });
-    expect((await readSlackOnboardingState(stateRoot))?.configRefreshToken).toBe("xoxe-new-refresh");
+    expect(readSlackOnboardingState(stateRoot)?.configRefreshToken).toBe("xoxe-new-refresh");
   });
 
   it("rejects a forged OAuth callback state before exchanging the code", async () => {

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -224,7 +224,7 @@ describe("tunnel: announceWebhooks", () => {
     const errs = captureErrors();
     const dir = await workspace(["slack"]);
     const stateRoot = join(dir, ".fastagent");
-    await writeSlackOnboardingState(stateRoot, {
+    writeSlackOnboardingState(stateRoot, {
       ...newSlackOnboardingState({
         appName: "Agent",
         groupBehavior: "mentions",


### PR DESCRIPTION
## Summary

`atomic-write.ts` exists because four copies of "a reader sees the whole file or none of it" had
drifted apart. Its header named the fifth and deferred it: *"Slack's onboarding state stays on its own
async path — converting that caller is a separate question."* This answers that question.

The Slack copy had its own temp-name policy (`<path>.<pid>.<now>.tmp`), its own permission handling
(`chmod` after the rename, which cannot promise the final path was never observable with the wrong
mode — the shared writer chmods the temp *before* renaming, for exactly that reason), and its own
cleanup branch that replaced the write failure with its own complaint. Three sets of rules for one
guarantee.

The only thing keeping it separate was `async`. That bought nothing: the file is ~1 KB, and its two
writers — an interactive `fastagent add slack`, and one config-token rotation at `--tunnel` webhook
registration — are both strictly less demanding than the serving path `writeFileAtomic` already
carries (channel state, per message, where the write must complete before a transport ACK).

`readSlackOnboardingState` is synchronous too, and that is not incidental. Converting only the write
leaves the sister function in the same module still returning a promise, and the asymmetry
propagates: `await` on a `void` is legal TypeScript that no linter catches, so every call site that
copies its neighbour keeps advertising a contract that no longer exists. The module now reads the way
it writes, matching `loadStateFile`/`saveStateFile` in `kit/state.ts`.

One assumption got weaker and is now written down instead of implied. The shared writer's fixed
`<path>.tmp` rests on one process writing one state root; slack onboarding state is the one file with
two writers, so a second terminal running `add slack --replace-config` can overlap a live
`dev --tunnel`. Kept fixed anyway — the window is a single write at tunnel startup, its repair is the
command the registration failure already prints, and the fixed name is the seam several channel tests
use to inject a write failure. `atomic-write.ts` states the exception and the condition to revisit it.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (114 files, 1546 tests)
- [x] Added or updated the smallest relevant tests

The 0600-permission assertion already covered the property that mattered (`renameSync` preserves the
temp's mode, so dropping the post-rename `chmod` changes nothing). Added the write-failure case, using
the same injection seam the other state tests use — occupy the fixed `<path>.tmp` with a directory —
asserting on `syscall`/`code` rather than "something threw", to prove the failure that surfaces is the
write's and the previous state survives it.

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (internal module only; `AGENTS.md` repo map updated)
