### PR TITLE
docs: four comments that documented nothing, and a convention that never fired

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -7,6 +7,7 @@
     "src/cli.ts",
     "src/index.ts",
     "src/core.ts",
+    "src/node.ts",
     "src/session.ts",
     "src/pi.ts",
     "src/github.ts",

--- a/src/deploy/railway/plan.ts
+++ b/src/deploy/railway/plan.ts
@@ -63,8 +63,6 @@ const MOUNT = "/data";
  *  convention); two mechanisms, two documented spellings, one fact each. */
 export const dockerfilePathVar = (prefix: string): string => `/${prefix}Dockerfile`;
 
-/** railway.json — build/deploy only (Railway's config-as-code scope). No env/volume/sleeping here: those
- *  are service settings the runbook applies via CLI. healthcheckPath gates routing on a live server. */
 /** railway.json is JSON, so its ownership marker is a KEY rather than a comment line. Railway ignores
  *  unknown keys; the predicate below is what lets `--force` reset OUR file and keep a hand-written one. */
 const GENERATED_RAILWAY_KEY = "x-generated-by";
@@ -79,6 +77,8 @@ export function isGeneratedRailwayJson(content: string): boolean {
   }
 }
 
+/** railway.json — build/deploy only (Railway's config-as-code scope). No env/volume/sleeping here: those
+ *  are service settings the runbook applies via CLI. healthcheckPath gates routing on a live server. */
 function railwayJson(prefix: string): string {
   return `${JSON.stringify(
     {

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -262,10 +262,9 @@ function buildPiAgent(opts: {
   thinkingLevel?: ThinkingLevel;
   providers?: Provider[];
   authPath?: string;
-  /** A pre-built collection, used verbatim. The DIRECTORY rungs pass one so the agent's own
+  /** The model registry to run on, used verbatim. The DIRECTORY rung passes one so the agent's own
    *  models.json is in scope (see createPiModelRuntime); building it is async, which is why it
    *  happens in the caller — L1 has no directory, so it keeps the synchronous built-ins path. */
-  /** The model registry to run on. The directory rung passes one built from the agent's models.json. */
   models?: ModelRuntime;
   systemPrompt?: string | (() => string);
   tools?: MountedTool[];

--- a/src/engines/pi/definition.ts
+++ b/src/engines/pi/definition.ts
@@ -180,11 +180,10 @@ export async function loadExtensionPaths(
 }
 
 /**
- * The first candidate that is a REAL file. `exists` would follow a symlink, which is how a
- * subdirectory's `index.ts` could otherwise point outside the definition and slip past the rule the
- * top-level entries already follow.
+ * The first candidate that is a REAL file, and whether one was found but REFUSED as a symlink.
+ * `exists` would follow the link, which is how a subdirectory's `index.ts` could otherwise point
+ * outside the definition and slip past the rule the top-level entries already follow.
  */
-/** The first real file among the candidates, and whether one was found but REFUSED as a symlink. */
 async function firstRealFile(e: ExecutionEnv, candidates: string[]): Promise<{ path?: string; refused: boolean }> {
   let refused = false;
   for (const candidate of candidates) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -82,7 +82,6 @@ export interface ServingSurface {
   /** Route-channel basenames; the tunnel registers only this subset. */
   routeChannels: string[];
   builtinInvoke: boolean;
-  /** Marks the built-in health route ready after every long-connection channel first connects. */
   /** Flip health between 200 and 503. Two-way on purpose: a long connection that dies after coming
    *  up leaves the surface serving something it no longer has, and a load balancer should hear it. */
   setReady(value: boolean): void;

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -130,6 +130,23 @@ describe("the public subpaths do not reach into the CLI", () => {
   }
 });
 
+describe("knip's entry list mirrors the package's subpath exports", () => {
+  // knip's own config says a forgotten entry "surfaces as its whole tree reported dead". That is only
+  // true for a subpath nothing else re-exports: `src/node.ts` was missing for as long as it has
+  // existed, and knip stayed silent because `index.ts` re-exports it. The claim needs its own check.
+  it("every exported subpath has a knip entry", () => {
+    const pkg = JSON.parse(readFileSync(resolve(srcDir, "../package.json"), "utf8")) as {
+      exports: Record<string, unknown>;
+    };
+    const knip = readFileSync(resolve(srcDir, "../knip.jsonc"), "utf8");
+    const missing = Object.keys(pkg.exports)
+      .filter((key) => key !== "./package.json")
+      .map((key) => (key === "." ? "src/index.ts" : `src/${key.slice(2)}.ts`))
+      .filter((entry) => !knip.includes(JSON.stringify(entry)));
+    expect(missing).toEqual([]);
+  });
+});
+
 describe("the assembly's parts stay out of the public surface", () => {
   // Each of these was public once. They are how `createAgentService` builds a service, not something
   // a caller reproduces — and every one re-exported is a promise we then have to keep.

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -138,11 +138,24 @@ describe("knip's entry list mirrors the package's subpath exports", () => {
     const pkg = JSON.parse(readFileSync(resolve(srcDir, "../package.json"), "utf8")) as {
       exports: Record<string, unknown>;
     };
+    // Read the `entry` ARRAY, not the file: a substring match over the whole config is satisfied by a
+    // path sitting in `ignore` or `project`, or merely named in a comment — which is the misconfigured
+    // shape this test exists to catch, not a passing one.
+    //
+    // Every comment in knip.jsonc is a whole-line `//`, and stripping only those keeps the `$schema`
+    // URL's own `//` intact. A trailing or block comment makes JSON.parse throw, which is the right
+    // outcome: better a loud failure here than a silently mis-read config.
     const knip = readFileSync(resolve(srcDir, "../knip.jsonc"), "utf8");
+    const { entry } = JSON.parse(
+      knip
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("//"))
+        .join("\n"),
+    ) as { entry: string[] };
     const missing = Object.keys(pkg.exports)
       .filter((key) => key !== "./package.json")
       .map((key) => (key === "." ? "src/index.ts" : `src/${key.slice(2)}.ts`))
