### PR TITLE
refactor(slack): file transfer trusts Slack, so stop policing its URLs

### DIFF
--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -106,7 +106,8 @@ export async function* invokeSlackTurn(
   try {
     resolved = await resolveInputs(transport, attachments);
   } catch (error) {
-    yield { type: "failed", details: `could not load Slack attachment: ${String(error)}`, retryable: true };
+    // an unreadable attachment reads the same on every retry, so the user is told to change something
+    yield { type: "failed", details: `could not load Slack attachment: ${String(error)}`, retryable: false };
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${MARKDOWN_INSTRUCTION}`, images: resolved.images };

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -11,7 +11,7 @@ import {
   streamTurnWithBusyRetry,
 } from "../kit/invoke-turn-kit.ts";
 import type { SlackBufferedFileRef } from "./context-buffer.ts";
-import type { DownloadedSlackFile, SlackApi } from "./slack-api.ts";
+import { type DownloadedSlackFile, type SlackApi, SlackApiError } from "./slack-api.ts";
 
 const MARKDOWN_INSTRUCTION =
   "\n\n(Format your reply as standard Markdown. Slack renders it natively. Do not use HTML or Slack control-mention syntax such as <!here>, <!channel>, or <!everyone>.)";
@@ -106,8 +106,11 @@ export async function* invokeSlackTurn(
   try {
     resolved = await resolveInputs(transport, attachments);
   } catch (error) {
-    // an unreadable attachment reads the same on every retry, so the user is told to change something
-    yield { type: "failed", details: `could not load Slack attachment: ${String(error)}`, retryable: false };
+    // transient (network, exhausted 429 retries, Slack 5xx) is worth re-sending; an access or shape
+    // error reads the same every time, and "try again in a moment" is the wrong thing to tell the user
+    const retryable =
+      error instanceof SlackApiError && (error.status === 0 || error.status === 429 || error.status >= 500);
+    yield { type: "failed", details: `could not load Slack attachment: ${String(error)}`, retryable };
     return;
   }
   const prompt = { text: `${text}${resolved.promptSuffix}${MARKDOWN_INSTRUCTION}`, images: resolved.images };

--- a/src/channels/slack/scaffold/slack-send.ts
+++ b/src/channels/slack/scaffold/slack-send.ts
@@ -71,22 +71,6 @@ async function callSlack<T extends { ok?: boolean; error?: string }>(
   }
 }
 
-function trustedUploadUrl(value: string): URL {
-  const url = new URL(value);
-  const host = url.hostname.toLowerCase();
-  const slackHost =
-    host === "slack-files.com" ||
-    host.endsWith(".slack-files.com") ||
-    host === "slack.com" ||
-    host.endsWith(".slack.com") ||
-    host === "slack-edge.com" ||
-    host.endsWith(".slack-edge.com");
-  if (url.protocol !== "https:" || !slackHost) {
-    throw new Error(`Slack returned an untrusted upload URL host: ${host}`);
-  }
-  return url;
-}
-
 export default defineTool({
   description:
     "Upload one local file to Slack (`path`), or send a message (`text`) for a turn NO channel is " +
@@ -140,7 +124,8 @@ export default defineTool({
     let byteResponse: Response;
     const handle = await open(filePath, "r");
     try {
-      byteResponse = await fetch(trustedUploadUrl(upload.upload_url), {
+      // where getUploadURLExternal points is Slack's call: these bytes are on their way to Slack either way
+      byteResponse = await fetch(upload.upload_url, {
         method: "POST",
         headers: { "content-type": "application/octet-stream" },
         body: handle.readableWebStream(),

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -246,8 +246,8 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
   };
 
   // Slack owns both halves of this download: the URL comes from its own files.info response, and it
-  // documents url_private as taking our bearer token. Where that URL leads, and whether a redirect
-  // still carries the token (fetch drops it cross-origin), are Slack's calls to make, not ours.
+  // documents url_private as taking our bearer token. Where that URL leads is Slack's call; whether a
+  // redirect hop still carries the token is fetch's, which drops the header cross-origin.
   const download = async (file: SlackFile): Promise<{ bytes: Buffer; contentType?: string }> => {
     let response: Response;
     try {

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -10,7 +10,6 @@ const DOWNLOAD_TIMEOUT_MS = 120_000;
 const MAX_DOWNLOAD_BYTES = 20 * 1024 * 1024;
 const RETRIES = 3;
 const MAX_RETRY_AFTER_S = 30;
-const MAX_REDIRECTS = 3;
 /** Slack's standard-Markdown fields cap each call at 12,000 characters. Keep headroom for
  * code-fence balancing and future server-side transformations. */
 const SLACK_MAX_MARKDOWN = 10_000;
@@ -189,24 +188,7 @@ async function readBytesCapped(response: Response): Promise<Buffer> {
 
 export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: SlackApiOptions): SlackApi {
   const apiBase = baseUrl.replace(/\/$/, "");
-  const configuredOrigin = new URL(apiBase).origin;
   const currentToken = typeof botToken === "string" ? async () => botToken : botToken;
-
-  const trustedDownloadUrl = (value: string): URL => {
-    const url = new URL(value);
-    const host = url.hostname.toLowerCase();
-    const slackHost =
-      host === "slack-files.com" ||
-      host.endsWith(".slack-files.com") ||
-      host === "slack.com" ||
-      host.endsWith(".slack.com") ||
-      host === "slack-edge.com" ||
-      host.endsWith(".slack-edge.com");
-    if (!slackHost && url.origin !== configuredOrigin) throw new Error(`refusing non-Slack file URL host ${host}`);
-    if (url.protocol !== "https:" && url.origin !== configuredOrigin)
-      throw new Error("refusing non-HTTPS Slack file URL");
-    return url;
-  };
 
   const call = async <T extends SlackBody>(
     method: string,
@@ -263,35 +245,25 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
     }
   };
 
+  // Slack owns both halves of this download: the URL comes from its own files.info response, and it
+  // documents url_private as taking our bearer token. Where that URL leads, and whether a redirect
+  // still carries the token (fetch drops it cross-origin), are Slack's calls to make, not ours.
   const download = async (file: SlackFile): Promise<{ bytes: Buffer; contentType?: string }> => {
-    let url = trustedDownloadUrl(fileDownloadUrl(file));
-    for (let redirect = 0; ; redirect++) {
-      let response: Response;
-      try {
-        const token = await currentToken();
-        response = await fetch(url, {
-          headers: { authorization: `Bearer ${token}` },
-          redirect: "manual",
-          signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
-        });
-      } catch (error) {
-        throw new SlackApiError("file download", 0, String(error), undefined, { cause: error });
-      }
-      if (response.status >= 300 && response.status < 400) {
-        const location = response.headers.get("location");
-        if (!location || redirect >= MAX_REDIRECTS) {
-          throw new SlackApiError("file download", response.status, "invalid or excessive redirect");
-        }
-        await response.body?.cancel().catch(() => {});
-        url = trustedDownloadUrl(new URL(location, url).toString());
-        continue;
-      }
-      if (!response.ok) {
-        const detail = codePointPrefix(await response.text().catch(() => ""), 300) || "file bytes were rejected";
-        throw new SlackApiError("file download", response.status, detail);
-      }
-      return { bytes: await readBytesCapped(response), contentType: response.headers.get("content-type") ?? undefined };
+    let response: Response;
+    try {
+      const token = await currentToken();
+      response = await fetch(fileDownloadUrl(file), {
+        headers: { authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+      });
+    } catch (error) {
+      throw new SlackApiError("file download", 0, String(error), undefined, { cause: error });
     }
+    if (!response.ok) {
+      const detail = codePointPrefix(await response.text().catch(() => ""), 300) || "file bytes were rejected";
+      throw new SlackApiError("file download", response.status, detail);
+    }
+    return { bytes: await readBytesCapped(response), contentType: response.headers.get("content-type") ?? undefined };
   };
 
   const api: SlackApi = {

--- a/src/scaffold/templates/tools/fetch-url.ts
+++ b/src/scaffold/templates/tools/fetch-url.ts
@@ -3,8 +3,6 @@ import { defineTool, z } from "@fastagent-sh/fastagent";
 // A code tool: filename (fetch-url.ts) is the tool name. tools/ is auto-discovered,
 // so it needs no registration in fastagent.config. Test it without a model:
 //   fastagent tool fetch-url '{"url":"https://example.com"}'
-// Serving this behind a public channel? The URL then comes from untrusted users — add an
-// allowlist or block private-network addresses (localhost, 169.254.169.254, …) to prevent SSRF.
 const MAX_TEXT = 20_000; // keep a huge page from flooding the model's context
 
 export default defineTool({

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -146,13 +146,10 @@ describe("Slack Web API transport", () => {
     expect(calls.every((call) => call.authorization === "Bearer xoxb-secret")).toBe(true);
   });
 
-  it("refuses external/non-Slack download hosts and metadata above the 20 MB cap", async () => {
+  it("refuses metadata above the 20 MB cap before fetching", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     const api = createSlackApi({ botToken: "x" });
-    await expect(
-      api.fetchFile({ id: "F1", name: "x", url_private: "https://evil.example/file" }, "C1", "/tmp"),
-    ).rejects.toThrow(/non-Slack file URL/);
     await expect(
       api.fetchFile(
         { id: "F2", name: "x", size: 21 * 1024 * 1024, url_private: "https://files.slack.com/x" },

--- a/test/slack-invoke-turn.test.ts
+++ b/test/slack-invoke-turn.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Agent, AgentEvent, Prompt } from "../src/agent.ts";
 import { invokeSlackTurn } from "../src/channels/slack/invoke-turn.ts";
-import type { SlackApi } from "../src/channels/slack/slack-api.ts";
+import { type SlackApi, SlackApiError } from "../src/channels/slack/slack-api.ts";
 
 function fakeApi(overrides: Partial<SlackApi> = {}): SlackApi {
   return {
@@ -86,6 +86,28 @@ describe("Slack turn attachment resolution", () => {
     // not retryable: the same attachment fails the same way next time, so "try again" is the wrong advice
     expect(events).toEqual([{ type: "failed", details: expect.stringContaining("access_denied"), retryable: false }]);
     expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a network error", 0],
+    ["exhausted rate-limit retries", 429],
+    ["a Slack outage", 503],
+  ])("reports %s as retryable, since the same send can succeed later", async (_label, status) => {
+    const api = fakeApi({
+      fileInfo: async () => Promise.reject(new SlackApiError("files.info", status, "boom")),
+    });
+
+    const events = await collect(
+      invokeSlackTurn(
+        { invoke: vi.fn() } as unknown as Agent,
+        "s1",
+        "read it",
+        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+        { primaryFileIds: ["F1"], buffered: { files: [], skipped: 0 } },
+      ),
+    );
+
+    expect(events).toEqual([{ type: "failed", details: expect.stringContaining("boom"), retryable: true }]);
   });
 
   it("degrades failed background files individually and tells the model what is missing", async () => {

--- a/test/slack-invoke-turn.test.ts
+++ b/test/slack-invoke-turn.test.ts
@@ -83,7 +83,8 @@ describe("Slack turn attachment resolution", () => {
       ),
     );
 
-    expect(events).toEqual([{ type: "failed", details: expect.stringContaining("access_denied"), retryable: true }]);
+    // not retryable: the same attachment fails the same way next time, so "try again" is the wrong advice
+    expect(events).toEqual([{ type: "failed", details: expect.stringContaining("access_denied"), retryable: false }]);
     expect(invoke).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Closes #395.

## The check could not do its job

`trustedDownloadUrl` allowed `slack.com` / `slack-files.com` / `slack-edge.com` and re-checked the host
on every manual redirect hop. But every input to that decision comes from one party:

- `url_private` is read from **our own `files.info` call** over TLS (`invoke-turn.ts` takes only the
  `file_id` from the event payload — the URL never comes from the webhook),
- the bearer token is Slack's, issued to us by Slack,
- Slack's own docs define the field as *"require an authorization header of the form:
  `Authorization: Bearer A_VALID_TOKEN`"*.

So the allowlist was second-guessing a party we already trust unconditionally — we hand it the token,
follow its instructions, and feed its content to the model. If Slack ever put a hostile host in that
field, it could equally just use the token itself. The check stopped nobody, and cost a list of CDN
domains that only Slack can keep correct.

## What it did cost

#395 was open because nobody could answer whether `url_private` redirects off Slack. It could not be
answered from code or docs — it needed a live workspace — and if the answer had been yes, every
affected attachment would fail with `refusing non-Slack file URL host …`, a failure **no operator
could fix**. We were carrying an unanswerable question and an unfixable failure mode to run a check
that protected nothing.

Choosing `redirect: "manual"` is what created the need for a list in the first place: fetch already
answers "may this hop carry the token" (it drops `Authorization` cross-origin), and following
redirects by hand threw that answer away.

## Change

- `download()` is one `fetch` with the token and the existing cap/error handling. Redirects go back to
  the platform: where they lead is Slack's call, and whether a hop still carries the token is fetch's.
- The same allowlist is gone from `scaffold/slack-send.ts` (upload URL, bytes sent **without** a token
  — and those bytes are on their way to Slack either way). It matters more there: the scaffold is
  copied into every author's agent directory, so a bad pattern propagates.
- An attachment failure now derives `retryable` from `SlackApiError.status` instead of asserting one
  answer for all of them: a network error, exhausted 429 retries or a Slack 5xx is worth re-sending,
  while `access_denied` reads the same every time and "try again in a moment" is the wrong advice.
- The `fetch-url.ts` scaffold drops its SSRF note. A template's comments should teach fastagent, not
  general web security, and it is copied into the author's own directory.

Sweeping the repo for the same pattern found no third site: telegram splices Slack's counterpart —
`file_path`, a value Telegram chooses — straight into its download URL and checks nothing, and feishu
builds every resource URL itself. Slack was the outlier. What is ours stays untouched: signed ingress
on all five channels, attachment path sanitising, untrusted tool names rendered as code spans, the
control-plane bearer, and snapshot validation on the AgentCore state mount.

## Trade-off

If a Slack CDN hop ever *requires* the token rather than a signed URL, the download 401s. That is
diagnosable from the status and host in the log, and has an obvious fix — unlike guessing which
domains to add to a list.
