### PR TITLE
docs: an agent merges on a maintainer's word, not on its own read of the CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ Full version: `CONTRIBUTING.md`. The essentials:
    ```
 2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`.
 3. **Squash merge only** (repo settings enforce it): one PR = one commit on `main`; curate the PR title/body — they become the commit message. Branch commits are working state, the PR is the design asset: put the durable *why* there, not in per-commit narration. `main` enforces linear history; force-push is forbidden.
-4. **Review policy.** Merging is an explicit maintainer decision — agents never merge. Green CI makes a PR eligible; report "ready to merge" and stop. External-contributor PRs are reviewed and merged by a maintainer.
+4. **Review policy.** Merging is a maintainer's decision, never an agent's. Green CI makes a PR eligible; report "ready to merge" and stop — merge only when told to. External-contributor PRs are reviewed and merged by a maintainer.
 5. **After merge:**
    ```bash
    git checkout main && git pull --ff-only && git branch -d <branch> && git fetch --prune origin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ One branch = one focused change. If a branch grows several unrelated changes, sp
 
 A maintainer is a collaborator with write or admin access. The project is open source: every change lands through a reviewed PR, without exception.
 
-- **Merging is an explicit maintainer decision.** Green CI makes a PR *eligible*; a maintainer *lands* it. Nothing merges automatically — not CI, and not coding agents: an agent may open a PR, respond to review, and report "CI green, ready to merge", but the merge itself is always issued by a human maintainer.
+- **Merging is an explicit maintainer decision.** Green CI makes a PR *eligible*; a maintainer *lands* it. An agent stops at "CI green, ready to merge" and merges only when a maintainer says so.
 - Maintainer-authored PRs require green CI before merging. Review by a second maintainer is recommended for SPEC and public API changes.
 - A PR from an external contributor must be reviewed and merged by a maintainer; external contributors do not have merge permission.
 - `CODEOWNERS` routes changes to the relevant maintainers.


### PR DESCRIPTION
`AGENTS.md` said "agents never merge". The intent is the default — an agent must not merge unprompted, and green CI is never its own permission. Read literally, the absolute also refuses a maintainer who is present and explicitly asking, which turns a clear instruction into an argument about the rule.

Both documents now state the same thing: stop at "ready to merge" by default; merge when a maintainer says to, because then the decision is still theirs.

- `AGENTS.md` — the workflow summary.
- `CONTRIBUTING.md` — the review policy, plus the part the absolute was protecting: absent an instruction the answer is always to report and stop, however obvious the merge looks.