-      .filter((entry) => !knip.includes(JSON.stringify(entry)));
+      .filter((subpath) => !entry.includes(subpath));
     expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
A JSDoc block immediately followed by another one documents nothing — the second wins and the first
is invisible to tooling while still being read by people. Four of them, found by scanning for the
pattern rather than by reading:

| Where | What the orphan said |
|---|---|
| `service.ts` `setReady` | "Marks the built-in health route ready after every long-connection channel first connects" — one-directional, directly contradicted by the block below it ("Two-way on purpose"). A channel that dies after coming up flips it back. Deleted. |
| `engines/pi/definition.ts` `firstRealFile` | Two halves of one description (the symlink reason; the return shape). Merged. |
| `deploy/railway/plan.ts` | `railway.json`'s scope, stranded above `GENERATED_RAILWAY_KEY` — three declarations away from `railwayJson`, which had no doc at all. Moved onto it. |
| `engines/pi/create.ts` `models` | Two descriptions of the same field. Merged. |

Only the first was dangerous: it asserted a mechanism the code had stopped implementing, which is
the shape `AGENTS.md` names as arguing the next person into the wrong change. The rest are noise.

## knip's entry list

`knip.jsonc` says: *"Adding a subpath export? Add its src entry here too; `npm run lint` runs knip,
so a forgotten entry surfaces as its whole tree reported dead."*

`src/node.ts` — an exported subpath (`@fastagent-sh/fastagent/node`) — was never in that list, and
knip never said so, because `index.ts` re-exports it and the tree stays reachable. The convention
only fires for a subpath nothing else re-exports, which is not the case it most needs to cover.

Entry added, plus the check that makes the comment true: `package-boundary.test.ts` derives the
expected entries from `package.json`'s `exports` and fails on a missing one. That file already
asserts facts about this same subpath list.

The check reads knip's `entry` **array**, not the file it sits in. A substring match over the whole
config is also satisfied by a path in `ignore` or `project`, or merely named in a comment — the
misconfigured shape this test exists to catch, not a passing one. Moving `src/node.ts` from `entry`
into `ignore` (strictly worse than the original bug: it excludes the file from knip's analysis) left
the substring version green.

Parsing rather than slicing between two key names is deliberate: `slice(indexOf('"entry"'),
indexOf('"project"'))` reintroduces the same class of silent failure, because a renamed or reordered
`"project"` makes `indexOf` return `-1` and `slice(start, -1)` widen back to almost the whole file.
Only whole-line `//` comments are stripped, so the `$schema` URL's own `//` survives; a trailing or
block comment makes `JSON.parse` throw, which is the intended outcome — a loud failure beats a
silently mis-read config.

Verified by mutation, each case with the config restored afterwards:

| Config | Expected | Result |
|---|---|---|
| unmodified | pass | pass |
| `src/node.ts` moved `entry` → `ignore` | fail | fail |
| `src/node.ts` entry deleted | fail | fail |
| trailing `//` comment added | loud parse error | `SyntaxError: Expected double-quoted property name in JSON` |

Local: `npm run lint && npm run typecheck && npm test` — 116 files, 1598 tests green.
