### PR TITLE
fix(paths): the secrets directory is created 0700 by whoever gets there first

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -2,12 +2,19 @@
  * `fastagent start [dir]`: run the agent in production posture — the SAME assembly as dev (your
  * directory is the agent), just no file-watching. No build step: start reads the definition directly.
  */
-import { mkdir, writeFile } from "node:fs/promises";
+import { chmod, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { authSeedBytes, collectAuthSeed } from "../../deploy/fly/run.ts";
 import { loadDotEnv } from "../../env.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
-import { resolveSecretsDir, workspaceHint, isUnderDir, exists } from "../../paths.ts";
+import {
+  SECRET_FILE_MODE,
+  ensureSecretsDir,
+  resolveSecretsDir,
+  workspaceHint,
+  isUnderDir,
+  exists,
+} from "../../paths.ts";
 import { reportFindingsIfChanged, reportToolCollisions } from "../../engines/pi/report.ts";
 import { reportModuleLoadFailures, log, setLogLevel } from "../../log.ts";
 import { CODING_TOOL_NAMES } from "../../engines/pi/create.ts";
@@ -177,8 +184,10 @@ async function maybeSeedAuth(authPath: string): Promise<void> {
   // env-value max length (AgentCore); single-var hosts are unchanged.
   const bytes = authSeedBytes(collectAuthSeed(process.env), await exists(authPath));
   if (!bytes) return;
-  await mkdir(dirname(authPath), { recursive: true });
-  await writeFile(authPath, bytes);
+  await ensureSecretsDir(dirname(authPath));
+  await writeFile(authPath, bytes, { mode: SECRET_FILE_MODE });
+  await chmod(authPath, SECRET_FILE_MODE); // `mode` above is ignored if the file somehow exists
+
   log.info(`[fastagent] seeded ${authPath} from FASTAGENT_AUTH_SEED (first boot)`);
 }
 

--- a/src/engines/pi/auth.ts
+++ b/src/engines/pi/auth.ts
@@ -25,10 +25,10 @@
  * partial one, so there is no torn-read window for an unlocked read to absorb. The write path
  * refuses to overwrite a corrupt file (never clobbering other providers' credentials).
  */
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { GLOBAL_HOME_DIR, SECRETS_DIRNAME } from "../../paths.ts";
+import { GLOBAL_HOME_DIR, SECRETS_DIRNAME, SECRET_FILE_MODE, ensureSecretsDir } from "../../paths.ts";
 import { writeFileAtomic } from "../../atomic-write.ts";
 import { log } from "../../log.ts";
 import type { Credential, CredentialInfo, CredentialStore } from "@earendil-works/pi-ai";
@@ -58,7 +58,7 @@ function pick(creds: Creds, providerId: string): Credential | undefined {
   return cred && (cred.type === "oauth" || cred.type === "api_key") ? cred : undefined;
 }
 
-const AUTH_FILE_WRITE_OPTIONS = { encoding: "utf8", mode: 0o600 } as const;
+const AUTH_FILE_WRITE_OPTIONS = { encoding: "utf8", mode: SECRET_FILE_MODE } as const;
 
 interface LockResult<T> {
   result: T;
@@ -78,12 +78,11 @@ async function withLockedAuthFile<T>(
   authPath: string,
   fn: (current: string | undefined) => Promise<LockResult<T>>,
 ): Promise<T> {
-  const dir = dirname(authPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  await ensureSecretsDir(dirname(authPath));
   if (!existsSync(authPath)) {
     try {
       writeFileSync(authPath, "{}", { ...AUTH_FILE_WRITE_OPTIONS, flag: "wx" });
-      chmodSync(authPath, 0o600);
+      chmodSync(authPath, SECRET_FILE_MODE);
     } catch (error) {
       // EEXIST: another process created the file between the existence check and this exclusive
       // create; its content (possibly already-written credentials) must not be clobbered.
@@ -113,7 +112,7 @@ async function withLockedAuthFile<T>(
     // spelling that applies the mode before the content is reachable — `writeFileSync`'s `mode` is
     // a no-op on an existing file, so a chmod after it leaves the new credential briefly readable
     // at whatever mode the old file carried.
-    if (out.next !== undefined) writeFileAtomic(authPath, out.next, 0o600);
+    if (out.next !== undefined) writeFileAtomic(authPath, out.next, SECRET_FILE_MODE);
     throwIfCompromised();
     result = out.result;
   } catch (error) {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -16,7 +16,7 @@
  * modules depend on it for something the engine has no say in.
  */
 import { type Dirent, existsSync, readdirSync, statSync } from "node:fs";
-import { access, realpath } from "node:fs/promises";
+import { access, chmod, mkdir, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
@@ -345,6 +345,28 @@ export function resolveStateRoot(dir: string, env: NodeJS.ProcessEnv = process.e
  */
 export function resolveSecretsDir(dir: string, env: NodeJS.ProcessEnv = process.env): string {
   return resolveOverridePath(env.FASTAGENT_SECRETS_DIR) ?? join(resolve(dir), SECRETS_DIRNAME);
+}
+
+/** What a file under {@link resolveSecretsDir} is written with (auth.json, .env). */
+export const SECRET_FILE_MODE = 0o600;
+/** What the secrets directory itself is created with. */
+const SECRETS_DIR_MODE = 0o700;
+
+/**
+ * Create the secrets directory with the mode its contents require — and REPAIR it when it already
+ * exists, which is the case that matters.
+ *
+ * The DIRECTORY is the boundary that actually protects a credential: without its `x` bit nothing
+ * below it is reachable, whatever a file's own mode says. And it is decided ONCE, by whichever
+ * writer gets there first — `mkdir`'s `mode` is ignored for a directory that already exists, so a
+ * later, more careful caller silently inherits the first one's answer. Four callers create this
+ * directory (`init`, `add <channel>`, the credential store, the deploy seed) and the ordinary order
+ * is init → add → login, so the careful one is LAST: the rule has to live where all of them can
+ * reach it, and it has to chmod rather than trust the create.
+ */
+export async function ensureSecretsDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: SECRETS_DIR_MODE });
+  await chmod(dir, SECRETS_DIR_MODE);
 }
 
 /**

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -7,7 +7,7 @@
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { detectRuntime } from "../runtime.ts";
-import { SECRETS_DIRNAME, assertInsideAgentDir, exists } from "../paths.ts";
+import { SECRETS_DIRNAME, assertInsideAgentDir, ensureSecretsDir, exists } from "../paths.ts";
 import { baseTemplate, channelBundleFiles, channelTemplate } from "./templates.ts";
 import { dotEnvPath, envExamplePath, parseEnvContent } from "../env.ts";
 import type { FeishuSubscriptionMode } from "../channels/feishu/setup-mode.ts";
@@ -291,7 +291,7 @@ export async function appendChannelDotEnv(
 ): Promise<DotEnvWriteResult> {
   const file = dotEnvPath(dir);
   const secretsDir = dirname(file);
-  await mkdir(secretsDir, { recursive: true });
+  await ensureSecretsDir(secretsDir);
   // THE one exception to "fastagent has no opinion about git": the directory it writes secrets into
   // carries its own `.gitignore`. `init` writes it, and so does this — the reachable case where it is
   // missing (a hand-made agent) is exactly the one where the next line mints an unrecoverable app

--- a/src/scaffold/init.ts
+++ b/src/scaffold/init.ts
@@ -34,6 +34,7 @@ import {
   agentDefinitionOwner,
   agentsAt,
   displayPath,
+  ensureSecretsDir,
   exists,
 } from "../paths.ts";
 import { baseTemplate, packageJson, toPackageName } from "./templates.ts";
@@ -244,7 +245,10 @@ export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}):
   try {
     for (const file of files) {
       const abs = join(dir, file.rel);
-      await mkdir(dirname(abs), { recursive: true });
+      // The secrets dir carries a mode; every other directory here is ordinary. `init` is usually the
+      // FIRST of the four writers to create it, and whoever creates it decides the mode for the rest.
+      if (basename(dirname(abs)) === SECRETS_DIRNAME) await ensureSecretsDir(dirname(abs));
+      else await mkdir(dirname(abs), { recursive: true });
       try {
         await writeFile(abs, file.content, { flag: "wx" });
         created.push(file.rel);

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -3,10 +3,10 @@
  * here rather than inside the config or scaffold suites that used to own the rule.
  */
 import { describe, expect, it } from "vitest";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { displayPath, resolvePlacement, workspaceHint } from "../src/paths.ts";
+import { displayPath, ensureSecretsDir, resolvePlacement, workspaceHint } from "../src/paths.ts";
 
 describe("paths: resolvePlacement — one marker, and the directory you point at", () => {
   const config = async (dir: string): Promise<void> => {
@@ -146,5 +146,28 @@ describe("paths: displayPath", () => {
     expect(displayPath("/a/b", "/a/b/..agent")).toBe("..agent"); // a dir literally named "..agent" is INSIDE cwd
     expect(displayPath("/a/b", "/a/b")).toBeUndefined(); // already in cwd → no cd step
     expect(displayPath("/a/b", "/tmp/x")).toBe("/tmp/x"); // outside → absolute, not ../../tmp/x noise
+  });
+});
+
+describe("paths: the secrets directory carries a mode", () => {
+  const modeOf = async (p: string) => ((await stat(p)).mode & 0o777).toString(8);
+
+  it("creates it 0700 — the x bit is what actually protects a credential", async () => {
+    const dir = join(await mkdtemp(join(tmpdir(), "fa-secrets-")), ".secrets");
+    await ensureSecretsDir(dir);
+    expect(await modeOf(dir)).toBe("700");
+  });
+
+  it("REPAIRS a directory another writer already created wide open", async () => {
+    // The case that matters, and the reason this chmods rather than trusting mkdir's `mode`: four
+    // callers create this directory and `mkdir` ignores `mode` when it already exists, so the first
+    // one decides for everyone. The ordinary order is init → add <channel> → login, which put the
+    // careful one LAST — every agent scaffolded before this got a 0755 secrets dir holding .env and
+    // auth.json.
+    const dir = join(await mkdtemp(join(tmpdir(), "fa-secrets-old-")), ".secrets");
+    await mkdir(dir, { recursive: true }); // exactly what init/add-channel used to do
+    expect(await modeOf(dir)).toBe("755");
+    await ensureSecretsDir(dir);
+    expect(await modeOf(dir)).toBe("700");
   });
 });


### PR DESCRIPTION
## `.secrets/` was world-readable in practice

Four writers create the secrets directory, and only one passed a mode:

| writer | directory | file |
|---|---|---|
| `engines/pi/auth.ts` (`login`) | **0700** | **0600** |
| `scaffold/init.ts` | — → 0755 | — |
| `scaffold/add-channel.ts` (writes `.env`) | — → 0755 | — → 0644 |
| `cli/commands/start.ts` (deploy auth seed) | — → 0755 | — → **0644** |

`mkdir`'s `mode` is ignored when the directory already exists, and the ordinary order is `init` → `add <channel>` → `login`. So the one careful writer ran **last**, against a directory another had already created 0755 — its `mkdir(…, { mode: 0o700 })` was a no-op every time. Measured on a fresh scaffold:

```
.secrets/       755
.secrets/.env   644   # TELEGRAM_BOT_TOKEN, FEISHU_APP_SECRET, SLACK_SIGNING_SECRET
auth.json       644   # OAuth tokens / API keys  (0600 only if login created the dir first)
```

On a shared machine any local user could read the whole credential set.

## The fix is where the rule lives, not four copies of it

The mode moved to `paths.ts`, next to `SECRETS_DIRNAME` and `resolveSecretsDir`, as `ensureSecretsDir`. It **chmods rather than trusting the create**, which is the part that matters: every agent scaffolded before this already has a 0755 directory, and it is repaired by the next command that touches it.

The directory is the boundary that actually protects the contents — without its `x` bit nothing below is reachable whatever a file's own mode says — so `.env` keeping 0644 inside a 0700 directory is not a hole, and rewriting the several `writeFile`/`appendFile` calls that produce it would be churn. The deploy seed's `auth.json` **is** fixed to 0600, because the credential store insists on 0600 for that same file and the disagreement was the bug.

## Verification

`npm run lint && npm run typecheck && npm test` — 1591 passing. The new test asserts the repair path (an existing 0755 directory becomes 0700) and fails with the `chmod` removed; that is the case a `mkdir`-only fix would silently miss.
