### PR TITLE
fix(schedule,channels): a wake-alarm reconciler, and a replay window on the Feishu ingress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ src/
 │   │   ├── context-buffer.ts# generic durable un-summoned-discussion buffer (peek→completed→commit)
 │   │   ├── thread-participants.ts # who the agent has HEARD in a thread (the summon rule)
 │   │   ├── state.ts, seen.ts# atomic channel state + bounded durable delivery dedup
+│   │   ├── signature.ts     # replay window for a signed webhook ingress (the LENGTH is the platform's)
 │   │   ├── tasks.ts         # fire-and-forget side-task tracking — channels drain it in turnsIdle
 │   │   ├── text.ts          # Unicode-safe code-point slicing (cards, preview kit)
 │   │   ├── attachment-path.ts # where an attachment lands: the conversation id is ENCODED into a

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -189,8 +189,8 @@ and resolves `closed`. There is deliberately no second public `close()` path. Se
 WebSocket authentication happens once while establishing the official-SDK connection. Webhook has two
 security modes, decided by the console's Encrypt Key setting and mirrored by `encryptKey`:
 
-- **Encrypt Key set (recommended):** ordinary events arrive AES-256-CBC encrypted with `X-Lark-Signature` headers. The channel verifies the signature over the raw body, decrypts, and **refuses plaintext events entirely** — accepting both would let a forger skip the stronger check.
-- **No Encrypt Key:** events arrive in plaintext and are authenticated by the Verification Token (constant-time compare).
+- **Encrypt Key set (recommended):** ordinary events arrive AES-256-CBC encrypted with `X-Lark-Signature` headers. The channel verifies the signature over the raw body, decrypts, and **refuses plaintext events entirely** — accepting both would let a forger skip the stronger check. It also refuses an `X-Lark-Request-Timestamp` more than 7 hours from now: a signature commits to its timestamp but does not make it recent. The window covers the platform's whole retry chain (15s / 5min / 1h / 6h), so a redelivery is never rejected as stale.
+- **No Encrypt Key:** events arrive in plaintext and are authenticated by the Verification Token (constant-time compare). There is no signature and therefore no replay window — the channel warns about this at startup.
 
 Request URL verification is the platform-documented narrow exception to event signatures. With an
 Encrypt Key, its `url_verification` body is encrypted but carries no event-signature headers: the

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -16,6 +16,7 @@ import { text } from "../respond.ts";
 import { createSeenRing } from "../kit/seen.ts";
 import { createTaskTracker } from "../kit/tasks.ts";
 import { ensureStateHome, loadStateFile, saveStateFile } from "../kit/state.ts";
+import { signatureIsFresh } from "../kit/signature.ts";
 import { dispatchStop, isStopText } from "../kit/stop-command.ts";
 import { createTurnQueue } from "../kit/turn-queue.ts";
 import { createTurnStore } from "../kit/turn-store.ts";
@@ -70,6 +71,16 @@ const MAX_TURN_ATTEMPTS = 3;
 
 /** Event body cap — events are small JSON; 1 MiB is generous and guards a public endpoint. */
 const MAX_EVENT_BYTES = 1 << 20;
