### PR TITLE
fix(secrets): the credential directory's 0700 is a promise, not a per-call guess

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -436,6 +436,13 @@ is `createPiModels`'s default when no `authPath` is passed, and the explicit one
 `createPiModels()` bare reads the global file, not a project-level `login` — pass `authPath` explicitly
 to read the project's credential (the `createPiAgentFrom*` openers already do).
 
+**The directory you name is managed as a secrets directory.** On its first write the store creates it
+if needed and sets it to `0700`, repairing an existing one — `auth.json` itself is `0600`, but the
+directory's `x` bit is what actually keeps another account out, and `mkdir`'s mode is a no-op on a
+directory that already exists. Point `authPath` at a file inside a directory fastagent may own, not
+into a shared one you need others to read. Where the process cannot chmod that directory, the
+credential write fails loudly rather than proceeding with it left readable.
+
 Provider injection:
 
 `Provider`, `ProviderAuth` and `Model` are re-exported as TYPES because they appear in our options —

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -436,8 +436,9 @@ is `createPiModels`'s default when no `authPath` is passed, and the explicit one
 `createPiModels()` bare reads the global file, not a project-level `login` — pass `authPath` explicitly
 to read the project's credential (the `createPiAgentFrom*` openers already do).
 
-**The directory you name is managed as a secrets directory.** On its first write the store creates it
-if needed and sets it to `0700`, repairing an existing one — `auth.json` itself is `0600`, but the
+**The directory you name is managed as a secrets directory.** Every credential write — including an
+OAuth refresh mid-run — creates it if needed and re-applies `0700`, so a directory you widen by hand
+is silently tightened again on the next token rotation. `auth.json` itself is `0600`, but the
 directory's `x` bit is what actually keeps another account out, and `mkdir`'s mode is a no-op on a
 directory that already exists. Point `authPath` at a file inside a directory fastagent may own, not
 into a shared one you need others to read. Where the process cannot chmod that directory, the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -108,6 +108,12 @@ for it again on the spot (cancel to stop), so a mistyped key is corrected at log
 failing at the first invoke; an inconclusive failure (network, quota, permissions) keeps the key and
 prints the provider's message.
 
+**The directory holding `auth.json` is managed as a secrets directory**, whichever knob named it:
+every credential write (including an OAuth refresh mid-run) re-applies `0700` to it, and where the
+process cannot chmod it the write fails instead of leaving the credential readable. Point
+`--auth-path` / `FASTAGENT_AUTH_PATH` inside a directory this process owns, not a shared one others
+need to read.
+
 **Running several agents off one account on your dev machine?** Point them all at the one global file: set `FASTAGENT_AUTH_PATH=~/.fastagent/.secrets/auth.json` (a `.env` entry, a shell env var, or `--auth-path`), or just `login` from outside any agent. A leading `~` is expanded to your home dir in `--auth-path` and `FASTAGENT_AUTH_PATH` (shell variables like `$HOME` are not — use `~` or an absolute path). Sharing **one file** is safe — a single cross-process lock serializes OAuth refresh, so concurrent instances always read the latest token. (What is *not* safe is copying the file around: two files over one grant each rotate the single-use refresh token and break the other.)
 
 ## `fastagent dev`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,6 +262,10 @@ auth:       --auth-path    > FASTAGENT_AUTH_PATH         > <secrets>/auth.json
 
 A leading `~` in any of these is expanded to your home dir.
 
+Wherever `auth.json` lands, its directory is managed as a secrets directory: every credential write
+(including an OAuth refresh mid-run) re-applies `0700` to it, and where the process cannot chmod it
+the write fails rather than leaving the credential readable. Name a directory this process owns.
+
 `FASTAGENT_SECRETS_DIR` moves both the agent's `.env` and `auth.json`. The `.env`'s own location
 resolves from the real environment — a `FASTAGENT_SECRETS_DIR` set *inside* `.env` still relocates
 `auth.json` but cannot move the file it is read from. The committable `.env.example` template always

