### PR TITLE
fix(channels): three turn-lifecycle facts the three chat channels each restated

### DIFF
--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -19,7 +19,8 @@ import { ensureStateHome, loadStateFile, saveStateFile } from "../kit/state.ts";
 import { signatureIsFresh } from "../kit/signature.ts";
 import { dispatchStop, isStopText } from "../kit/stop-command.ts";
 import { createTurnQueue } from "../kit/turn-queue.ts";
-import { createTurnStore } from "../kit/turn-store.ts";
+import { MAX_TURN_ATTEMPTS, commitAnsweredTurn, createTurnStore } from "../kit/turn-store.ts";
+import { discussionBlock } from "../kit/context-buffer.ts";
 import { FEISHU_CLOUD, type FeishuCloudProfile } from "./cloud.ts";
 import {
   collectFeishuBufferedAttachments,
@@ -63,11 +64,6 @@ import { connectFeishuWs } from "./ws-ingress.ts";
 // Canonical public surface; the Lark subpath aliases these types/functions at its compatibility boundary.
 export { defaultFeishuRoute, feishuEnvelope };
 export type { FeishuFailure, FeishuMessage, FeishuMessageEvent, FeishuRoute };
-
-/** Execution ceiling: a turn that has STARTED running this many times without finishing is dropped
- *  rather than run again (a poison turn must not loop forever under a restart policy). Counted per turn
- *  at dequeue, so a never-run turn queued behind a poison one keeps its full budget. */
-const MAX_TURN_ATTEMPTS = 3;
 
 /** Event body cap — events are small JSON; 1 MiB is generous and guards a public endpoint. */
 const MAX_EVENT_BYTES = 1 << 20;
@@ -477,8 +473,7 @@ function createFeishuRuntimeFactory(
         const roomBlock = room?.text
           ? `[recent discussion in the room this thread branched from — not yet answered there:\n${room.text}\n]\n\n`
           : "";
-        const threadBlock = recent ? `[recent group discussion:\n${recent}\n]\n\n` : "";
-        const prompt = `${roomBlock}${threadBlock}${rec.baseText}`;
+        const prompt = `${roomBlock}${discussionBlock(recent)}${rec.baseText}`;
         // Room entries FIRST: the collector keeps the TAIL under its cap, so the thread's own
         // attachments win the slots.
         const buffered = collectFeishuBufferedAttachments([...(room?.consumed ?? []), ...consumed], {
@@ -503,12 +498,7 @@ function createFeishuRuntimeFactory(
                 ...(parentSession !== undefined ? { parentSession } : {}),
               },
               { primary: { images: rec.images, files: rec.files, parentId: rec.parentId }, buffered },
-              () => {
-                // Drop intent first: a crash between these writes may re-fold answered context later,
-                // but can never replay this turn after its context was removed.
-                store.remove(rec.id);
-                buffer.commit(rec.bufferKey, consumed);
-              },
+              () => commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey: rec.bufferKey, consumed }),
             ),
             api,
             targetOf(rec),

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -19,7 +19,7 @@ import { ensureStateHome, loadStateFile, saveStateFile } from "../kit/state.ts";
 import { signatureIsFresh } from "../kit/signature.ts";
 import { dispatchStop, isStopText } from "../kit/stop-command.ts";
 import { createTurnQueue } from "../kit/turn-queue.ts";
-import { MAX_TURN_ATTEMPTS, commitAnsweredTurn, createTurnStore } from "../kit/turn-store.ts";
+import { commitAnsweredTurn, createTurnStore } from "../kit/turn-store.ts";
 import { discussionBlock } from "../kit/context-buffer.ts";
 import { FEISHU_CLOUD, type FeishuCloudProfile } from "./cloud.ts";
 import {
@@ -444,7 +444,7 @@ function createFeishuRuntimeFactory(
         await notice?.done;
         notices.delete(rec.id);
         // Count this execution against the durable record (poison-turn ceiling) before running it again.
-        const decision = store.startAttempt(rec.id, MAX_TURN_ATTEMPTS);
+        const decision = store.startAttempt(rec.id);
         if (decision === "exceeded") {
           notifyDropped(rec);
           return;

--- a/src/channels/kit/context-buffer.ts
+++ b/src/channels/kit/context-buffer.ts
@@ -43,6 +43,18 @@ export const BUFFER_LINE_MAX_CHARS = 280;
  *  each channel's attachment collector caps against this. */
 export const BUFFER_ATTACH_MAX = 3;
 
+/**
+ * The folded discussion as it reaches the model — the prompt block, or nothing when the buffer is
+ * empty. One renderer for every channel: what the agent is told about un-summoned discussion should
+ * not depend on which chat platform delivered it, and three copies of the literal is how that drifts.
+ *
+ * A channel that folds a SECOND source (feishu's originating room) labels that one itself — it is a
+ * different claim about a different place, not this block with another name.
+ */
+export function discussionBlock(text: string): string {
+  return text ? `[recent group discussion:\n${text}\n]\n\n` : "";
+}
+
 export interface ContextBuffer<E> {
   /** Record an un-summoned message. Persists BEFORE returning (pre-ACK; see the module header). */
   push(placeKey: string, entry: E): void;

--- a/src/channels/kit/turn-store.ts
+++ b/src/channels/kit/turn-store.ts
@@ -59,12 +59,13 @@ import { loadStateFile, saveStateFile } from "./state.ts";
  * DEPLOY frequency, which is a property of how fastagent is operated, not of which chat platform is in
  * front of it.
  *
- * Known limitation, and the reason it is not higher: the count cannot tell a self-inflicted crash from
- * an external SIGTERM (there is no graceful drain), so a legitimately long turn interrupted by this
- * many successive deploys is dropped as if it were poison. Catching SIGTERM to spare it would
- * reintroduce the drain the design refuses.
+ * Known limitation: the count cannot tell a self-inflicted crash from an external SIGTERM (there is no
+ * graceful drain), so a legitimately long turn interrupted by this many successive deploys is dropped
+ * as if it were poison. Three is a bet that such a turn is an outlier, not a defence against one:
+ * catching SIGTERM to spare it would reintroduce the drain the design refuses — raise this constant
+ * instead if such turns are expected.
  */
-export const MAX_TURN_ATTEMPTS = 3;
+const MAX_TURN_ATTEMPTS = 3;
 
 /** What every persisted turn record carries regardless of channel: identity, the session whose FIFO
  *  chain it runs on, and how many times it has STARTED executing without finishing (0 until its first
@@ -89,14 +90,14 @@ export interface TurnStore<T extends TurnRecordBase> {
   recover(): T[];
   /** Called when a turn is about to RUN (dequeued). Returns:
    *   - "run": bumped its persisted execution count; go ahead.
-   *   - "exceeded": over `maxAttempts` starts without finishing (killed mid-run every time, whatever the
-   *     cause); the record is dropped and the runner notifies the asker.
+   *   - "exceeded": over {@link MAX_TURN_ATTEMPTS} starts without finishing (killed mid-run every time,
+   *     whatever the cause); the record is dropped and the runner notifies the asker.
    *   - "defer": the bump could not be persisted — skip this cycle (fail closed: an unpersisted count
    *     would let a poison turn re-run forever); the record stays on disk and replays on the next start
    *     (a restart is required — disk recovery alone does not re-run it). The runner does NOT notify.
    *  An id with no record returns "run" (untracked): a completed turn's `remove` cleared it, so the
    *  redelivery-double-run tail (see the header's pre-ACK window) lands here. */
-  startAttempt(id: string, maxAttempts: number): "run" | "exceeded" | "defer";
+  startAttempt(id: string): "run" | "exceeded" | "defer";
 }
 
 export interface TurnStoreOptions<T extends TurnRecordBase> {
@@ -176,11 +177,11 @@ export function createTurnStore<T extends TurnRecordBase>(path: string, opts: Tu
       // happening to survive the load's JSON round-trip.
       return [...turns.values()].sort(order);
     },
-    startAttempt(id, maxAttempts) {
+    startAttempt(id) {
       const rec = turns.get(id);
       if (!rec) return "run"; // no record — run untracked (a redelivery double-run whose first run removed it)
       const attempts = rec.attempts + 1;
-      if (attempts > maxAttempts) {
+      if (attempts > MAX_TURN_ATTEMPTS) {
         // State the fact, not a cause the counter can't prove: a turn killed mid-run every time bumps
         // this whether IT poisoned the process or a deploy/OOM took it down each time.
         log.error(

--- a/src/channels/kit/turn-store.ts
+++ b/src/channels/kit/turn-store.ts
@@ -50,7 +50,21 @@
  * power-loss is best-effort — no fsync, consistent with the rest of the channel's state).
  */
 import { log } from "../../log.ts";
+import type { ContextBuffer } from "./context-buffer.ts";
 import { loadStateFile, saveStateFile } from "./state.ts";
+
+/**
+ * How many times a turn may START without finishing before it is dropped rather than run again — the
+ * poison-turn ceiling described at length above. One value for every channel: it prices replay against
+ * DEPLOY frequency, which is a property of how fastagent is operated, not of which chat platform is in
+ * front of it.
+ *
+ * Known limitation, and the reason it is not higher: the count cannot tell a self-inflicted crash from
+ * an external SIGTERM (there is no graceful drain), so a legitimately long turn interrupted by this
+ * many successive deploys is dropped as if it were poison. Catching SIGTERM to spare it would
+ * reintroduce the drain the design refuses.
+ */
+export const MAX_TURN_ATTEMPTS = 3;
 
 /** What every persisted turn record carries regardless of channel: identity, the session whose FIFO
  *  chain it runs on, and how many times it has STARTED executing without finishing (0 until its first
@@ -94,6 +108,25 @@ export interface TurnStoreOptions<T extends TurnRecordBase> {
   /** Arrival order for {@link TurnStore.recover} — the channel knows what its ids/fields encode
    *  (telegram: numeric update_id; lark: an explicit per-record seq). */
   order: (a: T, b: T) => number;
+}
+
+/**
+ * End an ANSWERED turn: drop its durable intent, then commit the discussion it folded in.
+ *
+ * The ORDER is the safety property, which is why this is a function and not two lines at each call
+ * site. A crash between the two writes may re-fold already-answered context into the next summon —
+ * additive and harmless. The reverse order leaves intent on disk with its context already consumed,
+ * so the replay runs the same turn with its context stripped.
+ *
+ * Called from the turn's `completed` event, when the fold provably lives in the durable session.
+ */
+export function commitAnsweredTurn<T extends TurnRecordBase, E>(
+  store: TurnStore<T>,
+  buffer: ContextBuffer<E>,
+  turn: { id: string; bufferKey: string; consumed: E[] },
+): void {
+  store.remove(turn.id);
+  buffer.commit(turn.bufferKey, turn.consumed);
 }
 
 export function createTurnStore<T extends TurnRecordBase>(path: string, opts: TurnStoreOptions<T>): TurnStore<T> {

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -13,7 +13,7 @@ import { ensureStateHome } from "../kit/state.ts";
 import { dispatchStop, isStopText } from "../kit/stop-command.ts";
 import { codePointPrefix } from "../kit/text.ts";
 import { createTurnQueue } from "../kit/turn-queue.ts";
-import { MAX_TURN_ATTEMPTS, commitAnsweredTurn, createTurnStore } from "../kit/turn-store.ts";
+import { commitAnsweredTurn, createTurnStore } from "../kit/turn-store.ts";
 import { discussionBlock } from "../kit/context-buffer.ts";
 import { createSlackBotTokenProvider } from "./bot-auth.ts";
 import { collectSlackBufferedFiles, createSlackContextBuffer } from "./context-buffer.ts";
@@ -326,7 +326,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
           log.error(`${label} deferring durable turn ${turn.id} because Slack authentication failed: ${String(error)}`);
           return;
         }
-        const attempt = store.startAttempt(turn.id, MAX_TURN_ATTEMPTS);
+        const attempt = store.startAttempt(turn.id);
         if (attempt === "exceeded") {
           notifyDropped(turn);
           return;

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -13,7 +13,8 @@ import { ensureStateHome } from "../kit/state.ts";
 import { dispatchStop, isStopText } from "../kit/stop-command.ts";
 import { codePointPrefix } from "../kit/text.ts";
 import { createTurnQueue } from "../kit/turn-queue.ts";
-import { createTurnStore } from "../kit/turn-store.ts";
+import { MAX_TURN_ATTEMPTS, commitAnsweredTurn, createTurnStore } from "../kit/turn-store.ts";
+import { discussionBlock } from "../kit/context-buffer.ts";
 import { createSlackBotTokenProvider } from "./bot-auth.ts";
 import { collectSlackBufferedFiles, createSlackContextBuffer } from "./context-buffer.ts";
 import { invokeSlackTurn } from "./invoke-turn.ts";
@@ -53,7 +54,6 @@ export { defaultSlackRoute, slackEnvelope };
 export type { SlackEventEnvelope, SlackFailure, SlackFile, SlackMessageEvent, SlackRendering, SlackRoute };
 
 const MAX_EVENT_BYTES = 1 << 20;
-const MAX_TURN_ATTEMPTS = 3;
 /** Slack's own documented window — it re-signs every redelivery with a current timestamp, so a tight
  *  one costs nothing. The Feishu ingress reads hours off the same helper for the opposite reason. */
 const MAX_SIGNATURE_AGE_S = 5 * 60;
@@ -347,7 +347,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
         const startedAt = Date.now();
         log.info(`${label} turn start: turn=${turn.id} session=${turn.session} channel=${turn.channelId}`);
         const { text: recent, consumed } = buffer.peek(turn.bufferKey);
-        const prompt = recent ? `[recent group discussion:\n${recent}\n]\n\n${turn.baseText}` : turn.baseText;
+        const prompt = `${discussionBlock(recent)}${turn.baseText}`;
         const buffered = collectSlackBufferedFiles(consumed, new Set(turn.fileIds));
         const messageRef = messageRefOf(turn.id);
         const reaction =
@@ -368,10 +368,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
               prompt,
               { api, channelId: turn.channelId, filesDir: join(stateHome, "files"), label },
               { primaryFileIds: turn.fileIds, buffered },
-              () => {
-                store.remove(turn.id);
-                buffer.commit(turn.bufferKey, consumed);
-              },
+              () => commitAnsweredTurn(store, buffer, { id: turn.id, bufferKey: turn.bufferKey, consumed }),
             ),
             api,
             targetOf(turn),

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -51,7 +51,7 @@ import { ensureStateHome } from "../kit/state.ts";
 import { dispatchStop } from "../kit/stop-command.ts";
 import { type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 import { createTurnQueue } from "../kit/turn-queue.ts";
-import { MAX_TURN_ATTEMPTS, commitAnsweredTurn } from "../kit/turn-store.ts";
+import { commitAnsweredTurn } from "../kit/turn-store.ts";
 import { discussionBlock } from "../kit/context-buffer.ts";
 import { type StoredTurn, createTurnStore } from "./turn-store.ts";
 
@@ -223,10 +223,10 @@ export function telegramChannel({
         await notices.get(rec.id);
         notices.delete(rec.id);
         // Count this execution against the durable record (poison-turn ceiling) before running it again.
-        const decision = store.startAttempt(rec.id, MAX_TURN_ATTEMPTS);
+        const decision = store.startAttempt(rec.id);
         if (decision === "exceeded") {
-          // Started MAX_TURN_ATTEMPTS times without finishing — tell the asker (reusing its ⏳ notice if
-          // any), drop it.
+          // Started the ceiling's worth of times without finishing (turn-store.ts MAX_TURN_ATTEMPTS) —
+          // tell the asker (reusing its ⏳ notice if any), drop it.
           notifyDropped(rec);
           return;
         }

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -51,22 +51,13 @@ import { ensureStateHome } from "../kit/state.ts";
 import { dispatchStop } from "../kit/stop-command.ts";
 import { type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
 import { createTurnQueue } from "../kit/turn-queue.ts";
+import { MAX_TURN_ATTEMPTS, commitAnsweredTurn } from "../kit/turn-store.ts";
+import { discussionBlock } from "../kit/context-buffer.ts";
 import { type StoredTurn, createTurnStore } from "./turn-store.ts";
 
 // Re-export the public surface authored elsewhere, so `@fastagent-sh/fastagent/telegram` keeps one entry point.
 export { defaultTelegramRoute, telegramEnvelope, telegramStop };
 export type { TelegramFailure, TelegramMessage, TelegramRoute, TelegramUpdate };
-
-/** Execution ceiling: a turn that has STARTED running this many times without finishing is dropped
- *  rather than run again (a poison turn must not loop forever under a restart policy). Counted per turn
- *  at dequeue, so a never-run turn queued behind a poison one keeps its full budget.
- *
- *  Known limitation: `startAttempt` cannot tell a self-inflicted process crash from an external SIGTERM
- *  (no graceful drain), so a legitimately LONG turn interrupted by this many successive deploys is
- *  dropped ("please ask again") as if it were poison. Accepted: catching SIGTERM to spare it would
- *  reintroduce the drain the design refuses, and a turn outliving this many deploy cycles is an outlier
- *  — raise this constant if such turns are expected. */
-const MAX_TURN_ATTEMPTS = 3;
 
 /** Update body cap — Telegram updates are small JSON; 1 MiB is generous and guards a public endpoint. */
 const MAX_UPDATE_BYTES = 1 << 20;
@@ -260,7 +251,7 @@ export function telegramChannel({
         // Fold the un-summoned discussion since the last answered turn into the prompt; it is cleared
         // only when the turn COMPLETES (then it lives in the session).
         const { text: recent, consumed } = buffer.peek(rec.placeKey);
-        const prompt = recent ? `[recent group discussion:\n${recent}\n]\n\n${rec.baseText}` : rec.baseText;
+        const prompt = `${discussionBlock(recent)}${rec.baseText}`;
         const buffered = collectAttachments(consumed, {
           files: new Set(rec.fileIds),
           images: new Set(rec.imageFileIds),
@@ -289,14 +280,7 @@ export function telegramChannel({
                 },
                 buffered,
               },
-              () => {
-                // On completed, ORDER the two durable clears so a crash between them can't replay a
-                // context-stripped turn: drop the intent FIRST (a crash after this won't replay it), THEN
-                // commit the context buffer (a crash before this just re-folds the same context into the
-                // next summon — harmless and additive). The reverse order would leave intent+no-context.
-                store.remove(rec.id);
-                buffer.commit(rec.placeKey, consumed);
-              },
+              () => commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey: rec.placeKey, consumed }),
             ),
             apiBaseUrl,
             botToken,

--- a/test/turn-store.test.ts
+++ b/test/turn-store.test.ts
@@ -40,7 +40,7 @@ describe("turn-store", () => {
     const path = freshPath();
     const store = createTurnStore(path);
     store.add(turn("t1"));
-    store.startAttempt("t1", 3); // attempts -> 1
+    store.startAttempt("t1"); // attempts -> 1
     store.add(turn("t1")); // redelivery re-submits the same update_id (a fresh record with attempts:0)
     expect(createTurnStore(path).recover()).toMatchObject([{ id: "t1", attempts: 1 }]); // preserved, not reset
   });
@@ -75,27 +75,27 @@ describe("turn-store", () => {
   it("startAttempt bumps the execution count and persists it", () => {
     const path = freshPath();
     createTurnStore(path).add(turn("t1"));
-    expect(createTurnStore(path).startAttempt("t1", 3)).toBe("run");
+    expect(createTurnStore(path).startAttempt("t1")).toBe("run");
     expect(createTurnStore(path).recover()).toMatchObject([{ id: "t1", attempts: 1 }]); // durable bump
   });
 
-  it("keeps a turn that lands exactly ON maxAttempts (the > vs >= boundary)", () => {
+  it("keeps a turn that lands exactly ON the ceiling (the > vs >= boundary)", () => {
     const path = freshPath();
     createTurnStore(path).add(turn("edge", { attempts: 2 }));
-    expect(createTurnStore(path).startAttempt("edge", 3)).toBe("run"); // 2 -> 3, still <= 3, not dropped
+    expect(createTurnStore(path).startAttempt("edge")).toBe("run"); // 2 -> 3, still <= 3, not dropped
     expect(createTurnStore(path).recover()).toMatchObject([{ id: "edge", attempts: 3 }]);
   });
 
   it("an unknown id runs untracked (a redelivery double-run whose first run already removed the record)", () => {
-    expect(createTurnStore(freshPath()).startAttempt("gone", 3)).toBe("run");
+    expect(createTurnStore(freshPath()).startAttempt("gone")).toBe("run");
   });
 
-  it("drops a turn on its N+1th start (over maxAttempts) and persists the drop", () => {
+  it("drops a turn on its N+1th start (over the ceiling) and persists the drop", () => {
     const path = freshPath();
     const store = createTurnStore(path);
     store.add(turn("poison", { attempts: 3 }));
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    expect(store.startAttempt("poison", 3)).toBe("exceeded"); // 3 -> 4 > 3, dropped
+    expect(store.startAttempt("poison")).toBe("exceeded"); // 3 -> 4 > 3, dropped
     expect(err).toHaveBeenCalledWith(expect.stringContaining("dropping turn poison"));
     expect(createTurnStore(path).recover()).toHaveLength(0); // the drop is persisted
   });
@@ -105,11 +105,11 @@ describe("turn-store", () => {
     // end to end (the seeded-count tests above each cover only one link).
     const path = freshPath();
     createTurnStore(path).add(turn("t1")); // accepted, attempts 0
-    expect(createTurnStore(path).startAttempt("t1", 3)).toBe("run"); // → 1
-    expect(createTurnStore(path).startAttempt("t1", 3)).toBe("run"); // → 2
-    expect(createTurnStore(path).startAttempt("t1", 3)).toBe("run"); // → 3
+    expect(createTurnStore(path).startAttempt("t1")).toBe("run"); // → 1
+    expect(createTurnStore(path).startAttempt("t1")).toBe("run"); // → 2
+    expect(createTurnStore(path).startAttempt("t1")).toBe("run"); // → 3
     vi.spyOn(console, "error").mockImplementation(() => {});
-    expect(createTurnStore(path).startAttempt("t1", 3)).toBe("exceeded"); // 4th start > 3 → dropped
+    expect(createTurnStore(path).startAttempt("t1")).toBe("exceeded"); // 4th start > 3 → dropped
     expect(createTurnStore(path).recover()).toHaveLength(0);
   });
 
@@ -127,8 +127,8 @@ describe("turn-store", () => {
         .recover()
         .map((t) => `${t.id}:${t.attempts}`),
     ).toEqual(["A:3", "B:0"]);
-    expect(store.startAttempt("A", 3)).toBe("exceeded");
-    expect(store.startAttempt("B", 3)).toBe("run"); // B was never charged for A's crashes
+    expect(store.startAttempt("A")).toBe("exceeded");
+    expect(store.startAttempt("B")).toBe("run"); // B was never charged for A's crashes
     expect(createTurnStore(path).recover()).toMatchObject([{ id: "B", attempts: 1 }]); // only B survives, at 1
   });
 
@@ -172,7 +172,7 @@ describe("turn-store", () => {
     rmSync(sub, { recursive: true });
     writeFileSync(sub, "x"); // now the parent is a FILE — the bump write fails
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    expect(store.startAttempt("t1", 3)).toBe("defer"); // an unpersistable bump must not run the turn
+    expect(store.startAttempt("t1")).toBe("defer"); // an unpersistable bump must not run the turn
     expect(err).toHaveBeenCalledWith(expect.stringContaining("deferring"));
   });
 
@@ -210,8 +210,10 @@ describe("commitAnsweredTurn (the order a crash between the two writes depends o
     expect(order).toEqual(["remove:t1", "commit:chat:1"]);
   });
 
-  it("commits the SNAPSHOT it was given, not the whole place", () => {
-    // The buffer removes by identity, so a message that arrived while the turn ran survives.
+  it("forwards the consumed entries by reference", () => {
+    // Not a copy: the buffer removes by object identity, so cloning the entries on the way through
+    // would commit a set that matches nothing and leave the answered discussion buffered forever.
+    // (That identity removal itself is context-buffer's own test; this only guards the hand-off.)
     const consumed = [{ body: "a" }];
     const seen: unknown[] = [];
     const buffer = { commit: (_k: string, c: unknown) => void seen.push(c) } as unknown as Parameters<

--- a/test/turn-store.test.ts
+++ b/test/turn-store.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type StoredTurn, createTurnStore } from "../src/channels/telegram/turn-store.ts";
+import { commitAnsweredTurn } from "../src/channels/kit/turn-store.ts";
 
 const dirs: string[] = [];
 const freshPath = (): string => {
@@ -181,5 +182,42 @@ describe("turn-store", () => {
     const err = vi.spyOn(console, "error").mockImplementation(() => {}); // log.warn/error both → console.error
     expect(createTurnStore(path).recover()).toHaveLength(0);
     expect(err).toHaveBeenCalledWith(expect.stringContaining("unexpected shape"));
+  });
+});
+
+describe("commitAnsweredTurn (the order a crash between the two writes depends on)", () => {
+  /** Records which durable write happened first. Both are real interfaces, faked to the two calls
+   *  this function makes — the assertion is ordering, not persistence (each side has its own tests). */
+  const recorder = () => {
+    const order: string[] = [];
+    return {
+      order,
+      store: { remove: (id: string) => void order.push(`remove:${id}`) } as unknown as Parameters<
+        typeof commitAnsweredTurn
+      >[0],
+      buffer: { commit: (key: string) => void order.push(`commit:${key}`) } as unknown as Parameters<
+        typeof commitAnsweredTurn
+      >[1],
+    };
+  };
+
+  it("drops the intent BEFORE committing the context", () => {
+    // Reversed, a crash between the writes leaves intent on disk with its context already consumed:
+    // the replay then runs the same turn with its folded discussion stripped. This order's failure is
+    // the harmless one — re-folding context that was already answered.
+    const { order, store, buffer } = recorder();
+    commitAnsweredTurn(store, buffer, { id: "t1", bufferKey: "chat:1", consumed: [] });
+    expect(order).toEqual(["remove:t1", "commit:chat:1"]);
+  });
+
+  it("commits the SNAPSHOT it was given, not the whole place", () => {
+    // The buffer removes by identity, so a message that arrived while the turn ran survives.
+    const consumed = [{ body: "a" }];
+    const seen: unknown[] = [];
+    const buffer = { commit: (_k: string, c: unknown) => void seen.push(c) } as unknown as Parameters<
+      typeof commitAnsweredTurn
+    >[1];
+    commitAnsweredTurn(recorder().store, buffer, { id: "t1", bufferKey: "chat:1", consumed });
+    expect(seen[0]).toBe(consumed);
   });
 });


### PR DESCRIPTION
Telegram, Slack and Feishu each run a durable turn, and the platform differences between them are
real — three renderers, three attachment models, three notions of a thread. Three things in those
run loops are *not* platform differences, and each was written out three times.

**The execution ceiling.** `const MAX_TURN_ATTEMPTS = 3`, once per channel. It prices replay against
how often fastagent is *deployed* (every SIGTERM mid-turn burns an attempt — there is no graceful
drain), which is a property of how the framework is operated, not of which chat platform is in front
of it. Now `kit/turn-store.ts`'s, beside the ceiling's own long explanation.

**The fold's wording.** `` `[recent group discussion:\n${text}\n]\n\n` `` verbatim in three files.
What the agent is told about discussion it did not see should not depend on the transport.
`discussionBlock()` renders it. Feishu's *second* block — the room a thread branched from — keeps its
own label, because it is a different claim about a different place.

**The order of two durable writes.** On `completed`, all three did:

```ts
store.remove(id);            // drop the intent
buffer.commit(key, consumed) // then consume the context
```

each under its own copy of the paragraph explaining why not the reverse. Reversed, a crash between
the writes leaves the intent on disk with its context already consumed, and the replay re-runs the
turn with its folded discussion stripped. This order's failure is the harmless one: re-folding
discussion that was already answered.

`commitAnsweredTurn()` makes the order unwritable-wrong, and it has the test the invariant never had
— verified red by swapping the two lines.

## Scope: much narrower than "extract the turn lifecycle"

The three `run()` bodies do share a skeleton, and the obvious move is a template method with
`onDropped`/`onDeferred`/`invoke` callbacks. The repository's own history argues against it. Every
cross-channel defect here landed *in* `kit/` — `tasks.ts` (#386), `signature.ts` (#390),
`attachment-path.ts` (#392) — because the mechanism was already extracted. The recurring failure is
a channel **forgetting to call** a kit function: #397 added `signatureIsFresh` to Slack's ingress
seven days after Feishu got it. A template method prevents none of that.

And the skeleton's remaining differences are argued, not accidental: on `defer`, Telegram *deletes*
its queued notice while Slack and Feishu *settle* theirs to a delayed status — Telegram's comment
says why (a stale "Queued" above a fresh preview). Folding that into a shared callback would erase a
decision to save three lines.

So: three extractions, no control-flow inversion, no new abstraction. `channels/*/` keeps owning its
protocol.

Local: `npm run lint && npm run typecheck && npm test` — 116 files, 1593 tests green.
