### PR TITLE
refactor(cli): dev and start print one report, not two copies of one

### DIFF
--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -7,18 +7,15 @@ import { resolve } from "node:path";
 import { runDevSupervisor } from "../../dev-supervisor.ts";
 import { loadDotEnv } from "../../env.ts";
 
-import { reportFindingsIfChanged, reportToolCollisions } from "../../engines/pi/report.ts";
-import { reportModuleLoadFailures, setLogLevel } from "../../log.ts";
-import { CODING_TOOL_NAMES } from "../../engines/pi/create.ts";
+import { setLogLevel } from "../../log.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { mountAgentService } from "../../service.ts";
 import { logAgentLoop } from "../../observe.ts";
 import { installProxyFetch } from "../../proxy.ts";
-import { workspaceHint } from "../../paths.ts";
 import { bindAddress } from "../../bind.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import { SHUTDOWN_GRACE_MS, assertTunnelBindable, maybeTunnel, reportServing, serve } from "../serve.ts";
-import { parseBind, parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
+import { parseBind, parsePort, reportAssembly, resolveFirstRunModel } from "../shared.ts";
 
 export interface DevOptions {
   port?: string;
@@ -69,15 +66,8 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
     authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
     serving: true, // long-running serve: the scheduler poller runs (wake mounts iff config.selfSchedule)
   }).catch(failStartup);
-  reportLine("agent", a.agentDir);
-  reportLine("workspace", a.workspace);
-  reportWorkspaceHint(workspaceHint(a));
-  reportLine("config", a.configPath ?? "(none)");
-  reportLine("model", `${a.modelSpec}${a.config.thinkingLevel ? ` (thinking: ${a.config.thinkingLevel})` : ""}`);
-  await reportAuth(a.agentDir, a.modelSpec, a.authPath);
-  reportAgentsSkillsTools(a);
-  // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev, gated
-  // out in start (level info), keeping end-user content out of production logs. Wired in both postures.
+  // The same report `start` prints; `config:` is dev's own extra (see reportAssembly on the asymmetry).
+  await reportAssembly(a, { beforeModel: [["config", a.configPath ?? "(none)"]] });
   // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
   // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
   const configured = a.config.http?.host;
@@ -108,21 +98,4 @@ async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
       onShutdown: () => service.close(),
     },
   );
