### PR TITLE
refactor(deploy): a channel's ingress belongs to the channel, not to each host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,14 @@ src/
 │       └── scaffold/        # `add lark` bundle
 ├── deploy/                  # `deploy docker|fly|railway`: host artifacts + runbook + `--run` CLI drive (docs/design/core.md §9)
 │   │                        # LAYOUT: neutral kernel at top (horizontal) + one dir per host (vertical) — new host = new dir, copy fly/
+│   ├── channel-ingress.ts   # HOW A RUNNING CHANNEL IS REACHED: default route, who can set that URL
+│   │                     # end-to-end, the words when nobody can. The ONE answer to "which channels
+│   │                     # have a webhook" — it was written per host (3 runbooks, 3 --run drivers, a
+│   │                     # docker path table, the tunnel announcer) and the long-connection exception
+│   │                     # reached only the feishu/lark branches, so a long-connection Telegram deploy
+│   │                     # printed setWebhook and 409'd the channel it just deployed. Every function
+│   │                     # filters the DeclaredChannel list ITSELF — a pre-filtered argument is how it
+│   │                     # drifted. Consumed by every host AND by the serving path (src/tunnel.ts)
 │   ├── registration-gate.ts # host-NEUTRAL step-7 gate policy: registrars report facts (registered|manual|failed), this owns gate-or-not
 │   ├── preflight.ts         # host-NEUTRAL pre-flight: model-travel gate (modelTravelIssue), channel discovery, auth probe, container facts + warnings
 │   ├── container.ts         # portable Dockerfile + .dockerignore (host-neutral) + the generated-marker predicate

--- a/src/channels/discover.ts
+++ b/src/channels/discover.ts
@@ -34,32 +34,55 @@ function validateLongConnectionModule(value: LongConnectionChannelModule, label:
 }
 
 /**
+ * HOW A CHANNEL IS REACHED — the authored structural fact, and the ONE shape it travels in.
+ *
+ * A webhook channel is reached at a URL someone must set; a long-connection channel dials out, so
+ * there is no URL and setting one breaks it (Telegram answers `getUpdates` with 409 once a webhook
+ * exists). Everything downstream — which secrets to carry, what the runbook says, what `--run` and
+ * `--tunnel` register — is a question about THIS.
+ *
+ * It is one list because it used to be three (`channels` + `routeChannels` + `longConnectionChannels`,
+ * two of them including custom channels and one not), and every consumer re-derived the answer from
+ * whichever pair it happened to hold. Two deploys shipped a webhook for a long-connection channel
+ * that way. A list of pairs cannot be recombined wrongly, and a consumer that needs a subset asks for
+ * it here rather than trusting its caller to have filtered.
+ */
+export type ChannelIngress = "webhook" | "long-connection";
+
+/** One channel a directory declares, with the ingress its module shape says it has. `name` is the
+ *  basename, which is a {@link ChannelKind} for the first-party ones and anything for a custom one. */
+export interface DeclaredChannel {
+  name: string;
+  ingress: ChannelIngress;
+}
+
+/** Declared channels from basenames that share one ingress: the serving surface's mounted route list
+ *  (a long-connection channel mounts no HTTP route, so every route IS a webhook channel), and fixtures. */
+export function declaredChannels(names: readonly string[], ingress: ChannelIngress = "webhook"): DeclaredChannel[] {
+  return names.map((name) => ({ name, ingress }));
+}
+
+/**
  * Import channel files without mounting route factories or opening connections. Deployment needs only
- * the authored structural fact: function exports are route channels; `{ connect() }` exports are
+ * the authored structural fact: function exports are webhook channels; `{ connect() }` exports are
  * long-connection channels. There is no second ingress/lifecycle declaration to keep in sync.
  */
 export async function inspectChannels(dir: string): Promise<{
-  channels: string[];
-  routeChannels: string[];
-  longConnectionChannels: string[];
+  channels: DeclaredChannel[];
   failures: ModuleLoadFailure[];
 }> {
   await assertInsideAgentDir(dir, "channels");
   const { modules, failures } = await loadModuleDir(join(dir, "channels"));
-  const channels: string[] = [];
-  const routeChannels: string[] = [];
-  const longConnectionChannels: string[] = [];
+  const channels: DeclaredChannel[] = [];
   for (const { name, label, file, mod } of modules) {
     try {
       if (typeof mod.default === "function") {
-        channels.push(name);
-        routeChannels.push(name);
+        channels.push({ name, ingress: "webhook" });
         continue;
       }
       if (longConnectionModule(mod.default)) {
         validateLongConnectionModule(mod.default, label);
-        channels.push(name);
-        longConnectionChannels.push(name);
+        channels.push({ name, ingress: "long-connection" });
         continue;
       }
       throw new Error(`${label} must default-export (ctx) => Routes or { name, connect(ctx, signal) }`);
@@ -67,7 +90,7 @@ export async function inspectChannels(dir: string): Promise<{
       failures.push({ label, file, message: (error as Error).message });
     }
   }
-  return { channels, routeChannels, longConnectionChannels, failures };
+  return { channels, failures };
 }
 
 /**

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -8,6 +8,7 @@
  * --force). `--run` drives the target CLI instead of printing.
  */
 import { MAX_WEBHOOK_BODY_BYTES } from "../../channels/agentcore-limits.ts";
+import type { DeclaredChannel } from "../../channels/discover.ts";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
@@ -23,7 +24,7 @@ import {
   planAgentcoreDeploy,
 } from "../../deploy/agentcore/plan.ts";
 import { deployAgentcoreRun } from "../../deploy/agentcore/run.ts";
-import { type Registrars, webhookChannels, webhookPaths } from "../../deploy/channel-ingress.ts";
+import { type Registrars, webhookPaths } from "../../deploy/channel-ingress.ts";
 import { isGeneratedDockerfile, isGeneratedDockerignore } from "../../deploy/container.ts";
 import {
   composeHasTunnelService,
@@ -52,7 +53,6 @@ import { type ResolvedPlacement, resolveStateRoot, exists } from "../../paths.ts
 import { loadSchedules } from "../../schedule/discover.ts";
 import { installProxyFetch } from "../../proxy.ts";
 import { openExternalUrl } from "../../open-url.ts";
-import type { ChannelKind } from "../../scaffold/add-channel.ts";
 import { announceWebhooks } from "../../tunnel.ts";
 import { failStartup, failUsage, placementOrExit } from "../fail.ts";
 import { resolveFirstRunModel } from "../shared.ts";
@@ -121,19 +121,10 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
   }).catch(failStartup);
   if (!pre.ok) failStartup(new Error(`deploy stopped: ${pre.gate}`));
   for (const m of pre.messages) console.error(`[fastagent] ${m.level}: ${m.text}`);
-  const {
-    channels,
-    routeChannels,
-    longConnectionChannels,
-    hasTimeTriggers,
-    modelAuth,
-    modelKeyInDefinition,
-    authPath,
-    container,
-    port,
-    extraSecrets,
-  } = pre;
-  const hasDeclaredChannels = routeChannels.length + longConnectionChannels.length > 0;
+  const { channels, hasTimeTriggers, modelAuth, modelKeyInDefinition, authPath, container, port, extraSecrets } = pre;
+  const webhookChannels = channels.filter((channel) => channel.ingress === "webhook");
+  const longConnectionChannels = channels.filter((channel) => channel.ingress === "long-connection");
+  const hasDeclaredChannels = channels.length > 0;
 
   // Docker: one app service + loopback port + state volume. `--tunnel` shapes the generated topology
   // with an optional Quick Tunnel service; `--run` alone decides whether Docker receives side effects.
@@ -151,13 +142,12 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
         port,
         modelAuth,
         channels,
-        longConnectionChannels,
         tunnel,
         extraSecrets,
         ...container,
       });
-    const requestedTunnel = !!opts.tunnel && (!hasDeclaredChannels || routeChannels.length > 0);
-    if (opts.tunnel && hasDeclaredChannels && routeChannels.length === 0) {
+    const requestedTunnel = !!opts.tunnel && (!hasDeclaredChannels || webhookChannels.length > 0);
+    if (opts.tunnel && hasDeclaredChannels && webhookChannels.length === 0) {
       console.error(`[fastagent] note: --tunnel skipped — every channel uses a long connection`);
     }
     let plan = dockerPlan(requestedTunnel);
@@ -187,7 +177,6 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
         modelKeyInDefinition,
         authPath,
         channels,
-        longConnectionChannels,
         extraSecrets,
       });
     }
@@ -220,7 +209,6 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
       serviceName,
       modelAuth,
       channels,
-      longConnectionChannels,
       extraSecrets,
       hasTimeTriggers,
       ...container,
@@ -246,7 +234,6 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
         modelKeyInDefinition,
         authPath,
         channels,
-        longConnectionChannels,
         extraSecrets,
         intoLinked: !!opts.intoLinked,
         dockerfilePath: dockerfilePathVar(pre.container.agentPrefix),
