### PR TITLE
fix(channels): a route names the attachment directory, so sanitize it like the file name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,8 @@ src/
 │   │   ├── state.ts, seen.ts# atomic channel state + bounded durable delivery dedup
 │   │   ├── tasks.ts         # fire-and-forget side-task tracking — channels drain it in turnsIdle
 │   │   ├── text.ts          # Unicode-safe code-point slicing (cards, preview kit)
+│   │   ├── fs-name.ts       # ONE reduction of external text to a path segment — the attachment file
+│   │   │                     # name AND the route-supplied conversation directory beside it
 │   │   └── stop-command.ts  # the shared /stop parsing every chat channel accepts
 │   ├── github/              # github channel (+ scaffold/ bundle)
 │   ├── telegram/            # telegram channel: see docs/design/core.md §7

--- a/src/channels/feishu/feishu-api.ts
+++ b/src/channels/feishu/feishu-api.ts
@@ -23,6 +23,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ImageRef } from "../../agent.ts";
 import type { FeishuCloudKind } from "./cloud.ts";
+import { safeSegment } from "../kit/fs-name.ts";
 import { utf8Prefix } from "../kit/text.ts";
 
 /** Per-attempt timeout for a JSON API call — small JSON round-trips, so 30s is generous. */
@@ -449,9 +450,10 @@ export function createFeishuApi(opts: FeishuApiOptions): FeishuApi {
     },
     async fetchFile(messageId, fileKey, name, chatId, filesDir) {
       const { bytes } = await api.downloadResource(messageId, fileKey, "file");
-      // The name is external input destined for a filesystem path — keep only its basename-safe core.
-      const safe = name.replace(/[/\\]/g, "_").replace(/^\.+/, "_") || "file";
-      const dir = join(filesDir, chatId);
+      // Both halves are external input destined for a filesystem path: the name from the platform,
+      // `chatId` from the ROUTE (a custom route supplies it).
+      const safe = safeSegment(name);
+      const dir = join(filesDir, safeSegment(chatId, "chat"));
       await mkdir(dir, { recursive: true });
       const dest = join(dir, safe);
       await writeFile(dest, bytes);

--- a/src/channels/kit/fs-name.ts
+++ b/src/channels/kit/fs-name.ts
@@ -8,6 +8,9 @@
  * `chatId: "../.."` wrote outside the state home, silently. The two halves are the same question, so
  * they get the same answer here rather than one guard per platform (which is how the directory came
  * to be missing three times).
+ *
+ * Containment beats uniqueness: `a/b` and `a_b` fold to one segment. Real platform ids carry no
+ * separator, so that collision needs a hostile custom route to reach.
  */
 
 /** A single path segment: no separators, no traversal, never empty. */

--- a/src/channels/kit/fs-name.ts
+++ b/src/channels/kit/fs-name.ts
@@ -1,0 +1,18 @@
+/**
+ * ONE reduction of external text to a single filesystem path segment, for the attachment directories
+ * every chat channel writes under its state home (`<filesDir>/<conversation>/<file>`).
+ *
+ * Both halves of that path are external: the file NAME comes from the platform, and the DIRECTORY
+ * comes from the channel's route — `route.chatId` / `route.channelId`, which the agent's author
+ * writes. Each channel sanitized the name and left the directory raw, so a route returning
+ * `chatId: "../.."` wrote outside the state home, silently. The two halves are the same question, so
+ * they get the same answer here rather than one guard per platform (which is how the directory came
+ * to be missing three times).
+ */
+
+/** A single path segment: no separators, no traversal, never empty. */
+export function safeSegment(value: string | number, fallback = "file"): string {
+  // `.` and `..` are traversal; a leading dot also hides the entry, which is not a channel's call to
+  // make. Collapsing every leading dot covers both without a special case per spelling.
+  return String(value).replace(/[/\\]/g, "_").replace(/^\.+/, "_") || fallback;
+}

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -2,6 +2,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ImageRef } from "../../agent.ts";
+import { safeSegment } from "../kit/fs-name.ts";
 import { codePointPrefix } from "../kit/text.ts";
 import type { SlackFile } from "./model.ts";
 
