### PR TITLE
refactor(login): selectProvider answers the provider, not its id

### DIFF
--- a/src/engines/pi/login.ts
+++ b/src/engines/pi/login.ts
@@ -86,11 +86,18 @@ function authCallbacks(
     signal: userSignal ?? new AbortController().signal,
     prompt: async (p: AuthPrompt): Promise<string> => {
       if (p.type === "select") {
-        // No signal, unlike the text/secret branch below, and not an oversight: every builtin
-        // provider's `select` is the FIRST call of its `login()` — which login method to use — so
-        // nothing is racing it. `doneSignal` fires when `auth.login()` RETURNS, and it cannot
-        // return while this await is what it is blocked on. The pending-prompt backstop is for the
-        // later ones (a manual code paste losing to the callback server), which do take it.
+        // This branch is UNCANCELLABLE: `LoginIO.select` takes no signal, so all three the line
+        // below composes — the provider's own, the caller's `loginFlow({ signal })`, and the
+        // pending-prompt backstop — are dropped here.
+        //
+        // It costs nothing against pi 0.84's providers, where every `select` is the FIRST call of
+        // `login()` (bedrock, vertex, openai-codex, radius — all of them asking which login method
+        // to use). Nothing is racing it: no callback server is up yet, and `doneSignal` fires when
+        // `auth.login()` RETURNS, which it cannot do while blocked on this await.
+        //
+        // That is a property of the providers, not a guarantee, and nothing here holds it. A
+        // provider that ever issues a `select` after starting its callback server shows up as the
+        // CLI parked on stdin — widen `LoginIO.select` with a signal then.
         const v = await io.select(
           p.message,
           p.options.map((o) => ({ value: o.id, label: o.label, hint: o.description })),
@@ -151,7 +158,6 @@ async function selectProvider(
 ): Promise<Provider> {
   const candidates = candidatesFor(providers, method);
   if (candidates.length === 0) throw new Error(`no provider supports ${method} login`);
-  const byId = new Map(candidates.map((p) => [p.id, p]));
   const options = await Promise.all(
     candidates.map(async (p): Promise<IoOption> => {
       const cred = await store.read(p.id);
@@ -162,8 +168,9 @@ async function selectProvider(
   const id = await io.select("Select a provider", options);
   // Answers the PROVIDER, not its id: the caller needs the object, and resolving it here means the
   // one place that can fail to is the one that just offered the list. Cancel and an id that was
-  // never offered are the same answer — nothing was chosen.
-  const chosen = id === undefined ? undefined : byId.get(id);
+  // never offered are the same answer — nothing was chosen — and `find` gives both, since a
+  // provider id is always a string and `undefined` matches none of them.
+  const chosen = candidates.find((p) => p.id === id);
   if (!chosen) throw new LoginCancelled("no provider selected");
   return chosen;
 }

--- a/src/engines/pi/login.ts
+++ b/src/engines/pi/login.ts
@@ -86,6 +86,11 @@ function authCallbacks(
     signal: userSignal ?? new AbortController().signal,
     prompt: async (p: AuthPrompt): Promise<string> => {
       if (p.type === "select") {
+        // No signal, unlike the text/secret branch below, and not an oversight: every builtin
+        // provider's `select` is the FIRST call of its `login()` — which login method to use — so
+        // nothing is racing it. `doneSignal` fires when `auth.login()` RETURNS, and it cannot
+        // return while this await is what it is blocked on. The pending-prompt backstop is for the
+        // later ones (a manual code paste losing to the callback server), which do take it.
         const v = await io.select(
           p.message,
           p.options.map((o) => ({ value: o.id, label: o.label, hint: o.description })),
@@ -143,9 +148,10 @@ async function selectProvider(
   providers: Provider[],
   method: LoginMethod,
   store: CredentialStore,
-): Promise<string> {
+): Promise<Provider> {
   const candidates = candidatesFor(providers, method);
   if (candidates.length === 0) throw new Error(`no provider supports ${method} login`);
+  const byId = new Map(candidates.map((p) => [p.id, p]));
   const options = await Promise.all(
     candidates.map(async (p): Promise<IoOption> => {
       const cred = await store.read(p.id);
@@ -154,8 +160,12 @@ async function selectProvider(
     }),
   );
   const id = await io.select("Select a provider", options);
-  if (!id) throw new LoginCancelled("no provider selected");
-  return id;
+  // Answers the PROVIDER, not its id: the caller needs the object, and resolving it here means the
+  // one place that can fail to is the one that just offered the list. Cancel and an id that was
+  // never offered are the same answer — nothing was chosen.
+  const chosen = id === undefined ? undefined : byId.get(id);
+  if (!chosen) throw new LoginCancelled("no provider selected");
+  return chosen;
 }
 
 /**
@@ -177,24 +187,24 @@ export async function loginFlow(
   const providers = options.providers ?? builtinProviders();
 
   let method: LoginMethod;
-  let providerId: string;
+  let provider: Provider;
   if (options.provider) {
-    providerId = options.provider;
-    const p = providers.find((x) => x.id === providerId);
-    if (!p) throw new Error(`unknown provider "${providerId}"`);
-    method = options.method ?? (await methodForProvider(io, p));
+    const named = providers.find((x) => x.id === options.provider);
+    if (!named) throw new Error(`unknown provider "${options.provider}"`);
+    provider = named;
+    method = options.method ?? (await methodForProvider(io, provider));
   } else {
     method = options.method ?? (await selectMethod(io));
-    providerId = await selectProvider(io, providers, method, store);
+    provider = await selectProvider(io, providers, method, store);
   }
 
   // Preflight: a no-op modify runs the refuse-corrupt / writability check BEFORE the flow.
-  await store.modify(providerId, async () => undefined);
+  await store.modify(provider.id, async () => undefined);
 
-  const provider = providers.find((p) => p.id === providerId);
-  if (!provider) throw new Error(`unknown provider "${providerId}"`);
+  // Reachable even though both branches above resolved a provider: an explicit `method` bypasses
+  // methodForProvider, so `{ provider: "openai-codex", method: "api_key" }` arrives here.
   const auth = method === "oauth" ? provider.auth.oauth : provider.auth.apiKey;
-  if (!auth?.login) throw new Error(`provider "${providerId}" has no ${method} login`);
+  if (!auth?.login) throw new Error(`provider "${provider.id}" has no ${method} login`);
 
   // `done` cancels any prompt left pending when login resolves (manual-code race backstop).
   const done = new AbortController();
@@ -204,6 +214,6 @@ export async function loginFlow(
   } finally {
     done.abort();
   }
-  await store.modify(providerId, async () => credential);
-  return { provider: providerId, method };
+  await store.modify(provider.id, async () => credential);
+  return { provider: provider.id, method };
 }


### PR DESCRIPTION
The last two findings from the #396 rounds, both narrow. One turned out not to be a defect.

## The unreachable second lookup — real, removed

`loginFlow` resolved the provider id to a `Provider` twice:

```ts
const p = providers.find((x) => x.id === providerId);   // explicit-provider branch
if (!p) throw new Error(`unknown provider "${providerId}"`);
…
const provider = providers.find((p) => p.id === providerId);   // again, after the preflight
if (!provider) throw new Error(`unknown provider "${providerId}"`);
```

The second `throw` is unreachable on both paths that reach it: the explicit branch already threw, and `selectProvider` returned an id drawn from the list it had just built. `selectProvider` answers the `Provider` now, so "nothing was chosen" is decided once — by the code that offered the choice — and the candidate map makes a cancel and an id that was never offered the same answer, which is what they mean.

The remaining `if (!auth?.login) throw` is reachable and gained a comment saying why: an explicit `method` bypasses `methodForProvider`, so `{ provider: "openai-codex", method: "api_key" }` lands there.

## The select-without-a-signal — a real limit, now stated as one

`authCallbacks` composes three signals for the `text`/`secret` prompt and passes none to `select`. That is not half a fix for the pending-prompt hang; it is that **`LoginIO.select` has no signal parameter**, so the branch drops the provider's own signal, the caller's `loginFlow({ signal })`, and the backstop alike.

It costs nothing against pi 0.84, where every `select` is the first call of its `login()` — `openai-codex`, `amazon-bedrock`, `google-vertex`, `radius`, all of them asking which login method to use. No callback server is up yet, and `doneSignal` fires when `auth.login()` *returns*, which it cannot while blocked on that await.

But that is a property of those providers, and nothing in this repo holds it. The comment says so, and names the symptom to look for (the CLI parked on stdin) so the next person does not have to re-derive the analysis. Widening `LoginIO` for a case no provider can currently produce would cost every `fakeIO` in the tests and the clack adapter; widening it the day one can is a small change with an obvious trigger.

## Verification

`npm run lint && npm run typecheck && npm test` — 1591 passing. The cancel path that now carries both rejections is covered by the existing "an empty provider selection fails visibly" test.

