### PR TITLE
refactor(agentcore): the adapter has one wiring, so it takes one shape

### DIFF
--- a/src/channels/agentcore-limits.ts
+++ b/src/channels/agentcore-limits.ts
@@ -1,3 +1,13 @@
+/**
+ * The HOST's body ceilings, and the one place they are computed.
+ *
+ * Lambda Function URLs cap a request at 6 MB, so the forwarder cannot deliver more than that no
+ * matter what the adapter accepts; the body arrives base64-encoded (×4/3) inside a JSON envelope, so
+ * the ORIGINAL body ceiling is smaller still. This is a real capability difference from a resident
+ * host — the GitHub channel's own contract is 25 MiB — which is why `deploy agentcore` states it at
+ * plan time rather than letting an oversized payload surface as an opaque 502.
+ */
+
 /** AWS Lambda Function URLs accept request payloads up to 6 MB. */
 const FUNCTION_URL_REQUEST_LIMIT = 6 * 1000 * 1000;
 

--- a/src/channels/agentcore-service.ts
+++ b/src/channels/agentcore-service.ts
@@ -122,8 +122,8 @@ export async function mountAgentcoreService(
  * by the generated deploy artifacts, never by hand).
  *
  * The adapter IS the surface: the agent's channels live in a table INSIDE the envelope dispatch, a