@@ -151,9 +152,7 @@ export function chunkSlackMarkdown(markdown: string, maxPoints = SLACK_MAX_MARKD
 }
 
 function safeFileName(file: SlackFile): string {
-  const raw = file.name ?? file.title ?? file.id ?? "file";
-  const safe = raw.replace(/[/\\]/g, "_").replace(/^\.+/, "_") || "file";
-  return `${file.id ?? "slack"}-${safe}`;
+  return `${file.id ?? "slack"}-${safeSegment(file.name ?? file.title ?? file.id ?? "file")}`;
 }
 
 function fileDownloadUrl(file: SlackFile): string {
@@ -430,7 +429,8 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
     },
     async fetchFile(file, channelId, filesDir) {
       const { bytes } = await download(file);
-      const dir = join(filesDir, channelId);
+      // `channelId` is the ROUTE's, not necessarily the platform's — a custom route supplies it.
+      const dir = join(filesDir, safeSegment(channelId, "channel"));
       await mkdir(dir, { recursive: true });
       const name = safeFileName(file);
       const path = join(dir, name);

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -152,7 +152,9 @@ export function chunkSlackMarkdown(markdown: string, maxPoints = SLACK_MAX_MARKD
 }
 
 function safeFileName(file: SlackFile): string {
-  return `${file.id ?? "slack"}-${safeSegment(file.name ?? file.title ?? file.id ?? "file")}`;
+  // `file.id` is as external as `file.name` (both come off the event), so the guard runs on the
+  // whole segment; the prefix keeps it from ever starting with a dot.
+  return safeSegment(`${file.id ?? "slack"}-${file.name ?? file.title ?? file.id ?? "file"}`);
 }
 
 function fileDownloadUrl(file: SlackFile): string {

--- a/src/channels/telegram/telegram-api.ts
+++ b/src/channels/telegram/telegram-api.ts
@@ -18,6 +18,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import type { ImageRef } from "../../agent.ts";
+import { safeSegment } from "../kit/fs-name.ts";
 
 /** Telegram's hard text limit per message. */
 export const TELEGRAM_MAX_TEXT = 4096;
@@ -386,8 +387,10 @@ async function downloadTelegramFile(
   filesDir: string,
 ): Promise<DownloadedFile> {
   const { bytes, remotePath } = await getFileBytes(api, botToken, fileId);
-  const name = basename(remotePath);
-  const dir = join(filesDir, String(chatId));
+  // `remotePath` is the Bot API's; `chatId` is the ROUTE's (a custom route supplies it). basename
+  // strips directories but keeps `..` whole, so the segment guard still has to run on it.
+  const name = safeSegment(basename(remotePath));
+  const dir = join(filesDir, safeSegment(chatId, "chat"));
   await mkdir(dir, { recursive: true });
   const dest = join(dir, name);
   await writeFile(dest, bytes);

--- a/test/fs-name.test.ts
+++ b/test/fs-name.test.ts
@@ -1,0 +1,25 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { safeSegment } from "../src/channels/kit/fs-name.ts";
+
+describe("safeSegment", () => {
+  it("keeps an ordinary conversation id or file name unchanged", () => {
+    expect(safeSegment("-1001234567890")).toBe("-1001234567890");
+    expect(safeSegment(42)).toBe("42");
+    expect(safeSegment("oc_abc123")).toBe("oc_abc123");
+    expect(safeSegment("report.pdf")).toBe("report.pdf");
+  });
+
+  it("cannot escape the directory it is joined under — the reason it exists", () => {
+    const home = "/state/channels/telegram/files";
+    for (const hostile of ["..", "../..", "../../etc", "/etc/passwd", "a/../..", ".\\..\\..", "..\\.."]) {
+      expect(join(home, safeSegment(hostile)).startsWith(`${home}/`)).toBe(true);
+    }
+  });
+
+  it("never yields an empty segment (which join would silently collapse away)", () => {
+    expect(safeSegment("", "chat")).toBe("chat");
+    expect(safeSegment("/")).toBe("_");
+    expect(safeSegment("...")).toBe("_");
+  });
+});

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -139,7 +139,9 @@ describe("Slack Web API transport", () => {
       "C1",
       root,
     );
-    expect(file.path).toBe(join(root, "C1", "F2-__report.txt"));
+    // the id prefix and the name are sanitized as ONE segment: separators go, and the prefix already
+    // rules out a leading dot
+    expect(file.path).toBe(join(root, "C1", "F2-.._report.txt"));
     expect(readFileSync(file.path, "utf8")).toBe("report");
     expect(calls.every((call) => call.authorization === "Bearer xoxb-secret")).toBe(true);
   });

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import {
   type TelegramChannelOptions,
   type TelegramUpdate,
@@ -1546,6 +1546,42 @@ describe("telegram channel", () => {
     expect(existsSync(dest)).toBe(true);
     expect(calls[0]?.text).toMatch(/attached files/);
     expect(calls[0]?.text).toContain(dest);
+  });
+
+  it("keeps a download inside files/ when the route names the directory with traversal", async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      String(url).endsWith("/getFile")
+        ? new Response(JSON.stringify({ ok: true, result: { file_path: "documents/report.pdf", file_size: 5 } }), {
+            status: 200,
+          })
+        : String(url).includes("/file/bot")
+          ? new Response(new Uint8Array([1, 2, 3, 4, 5]), { status: 200 })
+          : new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const state = freshStateDir();
+    const { agent, calls } = replyingAgent("ok");
+    const ch = telegramChannel(agent, {
+      secretToken: SECRET,
+      botToken: "BOT",
+      route: () => ({ chatId: "../.." }),
+      apiBaseUrl: API,
+      stateDir: state,
+    });
+    const doc: TelegramUpdate = {
+      update_id: 12,
+      message: {
+        message_id: 5,
+        caption: "summarize",
+        document: { file_id: "d1", file_name: "report.pdf" },
+        chat: { id: 77, type: "private" },
+      },
+    };
+    expect((await ch(tgRequest(doc))).status).toBe(200);
+    for (let i = 0; i < 100 && calls.length === 0; i++) await new Promise((r) => setTimeout(r, 5));
+    const dest = calls[0]?.text?.match(/\S+report\.pdf/)?.[0] ?? "";
+    expect(resolve(dest).startsWith(`${join(state, "files")}/`)).toBe(true);
+    expect(existsSync(dest)).toBe(true);
   });
 
   it("surfaces an attachment fetch failure to the user (not a silent skip) and does not run the agent", async () => {


### PR DESCRIPTION
## Summary

Every chat channel writes attachments to `<filesDir>/<conversation>/<file>`, and both halves of that
path are external. All three sanitized the file NAME and left the DIRECTORY raw:

```ts
const dir = join(filesDir, String(chatId));   // telegram
const dir = join(filesDir, channelId);        // slack
const dir = join(filesDir, chatId);           // feishu
```

That segment is `route.chatId` / `route.channelId` when a custom route supplies one. A route
returning `chatId: "../.."` writes outside the channel state home, silently. It is author-controlled
rather than attacker-controlled, so this is a footgun rather than a vulnerability — but it is a silent
one, and the guard for the *other half of the same join* was already sitting one line above it in two
of the three files.

The two halves are the same question, so they get one answer: `safeSegment` in `channels/kit/`. It
replaces the two duplicated inline name-sanitizers (feishu and slack had character-identical
expressions) and now also covers the directory. Telegram's `basename(remotePath)` keeps its
`basename` call and gains the guard, because `basename` strips directories but returns `".."` whole.
Slack builds its file name from two event fields, so the guard runs on the assembled
`${file.id}-${file.name}` rather than the name alone — the id is as external as the name, and the
prefix already rules out a leading dot.

It is a new kit file rather than an addition to `kit/text.ts`, whose header scopes it to rendering
paths — widening that to cover a filesystem concern would make the header false, which is the drift
this repo keeps paying to undo.

Containment beats uniqueness here: `a/b` and `a_b` fold to one segment. Real platform ids carry no
separator, so that collision needs a hostile custom route to reach, and a colliding directory is a
smaller problem than an escaping one.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (115 files, 1550 tests)
- [x] Added or updated the smallest relevant tests

Tests cover both the function and its call sites. `test/fs-name.test.ts` asserts the property —
`join(home, safeSegment(x))` stays under `home` for every traversal spelling, plus the non-empty
guarantee, since an empty segment is one `join` quietly collapses away. `test/telegram.test.ts` runs
a channel end to end with `route: () => ({ chatId: "../.." })` and asserts the downloaded file
resolves under `<stateDir>/files/`; restoring any call site to a raw id turns it red.

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (internal module + repo map)
