### PR TITLE
test(agentcore): the gate assertion covers the third secret too

### DIFF
--- a/test/agentcore-forwarder.test.ts
+++ b/test/agentcore-forwarder.test.ts
@@ -189,9 +189,12 @@ describe("agentcore forwarder: the shared-secret gates", () => {
     // noise. What this catches is the next endpoint copying the wrong neighbour.
     const src = forwarderSource();
     expect(src).not.toMatch(/req\.\w+\s*!==\s*process\.env/);
-    // …and each secret is still actually checked (a gate deleted rather than converted).
+    // …and each secret is still actually checked (a gate deleted rather than converted). The WHOLE
+    // call, not the argument position: `process.env.STATE_REFRESH_SECRET)` also closes the unrelated
+    // `(WAKE_SECRET || STATE_REFRESH_SECRET)` ownUrl guard, so that spelling stayed green with the
+    // state-urls gate deleted.
     for (const secret of ["INGRESS_SECRET", "WAKE_SECRET", "STATE_REFRESH_SECRET"]) {
-      expect(src).toContain(`process.env.${secret})`); // the secretEq argument position
+      expect(src).toMatch(new RegExp(`secretEq\\(req\\.\\w+, process\\.env\\.${secret}\\)`));
     }
   });
 });

--- a/test/agentcore-forwarder.test.ts
+++ b/test/agentcore-forwarder.test.ts
@@ -194,7 +194,7 @@ describe("agentcore forwarder: the shared-secret gates", () => {
     // `(WAKE_SECRET || STATE_REFRESH_SECRET)` ownUrl guard, so that spelling stayed green with the
     // state-urls gate deleted.
     for (const secret of ["INGRESS_SECRET", "WAKE_SECRET", "STATE_REFRESH_SECRET"]) {
-      expect(src).toMatch(new RegExp(`secretEq\\(req\\.\\w+, process\\.env\\.${secret}\\)`));
+      expect(src).toMatch(new RegExp(`secretEq\\([^)]+,\\s*process\\.env\\.${secret}\\)`));
     }
   });
 });


### PR DESCRIPTION
#404 made all three forwarder shared-secret gates constant-time and added a
structural regression test. Its second assertion — "each secret is still
actually checked (a gate deleted rather than converted)" — does not hold for
one of the three.

`toContain("process.env.STATE_REFRESH_SECRET)")` matches on the closing paren,
and that spelling also appears in an unrelated line:

```js
if ((process.env.WAKE_SECRET || process.env.STATE_REFRESH_SECRET) && !ownUrl) {
```

So removing the `/__fastagent/state-urls` gate keeps the test green. Verified by
deleting each gate in turn and re-running both assertions:

| secret | gate deleted |
|---|---|
| `INGRESS_SECRET` | RED (caught) |
| `WAKE_SECRET` | RED (caught) |
| `STATE_REFRESH_SECRET` | **STILL GREEN** |

Asserting the whole call instead of the argument position goes red for all
three.
