### PR TITLE
refactor(engines/pi): activation needs no lock, so it needs no second copy

### DIFF
--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -31,7 +31,13 @@ import type { PiSessionRecordStore } from "./session-store.ts";
 import { isDeferredTool, type MountedTool } from "./tool.ts";
 import { activePath, resolveSessionSettings } from "./session-settings.ts";
 import { DEFAULT_THINKING_LEVEL } from "./models.ts";
-import { type ToolActivation, additiveActivation, agentSessionManager, turnContext } from "./tool-context.ts";
+import {
+  type ToolActivation,
+  type TurnContext,
+  additiveActivation,
+  agentSessionManager,
+  turnContext,
+} from "./tool-context.ts";
 
 /** pi's Model with the API-shape generic erased; fastagent only passes models through. */
 // biome-ignore lint/suspicious/noExplicitAny: variance-friendly model type, audited at this single point
@@ -133,7 +139,10 @@ const warnedDroppedActivations = new Set<string>();
  */
 function sessionToolActivation(session: AgentSession): ToolActivation {
   // Serialize activations: the read-modify-write below is only race-free while nothing awaits
-  // between read and write, and parallel tool calls in one batch would otherwise double-stamp.
+  // between read and write, and pi's session setters happening to be synchronous today is not a
+  // contract worth betting parallel tool batches on. Built once per SESSION (the turn context
+  // below), because a chain rebuilt per tool call serializes nothing — it is a fresh chain each
+  // time, so the parallel calls it exists for never meet on it.
   let chain: Promise<string[]> = Promise.resolve([]);
   return {
     active: () => session.getActiveToolNames(),
@@ -166,14 +175,12 @@ function sessionToolActivation(session: AgentSession): ToolActivation {
  * tool needs the session to reach the turn context. A tool that somehow runs before that binding
  * throws rather than executing outside the turn: a broken lifecycle must not look like a normal
  * out-of-turn call.
+ *
+ * It carries the whole turn CONTEXT, not just the session: the activation bridge holds the lock that
+ * orders concurrent activations, so it has to live as long as the session the activations mutate.
+ * Building it here, per call, would hand each parallel tool its own.
  */
-function toolDefinitions(
-  tools: MountedTool[],
-  cwd: string,
-  env: ExecutionEnv,
-  sessionId: string,
-  bound: { session?: AgentSession },
-): ToolDefinition[] {
+function toolDefinitions(tools: MountedTool[], env: ExecutionEnv, bound: { context?: TurnContext }): ToolDefinition[] {
   return tools.map((tool) => ({
     name: tool.name,
     label: tool.name,
@@ -183,10 +190,10 @@ function toolDefinitions(
     // without it pi's outer active-set diff double-stamps parallel calls.
     executionMode: tool.executionMode,
     execute: (id: string, params: unknown, signal: AbortSignal | undefined) => {
-      const session = bound.session;
-      if (!session) throw new Error("tool executed before its session was bound (lifecycle invariant broken)");
+      const context = bound.context;
+      if (!context) throw new Error("tool executed before its session was bound (lifecycle invariant broken)");
       return turnContext.run(
-        { cwd, sessionManager: agentSessionManager(session, sessionId), tools: sessionToolActivation(session) },
+        context,
         // Lower-level MountedTools may consume the fifth-argument env. Directory coding tools are
         // cwd-bound and ignore it; authored tools read FastAgent's turnContext instead.
         () => tool.execute(id, params, signal, undefined, { env }) as Promise<unknown>,
@@ -346,7 +353,7 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       model,
       thinkingLevel: thinkingLevel ?? DEFAULT_THINKING_LEVEL,
     });
-    const bound: { session?: AgentSession } = {};
+    const bound: { context?: TurnContext } = {};
     const { session } = await createAgentSessionFromServices({
       services: await services,
       sessionManager,
@@ -356,9 +363,14 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       // Lower-level callers with an explicit list also rely on omitted built-ins staying omitted.
       noTools: "builtin",
       ...(excludedToolNames.length > 0 ? { excludeTools: [...excludedToolNames] } : {}),
-      customTools: toolDefinitions(tools, cwd, env, sessionId, bound),
+      customTools: toolDefinitions(tools, env, bound),
     });
-    bound.session = session;
+    // One context for the whole session — the same lifetime chat binds its bridge to.
+    bound.context = {
+      cwd,
+      sessionManager: agentSessionManager(session, sessionId),
+      tools: sessionToolActivation(session),
+    };
     // An extension handler that throws is otherwise dropped: pi fans errors out to registered
     // listeners and has none by default, which on a server means a broken extension looks like an
     // extension that simply did nothing.

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -191,7 +191,7 @@ function toolDefinitions(tools: MountedTool[], env: ExecutionEnv, bound: { conte
     executionMode: tool.executionMode,
     execute: (id: string, params: unknown, signal: AbortSignal | undefined) => {
       const context = bound.context;
-      if (!context) throw new Error("tool executed before its session was bound (lifecycle invariant broken)");
+      if (!context) throw new Error("tool executed before its turn context was bound (lifecycle invariant broken)");
       return turnContext.run(
         context,
         // Lower-level MountedTools may consume the fifth-argument env. Directory coding tools are

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -31,13 +31,7 @@ import type { PiSessionRecordStore } from "./session-store.ts";
 import { isDeferredTool, type MountedTool } from "./tool.ts";
 import { activePath, resolveSessionSettings } from "./session-settings.ts";
 import { DEFAULT_THINKING_LEVEL } from "./models.ts";
-import {
-  type ToolActivation,
-  type TurnContext,
-  additiveActivation,
-  agentSessionManager,
-  turnContext,
-} from "./tool-context.ts";
+import { type TurnContext, agentSessionManager, sessionToolActivation, turnContext } from "./tool-context.ts";
 
 /** pi's Model with the API-shape generic erased; fastagent only passes models through. */
 // biome-ignore lint/suspicious/noExplicitAny: variance-friendly model type, audited at this single point
@@ -128,45 +122,6 @@ function recordedActivations(session: AgentSession): string[] {
 /** Warned once per session+missing set: a fresh session is built per invoke and channel sessions run
  *  for weeks, so an un-deduped warn would repeat every turn and dilute its own signal. */
 const warnedDroppedActivations = new Set<string>();
-
-/**
- * The turn's {@link ToolActivation} over a live session — the same bridge chat uses, so one
- * built-in `search_tools` serves both.
- *
- * Activations are PERSISTED as deltas, so a tool discovered in one turn stays callable in the next.
- * pi's own chat session does not do this (it has no place to put the record); a served session does,
- * because the alternative is an agent that re-discovers the same capability every single turn.
- */
-function sessionToolActivation(session: AgentSession): ToolActivation {
-  // Serialize activations: the read-modify-write below is only race-free while nothing awaits
-  // between read and write, and pi's session setters happening to be synchronous today is not a
-  // contract worth betting parallel tool batches on. Built once per SESSION (the turn context
-  // below), because a chain rebuilt per tool call serializes nothing — it is a fresh chain each
-  // time, so the parallel calls it exists for never meet on it.
-  let chain: Promise<string[]> = Promise.resolve([]);
-  return {
-    active: () => session.getActiveToolNames(),
-    registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
-    activate(names) {
-      const run = async (): Promise<string[]> => {
-        const current = session.getActiveToolNames();
-        const added = additiveActivation(
-          session.getAllTools().map((t) => t.name),
-          current,
-          names,
-        );
-        if (added.length > 0) {
-          session.setActiveToolsByName([...current, ...added]);
-          session.sessionManager.appendCustomEntry(TOOL_ACTIVATION_ENTRY, { names: added });
-        }
-        return added;
-      };
-      const result = chain.then(run, run);
-      chain = result.catch(() => []);
-      return result;
-    },
-  };
-}
 
 /**
  * fastagent's tools as pi tool definitions, bound to ONE session.
@@ -365,11 +320,16 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       ...(excludedToolNames.length > 0 ? { excludeTools: [...excludedToolNames] } : {}),
       customTools: toolDefinitions(tools, env, bound),
     });
-    // One context for the whole session — the same lifetime chat binds its bridge to.
+    // One context for the whole session: it describes the SESSION, not the call. The activation
+    // bridge above all — a tool call has to see what the previous one activated.
     bound.context = {
       cwd,
       sessionManager: agentSessionManager(session, sessionId),
-      tools: sessionToolActivation(session),
+      // A served session HAS somewhere to record the discovery, so it does: the delta is what makes
+      // the tool still callable next turn (see {@link TOOL_ACTIVATION_ENTRY}).
+      tools: sessionToolActivation(session, (added) =>
+        session.sessionManager.appendCustomEntry(TOOL_ACTIVATION_ENTRY, { names: added }),
+      ),
     };
     // An extension handler that throws is otherwise dropped: pi fans errors out to registered
     // listeners and has none by default, which on a server means a broken extension looks like an

--- a/src/engines/pi/search-tools.ts
+++ b/src/engines/pi/search-tools.ts
@@ -130,7 +130,7 @@ export function makeSearchToolsTool(): MountedTool {
           .map((t) => t.name)
           .join(", ")}${more > 0 ? ` … and ${more} more` : ""}.${activeNote ? ` ${activeNote}` : ""}`;
       }
-      const activated = await ctx.tools.activate(inactiveMatches.map((t) => t.name));
+      const activated = ctx.tools.activate(inactiveMatches.map((t) => t.name));
       // Report what actually happened, not what was attempted: a parallel sibling call may have
       // activated the same matches first, leaving nothing new here — an empty "Activated:" would lie.
       if (activated.length === 0) {

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -50,8 +50,8 @@ import { log, reportModuleLoadFailures } from "../../log.ts";
 import {
   type ReadonlySessionManager,
   type ToolActivation,
-  additiveActivation,
   agentSessionManager,
+  sessionToolActivation,
   turnContext,
 } from "./tool-context.ts";
 import { reportFindingsIfChanged, reportToolCollisions } from "./report.ts";
@@ -76,38 +76,6 @@ export async function buildAgentSessionRuntime(
   /** Session backend. Defaults to pi's project-scoped store; tests inject SessionManager.inMemory(). */
   sessionManager?: SessionManager,
 ): Promise<AgentSessionRuntime> {
-  /** The turn's {@link ToolActivation} over pi's AgentSession — the counterpart of invoke.ts's
-   *  serving bridge, so the SAME builtin search_tools serves both paths. Additive; unknown names
-   *  filtered (`setActiveToolsByName` is authoritative on the session and rebuilds its prompt — our
-   *  static override keeps the prompt identical to serving). */
-  function sessionToolActivation(session: AgentSession): ToolActivation {
-    // Same serialization as invoke.ts's bridge (there per turn; here per session — interactive turns
-    // make per-session equivalent): the read-modify-write below is only race-free while nothing awaits
-    // between read and write, and pi's session setters happening to be synchronous today is not a
-    // contract worth betting parallel tool batches on. Built ONCE per session (createRuntime), so
-    // parallel calls actually share the chain.
-    let chain: Promise<string[]> = Promise.resolve([]);
-    return {
-      active: () => session.getActiveToolNames(),
-      registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
-      activate(names) {
-        const run = async (): Promise<string[]> => {
-          const current = session.getActiveToolNames();
-          const added = additiveActivation(
-            session.getAllTools().map((t) => t.name),
-            current,
-            names,
-          );
-          if (added.length > 0) session.setActiveToolsByName([...current, ...added]);
-          return added;
-        };
-        const result = chain.then(run, run); // run after the predecessor settles, success or failure
-        chain = result.catch(() => []); // the caller sees a rejection on `result`; the chain stays usable
-        return result;
-      },
-    };
-  }
-
   async function resolveAssembly(cwd: string) {
     // The shared front half — the SAME placement/config/model-spec/tool/auth resolution the serving
     // opener uses (open.ts); those inputs cannot drift between the two consumption shapes.
@@ -190,11 +158,13 @@ export async function buildAgentSessionRuntime(
   // would leak env or require mutating global env at runtime.
   const rootCwd = canonicalPath(dir);
   // The CURRENT pi session + its activation bridge, BOUND TOGETHER — rebuilt on /new//resume/fork
-  // while the memoized assembly (and its tool execute closures) stays. The bridge must share the
-  // session's lifetime, NOT be rebuilt per tool call (a per-call chain serializes nothing). Note on
+  // while the memoized assembly (and its tool execute closures) stays. The bridge shares the
+  // session's lifetime because a tool call has to see what the previous one activated. Note on
   // parallel batches: pi wraps SDK customTools in its own before/after active-set diff, so an
   // activating tool must carry `executionMode: "sequential"` (the builtin loader does) — pi then runs
   // the whole batch serially and the outer diff sees correct snapshots.
+  // NO activation record here: pi's chat session has nowhere to put one (see sessionToolActivation's
+  // `onActivated`), which is the documented divergence from serving — a resumed chat re-discovers.
   const sessionRef: {
     current?: { session: AgentSession; sessionManager: ReadonlySessionManager; activation: ToolActivation };
   } = {};

--- a/src/engines/pi/tool-context.ts
+++ b/src/engines/pi/tool-context.ts
@@ -50,8 +50,44 @@ export interface ToolActivation {
   /** Every registered tool (active or not) — the discovery corpus for a loader like `search_tools`. */
   registered(): Array<{ name: string; description: string }>;
   /** ADDITIVE activation. Unknown names are filtered out before reaching pi (whose `setActiveTools`
-   *  THROWS on them); resolves the names actually newly activated (already-active names don't repeat). */
-  activate(names: string[]): Promise<string[]>;
+   *  THROWS on them); answers the names actually newly activated (already-active names don't repeat).
+   *
+   *  SYNCHRONOUS, and that is the contract, not an implementation detail: read-modify-write against
+   *  pi's active set cannot be interleaved as long as no caller can await inside it. An async
+   *  signature would need a lock to say the same thing, and the lock is what a previous version had
+   *  — one rebuilt per tool call, so the parallel batch it existed for never met on it. If pi's
+   *  setters ever become async, this signature is where that breaks, loudly. */
+  activate(names: string[]): string[];
+}
+
+/**
+ * The activation bridge over a live pi session — the ONE implementation, for both consumers.
+ *
+ * Serving (`agent-session-factory.ts`) and chat (`session-builder.ts`) had a copy each, identical
+ * but for the persistence line; the neighbouring `definitionResourceLoaderOptions` exists because
+ * that exact duplication drifted once before. The difference is a PARAMETER now: `onActivated` is
+ * what a served session uses to record the delta that carries the discovery into its next turn,
+ * and chat has nowhere to put one (pi's SessionContext has no active-tool set).
+ *
+ * Bind it to the SESSION, never to a tool call: the next call has to see what this one activated.
+ */
+export function sessionToolActivation(session: AgentSession, onActivated?: (added: string[]) => void): ToolActivation {
+  return {
+    active: () => session.getActiveToolNames(),
+    registered: () => session.getAllTools().map((t) => ({ name: t.name, description: t.description ?? "" })),
+    activate(names) {
+      const current = session.getActiveToolNames();
+      const added = additiveActivation(
+        session.getAllTools().map((t) => t.name),
+        current,
+        names,
+      );
+      if (added.length === 0) return added;
+      session.setActiveToolsByName([...current, ...added]);
+      onActivated?.(added);
+      return added;
+    },
+  };
 }
 
 export interface TurnContext {
@@ -67,10 +103,9 @@ export interface TurnContext {
 
 export const turnContext = new AsyncLocalStorage<TurnContext>();
 
-/** The additive-activation contract, in ONE place for both bridges (the served session,
- *  chat.ts over pi's AgentSession): dedupe → keep registered names only (pi's setters THROW on
- *  unknown) → exclude already-active → the names to actually add (empty = nothing to set). */
-export function additiveActivation(registered: string[], current: string[], names: string[]): string[] {
+/** dedupe → keep registered names only (pi's setters THROW on unknown) → exclude already-active →
+ *  the names to actually add (empty = nothing to set). */
+function additiveActivation(registered: string[], current: string[], names: string[]): string[] {
   const known = new Set(registered);
   const active = new Set(current);
   return [...new Set(names)].filter((name) => known.has(name) && !active.has(name));

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -116,9 +116,9 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
       const tools = store?.tools
         ? {
             ...store.tools,
-            activate: async (names: string[]) => {
+            activate: (names: string[]) => {
               // biome-ignore lint/style/noNonNullAssertion: guarded by the ternary above
-              const activated = await store.tools!.activate(names);
+              const activated = store.tools!.activate(names);
               added.push(...activated);
               return activated;
             },

--- a/test/agent-session-factory.test.ts
+++ b/test/agent-session-factory.test.ts
@@ -116,6 +116,8 @@ describe("piAgentSessionFactory: the definition reaches the model", () => {
     await collect(agent.invoke({ session: "s" }, { text: "go" }));
 
     expect(seen).toHaveLength(2);
+    // Without this the assertion below passes on two undefineds — i.e. on the bridge being gone.
+    expect(seen[0]).toBeTypeOf("function");
     expect(seen[0]).toBe(seen[1]);
   });
 

--- a/test/agent-session-factory.test.ts
+++ b/test/agent-session-factory.test.ts
@@ -85,6 +85,40 @@ describe("piAgentSessionFactory: the definition reaches the model", () => {
     expect(seenSessionId).toBe("-1001234567890");
   });
 
+  it("every tool call in a turn shares one activation bridge", async () => {
+    // The bridge carries the lock that orders concurrent activations, so it has to live as long as
+    // the session those activations mutate. Rebuilt per tool CALL it is a fresh chain every time,
+    // and the parallel batch it exists for never meets on it — the shape chat's builder already
+    // names ("a per-call chain serializes nothing").
+    //
+    // The ordering ITSELF is not reachable from here: pi's session setters are synchronous today,
+    // so the read-modify-write cannot be interleaved no matter how many bridges exist. What is
+    // checkable is the thing the lock rests on — that both calls hold the same one.
+    const seen: unknown[] = [];
+    const probe = (name: string) =>
+      defineTool({
+        name,
+        description: `probe ${name}`,
+        input: z.object({}),
+        execute: async (_input, ctx) => {
+          seen.push(ctx.tools?.active);
+          return "probed";
+        },
+      });
+    const agent = await agentWith(
+      [
+        fauxAssistantMessage([fauxToolCall("probe-a", {}, { id: "a" }), fauxToolCall("probe-b", {}, { id: "b" })]),
+        fauxAssistantMessage("done"),
+      ],
+      { tools: [probe("probe-a"), probe("probe-b")] as Parameters<typeof piAgentSessionFactory>[0]["tools"] },
+    );
+
+    await collect(agent.invoke({ session: "s" }, { text: "go" }));
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBe(seen[1]);
+  });
+
   it("a deferred tool is not offered until something activates it", async () => {
     let offered: string[] = [];
     const agent = await agentWith(

--- a/test/agent-session-factory.test.ts
+++ b/test/agent-session-factory.test.ts
@@ -15,6 +15,7 @@ import { piAgentSessionFactory } from "../src/engines/pi/agent-session-factory.t
 import { createPiAgentFromSession } from "../src/engines/pi/invoke-session.ts";
 import { type PropertyWrites, piInMemorySessionRecordStore } from "../src/engines/pi/session-store.ts";
 import { defineTool, z } from "../src/pi.ts";
+import { type TurnContext, turnContext } from "../src/engines/pi/tool-context.ts";
 import { piAllCodingTools } from "../src/engines/pi/create.ts";
 import { withSearchTool } from "../src/engines/pi/search-tools.ts";
 import { makeFaux } from "./faux.ts";
@@ -85,23 +86,22 @@ describe("piAgentSessionFactory: the definition reaches the model", () => {
     expect(seenSessionId).toBe("-1001234567890");
   });
 
-  it("every tool call in a turn shares one activation bridge", async () => {
-    // The bridge carries the lock that orders concurrent activations, so it has to live as long as
-    // the session those activations mutate. Rebuilt per tool CALL it is a fresh chain every time,
-    // and the parallel batch it exists for never meets on it — the shape chat's builder already
-    // names ("a per-call chain serializes nothing").
+  it("every tool call in a turn runs in the same turn context", async () => {
+    // The context describes the SESSION, not the call — one cwd, one session manager, one activation
+    // bridge — and the bridge is why it matters: a tool call has to see what the previous one
+    // activated. Built inside `execute`, every call got its own set of objects.
     //
-    // The ordering ITSELF is not reachable from here: pi's session setters are synchronous today,
-    // so the read-modify-write cannot be interleaved no matter how many bridges exist. What is
-    // checkable is the thing the lock rests on — that both calls hold the same one.
-    const seen: unknown[] = [];
+    // Read through AsyncLocalStorage rather than off `ctx`: `defineTool` hands the tool a fresh
+    // wrapper object each call, so anything reachable from `ctx` can only stand IN for the context
+    // by way of a reference the wrapper happens to pass through.
+    const seen: (TurnContext | undefined)[] = [];
     const probe = (name: string) =>
       defineTool({
         name,
         description: `probe ${name}`,
         input: z.object({}),
-        execute: async (_input, ctx) => {
-          seen.push(ctx.tools?.active);
+        execute: async () => {
+          seen.push(turnContext.getStore());
           return "probed";
         },
       });
@@ -116,8 +116,8 @@ describe("piAgentSessionFactory: the definition reaches the model", () => {
     await collect(agent.invoke({ session: "s" }, { text: "go" }));
 
     expect(seen).toHaveLength(2);
-    // Without this the assertion below passes on two undefineds — i.e. on the bridge being gone.
-    expect(seen[0]).toBeTypeOf("function");
+    // Without this the assertion below would pass on two undefineds — on there being no context.
+    expect(seen[0]).toBeDefined();
     expect(seen[0]).toBe(seen[1]);
   });
 


### PR DESCRIPTION
Review round on `engines/pi/`'s assembly half (#396): `create.ts`, `agent-session-factory.ts`, `session-builder.ts`, `open.ts`, `config.ts`, `definition.ts`, `models.ts`, `tool.ts`, `tool-context.ts`, `search-tools.ts`, `wake-tool.ts` — ~3.5k lines.

## Activating a deferred tool is synchronous

The whole operation is a read-modify-write against pi's active set:

```ts
const current = session.getActiveToolNames();
const added   = additiveActivation(session.getAllTools().map(t => t.name), current, names);
session.setActiveToolsByName([...current, ...added]);
```

No step of it can await, so nothing can interleave between the read and the write. `ToolActivation.activate` now answers `string[]` and says so at the signature — if pi's setters ever become async, that is where it breaks, loudly, instead of being absorbed by a lock that would then have to be correct.

What the async signature cost, all of it downstream of a serialization the language already provides:

- a promise chain per bridge, ordering calls that cannot overlap;
- an `async` wrapper in `defineTool`, whose only job was to await that chain before collecting `addedToolNames`;
- a test that could only observe the invariant by comparing function identities through the wrapper.

## One bridge, one implementation

`sessionToolActivation` existed twice — serving and chat — identical but for a single line, `appendCustomEntry(TOOL_ACTIVATION_ENTRY, …)`. That line is the only real difference between the two: a served session has somewhere to record the discovery so the tool is still callable next turn; chat's has not (pi's `SessionContext` carries no active-tool set), so a resumed chat re-discovers.

It is a parameter now — `onActivated` — and the function lives in `tool-context.ts` next to the contract it implements. `additiveActivation` stops being exported along the way: it was only ever public so the second copy could reach it.

The duplication mattered: `definitionResourceLoaderOptions`, in the file right beside this one, exists because these same two assemblies drifted before and extensions silently vanished from chat.

## The turn context is a property of the session

It was built inside every tool `execute`, so each call in a batch got its own `cwd`, session manager and activation bridge. It describes the session, not the call — most concretely for the bridge, since a tool call has to see what the previous one activated.

The test reads `turnContext.getStore()` directly rather than something reachable from `ctx`: `defineTool` hands each call a fresh wrapper object, so anything on `ctx` can only stand in for the context by way of a reference the wrapper happens to pass through. It also asserts the store is defined — without that, two `undefined`s satisfy the equality and the test passes on the context being gone.

## Verification

`npm run lint && npm run typecheck && npm test` — 1589 passing. The new test fails when the context is rebuilt per call (`expected { …(3) } to be { …(3) }`); `dynamic-tools.test.ts` already covers the end-to-end activation path and the `addedToolNames` load point, which is what pins the synchronous collection in `defineTool`.

Net: −35 lines of source.
