### PR TITLE
docs(agentcore): name the one kind the settle-then-snapshot edge misses

### DIFF
--- a/src/channels/agentcore.ts
+++ b/src/channels/agentcore.ts
@@ -412,6 +412,14 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
 
   // Settle-then-snapshot: when the envelope leaves nothing in flight, its writes are final now (a
   // background turn instead reports through the idle edge above).
+  //
+  // A public `invoke` is the one kind this MISSES, measurably: it answers with an unconsumed SSE
+  // stream, so the turn runs after this line and its records wait for the next envelope's snapshot.
+  // Counting it as in-flight work would close that and cost more than it buys — the stream drains at
+  // the CLIENT's pace, so one parked reader pins /ping at HealthyBusy and defeats the idle reclaim,
+  // which is the quota-exhaustion failure the ping contract below warns about. The kinds that carry
+  // conversations (webhook, schedule-fire, wake-poke) all run their turn inside the request or
+  // through `beginWork`, so they land on one of the two edges; `invoke` is the direct/debug door.
   const invocations = async (req: Request): Promise<Response> => {
     const response = await handleInvocation(req);
     if (stateSync && !isBusy()) stateSync.save();


### PR DESCRIPTION
Review round over `channels/{serve,control,http,agentcore}.ts` (#396) — 1381 lines. **No bugs found**; these four are the most-worked files in the repo and it shows. One measured behaviour gap is now named at the line that has it.

## The gap

`POST /invocations` snapshots on the settle edge:

```ts
const response = await handleInvocation(req);
if (stateSync && !isBusy()) stateSync.save();
```

A public `invoke` answers with an **unconsumed** SSE stream, and nothing on that path calls `beginWork()`, so `isBusy()` is false and `save()` runs before the turn does. Measured with a probe agent:

```
turn:start → SAVE → turn:wrote-session → turn:end → client:stream-drained
```

The records then wait for the next envelope's snapshot. In a mixed deployment (a forwarder has already supplied the state URLs) that is a window in which a deploy erases them, since AgentCore wipes the mount on every version update.

**Not fixed on purpose.** Counting the stream as in-flight work would close it and cost more: the stream drains at the *client's* pace, so one parked reader pins `/ping` at `HealthyBusy` and defeats the idle reclaim — the quota-exhaustion failure the ping contract's own comment documents forty lines below. The kinds that carry conversations (`webhook`, `schedule-fire`, `wake-poke`) run their turn inside the request or through `beginWork`, so they land on one of the two edges; `invoke` is the direct/debug door, and its own comment already says a public invoke "runs in its own isolated storage".

So the trade is right and was undocumented. Now it is at the line.

## Checked, nothing to change

- **`serve.ts`** — the route-key rules (`URL`-normalised path equality, method conflict, mount overlap), the single-exit HEAD rule that covers a mount's reply and the router's own 404/405, and `bodyAlreadyRead`'s deliberate "only when certain" (a positive `content-length` plus `readableEnded`; guessing there would reject legal empty chunked bodies).
- **`control.ts`** — segment-wise path matching so a `%2F` in a session id cannot fool it, preflight answered before auth for any path under the prefix, `access-control-allow-origin: *` without credentials, the compile-time drift guards on `SessionAction`/`Prompt`/`ImageRef`, and the errno-shaped `code` test that keeps a row-building `TypeError` out of the retryable `sessions_unavailable` answer.
- **`http.ts` vs `control.ts` SSE** — the invoke stream's `pull` has no try/catch while the control stream's does. That reads like drift and is not: `cancellableStream` swallows `return()` rejections, and SPEC MUST 2 forbids the invoke iterator from throwing, while `SessionControl.events()` is the neutral contract face that explicitly permits it.
- **`agentcore.ts`** — the trust boundary (internal fields dropped rather than rejected on a public `invoke`), restore-before-read ordering, per-kind construction-failure policy, the base64-aware body caps against `agentcore-limits.ts`, and the `time_of_last_update` ping semantics.

## Verification

`npm run lint && npm run typecheck && npm test` — 1589 passing. Comment-only change; the ordering above was measured with a throwaway probe, not left behind as a test (asserting it would pin the gap rather than the trade).