@@ -273,7 +260,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
     // (deploying a channel that can't connect); generate-only warns and prints the runbook.
     if (longConnectionChannels.length > 0) {
       const msg =
-        `long-connection channel (${longConnectionChannels.join(", ")}) cannot run on AgentCore — there is no ` +
+        `long-connection channel (${longConnectionChannels.map((c) => c.name).join(", ")}) cannot run on AgentCore — there is no ` +
         `resident process to hold the connection, and nothing wakes a reclaimed session. Switch the channel ` +
         `to webhook mode (its events then ride the forwarder like every other channel).`;
       if (opts.run) failStartup(new Error(`deploy stopped: ${msg}`));
@@ -307,7 +294,6 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
       name: acName,
       modelAuth,
       channels,
-      routeChannels,
       extraSecrets,
       schedules: loaded.schedules.map((s) => ({ name: s.name, cron: s.cron, tz: s.tz })),
       selfSchedule: !!config.selfSchedule,
@@ -323,7 +309,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
     // Host capability limit, stated at plan time. GitHub's own webhook contract is 25 MiB, but a
     // Lambda Function URL request caps at 6 MB — so on this host a large payload cannot arrive at
     // all. Better a sentence here than an opaque 502 the first time someone pushes a big diff.
-    if (channels.includes("github")) {
+    if (channels.some((channel) => channel.name === "github")) {
       console.error(
         `[fastagent] note: on AgentCore a webhook body is capped at ~${Math.round(MAX_WEBHOOK_BODY_BYTES / (1 << 20))} MiB ` +
           `(the forwarder's Function URL limit); the GitHub channel accepts 25 MiB on a resident host, so the largest ` +
@@ -365,7 +351,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
         selfSchedule: !!config.selfSchedule,
         // Same predicate the template uses for the forwarder resource — kept in one expression so
         // the run path and the topology cannot disagree about whether a forwarder exists.
-        needsForwarder: routeChannels.length > 0 || loaded.schedules.length > 0 || !!config.selfSchedule,
+        needsForwarder: webhookChannels.length > 0 || loaded.schedules.length > 0 || !!config.selfSchedule,
       });
     }
     console.log(plan.runbook.join("\n"));
@@ -381,7 +367,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
   // The replay floor that makes scale-to-zero safe is Telegram-only (its L1 turn store). GitHub turns
   // are fire-and-forget (no replay), so the generated fly.toml keeps one machine running for them —
   // a note, not a warn, since the plan already did the safe thing (definition-aware autostop).
-  if (channels.includes("github")) {
+  if (channels.some((channel) => channel.name === "github")) {
     console.error(
       `[fastagent] note: github turns have no replay — the generated fly.toml uses min_machines_running=1 ` +
         `(no scale-to-zero) so autostop can't drop an in-flight review. Set it to 0 to accept that trade.`,
@@ -428,7 +414,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
       // hand-written fly.toml without the line scales to zero exactly like an explicit 0.
       const reason = hasTimeTriggers
         ? `schedules/self-scheduling need a running machine (no external wake-up)`
-        : `long-connection channel (${longConnectionChannels.join(", ")}) needs an always-on outbound connection`;
+        : `long-connection channel (${longConnectionChannels.map((c) => c.name).join(", ")}) needs an always-on outbound connection`;
       const msg =
         `your kept fly.toml scales to zero (min_machines_running = ${min ?? "absent → platform default 0"}), but ` +
         `${reason}. Set min_machines_running = 1, or pass --force to regenerate.`;
@@ -441,7 +427,6 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
     port,
     modelAuth,
     channels,
-    longConnectionChannels,
     extraSecrets,
     hasTimeTriggers,
     ...container,
@@ -461,7 +446,6 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
       modelKeyInDefinition,
       authPath,
       channels,
-      longConnectionChannels,
       flyTomlPath,
       extraSecrets,
     });
@@ -549,8 +533,8 @@ export async function writeArtifacts(
   }
 }
 
-function deployEnvironment(agentDir: string, channels: ChannelKind[]): NodeJS.ProcessEnv {
-  if (!channels.includes("slack")) return process.env;
+function deployEnvironment(agentDir: string, channels: readonly DeclaredChannel[]): NodeJS.ProcessEnv {
+  if (!channels.some((channel) => channel.name === "slack")) return process.env;
   const latest = readSlackBotAuthEnv(join(resolveStateRoot(agentDir), "channels", "slack", "bot-auth.json"));
   return { ...process.env, ...latest };
 }
@@ -568,8 +552,7 @@ async function runDeployDocker(
     modelAuth: string | undefined;
     modelKeyInDefinition: boolean;
     authPath: string;
-    channels: ChannelKind[];
-    longConnectionChannels: string[];
+    channels: readonly DeclaredChannel[];
     extraSecrets: string[];
   },
 ): Promise<void> {
@@ -583,7 +566,6 @@ async function runDeployDocker(
     modelKeyInDefinition,
     authPath,
     channels,
-    longConnectionChannels,
     extraSecrets,
   } = params;
   const { secrets, missingSecrets, needsModelCredential } = assembleSecrets({
@@ -591,7 +573,6 @@ async function runDeployDocker(
     modelKeyInDefinition,
     authFile: (await exists(authPath)) ? await readFile(authPath) : undefined,
     channels,
-    longConnectionChannels,
     extraSecrets,
     env: deployEnvironment(agentDir, channels),
   });
@@ -604,9 +585,8 @@ async function runDeployDocker(
       needsModelCredential,
       requireTunnel,
       announce: (tunnelUrl) =>
-        announceWebhooks(agentDir, tunnelUrl, {
+        announceWebhooks(agentDir, tunnelUrl, channels, {
           openUrl: openExternalUrl,
-          routeChannels: webhookChannels(channels, longConnectionChannels),
           stateRoot: resolveStateRoot(agentDir),
         }),
     },
@@ -634,7 +614,7 @@ async function runDeployDocker(
   }
   if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
   if (outcome.tunnelUrl) return;
-  const paths = webhookPaths(channels, longConnectionChannels);
+  const paths = webhookPaths(channels);
   if (paths.length > 0) {
     console.error(
       `[fastagent] note: public ingress is operator-owned — configure your tunnel/proxy, then wire the ` +
@@ -658,8 +638,7 @@ async function runDeployFly(
     modelAuth: string | undefined;
     modelKeyInDefinition: boolean;
     authPath: string;
-    channels: ChannelKind[];
-    longConnectionChannels: string[];
+    channels: readonly DeclaredChannel[];
     flyTomlPath: string;
     extraSecrets: string[];
   },
@@ -673,7 +652,6 @@ async function runDeployFly(
     modelKeyInDefinition,
     authPath,
     channels,
-    longConnectionChannels,
     flyTomlPath,
     extraSecrets,
   } = params;
@@ -689,7 +667,6 @@ async function runDeployFly(
     modelKeyInDefinition,
     authFile: (await exists(authPath)) ? await readFile(authPath) : undefined,
     channels,
-    longConnectionChannels,
     extraSecrets,
     env: deployEnvironment(agentDir, channels),
   });
@@ -710,7 +687,6 @@ async function runDeployFly(
       secrets,
       missingSecrets,
       channels,
-      longConnectionChannels,
       flyConfig: `${agentPrefix}fly.toml`,
       dockerfile: `${agentPrefix}Dockerfile`,
     },
@@ -736,7 +712,7 @@ async function runDeployAgentcore(
     modelAuth: string | undefined;
     modelKeyInDefinition: boolean;
     authPath: string;
-    channels: ChannelKind[];
+    channels: readonly DeclaredChannel[];
     extraSecrets: string[];
     selfSchedule: boolean;
     needsForwarder: boolean;
@@ -843,8 +819,7 @@ async function runDeployRailway(
     modelAuth: string | undefined;
     modelKeyInDefinition: boolean;
     authPath: string;
-    channels: ChannelKind[];
-    longConnectionChannels: string[];
+    channels: readonly DeclaredChannel[];
     extraSecrets: string[];
     intoLinked: boolean;
     /** RAILWAY_DOCKERFILE_PATH — the scriptable route to the agent's non-root Dockerfile. */
@@ -859,7 +834,6 @@ async function runDeployRailway(
     modelKeyInDefinition,
     authPath,
     channels,
-    longConnectionChannels,
     extraSecrets,
     intoLinked,
     dockerfilePath,
@@ -875,7 +849,6 @@ async function runDeployRailway(
     modelKeyInDefinition,
     authFile: (await exists(authPath)) ? await readFile(authPath) : undefined,
     channels,
-    longConnectionChannels,
     extraSecrets,
     env: deployEnvironment(agentDir, channels),
   });
@@ -889,7 +862,7 @@ async function runDeployRailway(
   }
 
   const outcome = await deployRailwayRun(
-    { name, mountPath: "/data", secrets, missingSecrets, channels, longConnectionChannels, intoLinked, dockerfilePath },
+    { name, mountPath: "/data", secrets, missingSecrets, channels, intoLinked, dockerfilePath },
     railway,
     (m) => console.error(`[fastagent] ${m}`),
     registrarsFor(agentDir),

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -23,10 +23,10 @@ import {
   planAgentcoreDeploy,
 } from "../../deploy/agentcore/plan.ts";
 import { deployAgentcoreRun } from "../../deploy/agentcore/run.ts";
+import { type Registrars, webhookChannels, webhookPaths } from "../../deploy/channel-ingress.ts";
 import { isGeneratedDockerfile, isGeneratedDockerignore } from "../../deploy/container.ts";
 import {
   composeHasTunnelService,
-  dockerWebhookPaths,
   isGeneratedCompose,
   planDockerDeploy,
   toDockerProjectName,
@@ -74,6 +74,16 @@ export interface DeployOptions {
 }
 
 /** A copy/paste-safe POSIX shell argument for the command hints deploy prints. */
+/** The registrars every host driver gets. One wiring: a channel's credentials are the channel's, not
+ *  the host's, so which of them can run end-to-end never varies by deployment target. */
+function registrarsFor(agentDir: string): Registrars {
+  return {
+    telegram: (baseUrl) => registerTelegramWebhook(baseUrl),
+    slack: (baseUrl) => registerSlackWebhook(baseUrl, { stateRoot: resolveStateRoot(agentDir) }),
+    feishu: (baseUrl, kind) => registerFeishuWebhook(baseUrl, kind),
+  };
+}
+
 function shellArg(value: string): string {
   return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
 }
@@ -596,7 +606,7 @@ async function runDeployDocker(
       announce: (tunnelUrl) =>
         announceWebhooks(agentDir, tunnelUrl, {
           openUrl: openExternalUrl,
-          routeChannels: channels.filter((kind) => !longConnectionChannels.includes(kind)),
+          routeChannels: webhookChannels(channels, longConnectionChannels),
           stateRoot: resolveStateRoot(agentDir),
         }),
     },
@@ -624,7 +634,7 @@ async function runDeployDocker(
   }
   if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
   if (outcome.tunnelUrl) return;
-  const paths = dockerWebhookPaths(channels.filter((kind) => !longConnectionChannels.includes(kind)));
+  const paths = webhookPaths(channels, longConnectionChannels);
   if (paths.length > 0) {
     console.error(
       `[fastagent] note: public ingress is operator-owned — configure your tunnel/proxy, then wire the ` +
@@ -706,9 +716,7 @@ async function runDeployFly(
     },
     fly,
     (m) => console.error(`[fastagent] ${m}`),
-    (baseUrl) => registerTelegramWebhook(baseUrl),
-    (baseUrl, kind) => registerFeishuWebhook(baseUrl, kind),
-    (baseUrl) => registerSlackWebhook(baseUrl, { stateRoot: resolveStateRoot(agentDir) }),
+    registrarsFor(agentDir),
   );
   if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
   console.error(`[fastagent] deployed → https://${appName}.fly.dev`);
@@ -802,9 +810,7 @@ async function runDeployAgentcore(
         await writeFile(path, bytes);
         return path;
       },
-      (baseUrl) => registerTelegramWebhook(baseUrl),
-      (baseUrl, kind) => registerFeishuWebhook(baseUrl, kind),
-      (baseUrl) => registerSlackWebhook(baseUrl, { stateRoot: resolveStateRoot(agentDir) }),
+      registrarsFor(agentDir),
     );
     if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
     console.error(`[fastagent] deployed → ${outcome.runtimeArn}`);
@@ -886,9 +892,7 @@ async function runDeployRailway(
     { name, mountPath: "/data", secrets, missingSecrets, channels, longConnectionChannels, intoLinked, dockerfilePath },
     railway,
     (m) => console.error(`[fastagent] ${m}`),
-    (baseUrl) => registerTelegramWebhook(baseUrl),
-    (baseUrl, kind) => registerFeishuWebhook(baseUrl, kind),
-    (baseUrl) => registerSlackWebhook(baseUrl, { stateRoot: resolveStateRoot(agentDir) }),
+    registrarsFor(agentDir),
   );
   if (!outcome.ok) failStartup(new Error(`deploy stopped: ${outcome.gate}`));
   console.error(`[fastagent] deployed → ${outcome.url}`);

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -12,6 +12,7 @@ import type { AgentService } from "../service.ts";
 import { serveNode } from "../channels/serve.ts";
 import { log } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
+import { declaredChannels } from "../channels/discover.ts";
 import { announceWebhooks, startCloudflareTunnel } from "../tunnel.ts";
 import { failStartup, failUsage } from "./fail.ts";
 
@@ -181,7 +182,10 @@ export function maybeTunnel(
   if (!tunnel || process.env.FASTAGENT_DEV_WORKER === "1") return;
   void startCloudflareTunnel(boundPort).then((instance) => {
     if (!instance) return;
-    void announceWebhooks(agentDir, instance.url, { openUrl: openExternalUrl, routeChannels, stateRoot });
+    void announceWebhooks(agentDir, instance.url, declaredChannels(routeChannels), {
+      openUrl: openExternalUrl,
+      stateRoot,
+    });
     const cleanup = (): void => instance.close();
     process.once("SIGINT", cleanup);
     process.once("SIGTERM", cleanup);

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -1026,11 +1026,13 @@ export function planAgentcoreDeploy(input: AgentcorePlanInput): AgentcorePlan {
   const post = webhookRunbook(`<ForwarderUrl>`, channels);
   // AgentCore asides the shared steps cannot carry: nothing else routes through a forwarder, and
   // nothing else has a compute ceiling.
-  for (const kind of ["feishu", "lark"] as const) {
-    if (!webhookKinds(channels).includes(kind)) continue;
+  // Named rather than positional: the asides land after ALL the steps, so "the console" has to say
+  // WHICH console. One line for both kinds — an agent that declares feishu AND lark reads the same
+  // fact twice otherwise and looks for a second step that does not exist.
+  if (webhookKinds(channels).some((kind) => kind === "feishu" || kind === "lark")) {
     post.push(
-      `#   The console's challenge rides through the forwarder to the channel and back verbatim, so the`,
-      `#   stack must be deployed when you save it.`,
+      `# NOTE: the Feishu/Lark console's challenge rides through the forwarder to the channel and back`,
+      `#   verbatim, so the stack must be deployed when you save the Request URL.`,
     );
   }
   if (channels.some((channel) => channel.name === "github")) {

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -30,8 +30,8 @@
 import { createHash } from "node:crypto";
 import { MAX_WEBHOOK_BODY_BYTES } from "../../channels/agentcore-limits.ts";
 import { SECRETS_DIRNAME } from "../../paths.ts";
-import type { ChannelKind } from "../../scaffold/add-channel.ts";
-import { webhookRunbook } from "../channel-ingress.ts";
+import type { DeclaredChannel } from "../../channels/discover.ts";
+import { webhookKinds, webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
 
@@ -47,10 +47,9 @@ export interface AgentcorePlanInput extends ContainerInput {
   name: string;
   /** What satisfies model auth locally: an env-var name, an OAuth/stored label, or undefined. */
   modelAuth: string | undefined;
-  /** Known first-party channels — each contributes its secret metadata + webhook step. */
-  channels: ChannelKind[];
-  /** ALL route-channel basenames (customs included) — any of them requires the forwarder. */
-  routeChannels: string[];
+  /** Every declared channel and its ingress — the source of the secret list, the webhook steps, and
+   *  whether the forwarder is needed at all (ANY webhook channel requires it, customs included). */
+  channels: readonly DeclaredChannel[];
   /** Extra secret env-var names (fastagent.config deploy.secrets). */
   extraSecrets?: string[];
   /** Static schedules — each becomes an EventBridge Scheduler rule targeting the forwarder. */
@@ -522,7 +521,8 @@ function template(input: AgentcorePlanInput, translated: { fact: ScheduleFact; e
   // a schedule turn can outlive both its original presigned URL and the Lambda credentials that signed
   // it. Schedule-only URLs reject every non-reserved HTTP path before invoking AgentCore, so they do
   // not expose a webhook/data plane (and start never mounts the builtin /invoke under AgentCore).
-  const needsForwarder = input.routeChannels.length > 0 || translated.length > 0 || input.selfSchedule;
+  const needsForwarder =
+    input.channels.some((channel) => channel.ingress === "webhook") || translated.length > 0 || input.selfSchedule;
   const needsFunctionUrl = needsForwarder;
   const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
   const forwarderFnArn = `!Sub arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:fastagent-${input.name}-forwarder`;
@@ -741,7 +741,7 @@ function template(input: AgentcorePlanInput, translated: { fact: ScheduleFact; e
       `          RUNTIME_ARN: !GetAtt Runtime.AgentRuntimeArn`,
       `          INGRESS_SESSION_ID: ${ingressSessionId(input.name)}`,
       ...(needsFunctionUrl ? [`          STATE_REFRESH_SECRET: !Ref FastagentIngressSecret`] : []),
-      ...(input.routeChannels.length > 0 ? [`          WEBHOOKS_ENABLED: "1"`] : []),
+      ...(input.channels.some((channel) => channel.ingress === "webhook") ? [`          WEBHOOKS_ENABLED: "1"`] : []),
       ...(input.selfSchedule
         ? [
             `          WAKE_SECRET: !Ref FastagentWakeSecret`,
@@ -917,7 +917,8 @@ export function planAgentcoreDeploy(input: AgentcorePlanInput): AgentcorePlan {
 
   // Every forwarder needs its authenticated Function URL to refresh S3 snapshot capabilities during
   // a long turn. Without route channels, ordinary HTTP paths are rejected before AgentCore is invoked.
-  const needsForwarder = input.routeChannels.length > 0 || translated.length > 0 || input.selfSchedule;
+  const needsForwarder =
+    input.channels.some((channel) => channel.ingress === "webhook") || translated.length > 0 || input.selfSchedule;
   const needsFunctionUrl = needsForwarder;
   const artifacts: Artifact[] = [
     { path: `${prefix}${TEMPLATE_FILE}`, content: template(input, translated) },
@@ -1019,11 +1020,20 @@ export function planAgentcoreDeploy(input: AgentcorePlanInput): AgentcorePlan {
   }
 
   // Post-deploy webhook registration — the shared channel-ingress steps, pointed at the forwarder's
-  // Function URL (read from the stack outputs). No long-connection channels exist here: the CLI gates
-  // them before an AgentCore deploy (nothing holds a connection through scale-to-zero).
+  // Function URL (read from the stack outputs). `--run` REFUSES a long-connection channel here, but
+  // generate-only only warns and still prints this runbook, so the steps are filtered on ingress like
+  // every other host's rather than on the CLI having gated.
   const post = webhookRunbook(`<ForwarderUrl>`, channels);
-  if (channels.includes("github")) {
-    // AgentCore-specific, so it is not in the shared step: nothing else has a compute ceiling.
+  // AgentCore asides the shared steps cannot carry: nothing else routes through a forwarder, and
+  // nothing else has a compute ceiling.
+  for (const kind of ["feishu", "lark"] as const) {
+    if (!webhookKinds(channels).includes(kind)) continue;
+    post.push(
+      `#   The console's challenge rides through the forwarder to the channel and back verbatim, so the`,
+      `#   stack must be deployed when you save it.`,
+    );
+  }
+  if (channels.some((channel) => channel.name === "github")) {
     post.push(
       `# NOTE: github turns are fire-and-forget with no replay — a compute reclaimed mid-review drops it`,
       `#   (the ping's HealthyBusy + time_of_last_update holds the session while turns run, but the 8 h compute ceiling is hard).`,

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -31,6 +31,7 @@ import { createHash } from "node:crypto";
 import { MAX_WEBHOOK_BODY_BYTES } from "../../channels/agentcore-limits.ts";
 import { SECRETS_DIRNAME } from "../../paths.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import { webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
 
@@ -1017,33 +1018,15 @@ export function planAgentcoreDeploy(input: AgentcorePlanInput): AgentcorePlan {
     );
   }
 
-  // Post-deploy webhook registration — same per-channel steps as every host, pointed at the
-  // forwarder's Function URL (read from the stack outputs).
-  const post: string[] = [];
-  if (channels.includes("telegram")) {
-    post.push(
-      `# Register the Telegram webhook (default route POST /telegram; secret_token MUST equal TELEGRAM_SECRET_TOKEN):`,
-      `curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \\`,
-      `  -d url=<ForwarderUrl>/telegram -d secret_token=<TELEGRAM_SECRET_TOKEN>`,
-    );
-  }
+  // Post-deploy webhook registration — the shared channel-ingress steps, pointed at the forwarder's
+  // Function URL (read from the stack outputs). No long-connection channels exist here: the CLI gates
+  // them before an AgentCore deploy (nothing holds a connection through scale-to-zero).
+  const post = webhookRunbook(`<ForwarderUrl>`, channels);
   if (channels.includes("github")) {
+    // AgentCore-specific, so it is not in the shared step: nothing else has a compute ceiling.
     post.push(
-      `# Set the GitHub webhook (repo Settings → Webhooks): Payload URL = <ForwarderUrl>/webhook,`,
-      `#   content type application/json, secret = GITHUB_WEBHOOK_SECRET.`,
       `# NOTE: github turns are fire-and-forget with no replay — a compute reclaimed mid-review drops it`,
       `#   (the ping's HealthyBusy + time_of_last_update holds the session while turns run, but the 8 h compute ceiling is hard).`,
-    );
-  }
-  if (channels.includes("slack")) {
-    post.push(`# Set Slack Event Subscriptions → Request URL = <ForwarderUrl>/slack (scopes per channels/slack.ts).`);
-  }
-  for (const kind of ["feishu", "lark"] as const) {
-    if (!channels.includes(kind)) continue;
-    post.push(
-      `# Set the ${kind === "feishu" ? "Feishu" : "Lark"} event Request URL (developer console → Events & Callbacks):`,
-      `#   Request URL = <ForwarderUrl>/${kind} (the stack must be deployed when you save — the console`,
-      `#   sends a challenge, which rides through the forwarder to the channel and back verbatim).`,
     );
   }
   if (post.length > 0) runbook.push(``, ...post);

--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -14,7 +14,7 @@
  * a caller-provided temp parameters file (`file://…`, mode 0600, deleted by the caller) — the write
  * is injected to keep this module pure and the security-sensitive wiring testable.
  */
-import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import type { DeclaredChannel } from "../../channels/discover.ts";
 import { type Registrars, registerWebhooks } from "../channel-ingress.ts";
 import type { CliRunner } from "../runner.ts";
 import { createHash } from "node:crypto";
@@ -47,7 +47,8 @@ export interface AgentcoreRunPlan {
   secrets: Record<string, string>;
   /** Required secret names with NO local value — gated before any side effect. */
   missingSecrets: string[];
-  channels: ChannelKind[];
+  /** Every declared channel and its ingress — the driver asks which of them have a webhook. */
+  channels: readonly DeclaredChannel[];
   /** Whether the topology includes the forwarder Lambda (route channels / schedules / selfSchedule).
    *  It owns the state snapshot's presigned URLs, so its absence means an invoke-only deployment
    *  with no cross-deploy state to keep. */

--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -14,9 +14,8 @@
  * a caller-provided temp parameters file (`file://…`, mode 0600, deleted by the caller) — the write
  * is injected to keep this module pure and the security-sensitive wiring testable.
  */
-import type { RegistrationOutcome } from "../../channels/registration.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
-import { registrationGate } from "../registration-gate.ts";
+import { type Registrars, registerWebhooks } from "../channel-ingress.ts";
 import type { CliRunner } from "../runner.ts";
 import { createHash } from "node:crypto";
 import { Buffer } from "node:buffer";
@@ -197,9 +196,7 @@ export async function deployAgentcoreRun(
   log: (msg: string) => void,
   writeSecretFile: (content: string) => Promise<string>,
   writeForwarderZip: (bytes: Uint8Array) => Promise<string>,
-  registerTelegram: (baseUrl: string) => Promise<RegistrationOutcome>,
-  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<RegistrationOutcome>,
-  registerSlack?: (baseUrl: string) => Promise<RegistrationOutcome>,
+  registrars: Registrars,
   /** Injected in tests; the probe itself stays inside the run so no deploy can skip it. */
   probe: { fetchImpl?: typeof fetch; timeoutMs?: number; intervalMs?: number } = {},
 ): Promise<AgentcoreRunOutcome> {
@@ -567,37 +564,17 @@ export async function deployAgentcoreRun(
 
   // 9. Post-deploy webhook registration — same registrar seam as every host, pointed at the
   //    forwarder's Function URL. Gate policy is the shared registration-gate kernel.
-  const reg = registrationGate(log, "re-run to retry registration (steps already done are skipped)");
-  if (url) {
-    if (plan.channels.includes("telegram")) {
-      log("registering telegram webhook…");
-      reg.track("telegram", await registerTelegram(url));
-    }
-    if (plan.channels.includes("github")) {
-      log(`github: set the webhook in the repo (Settings → Webhooks) → ${url}/webhook`);
-      reg.track("github", "manual"); // always a human step — re-surfaced after the registrar output
-    }
-    if (plan.channels.includes("slack")) {
-      if (registerSlack) {
-        log("registering slack event URL…");
-        reg.track("slack", await registerSlack(url));
-      } else {
-        log(`slack: set Event Subscriptions → Request URL → ${url}/slack`);
-        reg.track("slack", "manual");
-      }
-    }
-    for (const kind of ["feishu", "lark"] as const) {
-      if (!plan.channels.includes(kind)) continue;
-      if (registerFeishu) {
-        log(`registering ${kind} event URL…`);
-        reg.track(kind, await registerFeishu(url, kind));
-      } else {
-        log(`${kind}: set the event Request URL (developer console → Events & Callbacks) → ${url}/${kind}`);
-        reg.track(kind, "manual");
-      }
-    }
-  }
-  const registrationGateMsg = reg.gate();
+  // No long-connection channels reach here: `deploy.ts` gates them before the driver runs (AgentCore
+  // has no resident process to hold a connection), so the deploy's channels are all webhook ones.
+  const registrationGateMsg = url
+    ? await registerWebhooks({
+        baseUrl: url,
+        channels: plan.channels,
+        registrars,
+        log,
+        retryHint: "re-run to retry registration (steps already done are skipped)",
+      })
+    : undefined;
   if (registrationGateMsg) return gate(registrationGateMsg);
   return { ok: true, runtimeArn, url };
 }

--- a/src/deploy/channel-ingress.ts
+++ b/src/deploy/channel-ingress.ts
@@ -1,8 +1,10 @@
 /**
- * HOW A DEPLOYED CHANNEL IS REACHED — the host-neutral half of "point this channel at the running
- * agent": its default route, whether anything can set that URL end-to-end, and the words an operator
- * needs when nothing can. Only the base URL is the host's to know (`<app>.fly.dev`, a minted Railway
- * domain, a Function URL), which is the argument every function here takes.
+ * HOW A RUNNING CHANNEL IS REACHED — the URL-neutral half of "point this channel at the agent": its
+ * default route, whether anything can set that URL end-to-end, and the words an operator needs when
+ * nothing can. Only the base URL varies, which is the argument every function here takes — a deploy
+ * host's (`<app>.fly.dev`, a minted Railway domain, a Function URL) or `dev --tunnel`'s Quick Tunnel.
+ * It lives under `deploy/` because that is where its answers are mostly consumed and where the gate
+ * policy it composes with lives; the serving path reads the same answers through `tunnel.ts`.
  *
  * It exists because that knowledge belongs to the CHANNEL and was written per HOST: three runbook
  * plans, three `--run` drivers, a path table in the docker plan and the `--tunnel` announcer each
@@ -71,7 +73,10 @@ const INGRESS: Record<ChannelKind, ChannelIngress> = {
   },
   github: {
     path: "/webhook",
-    manual: (baseUrl) => `github: set the webhook in the repo (Settings → Webhooks) → ${baseUrl}/webhook`,
+    // The env-var name is the part a first-time operator cannot guess, and this line is all `--tunnel`
+    // prints — there is no runbook beside it to carry the detail.
+    manual: (baseUrl) =>
+      `github: set the webhook in the repo (Settings → Webhooks) → ${baseUrl}/webhook (content type application/json, secret = GITHUB_WEBHOOK_SECRET)`,
     runbook: (baseUrl) => [
       `# Set the GitHub webhook (repo Settings → Webhooks). Default route POST /webhook; if you remapped`,
       `# it in channels/github.ts, use your path:`,

--- a/src/deploy/channel-ingress.ts
+++ b/src/deploy/channel-ingress.ts
@@ -5,15 +5,20 @@
  * domain, a Function URL), which is the argument every function here takes.
  *
  * It exists because that knowledge belongs to the CHANNEL and was written per HOST: three runbook
- * plans and three `--run` drivers each hand-wrote the same five-branch if-chain, plus a fourth path
- * table in the docker plan. A rule spelled six times drifts, and it did — the long-connection
- * exception (a WebSocket channel has no webhook: the connection IS the ingress) reached only the
- * feishu/lark branches, so a long-connection Telegram deploy printed `setWebhook` in the runbook.
- * That is not noise: setting a webhook makes `getUpdates` return 409 and stops the channel the
- * operator just deployed.
+ * plans, three `--run` drivers, a path table in the docker plan and the `--tunnel` announcer each
+ * hand-wrote the same five-branch if-chain. A rule spelled seven times drifts, and it did — the
+ * long-connection exception reached only the feishu/lark branches, so a long-connection Telegram
+ * deploy printed `setWebhook` in its runbook, which makes `getUpdates` return 409 and stops the
+ * channel the operator just deployed.
+ *
+ * Every function here takes the {@link DeclaredChannel} list and filters it ITSELF. Taking a
+ * pre-filtered list would put the rule back at the call sites, which is where it drifted from: the
+ * `--tunnel` announcer trusted its caller that way and had a default that passed every channel,
+ * long-connection ones included.
  *
  * A host adds its base URL and its own asides; it does not restate which channels have a webhook.
  */
+import type { DeclaredChannel } from "../channels/discover.ts";
 import type { RegistrationOutcome } from "../channels/registration.ts";
 import type { ChannelKind } from "../scaffold/add-channel.ts";
 import { registrationGate } from "./registration-gate.ts";
@@ -88,63 +93,70 @@ const INGRESS: Record<ChannelKind, ChannelIngress> = {
 };
 
 /**
- * The channels this deploy must point at a URL: declared, minus the long-connection ones. ONE answer
- * for every host and every path — the runbooks, the `--run` drivers, the docker ingress note.
+ * The first-party channels this deployment must point at a URL: webhook ingress, and a kind this tool
+ * knows how to instruct. ONE answer for every host and every path — the runbooks, the `--run`
+ * drivers, the docker ingress note, `--tunnel`. A custom channel is skipped here and reported by the
+ * pre-flight instead: its URL is its author's to set.
  */
-export function webhookChannels(
-  channels: readonly ChannelKind[],
-  longConnectionChannels: readonly string[] = [],
-): ChannelKind[] {
-  return (Object.keys(INGRESS) as ChannelKind[]).filter(
-    (kind) => channels.includes(kind) && !longConnectionChannels.includes(kind),
-  );
+export function webhookKinds(channels: readonly DeclaredChannel[]): ChannelKind[] {
+  const declared = new Set(channels.filter((c) => c.ingress === "webhook").map((c) => c.name));
+  return (Object.keys(INGRESS) as ChannelKind[]).filter((kind) => declared.has(kind));
 }
 
-/** Default route keys for {@link webhookChannels}, in the same order (the docker plan's ingress note). */
-export function webhookPaths(
-  channels: readonly ChannelKind[],
-  longConnectionChannels: readonly string[] = [],
-): string[] {
-  return webhookChannels(channels, longConnectionChannels).map((kind) => INGRESS[kind].path);
+/** Default route keys for {@link webhookKinds}, in the same order (the docker plan's ingress note). */
+export function webhookPaths(channels: readonly DeclaredChannel[]): string[] {
+  return webhookKinds(channels).map((kind) => INGRESS[kind].path);
 }
 
 /** The runbook block for every channel that needs a URL set by hand, `baseUrl` spelled the host's way
  *  (a literal `https://app.fly.dev`, or a placeholder like `<your-domain>` the operator fills in). */
-export function webhookRunbook(
-  baseUrl: string,
-  channels: readonly ChannelKind[],
-  longConnectionChannels: readonly string[] = [],
-): string[] {
-  return webhookChannels(channels, longConnectionChannels).flatMap((kind) => INGRESS[kind].runbook(baseUrl));
+export function webhookRunbook(baseUrl: string, channels: readonly DeclaredChannel[]): string[] {
+  return webhookKinds(channels).flatMap((kind) => INGRESS[kind].runbook(baseUrl));
 }
 
 /**
- * Point every channel at `baseUrl`, then apply the shared gate policy. All channels are attempted
- * before the policy runs, so one failure does not skip the rest; a channel whose registrar the caller
- * did not wire reports `manual` with the operator's instruction. Returns the gate message, or
- * undefined when nothing gates.
+ * Point every channel that has a webhook at `baseUrl`, reporting what each one ended as. All channels
+ * are attempted — one failure does not skip the rest — and a channel whose registrar the caller did
+ * not wire reports `manual` with the operator's instruction. The two callers differ in what they do
+ * with the outcomes, not in how they are produced: a deploy gates on them, a long-running serve
+ * cannot ({@link registerWebhooks} is the gating half).
+ */
+export async function pointChannelsAt(input: {
+  baseUrl: string;
+  channels: readonly DeclaredChannel[];
+  registrars: Registrars;
+  log: (msg: string) => void;
+}): Promise<{ kind: ChannelKind; outcome: RegistrationOutcome }[]> {
+  const outcomes: { kind: ChannelKind; outcome: RegistrationOutcome }[] = [];
+  for (const kind of webhookKinds(input.channels)) {
+    const ingress = INGRESS[kind];
+    // Calling IS the question: a channel whose registrar the caller did not wire returns undefined.
+    const running = ingress.register?.(input.registrars, input.baseUrl);
+    if (!running) {
+      input.log(ingress.manual(input.baseUrl));
+      outcomes.push({ kind, outcome: "manual" }); // a human's step — re-surfaced after registrar output
+      continue;
+    }
+    input.log(`registering ${kind} webhook…`);
+    outcomes.push({ kind, outcome: await running });
+  }
+  return outcomes;
+}
+
+/**
+ * {@link pointChannelsAt} plus the shared gate policy, for a command that EXITS: an exit 0 claims the
+ * deployment is reachable, so a failed registration has to become a non-zero one. Returns the gate
+ * message, or undefined when nothing gates.
  */
 export async function registerWebhooks(input: {
   baseUrl: string;
-  channels: readonly ChannelKind[];
-  longConnectionChannels?: readonly string[];
+  channels: readonly DeclaredChannel[];
   registrars: Registrars;
   log: (msg: string) => void;
   /** How THIS host retries — the only per-host words in the gate. */
   retryHint: string;
 }): Promise<string | undefined> {
   const reg = registrationGate(input.log, input.retryHint);
-  for (const kind of webhookChannels(input.channels, input.longConnectionChannels)) {
-    const ingress = INGRESS[kind];
-    // Calling IS the question: a channel whose registrar the caller did not wire returns undefined.
-    const running = ingress.register?.(input.registrars, input.baseUrl);
-    if (!running) {
-      input.log(ingress.manual(input.baseUrl));
-      reg.track(kind, "manual"); // re-surfaced after the registrar output — it is a human's step
-      continue;
-    }
-    input.log(`registering ${kind} webhook…`);
-    reg.track(kind, await running);
-  }
+  for (const { kind, outcome } of await pointChannelsAt(input)) reg.track(kind, outcome);
   return reg.gate();
 }

--- a/src/deploy/channel-ingress.ts
+++ b/src/deploy/channel-ingress.ts
@@ -1,0 +1,150 @@
+/**
+ * HOW A DEPLOYED CHANNEL IS REACHED — the host-neutral half of "point this channel at the running
+ * agent": its default route, whether anything can set that URL end-to-end, and the words an operator
+ * needs when nothing can. Only the base URL is the host's to know (`<app>.fly.dev`, a minted Railway
+ * domain, a Function URL), which is the argument every function here takes.
+ *
+ * It exists because that knowledge belongs to the CHANNEL and was written per HOST: three runbook
+ * plans and three `--run` drivers each hand-wrote the same five-branch if-chain, plus a fourth path
+ * table in the docker plan. A rule spelled six times drifts, and it did — the long-connection
+ * exception (a WebSocket channel has no webhook: the connection IS the ingress) reached only the
+ * feishu/lark branches, so a long-connection Telegram deploy printed `setWebhook` in the runbook.
+ * That is not noise: setting a webhook makes `getUpdates` return 409 and stops the channel the
+ * operator just deployed.
+ *
+ * A host adds its base URL and its own asides; it does not restate which channels have a webhook.
+ */
+import type { RegistrationOutcome } from "../channels/registration.ts";
+import type { ChannelKind } from "../scaffold/add-channel.ts";
+import { registrationGate } from "./registration-gate.ts";
+
+/** The registrars a host can drive. `telegram` is always available (fastagent holds the token and the
+ *  URL); the others are optional so a caller without their credentials falls back to a manual step. */
+export interface Registrars {
+  telegram: (baseUrl: string) => Promise<RegistrationOutcome>;
+  slack?: (baseUrl: string) => Promise<RegistrationOutcome>;
+  feishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<RegistrationOutcome>;
+}
+
+interface ChannelIngress {
+  /** The channel's DEFAULT route key. Reading the real one would mean executing the channel factory
+   *  (getMe, state-dir creation) — wrong at plan time — so every message states the assumption. */
+  path: string;
+  /** Runs this channel's registration end-to-end, or undefined when the caller wired no registrar for
+   *  it. github never has one: it is a repo settings screen only a human can reach. */
+  register?: (registrars: Registrars, baseUrl: string) => Promise<RegistrationOutcome> | undefined;
+  /** The one line a driver prints when no registrar runs it. */
+  manual: (baseUrl: string) => string;
+  /** The runbook block for a plan, which cannot register anything (comment lines + commands). */
+  runbook: (baseUrl: string) => string[];
+}
+
+const feishuCloud = (kind: "feishu" | "lark", label: string): ChannelIngress => ({
+  path: `/${kind}`,
+  register: (r, baseUrl) => r.feishu?.(baseUrl, kind),
+  manual: (baseUrl) =>
+    `${kind}: set the event Request URL in the developer console (Events & Callbacks) → ${baseUrl}/${kind} (the app must be running when you save)`,
+  runbook: (baseUrl) => [
+    `# Set the ${label} event Request URL (developer console → Events & Callbacks). Default route`,
+    `# POST /${kind}; the app must be RUNNING when you save (the console verifies with a challenge):`,
+    `#   Request URL = ${baseUrl}/${kind}`,
+  ],
+});
+
+/** Declaration order — the order every runbook and every driver reports in. */
+const INGRESS: Record<ChannelKind, ChannelIngress> = {
+  telegram: {
+    path: "/telegram",
+    register: (r, baseUrl) => r.telegram(baseUrl),
+    manual: (baseUrl) => `telegram: set the webhook → ${baseUrl}/telegram (secret_token = TELEGRAM_SECRET_TOKEN)`,
+    runbook: (baseUrl) => [
+      `# Register the Telegram webhook. The path assumes the default route (POST /telegram); if you`,
+      `# remapped it in channels/telegram.ts, use your path. secret_token MUST equal TELEGRAM_SECRET_TOKEN:`,
+      `curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \\`,
+      `  -d url=${baseUrl}/telegram -d secret_token=<TELEGRAM_SECRET_TOKEN>`,
+    ],
+  },
+  github: {
+    path: "/webhook",
+    manual: (baseUrl) => `github: set the webhook in the repo (Settings → Webhooks) → ${baseUrl}/webhook`,
+    runbook: (baseUrl) => [
+      `# Set the GitHub webhook (repo Settings → Webhooks). Default route POST /webhook; if you remapped`,
+      `# it in channels/github.ts, use your path:`,
+      `#   Payload URL = ${baseUrl}/webhook, content type application/json, secret = GITHUB_WEBHOOK_SECRET`,
+    ],
+  },
+  slack: {
+    path: "/slack",
+    register: (r, baseUrl) => r.slack?.(baseUrl),
+    manual: (baseUrl) => `slack: set Event Subscriptions → Request URL → ${baseUrl}/slack`,
+    runbook: (baseUrl) => [
+      `# Set Slack Event Subscriptions → Request URL (default route POST /slack; the running service`,
+      `# answers Slack's challenge), and match scopes/subscriptions to channels/slack.ts groupBehavior:`,
+      `#   Request URL = ${baseUrl}/slack`,
+    ],
+  },
+  feishu: feishuCloud("feishu", "Feishu"),
+  lark: feishuCloud("lark", "Lark"),
+};
+
+/**
+ * The channels this deploy must point at a URL: declared, minus the long-connection ones. ONE answer
+ * for every host and every path — the runbooks, the `--run` drivers, the docker ingress note.
+ */
+export function webhookChannels(
+  channels: readonly ChannelKind[],
+  longConnectionChannels: readonly string[] = [],
+): ChannelKind[] {
+  return (Object.keys(INGRESS) as ChannelKind[]).filter(
+    (kind) => channels.includes(kind) && !longConnectionChannels.includes(kind),
+  );
+}
+
+/** Default route keys for {@link webhookChannels}, in the same order (the docker plan's ingress note). */
+export function webhookPaths(
+  channels: readonly ChannelKind[],
+  longConnectionChannels: readonly string[] = [],
+): string[] {
+  return webhookChannels(channels, longConnectionChannels).map((kind) => INGRESS[kind].path);
+}
+
+/** The runbook block for every channel that needs a URL set by hand, `baseUrl` spelled the host's way
+ *  (a literal `https://app.fly.dev`, or a placeholder like `<your-domain>` the operator fills in). */
+export function webhookRunbook(
+  baseUrl: string,
+  channels: readonly ChannelKind[],
+  longConnectionChannels: readonly string[] = [],
+): string[] {
+  return webhookChannels(channels, longConnectionChannels).flatMap((kind) => INGRESS[kind].runbook(baseUrl));
+}
+
+/**
+ * Point every channel at `baseUrl`, then apply the shared gate policy. All channels are attempted
+ * before the policy runs, so one failure does not skip the rest; a channel whose registrar the caller
+ * did not wire reports `manual` with the operator's instruction. Returns the gate message, or
+ * undefined when nothing gates.
+ */
+export async function registerWebhooks(input: {
+  baseUrl: string;
+  channels: readonly ChannelKind[];
+  longConnectionChannels?: readonly string[];
+  registrars: Registrars;
+  log: (msg: string) => void;
+  /** How THIS host retries — the only per-host words in the gate. */
+  retryHint: string;
+}): Promise<string | undefined> {
+  const reg = registrationGate(input.log, input.retryHint);
+  for (const kind of webhookChannels(input.channels, input.longConnectionChannels)) {
+    const ingress = INGRESS[kind];
+    // Calling IS the question: a channel whose registrar the caller did not wire returns undefined.
+    const running = ingress.register?.(input.registrars, input.baseUrl);
+    if (!running) {
+      input.log(ingress.manual(input.baseUrl));
+      reg.track(kind, "manual"); // re-surfaced after the registrar output — it is a human's step
+      continue;
+    }
+    input.log(`registering ${kind} webhook…`);
+    reg.track(kind, await running);
+  }
+  return reg.gate();
+}

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -5,6 +5,7 @@
  * `--tunnel` can add an ephemeral Cloudflare Quick Tunnel service; durable ingress remains operator-owned.
  */
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import { webhookPaths } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
 
@@ -60,18 +61,6 @@ export function toDockerProjectName(directoryName: string): string {
     .slice(0, 54)
     .replace(/[-_]+$/g, "");
   return `fastagent-${slug || "agent"}`;
-}
-
-/** Default first-party webhook paths. Workspace glue may remap them, so guidance labels them defaults. */
-export function dockerWebhookPaths(channels: ChannelKind[]): string[] {
-  const path: Record<ChannelKind, string> = {
-    github: "/webhook",
-    telegram: "/telegram",
-    slack: "/slack",
-    feishu: "/feishu",
-    lark: "/lark",
-  };
-  return channels.map((kind) => path[kind]);
 }
 
 /** `${NAME:-}` without making JavaScript treat it as interpolation. */
@@ -145,8 +134,7 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
   const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets, input.longConnectionChannels);
   const required = secrets.filter((secret) => secret.required);
   const optional = secrets.filter((secret) => !secret.required);
-  const routeChannels = input.channels.filter((kind) => !input.longConnectionChannels?.includes(kind));
-  const paths = dockerWebhookPaths(routeChannels);
+  const paths = webhookPaths(input.channels, input.longConnectionChannels);
 
   const runbook: string[] = [
     `# Run FastAgent in local Docker. ${composePath} / Dockerfile(.dockerignore) are generated above.`,

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -4,7 +4,7 @@
  * process, its loopback port, exact environment-variable names, and one persistent state volume.
  * `--tunnel` can add an ephemeral Cloudflare Quick Tunnel service; durable ingress remains operator-owned.
  */
-import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookPaths } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
@@ -16,10 +16,8 @@ export interface DockerPlanInput extends ContainerInput {
   port: number;
   /** What satisfies model auth locally: an env-var name, an OAuth/stored label, or undefined. */
   modelAuth: string | undefined;
-  /** Known channels contribute their environment-variable names and webhook registration. */
-  channels: ChannelKind[];
-  /** All long-connection channel basenames, including custom channels. */
-  longConnectionChannels?: string[];
+  /** Every declared channel and its ingress — the source of the secret list and the ingress note. */
+  channels: readonly DeclaredChannel[];
   /** Generate an optional Cloudflare Quick Tunnel service in Compose. Generation only; `--run` starts it. */
   tunnel: boolean;
   /** Extra environment-variable names declared in config.deploy.secrets. */
@@ -69,7 +67,7 @@ function composeInterpolation(name: string): string {
 }
 
 function composeYaml(input: DockerPlanInput): string {
-  const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets, input.longConnectionChannels);
+  const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
   // Always leave the auth-seed seam in the committed topology. `--run` uses it for OAuth/stored auth;
   // it is empty otherwise. Values never land in this file — Compose interpolates them at invocation.
   const envNames = [...new Set([...secrets.map((secret) => secret.name), "FASTAGENT_AUTH_SEED"])];
@@ -131,10 +129,10 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
   const composePath = `${input.agentPrefix}${DOCKER_COMPOSE_FILE}`;
   const artifacts: Artifact[] = [{ path: composePath, content: composeYaml(input) }, ...containerArtifacts(input)];
   const compose = `docker compose -f ${composePath}`;
-  const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets, input.longConnectionChannels);
+  const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
   const required = secrets.filter((secret) => secret.required);
   const optional = secrets.filter((secret) => !secret.required);
-  const paths = webhookPaths(input.channels, input.longConnectionChannels);
+  const paths = webhookPaths(input.channels);
 
   const runbook: string[] = [
     `# Run FastAgent in local Docker. ${composePath} / Dockerfile(.dockerignore) are generated above.`,

--- a/src/deploy/fly/plan.ts
+++ b/src/deploy/fly/plan.ts
@@ -16,7 +16,7 @@
  * snapshot is discarded replays on the next start (the Telegram L1 turn store) — at-least-once, the
  * documented floor. State on the /data volume survives stop/suspend on the same machine.
  */
-import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
@@ -33,10 +33,9 @@ export interface FlyPlanInput extends ContainerInput {
    * `"OAuth"`/`"stored credential"` (a local login the server can't use), or undefined (unconfigured).
    */
   modelAuth: string | undefined;
-  /** Known first-party channels — each contributes its secret metadata + webhook step. */
-  channels: ChannelKind[];
-  /** All long-connection channel basenames, including custom channels — require one running machine. */
-  longConnectionChannels?: string[];
+  /** Every declared channel and its ingress — the source of the secret list, the webhook steps, and
+   *  whether a machine must stay up for an outbound connection. */
+  channels: readonly DeclaredChannel[];
   /** Extra secret env-var names (fastagent.config deploy.secrets) — added to the runbook's secret list. */
   extraSecrets?: string[];
   /** `auto_stop_machines` — `"suspend"` (default, fast resume) or `"stop"` (cold start). CLI `--stop`. */
@@ -133,11 +132,11 @@ export function planFlyDeploy(input: FlyPlanInput): FlyPlan {
       content: flyToml(
         appName,
         port,
-        channels.includes("github"),
+        channels.some((channel) => channel.name === "github"),
         input.autostop,
         input.scaleToZero,
         input.hasTimeTriggers,
-        (input.longConnectionChannels?.length ?? 0) > 0,
+        channels.some((channel) => channel.ingress === "long-connection"),
       ),
     },
     ...containerArtifacts(input),
@@ -147,7 +146,7 @@ export function planFlyDeploy(input: FlyPlanInput): FlyPlan {
   // model key (when local auth is an env key) + every discovered channel's secrets. Names + hints as
   // COMMENT lines (a `#` inside a `\`-continued command would break the shell), then one flat, executable
   // `fly secrets set` the coding agent fills — `<value>` placeholders, never inline comments.
-  const secrets = deploymentSecrets(modelAuth, channels, input.extraSecrets, input.longConnectionChannels);
+  const secrets = deploymentSecrets(modelAuth, channels, input.extraSecrets);
   const requiredSecrets = secrets.filter((secret) => secret.required);
   const optionalSecrets = secrets.filter((secret) => !secret.required);
 
@@ -225,7 +224,7 @@ export function planFlyDeploy(input: FlyPlanInput): FlyPlan {
 
   // The fastagent-only post-step: point each channel at the live URL. WHICH channels and in what words
   // is the shared channel-ingress kernel's answer; Fly's contribution is that its URL is deterministic.
-  const steps = webhookRunbook(`https://${appName}.fly.dev`, channels, input.longConnectionChannels);
+  const steps = webhookRunbook(`https://${appName}.fly.dev`, channels);
   const post = steps.length > 0 ? [`# After deploy:`, ...steps] : [];
   if (post.length > 0) runbook.push(``, ...post);
 

--- a/src/deploy/fly/plan.ts
+++ b/src/deploy/fly/plan.ts
@@ -17,6 +17,7 @@
  * documented floor. State on the /data volume survives stop/suspend on the same machine.
  */
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import { webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
 
@@ -222,44 +223,10 @@ export function planFlyDeploy(input: FlyPlanInput): FlyPlan {
     );
   }
 
-  // The fastagent-only post-step: point each channel's webhook at the live URL. Only fastagent knows the routes.
-  // The URLs below assume each channel's DEFAULT route key (POST /telegram, POST /webhook). Reading the
-  // real key would mean executing the channel factory (getMe, state-dir creation) — wrong at plan time
-  // — so the runbook states the assumption instead of silently printing a stale path for remapped glue.
-  const post: string[] = [];
-  if (channels.includes("telegram")) {
-    post.push(
-      `# After deploy — register the Telegram webhook. The path assumes the default route (POST /telegram);`,
-      `# if you remapped it in channels/telegram.ts, use your path. secret_token MUST equal TELEGRAM_SECRET_TOKEN:`,
-      `curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \\`,
-      `  -d url=https://${appName}.fly.dev/telegram -d secret_token=<TELEGRAM_SECRET_TOKEN>`,
-    );
-  }
-  if (channels.includes("github")) {
-    post.push(
-      `# After deploy — set the GitHub webhook (repo Settings → Webhooks). Path assumes the default route`,
-      `# (POST /webhook); if you remapped it in channels/github.ts, use your path:`,
-      `#   Payload URL = https://${appName}.fly.dev/webhook, content type application/json, secret = GITHUB_WEBHOOK_SECRET`,
-    );
-  }
-  if (channels.includes("slack")) {
-    post.push(
-      `# After deploy — set Slack Event Subscriptions → Request URL. Path assumes POST /slack;`,
-      `# Slack verifies the running endpoint with a challenge:`,
-      `#   Request URL = https://${appName}.fly.dev/slack`,
-      `# Ensure OAuth scopes + message.* subscriptions match the groupBehavior in channels/slack.ts.`,
-    );
-  }
-  for (const kind of ["feishu", "lark"] as const) {
-    if (!channels.includes(kind) || input.longConnectionChannels?.includes(kind)) continue;
-    const label = kind === "feishu" ? "Feishu" : "Lark";
-    post.push(
-      `# After deploy — set the ${label} event Request URL (developer console → Events & Callbacks).`,
-      `# Path assumes the default route (POST /${kind}); the app must be RUNNING when you save (the console`,
-      `# verifies the URL with a challenge):`,
-      `#   Request URL = https://${appName}.fly.dev/${kind}`,
-    );
-  }
+  // The fastagent-only post-step: point each channel at the live URL. WHICH channels and in what words
+  // is the shared channel-ingress kernel's answer; Fly's contribution is that its URL is deterministic.
+  const steps = webhookRunbook(`https://${appName}.fly.dev`, channels, input.longConnectionChannels);
+  const post = steps.length > 0 ? [`# After deploy:`, ...steps] : [];
   if (post.length > 0) runbook.push(``, ...post);
 
   // Single-machine tier: state lives on ONE volume tied to ONE machine. Scaling to multiple machines

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -17,8 +17,7 @@
  * (one machine, the single-machine tier). Secrets go in via `secrets import` over stdin, so values
  * never land in argv/process listings.
  */
-import type { RegistrationOutcome } from "../../channels/registration.ts";
-import { registrationGate } from "../registration-gate.ts";
+import { type Registrars, registerWebhooks } from "../channel-ingress.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
 import type { CliRunner } from "../runner.ts";
 
@@ -84,18 +83,16 @@ function listHasName(stdout: string, name: string): boolean {
 }
 
 /**
- * Run the deploy through `fly`. `log` reports progress; the injected Telegram/Feishu/Slack registrars
- * perform post-deploy webhook steps from the builder machine (Slack's control credential never travels
- * to the host). Absent, the manual console
- * instruction is printed. Every gate is fail-visible.
+ * Run the deploy through `fly`. `log` reports progress; the injected {@link Registrars} perform the
+ * post-deploy webhook steps from the builder machine (Slack's control credential never travels to the
+ * host). A registrar the caller did not wire becomes the printed manual step. Every gate is
+ * fail-visible.
  */
 export async function deployFlyRun(
   plan: FlyRunPlan,
   fly: CliRunner,
   log: (msg: string) => void,
-  registerTelegram: (baseUrl: string) => Promise<RegistrationOutcome>,
-  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<RegistrationOutcome>,
-  registerSlack?: (baseUrl: string) => Promise<RegistrationOutcome>,
+  registrars: Registrars,
 ): Promise<FlyRunOutcome> {
   const gate = (g: string): FlyRunOutcome => ({ ok: false, gate: g });
 
@@ -174,41 +171,16 @@ export async function deployFlyRun(
     return gate("`fly deploy` failed — see the flyctl output above; fix and re-run");
   }
 
-  // 7. Post-deploy webhook — telegram end-to-end (fastagent has the token + the live URL); github is a
-  //    repo-settings step only a human can do. Gate policy is the shared registration-gate kernel
-  //    (registrars report facts, it owns the policy); all channels are attempted first.
-  const reg = registrationGate(log, "re-run to retry registration (steps already done are skipped)");
-  if (plan.channels.includes("telegram")) {
-    log("registering telegram webhook…");
-    reg.track("telegram", await registerTelegram(`https://${plan.appName}.fly.dev`));
-  }
-  if (plan.channels.includes("github")) {
-    log(`github: set the webhook in the repo (Settings → Webhooks) → https://${plan.appName}.fly.dev/webhook`);
-    reg.track("github", "manual"); // always a human step — re-surface it after the registrar output
-  }
-  if (plan.channels.includes("slack")) {
-    const baseUrl = `https://${plan.appName}.fly.dev`;
-    if (registerSlack) {
-      log("registering slack event URL…");
-      reg.track("slack", await registerSlack(baseUrl));
-    } else {
-      log(`slack: set Event Subscriptions → Request URL → ${baseUrl}/slack`);
-      reg.track("slack", "manual");
-    }
-  }
-  for (const kind of ["feishu", "lark"] as const) {
-    if (!plan.channels.includes(kind) || plan.longConnectionChannels?.includes(kind)) continue;
-    if (registerFeishu) {
-      log(`registering ${kind} event URL…`);
-      reg.track(kind, await registerFeishu(`https://${plan.appName}.fly.dev`, kind));
-    } else {
-      log(
-        `${kind}: set the event Request URL in the developer console (Events & Callbacks) → https://${plan.appName}.fly.dev/${kind} (the app must be running when you save)`,
-      );
-      reg.track(kind, "manual"); // no registrar wired — the console step above is the operator's
-    }
-  }
-  const registrationGateMsg = reg.gate();
+  // 7. Post-deploy webhook — which channels, in what words, and the gate policy are all the shared
+  //    kernel's; Fly contributes its deterministic URL and how to retry.
+  const registrationGateMsg = await registerWebhooks({
+    baseUrl: `https://${plan.appName}.fly.dev`,
+    channels: plan.channels,
+    longConnectionChannels: plan.longConnectionChannels,
+    registrars,
+    log,
+    retryHint: "re-run to retry registration (steps already done are skipped)",
+  });
   if (registrationGateMsg) return gate(registrationGateMsg);
   return { ok: true };
 }

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -18,7 +18,7 @@
  * never land in argv/process listings.
  */
 import { type Registrars, registerWebhooks } from "../channel-ingress.ts";
-import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import type { DeclaredChannel } from "../../channels/discover.ts";
 import type { CliRunner } from "../runner.ts";
 
 /**
@@ -57,8 +57,8 @@ export interface FlyRunPlan {
   secrets: Record<string, string>;
   /** Required secret names with NO local value — the run gates on these before any side effect. */
   missingSecrets: string[];
-  channels: ChannelKind[];
-  longConnectionChannels?: string[];
+  /** Every declared channel and its ingress — the driver asks which of them have a webhook. */
+  channels: readonly DeclaredChannel[];
   /** fly.toml path passed to `fly deploy -c` (relative to the run cwd = the workspace root). */
   flyConfig: string;
   /** Dockerfile path passed explicitly (`fastagent/Dockerfile`, with the workspace as context —
@@ -176,7 +176,6 @@ export async function deployFlyRun(
   const registrationGateMsg = await registerWebhooks({
     baseUrl: `https://${plan.appName}.fly.dev`,
     channels: plan.channels,
-    longConnectionChannels: plan.longConnectionChannels,
     registrars,
     log,
     retryHint: "re-run to retry registration (steps already done are skipped)",

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -15,10 +15,10 @@ import ignore from "ignore";
 import { classifyBind } from "../bind.ts";
 import { type FastagentConfig, resolveAuthPath } from "../engines/pi/config.ts";
 import { type ResolvedPlacement, resolveSecretsDir, resolveStateRoot, exists } from "../paths.ts";
-import { inspectChannels } from "../channels/discover.ts";
+import { type DeclaredChannel, inspectChannels } from "../channels/discover.ts";
 import { discoverScheduleFiles } from "../schedule/discover.ts";
 import { createPiModelRuntime, modelCredentialCarry, probeAuthSource } from "../engines/pi/models.ts";
-import { CHANNEL_KINDS, type ChannelKind } from "../scaffold/add-channel.ts";
+import { CHANNEL_KINDS } from "../scaffold/add-channel.ts";
 import { detectRuntime, readPackageJson } from "../runtime.ts";
 import { fastagentVersion } from "../version.ts";
 import { type ContainerInput, isGeneratedDockerfile, isGeneratedDockerignore } from "./container.ts";
@@ -34,11 +34,10 @@ interface DeployMessage {
 /** The resolved facts every host plan needs (the container shape, channels, model auth, ports/secrets). */
 interface DeployFacts {
   messages: DeployMessage[];
-  channels: ChannelKind[];
-  /** Every structurally detected HTTP-route channel basename, including custom channels. */
-  routeChannels: string[];
-  /** Every structurally detected long-connection channel basename, including custom channels. */
-  longConnectionChannels: string[];
+  /** Every declared channel with the ingress its module shape says it has, custom ones included. The
+   *  ONE channel fact the plans and drivers read: a consumer that needs a subset derives it (see
+   *  {@link webhookKinds}) rather than receiving a list someone else already filtered. */
+  channels: DeclaredChannel[];
   /** Whether the agent has TIME triggers — `schedules/` files or `selfSchedule` (the wake tool). Cron/wake
    *  has no external wake-up, so the deployment must keep one machine running: the fly plan forces
    *  `min_machines_running=1`, the railway runbook forbids App Sleeping. */
@@ -165,19 +164,18 @@ export async function preflightDeploy(input: {
       `cannot inspect channel modules: ${inspected.failures.map((failure) => `${failure.label}: ${failure.message}`).join("; ")}`,
     );
   }
-  const discovered = inspected.channels;
-  const channels = discovered.filter((c): c is ChannelKind => (CHANNEL_KINDS as string[]).includes(c));
-  const routeChannels = inspected.routeChannels;
-  const longConnectionChannels = inspected.longConnectionChannels;
-  for (const c of discovered) {
-    if (channels.includes(c as ChannelKind)) continue;
+  const channels = inspected.channels;
+  for (const { name, ingress } of channels) {
+    if ((CHANNEL_KINDS as string[]).includes(name)) continue;
     messages.push({
       level: "note",
-      text: longConnectionChannels.includes(c)
-        ? `long-connection channel "${c}" is custom — configure its secrets yourself; generated deploy plans keep the process running and skip webhook registration`
-        : `route channel "${c}" is custom — configure its secrets and webhook yourself`,
+      text:
+        ingress === "long-connection"
+          ? `long-connection channel "${name}" is custom — configure its secrets yourself; generated deploy plans keep the process running and skip webhook registration`
+          : `route channel "${name}" is custom — configure its secrets and webhook yourself`,
     });
   }
+  const longConnectionChannels = channels.filter((c) => c.ingress === "long-connection").map((c) => c.name);
 
   // Time triggers (static schedules or self-scheduling) need a machine kept running — unlike a webhook,
   // nothing external wakes a scale-to-zero box for a cron instant or a wake-up. The note is CONDITIONAL
@@ -507,8 +505,6 @@ export async function preflightDeploy(input: {
     ok: true,
     messages,
     channels,
-    routeChannels,
-    longConnectionChannels,
     hasTimeTriggers,
     modelAuth,
     modelKeyInDefinition,

--- a/src/deploy/railway/plan.ts
+++ b/src/deploy/railway/plan.ts
@@ -22,6 +22,7 @@
  * server is listening" boot race Fly's deploy hit — Railway only routes once /health passes.
  */
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import { webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
 
@@ -203,49 +204,16 @@ export function planRailwayDeploy(input: RailwayPlanInput): RailwayPlan {
 
   // The public URL is minted, not deterministic (unlike Fly's <app>.fly.dev) — ONE mint step, then each
   // channel's webhook uses that domain (mint once even when both channels are present).
-  const hasFeishuCloudChannel = (["feishu", "lark"] as const).some((kind) => channels.includes(kind));
-  if (
-    channels.includes("telegram") ||
-    channels.includes("github") ||
-    channels.includes("slack") ||
-    hasFeishuCloudChannel
-  ) {
+  // Mint only when something below needs it: with nothing to point at the domain (no channels, or only
+  // long-connection ones), "use it in the step(s) below" would refer to steps that do not follow.
+  const steps = webhookRunbook(`https://<your-domain>`, channels, input.longConnectionChannels);
+  if (steps.length > 0) {
     runbook.push(
       ``,
       `# Public URL — Railway mints a *.up.railway.app domain (NOT deterministic). Generate it, then read`,
       `# the printed https URL and use it as <your-domain> in the webhook step(s) below:`,
       `railway domain`,
-    );
-  }
-  if (channels.includes("telegram")) {
-    runbook.push(
-      `# Register the Telegram webhook (default route POST /telegram; if you remapped it in`,
-      `# channels/telegram.ts, use your path). secret_token MUST equal TELEGRAM_SECRET_TOKEN:`,
-      `curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \\`,
-      `  -d url=https://<your-domain>/telegram -d secret_token=<TELEGRAM_SECRET_TOKEN>`,
-    );
-  }
-  if (channels.includes("github")) {
-    runbook.push(
-      `# Set the GitHub webhook (repo Settings → Webhooks). Default route POST /webhook; if you remapped it`,
-      `# in channels/github.ts, use your path:`,
-      `#   Payload URL = https://<your-domain>/webhook, content type application/json, secret = GITHUB_WEBHOOK_SECRET`,
-    );
-  }
-  if (channels.includes("slack")) {
-    runbook.push(
-      `# Set Slack Event Subscriptions → Request URL (default route POST /slack; the running service`,
-      `# answers Slack's challenge), and match scopes/subscriptions to channels/slack.ts groupBehavior:`,
-      `#   Request URL = https://<your-domain>/slack`,
-    );
-  }
-  for (const kind of ["feishu", "lark"] as const) {
-    if (!channels.includes(kind) || input.longConnectionChannels?.includes(kind)) continue;
-    const label = kind === "feishu" ? "Feishu" : "Lark";
-    runbook.push(
-      `# Set the ${label} event Request URL (developer console → Events & Callbacks). Default route`,
-      `# POST /${kind}; the service must be RUNNING when you save (the console verifies with a challenge):`,
-      `#   Request URL = https://<your-domain>/${kind}`,
+      ...steps,
     );
   }
 

--- a/src/deploy/railway/plan.ts
+++ b/src/deploy/railway/plan.ts
@@ -21,7 +21,7 @@
  * the required-secret list. `railway.json`'s `healthcheckPath=/health` also fixes the "routed before the
  * server is listening" boot race Fly's deploy hit — Railway only routes once /health passes.
  */
-import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
@@ -34,10 +34,9 @@ export interface RailwayPlanInput extends ContainerInput {
   serviceName: string;
   /** What satisfies model auth locally: an env-var name, an OAuth/stored label, or undefined. */
   modelAuth: string | undefined;
-  /** Known first-party channels — each contributes its secret metadata + webhook step. */
-  channels: ChannelKind[];
-  /** All long-connection channel basenames, including custom channels — no App Sleeping. */
-  longConnectionChannels?: string[];
+  /** Every declared channel and its ingress — the source of the secret list, the webhook steps, and
+   *  whether App Sleeping must stay off for an outbound connection. */
+  channels: readonly DeclaredChannel[];
   // Container facts (hasPackageJson, runtime, hasLockfile, bunVersion, version, apt) come from
   // ContainerInput — ONE source, so the plan and the generated Dockerfile can't drift.
   /** Extra secret env-var names (fastagent.config deploy.secrets) — added to the runbook's secret list. */
@@ -109,7 +108,7 @@ export function planRailwayDeploy(input: RailwayPlanInput): RailwayPlan {
     ...containerArtifacts(input),
   ];
 
-  const secrets = deploymentSecrets(modelAuth, channels, input.extraSecrets, input.longConnectionChannels);
+  const secrets = deploymentSecrets(modelAuth, channels, input.extraSecrets);
   const requiredSecrets = secrets.filter((secret) => secret.required);
   const optionalSecrets = secrets.filter((secret) => !secret.required);
 
@@ -206,7 +205,7 @@ export function planRailwayDeploy(input: RailwayPlanInput): RailwayPlan {
   // channel's webhook uses that domain (mint once even when both channels are present).
   // Mint only when something below needs it: with nothing to point at the domain (no channels, or only
   // long-connection ones), "use it in the step(s) below" would refer to steps that do not follow.
-  const steps = webhookRunbook(`https://<your-domain>`, channels, input.longConnectionChannels);
+  const steps = webhookRunbook(`https://<your-domain>`, channels);
   if (steps.length > 0) {
     runbook.push(
       ``,
@@ -222,11 +221,11 @@ export function planRailwayDeploy(input: RailwayPlanInput): RailwayPlan {
   // turn store), so a sleep mid-review would drop it — the same floor the Fly plan enforces via config.
   runbook.push(
     ``,
-    channels.includes("github")
+    channels.some((channel) => channel.name === "github")
       ? `# Scale-to-zero: do NOT enable App Sleeping — github turns have no replay, a sleep mid-review is lost.`
       : input.hasTimeTriggers
         ? `# Scale-to-zero: do NOT enable App Sleeping — schedules/wake-ups have no external wake-up; a sleeping service sleeps through them.`
-        : (input.longConnectionChannels?.length ?? 0) > 0
+        : channels.some((channel) => channel.ingress === "long-connection")
           ? `# Scale-to-zero: do NOT enable App Sleeping — a long-connection channel must remain connected.`
           : `# Scale-to-zero (optional, dashboard-only — no CLI/API): Settings → Deploy → Serverless → App Sleeping.`,
     `# Keep this a SINGLE service: the ${MOUNT} volume is tied to one service; extra replicas split state.`,

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -23,8 +23,7 @@
  * no bulk stdin import like Fly's `secrets import`). Auth needs an ACCOUNT credential (login or
  * `RAILWAY_API_KEY`), not a project token: `init` creates a project that a project token can't predate.
  */
-import type { RegistrationOutcome } from "../../channels/registration.ts";
-import { registrationGate } from "../registration-gate.ts";
+import { type Registrars, registerWebhooks } from "../channel-ingress.ts";
 import type { ChannelKind } from "../../scaffold/add-channel.ts";
 import type { CliRunner } from "../runner.ts";
 
@@ -123,18 +122,16 @@ export function parseHasVolume(stdout: string, mountPath: string): boolean {
 }
 
 /**
- * Run the deploy through `railway`. `log` reports progress; the injected Telegram/Feishu/Slack
- * registrars perform post-deploy webhook steps from the builder machine (Slack's control credential
- * never travels to the host). Absent, the manual console
- * instruction is printed. Every gate is fail-visible.
+ * Run the deploy through `railway`. `log` reports progress; the injected {@link Registrars} perform
+ * the post-deploy webhook steps from the builder machine (Slack's control credential never travels to
+ * the host). A registrar the caller did not wire becomes the printed manual step. Every gate is
+ * fail-visible.
  */
 export async function deployRailwayRun(
   plan: RailwayRunPlan,
   railway: CliRunner,
   log: (msg: string) => void,
-  registerTelegram: (baseUrl: string) => Promise<RegistrationOutcome>,
-  registerFeishu?: (baseUrl: string, kind: "feishu" | "lark") => Promise<RegistrationOutcome>,
-  registerSlack?: (baseUrl: string) => Promise<RegistrationOutcome>,
+  registrars: Registrars,
 ): Promise<RailwayRunOutcome> {
   const gate = (g: string): RailwayRunOutcome => ({ ok: false, gate: g });
   // Every --service below targets plan.name — the name this tool gives BOTH the project and the service
@@ -258,39 +255,16 @@ export async function deployRailwayRun(
   if (!url) {
     return gate("couldn't read a domain from `railway domain` — run `railway domain` manually, then set any webhook");
   }
-  // 7. Post-deploy webhook — gate policy is the shared registration-gate kernel (registrars report
-  //    facts, it owns the policy); all channels are attempted first.
-  const reg = registrationGate(log, "re-run with --into-linked to retry registration");
-  if (plan.channels.includes("telegram")) {
-    log("registering telegram webhook…");
-    reg.track("telegram", await registerTelegram(url));
-  }
-  if (plan.channels.includes("github")) {
-    log(`github: set the webhook in the repo (Settings → Webhooks) → ${url}/webhook`);
-    reg.track("github", "manual"); // always a human step — re-surface it after the registrar output
-  }
-  if (plan.channels.includes("slack")) {
-    if (registerSlack) {
-      log("registering slack event URL…");
-      reg.track("slack", await registerSlack(url));
-    } else {
-      log(`slack: set Event Subscriptions → Request URL → ${url}/slack`);
-      reg.track("slack", "manual");
-    }
-  }
-  for (const kind of ["feishu", "lark"] as const) {
-    if (!plan.channels.includes(kind) || plan.longConnectionChannels?.includes(kind)) continue;
-    if (registerFeishu) {
-      log(`registering ${kind} event URL…`);
-      reg.track(kind, await registerFeishu(url, kind));
-    } else {
-      log(
-        `${kind}: set the event Request URL in the developer console (Events & Callbacks) → ${url}/${kind} (the service must be running when you save)`,
-      );
-      reg.track(kind, "manual"); // no registrar wired — the console step above is the operator's
-    }
-  }
-  const registrationGateMsg = reg.gate();
+  // 7. Post-deploy webhook — which channels, in what words, and the gate policy are all the shared
+  //    kernel's; Railway contributes the minted URL and how to retry.
+  const registrationGateMsg = await registerWebhooks({
+    baseUrl: url,
+    channels: plan.channels,
+    longConnectionChannels: plan.longConnectionChannels,
+    registrars,
+    log,
+    retryHint: "re-run with --into-linked to retry registration",
+  });
   if (registrationGateMsg) return gate(registrationGateMsg);
   return { ok: true, url };
 }

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -24,7 +24,7 @@
  * `RAILWAY_API_KEY`), not a project token: `init` creates a project that a project token can't predate.
  */
 import { type Registrars, registerWebhooks } from "../channel-ingress.ts";
-import type { ChannelKind } from "../../scaffold/add-channel.ts";
+import type { DeclaredChannel } from "../../channels/discover.ts";
 import type { CliRunner } from "../runner.ts";
 
 export interface RailwayRunPlan {
@@ -39,8 +39,8 @@ export interface RailwayRunPlan {
   secrets: Record<string, string>;
   /** Required secret names with NO local value — the run gates on these before any side effect. */
   missingSecrets: string[];
-  channels: ChannelKind[];
-  longConnectionChannels?: string[];
+  /** Every declared channel and its ingress — the driver asks which of them have a webhook. */
+  channels: readonly DeclaredChannel[];
   /** Opt-in (CLI `--into-linked`) to provision INTO the project this directory is already linked to. Off
    *  by default so `--run` only creates on an unlinked dir and never deploys into a pre-existing (possibly
    *  unrelated/production) project; the flag is the operator's explicit "yes, this project". */
@@ -260,7 +260,6 @@ export async function deployRailwayRun(
   const registrationGateMsg = await registerWebhooks({
     baseUrl: url,
     channels: plan.channels,
-    longConnectionChannels: plan.longConnectionChannels,
     registrars,
     log,
     retryHint: "re-run with --into-linked to retry registration",

--- a/src/deploy/secrets.ts
+++ b/src/deploy/secrets.ts
@@ -4,7 +4,20 @@
  * (`fly secrets import` vs `railway variables set`). The runbooks list both classes; `--run` reads local values.
  */
 import { CONTROL_TOKEN_ENV } from "../channels/control.ts";
-import { type ChannelKind, channelSetup } from "../scaffold/add-channel.ts";
+import type { DeclaredChannel } from "../channels/discover.ts";
+import { CHANNEL_KINDS, type ChannelKind, channelSetup } from "../scaffold/add-channel.ts";
+
+/** The declared channels this tool has setup metadata for. A custom channel carries its own secrets;
+ *  nothing here can name them, and guessing would print a runbook line no one can act on. */
+function firstPartyChannels(
+  channels: readonly DeclaredChannel[],
+): { kind: ChannelKind; ingress: DeclaredChannel["ingress"] }[] {
+  return channels.flatMap((channel) =>
+    (CHANNEL_KINDS as string[]).includes(channel.name)
+      ? [{ kind: channel.name as ChannelKind, ingress: channel.ingress }]
+      : [],
+  );
+}
 
 /**
  * Is this local auth source an env-var API key (→ becomes a deploy secret) vs OAuth / stored / none?
@@ -24,15 +37,13 @@ export function isEnvKey(source: string | undefined): source is string {
  */
 export function deploymentSecrets(
   modelAuth: string | undefined,
-  channels: ChannelKind[],
+  channels: readonly DeclaredChannel[],
   extraSecrets: string[] = [],
-  longConnectionChannels: string[] = [],
 ): { name: string; hint: string; required: boolean }[] {
   const secrets: { name: string; hint: string; required: boolean }[] = [];
   if (isEnvKey(modelAuth)) secrets.push({ name: modelAuth, hint: "your model provider key", required: true });
-  for (const kind of channels) {
-    const setupMode = longConnectionChannels.includes(kind) ? "websocket" : "webhook";
-    for (const e of channelSetup(kind, setupMode).env) {
+  for (const { kind, ingress } of firstPartyChannels(channels)) {
+    for (const e of channelSetup(kind, ingress === "long-connection" ? "websocket" : "webhook").env) {
       secrets.push({ name: e.name, hint: e.hint, required: e.required });
     }
   }
@@ -76,8 +87,7 @@ export function assembleSecrets(input: {
    *  no value to carry and no gate to raise — see {@link modelCredentialCarry}. */
   modelKeyInDefinition?: boolean;
   authFile: Buffer | undefined;
-  channels: ChannelKind[];
-  longConnectionChannels?: string[];
+  channels: readonly DeclaredChannel[];
   /** Extra secret env-var names from `fastagent.config` deploy.secrets — carried like channel secrets. */
   extraSecrets?: string[];
   env: NodeJS.ProcessEnv;
@@ -105,9 +115,8 @@ export function assembleSecrets(input: {
     needsModelCredential = true; // no env key, no auth.json — `fastagent login` remediation
   }
 
-  for (const kind of input.channels) {
-    const setupMode = input.longConnectionChannels?.includes(kind) ? "websocket" : "webhook";
-    for (const e of channelSetup(kind, setupMode).env) {
+  for (const { kind, ingress } of firstPartyChannels(input.channels)) {
+    for (const e of channelSetup(kind, ingress === "long-connection" ? "websocket" : "webhook").env) {
       const v = input.env[e.name];
       if (v)
         secrets[e.name] = v; // optional channel values travel when configured
@@ -119,7 +128,7 @@ export function assembleSecrets(input: {
   // Slack bot-token rotation is an all-or-nothing credential bundle. Its fields remain optional so a
   // manually configured long-lived token works, but a partial bundle must gate before the container
   // reaches slackChannel construction.
-  if (input.channels.includes("slack")) {
+  if (input.channels.some((channel) => channel.name === "slack")) {
     const rotation = [
       "SLACK_BOT_REFRESH_TOKEN",
       "SLACK_BOT_TOKEN_EXPIRES_AT",

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -24,6 +24,7 @@ import { dotEnvPath } from "./env.ts";
 import { log } from "./log.ts";
 import { installProxyFetch } from "./proxy.ts";
 import { openExternalUrl } from "./open-url.ts";
+import { declaredChannels } from "./channels/discover.ts";
 import { type Tunnel, announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
 
 /** What the dev watcher restarts on (agent-dir-relative): the process-bound code inputs only. */
@@ -113,9 +114,8 @@ export async function runDevSupervisor(
         void startCloudflareTunnel(m.port).then((t) => {
           if (t) {
             tunnel = t;
-            void announceWebhooks(placement.agentDir, t.url, {
+            void announceWebhooks(placement.agentDir, t.url, declaredChannels(m.routeChannels ?? []), {
               openUrl: openExternalUrl,
-              routeChannels: m.routeChannels,
               stateRoot: resolveStateRoot(placement.agentDir),
             });
           }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -7,12 +7,12 @@
  * Process orchestration, not assembly — lives outside the engine, beside dev-supervisor.ts.
  */
 import { type ChildProcess, spawn } from "node:child_process";
-import { join } from "node:path";
-import { moduleInventory } from "./loader.ts";
 import type { RegistrationOutcome } from "./channels/registration.ts";
+import type { DeclaredChannel } from "./channels/discover.ts";
 import { registerFeishuWebhook } from "./channels/feishu/register-webhook.ts";
 import { registerSlackWebhook } from "./channels/slack/register-webhook.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
+import { pointChannelsAt } from "./deploy/channel-ingress.ts";
 import { dotEnvPath, loadDotEnv } from "./env.ts";
 import { resolveStateRoot } from "./paths.ts";
 import { log } from "./log.ts";
@@ -130,24 +130,6 @@ function lastErrorLine(tail: string): string {
   return ([...lines].reverse().find((l) => /err|error|failed/i.test(l)) ?? lines.at(-1) ?? "").slice(0, 200);
 }
 
-/** Channel basenames present in `<dir>/channels/` — {@link moduleInventory}, the same reading the
- *  serve loads from, so the tunnel cannot register a set the deployment does not have.
- *
- *  The one thing it does differently is the FAILURE: `announceWebhooks` is void-called with no
- *  unhandledRejection handler, so a throw here would take the serve down. It reports and continues
- *  — silence would hide exactly the fault this scan exists to feed (a `channels/` that cannot be
- *  read registers nothing while the tunnel announces its public URL). */
-async function channelBasenames(dir: string): Promise<string[]> {
-  const channels = join(dir, "channels");
-  try {
-    const entries = await moduleInventory(channels);
-    return entries.map((entry) => entry.name);
-  } catch (error) {
-    log.warn(`[fastagent] --tunnel: cannot read ${channels}: ${(error as Error).message} — no webhooks registered`);
-    return [];
-  }
-}
-
 /**
  * Print the public URL and wire up first-party webhook channels found under `dir` (the agent
  * ROOT): Telegram and Feishu/Lark use runtime credentials; onboarded Slack uses its owner-local config
@@ -163,9 +145,12 @@ async function channelBasenames(dir: string): Promise<string[]> {
 export async function announceWebhooks(
   dir: string,
   baseUrl: string,
-  opts: { openUrl?: (url: string) => void; routeChannels?: string[]; stateRoot?: string } = {},
+  /** Every declared channel with its ingress. Not a pre-filtered list: this used to accept "the route
+   *  channels" and default to every basename in `channels/`, which pointed a webhook at a
+   *  long-connection channel whenever a caller forgot to filter. {@link pointChannelsAt} filters. */
+  channels: readonly DeclaredChannel[],
+  opts: { openUrl?: (url: string) => void; stateRoot?: string } = {},
 ): Promise<{ kind: string; outcome: RegistrationOutcome }[]> {
-  const registrations: { kind: string; outcome: RegistrationOutcome }[] = [];
   log.info(`[fastagent] public URL: ${baseUrl}`);
   try {
     loadDotEnv(dir); // webhook registrars read channel credentials from .env
@@ -177,39 +162,27 @@ export async function announceWebhooks(
     // missing-credential guidance. loadDotEnv keeps throwing for the synchronous command callers.
     log.warn(`[fastagent] could not read ${dotEnvPath(dir)}: ${(error as Error).message} — continuing without it`);
   }
-  // Serving passes the validated route-channel subset. The basename fallback preserves the public
-  // helper's behavior for callers that did not assemble channels first.
-  const routeChannels = opts.routeChannels ?? (await channelBasenames(dir));
-  if (routeChannels.length === 0) return registrations;
-  // Readiness is the registrar's job now: a fresh quick tunnel returns Cloudflare 530 for ~20-30s before
-  // its origin connects, and the automatic registrars poll /health before configuring the platform (the
-  // same wait the deploy runners rely on). GitHub needs no wait — the operator adds that webhook by hand.
-  const track = (kind: string, outcome: RegistrationOutcome): void => {
-    registrations.push({ kind, outcome });
-  };
-  if (routeChannels.includes("telegram")) track("telegram", await registerTelegramWebhook(baseUrl));
-  if (routeChannels.includes("github")) {
-    log.info(
-      `[fastagent] github: add a webhook in your repo (Settings → Webhooks): Payload URL = ${baseUrl}/webhook, content type application/json, secret = GITHUB_WEBHOOK_SECRET`,
-    );
-    track("github", "manual"); // always a human step — the console line above IS the instruction
-  }
-  if (routeChannels.includes("slack")) {
-    track(
-      "slack",
-      await registerSlackWebhook(baseUrl, {
-        stateRoot: opts.stateRoot ?? resolveStateRoot(dir),
-        log: (message) => log.info(message),
-      }),
-    );
-  }
-  // feishu/lark register programmatically too (application-v7 config PATCH — telegram-setWebhook
-  // parity), once per mounted kind (each kind is its own app with its own credentials); the registrar
-  // owns its own health wait and degrades to the manual console instruction.
+  // Readiness is the registrar's job: a fresh quick tunnel returns Cloudflare 530 for ~20-30s before its
+  // origin connects, and the automatic registrars poll /health before configuring the platform (the same
+  // wait the deploy runners rely on). GitHub needs no wait — the operator adds that webhook by hand.
+  //
+  // The registrars differ from the deploy path's in what they carry, not in which channels they answer
+  // for: this one narrates to the log and opens the console for a manual Feishu step.
   const feishuOptions = {
     onManualRegistration: ({ consoleUrl }: { consoleUrl: string }) => opts.openUrl?.(consoleUrl),
   };
-  if (routeChannels.includes("feishu")) track("feishu", await registerFeishuWebhook(baseUrl, "feishu", feishuOptions));
-  if (routeChannels.includes("lark")) track("lark", await registerFeishuWebhook(baseUrl, "lark", feishuOptions));
-  return registrations;
+  return pointChannelsAt({
+    baseUrl,
+    channels,
+    log: (message) => log.info(`[fastagent] ${message}`),
+    registrars: {
+      telegram: (url) => registerTelegramWebhook(url),
+      slack: (url) =>
+        registerSlackWebhook(url, {
+          stateRoot: opts.stateRoot ?? resolveStateRoot(dir),
+          log: (message) => log.info(message),
+        }),
+      feishu: (url, kind) => registerFeishuWebhook(url, kind, feishuOptions),
+    },
+  });
 }

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -176,9 +176,7 @@ describe("loadChannels (filesystem discovery)", () => {
     expect(loaded.failures).toEqual([]);
 
     const inspected = await inspectChannels(dir);
-    expect(inspected.channels).toEqual(["socket"]);
-    expect(inspected.routeChannels).toEqual([]);
-    expect(inspected.longConnectionChannels).toEqual(["socket"]);
+    expect(inspected.channels).toEqual([{ name: "socket", ingress: "long-connection" }]);
   });
 
   it("rejects an object export that is not an explicit long-connection module", async () => {

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { declaredChannels } from "../src/channels/discover.ts";
 import type { RegistrationOutcome } from "../src/channels/registration.ts";
 import { AUTH_SEED_MAX_CHUNKS, ingressSessionId } from "../src/deploy/agentcore/plan.ts";
 import {
@@ -245,7 +246,7 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
     const tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered");
     const out = await run(
       plan({
-        channels: ["telegram"],
+        channels: declaredChannels(["telegram"]),
         needsForwarder: true,
         secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" },
       }),
@@ -416,7 +417,7 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
         ? { stdout: JSON.stringify([{ OutputKey: "RuntimeArn", OutputValue: "arn:x" }]) }
         : happyAws(a),
     );
-    const out = await run(plan({ channels: ["telegram"] }), aws, fakeCli().cli);
+    const out = await run(plan({ channels: declaredChannels(["telegram"]) }), aws, fakeCli().cli);
     expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("ForwarderUrl") });
   });
 
@@ -480,7 +481,7 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
   it("a failed telegram registration gates AFTER the deploy (the app itself deployed)", async () => {
     const { cli: aws } = fakeCli(happyAws);
     const tg = vi.fn(async (): Promise<RegistrationOutcome> => "failed");
-    const out = await run(plan({ channels: ["telegram"] }), aws, fakeCli().cli, tg);
+    const out = await run(plan({ channels: declaredChannels(["telegram"]) }), aws, fakeCli().cli, tg);
     expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("telegram") });
   });
 });
@@ -559,7 +560,11 @@ describe("the post-deploy probe (verify restore + construction before registrati
       return "registered";
     });
     const out = await deployAgentcoreRun(
-      plan({ channels: ["telegram"], needsForwarder: true, secrets: { FASTAGENT_INGRESS_SECRET: "s3cret" } }),
+      plan({
+        channels: declaredChannels(["telegram"]),
+        needsForwarder: true,
+        secrets: { FASTAGENT_INGRESS_SECRET: "s3cret" },
+      }),
       fakeCli(happyAws).cli,
       fakeCli().cli,
       (m) => logs.push(m),

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -67,7 +67,7 @@ const run = (
   aws: CliRunner,
   docker: CliRunner,
   tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-) => deployAgentcoreRun(p, aws, docker, () => {}, writeParams, writeZip, tg);
+) => deployAgentcoreRun(p, aws, docker, () => {}, writeParams, writeZip, { telegram: tg });
 
 describe("the deployment bucket (the agent's memory outlives the stack)", () => {
   const withForwarder = plan({ needsForwarder: true });
@@ -160,7 +160,7 @@ describe("the pre-stop checkpoint", () => {
       (m) => logs.push(m),
       writeParams,
       writeZip,
-      async () => "registered",
+      { telegram: async () => "registered" },
     );
     expect(logs.join("\n")).toContain("checkpointed the ingress session");
   });
@@ -175,7 +175,7 @@ describe("the pre-stop checkpoint", () => {
       (m) => logs.push(m),
       writeParams,
       writeZip,
-      async () => "registered",
+      { telegram: async () => "registered" },
     );
     const out = logs.join("\n");
     expect(out).not.toContain("checkpointed the ingress session");
@@ -193,7 +193,7 @@ describe("the pre-stop checkpoint", () => {
       (m) => logs.push(m),
       writeParams,
       writeZip,
-      async () => "registered",
+      { telegram: async () => "registered" },
     );
     expect(logs.join("\n")).toContain("it is lost");
   });
@@ -213,7 +213,7 @@ describe("the pre-stop checkpoint", () => {
       () => {},
       writeSecret,
       writeZip,
-      async () => "registered",
+      { telegram: async () => "registered" },
     );
     const invoke = calls.find((call) => call.args[1] === "invoke-agent-runtime")!.args;
     expect(invoke.join(" ")).not.toContain(ingressSecret);
@@ -231,7 +231,7 @@ describe("the pre-stop checkpoint", () => {
       (message) => logs.push(message),
       writeParams,
       writeZip,
-      async () => "registered",
+      { telegram: async () => "registered" },
     );
     expect(logs.join("\n")).toContain("invalid checkpoint response");
     expect(logs.join("\n")).not.toContain("checkpointed the ingress session");
@@ -434,7 +434,7 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
       (m) => logs.push(m),
       writeParams,
       writeZip,
-      async () => "registered",
+      { telegram: async () => "registered" },
     );
     expect(out).toMatchObject({ ok: true });
     expect(logs.join("\n")).toContain("no ingress session to stop");
@@ -459,7 +459,7 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
       () => {},
       writeParams,
       writeZip,
-      async () => "registered",
+      { telegram: async () => "registered" },
     );
     expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("stop-runtime-session") });
     expect((out as { gate: string }).gate).toContain("AccessDeniedException");
@@ -565,7 +565,7 @@ describe("the post-deploy probe (verify restore + construction before registrati
       (m) => logs.push(m),
       writeParams,
       writeZip,
-      tg,
+      { telegram: tg },
     );
     expect(out).toMatchObject({ ok: true });
     // The reserved path (works on EVERY forwarder topology — a schedule-only URL 404s /health), with
@@ -594,9 +594,7 @@ describe("the post-deploy probe (verify restore + construction before registrati
       () => {},
       writeParams,
       writeZip,
-      async () => "registered",
-      undefined,
-      undefined,
+      { telegram: async () => "registered", feishu: undefined, slack: undefined },
       { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 5_000, intervalMs: 1_000 },
     );
     expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("FEISHU_APP_SECRET is not set") });
@@ -612,9 +610,7 @@ describe("the post-deploy probe (verify restore + construction before registrati
       () => {},
       writeParams,
       writeZip,
-      async () => "registered",
-      undefined,
-      undefined,
+      { telegram: async () => "registered", feishu: undefined, slack: undefined },
       { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 20, intervalMs: 1 },
     );
     expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("403 forbidden") });
@@ -632,9 +628,7 @@ describe("the post-deploy probe (verify restore + construction before registrati
       () => {},
       writeParams,
       writeZip,
-      async () => "registered",
-      undefined,
-      undefined,
+      { telegram: async () => "registered", feishu: undefined, slack: undefined },
       { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 20, intervalMs: 1 },
     );
     expect(out).toMatchObject({ ok: false, gate: expect.stringContaining("never answered") });

--- a/test/deploy-agentcore-template.test.ts
+++ b/test/deploy-agentcore-template.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { parseDocument } from "yaml";
+import { declaredChannels } from "../src/channels/discover.ts";
 import {
   type AgentcorePlanInput,
   type ScheduleFact,
@@ -44,7 +45,6 @@ const baseInput = (over: Partial<AgentcorePlanInput> = {}): AgentcorePlanInput =
   name: "my-agent",
   modelAuth: "OPENAI_API_KEY",
   channels: [],
-  routeChannels: [],
   schedules: [],
   selfSchedule: false,
   hasPackageJson: false,
@@ -83,7 +83,7 @@ function references(node: unknown, path = "$"): { path: string; target: string; 
   return found;
 }
 
-const WEBHOOK_CHANNELS = { channels: ["telegram" as const], routeChannels: ["telegram"] };
+const WEBHOOK_CHANNELS = { channels: declaredChannels(["telegram"]) };
 const SCHEDULES: ScheduleFact[] = [{ name: "digest", cron: "0 9 * * *", tz: "Asia/Shanghai" }];
 
 describe("the agentcore template (parsed)", () => {

--- a/test/deploy-agentcore.test.ts
+++ b/test/deploy-agentcore.test.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { crc32 } from "node:zlib";
 import { Cron } from "croner";
+import { declaredChannels } from "../src/channels/discover.ts";
 import { cronError } from "../src/schedule/cron.ts";
 import { describe, expect, it } from "vitest";
 import {
@@ -31,7 +32,6 @@ const baseInput = (over: Partial<AgentcorePlanInput> = {}): AgentcorePlanInput =
   name: "my-agent",
   modelAuth: "OPENAI_API_KEY",
   channels: [],
-  routeChannels: [],
   schedules: [],
   selfSchedule: false,
   hasPackageJson: false,
@@ -163,7 +163,7 @@ describe("deploy agentcore: the plan", () => {
   });
 
   it("a route channel brings the forwarder (Lambda + URL + permission) and the webhook step", () => {
-    const plan = planAgentcoreDeploy(baseInput({ channels: ["telegram"], routeChannels: ["telegram"] }));
+    const plan = planAgentcoreDeploy(baseInput({ channels: declaredChannels(["telegram"]) }));
     expect(plan.artifacts.map((a) => a.path)).toContain(FORWARDER_FILE);
     const template = plan.artifacts[0]!.content;
     expect(template).toContain("Type: AWS::Lambda::Function");
@@ -236,15 +236,12 @@ describe("deploy agentcore: the plan", () => {
   });
 
   it("the forwarder Lambda timeout covers a whole schedule turn (EventBridge invokes async)", () => {
-    const template = planAgentcoreDeploy(baseInput({ routeChannels: ["telegram"], channels: ["telegram"] }))
-      .artifacts[0]!.content;
+    const template = planAgentcoreDeploy(baseInput({ channels: declaredChannels(["telegram"]) })).artifacts[0]!.content;
     expect(template).toContain("Timeout: 900");
   });
 
   it("kit layout namespaces the template + forwarder under the kit", () => {
-    const plan = planAgentcoreDeploy(
-      baseInput({ agentPrefix: "agent/", routeChannels: ["telegram"], channels: ["telegram"] }),
-    );
+    const plan = planAgentcoreDeploy(baseInput({ agentPrefix: "agent/", channels: declaredChannels(["telegram"]) }));
     const paths = plan.artifacts.map((a) => a.path);
     expect(paths).toContain(`agent/${TEMPLATE_FILE}`);
     expect(paths).toContain(`agent/${FORWARDER_FILE}`);
@@ -364,7 +361,7 @@ describe("deploy agentcore: the plan", () => {
   });
 
   it("ships the forwarder as a REAL Lambda entry (index.js) loaded from S3 by content-hashed key", () => {
-    const plan = planAgentcoreDeploy(baseInput({ routeChannels: ["telegram"], channels: ["telegram"] }));
+    const plan = planAgentcoreDeploy(baseInput({ channels: declaredChannels(["telegram"]) }));
     // The artifact IS the deployment package's entry: zipping it as-is matches `Handler: index.handler`.
     expect(FORWARDER_FILE).toBe("lambda/index.js");
     expect(plan.artifacts.map((a) => a.path)).toContain("lambda/index.js");
@@ -377,8 +374,7 @@ describe("deploy agentcore: the plan", () => {
   });
 
   it("grants the forwarder ONLY the one snapshot object, and hands the container its bucket/key", () => {
-    const template = planAgentcoreDeploy(baseInput({ routeChannels: ["telegram"], channels: ["telegram"] }))
-      .artifacts[0]!.content;
+    const template = planAgentcoreDeploy(baseInput({ channels: declaredChannels(["telegram"]) })).artifacts[0]!.content;
     expect(template).toContain("Action: [s3:GetObject, s3:PutObject]");
     expect(template).toContain(`Resource: !Sub arn:aws:s3:::\${StateBucket}/${STATE_KEY}`);
     expect(template).toContain("STATE_BUCKET: !Ref StateBucket");
@@ -388,8 +384,7 @@ describe("deploy agentcore: the plan", () => {
   it("grants s3:ListBucket on the snapshot prefix — without it a MISSING first-deploy snapshot reads 403, not 404", () => {
     // S3 folds "key absent" into 403 unless the caller may list (anti-enumeration), and the restore
     // contract accepts ONLY 404 as first deploy — dropping this statement deadlocks every first boot.
-    const template = planAgentcoreDeploy(baseInput({ routeChannels: ["telegram"], channels: ["telegram"] }))
-      .artifacts[0]!.content;
+    const template = planAgentcoreDeploy(baseInput({ channels: declaredChannels(["telegram"]) })).artifacts[0]!.content;
     expect(template).toContain("Action: s3:ListBucket");
     expect(template).toContain(`Resource: !Sub arn:aws:s3:::\${StateBucket}\n`); // the BUCKET arn, not an object
     expect(template).toContain("StringLike: { s3:prefix: state/* }"); // scoped: existence of the snapshot, not a full listing
@@ -415,7 +410,7 @@ describe("deploy agentcore: the plan", () => {
   });
 
   it("tells the truth about state: the mount is wiped per deploy, the S3 snapshot is what survives", () => {
-    const plan = planAgentcoreDeploy(baseInput({ routeChannels: ["telegram"], channels: ["telegram"] }));
+    const plan = planAgentcoreDeploy(baseInput({ channels: declaredChannels(["telegram"]) }));
     const template = plan.artifacts[0]!.content;
     expect(template).toContain("wipes it on every VERSION UPDATE");
     expect(template).not.toMatch(/SessionStorage: platform-persistent/);
@@ -469,8 +464,8 @@ describe("deploy agentcore: the plan", () => {
     });
 
     it("a webhook channel mints one, and scopes the second permission to URL traffic", () => {
-      const template = planAgentcoreDeploy(baseInput({ routeChannels: ["telegram"], channels: ["telegram"] }))
-        .artifacts[0]!.content;
+      const template = planAgentcoreDeploy(baseInput({ channels: declaredChannels(["telegram"]) })).artifacts[0]!
+        .content;
       expect(template).toContain("AWS::Lambda::Url");
       expect(template).toContain('WEBHOOKS_ENABLED: "1"');
       expect(template).toContain("Action: lambda:InvokeFunctionUrl");
@@ -480,8 +475,8 @@ describe("deploy agentcore: the plan", () => {
     });
 
     it("declares the ingress secret whenever a forwarder exists, and stamps it on both sides", () => {
-      const template = planAgentcoreDeploy(baseInput({ routeChannels: ["telegram"], channels: ["telegram"] }))
-        .artifacts[0]!.content;
+      const template = planAgentcoreDeploy(baseInput({ channels: declaredChannels(["telegram"]) })).artifacts[0]!
+        .content;
       expect(template).toContain("  FastagentIngressSecret:");
       expect(template).toContain("FASTAGENT_INGRESS_SECRET: !Ref FastagentIngressSecret"); // runtime
       expect(template).toContain("INGRESS_SECRET: !Ref FastagentIngressSecret"); // forwarder

--- a/test/deploy-channel-ingress.test.ts
+++ b/test/deploy-channel-ingress.test.ts
@@ -54,6 +54,9 @@ describe("deploy/channel-ingress: which channels have a webhook", () => {
     expect(said.filter((m) => m.includes("https://x"))).toHaveLength(2);
     expect(said.join("\n")).toContain("Settings → Webhooks");
     expect(said.join("\n")).toContain("Event Subscriptions");
+    // The env-var name is the part nobody can guess, and `--tunnel` prints this line ALONE — there is
+    // no runbook next to it carrying the detail.
+    expect(said.join("\n")).toContain("GITHUB_WEBHOOK_SECRET");
     // manual never gates: a re-run cannot clear it, and an unclearable gate spins a coding agent.
     expect(gate).toBeUndefined();
   });
@@ -140,5 +143,9 @@ describe("every host's runbook reads the same answer", () => {
 
   it("agentcore: a feishu step carries the forwarder challenge note the shared wording cannot", () => {
     expect(agentcore(webhook("feishu"))).toContain("rides through the forwarder");
+    // ONE note for both kinds: the asides land after all the steps, so a second copy reads as a
+    // second step that does not exist.
+    const both = agentcore(webhook("feishu", "lark")).split("rides through the forwarder");
+    expect(both).toHaveLength(2);
   });
 });

--- a/test/deploy-channel-ingress.test.ts
+++ b/test/deploy-channel-ingress.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RegistrationOutcome } from "../src/channels/registration.ts";
+import { registerWebhooks, webhookChannels, webhookPaths, webhookRunbook } from "../src/deploy/channel-ingress.ts";
+import { planAgentcoreDeploy } from "../src/deploy/agentcore/plan.ts";
+import { planFlyDeploy } from "../src/deploy/fly/plan.ts";
+import { planRailwayDeploy } from "../src/deploy/railway/plan.ts";
+
+const registered = (): Promise<RegistrationOutcome> => Promise.resolve("registered");
+
+describe("deploy/channel-ingress: which channels have a webhook", () => {
+  it("answers in declaration order, whatever order the channels arrive in", () => {
+    expect(webhookChannels(["lark", "github", "telegram"])).toEqual(["telegram", "github", "lark"]);
+    expect(webhookPaths(["slack", "github"])).toEqual(["/webhook", "/slack"]);
+  });
+
+  it("EVERY long-connection channel is excluded, not just feishu/lark", () => {
+    // The rule used to be spelled per host and only reached the feishu/lark branches. A long-connection
+    // telegram is the case that made it expensive: setting a webhook makes getUpdates return 409, so a
+    // runbook that prints setWebhook stops the channel the operator just deployed.
+    expect(webhookChannels(["telegram", "github"], ["telegram"])).toEqual(["github"]);
+    expect(webhookRunbook("https://x", ["telegram"], ["telegram"])).toEqual([]);
+    expect(webhookPaths(["telegram", "slack"], ["telegram", "slack"])).toEqual([]);
+  });
+
+  it("does not register one either — the connection IS the ingress", async () => {
+    const telegram = vi.fn(registered);
+    const gate = await registerWebhooks({
+      baseUrl: "https://x",
+      channels: ["telegram"],
+      longConnectionChannels: ["telegram"],
+      registrars: { telegram },
+      log: () => {},
+      retryHint: "re-run",
+    });
+    expect(telegram).not.toHaveBeenCalled();
+    expect(gate).toBeUndefined();
+  });
+
+  it("a channel with no registrar wired reports manual with the operator's instruction", async () => {
+    const said: string[] = [];
+    const gate = await registerWebhooks({
+      baseUrl: "https://x",
+      channels: ["github", "slack"], // github never has a registrar; slack's is not wired here
+      registrars: { telegram: vi.fn(registered) },
+      log: (m) => said.push(m),
+      retryHint: "re-run",
+    });
+    expect(said.filter((m) => m.includes("https://x"))).toHaveLength(2);
+    expect(said.join("\n")).toContain("Settings → Webhooks");
+    expect(said.join("\n")).toContain("Event Subscriptions");
+    // manual never gates: a re-run cannot clear it, and an unclearable gate spins a coding agent.
+    expect(gate).toBeUndefined();
+  });
+
+  it("a failed registrar gates, and one failure does not skip the rest", async () => {
+    const feishu = vi.fn(async (): Promise<RegistrationOutcome> => "registered");
+    const gate = await registerWebhooks({
+      baseUrl: "https://x",
+      channels: ["telegram", "feishu"],
+      registrars: { telegram: async () => "failed", feishu },
+      log: () => {},
+      retryHint: "re-run with --into-linked",
+    });
+    expect(feishu).toHaveBeenCalledWith("https://x", "feishu");
+    expect(gate).toContain("telegram");
+    expect(gate).toContain("re-run with --into-linked");
+  });
+});
+
+describe("every host's runbook reads the same answer", () => {
+  const fly = (channels: ("telegram" | "github")[], longConnectionChannels?: string[]) =>
+    planFlyDeploy({
+      agentPrefix: "fastagent/",
+      appName: "bot",
+      port: 8787,
+      hasPackageJson: true,
+      runtime: "node",
+      hasLockfile: true,
+      version: "9.9.9",
+      autostop: "suspend",
+      scaleToZero: true,
+      hasTimeTriggers: false,
+      modelAuth: undefined,
+      channels,
+      longConnectionChannels,
+    }).runbook.join("\n");
+
+  it("fly: a long-connection telegram gets no setWebhook step", () => {
+    expect(fly(["telegram"])).toContain("setWebhook");
+    expect(fly(["telegram"], ["telegram"])).not.toContain("setWebhook");
+  });
+
+  it("railway: with nothing left to point at a domain, the mint step goes too", () => {
+    const runbook = (channels: ("telegram" | "github")[], longConnectionChannels?: string[]) =>
+      planRailwayDeploy({
+        agentPrefix: "fastagent/",
+        serviceName: "bot",
+        hasPackageJson: true,
+        runtime: "node",
+        hasLockfile: true,
+        version: "9.9.9",
+        hasTimeTriggers: false,
+        modelAuth: undefined,
+        channels,
+        longConnectionChannels,
+      }).runbook.join("\n");
+    expect(runbook(["telegram"])).toContain("railway domain");
+    // Otherwise it says "use it in the webhook step(s) below" with no step below it.
+    expect(runbook(["telegram"], ["telegram"])).not.toContain("railway domain");
+  });
+
+  it("agentcore: the same steps, pointed at the forwarder URL", () => {
+    const runbook = planAgentcoreDeploy({
+      name: "bot",
+      modelAuth: undefined,
+      channels: ["telegram", "github"],
+      routeChannels: ["telegram", "github"],
+      schedules: [],
+      selfSchedule: false,
+      hasPackageJson: true,
+      runtime: "node",
+      hasLockfile: true,
+      version: "9.9.9",
+      agentPrefix: "",
+    }).runbook.join("\n");
+    expect(runbook).toContain("-d url=<ForwarderUrl>/telegram");
+    expect(runbook).toContain("Payload URL = <ForwarderUrl>/webhook");
+    // AgentCore's own aside stays with AgentCore.
+    expect(runbook).toContain("8 h compute ceiling");
+  });
+});

--- a/test/deploy-channel-ingress.test.ts
+++ b/test/deploy-channel-ingress.test.ts
@@ -1,33 +1,39 @@
 import { describe, expect, it, vi } from "vitest";
+import { declaredChannels } from "../src/channels/discover.ts";
 import type { RegistrationOutcome } from "../src/channels/registration.ts";
-import { registerWebhooks, webhookChannels, webhookPaths, webhookRunbook } from "../src/deploy/channel-ingress.ts";
 import { planAgentcoreDeploy } from "../src/deploy/agentcore/plan.ts";
+import { registerWebhooks, webhookKinds, webhookPaths, webhookRunbook } from "../src/deploy/channel-ingress.ts";
 import { planFlyDeploy } from "../src/deploy/fly/plan.ts";
 import { planRailwayDeploy } from "../src/deploy/railway/plan.ts";
 
 const registered = (): Promise<RegistrationOutcome> => Promise.resolve("registered");
+const webhook = (...names: string[]) => declaredChannels(names);
+const longConnection = (...names: string[]) => declaredChannels(names, "long-connection");
 
 describe("deploy/channel-ingress: which channels have a webhook", () => {
   it("answers in declaration order, whatever order the channels arrive in", () => {
-    expect(webhookChannels(["lark", "github", "telegram"])).toEqual(["telegram", "github", "lark"]);
-    expect(webhookPaths(["slack", "github"])).toEqual(["/webhook", "/slack"]);
+    expect(webhookKinds(webhook("lark", "github", "telegram"))).toEqual(["telegram", "github", "lark"]);
+    expect(webhookPaths(webhook("slack", "github"))).toEqual(["/webhook", "/slack"]);
   });
 
   it("EVERY long-connection channel is excluded, not just feishu/lark", () => {
     // The rule used to be spelled per host and only reached the feishu/lark branches. A long-connection
     // telegram is the case that made it expensive: setting a webhook makes getUpdates return 409, so a
     // runbook that prints setWebhook stops the channel the operator just deployed.
-    expect(webhookChannels(["telegram", "github"], ["telegram"])).toEqual(["github"]);
-    expect(webhookRunbook("https://x", ["telegram"], ["telegram"])).toEqual([]);
-    expect(webhookPaths(["telegram", "slack"], ["telegram", "slack"])).toEqual([]);
+    expect(webhookKinds([...longConnection("telegram"), ...webhook("github")])).toEqual(["github"]);
+    expect(webhookRunbook("https://x", longConnection("telegram"))).toEqual([]);
+    expect(webhookPaths(longConnection("telegram", "slack"))).toEqual([]);
   });
 
-  it("does not register one either — the connection IS the ingress", async () => {
+  it("skips a custom channel: this tool cannot instruct anyone about a URL it does not know", () => {
+    expect(webhookKinds(webhook("discord", "telegram"))).toEqual(["telegram"]);
+  });
+
+  it("does not register a long-connection channel either — the connection IS the ingress", async () => {
     const telegram = vi.fn(registered);
     const gate = await registerWebhooks({
       baseUrl: "https://x",
-      channels: ["telegram"],
-      longConnectionChannels: ["telegram"],
+      channels: longConnection("telegram"),
       registrars: { telegram },
       log: () => {},
       retryHint: "re-run",
@@ -40,7 +46,7 @@ describe("deploy/channel-ingress: which channels have a webhook", () => {
     const said: string[] = [];
     const gate = await registerWebhooks({
       baseUrl: "https://x",
-      channels: ["github", "slack"], // github never has a registrar; slack's is not wired here
+      channels: webhook("github", "slack"), // github never has a registrar; slack's is not wired here
       registrars: { telegram: vi.fn(registered) },
       log: (m) => said.push(m),
       retryHint: "re-run",
@@ -56,7 +62,7 @@ describe("deploy/channel-ingress: which channels have a webhook", () => {
     const feishu = vi.fn(async (): Promise<RegistrationOutcome> => "registered");
     const gate = await registerWebhooks({
       baseUrl: "https://x",
-      channels: ["telegram", "feishu"],
+      channels: webhook("telegram", "feishu"),
       registrars: { telegram: async () => "failed", feishu },
       log: () => {},
       retryHint: "re-run with --into-linked",
@@ -68,7 +74,7 @@ describe("deploy/channel-ingress: which channels have a webhook", () => {
 });
 
 describe("every host's runbook reads the same answer", () => {
-  const fly = (channels: ("telegram" | "github")[], longConnectionChannels?: string[]) =>
+  const fly = (channels: ReturnType<typeof webhook>) =>
     planFlyDeploy({
       agentPrefix: "fastagent/",
       appName: "bot",
@@ -82,39 +88,26 @@ describe("every host's runbook reads the same answer", () => {
       hasTimeTriggers: false,
       modelAuth: undefined,
       channels,
-      longConnectionChannels,
     }).runbook.join("\n");
 
-  it("fly: a long-connection telegram gets no setWebhook step", () => {
-    expect(fly(["telegram"])).toContain("setWebhook");
-    expect(fly(["telegram"], ["telegram"])).not.toContain("setWebhook");
-  });
+  const railway = (channels: ReturnType<typeof webhook>) =>
+    planRailwayDeploy({
+      agentPrefix: "fastagent/",
+      serviceName: "bot",
+      hasPackageJson: true,
+      runtime: "node",
+      hasLockfile: true,
+      version: "9.9.9",
+      hasTimeTriggers: false,
+      modelAuth: undefined,
+      channels,
+    }).runbook.join("\n");
 
-  it("railway: with nothing left to point at a domain, the mint step goes too", () => {
-    const runbook = (channels: ("telegram" | "github")[], longConnectionChannels?: string[]) =>
-      planRailwayDeploy({
-        agentPrefix: "fastagent/",
-        serviceName: "bot",
-        hasPackageJson: true,
-        runtime: "node",
-        hasLockfile: true,
-        version: "9.9.9",
-        hasTimeTriggers: false,
-        modelAuth: undefined,
-        channels,
-        longConnectionChannels,
-      }).runbook.join("\n");
-    expect(runbook(["telegram"])).toContain("railway domain");
-    // Otherwise it says "use it in the webhook step(s) below" with no step below it.
-    expect(runbook(["telegram"], ["telegram"])).not.toContain("railway domain");
-  });
-
-  it("agentcore: the same steps, pointed at the forwarder URL", () => {
-    const runbook = planAgentcoreDeploy({
+  const agentcore = (channels: ReturnType<typeof webhook>) =>
+    planAgentcoreDeploy({
       name: "bot",
       modelAuth: undefined,
-      channels: ["telegram", "github"],
-      routeChannels: ["telegram", "github"],
+      channels,
       schedules: [],
       selfSchedule: false,
       hasPackageJson: true,
@@ -123,9 +116,29 @@ describe("every host's runbook reads the same answer", () => {
       version: "9.9.9",
       agentPrefix: "",
     }).runbook.join("\n");
-    expect(runbook).toContain("-d url=<ForwarderUrl>/telegram");
-    expect(runbook).toContain("Payload URL = <ForwarderUrl>/webhook");
-    // AgentCore's own aside stays with AgentCore.
-    expect(runbook).toContain("8 h compute ceiling");
+
+  it("fly: a long-connection telegram gets no setWebhook step", () => {
+    expect(fly(webhook("telegram"))).toContain("setWebhook");
+    expect(fly(longConnection("telegram"))).not.toContain("setWebhook");
+  });
+
+  it("railway: with nothing left to point at a domain, the mint step goes too", () => {
+    expect(railway(webhook("telegram"))).toContain("railway domain");
+    // Otherwise it says "use it in the step(s) below" with no step below it.
+    expect(railway(longConnection("telegram"))).not.toContain("railway domain");
+  });
+
+  it("agentcore: the same steps at the forwarder URL, and generate-only skips a long-connection one", () => {
+    const out = agentcore(webhook("telegram", "github"));
+    expect(out).toContain("-d url=<ForwarderUrl>/telegram");
+    expect(out).toContain("Payload URL = <ForwarderUrl>/webhook");
+    expect(out).toContain("8 h compute ceiling"); // AgentCore's own aside stays with AgentCore
+    // `--run` refuses a long-connection channel, but generate-only only warns and still prints this
+    // runbook — so the steps filter on ingress rather than on the CLI having gated.
+    expect(agentcore(longConnection("telegram"))).not.toContain("setWebhook");
+  });
+
+  it("agentcore: a feishu step carries the forwarder challenge note the shared wording cannot", () => {
+    expect(agentcore(webhook("feishu"))).toContain("rides through the forwarder");
   });
 });

--- a/test/deploy-docker.test.ts
+++ b/test/deploy-docker.test.ts
@@ -3,10 +3,10 @@ import {
   CLOUDFLARED_IMAGE,
   MIN_DOCKER_COMPOSE_VERSION,
   composeHasTunnelService,
-  dockerWebhookPaths,
   planDockerDeploy,
   toDockerProjectName,
 } from "../src/deploy/docker/plan.ts";
+import { webhookPaths } from "../src/deploy/channel-ingress.ts";
 
 const compose = (plan: ReturnType<typeof planDockerDeploy>) =>
   plan.artifacts.find((artifact) => artifact.path.endsWith("fastagent.compose.yml"))!.content;
@@ -132,7 +132,7 @@ describe("deploy/docker: planDockerDeploy", () => {
     expect(composeHasTunnelService("services:\n    tunnel:\n        image: cloudflare/cloudflared\n")).toBe(true);
     expect(composeHasTunnelService("services:\n\ttunnel:\n\t\timage: cloudflare/cloudflared\n")).toBe(true);
     expect(composeHasTunnelService("services:\n  agent:\n")).toBe(false);
-    expect(dockerWebhookPaths(["telegram", "github", "slack", "feishu", "lark"])).toEqual([
+    expect(webhookPaths(["telegram", "github", "slack", "feishu", "lark"])).toEqual([
       "/telegram",
       "/webhook",
       "/slack",

--- a/test/deploy-docker.test.ts
+++ b/test/deploy-docker.test.ts
@@ -6,6 +6,7 @@ import {
   planDockerDeploy,
   toDockerProjectName,
 } from "../src/deploy/docker/plan.ts";
+import { declaredChannels } from "../src/channels/discover.ts";
 import { webhookPaths } from "../src/deploy/channel-ingress.ts";
 
 const compose = (plan: ReturnType<typeof planDockerDeploy>) =>
@@ -25,7 +26,7 @@ const base = {
 
 describe("deploy/docker: planDockerDeploy", () => {
   it("generates only the app topology: loopback port + persistent state, no tunnel/ingress coupling", () => {
-    const plan = planDockerDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: ["telegram"] });
+    const plan = planDockerDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: declaredChannels(["telegram"]) });
     expect(plan.artifacts.map((artifact) => artifact.path)).toEqual([
       "fastagent/fastagent.compose.yml",
       "fastagent/Dockerfile",
@@ -48,7 +49,7 @@ describe("deploy/docker: planDockerDeploy", () => {
     const plan = planDockerDeploy({
       ...base,
       modelAuth: "OPENAI_API_KEY",
-      channels: ["telegram"],
+      channels: declaredChannels(["telegram"]),
       tunnel: true,
     });
     const yaml = compose(plan);
@@ -67,8 +68,7 @@ describe("deploy/docker: planDockerDeploy", () => {
     const plan = planDockerDeploy({
       ...base,
       modelAuth: undefined,
-      channels: ["feishu"],
-      longConnectionChannels: ["feishu"],
+      channels: [...declaredChannels(["feishu"], "long-connection")],
     });
     const yaml = compose(plan);
     expect(yaml).toContain("FEISHU_APP_ID");
@@ -82,7 +82,7 @@ describe("deploy/docker: planDockerDeploy", () => {
       planDockerDeploy({
         ...base,
         modelAuth: "OPENAI_API_KEY",
-        channels: ["telegram", "feishu"],
+        channels: declaredChannels(["telegram", "feishu"]),
         extraSecrets: ["GH_TOKEN"],
       }),
     );
@@ -115,7 +115,9 @@ describe("deploy/docker: planDockerDeploy", () => {
   });
 
   it("prints lifecycle + operator-owned ingress guidance for detected webhook channels", () => {
-    const out = runbook(planDockerDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: ["telegram", "github"] }));
+    const out = runbook(
+      planDockerDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: declaredChannels(["telegram", "github"]) }),
+    );
     expect(out).toContain(`Docker Engine/Desktop with Compose >= ${MIN_DOCKER_COMPOSE_VERSION}`);
     expect(out).toContain("docker compose -f fastagent/fastagent.compose.yml up -d --build");
     expect(out).toContain("down        # stops containers; keeps the state volume");
@@ -132,7 +134,7 @@ describe("deploy/docker: planDockerDeploy", () => {
     expect(composeHasTunnelService("services:\n    tunnel:\n        image: cloudflare/cloudflared\n")).toBe(true);
     expect(composeHasTunnelService("services:\n\ttunnel:\n\t\timage: cloudflare/cloudflared\n")).toBe(true);
     expect(composeHasTunnelService("services:\n  agent:\n")).toBe(false);
-    expect(webhookPaths(["telegram", "github", "slack", "feishu", "lark"])).toEqual([
+    expect(webhookPaths(declaredChannels(["telegram", "github", "slack", "feishu", "lark"]))).toEqual([
       "/telegram",
       "/webhook",
       "/slack",

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -28,7 +28,7 @@ const plan = (over: Partial<FlyRunPlan> = {}): FlyRunPlan => ({
 });
 
 const run = (p: FlyRunPlan, fly: CliRunner, tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered")) =>
-  deployFlyRun(p, fly, () => {}, tg);
+  deployFlyRun(p, fly, () => {}, { telegram: tg });
 
 describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
   it("happy path: auth → create app+volume → set secrets → deploy → telegram webhook", async () => {
@@ -60,13 +60,10 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
 
-    const out = await deployFlyRun(
-      plan({ channels: ["feishu", "lark"] }),
-      fly,
-      () => {},
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-      registerFeishu,
-    );
+    const out = await deployFlyRun(plan({ channels: ["feishu", "lark"] }), fly, () => {}, {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      feishu: registerFeishu,
+    });
 
     expect(out).toEqual({ ok: true });
     expect(registerFeishu.mock.calls).toEqual([
@@ -80,13 +77,10 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const registerFeishu = vi.fn(
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
-    const out = await deployFlyRun(
-      plan({ channels: ["feishu"], longConnectionChannels: ["feishu"] }),
-      fly,
-      () => {},
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-      registerFeishu,
-    );
+    const out = await deployFlyRun(plan({ channels: ["feishu"], longConnectionChannels: ["feishu"] }), fly, () => {}, {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      feishu: registerFeishu,
+    });
     expect(out).toEqual({ ok: true });
     expect(registerFeishu).not.toHaveBeenCalled();
   });
@@ -97,13 +91,11 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
 
-    const out = await deployFlyRun(
-      plan({ channels: ["telegram", "feishu"] }),
-      fly,
-      () => {},
-      vi.fn(async (): Promise<RegistrationOutcome> => "failed"), // telegram registration ends with the webhook NOT set
-      registerFeishu,
-    );
+    const out = await deployFlyRun(plan({ channels: ["telegram", "feishu"] }), fly, () => {}, {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
+      feishu: // telegram registration ends with the webhook NOT set
+        registerFeishu,
+    });
 
     // Exit 0 here would tell a coding agent "done" while the agent can't receive messages.
     expect(out).toEqual({
@@ -118,13 +110,10 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
 
-    const out = await deployFlyRun(
-      plan({ channels: ["lark"] }),
-      fly,
-      (m) => logs.push(m),
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-      vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
-    );
+    const out = await deployFlyRun(plan({ channels: ["lark"] }), fly, (m) => logs.push(m), {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      feishu: vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
+    });
 
     expect(out).toEqual({ ok: true });
     expect(logs.at(-1)).toMatch(/lark: webhook registration needs a one-time manual step/);
@@ -134,14 +123,11 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((args) => (args[0] === "apps" || args[0] === "volumes" ? { stdout: "[]" } : {}));
     const registerSlack = vi.fn(async (_baseUrl: string): Promise<RegistrationOutcome> => "registered");
 
-    const out = await deployFlyRun(
-      plan({ channels: ["slack"] }),
-      fly,
-      () => {},
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-      undefined,
-      registerSlack,
-    );
+    const out = await deployFlyRun(plan({ channels: ["slack"] }), fly, () => {}, {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      feishu: undefined,
+      slack: registerSlack,
+    });
 
     expect(out).toEqual({ ok: true });
     expect(registerSlack).toHaveBeenCalledWith("https://bot.fly.dev");
@@ -151,12 +137,9 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((args) => (args[0] === "apps" || args[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
 
-    const out = await deployFlyRun(
-      plan({ channels: ["slack"] }),
-      fly,
-      (message) => logs.push(message),
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-    );
+    const out = await deployFlyRun(plan({ channels: ["slack"] }), fly, (message) => logs.push(message), {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+    });
 
     expect(out).toEqual({ ok: true });
     expect(logs.join("\n")).toContain("https://bot.fly.dev/slack");
@@ -167,13 +150,10 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
 
-    const out = await deployFlyRun(
-      plan({ channels: ["telegram", "lark"] }),
-      fly,
-      (m) => logs.push(m),
-      vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
-      vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
-    );
+    const out = await deployFlyRun(plan({ channels: ["telegram", "lark"] }), fly, (m) => logs.push(m), {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
+      feishu: vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
+    });
 
     expect(logs.at(-1)).toMatch(/lark: webhook registration needs a one-time manual step/);
     expect(out).toEqual({
@@ -186,12 +166,9 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
 
-    const out = await deployFlyRun(
-      plan({ channels: ["feishu", "lark"] }),
-      fly,
-      (message) => logs.push(message),
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-    );
+    const out = await deployFlyRun(plan({ channels: ["feishu", "lark"] }), fly, (message) => logs.push(message), {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+    });
 
     expect(out).toEqual({ ok: true });
     expect(logs.join("\n")).toContain("https://bot.fly.dev/feishu");

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -4,6 +4,7 @@ import type { RegistrationOutcome } from "../src/channels/registration.ts";
 import type { CliRunner } from "../src/deploy/runner.ts";
 import { CONTROL_TOKEN_ENV } from "../src/channels/control.ts";
 import { assembleSecrets, deploymentSecrets } from "../src/deploy/secrets.ts";
+import { declaredChannels } from "../src/channels/discover.ts";
 
 /** A fake flyctl: records every call, returns per-command scripted results (default code 0, empty out). */
 function fakeFly(script: (args: string[]) => { code?: number; stdout?: string } = () => ({})) {
@@ -36,7 +37,10 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly, cmds } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered");
     const out = await run(
-      plan({ channels: ["telegram"], secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" } }),
+      plan({
+        channels: declaredChannels(["telegram"]),
+        secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" },
+      }),
       fly,
       tg,
     );
@@ -60,7 +64,7 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
 
-    const out = await deployFlyRun(plan({ channels: ["feishu", "lark"] }), fly, () => {}, {
+    const out = await deployFlyRun(plan({ channels: declaredChannels(["feishu", "lark"]) }), fly, () => {}, {
       telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
       feishu: registerFeishu,
     });
@@ -77,7 +81,7 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const registerFeishu = vi.fn(
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
-    const out = await deployFlyRun(plan({ channels: ["feishu"], longConnectionChannels: ["feishu"] }), fly, () => {}, {
+    const out = await deployFlyRun(plan({ channels: declaredChannels(["feishu"], "long-connection") }), fly, () => {}, {
       telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
       feishu: registerFeishu,
     });
@@ -91,7 +95,7 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
 
-    const out = await deployFlyRun(plan({ channels: ["telegram", "feishu"] }), fly, () => {}, {
+    const out = await deployFlyRun(plan({ channels: declaredChannels(["telegram", "feishu"]) }), fly, () => {}, {
       telegram: vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
       feishu: // telegram registration ends with the webhook NOT set
         registerFeishu,
@@ -110,7 +114,7 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
 
-    const out = await deployFlyRun(plan({ channels: ["lark"] }), fly, (m) => logs.push(m), {
+    const out = await deployFlyRun(plan({ channels: declaredChannels(["lark"]) }), fly, (m) => logs.push(m), {
       telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
       feishu: vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
     });
@@ -123,7 +127,7 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((args) => (args[0] === "apps" || args[0] === "volumes" ? { stdout: "[]" } : {}));
     const registerSlack = vi.fn(async (_baseUrl: string): Promise<RegistrationOutcome> => "registered");
 
-    const out = await deployFlyRun(plan({ channels: ["slack"] }), fly, () => {}, {
+    const out = await deployFlyRun(plan({ channels: declaredChannels(["slack"]) }), fly, () => {}, {
       telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
       feishu: undefined,
       slack: registerSlack,
@@ -137,9 +141,14 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((args) => (args[0] === "apps" || args[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
 
-    const out = await deployFlyRun(plan({ channels: ["slack"] }), fly, (message) => logs.push(message), {
-      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-    });
+    const out = await deployFlyRun(
+      plan({ channels: declaredChannels(["slack"]) }),
+      fly,
+      (message) => logs.push(message),
+      {
+        telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      },
+    );
 
     expect(out).toEqual({ ok: true });
     expect(logs.join("\n")).toContain("https://bot.fly.dev/slack");
@@ -150,10 +159,15 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
 
-    const out = await deployFlyRun(plan({ channels: ["telegram", "lark"] }), fly, (m) => logs.push(m), {
-      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
-      feishu: vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
-    });
+    const out = await deployFlyRun(
+      plan({ channels: declaredChannels(["telegram", "lark"]) }),
+      fly,
+      (m) => logs.push(m),
+      {
+        telegram: vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
+        feishu: vi.fn(async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "manual"),
+      },
+    );
 
     expect(logs.at(-1)).toMatch(/lark: webhook registration needs a one-time manual step/);
     expect(out).toEqual({
@@ -166,9 +180,14 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     const { fly } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
     const logs: string[] = [];
 
-    const out = await deployFlyRun(plan({ channels: ["feishu", "lark"] }), fly, (message) => logs.push(message), {
-      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-    });
+    const out = await deployFlyRun(
+      plan({ channels: declaredChannels(["feishu", "lark"]) }),
+      fly,
+      (message) => logs.push(message),
+      {
+        telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      },
+    );
 
     expect(out).toEqual({ ok: true });
     expect(logs.join("\n")).toContain("https://bot.fly.dev/feishu");
@@ -273,7 +292,12 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
 
   it("channel secrets come from env; never minted (a re-run is stable; a human-shared secret stays known)", () => {
     const env = { OPENAI_API_KEY: "k", TELEGRAM_BOT_TOKEN: "bot", TELEGRAM_SECRET_TOKEN: "sec" };
-    const r = assembleSecrets({ modelAuth: "OPENAI_API_KEY", authFile: undefined, channels: ["telegram"], env });
+    const r = assembleSecrets({
+      modelAuth: "OPENAI_API_KEY",
+      authFile: undefined,
+      channels: declaredChannels(["telegram"]),
+      env,
+    });
     expect(r.secrets.TELEGRAM_SECRET_TOKEN).toBe("sec"); // from env, not a mint
     expect(r.missingSecrets).toEqual([]);
   });
@@ -283,7 +307,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
     const r = assembleSecrets({
       modelAuth: "OPENAI_API_KEY",
       authFile: undefined,
-      channels: ["github", "telegram"],
+      channels: declaredChannels(["github", "telegram"]),
       env: { OPENAI_API_KEY: "k" },
     });
     expect(r.missingSecrets).toEqual(["GITHUB_WEBHOOK_SECRET", "TELEGRAM_BOT_TOKEN", "TELEGRAM_SECRET_TOKEN"]);
@@ -299,7 +323,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
     const manual = assembleSecrets({
       modelAuth: "OPENAI_API_KEY",
       authFile: undefined,
-      channels: ["slack"],
+      channels: declaredChannels(["slack"]),
       env: base,
     });
     expect(manual.missingSecrets).toEqual([]);
@@ -308,7 +332,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
     const rotating = assembleSecrets({
       modelAuth: "OPENAI_API_KEY",
       authFile: undefined,
-      channels: ["slack"],
+      channels: declaredChannels(["slack"]),
       env: {
         ...base,
         SLACK_BOT_REFRESH_TOKEN: "refresh",
@@ -328,7 +352,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
     const partial = assembleSecrets({
       modelAuth: "OPENAI_API_KEY",
       authFile: undefined,
-      channels: ["slack"],
+      channels: declaredChannels(["slack"]),
       env: { ...base, SLACK_BOT_REFRESH_TOKEN: "refresh" },
     });
     expect(partial.missingSecrets).toEqual(["SLACK_BOT_TOKEN_EXPIRES_AT", "SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET"]);
@@ -348,7 +372,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
       const absent = assembleSecrets({
         modelAuth: "OPENAI_API_KEY",
         authFile: undefined,
-        channels: [kind],
+        channels: declaredChannels([kind]),
         env: baseEnv,
       });
       expect(absent.missingSecrets).toEqual([]);
@@ -357,7 +381,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
       const present = assembleSecrets({
         modelAuth: "OPENAI_API_KEY",
         authFile: undefined,
-        channels: [kind],
+        channels: declaredChannels([kind]),
         env: { ...baseEnv, [`${prefix}_ENCRYPT_KEY`]: "encrypt" },
       });
       expect(present.missingSecrets).toEqual([]);
@@ -388,7 +412,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
     const dup = assembleSecrets({
       modelAuth: "OPENAI_API_KEY",
       authFile: undefined,
-      channels: ["telegram"],
+      channels: declaredChannels(["telegram"]),
       extraSecrets: ["TELEGRAM_BOT_TOKEN"],
       env: { OPENAI_API_KEY: "k" },
     });

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -1,6 +1,7 @@
 import { posix } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseFlyAppName, parseFlyMinMachines, planFlyDeploy, toFlyAppName } from "../src/deploy/fly/plan.ts";
+import { declaredChannels } from "../src/channels/discover.ts";
 import { modelTravelIssue } from "../src/deploy/preflight.ts";
 
 const flyToml = (p: ReturnType<typeof planFlyDeploy>) =>
@@ -35,23 +36,22 @@ describe("deploy/fly: planFlyDeploy", () => {
   });
 
   it("keeps one machine running for github (no replay), scales to zero otherwise (definition-aware)", () => {
-    expect(flyToml(planFlyDeploy({ ...base, modelAuth: undefined, channels: ["github"] }))).toContain(
+    expect(flyToml(planFlyDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["github"]) }))).toContain(
       "min_machines_running = 1",
     );
     expect(flyToml(planFlyDeploy({ ...base, modelAuth: undefined, channels: [], hasTimeTriggers: true }))).toContain(
       "min_machines_running = 1", // schedules/wake need a running machine — no external wake-up for a cron instant
     );
-    expect(flyToml(planFlyDeploy({ ...base, modelAuth: undefined, channels: ["telegram"] }))).toContain(
-      "min_machines_running = 0",
-    );
+    expect(
+      flyToml(planFlyDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["telegram"]) })),
+    ).toContain("min_machines_running = 0");
   });
 
   it("keeps one machine running and drops webhook-only secrets/URLs for long-connection Feishu", () => {
     const plan = planFlyDeploy({
       ...base,
       modelAuth: undefined,
-      channels: ["feishu"],
-      longConnectionChannels: ["feishu"],
+      channels: [...declaredChannels(["feishu"], "long-connection")],
     });
     const toml = flyToml(plan);
     const out = runbook(plan);
@@ -67,8 +67,7 @@ describe("deploy/fly: planFlyDeploy", () => {
     const plan = planFlyDeploy({
       ...base,
       modelAuth: undefined,
-      channels: [],
-      longConnectionChannels: ["socket"],
+      channels: declaredChannels(["socket"], "long-connection"),
     });
     expect(flyToml(plan)).toContain("min_machines_running = 1");
   });
@@ -87,7 +86,12 @@ describe("deploy/fly: planFlyDeploy", () => {
 
   it("computes the secret list from the model key + discovered channels + config deploy.secrets", () => {
     const out = runbook(
-      planFlyDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: ["telegram"], extraSecrets: ["GH_TOKEN"] }),
+      planFlyDeploy({
+        ...base,
+        modelAuth: "OPENAI_API_KEY",
+        channels: declaredChannels(["telegram"]),
+        extraSecrets: ["GH_TOKEN"],
+      }),
     );
     expect(out).toContain("OPENAI_API_KEY=");
     expect(out).toContain("TELEGRAM_BOT_TOKEN=");
@@ -98,7 +102,9 @@ describe("deploy/fly: planFlyDeploy", () => {
   });
 
   it("keeps Feishu/Lark Encrypt Keys optional in the runbook instead of deployment prerequisites", () => {
-    const out = runbook(planFlyDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: ["feishu", "lark"] }));
+    const out = runbook(
+      planFlyDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: declaredChannels(["feishu", "lark"]) }),
+    );
     const requiredCommand = out.split("\n").find((line) => line.startsWith("fly secrets set")) ?? "";
     expect(requiredCommand).toContain("FEISHU_APP_ID=<value>");
     expect(requiredCommand).toContain("LARK_VERIFICATION_TOKEN=<value>");
@@ -108,7 +114,7 @@ describe("deploy/fly: planFlyDeploy", () => {
   });
 
   it("includes Slack secrets and its manual Events API Request URL", () => {
-    const out = runbook(planFlyDeploy({ ...base, modelAuth: undefined, channels: ["slack"] }));
+    const out = runbook(planFlyDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["slack"]) }));
     expect(out).toContain("SLACK_BOT_TOKEN=<value>");
     expect(out).toContain("SLACK_SIGNING_SECRET=<value>");
     expect(out).toContain("POST /slack");
@@ -116,12 +122,14 @@ describe("deploy/fly: planFlyDeploy", () => {
   });
 
   it("prints one event Request URL for each mounted Feishu-cloud kind", () => {
-    const feishu = runbook(planFlyDeploy({ ...base, modelAuth: undefined, channels: ["feishu"] }));
+    const feishu = runbook(planFlyDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["feishu"]) }));
     expect(feishu).toContain("POST /feishu");
     expect(feishu).toContain("https://bot.fly.dev/feishu");
     expect(feishu).not.toContain("https://bot.fly.dev/lark");
 
-    const both = runbook(planFlyDeploy({ ...base, modelAuth: undefined, channels: ["feishu", "lark"] }));
+    const both = runbook(
+      planFlyDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["feishu", "lark"]) }),
+    );
     expect(both).toContain("https://bot.fly.dev/feishu");
     expect(both).toContain("https://bot.fly.dev/lark");
   });

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -316,8 +316,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     const pre = await call(dir, { model: "openai/gpt-4o-mini" });
     expect(pre.ok).toBe(true);
     if (pre.ok) {
-      expect(pre.channels).toEqual(["slack"]);
-      expect(pre.routeChannels).toEqual(["slack"]);
+      expect(pre.channels).toEqual([{ name: "slack", ingress: "webhook" }]);
       expect(pre.messages.some((message) => message.text.includes('channel "slack" is custom'))).toBe(false);
     }
   });
@@ -330,8 +329,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     const pre = await call(dir, { model: "openai/gpt-4o-mini" });
     expect(pre.ok).toBe(true);
     if (pre.ok) {
-      expect(pre.routeChannels).toEqual(["discord"]);
-      expect(pre.longConnectionChannels).toEqual([]);
+      expect(pre.channels).toEqual([{ name: "discord", ingress: "webhook" }]);
       expect(pre.messages).toContainEqual({
         level: "note",
         text: expect.stringContaining('route channel "discord" is custom'),
@@ -349,9 +347,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     const pre = await call(dir, { model: "openai/gpt-4o-mini" });
     expect(pre.ok).toBe(true);
     if (pre.ok) {
-      expect(pre.channels).toEqual(["feishu"]);
-      expect(pre.routeChannels).toEqual([]);
-      expect(pre.longConnectionChannels).toEqual(["feishu"]);
+      expect(pre.channels).toEqual([{ name: "feishu", ingress: "long-connection" }]);
       expect(pre.messages).toContainEqual({
         level: "note",
         text: expect.stringMatching(/long-connection channel.*keeps one machine running/),
@@ -366,9 +362,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     const pre = await call(dir, { model: "openai/gpt-4o-mini" });
     expect(pre.ok).toBe(true);
     if (pre.ok) {
-      expect(pre.channels).toEqual([]);
-      expect(pre.routeChannels).toEqual([]);
-      expect(pre.longConnectionChannels).toEqual(["socket"]);
+      expect(pre.channels).toEqual([{ name: "socket", ingress: "long-connection" }]);
       expect(pre.messages).toContainEqual({
         level: "note",
         text: expect.stringMatching(/long-connection channel "socket".*keep the process running.*skip webhook/),

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -42,7 +42,7 @@ const run = (
   p: RailwayRunPlan,
   railway: CliRunner,
   tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-) => deployRailwayRun(p, railway, () => {}, tg);
+) => deployRailwayRun(p, railway, () => {}, { telegram: tg });
 
 describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () => {
   it("fresh (unlinked): auth → init+add+volume → variables → up → domain → telegram webhook", async () => {
@@ -108,13 +108,11 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
 
-    const out = await deployRailwayRun(
-      plan({ channels: ["telegram", "feishu"] }),
-      railway,
-      () => {},
-      vi.fn(async (): Promise<RegistrationOutcome> => "failed"), // telegram registration ends with the webhook NOT set
-      registerFeishu,
-    );
+    const out = await deployRailwayRun(plan({ channels: ["telegram", "feishu"] }), railway, () => {}, {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
+      feishu: // telegram registration ends with the webhook NOT set
+        registerFeishu,
+    });
 
     // Exit 0 here would tell a coding agent "done" while the agent can't receive messages.
     expect(out).toEqual({
@@ -134,13 +132,10 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
 
-    const out = await deployRailwayRun(
-      plan({ channels: ["feishu", "lark"] }),
-      railway,
-      () => {},
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-      registerFeishu,
-    );
+    const out = await deployRailwayRun(plan({ channels: ["feishu", "lark"] }), railway, () => {}, {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      feishu: registerFeishu,
+    });
 
     expect(out).toEqual({ ok: true, url: "https://bot-production.up.railway.app" });
     expect(registerFeishu.mock.calls).toEqual([
@@ -157,14 +152,11 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     });
     const registerSlack = vi.fn(async (_baseUrl: string): Promise<RegistrationOutcome> => "registered");
 
-    const out = await deployRailwayRun(
-      plan({ channels: ["slack"] }),
-      railway,
-      () => {},
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-      undefined,
-      registerSlack,
-    );
+    const out = await deployRailwayRun(plan({ channels: ["slack"] }), railway, () => {}, {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      feishu: undefined,
+      slack: registerSlack,
+    });
 
     expect(out).toEqual({ ok: true, url: "https://bot-production.up.railway.app" });
     expect(registerSlack).toHaveBeenCalledWith("https://bot-production.up.railway.app");
@@ -178,12 +170,9 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     });
     const logs: string[] = [];
 
-    const out = await deployRailwayRun(
-      plan({ channels: ["slack"] }),
-      railway,
-      (message) => logs.push(message),
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-    );
+    const out = await deployRailwayRun(plan({ channels: ["slack"] }), railway, (message) => logs.push(message), {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+    });
 
     expect(out).toEqual({ ok: true, url: "https://bot-production.up.railway.app" });
     expect(logs.join("\n")).toContain("https://bot-production.up.railway.app/slack");
@@ -203,8 +192,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       plan({ channels: ["lark"], longConnectionChannels: ["lark"] }),
       railway,
       () => {},
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-      registerFeishu,
+      { telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"), feishu: registerFeishu },
     );
     expect(out).toEqual({ ok: true, url: "https://bot-production.up.railway.app" });
     expect(registerFeishu).not.toHaveBeenCalled();
@@ -222,7 +210,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       plan({ channels: ["feishu", "lark"] }),
       railway,
       (message) => logs.push(message),
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      { telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered") },
     );
 
     expect(out).toEqual({ ok: true, url: "https://bot-production.up.railway.app" });
@@ -303,12 +291,9 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       return {};
     });
     const logs: string[] = [];
-    await deployRailwayRun(
-      plan({ intoLinked: true }),
-      railway,
-      (m) => logs.push(m),
-      vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-    );
+    await deployRailwayRun(plan({ intoLinked: true }), railway, (m) => logs.push(m), {
+      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+    });
     expect(logs.join("\n")).toMatch(/--into-linked.*isn't linked|creating a fresh/i);
   });
 

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/deploy/railway/run.ts";
 import type { RegistrationOutcome } from "../src/channels/registration.ts";
 import type { CliRunner } from "../src/deploy/runner.ts";
+import { declaredChannels } from "../src/channels/discover.ts";
 
 /** A fake railway CLI: records every call, returns per-command scripted results (default code 0, empty). */
 function fakeRailway(script: (args: string[]) => { code?: number; stdout?: string } = () => ({})) {
@@ -53,7 +54,10 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     });
     const tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered");
     const out = await run(
-      plan({ channels: ["telegram"], secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" } }),
+      plan({
+        channels: declaredChannels(["telegram"]),
+        secrets: { TELEGRAM_BOT_TOKEN: "t", TELEGRAM_SECRET_TOKEN: "s" },
+      }),
       railway,
       tg,
     );
@@ -108,11 +112,16 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
 
-    const out = await deployRailwayRun(plan({ channels: ["telegram", "feishu"] }), railway, () => {}, {
-      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
-      feishu: // telegram registration ends with the webhook NOT set
-        registerFeishu,
-    });
+    const out = await deployRailwayRun(
+      plan({ channels: declaredChannels(["telegram", "feishu"]) }),
+      railway,
+      () => {},
+      {
+        telegram: vi.fn(async (): Promise<RegistrationOutcome> => "failed"),
+        feishu: // telegram registration ends with the webhook NOT set
+          registerFeishu,
+      },
+    );
 
     // Exit 0 here would tell a coding agent "done" while the agent can't receive messages.
     expect(out).toEqual({
@@ -132,7 +141,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
 
-    const out = await deployRailwayRun(plan({ channels: ["feishu", "lark"] }), railway, () => {}, {
+    const out = await deployRailwayRun(plan({ channels: declaredChannels(["feishu", "lark"]) }), railway, () => {}, {
       telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
       feishu: registerFeishu,
     });
@@ -152,7 +161,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     });
     const registerSlack = vi.fn(async (_baseUrl: string): Promise<RegistrationOutcome> => "registered");
 
-    const out = await deployRailwayRun(plan({ channels: ["slack"] }), railway, () => {}, {
+    const out = await deployRailwayRun(plan({ channels: declaredChannels(["slack"]) }), railway, () => {}, {
       telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
       feishu: undefined,
       slack: registerSlack,
@@ -170,9 +179,14 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     });
     const logs: string[] = [];
 
-    const out = await deployRailwayRun(plan({ channels: ["slack"] }), railway, (message) => logs.push(message), {
-      telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
-    });
+    const out = await deployRailwayRun(
+      plan({ channels: declaredChannels(["slack"]) }),
+      railway,
+      (message) => logs.push(message),
+      {
+        telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"),
+      },
+    );
 
     expect(out).toEqual({ ok: true, url: "https://bot-production.up.railway.app" });
     expect(logs.join("\n")).toContain("https://bot-production.up.railway.app/slack");
@@ -189,7 +203,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       async (_baseUrl: string, _kind: "feishu" | "lark"): Promise<RegistrationOutcome> => "registered",
     );
     const out = await deployRailwayRun(
-      plan({ channels: ["lark"], longConnectionChannels: ["lark"] }),
+      plan({ channels: declaredChannels(["lark"], "long-connection") }),
       railway,
       () => {},
       { telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered"), feishu: registerFeishu },
@@ -207,7 +221,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     const logs: string[] = [];
 
     const out = await deployRailwayRun(
-      plan({ channels: ["feishu", "lark"] }),
+      plan({ channels: declaredChannels(["feishu", "lark"]) }),
       railway,
       (message) => logs.push(message),
       { telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered") },
@@ -344,7 +358,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
       if (a[0] === "domain") return { stdout: "not-json" }; // `railway domain --json` returns unreadable output
       return {};
     });
-    const out = await run(plan({ channels: ["telegram"] }), railway);
+    const out = await run(plan({ channels: declaredChannels(["telegram"]) }), railway);
     expect(out).toEqual({ ok: false, gate: expect.stringMatching(/railway domain/) });
   });
 });

--- a/test/deploy-railway.test.ts
+++ b/test/deploy-railway.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { planRailwayDeploy } from "../src/deploy/railway/plan.ts";
+import { declaredChannels } from "../src/channels/discover.ts";
 
 const json = (p: ReturnType<typeof planRailwayDeploy>) =>
   p.artifacts.find((a) => a.path === "fastagent/railway.json")!.content;
@@ -78,7 +79,9 @@ describe("deploy/railway: planRailwayDeploy", () => {
   });
 
   it("sets the state root as a variable matched to the volume mount, + the secret list", () => {
-    const out = runbook(planRailwayDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: ["telegram"] }));
+    const out = runbook(
+      planRailwayDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: declaredChannels(["telegram"]) }),
+    );
     expect(out).toContain("railway volume add --mount-path /data");
     // `set` subcommand, NOT the deprecated `--set` legacy flag; secrets space-separated in one command.
     expect(out).toContain(
@@ -91,7 +94,9 @@ describe("deploy/railway: planRailwayDeploy", () => {
   });
 
   it("keeps Feishu/Lark Encrypt Keys optional in the runbook instead of deployment prerequisites", () => {
-    const out = runbook(planRailwayDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: ["feishu", "lark"] }));
+    const out = runbook(
+      planRailwayDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: declaredChannels(["feishu", "lark"]) }),
+    );
     const requiredCommand = out.split("\n").find((line) => line.startsWith("railway variables set OPENAI")) ?? "";
     expect(requiredCommand).toContain("FEISHU_APP_ID=<value>");
     expect(requiredCommand).toContain("LARK_VERIFICATION_TOKEN=<value>");
@@ -105,8 +110,7 @@ describe("deploy/railway: planRailwayDeploy", () => {
       planRailwayDeploy({
         ...base,
         modelAuth: undefined,
-        channels: ["lark"],
-        longConnectionChannels: ["lark"],
+        channels: [...declaredChannels(["lark"], "long-connection")],
       }),
     );
     expect(out).toContain("LARK_APP_ID=<value>");
@@ -121,8 +125,7 @@ describe("deploy/railway: planRailwayDeploy", () => {
       planRailwayDeploy({
         ...base,
         modelAuth: undefined,
-        channels: [],
-        longConnectionChannels: ["socket"],
+        channels: declaredChannels(["socket"], "long-connection"),
       }),
     );
     expect(out).toContain("do NOT enable App Sleeping — a long-connection channel");
@@ -142,21 +145,21 @@ describe("deploy/railway: planRailwayDeploy", () => {
   });
 
   it("points the webhook at the MINTED domain (railway domain), not a precomputed URL", () => {
-    const out = runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["telegram"] }));
+    const out = runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["telegram"]) }));
     expect(out).toContain("railway domain"); // must generate + read the domain first
     expect(out).toContain("https://<your-domain>/telegram"); // placeholder, not a deterministic guess
     expect(out).not.toContain(".fly.dev");
   });
 
   it("mints a domain and prints Slack's manual Events API Request URL", () => {
-    const out = runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["slack"] }));
+    const out = runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["slack"]) }));
     expect(out).toContain("railway domain");
     expect(out).toContain("SLACK_BOT_TOKEN=<value>");
     expect(out).toContain("https://<your-domain>/slack");
   });
 
   it("mints a domain and prints the Feishu Request URL for a feishu-only agent", () => {
-    const out = runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["feishu"] }));
+    const out = runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["feishu"]) }));
     expect(out).toContain("railway domain");
     expect(out).toContain("POST /feishu");
     expect(out).toContain("https://<your-domain>/feishu");
@@ -173,7 +176,11 @@ describe("deploy/railway: planRailwayDeploy", () => {
 
   it("mints the domain ONCE and prints every path when all webhook channels are present", () => {
     const out = runbook(
-      planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["telegram", "github", "feishu", "lark"] }),
+      planRailwayDeploy({
+        ...base,
+        modelAuth: undefined,
+        channels: declaredChannels(["telegram", "github", "feishu", "lark"]),
+      }),
     );
     expect(out.match(/railway domain/g)).toHaveLength(1); // not once per channel
     expect(out).toContain("https://<your-domain>/feishu");
@@ -181,16 +188,23 @@ describe("deploy/railway: planRailwayDeploy", () => {
   });
 
   it("states App Sleeping as a manual dashboard step; forbids it for github (no replay)", () => {
-    expect(runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["telegram"] }))).toContain(
-      "App Sleeping",
-    );
+    expect(
+      runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["telegram"]) })),
+    ).toContain("App Sleeping");
     // github: fire-and-forget reviews have no replay → do NOT sleep (same floor Fly enforces via config).
-    expect(runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["github"] }))).toContain(
-      "do NOT enable App Sleeping",
-    );
+    expect(
+      runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: declaredChannels(["github"]) })),
+    ).toContain("do NOT enable App Sleeping");
     // time triggers: cron/wake has no external wake-up — a sleeping service sleeps through them.
     expect(
-      runbook(planRailwayDeploy({ ...base, modelAuth: undefined, channels: ["telegram"], hasTimeTriggers: true })),
+      runbook(
+        planRailwayDeploy({
+          ...base,
+          modelAuth: undefined,
+          channels: declaredChannels(["telegram"]),
+          hasTimeTriggers: true,
+        }),
+      ),
     ).toContain("do NOT enable App Sleeping");
   });
 

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -1,13 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { chmodSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { log } from "../src/log.ts";
 import { newSlackOnboardingState } from "../src/channels/slack/onboard.ts";
 import { writeSlackOnboardingState } from "../src/channels/slack/onboarding-state.ts";
+import { declaredChannels } from "../src/channels/discover.ts";
 import { announceWebhooks, parseTunnelUrl, startCloudflareTunnel } from "../src/tunnel.ts";
 
 // Mirrors TUNNEL_RETRY_MS in tunnel.ts (the constant is not exported).
@@ -165,7 +164,7 @@ describe("tunnel: announceWebhooks", () => {
     process.env.TELEGRAM_SECRET_TOKEN = "sek";
     const dir = await workspace(["telegram"]);
 
-    await announceWebhooks(dir, "https://x.trycloudflare.com");
+    await announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["telegram"]));
 
     const call = setWebhookCall(fetchMock);
     expect(call).toBeDefined();
@@ -185,7 +184,7 @@ describe("tunnel: announceWebhooks", () => {
     });
     const dir = await workspace(["telegram"]);
 
-    await announceWebhooks(dir, "https://x.trycloudflare.com");
+    await announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["telegram"]));
 
     expect(setWebhookCall(fetchMock)).toBeUndefined();
     expect(errs.some((e) => /set TELEGRAM_BOT_TOKEN/.test(e) && /x\.trycloudflare\.com\/telegram/.test(e))).toBe(true);
@@ -200,7 +199,7 @@ describe("tunnel: announceWebhooks", () => {
     });
     const dir = await workspace(["github"]);
 
-    await announceWebhooks(dir, "https://x.trycloudflare.com");
+    await announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["github"]));
 
     expect(setWebhookCall(fetchMock)).toBeUndefined();
     expect(errs.some((e) => /github:/.test(e) && /x\.trycloudflare\.com\/webhook/.test(e))).toBe(true);
@@ -215,7 +214,7 @@ describe("tunnel: announceWebhooks", () => {
     );
     const dir = await workspace(["slack"]);
 
-    await announceWebhooks(dir, "https://x.trycloudflare.com");
+    await announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["slack"]));
 
     expect(errs.some((line) => /slack:/.test(line) && /x\.trycloudflare\.com\/slack/.test(line))).toBe(true);
   });
@@ -245,7 +244,7 @@ describe("tunnel: announceWebhooks", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await announceWebhooks(dir, "https://x.trycloudflare.com", { stateRoot });
+    await announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["slack"]), { stateRoot });
 
     expect(errs.some((line) => /slack: Event Subscriptions Request URL registered/.test(line))).toBe(true);
   });
@@ -257,7 +256,7 @@ describe("tunnel: announceWebhooks", () => {
     vi.stubGlobal("fetch", fetchMock);
     const dir = await workspace(["feishu"]);
 
-    await announceWebhooks(dir, "https://x.trycloudflare.com", { routeChannels: [] });
+    await announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["feishu"], "long-connection"));
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -280,7 +279,7 @@ describe("tunnel: announceWebhooks", () => {
     const openUrl = vi.fn();
     const dir = await workspace(["lark"]);
 
-    await announceWebhooks(dir, "https://x.trycloudflare.com", { openUrl });
+    await announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["lark"]), { openUrl });
 
     expect(openUrl).toHaveBeenCalledOnce();
     expect(openUrl).toHaveBeenCalledWith("https://open.larksuite.com/app/cli_app/event");
@@ -304,7 +303,7 @@ describe("tunnel: announceWebhooks", () => {
     vi.stubGlobal("fetch", fetchMock);
     vi.useFakeTimers();
 
-    const p = announceWebhooks(dir, "https://x.trycloudflare.com");
+    const p = announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["telegram"]));
     await vi.advanceTimersByTimeAsync(6000); // past the 5s retry backoff
     await p;
 
@@ -324,7 +323,7 @@ describe("tunnel: announceWebhooks", () => {
     await mkdir(join(dir, ".secrets", ".env"), { recursive: true }); // a directory at the .env path → loadDotEnv throws EISDIR, not ENOENT
 
     // No channels, so nothing to register — the point is that it RESOLVES rather than throwing.
-    await expect(announceWebhooks(dir, "https://x.trycloudflare.com")).resolves.toEqual([]);
+    await expect(announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels([]))).resolves.toEqual([]);
     expect(errs.some((e) => /could not read/.test(e) && /\.env/.test(e))).toBe(true); // surfaced, not silent
   });
 
@@ -342,75 +341,11 @@ describe("tunnel: announceWebhooks", () => {
     vi.stubGlobal("fetch", fetchMock);
     vi.useFakeTimers();
 
-    const p = announceWebhooks(dir, "https://x.trycloudflare.com");
+    const p = announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["telegram"]));
     await vi.advanceTimersByTimeAsync(20000); // well past any retry window
     await p;
 
     expect(setWebhookCount(fetchMock)).toBe(1); // permanent error → no retry
     expect(errs.some((e) => /Register manually/.test(e))).toBe(true);
-  });
-
-  it("a DIRECTORY named like a channel file is not a channel", async () => {
-    // The name test alone passes for `github.ts/` — and announcing a webhook for a channel the serve
-    // never mounted is the same wrong answer as missing one. `loadModuleDir` checks isFile(); so does
-    // this, or the two disagree about what the deployment serves.
-    const dir = await mkdtemp(join(tmpdir(), "fa-tunnel-dirch-"));
-    await mkdir(join(dir, "channels", "github.ts"), { recursive: true });
-    const said: string[] = [];
-    const info = vi.spyOn(log, "info").mockImplementation((message) => void said.push(message));
-    try {
-      await announceWebhooks(dir, "https://x.trycloudflare.com");
-      expect(said.join("\n")).not.toContain("github:");
-      // The positive half, in the same test: without it the assertion above passes for any reason
-      // the announcement never happens — including github's line moving off `log.info`, which would
-      // retire this guard silently.
-      said.length = 0;
-      await rm(join(dir, "channels", "github.ts"), { recursive: true });
-      await writeFile(join(dir, "channels", "github.ts"), "export default () => ({});\n");
-      await announceWebhooks(dir, "https://x.trycloudflare.com");
-      expect(said.join("\n")).toContain("github:");
-    } finally {
-      info.mockRestore();
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("a channels/ that is a FILE is reported, not read as 'no channels'", async () => {
-    // ENOTDIR is the author putting a file where the directory goes. #381 folded it in with ENOENT
-    // and said nothing — the same silence this scan exists to break, for a case that IS a mistake.
-    const dir = await mkdtemp(join(tmpdir(), "fa-tunnel-notdir-"));
-    await writeFile(join(dir, "channels"), "not a directory\n");
-    const said: string[] = [];
-    const warn = vi.spyOn(log, "warn").mockImplementation((message) => void said.push(message));
-    try {
-      await announceWebhooks(dir, "https://x.trycloudflare.com");
-      expect(said.join("\n")).toContain("cannot read");
-    } finally {
-      warn.mockRestore();
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  // chmod is the only way to reach this branch, and it does not bite as root (root reads any
-  // directory) or on Windows. Skipped rather than faked there: a guard that cannot run its own case
-  // should say so instead of passing quietly.
-  const canDenyRead = process.platform !== "win32" && process.getuid?.() !== 0;
-  it.skipIf(!canDenyRead)("reports an unreadable channels/ instead of reading it as 'no channels'", async () => {
-    // Returning [] for a directory it could not read registers no webhooks while the tunnel reports
-    // itself up — the exact failure this scan exists to feed, made invisible.
-    const dir = await mkdtemp(join(tmpdir(), "fa-tunnel-eacces-"));
-    const channels = join(dir, "channels");
-    await mkdir(channels);
-    await writeFile(join(channels, "telegram.ts"), "export default () => ({});\n");
-    chmodSync(channels, 0o000);
-    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
-    try {
-      await announceWebhooks(dir, "https://x.trycloudflare.com");
-      expect(warn.mock.calls.flat().join("\n")).toContain(`cannot read ${channels}`);
-    } finally {
-      chmodSync(channels, 0o755);
-      warn.mockRestore();
-      await rm(dir, { recursive: true, force: true });
-    }
   });
 });


### PR DESCRIPTION
## Summary

`fastagent deploy fly` with a long-connection Telegram channel printed a `setWebhook` command in its
runbook. Setting that webhook makes `getUpdates` return 409 — the runbook stops the channel the
operator just deployed. `--run` did not do it, so the two paths gave opposite instructions for the
same definition.

The missing branch was not the cause. "Which channels have a webhook, at which route, in what words"
belongs to the CHANNEL, and it was written per HOST — three runbook plans, three `--run` drivers, a
path table in the docker plan, and the `--tunnel` announcer, each with its own five-branch if-chain.
The long-connection exception was added to the feishu/lark branches only, because nothing else had a
long-connection mode at the time.

Underneath that, the fact itself travelled as **three parallel arrays** — `channels` (first-party
kinds only), `routeChannels` and `longConnectionChannels` (both including custom channels) — so every
consumer recombined them for itself, and the type system could not tell a right combination from a
wrong one. That is why fixing the chains was not enough: the first version of this refactor still
passed the *unfiltered* list at the AgentCore plan and printed `setWebhook` for a channel that has no
webhook.

Now `inspectChannels` reports each channel with the ingress its module shape says it has, and that one
list is what the pre-flight, the plans, the drivers and the announcer receive:

| | before | after |
|---|---|---|
| the channel fact | 3 arrays, recombined at ~8 consumers | one `DeclaredChannel[]` |
| which channels register | 7 hand-written chains | `webhookKinds()` |
| default routes | a table in `docker/plan.ts` + 3 sets of literals | `webhookPaths()` |
| runbook wording | 3 near-identical copies | `webhookRunbook(baseUrl, …)` |
| registration | 3 copies of the loop + a 4th in `announceWebhooks` | `pointChannelsAt()` / `registerWebhooks()` |
| registrar parameters | 3 identical trios, wired 3x in the CLI | one `Registrars`, wired once |

Every function filters the list **itself**. Taking a pre-filtered one is what let this drift: the
`--tunnel` announcer trusted its caller and defaulted to *every basename in `channels/`* when none was
passed, so any caller that forgot to filter pointed a webhook at a long-connection channel. That
default is gone and the argument is required.

A host contributes its base URL (`<app>.fly.dev`, a minted domain, a Function URL), its retry hint,
and its own asides — AgentCore keeps its compute-ceiling note and regains the forwarder-challenge note
for Feishu; Railway keeps its domain-mint step and now emits it only when a step below needs the
domain (it used to say "use it in the step(s) below" with nothing below).

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (117 files, 1574 tests)
- [x] Added or updated the smallest relevant tests

Nothing tested the rule this bug lives in — the first version of this refactor passed the whole suite
untouched. `test/deploy-channel-ingress.test.ts` pins it: a long-connection channel is absent from the
kinds, the paths, the runbook and the registration; a custom channel is skipped (its URL is its
author's); github is always manual; an unwired registrar becomes a manual step; a failed one gates
while the rest still run. Plus one per host, AgentCore included this time — the host the first version
got wrong. Removing the ingress filter turns **9** of them red, across all four hosts and the tunnel.

Three `announceWebhooks` cases went with the directory-scanning default they tested (a directory named
`github.ts`, a `channels/` that is a file, an unreadable `channels/`). Those boundaries belong to
`moduleInventory`, which is where they are asserted — `test/channel.test.ts` covers the same three
through the listing path.

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (no public surface changed; `docs/deploy.md` already stated that long-connection channels are skipped — this is the code catching up)
