### PR TITLE
docs(loader): code inputs are real files, and the listing says so too

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,6 +267,20 @@ resolves from the real environment — a `FASTAGENT_SECRETS_DIR` set *inside* `.
 `auth.json` but cannot move the file it is read from. The committable `.env.example` template always
 stays at `<agent dir>/.secrets/.env.example`.
 
+## Code inputs must be real files
+
+`tools/`, `channels/`, and `schedules/` are code the agent imports. Each directory must stay inside
+the agent directory, and each entry in it must be a real file. A symlink is skipped with a warning
+(`fastagent info`, `dev`, and `start` all say so) — it is never followed.
+
+This is deliberate, not a gap. The containment check guards the *directory*; nothing guards the
+entries inside it, so following a link would import code from anywhere on the machine past the check
+that exists to prevent exactly that. It also would not survive deployment: `deploy` bakes the
+workspace into an image, and a link pointing outside it resolves to nothing there — an agent that
+works locally and is silently missing a tool in production.
+
+To share code between agents, publish it as a package and import it, or copy the file.
+
 ## Tools
 
 There are two ways to add tools:
@@ -386,6 +400,8 @@ fastagent init releaser     # releaser/fastagent/
 
 Each is fully independent: its own persona, skills, tools, config, model, channels, schedules,
 `.state/` and `.secrets/`. Run them separately (`fastagent dev reviewer`), deploy them separately.
+They do not share code by symlink (see [Code inputs must be real files](#code-inputs-must-be-real-files));
+publish a package, or copy the file.
 
 One consequence to know: an agent's workspace is always the directory holding its `fastagent/`, so
 `reviewer`'s cwd is `reviewer/`, not the repo above it. Its `AGENTS.md` context still walks up to the

--- a/src/channels/discover.ts
+++ b/src/channels/discover.ts
@@ -76,7 +76,7 @@ export async function inspectChannels(dir: string): Promise<{
  */
 export async function discoverChannelFiles(dir: string): Promise<string[]> {
   await assertInsideAgentDir(dir, "channels");
-  const { entries } = await moduleInventory(join(dir, "channels"));
+  const entries = await moduleInventory(join(dir, "channels"));
   return entries.map((entry) => entry.name);
 }
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -32,9 +32,8 @@ export interface InventoryEntry {
   file: string;
 }
 
-/** An entry whose NAME says module and whose kind says otherwise. Data, not a log line: the loader
- *  warns, `info` could show it, and a test can assert it. */
-export interface SkippedEntry {
+/** An entry whose NAME says module and whose kind says otherwise. */
+interface SkippedEntry {
   label: string;
   /** Why it is not loadable, in words an author can act on. */
   why: string;
@@ -61,18 +60,22 @@ export interface SkippedEntry {
  * SYMLINKS ARE SKIPPED, and that is a boundary rather than an oversight: `assertInsideAgentDir`
  * guards the code-input DIRECTORY against escaping the definition, and nothing guards the entries
  * inside it, so following a link would import from anywhere on the box past the very check meant to
- * prevent it. Do not "fix" this by following them — report them, which is what `skipped` is for.
+ * prevent it. Do not "fix" this by following them — report them, which this does.
+ *
+ * The skip is WARNED HERE, not handed back, because the fact is the same for all four consumers and
+ * only one of them imports. It used to be warned by `loadModuleDir`, on the reasoning that the
+ * loader is "the path where an author finds out their channel does not exist" — which had it exactly
+ * backwards: `fastagent info` is where an author looks, it only lists names, and it therefore
+ * reported a symlinked channel as simply ABSENT. What to do about a load FAILURE still differs per
+ * caller and still travels as data; "this file is not loadable" does not.
  */
-export async function moduleInventory(subDir: string): Promise<{
-  entries: InventoryEntry[];
-  skipped: SkippedEntry[];
-}> {
+export async function moduleInventory(subDir: string): Promise<InventoryEntry[]> {
   let dirents: Dirent[];
   try {
     dirents = await readdir(subDir, { withFileTypes: true });
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ENOENT" || code === "not_found") return { entries: [], skipped: [] };
+    if (code === "ENOENT" || code === "not_found") return [];
     throw new Error(`cannot read ${subDir}: ${(error as Error).message}`);
   }
   const sub = basename(subDir);
@@ -94,7 +97,8 @@ export async function moduleInventory(subDir: string): Promise<{
       skipped.push({ label, why: dirent.isDirectory() ? "a directory, not a file" : "not a regular file" });
     }
   }
-  return { entries, skipped };
+  for (const { label, why } of skipped) log.warn(`[fastagent] ${label} is ${why} — not loaded`);
+  return entries;
 }
 
 export interface DiscoveredModule {
@@ -121,16 +125,12 @@ export interface ModuleLoadFailure {
  * Import every module the directory declares ({@link moduleInventory}). A file that fails to IMPORT
  * is collected into `failures` (with {@link moduleLoadHint}) rather than thrown, so the caller can
  * report every bad file and apply domain policy; `loadTools`/`loadChannels` add validation failures
- * the same way.
- *
- * Skipped entries are warned HERE rather than returned: this is the path where an author finds out
- * their channel does not exist, and the inventory's other two consumers only list names.
+ * the same way. Entries the inventory SKIPPED are already reported by it, for every consumer.
  */
 export async function loadModuleDir(
   subDir: string,
 ): Promise<{ modules: DiscoveredModule[]; failures: ModuleLoadFailure[] }> {
-  const { entries, skipped } = await moduleInventory(subDir);
-  for (const { label, why } of skipped) log.warn(`[fastagent] ${label} is ${why} — not loaded`);
+  const entries = await moduleInventory(subDir);
   const modules: DiscoveredModule[] = [];
   const failures: ModuleLoadFailure[] = [];
   for (const { name, label, file } of entries) {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -32,13 +32,6 @@ export interface InventoryEntry {
   file: string;
 }
 
-/** An entry whose NAME says module and whose kind says otherwise. */
-interface SkippedEntry {
-  label: string;
-  /** Why it is not loadable, in words an author can act on. */
-  why: string;
-}
-
 /**
  * WHAT A CODE-INPUT DIRECTORY DECLARES — the single answer to "which files here are modules",
  * without importing any of them.
@@ -62,12 +55,17 @@ interface SkippedEntry {
  * inside it, so following a link would import from anywhere on the box past the very check meant to
  * prevent it. Do not "fix" this by following them — report them, which this does.
  *
- * The skip is WARNED HERE, not handed back, because the fact is the same for all four consumers and
- * only one of them imports. It used to be warned by `loadModuleDir`, on the reasoning that the
- * loader is "the path where an author finds out their channel does not exist" — which had it exactly
- * backwards: `fastagent info` is where an author looks, it only lists names, and it therefore
- * reported a symlinked channel as simply ABSENT. What to do about a load FAILURE still differs per
- * caller and still travels as data; "this file is not loadable" does not.
+ * The skip is WARNED HERE, not handed back, because "this file is not loadable" holds for all four
+ * consumers and only one of them imports — a listing that reports the name it cannot load reads as
+ * "I never created it". What to do about a load FAILURE does differ per caller, so that travels as
+ * data. One warning per READ, so a command that both lists and loads the same directory (`deploy
+ * agentcore` does) says it twice — both readings are true, and remembering what was already said
+ * would mean a restart stops mentioning a skip that is still there.
+ *
+ * A skip is therefore a warning ONLY, unlike a {@link ModuleLoadFailure}: it is absent from `info
+ * --json` and `deploy` does not gate on it. That is the deliberate cost of one report for four
+ * consumers, three of which list names and have nowhere to put data. To give a machine consumer the
+ * skips, return them beside the entries — do not reconstruct them from stderr.
  */
 export async function moduleInventory(subDir: string): Promise<InventoryEntry[]> {
   let dirents: Dirent[];
@@ -80,7 +78,6 @@ export async function moduleInventory(subDir: string): Promise<InventoryEntry[]>
   }
   const sub = basename(subDir);
   const entries: InventoryEntry[] = [];
-  const skipped: SkippedEntry[] = [];
   // Sorted by the NAME a consumer sees, so none of them re-sorts and none can disagree about order.
   // Filename breaks a tie: `foo.js` and `foo.ts` both read as `foo`, and the domain loaders document
   // that the FIRST wins — deciding that here keeps it from depending on readdir's order.
@@ -92,12 +89,13 @@ export async function moduleInventory(subDir: string): Promise<InventoryEntry[]>
     if (dirent.isFile()) {
       entries.push({ name: moduleName(dirent.name), label, file: join(subDir, dirent.name) });
     } else if (dirent.isSymbolicLink()) {
-      skipped.push({ label, why: "a symlink — code inputs must be real files inside the agent dir" });
+      log.warn(`[fastagent] ${label} is a symlink — code inputs must be real files inside the agent dir — not loaded`);
+    } else if (dirent.isDirectory()) {
+      log.warn(`[fastagent] ${label} is a directory, not a file — not loaded`);
     } else {
-      skipped.push({ label, why: dirent.isDirectory() ? "a directory, not a file" : "not a regular file" });
+      log.warn(`[fastagent] ${label} is not a regular file — not loaded`);
     }
   }
-  for (const { label, why } of skipped) log.warn(`[fastagent] ${label} is ${why} — not loaded`);
   return entries;
 }
 

--- a/src/schedule/discover.ts
+++ b/src/schedule/discover.ts
@@ -15,7 +15,7 @@ import type { LoadedSchedule, Schedule } from "./schedule.ts";
  *  since it also reports broken files and next instants). */
 export async function discoverScheduleFiles(dir: string): Promise<string[]> {
   await assertInsideAgentDir(dir, "schedules");
-  const { entries } = await moduleInventory(join(dir, "schedules"));
+  const entries = await moduleInventory(join(dir, "schedules"));
   return entries.map((entry) => entry.name);
 }
 

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -140,7 +140,7 @@ function lastErrorLine(tail: string): string {
 async function channelBasenames(dir: string): Promise<string[]> {
   const channels = join(dir, "channels");
   try {
-    const { entries } = await moduleInventory(channels);
+    const entries = await moduleInventory(channels);
     return entries.map((entry) => entry.name);
   } catch (error) {
     log.warn(`[fastagent] --tunnel: cannot read ${channels}: ${(error as Error).message} — no webhooks registered`);

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -302,6 +302,14 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
       const loaded = await loadChannels(dir, { agent: {} as never, stateRoot: dir });
       expect(loaded.routeChannels).toEqual([]);
       expect(said.join("\n")).toContain("symlink");
+
+      // The LISTING path says it too. `fastagent info` is where an author looks for what their
+      // directory assembles into, and it only lists names — so while the skip was reported by the
+      // loader alone, info showed a symlinked channel as simply absent, which reads as "I never
+      // created it" rather than "this one cannot be loaded".
+      said.length = 0;
+      expect(await discoverChannelFiles(dir)).toEqual([]);
+      expect(said.join("\n")).toContain("symlink");
     } finally {
       warn.mockRestore();
     }

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -272,7 +272,14 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     // A DIRECTORY passes the name test on its own. Every reader of channels/ has to answer this the
     // same way loadModuleDir does, or `info` lists a channel the serve never mounts.
     await mkdir(join(dir, "channels", "feishu.ts"));
-    expect(await discoverChannelFiles(dir)).toEqual(["github", "telegram"]);
+    const said: string[] = [];
+    const warn = vi.spyOn(log, "warn").mockImplementation((message: string) => void said.push(message));
+    try {
+      expect(await discoverChannelFiles(dir)).toEqual(["github", "telegram"]);
+    } finally {
+      warn.mockRestore();
+    }
+    expect(said.filter((m) => m.includes("feishu.ts") && m.includes("a directory"))).toHaveLength(1);
   });
 
   it("orders by the NAME a consumer sees, not by filename", async () => {
@@ -301,15 +308,14 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     try {
       const loaded = await loadChannels(dir, { agent: {} as never, stateRoot: dir });
       expect(loaded.routeChannels).toEqual([]);
-      expect(said.join("\n")).toContain("symlink");
+      // Once per read of the directory: the inventory is the only place that says it.
+      expect(said.filter((m) => m.includes("symlink"))).toHaveLength(1);
 
-      // The LISTING path says it too. `fastagent info` is where an author looks for what their
-      // directory assembles into, and it only lists names — so while the skip was reported by the
-      // loader alone, info showed a symlinked channel as simply absent, which reads as "I never
-      // created it" rather than "this one cannot be loaded".
+      // The LISTING path says it too: `fastagent info` only lists names, so a silent skip there
+      // reads as "I never created it" rather than "this one cannot be loaded".
       said.length = 0;
       expect(await discoverChannelFiles(dir)).toEqual([]);
-      expect(said.join("\n")).toContain("symlink");
+      expect(said.filter((m) => m.includes("symlink"))).toHaveLength(1);
     } finally {
       warn.mockRestore();
     }


### PR DESCRIPTION
## Summary

Closes the open decision `loader.ts` had been carrying: symlinked code inputs are **refused, on
purpose**, and that is now written down where an author reads rather than only in a module header.

The reasoning was already correct and stays: `assertInsideAgentDir` guards the code-input
*directory*, nothing guards the entries inside it, so following a link would import from anywhere on
the machine past the check that exists to stop that. The docs add the second half, which the header
did not have — a link does not survive `deploy` either, since the image is the baked workspace. So
the failure mode of "supporting" it is an agent that works locally and is silently missing a tool in
production. Sharing code between agents is a package or a copy.

**The listing path now says it too.** `fastagent info` is where an author looks for what their
directory assembles into, and it only lists names — so a skip reported by `loadModuleDir` alone
showed a symlinked channel as simply **absent**, which reads as "I never created it" rather than
"this one cannot be loaded". The warning moves into `moduleInventory`, the single place that reads a
code-input directory, so all four consumers report it and `SkippedEntry` is gone.

That makes a skip a **warning only**, unlike a `ModuleLoadFailure`: it is absent from `info --json`
and `deploy` does not gate on it. Deliberate, and now recorded at the function — three of the four
consumers list names and have nowhere to put data, so one report for all four costs the data channel.
A machine consumer that needs the skips should get them beside the entries, not by parsing stderr.
One warning per *read*, so a command that both lists and loads the same directory says it twice;
remembering what was already said would mean a restart stops mentioning a skip that is still there.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (115 files, 1563 tests)
- [x] Added or updated the smallest relevant tests

The existing symlink test covered `loadChannels` only. It now also asserts the `discoverChannelFiles`
path — the one that was silent — and counts the warnings rather than matching a substring, so a
duplicate is a failure too. The directory branch is pinned the same way; changing either message
turns the test red.

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (`docs/configuration.md`)