### PR TITLE
test(slack): cover the redirect hop of the file-download host guard

### DIFF
--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -151,7 +151,7 @@ describe("Slack Web API transport", () => {
     const redirectTo = (location: string) =>
       vi.stubGlobal("fetch", async (input: string | URL, init?: RequestInit) => {
         calls.push({ url: String(input), authorization: new Headers(init?.headers).get("authorization") ?? undefined });
-        return String(input).includes("files.slack.com")
+        return new URL(String(input)).hostname === "files.slack.com"
           ? new Response(null, { status: 302, headers: { location } })
           : new Response(Buffer.from("png"), { headers: { "content-type": "image/png" } });
       });

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -146,6 +146,35 @@ describe("Slack Web API transport", () => {
     expect(calls.every((call) => call.authorization === "Bearer xoxb-secret")).toBe(true);
   });
 
+  it("re-sends the token across a Slack CDN redirect and refuses one that leaves Slack", async () => {
+    const calls: { url: string; authorization?: string }[] = [];
+    const redirectTo = (location: string) =>
+      vi.stubGlobal("fetch", async (input: string | URL, init?: RequestInit) => {
+        calls.push({ url: String(input), authorization: new Headers(init?.headers).get("authorization") ?? undefined });
+        return String(input).includes("files.slack.com")
+          ? new Response(null, { status: 302, headers: { location } })
+          : new Response(Buffer.from("png"), { headers: { "content-type": "image/png" } });
+      });
+
+    redirectTo("https://a.slack-edge.com/signed/image");
+    const api = createSlackApi({ botToken: "xoxb-secret" });
+    await expect(
+      api.fetchImage({ id: "F1", mimetype: "image/png", url_private: "https://files.slack.com/image" }),
+    ).resolves.toMatchObject({ mimeType: "image/png" });
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://files.slack.com/image",
+      "https://a.slack-edge.com/signed/image",
+    ]);
+    expect(calls.every((call) => call.authorization === "Bearer xoxb-secret")).toBe(true);
+
+    calls.length = 0;
+    redirectTo("https://cdn.example/signed/image");
+    await expect(
+      api.fetchImage({ id: "F1", mimetype: "image/png", url_private: "https://files.slack.com/image" }),
+    ).rejects.toThrow(/non-Slack file URL host cdn\.example/);
+    expect(calls).toHaveLength(1);
+  });
+
   it("refuses external/non-Slack download hosts and metadata above the 20 MB cap", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
The allowlist in `trustedDownloadUrl` had a test for the *first* URL only. Its load-bearing half — the
manual redirect hop, where the bearer token is re-sent — had none: the guard could stop refusing
off-Slack hosts on redirect, or stop carrying the token to a Slack CDN host, with every test green.

One test now covers both hops: a `302` to `a.slack-edge.com` is followed with `Authorization` intact,
and a `302` to `cdn.example` is refused before the second fetch. Verified it fails without the guard
(neutering the host check turns it red).

No allowlist change — #395 (does `url_private` ever redirect off Slack?) still needs a live workspace.