### PR TITLE
docs: two claims narrowed to what actually holds

### DIFF
--- a/src/engines/pi/session-inheritance.ts
+++ b/src/engines/pi/session-inheritance.ts
@@ -15,7 +15,7 @@
  * inheritance edge.
  */
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { SessionManager } from "@earendil-works/pi-coding-agent";
+import type { CompactionEntry, SessionManager } from "@earendil-works/pi-coding-agent";
 import { log } from "../../log.ts";
 import { isPlaneMarker } from "./session-markers.ts";
 
@@ -53,7 +53,10 @@ type Entry = {
   message?: AgentMessage;
   content?: string | unknown[];
   summary?: string;
-  firstKeptEntryId?: string;
+  // Bound to pi's own field so the shape change the compaction reader documents cannot land quietly:
+  // dropping `firstKeptEntryId` for a self-contained `retainedTail` (pi-agent-core's form) makes this
+  // index fail to typecheck. Adding `retainedTail` BESIDE the pointer would still compile.
+  firstKeptEntryId?: CompactionEntry["firstKeptEntryId"];
 };
 
 function isUserMessage(entry: Entry | undefined): boolean {
@@ -89,9 +92,11 @@ function estimateEntryTokens(entry: Entry): number {
  *  writes `firstKeptEntryId`, and both of AgentSession's compaction paths go through it).
  *
  *  pi-agent-core's harness writes the newer self-contained form instead — `retainedTail` on the entry,
- *  no pointer. If pi-coding-agent adopts it, the pointer here stops resolving: this function prices
- *  the tail at zero and {@link copyBranchInto} drops it, both silently. That is the change to make
- *  here, not a reason to read both shapes today. */
+ *  no pointer. If pi-coding-agent adopts it the pointer stops resolving, and this function prices the
+ *  tail at zero while {@link copyBranchInto} drops it. Adopting it the way pi-agent-core did, by
+ *  REPLACING the pointer, fails to typecheck at `Entry.firstKeptEntryId` rather than running quietly;
+ *  a `retainedTail` added BESIDE the pointer would not, and is the case to watch on the next bump.
+ *  Either way this is the place to change — not a reason to read both shapes today. */
 function estimateCompactionTokens(path: Entry[], compactionIdx: number): number {
   const compaction = path[compactionIdx];
   if (compaction?.type !== "compaction") return 0;

--- a/src/engines/pi/session-inheritance.ts
+++ b/src/engines/pi/session-inheritance.ts
@@ -84,8 +84,14 @@ function estimateEntryTokens(entry: Entry): number {
 
 /** A compaction entry's summary AND its retained tail — the entries from `firstKeptEntryId` up to
  *  the compaction — DO reach the model. They are the floor under every window that starts above the
- *  compaction, so the budget must count them; the tail is read off the path, since pi stores it as a
- *  pointer and not as messages on the entry. */
+ *  compaction, so the budget must count them; the tail is read off the path, since pi-coding-agent's
+ *  SessionManager stores it as a POINTER and not as messages on the entry (0.84: `appendCompaction`
+ *  writes `firstKeptEntryId`, and both of AgentSession's compaction paths go through it).
+ *
+ *  pi-agent-core's harness writes the newer self-contained form instead — `retainedTail` on the entry,
+ *  no pointer. If pi-coding-agent adopts it, the pointer here stops resolving: this function prices
+ *  the tail at zero and {@link copyBranchInto} drops it, both silently. That is the change to make
+ *  here, not a reason to read both shapes today. */
 function estimateCompactionTokens(path: Entry[], compactionIdx: number): number {
   const compaction = path[compactionIdx];
   if (compaction?.type !== "compaction") return 0;

--- a/test/agentcore-forwarder.test.ts
+++ b/test/agentcore-forwarder.test.ts
@@ -188,7 +188,9 @@ describe("agentcore forwarder: the shared-secret gates", () => {
     // the property itself is not observable from a test: timing measurements against a Lambda are
     // noise. What this catches is the next endpoint copying the wrong neighbour.
     const src = forwarderSource();
-    expect(src).not.toMatch(/req\.\w+\s*!==\s*process\.env/);
+    // Either operand order, and `!=`/`!==`/`==`/`===` alike: `process.env.X !== req.auth` is the same
+    // bug written backwards, and a one-sided pattern reads as covering it while passing.
+    expect(src).not.toMatch(/req\.\w+\s*[!=]=+\s*process\.env|process\.env\.\w+\s*[!=]=+\s*req\.\w+/);
     // …and each secret is still actually checked (a gate deleted rather than converted). The WHOLE
     // call, not the argument position: `process.env.STATE_REFRESH_SECRET)` also closes the unrelated
     // `(WAKE_SECRET || STATE_REFRESH_SECRET)` ownUrl guard, so that spelling stayed green with the

--- a/test/agentcore-forwarder.test.ts
+++ b/test/agentcore-forwarder.test.ts
@@ -188,9 +188,11 @@ describe("agentcore forwarder: the shared-secret gates", () => {
     // the property itself is not observable from a test: timing measurements against a Lambda are
     // noise. What this catches is the next endpoint copying the wrong neighbour.
     const src = forwarderSource();
-    // Either operand order, and `!=`/`!==`/`==`/`===` alike: `process.env.X !== req.auth` is the same
-    // bug written backwards, and a one-sided pattern reads as covering it while passing.
-    expect(src).not.toMatch(/req\.\w+\s*[!=]=+\s*process\.env|process\.env\.\w+\s*[!=]=+\s*req\.\w+/);
+    // Anchored on the SECRET, not on the request variable: either operand order, `!=`/`!==`/`==`/
+    // `===` alike, and whatever the next endpoint calls its parsed body. Naming `req` here would let
+    // `if (body.auth !== process.env.WAKE_SECRET)` through while reading as covered. (A subscript,
+    // `process.env["WAKE_SECRET"]`, still escapes — no spelling of this catches every spelling.)
+    expect(src).not.toMatch(/[!=]=+\s*process\.env\.\w*SECRET|process\.env\.\w*SECRET\s*[!=]=+/);
     // …and each secret is still actually checked (a gate deleted rather than converted). The WHOLE
     // call, not the argument position: `process.env.STATE_REFRESH_SECRET)` also closes the unrelated
     // `(WAKE_SECRET || STATE_REFRESH_SECRET)` ownUrl guard, so that spelling stayed green with the


### PR DESCRIPTION
Two places where the prose claimed more than the code delivers, and — after review — two guards that
depended on a name they do not control.

**`estimateCompactionTokens` walks a pointer because *this* pi keeps one.** The comment said "pi
stores it as a pointer", which gives the next reader no way to tell a verified fact from an
assumption — and the two pi packages in our own dependency tree disagree. pi-coding-agent's
`SessionManager.appendCompaction` writes `firstKeptEntryId` (0.84, and both of `AgentSession`'s
compaction paths go through it); pi-agent-core's harness writes the newer self-contained form, with
`retainedTail` materialized on the entry and no pointer. The comment now names the version it was
checked against and what breaks if pi-coding-agent moves.

And that break is no longer only described: `Entry.firstKeptEntryId` was a local `string`, so the
shape change could land with typecheck green. It now indexes pi's own exported `CompactionEntry`, so
*replacing* the pointer — what pi-agent-core already did — fails to compile here rather than quietly
pricing the retained tail at zero. Verified by editing the installed `.d.ts`:

```
src/engines/pi/session-inheritance.ts(59,38): error TS2339:
  Property 'firstKeptEntryId' does not exist on type 'CompactionEntry<unknown>'.
```

A `retainedTail` added *beside* the pointer still compiles; the comment names that as the case to
watch on the next bump.

**The forwarder's gate assertion caught one spelling of the bug it described.** Its comment promises
to catch "the next endpoint copying the wrong neighbour", but the pattern was
`req.x !== process.env.Y` alone: a gate with the operands swapped passed, as did `!=` and `===`. Both
orders and all four operators are covered now — and the pattern is anchored on the *secret* rather
than on the identifier `req`, because an endpoint that names its parsed body `body` or `payload` was
the same silent pass one level up. A subscript (`process.env["WAKE_SECRET"]`) still escapes; the
comment says so instead of implying the pattern is total. (The positive `secretEq(…)` half landed in
#415; this is the other side of it.)

Local: `npm run lint && npm run typecheck && npm test` — 116 files, 1601 tests green.