-}
-
-type Assembled = Awaited<ReturnType<typeof createPiAgentFromDir>>;
-
-/** The agents/skills/tools/collisions report lines. */
-function reportAgentsSkillsTools(a: Assembled): void {
-  reportLine("context", a.definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
-  if (a.definition.persona) reportLine("persona", "persona.md");
-  reportLine("skills", a.definition.skills.map((s) => s.name).join(", ") || "(none)");
-  reportLine("codingTools", CODING_TOOL_NAMES.join(", "));
-  if (a.toolNames.length > 0) reportLine("tools", a.toolNames.join(", "));
-  if (a.deferredToolNames.length > 0) {
-    reportLine("deferred", `${a.deferredToolNames.join(", ")} (activated via search_tools)`);
-  }
-  reportToolCollisions(a.toolCollisions);
-  reportModuleLoadFailures(a.toolFailures);
-  reportFindingsIfChanged(a.definition.dir, a.definition);
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -7,17 +7,8 @@ import { dirname, resolve } from "node:path";
 import { authSeedBytes, collectAuthSeed } from "../../deploy/fly/run.ts";
 import { loadDotEnv } from "../../env.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
-import {
-  SECRET_FILE_MODE,
-  ensureSecretsDir,
-  resolveSecretsDir,
-  workspaceHint,
-  isUnderDir,
-  exists,
-} from "../../paths.ts";
-import { reportFindingsIfChanged, reportToolCollisions } from "../../engines/pi/report.ts";
-import { reportModuleLoadFailures, log, setLogLevel } from "../../log.ts";
-import { CODING_TOOL_NAMES } from "../../engines/pi/create.ts";
+import { SECRET_FILE_MODE, ensureSecretsDir, resolveSecretsDir, isUnderDir, exists } from "../../paths.ts";
+import { log, setLogLevel } from "../../log.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { mountAgentService } from "../../service.ts";
 import { logAgentLoop } from "../../observe.ts";
@@ -29,7 +20,7 @@ import { createWakeAlarmSink } from "../../schedule/wake-alarm.ts";
 import { setWakeupsSink } from "../../schedule/wakeups.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import { SHUTDOWN_GRACE_MS, assertTunnelBindable, maybeTunnel, reportServing, serve } from "../serve.ts";
-import { parseBind, parsePort, reportAuth, reportLine, resolveFirstRunModel, reportWorkspaceHint } from "../shared.ts";
+import { parseBind, parsePort, reportAssembly, resolveFirstRunModel } from "../shared.ts";
 
 export interface StartOptions {
   port?: string;
@@ -62,39 +53,16 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   // The same opener dev uses (single assembly source), just no watch.
   const sessionsDirOverride = resolveSessionsDirOverride(opts.sessionsDir);
   const opened = await openStartDir(dir, opts, sessionsDirOverride);
-  const {
-    agent,
-    definition,
-    agentDir,
-    workspace,
-    config,
-    modelSpec,
-    stateRoot,
-    sessionsDir,
-    authPath,
-    toolNames,
-    deferredToolNames,
-    toolCollisions,
-    toolFailures,
-  } = opened;
+  const { agent, agentDir, config, stateRoot, sessionsDir } = opened;
 
-  reportLine("agent", agentDir);
-  reportLine("workspace", workspace);
-  reportWorkspaceHint(workspaceHint({ agentDir, workspace }));
-  reportLine("model", `${modelSpec}${config.thinkingLevel ? ` (thinking: ${config.thinkingLevel})` : ""}`);
-  await reportAuth(agentDir, modelSpec, authPath);
-  reportLine("context", definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
-  if (definition.persona) reportLine("persona", "persona.md");
-  reportLine("skills", definition.skills.map((s) => s.name).join(", ") || "(none)");
-  reportLine("codingTools", CODING_TOOL_NAMES.join(", "));
-  if (toolNames.length > 0) reportLine("tools", toolNames.join(", "));
-  if (deferredToolNames.length > 0) {
-    reportLine("deferred", `${deferredToolNames.join(", ")} (activated via search_tools)`);
-  }
-  reportToolCollisions(toolCollisions);
-  reportModuleLoadFailures(toolFailures);
-  reportLine("state", stateRoot);
-  reportLine("sessions", sessionsDir);
+  // The same report `dev` prints; `state:`/`sessions:` are start's own extras, and the persistence
+  // notes below are why (see reportAssembly on the asymmetry).
+  await reportAssembly(opened, {
+    afterTools: [
+      ["state", stateRoot],
+      ["sessions", sessionsDir],
+    ],
+  });
   // State defaults under the agent dir, which a redeploy may replace wholesale. Gate on where the
   // state root ACTUALLY resolved (inside the agent dir?), not on the raw env var: an empty
   // `FASTAGENT_STATE_DIR=""` reads as unset (resolveStateRoot) and still lands in-agent, so a raw
@@ -117,7 +85,6 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
         `FASTAGENT_SECRETS_DIR at a persistent volume so a redeploy that replaces the dir does not wipe them.`,
     );
   }
-  reportFindingsIfChanged(definition.dir, definition);
 
   // Same debug turn trace as dev; gated out here by the info level (see dev.ts serveOnce).
   const traced = logAgentLoop(agent);

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -17,17 +17,6 @@ import { announceWebhooks, startCloudflareTunnel } from "../tunnel.ts";
 import { failStartup, failUsage } from "./fail.ts";
 
 /**
- * Mount the session control plane (`/control/*`) when the agent enabled it
- * (`config.sessionControl`): merge the bearer-authenticated routes and return an announcer that
- * writes `<stateRoot>/control.json` — `{ url, token }`, 0600 — once the port is known. The file is
- * the LOCAL discovery channel (`fastagent attach`, a local desktop app); filesystem permissions are
- * its trust boundary, and each boot overwrites it with a fresh per-boot token. A user channel
- * colliding on `/control/*` fails startup — the same disposition as a channel-channel collision
- * (routesFor): `sessionControl` is an explicit opt-in, so declaring both is a configuration error,
- * and silently shadowing either side would serve a surface the author didn't write.
- */
-
-/**
  * Refuse `--tunnel` with a bind that cloudflared cannot reach: it dials the NAME `localhost:<port>`
  * (the dev supervisor's tunnel too), so anything outside `127.0.0.1`/`::1`/wildcard — including a
  * `127.0.0.2` bind, loopback though it is — would leave the tunnel up and 502ing every request.
@@ -50,15 +39,6 @@ export function assertTunnelBindable(host: string | undefined, tunnel: boolean, 
 }
 
 /**
- * The startup lines that name WHERE the serve is: the bind report, and the curl the reader copies.
- * ONE function because they are one message — they were two, and `--bind` updated the first while the
- * second went on dialing `localhost`, which is precisely what a non-wildcard bind stops answering. Now
- * neither can be changed without the other in view, and the address has a single derivation.
- *
- * A wildcard bind is every interface, and naming one address there would understate it — but the curl
- * still needs one to dial, which is what `clientHost` gives (loopback for a wildcard, itself otherwise).
- */
-/**
  * The "we are serving" report: the supervisor message `dev`'s watcher waits for, the addresses, and
  * what mounted. One function because both commands must say the same thing at the same moment —
  * after readiness, never at socket bind.
@@ -72,6 +52,15 @@ export function reportServing(service: AgentService, host: string | undefined, b
   }
 }
 
+/**
+ * The startup lines that name WHERE the serve is: the bind report, and the curl the reader copies.
+ * ONE function because they are one message — they were two, and `--bind` updated the first while the
+ * second went on dialing `localhost`, which is precisely what a non-wildcard bind stops answering. Now
+ * neither can be changed without the other in view, and the address has a single derivation.
+ *
+ * A wildcard bind is every interface, and naming one address there would understate it — but the curl
+ * still needs one to dial, which is what `clientHost` gives (loopback for a wildcard, itself otherwise).
+ */
 export function readyAddressLines(host: string | undefined, boundPort: number, builtinInvoke: boolean): string[] {
   const dial = `${clientHost(host)}:${boundPort}`;
   const lines = [
@@ -85,16 +74,17 @@ export function readyAddressLines(host: string | undefined, boundPort: number, b
   return lines;
 }
 
-/**
- * Bind HTTP, open long-connection channels, and report ready only when both forms are usable. Each
- * adapter owns reconnects; a terminal close rejects `closed` and fails the process visibly. Abort is
- * the sole clean-shutdown command. `host` unset binds all interfaces.
- */
 /** What the CLI gives a service to stop in, and the hard exit that follows it. The order matters:
  *  a forced exit before the service answers would report a clean shutdown over a stuck channel. */
 export const SHUTDOWN_GRACE_MS = 800;
 const FORCED_EXIT_MS = 1_500;
 
+/**
+ * Bind HTTP and report ready — but only once the SERVICE is, which is not the same moment: a bound
+ * socket is not a serving agent while a declared long-connection channel is still dialling, so this
+ * awaits `hooks.ready` (mountAgentService owns the connections themselves) before announcing
+ * anything. Signals are the sole clean-shutdown command; `host` unset binds all interfaces.
+ */
 export function serve(
   handler: ChannelHandler,
   bind: { port: number; host?: string },

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -28,7 +28,13 @@ import {
   providerAuthStatuses,
 } from "../engines/pi/models.ts";
 import { formatAuthReport } from "./auth-view.ts";
-import { log } from "../log.ts";
+import { CODING_TOOL_NAMES } from "../engines/pi/create.ts";
+import type { LoadedDefinition } from "../engines/pi/definition.ts";
+import type { ModuleLoadFailure } from "../loader.ts";
+import type { ToolCollision } from "../engines/pi/tool.ts";
+import { reportFindingsIfChanged, reportToolCollisions } from "../engines/pi/report.ts";
+import { workspaceHint } from "../paths.ts";
+import { log, reportModuleLoadFailures } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
 import { bindAddress, isBindAddress } from "../bind.ts";
 import { failStartup, failUsage } from "./fail.ts";
@@ -39,16 +45,76 @@ import { failStartup, failUsage } from "./fail.ts";
  * `codingTools:` joined `workspace:`/`config:`/`model:`/`state:`. `info` keeps its own writer on purpose: its report is
  * stdout DATA (pipeable, its own label set, its own width), not a log line — the shared thing is the
  * policy (pad, never hand-space), not a constant.
+ *
+ * Private to this module: {@link reportAssembly} is the report, and a command reaching past it for a
+ * line of its own is how the two copies of that report came to differ.
  */
-export function reportLine(label: string, value: string): void {
+function reportLine(label: string, value: string): void {
   log.info(`[fastagent] ${`${label}:`.padEnd(13)}${value}`);
 }
 
 /** The workspace hint under the `agent:`/`workspace:` pair, when there is one ({@link workspaceHint}):
  *  you pointed at the agent, and the project around it is probably what you meant. A hint, so it renders
- *  as one and is silent otherwise — `dev` and `start` both print the pair, so both ask for it. */
-export function reportWorkspaceHint(hint: string | undefined): void {
+ *  as one and is silent otherwise. */
+function reportWorkspaceHint(hint: string | undefined): void {
   if (hint) reportLine("hint", hint);
+}
+
+/** What the startup report reads off an opened directory — a structural subset of the opener's return,
+ *  spelled out so this module does not depend on that function's whole shape. */
+export interface ReportableAssembly {
+  agentDir: string;
+  workspace: string;
+  modelSpec: string;
+  authPath: string;
+  config: { thinkingLevel?: string };
+  definition: LoadedDefinition;
+  toolNames: string[];
+  deferredToolNames: string[];
+  toolCollisions: ToolCollision[];
+  toolFailures: ModuleLoadFailure[];
+}
+
+/**
+ * What `dev` and `start` say about the directory they just opened, in the order they say it.
+ *
+ * ONE function because it is one report: the two commands wrote it out line by line, and the copies
+ * had already diverged over which lines exist at all — `dev` naming the config file, `start` naming
+ * state and sessions. A line added to one of two hand-written copies is invisible in the other.
+ *
+ * The divergence itself is PRESERVED, not resolved: `start`'s `state:`/`sessions:` pair introduces the
+ * persistence warnings that follow it in production posture, and `dev`'s `config:` has no counterpart
+ * there. Both are passed as explicit extras by the caller, so the asymmetry is visible at the call
+ * site rather than buried in two copies of a list. Whether it is RIGHT is a separate question from
+ * whether it has one owner.
+ */
+export async function reportAssembly(
+  a: ReportableAssembly,
+  extras: {
+    /** Printed between `workspace:`/`hint:` and `model:` (`dev` names the config file here). */
+    beforeModel?: [label: string, value: string][];
+    /** Printed after the tool lines, before findings (`start` names state + sessions here). */
+    afterTools?: [label: string, value: string][];
+  } = {},
+): Promise<void> {
+  reportLine("agent", a.agentDir);
+  reportLine("workspace", a.workspace);
+  reportWorkspaceHint(workspaceHint(a));
+  for (const [label, value] of extras.beforeModel ?? []) reportLine(label, value);
+  reportLine("model", `${a.modelSpec}${a.config.thinkingLevel ? ` (thinking: ${a.config.thinkingLevel})` : ""}`);
+  await reportAuth(a.agentDir, a.modelSpec, a.authPath);
+  reportLine("context", a.definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
+  if (a.definition.persona) reportLine("persona", "persona.md");
+  reportLine("skills", a.definition.skills.map((s) => s.name).join(", ") || "(none)");
+  reportLine("codingTools", CODING_TOOL_NAMES.join(", "));
+  if (a.toolNames.length > 0) reportLine("tools", a.toolNames.join(", "));
+  if (a.deferredToolNames.length > 0) {
+    reportLine("deferred", `${a.deferredToolNames.join(", ")} (activated via search_tools)`);
+  }
+  reportToolCollisions(a.toolCollisions);
+  reportModuleLoadFailures(a.toolFailures);
+  for (const [label, value] of extras.afterTools ?? []) reportLine(label, value);
+  reportFindingsIfChanged(a.definition.dir, a.definition);
 }
 
 /** Both stdin and stdout are a terminal — the precondition for an interactive prompt. */

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -87,6 +87,10 @@ export interface ReportableAssembly {
  * there. Both are passed as explicit extras by the caller, so the asymmetry is visible at the call
  * site rather than buried in two copies of a list. Whether it is RIGHT is a separate question from
  * whether it has one owner.
+ *
+ * Findings (skill collisions, definition diagnostics) CLOSE the report — they are about the assembly
+ * just printed. What a command says next is its own posture talk, not report: `start`'s persistence
+ * notes now follow them rather than precede them.
  */
 export async function reportAssembly(
   a: ReportableAssembly,

--- a/test/cli-shared.test.ts
+++ b/test/cli-shared.test.ts
@@ -94,6 +94,7 @@ describe("reportAssembly (the startup report dev and start share)", () => {
       await reportAssembly(opened, extras);
     } finally {
       spy.mockRestore();
+      setLogLevel("info"); // restore the default the other suites rely on — the level is a module singleton
     }
     // Lines arrive as `INFO  [fastagent] <label>: <value>`; the label is what this pins.
     return out.map(

--- a/test/cli-shared.test.ts
+++ b/test/cli-shared.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { loginWithKeyCheck } from "../src/cli/shared.ts";
+import { describe, expect, it, vi } from "vitest";
+import { loginWithKeyCheck, reportAssembly } from "../src/cli/shared.ts";
+import { setLogLevel } from "../src/log.ts";
 import { LoginCancelled, type LoginMethod } from "../src/engines/pi/login.ts";
 
 /** Record every flow call's (provider, method) and pop canned results/verdicts in order. */
@@ -61,5 +62,73 @@ describe("loginWithKeyCheck (the rejected-key retry loop)", () => {
     await expect(
       loginWithKeyCheck(undefined, "/tmp/auth.json", undefined, { flow, verify: f.verify }),
     ).rejects.toBeInstanceOf(LoginCancelled);
+  });
+});
+
+describe("reportAssembly (the startup report dev and start share)", () => {
+  const opened = {
+    agentDir: "/w/agent",
+    workspace: "/w",
+    modelSpec: "p/m",
+    authPath: "/w/agent/.secrets/auth.json",
+    config: {},
+    definition: {
+      dir: "/w/agent",
+      contextFiles: [{ path: "AGENTS.md" }],
+      skills: [{ name: "release" }],
+      collisions: [],
+      diagnostics: [],
+    },
+    toolNames: ["fetch-url"],
+    deferredToolNames: [],
+    toolCollisions: [],
+    toolFailures: [],
+  } as unknown as Parameters<typeof reportAssembly>[0];
+
+  /** The report writes through the leveled logger; `info` is the posture both commands report at. */
+  const lines = async (extras?: Parameters<typeof reportAssembly>[1]): Promise<string[]> => {
+    const out: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: unknown) => void out.push(String(m)));
+    setLogLevel("info");
+    try {
+      await reportAssembly(opened, extras);
+    } finally {
+      spy.mockRestore();
+    }
+    // Lines arrive as `INFO  [fastagent] <label>: <value>`; the label is what this pins.
+    return out.map(
+      (l) =>
+        l
+          .replace(/^\S+\s+\[fastagent\]\s+/, "")
+          .split(":")[0]
+          ?.trim() ?? "",
+    );
+  };
+
+  it("prints ONE spine, in order — the thing the two commands each used to write out by hand", async () => {
+    // `auth` is reportAuth's line; it reads real credentials, so only its position is pinned here.
+    const spine = await lines();
+    expect(spine.slice(0, 3)).toEqual(["agent", "workspace", "model"]);
+    expect(spine).toContain("context");
+    expect(spine).toContain("skills");
+    expect(spine).toContain("codingTools");
+    expect(spine).toContain("tools");
+    expect(spine).not.toContain("deferred"); // omitted when there are none
+  });
+
+  it("places each command's extras where that command puts them", async () => {
+    const dev = await lines({ beforeModel: [["config", "/w/agent/fastagent.config.mjs"]] });
+    expect(dev.indexOf("config")).toBe(2); // after agent/workspace, before model
+    expect(dev.indexOf("config")).toBeLessThan(dev.indexOf("model"));
+
+    const start = await lines({
+      afterTools: [
+        ["state", "/w/agent/.state"],
+        ["sessions", "/w/s"],
+      ],
+    });
+    expect(start.indexOf("state")).toBeGreaterThan(start.indexOf("codingTools"));
+    expect(start.slice(-2)).toEqual(["state", "sessions"]);
+    expect(start).not.toContain("config"); // start's report has never named it
   });
 });


### PR DESCRIPTION
`dev` and `start` open the same directory and say the same twelve things about it. Both wrote those
lines out by hand, and the copies had drifted past formatting into *which lines exist*: `dev` names
the config file, `start` names state and sessions, and neither knows the other does.

`reportAssembly` owns the spine. Each command passes only its own extras, so the asymmetry is one
argument at the call site instead of a diff between two lists:

```ts
await reportAssembly(a, { beforeModel: [["config", a.configPath ?? "(none)"]] });          // dev
await reportAssembly(opened, { afterTools: [["state", …], ["sessions", …]] });             // start
```

The asymmetry is **preserved, not resolved**. `start`'s `state:`/`sessions:` pair introduces the
persistence warnings that follow it in production posture, and `dev` has no counterpart. Whether the
difference is right is a separate question from whether it has one owner; this PR answers only the
second.

`reportLine` and `reportWorkspaceHint` stop being exported — a command reaching past the report for a
line of its own is how the two copies came to differ. knip caught them.

The extraction is what made the report testable: it is now a function over a plain object rather than
something reachable only by spawning a serve. `test/cli-shared.test.ts` pins the spine's order and
each extras slot — verified red by moving the `afterTools` slot.

## Not done, deliberately

`info` also resolves config → model → tools → state root → auth path, and I had it down as a third
copy. It is not one worth removing: `info` reports every failure as data (`model: null`,
`toolError`) where the openers fail visibly at startup, so routing it through `resolveAgentAssembly`
would mean a `{ throwOnMissingModel: false }` knob for exactly one caller. The resolvers it calls are
already the shared thing. Its report writer is separate on purpose too — stdout data, not a log line,
as `reportLine`'s doc has always said.

## Stale docs in `cli/serve.ts`

Three JSDoc blocks documented nothing, and one of them was actively wrong:

- "Mount the session control plane…" — that function is `mountSessionControl` in `src/service.ts`,
  which this file's own header points at. Deleted.
- "Bind HTTP, **open long-connection channels**, and report ready" sat above `SHUTDOWN_GRACE_MS`.
  `serve()` has not opened long connections since `mountAgentService` took them; it awaits
  `hooks.ready`. Rewritten onto `serve` saying what it now does.
- `readyAddressLines`'s doc sat above `reportServing`. Moved onto its function.

Local: `npm run lint && npm run typecheck && npm test` — 116 files, 1593 tests green.


## Review follow-ups

- **Findings close the report.** They describe the assembly just printed, so `start`'s two
  persistence notes now follow them rather than precede them. The reordering fell out of unifying the
  copies; `reportAssembly`'s doc now says so, which makes it a choice instead of a side effect.
- **The report test restores the log level.** It is a module singleton, so a suite appended after
  this one would have inherited `info`.
