### PR TITLE
refactor(slack): the replay window every ingress needs, actually shared

### DIFF
--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -6,6 +6,7 @@ import { log } from "../../log.ts";
 import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { createSeenRing } from "../kit/seen.ts";
+import { signatureIsFresh } from "../kit/signature.ts";
 import { createThreadParticipants } from "../kit/thread-participants.ts";
 import { createTaskTracker } from "../kit/tasks.ts";
 import { ensureStateHome } from "../kit/state.ts";
@@ -53,6 +54,8 @@ export type { SlackEventEnvelope, SlackFailure, SlackFile, SlackMessageEvent, Sl
 
 const MAX_EVENT_BYTES = 1 << 20;
 const MAX_TURN_ATTEMPTS = 3;
+/** Slack's own documented window — it re-signs every redelivery with a current timestamp, so a tight
+ *  one costs nothing. The Feishu ingress reads hours off the same helper for the opposite reason. */
 const MAX_SIGNATURE_AGE_S = 5 * 60;
 const QUEUED_PLACEHOLDER = "⏳ Queued — I’ll start once the current task finishes.";
 const DEFERRED_PLACEHOLDER = "⏳ Delayed by a temporary system issue — I’ll retry automatically.";
@@ -146,10 +149,8 @@ export function verifySlackSignature(
   rawBody: string,
   nowMs = Date.now(),
 ): boolean {
-  if (!/^\d+$/.test(timestamp) || !/^v0=[a-f0-9]{64}$/i.test(signature)) return false;
-  const seconds = Number(timestamp);
-  if (!Number.isSafeInteger(seconds) || Math.abs(Math.floor(nowMs / 1000) - seconds) > MAX_SIGNATURE_AGE_S)
-    return false;
+  if (!/^v0=[a-f0-9]{64}$/i.test(signature)) return false;
+  if (!signatureIsFresh(timestamp, MAX_SIGNATURE_AGE_S, nowMs)) return false;
   const expected = `v0=${createHmac("sha256", signingSecret).update(`v0:${timestamp}:${rawBody}`).digest("hex")}`;
   const actualBytes = Buffer.from(signature);
   const expectedBytes = Buffer.from(expected);

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -330,10 +330,8 @@ describe("Slack signed ingress", () => {
   });
 
   it("refuses a VALID signature over a stale timestamp, in either direction", async () => {
-    // The signature commits to the timestamp; it does not make it recent. Without the window a captured
-    // body plus its two headers replays forever. Both directions: a clock ahead of ours is as suspect as
-    // one behind. Slack re-signs every redelivery, which is why 5 minutes is affordable here — the
-    // Feishu ingress reads hours off the same helper because its platform does not.
+    // End-to-end through the ingress: the unit test above proves the predicate, this proves the 401.
+    // A clock AHEAD of ours is the direction that test does not reach.
     vi.stubGlobal("fetch", okFetch());
     const { agent } = replyingAgent();
     const { handler } = mount(agent);

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -328,6 +328,22 @@ describe("Slack signed ingress", () => {
     expect(await challenge.json()).toEqual({ challenge: "abc" });
     expect((await handler(signedRequest(message("1.0"), { signature: "v0=bad" }))).status).toBe(401);
   });
+
+  it("refuses a VALID signature over a stale timestamp, in either direction", async () => {
+    // The signature commits to the timestamp; it does not make it recent. Without the window a captured
+    // body plus its two headers replays forever. Both directions: a clock ahead of ours is as suspect as
+    // one behind. Slack re-signs every redelivery, which is why 5 minutes is affordable here — the
+    // Feishu ingress reads hours off the same helper because its platform does not.
+    vi.stubGlobal("fetch", okFetch());
+    const { agent } = replyingAgent();
+    const { handler } = mount(agent);
+    const now = Math.floor(Date.now() / 1000);
+    for (const skew of [-6 * 60, 6 * 60]) {
+      const stale = await handler(signedRequest(message("1.0"), { timestamp: now + skew }));
+      expect(stale.status).toBe(401);
+    }
+    expect((await handler(signedRequest(message("1.0"), { timestamp: now - 60 }))).status).toBe(200);
+  });
 });
 
 describe("Slack sessions, context, and thread participation", () => {


### PR DESCRIPTION
## Summary

`src/channels/kit/signature.ts` says it is "the replay window **every** signed webhook ingress needs",
but it had one consumer. Slack kept its own copy inline — the same `/^\d+$/`, the same
`Number.isSafeInteger`, the same `Math.abs(now - seconds) > MAX_AGE`, three lines up in
`verifySlackSignature`. The claim ran ahead of the code, which is the shape this repo keeps paying for:
one rule, two spellings, and a comment asserting they are one.

Slack now reads the shared helper. The window LENGTH stays per-platform, because that is the part that
genuinely differs, and each constant now says why it is what it is: Slack re-signs every redelivery, so
5 minutes costs nothing; Feishu does not, so its ingress reads hours off the same function.

The judgement set is unchanged: format regex → freshness → constant-time HMAC compare, freshness still
ordered before the HMAC, a missing header still failing the regex through `?? ""`.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (117 files, 1581 tests)
- [x] Added or updated the smallest relevant tests

The existing unit test (`verifies the raw-body HMAC and rejects stale timestamps`) already covered a
timestamp ~17 minutes in the past, so the predicate itself was guarded. The added case covers the two
things it does not reach: a clock AHEAD of ours, and the ingress answering 401 rather than the
predicate returning false. Verified it fails for the two ways this refactor could go wrong — deleting
the freshness call, and swapping the `maxAgeS` / `nowMs` arguments — each turning it red.

## Checklist

- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added
- [x] Docs were updated when behavior or public APIs changed (no behavior or public surface changed)