+
+/**
+ * Replay window for a SIGNED event, sized by the OPEN PLATFORM'S REDELIVERY SCHEDULE, not by Slack's
+ * 5 minutes: a failed push is retried at 15s / 5min / 1h / 6h. It is not established whether a retry
+ * is re-signed with a fresh timestamp or replays the original one, and only the second case is safe
+ * to guess wrong about in one direction — a window under 6h would 401 three of the four retries, i.e.
+ * turn one transient fault into a permanently lost user message (and a callback-health alarm). Wide
+ * enough to cover the chain, still bounded, and the `seen` ring dedups an event_id inside it.
+ */
+const MAX_SIGNATURE_AGE_S = 7 * 60 * 60;
 
 /** Queue feedback is immediate by default: it is the user's acknowledgement that this exact ask was
  *  accepted behind another turn. The same reply-quoted card becomes the preview/final answer, so there
@@ -775,6 +786,14 @@ function createFeishuWebhookRoutes(
   const { verificationToken, encryptKey } = opts;
   const { kind, envPrefix } = profile;
   const label = `[${kind}]`;
+  if (!encryptKey) {
+    // Said once at wiring, not per request: without an encrypt key events arrive in plaintext and
+    // carry no signature, so the freshness window below never runs and a captured body replays for
+    // as long as the verification token lives.
+    log.warn(
+      `${label} no ${envPrefix}_ENCRYPT_KEY: events are accepted unsigned, with no replay window — set one in the console to enable it`,
+    );
+  }
   const handler = async (req: Request): Promise<Response> => {
     if (req.method !== "POST") return text("POST only\n", 405);
     const body = await readBodyCapped(req, MAX_EVENT_BYTES);
@@ -800,9 +819,21 @@ function createFeishuWebhookRoutes(
         nonce: req.headers.get("x-lark-request-nonce") ?? "",
         signature: req.headers.get("x-lark-signature") ?? "",
       };
-      if (sig.signature && !verifySignature(encryptKey, sig, body.text)) {
-        log.warn(`${label} rejected an event: invalid X-Lark-Signature (encrypt key mismatch, or a forgery)`);
-        return text("invalid signature\n", 401);
+      if (sig.signature) {
+        // Freshness BEFORE the signature: the signature covers the timestamp but proves nothing about
+        // it, so without a window a captured body + its three x-lark-* headers replays forever. The
+        // `seen` ring is not that defence — it is bounded, and past its rollover a replay re-runs the
+        // turn (a re-sent message, a re-fired tool).
+        if (!signatureIsFresh(sig.timestamp, MAX_SIGNATURE_AGE_S)) {
+          log.warn(
+            `${label} rejected an event: X-Lark-Request-Timestamp outside the ±${MAX_SIGNATURE_AGE_S / 3600} h replay window`,
+          );
+          return text("stale signature\n", 401);
+        }
+        if (!verifySignature(encryptKey, sig, body.text)) {
+          log.warn(`${label} rejected an event: invalid X-Lark-Signature (encrypt key mismatch, or a forgery)`);
+          return text("invalid signature\n", 401);
+        }
       }
       try {
         envelope = JSON.parse(decryptEvent(encryptKey, outer.encrypt)) as Record<string, unknown>;

--- a/src/channels/kit/signature.ts
+++ b/src/channels/kit/signature.ts
@@ -1,0 +1,17 @@
+/**
+ * The replay window every signed webhook ingress needs. A signature covers its timestamp but proves
+ * nothing about it, so without a window a captured body plus its signed headers replays forever.
+ * The window LENGTH is the caller's: it is set by the platform's own redelivery schedule, not by us.
+ */
+
+/**
+ * Whether a Unix-SECONDS timestamp header is within `maxAgeS` of now, in either direction (a clock
+ * ahead of ours is as suspect as one behind). Non-numeric is not fresh: the header is part of the
+ * signed material, so a value the signature commits to but this cannot read is a reason to refuse,
+ * not to wave through.
+ */
+export function signatureIsFresh(timestamp: string, maxAgeS: number, nowMs = Date.now()): boolean {
+  if (!/^\d+$/.test(timestamp)) return false;
+  const seconds = Number(timestamp);
+  return Number.isSafeInteger(seconds) && Math.abs(Math.floor(nowMs / 1000) - seconds) <= maxAgeS;
+}

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -18,7 +18,7 @@ import { installProxyFetch } from "../../proxy.ts";
 import { bindAddress } from "../../bind.ts";
 
 import { isAgentcoreRuntime, mountAgentcoreService } from "../../channels/agentcore-service.ts";
-import { createWakeAlarmSink, reconcileWakeAlarms } from "../../schedule/wake-alarm.ts";
+import { createWakeAlarmSink } from "../../schedule/wake-alarm.ts";
 import { setWakeupsSink } from "../../schedule/wakeups.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import { SHUTDOWN_GRACE_MS, assertTunnelBindable, maybeTunnel, reportServing, serve } from "../serve.ts";
@@ -200,5 +200,7 @@ function armWakeAlarms(stateRoot: string): (() => void) | undefined {
   const sink = createWakeAlarmSink({ secret });
   setWakeupsSink(sink);
   log.info(`[fastagent] wake alarms: EventBridge-backed via the forwarder`);
-  return () => reconcileWakeAlarms(stateRoot, sink);
+  // Boot reconcile: pending wake-ups may exist while their alarms were lost (a deploy replaced the
+  // forwarder, a sink call failed). The sink re-reads the store, so a bare notification is enough.
+  return () => sink(stateRoot);
 }

--- a/src/schedule/wake-alarm.ts
+++ b/src/schedule/wake-alarm.ts
@@ -17,7 +17,8 @@
  * Function URL at cold start), and the adapter persists it here; every wake write happens inside a
  * turn, and every ingress turn arrived through an envelope, so the URL is always known by then.
  *
- * Reconciliation is DECLARATIVE (the full pending set travels each time) and deletion is lazy: a
+ * Reconciliation is DECLARATIVE (the sink is told only THAT the store changed and reads the full
+ * pending set back per attempt, so no retry ever carries a stale view) and deletion is lazy: a
  * cancelled wake-up's alarm still fires its poke, finds nothing due, and self-deletes — a harmless
  * wasted wake-up of the box, traded for never needing list/delete choreography.
  */
