### PR TITLE
fix(slack): a rejected download names the host that rejected it

### DIFF
--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -261,7 +261,10 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
     }
     if (!response.ok) {
       const detail = codePointPrefix(await response.text().catch(() => ""), 300) || "file bytes were rejected";
-      throw new SlackApiError("file download", response.status, detail);
+      // response.url is the LAST hop, so a download that redirected before failing names the host that
+      // actually rejected it — otherwise the operator sees a status with nothing to point it at
+      const from = response.url ? ` from ${new URL(response.url).host}` : "";
+      throw new SlackApiError(`file download${from}`, response.status, detail);
     }
     return { bytes: await readBytesCapped(response), contentType: response.headers.get("content-type") ?? undefined };
   };

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -146,6 +146,19 @@ describe("Slack Web API transport", () => {
     expect(calls.every((call) => call.authorization === "Bearer xoxb-secret")).toBe(true);
   });
 
+  it("names the host that rejected the bytes, which a redirect makes different from the one asked", async () => {
+    vi.stubGlobal("fetch", async () => {
+      const rejected = new Response("expired signature", { status: 401 });
+      // what fetch reports after following a redirect: the last hop, not the URL we asked for
+      Object.defineProperty(rejected, "url", { value: "https://cdn.example/signed/x" });
+      return rejected;
+    });
+    const api = createSlackApi({ botToken: "x" });
+    await expect(
+      api.fetchFile({ id: "F1", name: "x", url_private: "https://files.slack.com/x" }, "C1", "/tmp"),
+    ).rejects.toThrow(/file download from cdn\.example failed: 401 expired signature/);
+  });
+
   it("refuses metadata above the 20 MB cap before fetching", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
Follow-up to #399. Now that redirects are followed by the platform, the host that answers a download
is no longer always the host we asked for — but a failure only reported the status:

```
slack file download failed: 401 <first 300 chars of the body>
```

An operator reading that cannot tell whether Slack refused the file or a CDN hop refused our token,
and the answer decides what to do next. `response.url` is the last hop after fetch follows redirects
(verified), so naming it costs one line:

```
slack file download from cdn.example failed: 401 expired signature
```

This is not a guess about redirect behaviour and adds no mechanism for one — it makes the failure that
already exists say where it happened, which the repo requires of every failure path. It applies to
every rejected download, not just redirected ones.