--- a/src/atomic-write.ts
+++ b/src/atomic-write.ts
@@ -32,7 +32,7 @@ import { dirname } from "node:path";
  * It runs on the temp, before the rename — the final path is then never observable with the wrong
  * permissions, which a chmod after the rename cannot promise.
  */
-export function writeFileAtomic(path: string, data: string, mode?: number): void {
+export function writeFileAtomic(path: string, data: string | Buffer, mode?: number): void {
   mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.tmp`;
   try {

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -9,7 +9,7 @@
  */
 import { MAX_WEBHOOK_BODY_BYTES } from "../../channels/agentcore-limits.ts";
 import type { DeclaredChannel } from "../../channels/discover.ts";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { registerFeishuWebhook } from "../../channels/feishu/register-webhook.ts";
@@ -801,7 +801,6 @@ async function runDeployAgentcore(
       async (content) => {
         const path = join(paramsDir, "params.json");
         await writeFile(path, content, { mode: 0o600 });
-        await chmod(path, 0o600);
         return path;
       },
       async (bytes) => {

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -2,8 +2,8 @@
  * `fastagent start [dir]`: run the agent in production posture — the SAME assembly as dev (your
  * directory is the agent), just no file-watching. No build step: start reads the definition directly.
  */
-import { chmod, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
+import { writeFileAtomic } from "../../atomic-write.ts";
 import { authSeedBytes, collectAuthSeed } from "../../deploy/secrets.ts";
 import { loadDotEnv } from "../../env.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
@@ -152,9 +152,12 @@ async function maybeSeedAuth(authPath: string): Promise<void> {
   const bytes = authSeedBytes(collectAuthSeed(process.env), await exists(authPath));
   if (!bytes) return;
   await ensureSecretsDir(dirname(authPath));
-  await writeFile(authPath, bytes, { mode: SECRET_FILE_MODE });
-  await chmod(authPath, SECRET_FILE_MODE); // `mode` above is ignored if the file somehow exists
-
+  // Same spelling as the credential store: the mode is applied before the content is reachable, so
+  // the seed can never be published at some other file's looser permissions. It does NOT close the
+  // gap between the `exists` check and the write — the rename would overwrite a file created in
+  // between, against this function's absent-only promise. That window needs two `start` processes on
+  // one secrets dir, which no supported deployment runs (one container, one volume).
+  writeFileAtomic(authPath, bytes, SECRET_FILE_MODE);
   log.info(`[fastagent] seeded ${authPath} from FASTAGENT_AUTH_SEED (first boot)`);
 }
 

--- a/src/engines/pi/auth.ts
+++ b/src/engines/pi/auth.ts
@@ -20,10 +20,13 @@
  * Locking is vendored here on `proper-lockfile`, with the same parameters pi's file backend used
  * before pi 0.80.8 stopped exporting it (upstream's stated migration path for SDK consumers is a
  * custom pi-ai `CredentialStore`, which this file is). The lock guards the WRITE path only. `read`
- * is pi-ai's per-request hot path, so it stays UNLOCKED — safe because the write publishes by
- * rename ({@link writeFileAtomic}): a reader sees one whole version of the file or another, never a
- * partial one, so there is no torn-read window for an unlocked read to absorb. The write path
- * refuses to overwrite a corrupt file (never clobbering other providers' credentials).
+ * is pi-ai's per-request hot path, so it stays UNLOCKED — safe because every write that carries a
+ * CREDENTIAL publishes by rename ({@link writeFileAtomic}): a reader sees one whole version of the
+ * file or another, never a partial one, so a rotation has no torn-read window for an unlocked read
+ * to absorb. The one in-place write left is the `{}` bootstrap below, whose window an unlocked read
+ * observes as an empty file — reported as corrupt, which for a zero-byte auth.json is the right
+ * answer either way. The write path refuses to overwrite a corrupt file (never clobbering other
+ * providers' credentials).
  */
 import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -78,6 +81,10 @@ async function withLockedAuthFile<T>(
   authPath: string,
   fn: (current: string | undefined) => Promise<LockResult<T>>,
 ): Promise<T> {
+  // 0700 unconditionally, including on a directory an operator named with `--auth-path`: pointing a
+  // credential file somewhere is asking for that somewhere to hold a credential. Where the process
+  // cannot chmod (a mount it does not own), this raises — the write fails visibly instead of
+  // quietly leaving the directory readable, which is the trade this repo takes everywhere else.
   await ensureSecretsDir(dirname(authPath));
   if (!existsSync(authPath)) {
     try {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -363,10 +363,19 @@ const SECRETS_DIR_MODE = 0o700;
  * directory (`init`, `add <channel>`, the credential store, the deploy seed) and the ordinary order
  * is init → add → login, so the careful one is LAST: the rule has to live where all of them can
  * reach it, and it has to chmod rather than trust the create.
+ *
+ * A chmod the caller never asked for owes them its reason: the raw `EPERM ... chmod '/shared/creds'`
+ * reads as a bug in whatever they WERE doing (storing a credential), not as fastagent tightening a
+ * directory they pointed it at, and says nothing about the way out.
  */
 export async function ensureSecretsDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true, mode: SECRETS_DIR_MODE });
-  await chmod(dir, SECRETS_DIR_MODE);
+  await chmod(dir, SECRETS_DIR_MODE).catch((e: Error) => {
+    throw new Error(
+      `cannot secure secrets dir ${dir} (fastagent keeps it 0700): ${e.message} — point --auth-path/FASTAGENT_SECRETS_DIR at a directory this process owns`,
+      { cause: e },
+    );
+  });
 }
 
 /**

--- a/test/add-channel-env.test.ts
+++ b/test/add-channel-env.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -75,6 +75,7 @@ describe("appendChannelDotEnv", () => {
   it("writes to the RESOLVED secrets dir — FASTAGENT_SECRETS_DIR moves the .env target with the protection", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-env-move-"));
     const secrets = await mkdtemp(join(tmpdir(), "fa-env-external-"));
+    await chmod(secrets, 0o755); // an existing dir the operator (or a volume mount) left wide open
     process.env.FASTAGENT_SECRETS_DIR = secrets;
     try {
       const r = await appendChannelDotEnv(dir, "github", { GITHUB_WEBHOOK_SECRET: "s" });
@@ -82,6 +83,10 @@ describe("appendChannelDotEnv", () => {
       expect(await readFile(join(secrets, ".env"), "utf8")).toContain("GITHUB_WEBHOOK_SECRET=s");
       // Nothing lands at the workspace default — the write and the leak protection target ONE dir.
       expect(existsSync(join(dir, ".secrets", ".env"))).toBe(false);
+      // …and the protection this test's name promises: `.env` is written with no mode of its own, so
+      // the DIRECTORY is the only thing keeping `GITHUB_WEBHOOK_SECRET` off other accounts. The
+      // override moves the target; it does not move it out of protection.
+      expect(((await stat(secrets)).mode & 0o777).toString(8)).toBe("700");
     } finally {
       delete process.env.FASTAGENT_SECRETS_DIR;
     }

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -2,10 +2,27 @@
  * PLACEMENT and the neutral path helpers (src/paths.ts): engine-neutral by nature, so their spec lives
  * here rather than inside the config or scaffold suites that used to own the rule.
  */
-import { describe, expect, it } from "vitest";
-import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+// A directory this process cannot chmod (a mount it does not own) is not reachable from a test that
+// runs as its own user, so the refusal is armed here instead.
+const { denyChmod } = vi.hoisted(() => ({ denyChmod: { path: "", armed: false } }));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    chmod: async (p: unknown, mode: unknown) => {
+      if (denyChmod.armed && p === denyChmod.path)
+        throw new Error(`EPERM: operation not permitted, chmod '${p as string}'`);
+      return actual.chmod(p as string, mode as number);
+    },
+  };
+});
+
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { displayPath, ensureSecretsDir, resolvePlacement, workspaceHint } from "../src/paths.ts";
 
 describe("paths: resolvePlacement — one marker, and the directory you point at", () => {
@@ -169,5 +186,18 @@ describe("paths: the secrets directory carries a mode", () => {
     expect(await modeOf(dir)).toBe("755");
     await ensureSecretsDir(dir);
     expect(await modeOf(dir)).toBe("700");
+  });
+
+  it("names itself and the way out when it cannot chmod — the caller asked to store a credential", async () => {
+    const dir = join(await mkdtemp(join(tmpdir(), "fa-secrets-deny-")), ".secrets");
+    denyChmod.path = dir;
+    denyChmod.armed = true;
+    try {
+      await expect(ensureSecretsDir(dir)).rejects.toThrow(
+        /cannot secure secrets dir .*\.secrets \(fastagent keeps it 0700\): EPERM.*--auth-path\/FASTAGENT_SECRETS_DIR/,
+      );
+    } finally {
+      denyChmod.armed = false;
+    }
   });
 });


### PR DESCRIPTION
Every credential fastagent writes lands in a directory whose `x` bit is the thing that actually keeps
another account out — `auth.json` is `0600` and survives a loose directory, but `.env` is `0644` by
deliberate choice, and both live in that one directory. `mkdir`'s mode is a no-op when the directory
already exists, so the mode has to be re-applied rather than trusted; `ensureSecretsDir` does that on
every write.

That makes fastagent tighten a directory the caller only pointed it at. `--auth-path`,
`FASTAGENT_AUTH_PATH` and an embedder's `fastagentCredentialStore(path)` all name a file wherever
they like, and the directory around it might be shared, or owned by someone else. **Deciding per call
whether we may re-permission it is not possible**: the fact needed — which branch of the resolution
produced this path — is not in the path string, and any answer has to be simultaneously right for the
`0600` file and the `0644` file sitting side by side in it.

So the rule stays unconditional and moves into the contract:

- **It is documented as a promise, not inferred.** Pointing a credential file somewhere is asking for
  that somewhere to hold a credential. `api-reference.md`, `cli.md` and `configuration.md` now each
  state that the directory is managed as a secrets directory and gets `0700` re-applied on *every*
  credential write, including an OAuth refresh mid-run — so a directory widened by hand is tightened
  again on the next token rotation, which is what makes "don't point it at a shared directory" worth
  saying.
- **Where we cannot honour it, the write fails loudly** rather than proceeding with the directory
  left readable. The refusal names what it was securing and which knob to move, instead of surfacing
  a bare `EPERM … chmod '/shared/creds'` under an action the user experienced as "store a
  credential".

## Credential writes go through one spelling

The deploy seed was the last one that did not: `writeFile(path, bytes, { mode })` followed by a
`chmod` that could never run (the mode is only ignored for a file that already exists, and the caller
returns early in exactly that case). It now uses `writeFileAtomic` like the store does, so the mode
reaches the temp before the rename and the seed is never visible at some other file's permissions.
`writeFileAtomic` takes `string | Buffer` for it — the seed is decoded bytes, and forcing them
through UTF-8 to fit the old signature would turn an invalid byte into U+FFFD. `deploy`'s
`params.json` carried the same dead `chmod`; it is gone too.

## Tests

- `.env` is pinned where the directory is its only boundary — the add-channel test whose name already
  promised "with the protection" asserted only the path, and now asserts the mode on a secrets dir
  left 0755 the way a volume mount leaves one.
- The refusal arms `EPERM` through a mocked `chmod`: a directory this process cannot chmod is not
  reachable from a test running as its own user.

Both verified red without the code they cover.

Local: `npm run lint && npm run typecheck && npm test` — 116 files, 1601 tests green.