@@ -88,6 +89,17 @@ export function toAlarms(pending: Wakeup[], now: Date): WakeAlarm[] {
  * when `FASTAGENT_AGENTCORE=1` + `FASTAGENT_WAKE_SECRET` are present). Fire-and-forget by contract:
  * failures are logged, never thrown — a broken alarm degrades to the pre-alarm behavior (the wake
  * still fires on the next time the box happens to be awake), it must never break the store write.
+ *
+ * A single-flight RECONCILER, not a per-mutation delivery: a notification only marks the desired
+ * state dirty, and the loop re-derives it from the store before every attempt. So a mutation during
+ * a retry needs no ordering rule — there is one desired state, never two snapshots to rank — and the
+ * {@link DUE_MARGIN_MS} filter is re-applied with a fresh clock, which a captured payload could not
+ * do: entries that became due mid-retry would keep being POSTed with a past `at()`, a rejection no
+ * number of retries could clear.
+ *
+ * Assumes ONE sink per process over ONE state root (what `start` builds): the loop keeps the root of
+ * the call that started it, and its dirty flag is shared, so a second root would fold into the first
+ * one's pass.
  */
 export function createWakeAlarmSink(options: {
   secret: string;
@@ -96,64 +108,92 @@ export function createWakeAlarmSink(options: {
   now?: () => Date;
   /** Injectable retry pause (tests); defaults to exponential-ish backoff off RETRY_BASE_MS. */
   delay?: (ms: number) => Promise<void>;
-}): (stateRoot: string, pending: Wakeup[]) => void {
+}): (stateRoot: string) => void {
   const { secret, fetchImpl = fetch, now = () => new Date() } = options;
   const delay = options.delay ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  // Supersession token: a newer mutation's sync REPLACES an older one still retrying — without it,
-  // an old in-flight set could win the race and mirror stale state.
-  let latest: symbol | undefined;
+  let running = false;
+  let dirty = false;
 
-  async function sync(url: string, body: WakeAlarmRequest, token: symbol): Promise<void> {
+  /** One POST of the CURRENT desired set. Returns false to retry, true when there is nothing left
+   *  to do (converged, or nothing this loop can act on). */
+  async function attemptOnce(stateRoot: string, attempt: number): Promise<boolean> {
+    const alarms = toAlarms(listWakeups(stateRoot), now());
+    // Nothing future to mirror: converged. Deletion is lazy by design — alarms already mirrored for
+    // cancelled wake-ups fire, find nothing, self-delete — so an empty set is never POSTed.
+    if (alarms.length === 0) return true;
+    const url = readWakeAlarmUrl(stateRoot);
+    if (!url) {
+      // Before the first envelope, or an unreadable state mount (readWakeAlarmUrl folds both into
+      // undefined). The wake itself is stored; the next store mutation or boot re-mirrors it.
+      log.warn("[schedule] wake alarm skipped — forwarder URL unavailable (not seen yet, or unreadable)");
+      return true;
+    }
+    const body: WakeAlarmRequest = { secret, alarms };
+    try {
+      const res = await fetchImpl(`${url.replace(/\/$/, "")}${WAKE_ALARM_PATH}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(SYNC_TIMEOUT_MS),
+      });
+      if (res.ok) return true;
+      log.warn(`[schedule] wake alarm sync attempt ${attempt}/${MAX_SYNC_ATTEMPTS} failed: HTTP ${res.status}`);
+    } catch (e) {
+      log.warn(`[schedule] wake alarm sync attempt ${attempt}/${MAX_SYNC_ATTEMPTS} failed: ${String(e)}`);
+    }
+    return false;
+  }
+
+  async function reconcile(stateRoot: string): Promise<void> {
     // Counted as in-flight work: the retry loop is exactly the window where the box must not be
     // reclaimed — idle away mid-retry and a pending wake has no alarm until the next boot.
     const workDone = beginWork();
+    // Consecutive failures ACROSS passes, not within one. A mid-retry mutation restarts the attempt
+    // sequence (the backoff and the log's `n/N` are about the new desired set), but it must not renew
+    // the budget: a store mutating faster than the backoff would keep the loop alive forever, and the
+    // one loud line saying the forwarder is down — the per-attempt warns are filterable — would never
+    // be reached. This counter is the thing that survives to reach it.
+    let failures = 0;
     try {
-      for (let attempt = 1; attempt <= MAX_SYNC_ATTEMPTS; attempt++) {
-        if (latest !== token) return; // superseded by a newer set — that sync owns correctness now
-        try {
-          const res = await fetchImpl(`${url.replace(/\/$/, "")}${WAKE_ALARM_PATH}`, {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify(body),
-            signal: AbortSignal.timeout(SYNC_TIMEOUT_MS),
-          });
-          if (res.ok) return;
-          log.warn(`[schedule] wake alarm sync attempt ${attempt}/${MAX_SYNC_ATTEMPTS} failed: HTTP ${res.status}`);
-        } catch (e) {
-          log.warn(`[schedule] wake alarm sync attempt ${attempt}/${MAX_SYNC_ATTEMPTS} failed: ${String(e)}`);
+      while (dirty && failures < MAX_SYNC_ATTEMPTS) {
+        dirty = false;
+        for (let attempt = 1; attempt <= MAX_SYNC_ATTEMPTS; attempt++) {
+          if (await attemptOnce(stateRoot, attempt)) {
+            failures = 0;
+            break;
+          }
+          failures++;
+          if (attempt === MAX_SYNC_ATTEMPTS || failures >= MAX_SYNC_ATTEMPTS) break;
+          await delay(RETRY_BASE_MS * attempt);
+          // A mutation landed mid-retry: the desired state moved, so this budget is spent on a set
+          // that no longer exists. Restart the attempt count against the new one.
+          if (dirty) break;
         }
-        await delay(RETRY_BASE_MS * attempt);
       }
-      log.error(
-        `[schedule] wake alarm sync FAILED after ${MAX_SYNC_ATTEMPTS} attempts — pending wake-ups have no ` +
-          `external alarm until the next store change or boot re-mirrors them`,
-      );
+      if (failures >= MAX_SYNC_ATTEMPTS) {
+        log.error(
+          `[schedule] wake alarm sync FAILED after ${MAX_SYNC_ATTEMPTS} attempts — pending wake-ups have no ` +
+            `external alarm until the next store change or boot re-mirrors them`,
+        );
+      }
+    } catch (e) {
+      // The END of the error path: nothing awaits this loop, so an escape is an unhandled rejection
+      // that kills the container. `listWakeups` throws by design on an unreadable store (state.ts),
+      // exactly the fault a wake alarm cannot fix — report it and leave the store write untouched,
+      // which is this sink's whole contract. The next mutation or boot re-runs the mirror.
+      log.error(`[schedule] wake alarm reconcile failed (alarms are stale until the next store change): ${String(e)}`);
     } finally {
+      running = false;
       workDone();
     }
   }
 
-  return (stateRoot, pending) => {
-    const url = readWakeAlarmUrl(stateRoot);
-    if (!url) {
-      // First-ever boot before any envelope: nothing to call yet. The wake itself is stored; the
-      // alarm catches up on the next store mutation after an envelope has arrived.
-      log.warn("[schedule] wake alarm skipped — forwarder URL not seen yet (it arrives with the first envelope)");
-      return;
-    }
-    const alarms = toAlarms(pending, now());
-    if (alarms.length === 0) return; // nothing future to mirror (deletion is lazy by design)
-    const token = Symbol("wake-alarm-sync");
-    latest = token;
-    void sync(url, { secret, alarms }, token);
+  // Single-flight: a save arriving while the loop runs only marks it dirty, so a burst coalesces
+  // into one more pass instead of one concurrent loop each.
+  return (stateRoot) => {
+    dirty = true;
+    if (running) return;
+    running = true;
+    void reconcile(stateRoot);
   };
-}
-
-/**
- * One boot-time reconcile: pending wake-ups may exist while their alarms were lost (a deploy
- * replaced the forwarder, a sink call failed) — re-mirror the current set once at start.
- */
-export function reconcileWakeAlarms(stateRoot: string, sink: (stateRoot: string, pending: Wakeup[]) => void): void {
-  const pending = listWakeups(stateRoot);
-  if (pending.length > 0) sink(stateRoot, pending);
 }

--- a/src/schedule/wakeups.ts
+++ b/src/schedule/wakeups.ts
@@ -71,15 +71,18 @@ function isWakeup(e: unknown): e is Wakeup {
 }
 
 /**
- * The wake-ALARM sink: notified after EVERY wakeups-store mutation with the new pending set. The
- * AgentCore deployment registers one (schedule/wake-alarm.ts) that mirrors pending wake-ups into
- * one-shot EventBridge schedules — the external clock that makes `wake` reliable on a host with no
- * resident process. Neutral seam: this module knows only "someone wants to observe changes"; a
- * resident host registers nothing and behaves exactly as before. The sink is fire-and-forget and
- * must own its errors; a throw is caught here so a broken alarm never corrupts a store write.
+ * The wake-ALARM sink: notified after EVERY wakeups-store mutation. A notification, not a delivery
+ * — it carries no set, because the sink reconciles by re-reading the store, and handing it a set
+ * captured here would go stale in its retries. The AgentCore deployment registers one
+ * (schedule/wake-alarm.ts) that mirrors pending wake-ups into one-shot EventBridge schedules — the
+ * external clock that makes `wake` reliable on a host with no resident process. Neutral seam: this
+ * module knows only "someone wants to observe changes"; a resident host registers nothing and
+ * behaves exactly as before. The sink is fire-and-forget and must own its errors. The guard below
+ * catches a SYNCHRONOUS throw so a broken alarm never corrupts a store write; an async sink returns
+ * before it does any work, so its rejections are ITS to terminate — nothing here can see them.
  */
-let wakeupsSink: ((stateRoot: string, pending: Wakeup[]) => void) | undefined;
-export function setWakeupsSink(sink: ((stateRoot: string, pending: Wakeup[]) => void) | undefined): void {
+let wakeupsSink: ((stateRoot: string) => void) | undefined;
+export function setWakeupsSink(sink: ((stateRoot: string) => void) | undefined): void {
   wakeupsSink = sink;
 }
 
@@ -102,7 +105,7 @@ function load(stateRoot: string): Wakeup[] {
 function save(stateRoot: string, wakeups: Wakeup[]): void {
   writeScheduleFile(scheduleFile(stateRoot, "wakeups"), wakeups);
   try {
-    wakeupsSink?.(stateRoot, wakeups);
+    wakeupsSink?.(stateRoot);
   } catch (e) {
     log.error(`[schedule] wake-alarm sink failed (store write is unaffected): ${String(e)}`);
   }

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -395,8 +395,11 @@ describe("ingress verification", () => {
     };
     const encryptedBody = (plain: Record<string, unknown>): string =>
       JSON.stringify({ encrypt: encrypt(JSON.stringify(plain)) });
-    const headers = (sig: string) => ({
-      "x-lark-request-timestamp": "170",
+    // A real (fresh) timestamp: the ingress refuses a signed event outside the replay window, so a
+    // fixed epoch constant here would only ever exercise that rejection.
+    const TS = String(Math.floor(Date.now() / 1000));
+    const headers = (sig: string, ts = TS) => ({
+      "x-lark-request-timestamp": ts,
       "x-lark-request-nonce": "n1",
       "x-lark-signature": sig,
     });
@@ -427,7 +430,7 @@ describe("ingress verification", () => {
       new Request("http://app/feishu", {
         method: "POST",
         body: eventBody,
-        headers: headers(eventSignature(KEY, "170", "n1", eventBody)),
+        headers: headers(eventSignature(KEY, TS, "n1", eventBody)),
       }),
     );
     expect(signedEvent.status).toBe(200);
@@ -435,6 +438,36 @@ describe("ingress verification", () => {
       (await handler(new Request("http://app/feishu", { method: "POST", body: eventBody, headers: headers("bad") })))
         .status,
     ).toBe(401);
+
+    // The platform retries a failed push at 15s / 5min / 1h / 6h, and it is not established whether a
+    // retry is re-signed. The last one in that chain MUST still be accepted — refusing it would turn a
+    // transient fault into a permanently lost user message.
+    const lastRetry = String(Math.floor(Date.now() / 1000) - 6 * 60 * 60);
+    expect(
+      (
+        await handler(
+          new Request("http://app/feishu", {
+            method: "POST",
+            body: eventBody,
+            headers: headers(eventSignature(KEY, lastRetry, "n1", eventBody), lastRetry),
+          }),
+        )
+      ).status,
+    ).toBe(200);
+    // Past the retry chain a VALID signature over a stale timestamp is refused: the signature commits
+    // to the timestamp, it does not make it recent, and the bounded `seen` ring is not a replay defence.
+    for (const skew of [-8 * 60 * 60, 8 * 60 * 60]) {
+      const stale = String(Math.floor(Date.now() / 1000) + skew);
+      const res = await handler(
+        new Request("http://app/feishu", {
+          method: "POST",
+          body: eventBody,
+          headers: headers(eventSignature(KEY, stale, "n1", eventBody), stale),
+        }),
+      );
+      expect(res.status).toBe(401);
+      expect(await res.text()).toContain("stale signature");
+    }
     expect((await handler(new Request("http://app/feishu", { method: "POST", body: eventBody }))).status).toBe(401);
     // Encrypt Key mode remains modal: plaintext events are never accepted.
     expect((await handler(feishuRequest(messageEvent({})))).status).toBe(401);

--- a/test/wake-alarm.test.ts
+++ b/test/wake-alarm.test.ts
@@ -1,20 +1,55 @@
+import { mkdirSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { log } from "../src/log.ts";
+import { scheduleFile, writeScheduleFile } from "../src/schedule/state.ts";
 import {
   MAX_SYNC_ATTEMPTS,
   WAKE_ALARM_PATH,
   type WakeAlarmRequest,
   createWakeAlarmSink,
   readWakeAlarmUrl,
-  reconcileWakeAlarms,
   rememberWakeAlarmUrl,
   toAlarms,
 } from "../src/schedule/wake-alarm.ts";
 import { type Wakeup, addWakeup, removeWakeup, setWakeupsSink, takeFirstDueWakeup } from "../src/schedule/wakeups.ts";
 
 const freshRoot = (): Promise<string> => mkdtemp(join(tmpdir(), "fa-wake-alarm-"));
+
+/** Write the wakeups store directly — the sink reads it, and this bypasses addWakeup's guardrails
+ *  so a test can stage past/impossible fireAts. */
+const seed = (root: string, wakeups: Wakeup[]): void => writeScheduleFile(scheduleFile(root, "wakeups"), wakeups);
+
+/** A sink whose POSTs fail until `succeed()`, parked between attempts until `release()` — the window
+ *  where a store mutation must reach the loop. */
+function retryingSink(now = new Date("2026-07-28T09:00:00Z")) {
+  const posted: WakeAlarmRequest[] = [];
+  let failing = true;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const impl = vi.fn(async (_url: string, init: RequestInit) => {
+    posted.push(JSON.parse(String(init.body)) as WakeAlarmRequest);
+    return failing ? new Response("boom", { status: 500 }) : new Response("ok");
+  });
+  const sink = createWakeAlarmSink({
+    secret: "x",
+    fetchImpl: impl as unknown as typeof fetch,
+    now: () => now,
+    delay: () => gate,
+  });
+  return {
+    sink,
+    posted,
+    succeed: () => {
+      failing = false;
+    },
+    release: () => release(),
+  };
+}
 
 afterEach(() => {
   setWakeupsSink(undefined);
@@ -52,11 +87,11 @@ describe("schedule/wake-alarm: the sink", () => {
       fetchImpl: impl,
       now: () => new Date("2026-07-28T09:00:00Z"),
     });
-    const pending: Wakeup[] = [
+    seed(root, [
       { id: "a", session: "s", prompt: "p", fireAt: "2026-07-28T10:00:00.000Z" },
       { id: "b", session: "s", prompt: "q", fireAt: "2026-07-28T11:00:00.000Z", cron: "0 * * * *" },
-    ];
-    sink(root, pending);
+    ]);
+    sink(root);
     await vi.waitFor(() => expect(calls).toHaveLength(1));
     expect(calls[0]!.url).toBe(`https://fn.on.aws${WAKE_ALARM_PATH}`); // trailing slash normalized
     expect(calls[0]!.body).toEqual({
@@ -73,15 +108,74 @@ describe("schedule/wake-alarm: the sink", () => {
     rememberWakeAlarmUrl(root, "https://fn.on.aws");
     const { impl, calls } = fakeFetch();
     const sink = createWakeAlarmSink({ secret: "x", fetchImpl: impl, now: () => new Date("2026-07-28T10:00:00Z") });
-    sink(root, [
+    seed(root, [
       { id: "due", session: "s", prompt: "p", fireAt: "2026-07-28T09:59:00.000Z" }, // past — filtered
       { id: "future", session: "s", prompt: "p", fireAt: "2026-07-28T10:30:00.000Z" },
     ]);
+    sink(root);
     await vi.waitFor(() => expect(calls).toHaveLength(1));
     expect(calls[0]!.body.alarms).toEqual([{ id: "future", at: "2026-07-28T10:30:00.000Z" }]);
-    sink(root, [{ id: "due", session: "s", prompt: "p", fireAt: "2026-07-28T09:59:00.000Z" }]); // nothing future
+    seed(root, [{ id: "due", session: "s", prompt: "p", fireAt: "2026-07-28T09:59:00.000Z" }]); // nothing future
+    sink(root);
     await new Promise((r) => setTimeout(r, 20));
     expect(calls).toHaveLength(1); // no empty POST — deletion is lazy by design
+  });
+
+  it("re-reads the store between attempts — a mutation mid-retry redirects the loop to the new set", async () => {
+    // The reason the loop carries no payload: a retry that keeps re-POSTing the set it started with
+    // would need an ordering rule to decide which of two in-flight views wins. There is only one.
+    const root = await freshRoot();
+    rememberWakeAlarmUrl(root, "https://fn.on.aws");
+    seed(root, [{ id: "a", session: "s", prompt: "p", fireAt: "2026-07-28T10:00:00.000Z" }]);
+    const { sink, posted, succeed, release } = retryingSink();
+    sink(root);
+    await vi.waitFor(() => expect(posted).toHaveLength(1));
+    expect(posted[0]!.alarms).toEqual([{ id: "a", at: "2026-07-28T10:00:00.000Z" }]);
+
+    seed(root, [{ id: "b", session: "s", prompt: "p", fireAt: "2026-07-28T11:00:00.000Z" }]);
+    succeed();
+    sink(root);
+    release();
+
+    await vi.waitFor(() => expect(posted).toHaveLength(2));
+    expect(posted[1]!.alarms).toEqual([{ id: "b", at: "2026-07-28T11:00:00.000Z" }]); // `a` is gone
+  });
+
+  it("single-flight: a burst of mutations coalesces into ONE more pass, not one loop each", async () => {
+    const root = await freshRoot();
+    rememberWakeAlarmUrl(root, "https://fn.on.aws");
+    seed(root, [{ id: "a", session: "s", prompt: "p", fireAt: "2026-07-28T10:00:00.000Z" }]);
+    const { sink, posted, succeed, release } = retryingSink();
+    sink(root);
+    await vi.waitFor(() => expect(posted).toHaveLength(1)); // parked mid-retry
+
+    succeed();
+    for (let i = 0; i < 3; i++) sink(root); // three saves land while the loop is parked
+    expect(posted).toHaveLength(1); // none of them started a loop of its own
+    release();
+
+    await vi.waitFor(() => expect(posted).toHaveLength(2)); // one re-read covers all three
+    for (let turn = 0; turn < 5; turn++) await new Promise((resolve) => setImmediate(resolve));
+    expect(posted).toHaveLength(2);
+  });
+
+  it("a cancel mid-retry converges silently — the abandoned set is never re-POSTed", async () => {
+    const root = await freshRoot();
+    rememberWakeAlarmUrl(root, "https://fn.on.aws");
+    seed(root, [{ id: "a", session: "s", prompt: "p", fireAt: "2026-07-28T10:00:00.000Z" }]);
+    const { sink, posted, succeed, release } = retryingSink();
+    sink(root);
+    await vi.waitFor(() => expect(posted).toHaveLength(1));
+
+    seed(root, []); // unwake landed while the loop was parked
+    succeed();
+    sink(root);
+    release();
+
+    // "It must not re-post" is a negative, so the wait is bounded by event-loop TURNS, not wall
+    // clock: the parked loop needs one to resume, re-read, and find nothing to mirror.
+    for (let turn = 0; turn < 5; turn++) await new Promise((resolve) => setImmediate(resolve));
+    expect(posted).toHaveLength(1); // no empty POST either — deletion is lazy by design
   });
 
   it("retries a failed sync with backoff (counted as in-flight work), then gives up loudly", async () => {
@@ -102,16 +196,47 @@ describe("schedule/wake-alarm: the sink", () => {
       now: () => new Date("2026-07-28T09:00:00Z"),
       delay: async () => {}, // no real waiting in tests
     });
-    sink(root, [{ id: "a", session: "s", prompt: "p", fireAt: "2026-07-28T10:00:00.000Z" }]);
+    seed(root, [{ id: "a", session: "s", prompt: "p", fireAt: "2026-07-28T10:00:00.000Z" }]);
+    sink(root);
     await vi.waitFor(() => expect(attempts.length).toBe(MAX_SYNC_ATTEMPTS));
     expect(sawBusy).toBe(true);
     await vi.waitFor(() => expect(activeWork()).toBe(base)); // released after giving up
   });
 
-  it("is a no-op (warned, not thrown) before the first envelope delivered the URL", async () => {
+  it("a store mutating faster than the backoff cannot renew the retry budget", async () => {
+    // Each mutation restarts the attempt SEQUENCE against the new desired set, but not the budget:
+    // counting failures only within a pass, a save landing inside every backoff would keep the loop
+    // alive forever and the one loud give-up line — the only non-filterable signal that the forwarder
+    // is down — would never be reached. Reverting to a per-pass counter hangs this test.
+    const { activeWork } = await import("../src/channels/busy.ts");
+    const root = await freshRoot();
+    rememberWakeAlarmUrl(root, "https://fn.on.aws");
+    const base = activeWork();
+    let attempts = 0;
+    const failing = vi.fn(async () => {
+      attempts++;
+      return new Response("boom", { status: 500 });
+    });
+    let sink: (stateRoot: string) => void = () => {};
+    sink = createWakeAlarmSink({
+      secret: "x",
+      fetchImpl: failing as unknown as typeof fetch,
+      now: () => new Date("2026-07-28T09:00:00Z"),
+      delay: async () => sink(root), // a save lands inside every single backoff
+    });
+    seed(root, [{ id: "a", session: "s", prompt: "p", fireAt: "2026-07-28T10:00:00.000Z" }]);
+    sink(root);
+    await vi.waitFor(() => expect(activeWork()).toBe(base)); // it gave up instead of spinning
+    expect(attempts).toBe(MAX_SYNC_ATTEMPTS);
+  });
+
+  it("is a no-op (warned, not thrown) when the forwarder URL is unavailable", async () => {
     const root = await freshRoot();
     const { impl, calls } = fakeFetch();
-    createWakeAlarmSink({ secret: "x", fetchImpl: impl })(root, []);
+    // A FUTURE wake-up: an empty store converges before the URL is ever read, so it would not reach
+    // the branch under test.
+    seed(root, [{ id: "a", session: "s", prompt: "p", fireAt: new Date(Date.now() + 3_600_000).toISOString() }]);
+    createWakeAlarmSink({ secret: "x", fetchImpl: impl })(root);
     await new Promise((r) => setTimeout(r, 20));
     expect(calls).toHaveLength(0);
   });
@@ -143,6 +268,29 @@ describe("schedule/wake-alarm: the sink", () => {
     await vi.waitFor(() => expect(calls).toHaveLength(4));
   });
 
+  it("an unreadable store is reported, not thrown — nothing awaits the loop", async () => {
+    // `listWakeups` throws by design on a read fault (state.ts), and it now runs INSIDE the async
+    // loop: without the sink terminating its own errors this is an unhandled rejection, which Node
+    // turns into a dead container — on the one path a broken state mount guarantees.
+    const root = await freshRoot();
+    rememberWakeAlarmUrl(root, "https://fn.on.aws");
+    mkdirSync(scheduleFile(root, "wakeups"), { recursive: true }); // a directory where the file goes: EISDIR
+    const errors: string[] = [];
+    vi.spyOn(log, "error").mockImplementation((m: string) => void errors.push(m));
+    const rejections: unknown[] = [];
+    const onRejection = (e: unknown) => rejections.push(e);
+    process.on("unhandledRejection", onRejection);
+    try {
+      const { impl, calls } = fakeFetch();
+      createWakeAlarmSink({ secret: "x", fetchImpl: impl })(root);
+      await vi.waitFor(() => expect(errors.some((m) => m.includes("reconcile failed"))).toBe(true));
+      expect(calls).toHaveLength(0);
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  });
+
   it("a failing sink never breaks the store write", async () => {
     const root = await freshRoot();
     rememberWakeAlarmUrl(root, "https://fn.on.aws");
@@ -168,12 +316,12 @@ describe("schedule/wake-alarm: boot reconcile", () => {
       new Date("2099-07-28T10:00:00Z"),
     );
     const { impl, calls } = fakeFetch();
-    reconcileWakeAlarms(root, createWakeAlarmSink({ secret: "x", fetchImpl: impl }));
+    createWakeAlarmSink({ secret: "x", fetchImpl: impl })(root); // what `start` calls at boot
     await vi.waitFor(() => expect(calls).toHaveLength(1));
 
     const empty = await freshRoot();
     const quiet = fakeFetch();
-    reconcileWakeAlarms(empty, createWakeAlarmSink({ secret: "x", fetchImpl: quiet.impl }));
+    createWakeAlarmSink({ secret: "x", fetchImpl: quiet.impl })(empty);
     await new Promise((r) => setTimeout(r, 20));
     expect(quiet.calls).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

Two independent fixes. Each behaviour change has a check that fails without it.

## The wake-alarm sink is a reconciler, not a delivery

It used to capture the pending set at call time and spend up to 20s retrying *that payload*, with a
supersession token deciding which of two in-flight snapshots won. The snapshot was the problem: it is
what created the question. The sink now takes no payload — a store save only marks it dirty, and the
loop re-derives the desired set from the store before every attempt.

That removes the token and its asymmetric claim rules, and it fixes a retry that could not converge:
entries crossing into `DUE_MARGIN_MS` mid-retry kept being POSTed with a past `at()`, which the
Scheduler API rejects, so the budget was spent on a payload no attempt could land. The filter now
re-runs against a fresh clock. Concurrency is single-flight — a burst of saves coalesces into one
more pass instead of one loop each — and the consecutive-failure count survives across passes, so a
store mutating faster than the backoff cannot suppress the one loud line saying the forwarder is down.

The loop also terminates its own errors: nothing awaits it, and `listWakeups` throws by design on an
unreadable store, so an escape was an unhandled rejection — a dead container on exactly the fault a
broken state mount produces. The guard in `wakeups.ts` never covered that (it only ever saw a
synchronous sink) and now says so instead of implying otherwise.

Carried through: `setWakeupsSink` takes `(stateRoot)`, and `reconcileWakeAlarms` is gone — a boot
reconcile is now just a sink call.

## A replay window on the Feishu ingress

A signature commits to its timestamp but does not make it recent, so a captured body plus its three
`x-lark-*` headers replayed forever. The window is 7h, sized by the platform's own redelivery
schedule (15s / 5min / 1h / 6h) rather than copied from Slack's 5 minutes: it is not established
whether a retry is re-signed, and a narrower window would 401 three of the four retries — turning one
transient fault into a permanently lost user message. `channels/kit/signature.ts` holds the check;
the length stays the caller's, because it is a fact about each platform.

A deployment with no encrypt key gets no signature at all, so it has no replay window either. It now
says so once at wiring instead of looking protected.

## Breaking (pre-1.0)

`setWakeupsSink` / `createWakeAlarmSink` callbacks take `(stateRoot)`; `reconcileWakeAlarms` is
removed.
