### PR TITLE
fix(engines/pi): a fork keeps the parent's retained tail

### DIFF
--- a/src/engines/pi/session-inheritance.ts
+++ b/src/engines/pi/session-inheritance.ts
@@ -51,8 +51,9 @@ type Entry = {
   id: string;
   parentId: string | null;
   message?: AgentMessage;
+  content?: string | unknown[];
   summary?: string;
-  retainedTail?: AgentMessage[];
+  firstKeptEntryId?: string;
 };
 
 function isUserMessage(entry: Entry | undefined): boolean {
@@ -61,8 +62,7 @@ function isUserMessage(entry: Entry | undefined): boolean {
 
 /** Rough token estimate for windowing — text at chars/4, images flat. Precision is not the point:
  *  the window is a budget, and being 20% off moves a boundary by an exchange, not correctness. */
-function estimateMessageTokens(message: AgentMessage): number {
-  const content = (message as { content?: unknown }).content;
+function estimateContentTokens(content: unknown): number {
   if (typeof content === "string") return Math.ceil(content.length / 4);
   if (!Array.isArray(content)) return 0;
   let tokens = 0;
@@ -74,16 +74,28 @@ function estimateMessageTokens(message: AgentMessage): number {
   return tokens;
 }
 
+/** Both entry kinds pi projects into model context from a copied path: a `custom_message` is an
+ *  extension's injection INTO the conversation, so it charges the budget like any message. */
 function estimateEntryTokens(entry: Entry): number {
-  return entry.type === "message" && entry.message ? estimateMessageTokens(entry.message) : 0;
+  if (entry.type === "message") return estimateContentTokens((entry.message as { content?: unknown })?.content);
+  if (entry.type === "custom_message") return estimateContentTokens(entry.content);
+  return 0;
 }
 
-/** A compaction entry's summary and retained tail DO reach the model — they are the floor under
- *  every window that starts above the compaction, so the budget must count them. */
-function estimateCompactionTokens(entry: Entry | undefined): number {
-  if (entry?.type !== "compaction") return 0;
-  let tokens = Math.ceil((entry.summary ?? "").length / 4);
-  for (const message of entry.retainedTail ?? []) tokens += estimateMessageTokens(message);
+/** A compaction entry's summary AND its retained tail — the entries from `firstKeptEntryId` up to
+ *  the compaction — DO reach the model. They are the floor under every window that starts above the
+ *  compaction, so the budget must count them; the tail is read off the path, since pi stores it as a
+ *  pointer and not as messages on the entry. */
+function estimateCompactionTokens(path: Entry[], compactionIdx: number): number {
+  const compaction = path[compactionIdx];
+  if (compaction?.type !== "compaction") return 0;
+  let tokens = Math.ceil((compaction.summary ?? "").length / 4);
+  const firstKept = path.findIndex((entry) => entry.id === compaction.firstKeptEntryId);
+  if (firstKept < 0) return tokens; // an unresolvable pointer keeps nothing — pi's own reading
+  for (let i = firstKept; i < compactionIdx; i++) {
+    const entry = path[i];
+    if (entry) tokens += estimateEntryTokens(entry);
+  }
   return tokens;
 }
 
@@ -136,7 +148,7 @@ function markInheritanceWindow(child: SessionManager): void {
   const scanned = path.slice(scanFrom);
   // The compaction's own summary + retained tail reach the model regardless of where the window
   // lands, so they charge the budget as a base cost — not estimating them would over-admit.
-  const baseTokens = estimateCompactionTokens(path[scanFrom - 1]);
+  const baseTokens = estimateCompactionTokens(path, scanFrom - 1);
   const starts: number[] = [];
   scanned.forEach((entry, i) => {
     if (isUserMessage(entry)) starts.push(i);
@@ -193,9 +205,19 @@ export function inheritanceCut(parent: SessionManager, branchHints?: string[]): 
  * exact entries its user forked to keep.
  */
 export function copyBranchInto(parent: SessionManager, child: SessionManager, at: string): void {
-  /** Parent entry id → the child's id for the same entry: the copy mints its own, and a compaction
+  /** Parent entry id → the child's id for that entry: the copy mints its own, and a compaction
    *  points BACK into the path it was appended to. */
   const copied = new Map<string, string>();
+  /** Ids of entries this copy did NOT append. A compaction's `firstKeptEntryId` routinely names one:
+   *  pi walks the cut point backwards onto the metadata entries adjacent to it, which carry no
+   *  context. They resolve to the next entry that survived — the retained tail starts there — so a
+   *  dropped anchor moves the boundary by an invisible entry instead of erasing the whole tail. */
+  let unanchored: string[] = [];
+  const record = (parentId: string, childId: string) => {
+    for (const id of unanchored) copied.set(id, childId);
+    unanchored = [];
+    copied.set(parentId, childId);
+  };
   for (const raw of parent.getBranch(at)) {
     const entry = raw as Entry & {
       customType?: string;
@@ -205,27 +227,24 @@ export function copyBranchInto(parent: SessionManager, child: SessionManager, at
       provider?: string;
       modelId?: string;
       thinkingLevel?: string;
-      firstKeptEntryId?: string;
       tokensBefore?: number;
       details?: unknown;
     };
+    let childId: string | undefined;
     switch (entry.type) {
       case "message":
         if (entry.message) {
-          copied.set(entry.id, child.appendMessage(entry.message as Parameters<SessionManager["appendMessage"]>[0]));
+          childId = child.appendMessage(entry.message as Parameters<SessionManager["appendMessage"]>[0]);
         }
         break;
       case "custom_message":
         // Model-visible history, unlike the `custom` entries below it: an extension injected it INTO
         // the conversation, and the assistant messages answering it are being copied.
-        copied.set(
-          entry.id,
-          child.appendCustomMessageEntry(
-            entry.customType ?? "",
-            entry.content as Parameters<SessionManager["appendCustomMessageEntry"]>[1],
-            entry.display ?? false,
-            entry.details,
-          ),
+        childId = child.appendCustomMessageEntry(
+          entry.customType ?? "",
+          entry.content as Parameters<SessionManager["appendCustomMessageEntry"]>[1],
+          entry.display ?? false,
+          entry.details,
         );
         break;
       case "compaction":
@@ -235,21 +254,18 @@ export function copyBranchInto(parent: SessionManager, child: SessionManager, at
         // lands wherever the turn ended) the child's first request opened with a tool result whose
         // call had been summarized away, which every provider rejects. An id the copy never saw
         // keeps nothing, which is what pi itself does with a pointer it cannot resolve.
-        copied.set(
-          entry.id,
-          child.appendCompaction(
-            entry.summary ?? "",
-            copied.get(entry.firstKeptEntryId ?? "") ?? "",
-            entry.tokensBefore ?? 0,
-            entry.details,
-          ),
+        childId = child.appendCompaction(
+          entry.summary ?? "",
+          copied.get(entry.firstKeptEntryId ?? "") ?? "",
+          entry.tokensBefore ?? 0,
+          entry.details,
         );
         break;
       case "model_change":
-        if (entry.provider && entry.modelId) child.appendModelChange(entry.provider, entry.modelId);
+        if (entry.provider && entry.modelId) childId = child.appendModelChange(entry.provider, entry.modelId);
         break;
       case "thinking_level_change":
-        if (entry.thinkingLevel) child.appendThinkingLevelChange(entry.thinkingLevel);
+        if (entry.thinkingLevel) childId = child.appendThinkingLevelChange(entry.thinkingLevel);
         break;
       case "custom":
         // The plane's markers describe the parent's RECORD, not the thread's history: a copied
@@ -259,12 +275,14 @@ export function copyBranchInto(parent: SessionManager, child: SessionManager, at
         // — the engine's tool-activation delta above all, since the copied assistant messages call
         // the tools it records.
         if (entry.customType && !isPlaneMarker(entry)) {
-          child.appendCustomEntry(entry.customType, entry.data);
+          childId = child.appendCustomEntry(entry.customType, entry.data);
         }
         break;
       default:
         break; // label / session_info / branch_summary: the parent's facts, not the thread's history
     }
+    if (childId === undefined) unanchored.push(entry.id);
+    else record(entry.id, childId);
   }
 }
 

--- a/src/engines/pi/session-inheritance.ts
+++ b/src/engines/pi/session-inheritance.ts
@@ -193,22 +193,57 @@ export function inheritanceCut(parent: SessionManager, branchHints?: string[]): 
  * exact entries its user forked to keep.
  */
 export function copyBranchInto(parent: SessionManager, child: SessionManager, at: string): void {
+  /** Parent entry id → the child's id for the same entry: the copy mints its own, and a compaction
+   *  points BACK into the path it was appended to. */
+  const copied = new Map<string, string>();
   for (const raw of parent.getBranch(at)) {
     const entry = raw as Entry & {
       customType?: string;
+      content?: string | unknown[];
+      display?: boolean;
       data?: unknown;
       provider?: string;
       modelId?: string;
       thinkingLevel?: string;
+      firstKeptEntryId?: string;
       tokensBefore?: number;
       details?: unknown;
     };
     switch (entry.type) {
       case "message":
-        if (entry.message) child.appendMessage(entry.message as Parameters<SessionManager["appendMessage"]>[0]);
+        if (entry.message) {
+          copied.set(entry.id, child.appendMessage(entry.message as Parameters<SessionManager["appendMessage"]>[0]));
+        }
+        break;
+      case "custom_message":
+        // Model-visible history, unlike the `custom` entries below it: an extension injected it INTO
+        // the conversation, and the assistant messages answering it are being copied.
+        copied.set(
+          entry.id,
+          child.appendCustomMessageEntry(
+            entry.customType ?? "",
+            entry.content as Parameters<SessionManager["appendCustomMessageEntry"]>[1],
+            entry.display ?? false,
+            entry.details,
+          ),
+        );
         break;
       case "compaction":
-        child.appendCompaction(entry.summary ?? "", child.getLeafId() ?? "", entry.tokensBefore ?? 0, entry.details);
+        // `firstKeptEntryId` is where the RETAINED TAIL starts — the entries pi did not summarize,
+        // which still reach the model. Translated through the copy rather than pinned to the child's
+        // leaf: pinning kept exactly ONE entry, and when that entry was a toolResult (a compaction
+        // lands wherever the turn ended) the child's first request opened with a tool result whose
+        // call had been summarized away, which every provider rejects. An id the copy never saw
+        // keeps nothing, which is what pi itself does with a pointer it cannot resolve.
+        copied.set(
+          entry.id,
+          child.appendCompaction(
+            entry.summary ?? "",
+            copied.get(entry.firstKeptEntryId ?? "") ?? "",
+            entry.tokensBefore ?? 0,
+            entry.details,
+          ),
+        );
         break;
       case "model_change":
         if (entry.provider && entry.modelId) child.appendModelChange(entry.provider, entry.modelId);

--- a/src/engines/pi/session-store.ts
+++ b/src/engines/pi/session-store.ts
@@ -229,11 +229,11 @@ export function piSessionRecordStore(options: { dir: string; cwd?: string }): Pi
   };
   /** Fork the named parent into `id`, or answer undefined so the caller starts empty. Every failure
    *  is a warn: a thread must not lose its first turn to an inheritance edge. */
-  const inheritInto = async (id: string, inherit: SessionInheritance): Promise<SessionManager | undefined> => {
+  const inheritInto = async (sessionId: string, inherit: SessionInheritance): Promise<SessionManager | undefined> => {
     const found = locate(inherit.parentSession);
     if (!found) {
       log.warn(
-        `[fastagent] session "${id}" names parent "${inherit.parentSession}", which has no record — starting empty`,
+        `[fastagent] session "${sessionId}" names parent "${inherit.parentSession}", which has no record — starting empty`,
       );
       return undefined;
     }
@@ -243,11 +243,11 @@ export function piSessionRecordStore(options: { dir: string; cwd?: string }): Pi
       const parent = reconcileInterruptedToolCalls(SessionManager.open(found.path, found.dir));
       const cut = inheritanceCut(parent, inherit.branchHints);
       if (!cut) return undefined;
-      return fillStaged(id, (staged) => copyBranchForInheritance(parent, staged, cut.at));
+      return fillStaged(piSessionId(sessionId), (staged) => copyBranchForInheritance(parent, staged, cut.at));
     } catch (error) {
       // Unattributed on purpose: this spans reading the parent AND writing the child.
       log.warn(
-        `[fastagent] could not inherit from "${inherit.parentSession}" into "${id}" (${String(error)}) — starting empty`,
+        `[fastagent] could not inherit from "${inherit.parentSession}" into "${sessionId}" (${String(error)}) — starting empty`,
       );
       return undefined;
     }
@@ -274,15 +274,15 @@ export function piSessionRecordStore(options: { dir: string; cwd?: string }): Pi
     async openOrCreate(sessionId, inherit) {
       const found = locate(sessionId);
       if (found) return reconcileInterruptedToolCalls(SessionManager.open(found.path, found.dir));
-      const id = piSessionId(sessionId);
       mkdirSync(own, { recursive: true });
       // Inheritance is a CREATE-path decision: an existing session above ignores it entirely, which
       // is what makes it one-time by construction.
       if (inherit) {
-        const inherited = await inheritInto(id, inherit);
+        const inherited = await inheritInto(sessionId, inherit);
         if (inherited) return inherited;
       }
-      return materialize(SessionManager.create(cwd, own, { id }), own);
+      // The CALLER's id in every message above; pi's spelling only where pi names the file.
+      return materialize(SessionManager.create(cwd, own, { id: piSessionId(sessionId) }), own);
     },
     openIfExists: openExisting,
     applyProperties: (sessionId, writes) => applyProperties(() => openExisting(sessionId), writes),

--- a/test/session-inheritance.test.ts
+++ b/test/session-inheritance.test.ts
@@ -138,6 +138,31 @@ describe("inheritance edges", () => {
     expect(repaired).toHaveLength(1); // the thread starts on a transcript a provider will accept
   });
 
+  it("the window's budget counts the copied compaction's retained tail", async () => {
+    // The tail is a POINTER on pi's compaction entry, not messages on it, so a budget that reads the
+    // entry alone saw only the summary — and admitted a window on top of a tail that can be the
+    // engine's whole `keepRecentTokens` (20K by default), blowing past INHERIT_MAX_TOKENS. Here the
+    // tail is a `custom_message`, which reaches the model exactly like a message and was likewise
+    // uncounted.
+    const store = piInMemorySessionRecordStore({ cwd: process.cwd() });
+    const room = await store.openOrCreate("room");
+    room.appendMessage({ role: "user", content: "summarized away", timestamp: 1 });
+    const anchor = room.appendCustomMessageEntry("ext.dump", "T".repeat(240_000), true); // ~60K tokens
+    room.appendCompaction("the older part", anchor, 1000);
+    for (let i = 0; i < 3; i++) {
+      room.appendMessage({ role: "user", content: `question ${i}`, timestamp: 10 + i });
+      room.appendMessage(fauxAssistantMessage(`answer ${i}`));
+    }
+
+    const thread = await store.openOrCreate("thread-budget", { parentSession: "room" });
+
+    // Two compactions: the copied one, plus the inheritance mark the budget now demands.
+    expect(thread.getBranch().filter((e) => e.type === "compaction")).toHaveLength(2);
+    const context = JSON.stringify(thread.buildSessionContext().messages);
+    expect(context).toContain("answer 2"); // the newest exchange is the window's floor
+    expect(context).not.toContain("question 0"); // …and the older ones are outside it
+  });
+
   it("a failure while preparing the fork leaves no record under the id", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-inherit-partial-"));
     const cwd = process.cwd();

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -515,14 +515,48 @@ describe("fork: the copy is a copy", () => {
   it("carries an extension's injected context message", async () => {
     // A `custom_message` IS the model's context (unlike a plain `custom` entry, which is not), so a
     // fork that dropped it handed the child assistant messages answering something it cannot see.
-    const store = piInMemorySessionRecordStore();
-    const parent = await store.openOrCreate("room");
-    parent.appendCustomMessageEntry("ext.note", "the extension said this", true);
-    const at = parent.appendMessage(fauxAssistantMessage("answering the note"));
+    // Both backends: its content/display/details cross a JSONL round-trip only on disk.
+    for (const store of [
+      piInMemorySessionRecordStore(),
+      piSessionRecordStore({ dir: await mkdtemp(join(tmpdir(), "fa-store-forkcustom-")), cwd: process.cwd() }),
+    ]) {
+      const parent = await store.openOrCreate("room");
+      parent.appendCustomMessageEntry("ext.note", "the extension said this", true, { origin: "ext" });
+      const at = parent.appendMessage(fauxAssistantMessage("answering the note"));
 
-    await store.fork("room", at, "copy", "test-provenance");
-    const child = await store.openIfExists("copy");
-    expect(JSON.stringify(child?.buildSessionContext().messages)).toContain("the extension said this");
+      await store.fork("room", at, "copy", "test-provenance");
+      const child = await store.openIfExists("copy");
+      expect(JSON.stringify(child?.buildSessionContext().messages)).toContain("the extension said this");
+      const copied = child?.getBranch().find((e) => e.type === "custom_message");
+      expect(copied).toMatchObject({ customType: "ext.note", display: true, details: { origin: "ext" } });
+    }
+  });
+
+  it("a compaction anchored on a metadata entry still keeps its whole tail", async () => {
+    // pi walks a cut point BACKWARDS onto the adjacent entries that carry no context, so
+    // `firstKeptEntryId` naming a `model_change` (or a tool-activation `custom`) is pi's normal
+    // output, not malformed data. Those entries were copied but never registered, so the pointer
+    // resolved to "" and pi's reading of an unresolvable anchor — keep nothing — erased the whole
+    // retained tail: the child opened on the summary alone.
+    for (const store of [
+      piInMemorySessionRecordStore(),
+      piSessionRecordStore({ dir: await mkdtemp(join(tmpdir(), "fa-store-forkmeta-")), cwd: process.cwd() }),
+    ]) {
+      const parent = await store.openOrCreate("room");
+      parent.appendMessage({ role: "user", content: "summarized away", timestamp: 1 });
+      parent.appendMessage(fauxAssistantMessage("also summarized"));
+      const anchor = parent.appendModelChange("anthropic", "claude-sonnet-4-5");
+      parent.appendMessage({ role: "user", content: "kept question", timestamp: 3 });
+      parent.appendMessage(fauxAssistantMessage("kept answer"));
+      parent.appendCompaction("the older part", anchor, 1000);
+      const at = parent.appendMessage(fauxAssistantMessage("after the compaction"));
+
+      await store.fork("room", at, "copy", "test-provenance");
+      const child = await store.openIfExists("copy");
+      const roles = (child?.buildSessionContext().messages ?? []).map((m) => m.role);
+      expect(roles).toEqual(["compactionSummary", "user", "assistant", "assistant"]);
+      expect(JSON.stringify(child?.buildSessionContext().messages)).toContain("kept question");
+    }
   });
 
   it("never writes to the record it copies FROM", async () => {

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -473,6 +473,58 @@ describe("fork: the copy is a copy", () => {
     }
   });
 
+  it("a compacted parent forks onto a transcript a provider accepts", async () => {
+    // The copied compaction's `firstKeptEntryId` used to be pinned to the child's leaf, keeping ONE
+    // entry of the retained tail. A compaction lands wherever the turn ended, so that entry is
+    // routinely a toolResult — and the child's first request then opened with a tool result whose
+    // tool_use had been summarized away, which every provider rejects. Same poison class as an
+    // interrupted tool call, reached by forking instead of by crashing.
+    for (const store of [
+      piInMemorySessionRecordStore(),
+      piSessionRecordStore({ dir: await mkdtemp(join(tmpdir(), "fa-store-forkcmp-")), cwd: process.cwd() }),
+    ]) {
+      const parent = await store.openOrCreate("room");
+      parent.appendMessage({ role: "user", content: "summarized away", timestamp: 1 });
+      parent.appendMessage(fauxAssistantMessage("also summarized"));
+      const kept = parent.appendMessage({ role: "user", content: "kept question", timestamp: 3 });
+      parent.appendMessage({
+        ...fauxAssistantMessage(""),
+        content: [{ type: "toolCall", id: "call-1", name: "doer", arguments: {} }],
+        stopReason: "toolUse",
+      } as never);
+      parent.appendMessage({
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "doer",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 5,
+      } as never);
+      parent.appendCompaction("the older part", kept, 1000);
+      const at = parent.appendMessage(fauxAssistantMessage("after the compaction"));
+
+      await store.fork("room", at, "copy", "test-provenance");
+      const child = await store.openIfExists("copy");
+      const roles = (child?.buildSessionContext().messages ?? []).map((m) => m.role);
+      // The tail travels whole, so the tool result still follows the call it belongs to.
+      expect(roles).toEqual(["compactionSummary", "user", "assistant", "toolResult", "assistant"]);
+      expect(JSON.stringify(child?.buildSessionContext().messages)).toContain("kept question");
+    }
+  });
+
+  it("carries an extension's injected context message", async () => {
+    // A `custom_message` IS the model's context (unlike a plain `custom` entry, which is not), so a
+    // fork that dropped it handed the child assistant messages answering something it cannot see.
+    const store = piInMemorySessionRecordStore();
+    const parent = await store.openOrCreate("room");
+    parent.appendCustomMessageEntry("ext.note", "the extension said this", true);
+    const at = parent.appendMessage(fauxAssistantMessage("answering the note"));
+
+    await store.fork("room", at, "copy", "test-provenance");
+    const child = await store.openIfExists("copy");
+    expect(JSON.stringify(child?.buildSessionContext().messages)).toContain("the extension said this");
+  });
+
   it("never writes to the record it copies FROM", async () => {
     // The reconcile this used to run appends at the parent's LEAF — unreachable from a copy that
     // stops at `at`, so it repaired nothing and durably mutated the source: a "copy" bumping the


### PR DESCRIPTION
Review round on `engines/pi/`'s durable half (#396): `session-store.ts`, `session-inheritance.ts`, `session-markers.ts`, `session-settings.ts`, `invoke-session.ts`, `turn-kit.ts`, `session-control.ts` — ~2.6k lines.

## A fork of a compacted session opened on a transcript providers reject

`copyBranchInto` re-appends the parent's entries, so pi mints new ids. For a `compaction` entry it passed `child.getLeafId()` as `firstKeptEntryId` — the entry it had just appended — instead of the copy's id for the entry the parent pointed at.

`firstKeptEntryId` names where the **retained tail** starts: the entries pi did not summarize, which still reach the model. Pinning it to the leaf keeps exactly one of them. A compaction is appended wherever the turn ended, so that one entry is routinely a `toolResult` — and the child's context then reads `[summary, toolResult, …]`, a tool result whose `tool_use` was summarized away. Every provider rejects it. Same poison class as an interrupted tool call, reached by forking instead of by crashing.

| | context |
|---|---|
| parent | `compactionSummary, user, assistant, toolResult, user, assistant` |
| child, before | `compactionSummary, toolResult, user, assistant` |
| child, after | `compactionSummary, user, assistant, toolResult, assistant` |

The copy now carries a parent id → child id map and translates the pointer through it. **Every** copied entry registers its id, because pi's `findCutPoint` walks the cut backwards onto the metadata entries adjacent to it — a `firstKeptEntryId` naming a `model_change` or a `custom` entry is pi's normal output, not malformed data, and resolving one to nothing erases the whole tail. An entry the copy deliberately dropped (a plane marker, a label) resolves to the next entry that survived: the tail starts there, so a dropped anchor moves the boundary by an entry that carries no context instead of erasing it.

Reaches both callers: `fork()` always, and thread inheritance whenever `markInheritanceWindow` adds no mark of its own (at most one exchange after the parent's last compaction), which leaves the copied compaction as the latest one on the path.

## The inheritance window now prices what it admits

`estimateCompactionTokens` read the retained tail off the compaction entry, where pi stores a pointer rather than messages, so it counted only the summary. With the tail restored above, that let `INHERIT_MAX_TOKENS` be exceeded by up to `keepRecentTokens` (20k by default) on top of a budget documented as "~1/4 of a 200K context". It now sums the entries from `firstKeptEntryId` along the path.

## Two consistency fixes

- `copyBranchInto` dropped `custom_message` entries. Unlike the plain `custom` entries beside them, those ARE the model's context (an extension injecting into the conversation), so the child was getting assistant messages that answer something it cannot see — the same argument the `custom` branch already makes for the engine's tool-activation entry. They are copied, and priced like any message.
- The disk store's inheritance warns named the session by its pi record name (`s-1001234567890`), while the in-memory store named it by the caller's id. A session id belongs to the Caller; pi's spelling stays where pi names the file.

## Verification

`npm run lint && npm run typecheck && npm test` — 1588 passing. Every new test fails on `main`'s copier. The fork tests run against both backends: `custom_message`'s content/display/details cross a JSONL round-trip only on disk.
