### PR TITLE
chore(release): 0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, Telegram, Slack, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Version bump only — `package.json` + `package-lock.json`, 0.19.0 → 0.20.0.

**Minor, not patch:** #373 reshaped the session control plane (breaking), and #402 made
`ToolActivation.activate` synchronous. Under 0.x that lands in MINOR.

39 commits since `v0.19.0`: 2 feat, 16 fix, 10 refactor, 7 docs, 1 test, 2 chore. The release notes
(drafted, to go on the GitHub Release once this merges and `v0.20.0` is tagged) lead with the control
plane and the credential-permission work (#406/#414, #404, #403, #390).

After merge: tag `v0.20.0` → create the Release → `publish.yml` re-verifies and publishes to npm via OIDC.