- * separate namespace from these two paths, so a channel route named `/invocations` is unreachable
- * through the Function URL and cannot shadow anything.
+ * separate namespace from these two paths, so a channel route named `/invocations` is reached
+ * through the Function URL as itself and cannot shadow anything.
  */
 export function mountAgentcore(options: {
   agent: Agent;

--- a/src/channels/agentcore-service.ts
+++ b/src/channels/agentcore-service.ts
@@ -27,10 +27,10 @@ import {
   routesFor,
   startSchedules,
 } from "../service.ts";
-import { type RouteSurface, UnknownScheduleError, agentcoreRoutes } from "./agentcore.ts";
+import { type AgentcoreAdapterOptions, type RouteSurface, UnknownScheduleError, agentcoreRoutes } from "./agentcore.ts";
 import { createStateSync } from "./agentcore-state.ts";
 import { activeWork } from "./busy.ts";
-import { routeKeysConflict, router } from "./serve.ts";
+import { router } from "./serve.ts";
 
 export interface MountAgentcoreServiceOptions {
   /** Wrap the opened agent before anything binds to it (the CLI's turn trace). */
@@ -77,17 +77,14 @@ export async function mountAgentcoreService(
 
   // The adapter registers process-global listeners; this is what takes them down on close.
   const closed = new AbortController();
-  const adapterRoutes = mountAgentcore(
-    {},
-    {
-      signal: closed.signal,
-      agent,
-      stateRoot,
-      schedules: scheduled.schedules,
-      onStateReady: options.onStateReady,
-      lazyChannels,
-    },
-  );
+  const adapterRoutes = mountAgentcore({
+    signal: closed.signal,
+    agent,
+    stateRoot,
+    schedules: scheduled.schedules,
+    onStateReady: options.onStateReady,
+    channels: lazyChannels,
+  });
   const handler = router(adapterRoutes, withControl.mounts);
   log.info(`[fastagent] agentcore: serving POST /invocations + GET /ping (FASTAGENT_AGENTCORE=1)`);
 
@@ -120,30 +117,28 @@ export async function mountAgentcoreService(
 }
 
 /**
- * Mount the AgentCore Runtime adapter (`POST /invocations` + `GET /ping`) over the serving routes —
- * the deployed container's ONLY reachable surface (channels/agentcore.ts). Wired by `start` when
- * `FASTAGENT_AGENTCORE=1` (set by the generated deploy artifacts, never by hand). A channel colliding
- * on either path fails startup, same disposition as the control-plane mount: the adapter's paths are
- * the platform's contract, so a channel shadowing them would silently unserve the whole deployment.
+ * Mount the AgentCore Runtime adapter (`POST /invocations` + `GET /ping`) — the deployed container's
+ * ONLY reachable surface (channels/agentcore.ts). Wired by `start` when `FASTAGENT_AGENTCORE=1` (set
+ * by the generated deploy artifacts, never by hand).
+ *
+ * The adapter IS the surface: the agent's channels live in a table INSIDE the envelope dispatch, a
+ * separate namespace from these two paths, so a channel route named `/invocations` is unreachable
+ * through the Function URL and cannot shadow anything.
  */
-export function mountAgentcore(
-  routes: Routes,
-  options: {
-    agent: Agent;
-    stateRoot: string;
-    schedules: readonly LoadedSchedule[];
-    onStateReady?: () => void;
-    /** Cancels the adapter's process-global registrations on close. */
-    signal?: AbortSignal;
-    /** The serving path's LAZY channel surface: constructed by the adapter on the first envelope
-     *  AFTER the state-snapshot restore, never at boot (channels/agentcore.ts). When absent,
-     *  `routes` is the dispatch target — for wirings whose state root is already authoritative. */
-    lazyChannels?: () => Promise<RouteSurface>;
-  },
-): Routes {
-  const { agent, stateRoot, schedules, onStateReady, lazyChannels, signal } = options;
-  const mounted = agentcoreRoutes({
-    routes: lazyChannels ?? { routes },
+export function mountAgentcore(options: {
+  agent: Agent;
+  stateRoot: string;
+  schedules: readonly LoadedSchedule[];
+  onStateReady?: () => void;
+  /** Cancels the adapter's process-global registrations on close. */
+  signal?: AbortSignal;
+  /** The channel surface, constructed on the first envelope AFTER the state-snapshot restore — never
+   *  at boot, where the mount is pre-restore (channels/agentcore.ts). */
+  channels: AgentcoreAdapterOptions["channels"];
+}): Routes {
+  const { agent, stateRoot, schedules, onStateReady, channels, signal } = options;
+  return agentcoreRoutes({
+    channels,
     agent,
     stateRoot,
     isBusy: () => activeWork() > 0,
@@ -166,18 +161,4 @@ export function mountAgentcore(
             return fireScheduleOnce({ agent, stateRoot, schedule, slot });
           },
   });
-  // EMPTY on the lazy path, and that is not a hole: there the channels are a table INSIDE the
-  // envelope dispatch, while these two are the outer router's — separate namespaces, so a channel
-  // route named `/invocations` is reachable through the Function URL and cannot shadow the adapter.
-  // The check is for the eager wiring, where `routes` and the adapter merge into one table.
-  const collisions = Object.keys(routes).filter((key) =>
-    Object.keys(mounted).some((adapterKey) => routeKeysConflict(key, adapterKey)),
-  );
-  if (collisions.length > 0) {
-    throw new Error(
-      `channel route(s) ${collisions.map((key) => `"${key}"`).join(", ")} collide with the AgentCore adapter ` +
-        `(/invocations, /ping) — rename the channel route`,
-    );
-  }
-  return { ...routes, ...mounted };
 }

--- a/src/channels/agentcore.ts
+++ b/src/channels/agentcore.ts
@@ -40,15 +40,6 @@ import { createInvokeHandler } from "./http.ts";
 import { text } from "./respond.ts";
 import { MAX_ENVELOPE_BYTES, MAX_WEBHOOK_BODY_BYTES } from "./agentcore-limits.ts";
 
-/**
- * The HOST's webhook body limit, and the one place it is computed. Lambda Function URLs cap a request
- * at 6 MB, so the forwarder cannot deliver more than that no matter what the adapter accepts; the
- * body arrives base64-encoded (×4/3) inside a JSON envelope, so the ORIGINAL body ceiling is smaller
- * still. This is a real capability difference from a resident host — the GitHub channel's own
- * contract is 25 MiB — so `deploy agentcore` says so at plan time rather than letting an oversized
- * payload surface as an opaque 502.
- */
-
 /** What the forwarder Lambda / EventBridge deliver in the `/invocations` payload. Every kind may
  *  carry `wake` — the forwarder's self-resolved public URL, which the adapter persists so the wake
  *  ALARM sink (schedule/wake-alarm.ts) can call back without the URL being baked anywhere. */
@@ -112,13 +103,14 @@ export interface RouteSurface {
 }
 
 export interface AgentcoreAdapterOptions {
-  /** The serving routes a direct deployment would mount (channels or the builtin invoke + health).
-   *  The serving path passes a LAZY factory: channel construction loads channel state and replays
-   *  durable turn intent, so on AgentCore it must not run until the state root is authoritative —
-   *  which happens at the first envelope's `stateSync.ready()` (the restore URLs only an envelope
-   *  carries), never at boot, where the mount is pre-restore (empty after every version update).
-   *  An eager `Routes` value remains supported for wirings whose state root is already durable. */
-  routes: RouteSurface | (() => Promise<RouteSurface> | RouteSurface);
+  /** The serving routes a direct deployment would mount (channels or the builtin invoke + health),
+   *  built LAZILY: channel construction loads channel state and replays durable turn intent, so on
+   *  AgentCore it must not run until the state root is authoritative — which happens at the first
+   *  envelope's `stateSync.ready()` (the restore URLs only an envelope carries), never at boot, where
+   *  the mount is pre-restore (empty after every version update). A factory, not a value: there is no
+   *  moment during construction at which the right answer is knowable. May answer synchronously — the
+   *  resolution chain normalizes it either way. */
+  channels: () => Promise<RouteSurface> | RouteSurface;
   agent: Agent;
   /** Where the forwarder URL from envelopes is persisted for the wake-alarm sink (the state root). */
   stateRoot: string;
@@ -159,14 +151,13 @@ function secretMatches(actual: unknown, expected: string | undefined): boolean {
 }
 
 /**
- * Build the AgentCore serving surface: `{ "POST /invocations", "GET /ping" }`. The caller merges it
- * over its routes (collision-checked at the mount site, serve.ts) — the inner routes stay mounted
- * too, which is harmless (AgentCore routes only /invocations and /ping into the container) and keeps
- * a local `curl` debug surface.
+ * Build the AgentCore serving surface: `{ "POST /invocations", "GET /ping" }` — the whole of what the
+ * platform routes into the container. The agent's own channels are not beside these: they are a table
+ * inside the envelope dispatch below, reached only by unwrapping a forwarder envelope.
  */
 export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
-  const { routes, agent, stateRoot, isBusy, fire, stateSync, ingressSecret, onStateReady } = options;
-  // Lazy channel construction (see AgentcoreAdapterOptions.routes) — resolved ONCE per process, on
+  const { channels, agent, stateRoot, isBusy, fire, stateSync, ingressSecret, onStateReady } = options;
+  // Lazy channel construction (see AgentcoreAdapterOptions.channels) — resolved ONCE per process, on
   // the first trusted envelope after the state root is authoritative, and the outcome is cached
   // EITHER WAY. Success: the same resident channels a direct host keeps. Failure too: construction
   // is an ACTIVATION with side effects — loadChannels builds every healthy channel (starting its
@@ -182,7 +173,7 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
       // The factory runs INSIDE the chain: a synchronous throw must land in the cached rejection,
       // not escape before `dispatchP` is assigned (which would silently re-run the activation).
       dispatchP = Promise.resolve()
-        .then(() => (typeof routes === "function" ? routes() : routes))
+        .then(channels)
         .then((surface) => router(surface.routes, surface.mounts));
       dispatchP.catch(() => {}); // observed here so the CACHED rejection is never "unhandled"
     }

--- a/test/agentcore-adapter.test.ts
+++ b/test/agentcore-adapter.test.ts
@@ -30,7 +30,9 @@ function scriptedAgent(events: AgentEvent[] = [{ type: "text", delta: "hi" }, { 
 const SECRET = "ingress-s3cret";
 
 interface AdapterOverrides {
-  routes?: RouteSurface | (() => Promise<RouteSurface> | RouteSurface);
+  /** A surface, or a factory for one. Production takes only the factory (construction must not run
+   *  until the state root is authoritative); the plain value is this fixture's shorthand. */
+  channels?: RouteSurface | (() => Promise<RouteSurface> | RouteSurface);
   agent?: Agent;
   isBusy?: () => boolean;
   fire?: (name: string, slot: Date) => Promise<ScheduleFireOutcome>;
@@ -58,9 +60,13 @@ function fakeStateSync(over: Partial<StateSync> = {}): StateSync & { seen: strin
 
 const stateRoot = await mkdtemp(join(tmpdir(), "fa-agentcore-adapter-"));
 
+/** A narrowing local: a property access is not narrowed inside the closure below. */
+const asFactory = (given: AdapterOverrides["channels"]): (() => Promise<RouteSurface> | RouteSurface) =>
+  typeof given === "function" ? given : () => given ?? { routes: {} };
+
 const adapter = (over: AdapterOverrides = {}): Routes =>
   agentcoreRoutes({
-    routes: over.routes ?? { routes: {} },
+    channels: asFactory(over.channels),
     agent: over.agent ?? scriptedAgent(),
     stateRoot,
     isBusy: over.isBusy ?? (() => false),
@@ -95,7 +101,7 @@ describe("agentcore adapter: lazy channel construction", () => {
     let built = 0;
     const routes = adapter({
       stateSync: sync,
-      routes: () => {
+      channels: () => {
         order.push("construct");
         built += 1;
         return { routes: health };
@@ -119,7 +125,7 @@ describe("agentcore adapter: lazy channel construction", () => {
     // (and 3s-apart deploy probes) follow; a fresh session is the retry boundary.
     let attempts = 0;
     const routes = adapter({
-      routes: () => {
+      channels: () => {
         attempts += 1;
         throw new Error("FEISHU_APP_SECRET is not set");
       },
@@ -135,7 +141,7 @@ describe("agentcore adapter: lazy channel construction", () => {
   });
 
   it("a probe reports construction structurally over transport-200 (diagnostics must survive the forwarder)", async () => {
-    const ok = adapter({ routes: () => ({ routes: health }) });
+    const ok = adapter({ channels: () => ({ routes: health }) });
     const okRes = await postEnvelope(ok, { kind: "probe" });
     expect(okRes.status).toBe(200);
     expect(await okRes.json()).toEqual({ ok: true });
@@ -143,7 +149,7 @@ describe("agentcore adapter: lazy channel construction", () => {
     // The forwarder rewrites any non-200 transport into an opaque 502, so the failure verdict MUST
     // ride a transport-200 body — that is the whole reason the probe kind exists.
     const broken = adapter({
-      routes: () => {
+      channels: () => {
         throw new Error("FEISHU_APP_SECRET is not set");
       },
     });
@@ -160,7 +166,7 @@ describe("agentcore adapter: lazy channel construction", () => {
         throw new Error("snapshot GET failed: 403");
       },
     });
-    const routes = adapter({ stateSync: sync, routes: () => ({ routes: health }) });
+    const routes = adapter({ stateSync: sync, channels: () => ({ routes: health }) });
     const res = await postEnvelope(routes, {
       kind: "probe",
       state: { getUrl: "https://s3/g", putUrl: "https://s3/p" },
@@ -170,7 +176,9 @@ describe("agentcore adapter: lazy channel construction", () => {
     expect(verdict.ok).toBe(false);
     expect(verdict.error).toContain("state restore failed");
 
-    expect((await postUntrusted(adapter({ routes: () => ({ routes: health }) }), { kind: "probe" })).status).toBe(403);
+    expect((await postUntrusted(adapter({ channels: () => ({ routes: health }) }), { kind: "probe" })).status).toBe(
+      403,
+    );
   });
 
   it("a schedule fire initializes the channels first, and a broken channel does NOT silence the clock", async () => {
@@ -181,7 +189,7 @@ describe("agentcore adapter: lazy channel construction", () => {
     });
     const routes = adapter({
       fire,
-      routes: () => {
+      channels: () => {
         order.push("construct");
         return { routes: health };
       },
@@ -195,7 +203,7 @@ describe("agentcore adapter: lazy channel construction", () => {
     const fire2 = vi.fn(async (): Promise<ScheduleFireOutcome> => ({ fired: true, ms: 5 }));
     const broken = adapter({
       fire: fire2,
-      routes: () => {
+      channels: () => {
         throw new Error("channels/lark.ts is broken");
       },
     });
@@ -206,7 +214,7 @@ describe("agentcore adapter: lazy channel construction", () => {
   it("a wake-poke resolves construction too (the deploy probe; alarm wakes replay checkpointed turns)", async () => {
     let built = 0;
     const routes = adapter({
-      routes: () => {
+      channels: () => {
         built += 1;
         return { routes: {} };
       },
@@ -215,7 +223,7 @@ describe("agentcore adapter: lazy channel construction", () => {
     expect(built).toBe(1);
 
     const broken = adapter({
-      routes: () => {
+      channels: () => {
         throw new Error("channels/lark.ts is broken");
       },
     });
@@ -284,7 +292,7 @@ describe("agentcore adapter: webhook envelope", () => {
   it("reconstructs the original request (method/path/headers/body) and rides the reply back byte-exact", async () => {
     const seen: { method: string; secret: string | null; body: string }[] = [];
     const routes = adapter({
-      routes: {
+      channels: {
         routes: {
           "POST /telegram": async (req) => {
             seen.push({
@@ -316,7 +324,7 @@ describe("agentcore adapter: webhook envelope", () => {
   });
 
   it("enforces the original webhook-body limit even if a caller bypasses the public forwarder", async () => {
-    const routes = adapter({ routes: { routes: { "POST /hook": () => new Response("must not run") } } });
+    const routes = adapter({ channels: { routes: { "POST /hook": () => new Response("must not run") } } });
     const res = await postEnvelope(routes, {
       kind: "webhook",
       method: "POST",
@@ -330,7 +338,7 @@ describe("agentcore adapter: webhook envelope", () => {
 
   it("carries a non-2xx channel response inside the envelope (transport stays 200)", async () => {
     const routes = adapter({
-      routes: { routes: { "POST /telegram": () => new Response("forbidden\n", { status: 403 }) } },
+      channels: { routes: { "POST /telegram": () => new Response("forbidden\n", { status: 403 }) } },
     });
     const res = await postEnvelope(routes, { kind: "webhook", method: "POST", path: "/telegram" });
     expect(res.status).toBe(200);
@@ -350,7 +358,7 @@ describe("agentcore adapter: webhook envelope", () => {
   it("the query string survives the round trip (a channel reading searchParams sees it)", async () => {
     const seen: string[] = [];
     const routes = adapter({
-      routes: {
+      channels: {
         routes: {
           "GET /hook": (req) => {
             seen.push(new URL(req.url).searchParams.get("code") ?? "(none)");
@@ -440,7 +448,7 @@ describe("agentcore adapter: wake-poke envelope + wake-url capture", () => {
   it("persists the forwarder URL ridden on an envelope for the wake-alarm sink", async () => {
     const root = await mkdtemp(join(tmpdir(), "fa-wake-url-"));
     const routes = agentcoreRoutes({
-      routes: { routes: {} },
+      channels: () => ({ routes: {} }),
       agent: scriptedAgent(),
       stateRoot: root,
       isBusy: () => false,
@@ -507,7 +515,7 @@ describe("agentcore adapter: cross-deploy state", () => {
     });
     const routes = adapter({
       stateSync: sync,
-      routes: {
+      channels: {
         routes: {
           "POST /hook": () => {
             order.push("dispatch");
@@ -530,7 +538,7 @@ describe("agentcore adapter: cross-deploy state", () => {
           throw new Error("snapshot GET failed: 500");
         },
       }),
-      routes: {
+      channels: {
         routes: {
           "POST /hook": () => new Response("must not run"),
         },
@@ -565,7 +573,7 @@ describe("agentcore adapter: cross-deploy state", () => {
 describe("agentcore adapter: the authentication boundary", () => {
   it("rejects unauthenticated INTERNAL kinds — InvokeAgentRuntime is an ordinary IAM action, not proof of origin", async () => {
     const fire = vi.fn(async () => ({ fired: true, ms: 1 }) as ScheduleFireOutcome);
-    const routes = adapter({ fire, routes: { routes: { "POST /hook": () => new Response("must not run") } } });
+    const routes = adapter({ fire, channels: { routes: { "POST /hook": () => new Response("must not run") } } });
 
     for (const envelope of [
       { kind: "schedule-fire", name: "digest", slot: "2026-07-28T09:00:00Z" },

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -61,7 +61,7 @@ describe("mountAgentcore", () => {
 
     const closed = new AbortController();
     agentcoreRoutes({
-      routes: { routes: {}, mounts: [] },
+      channels: () => ({ routes: {}, mounts: [] }),
       agent,
       stateRoot: "/tmp",
       isBusy: () => false,
@@ -85,26 +85,21 @@ describe("mountAgentcore", () => {
   };
   const schedule: LoadedSchedule = { name: "job", cron: "0 * * * *", tz: "UTC", prompt: "go" };
 
-  it("mounts /invocations + /ping over the serving routes", async () => {
+  it("mounts the adapter's two paths, and ONLY those — the channels live behind the envelope", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-agentcore-mount-"));
-    const routes = mountAgentcore(
-      { "POST /telegram": () => text("ok\n", 200) },
-      { agent, stateRoot: dir, schedules: [] },
-    );
-    expect(Object.keys(routes).sort()).toEqual(["GET /ping", "POST /invocations", "POST /telegram"]);
+    const routes = mountAgentcore({
+      agent,
+      stateRoot: dir,
+      schedules: [],
+      channels: () => ({ routes: { "POST /telegram": () => text("ok\n", 200) } }),
+    });
+    // The channel is NOT beside them: AgentCore routes only these two into the container, so a
+    // channel mounted alongside would be unreachable anyway — and a channel keyed `/invocations`
+    // cannot shadow the adapter, because it is dispatched in the envelope's own namespace.
+    expect(Object.keys(routes).sort()).toEqual(["GET /ping", "POST /invocations"]);
     expect(await (await routes["GET /ping"]!(new Request("http://x/ping"))).json()).toMatchObject({
       status: "Healthy",
     });
-  });
-
-  it("fails startup on a channel colliding with the adapter's paths", () => {
-    expect(() =>
-      mountAgentcore({ "POST /invocations": () => text("mine\n", 200) }, { agent, stateRoot: "/tmp", schedules: [] }),
-    ).toThrow(/collide with the AgentCore adapter/);
-    // An any-method key names the same route as the adapter's method-qualified one.
-    expect(() =>
-      mountAgentcore({ "/ping": () => text("mine\n", 200) }, { agent, stateRoot: "/tmp", schedules: [] }),
-    ).toThrow(/collide with the AgentCore adapter/);
   });
 
   it("binds schedule fires by name — an unknown name 404s through the adapter", async () => {
@@ -112,7 +107,7 @@ describe("mountAgentcore", () => {
     // schedule-fire is an INTERNAL kind: without the ingress secret the adapter 403s it before
     // routing (see the adapter's authentication boundary), so the mount must carry it.
     process.env.FASTAGENT_INGRESS_SECRET = "ingress-s3cret";
-    const routes = mountAgentcore({}, { agent, stateRoot: dir, schedules: [schedule] });
+    const routes = mountAgentcore({ agent, stateRoot: dir, schedules: [schedule], channels: () => ({ routes: {} }) });
     const fire = (name: string): Promise<Response> | Response =>
       routes["POST /invocations"]!(
         new Request("http://x/invocations", {


### PR DESCRIPTION
`agentcoreRoutes` accepted its channel surface two ways — a `RouteSurface` value or a factory — and
`mountAgentcore` took a `Routes` table to merge the adapter over. Neither served a caller.

The serving path (`mountAgentcoreService`) always passes a factory, and always passes `{}` as the
table, because on this host it cannot do anything else: channel construction loads channel state and
replays durable turn intent, and the state mount at boot is pre-restore — empty after every runtime
version update. There is no moment during construction at which an eager value is the right answer.
The union's second arm described a wiring that cannot exist here.

What went with it:

- The route-collision check in `mountAgentcore`. Its own comment already said it was inert on the
  lazy path — the channels are a table *inside* the envelope dispatch, a separate namespace from the
  adapter's two paths, so a channel keyed `/invocations` was never able to shadow anything. It was
  guarding the eager wiring, which was only ever reached from tests.
- `routeKeysConflict` from this module's imports.

`channels` may still answer synchronously: the resolution chain is `Promise.resolve().then(channels)`,
which normalizes either form with no branch. The eager *value* shorthand moved into the adapter test's
own fixture, where a convenience for writing tests belongs — production takes only the factory.

Also: the "HOST's webhook body limit, and the one place it is computed" block sat in `agentcore.ts`
above the envelope type, documenting constants that live in `agentcore-limits.ts`. It carried the
rationale that file was missing (why the ceiling is smaller than 6 MB, and why `deploy agentcore`
states it at plan time), so it moved there rather than being deleted.

The mount test now asserts the surface is exactly `POST /invocations` + `GET /ping` — the fact the
deleted collision check was obscuring.

Local: `npm run lint && npm run typecheck && npm test` — 116 files, 1590 tests green (the collision
test went with the collision check).
