### PR TITLE
test: live probes for what the offline suite fakes

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -1,0 +1,66 @@
+name: Live
+
+# The probes that need the real world: a published tarball, a real model provider, a real container.
+# Never a PR check — an external contributor has no credentials, and a platform's bad night must not
+# read as a broken pull request. Nightly, plus on demand.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published version to probe (default: this checkout's)"
+        required: false
+  schedule:
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live
+  cancel-in-progress: false
+
+jobs:
+  live:
+    name: Live probes
+    runs-on: ubuntu-latest
+    environment: live # holds FASTAGENT_LIVE_MODEL and the provider key
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22.19.0'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ONE credential mechanism for both probes: an auth.json, named by the product's own
+      # FASTAGENT_AUTH_PATH. It carries an OAuth grant (openai-codex) as readily as an API key, and
+      # `deploy docker --run` turns the same file into the container's FASTAGENT_AUTH_SEED.
+      #
+      # The secret holds a grant minted FOR CI and used nowhere else (`fastagent login openai-codex
+      # --auth-path <ci file>`, device-code flow). That isolation is the point: pi persists a NEW
+      # refresh token on every refresh, so any file sharing this grant goes stale the moment another
+      # one refreshes it — a maintainer's laptop and this workflow must not be the same grant.
+      #
+      # The secret is still a SNAPSHOT: CI's own refreshes live and die with the runner, so the stored
+      # token ages. Whether it eventually stops being accepted is the provider's call, not something
+      # this file should claim. When a run fails to authenticate, re-run the login above and re-set the
+      # secret; an API-key credential in the same variable avoids the question entirely.
+      - name: Stage the model credential
+        env:
+          FASTAGENT_AUTH_JSON: ${{ secrets.FASTAGENT_AUTH_JSON }}
+        run: |
+          install -d -m 700 "$RUNNER_TEMP/secrets"
+          umask 077 && printf '%s' "$FASTAGENT_AUTH_JSON" > "$RUNNER_TEMP/secrets/auth.json"
+
+      - name: Run live probes
+        env:
+          FASTAGENT_LIVE_MODEL: ${{ vars.FASTAGENT_LIVE_MODEL }}
+          FASTAGENT_LIVE_VERSION: ${{ inputs.version }}
+          FASTAGENT_AUTH_PATH: ${{ runner.temp }}/secrets/auth.json
+        run: npm run test:live

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -3,11 +3,16 @@ name: Live
 # The probes that need the real world: a published tarball, a real model provider, a real container.
 # Never a PR check — an external contributor has no credentials, and a platform's bad night must not
 # read as a broken pull request. Nightly, plus on demand.
+#
+# One nightly failure is EXPECTED and not a defect: between a `chore(release)` merge and the Release
+# that triggers publish.yml, this checkout names a version npm does not serve yet, so the registry
+# install and the container build both fail on it. Dispatch with `version` set to the last published
+# one to get a clean read during that window — it moves both probes together.
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Published version to probe (default: this checkout's)"
+        description: "Published version to probe (default: this checkout's). Applies to BOTH the registry install and the container image."
         required: false
   schedule:
     - cron: "17 3 * * *"
@@ -23,6 +28,10 @@ jobs:
   live:
     name: Live probes
     runs-on: ubuntu-latest
+    # vitest's own ceiling covers the tests; `npm ci` and a container build sit outside it. Nobody is
+    # watching a nightly run, and the 6h default would hold the next one behind it (the group does not
+    # cancel in progress).
+    timeout-minutes: 60
     environment: live # holds FASTAGENT_LIVE_MODEL and the provider key
     steps:
       - name: Check out repository
@@ -55,6 +64,10 @@ jobs:
         env:
           FASTAGENT_AUTH_JSON: ${{ secrets.FASTAGENT_AUTH_JSON }}
         run: |
+          # An unset secret would write an EMPTY auth.json, and the probes would then report the
+          # product's own "no model credential" gate — a CI misconfiguration wearing a product bug's
+          # face. Same rule as test/live/env.ts: missing configuration fails here, loudly.
+          test -n "$FASTAGENT_AUTH_JSON" || { echo "secrets.FASTAGENT_AUTH_JSON is not set for this environment"; exit 1; }
           install -d -m 700 "$RUNNER_TEMP/secrets"
           umask 077 && printf '%s' "$FASTAGENT_AUTH_JSON" > "$RUNNER_TEMP/secrets/auth.json"
 

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -4,15 +4,11 @@ name: Live
 # Never a PR check — an external contributor has no credentials, and a platform's bad night must not
 # read as a broken pull request. Nightly, plus on demand.
 #
-# One nightly failure is EXPECTED and not a defect: between a `chore(release)` merge and the Release
-# that triggers publish.yml, this checkout names a version npm does not serve yet, so the registry
-# install and the container build both fail on it. Dispatch with `version` set to the last published
-# one to get a clean read during that window — it moves both probes together.
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Published version to probe (default: this checkout's). Applies to BOTH the registry install and the container image."
+        description: "Exact published version to probe (default: the registry's current latest). Applies to BOTH the registry install and the container image."
         required: false
   schedule:
     - cron: "17 3 * * *"
@@ -71,9 +67,22 @@ jobs:
           install -d -m 700 "$RUNNER_TEMP/secrets"
           umask 077 && printf '%s' "$FASTAGENT_AUTH_JSON" > "$RUNNER_TEMP/secrets/auth.json"
 
+      # The ONE version both probes land on, resolved here so they cannot land on two. `latest`
+      # rather than this checkout's version: between a `chore(release)` merge and the Release that
+      # triggers publish.yml, this checkout names a version npm does not serve, and a nightly that is
+      # red every release cycle for a non-defect trains people to ignore it. Resolved to an EXACT
+      # version, never handed down as the tag: the registry probe asserts what `--version` reports,
+      # and the container image would resolve the tag a second time.
+      - name: Resolve the version under probe
+        env:
+          PINNED: ${{ inputs.version }}
+        run: |
+          VERSION="${PINNED:-$(npm view @fastagent-sh/fastagent version)}"
+          test -n "$VERSION" || { echo "could not resolve a published version to probe"; exit 1; }
+          echo "FASTAGENT_LIVE_VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Run live probes
         env:
           FASTAGENT_LIVE_MODEL: ${{ vars.FASTAGENT_LIVE_MODEL }}
-          FASTAGENT_LIVE_VERSION: ${{ inputs.version }}
           FASTAGENT_AUTH_PATH: ${{ runner.temp }}/secrets/auth.json
         run: npm run test:live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,12 +257,13 @@ test/                        # vitest; faux models by default + reusable SPEC co
 │                            # test green while breaking the paste-this-in promise
 └── live/                   # the probes for what the offline suite FAKES — every file here exists to
                              # check an assumption about a system we do not own, never to re-run logic:
-                             # the published tarball (registry), a real provider's stream/errors/cancel
-                             # (model), a real container build + boot + state volume (docker). Excluded
-                             # from `npm test`; `npm run test:live` (vitest.live.config.ts) opts in, and
-                             # a missing credential FAILS rather than skips — you asked for them.
-                             # Credentials arrive the PRODUCT's way (FASTAGENT_AUTH_PATH → an auth.json),
-                             # which is what lets an OAuth-only provider be the model under test.
+                             # the published tarball (registry), a real provider's stream and errors
+                             # (model), a real container build + boot + state volume (docker). Each one
+                             # drives a PRODUCT ENTRY and observes from outside (see the rule below).
+                             # Excluded from `npm test`; `npm run test:live` (vitest.live.config.ts)
+                             # opts in, and a missing credential FAILS rather than skips — you asked
+                             # for them. Credentials arrive the PRODUCT's way (FASTAGENT_AUTH_PATH → an
+                             # auth.json), which is what lets an OAuth-only provider be the model.
 docs/                        # SPEC, guides, and maintainer design notes (design/core.md = architecture)
 ```
 
@@ -286,6 +287,7 @@ fastagent *is* a developer-experience product: its whole promise is turning an e
 - **A session id belongs to the Caller.** `scope.session` is opaque and arbitrary — a telegram group is `-1001234567890`, a feishu thread carries `:` and `/`. What an engine needs to store it (pi rejects all of those as record names, so they are encoded) is storage detail and must not leak back out: a tool asking which conversation it is in gets the id the channel minted, not the record's name.
 - **The run plane and the observation plane read the same state, through the same function.** They answer different questions about one session — what will execute, and what to report — so deriving them separately is how they come to disagree. The concrete failures this rule is made of: a turn running on assembly defaults while `state()` reported the recorded override, and one plane refusing a record with a cut parent chain while the other silently ran on the truncated path.
 - **A convention with four enforcers has none.** When several call sites must each remember to do a thing, the thing belongs in a function they all call, and that function must REPAIR rather than trust the first writer. `.secrets/` was created by four paths and only one passed `0700` — and `mkdir`'s mode is a no-op on an existing directory, so the careful one (login, which runs last) never applied it: every scaffolded agent held its credentials in a 0755 directory. `ensureSecretsDir` (paths.ts) is that function; `writeFileAtomic` and `sessionToolActivation` are the same lesson from the same review.
+- **A test that rebuilds the assembly measures the rebuild.** Drive the entry a user drives (`createPiAgentFromDir`, `deploy docker --run`, `npm install`) and observe from OUTSIDE it. Reaching one layer down to get an observation point means re-doing everything the entry does — `installProxyFetch` (which the CLI calls and the library deliberately does not), credential resolution, pinning pi's agent dir away from `~/.pi/agent` — and each omission surfaces one at a time, as a defect in the test. The live model probe was built on the `AgentSession` L0 to satisfy one conformance subject (`hanging`, which intercepts `session.abort`); across three review rounds every defect it produced was in that rebuilt assembly and none was in the product, while the two probes that drove real entries were right the first time. That subject asserted the same thing its faux twin does — the engine's abort ran — so the layer it forced bought nothing. When the observation point is out of reach from the entry, change what you assert, not which layer you call.
 
 ### Reviewing this repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,13 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # check an assumption about a system we do not own, never to re-run logic:
                              # the published tarball (registry), a real provider's stream and errors
                              # (model), a real container build + boot + state volume (docker). Each one
-                             # drives a PRODUCT ENTRY and observes from outside (see the rule below).
+                             # drives a PRODUCT ENTRY (`createPiAgentFromDir`, `deploy docker --run`,
+                             # `npm install`) and observes from OUTSIDE it — a probe that rebuilds the
+                             # assembly to get a better observation point measures the rebuild, and the
+                             # entry's own steps (installProxyFetch, credential resolution, pinning pi's
+                             # agent dir) go missing one at a time. Unit tests below DO reach into that
+                             # layer, correctly — the rule is this directory's, because only these files
+                             # claim to report on the real thing.
                              # Excluded from `npm test`; `npm run test:live` (vitest.live.config.ts)
                              # opts in, and a missing credential FAILS rather than skips — you asked
                              # for them. Credentials arrive the PRODUCT's way (FASTAGENT_AUTH_PATH → an
@@ -287,7 +293,6 @@ fastagent *is* a developer-experience product: its whole promise is turning an e
 - **A session id belongs to the Caller.** `scope.session` is opaque and arbitrary — a telegram group is `-1001234567890`, a feishu thread carries `:` and `/`. What an engine needs to store it (pi rejects all of those as record names, so they are encoded) is storage detail and must not leak back out: a tool asking which conversation it is in gets the id the channel minted, not the record's name.
 - **The run plane and the observation plane read the same state, through the same function.** They answer different questions about one session — what will execute, and what to report — so deriving them separately is how they come to disagree. The concrete failures this rule is made of: a turn running on assembly defaults while `state()` reported the recorded override, and one plane refusing a record with a cut parent chain while the other silently ran on the truncated path.
 - **A convention with four enforcers has none.** When several call sites must each remember to do a thing, the thing belongs in a function they all call, and that function must REPAIR rather than trust the first writer. `.secrets/` was created by four paths and only one passed `0700` — and `mkdir`'s mode is a no-op on an existing directory, so the careful one (login, which runs last) never applied it: every scaffolded agent held its credentials in a 0755 directory. `ensureSecretsDir` (paths.ts) is that function; `writeFileAtomic` and `sessionToolActivation` are the same lesson from the same review.
-- **A test that rebuilds the assembly measures the rebuild.** Drive the entry a user drives (`createPiAgentFromDir`, `deploy docker --run`, `npm install`) and observe from OUTSIDE it. Reaching one layer down to get an observation point means re-doing everything the entry does — `installProxyFetch` (which the CLI calls and the library deliberately does not), credential resolution, pinning pi's agent dir away from `~/.pi/agent` — and each omission surfaces one at a time, as a defect in the test. The live model probe was built on the `AgentSession` L0 to satisfy one conformance subject (`hanging`, which intercepts `session.abort`); across three review rounds every defect it produced was in that rebuilt assembly and none was in the product, while the two probes that drove real entries were right the first time. That subject asserted the same thing its faux twin does — the engine's abort ran — so the layer it forced bought nothing. When the observation point is out of reach from the entry, change what you assert, not which layer you call.
 
 ### Reviewing this repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,10 +251,18 @@ src/
     │                         # definition-local so it travels; the machine-global ~/.pi one stays unread)
     └── report.ts            # startup report (auth/model/skills/tools surface)
 test/                        # vitest; faux models by default + reusable SPEC conformance.
-└── embedding.test.ts       # the docs/embedding.md snippets, run against REAL express/fastify (the
-                             # only reason they are devDeps): that path crosses the Node/Fetch seam
-                             # through code we do not own, so a swap underneath can keep every unit
-                             # test green while breaking the paste-this-in promise
+├── embedding.test.ts       # the docs/embedding.md snippets, run against REAL express/fastify (the
+│                            # only reason they are devDeps): that path crosses the Node/Fetch seam
+│                            # through code we do not own, so a swap underneath can keep every unit
+│                            # test green while breaking the paste-this-in promise
+└── live/                   # the probes for what the offline suite FAKES — every file here exists to
+                             # check an assumption about a system we do not own, never to re-run logic:
+                             # the published tarball (registry), a real provider's stream/errors/cancel
+                             # (model), a real container build + boot + state volume (docker). Excluded
+                             # from `npm test`; `npm run test:live` (vitest.live.config.ts) opts in, and
+                             # a missing credential FAILS rather than skips — you asked for them.
+                             # Credentials arrive the PRODUCT's way (FASTAGENT_AUTH_PATH → an auth.json),
+                             # which is what lets an OAuth-only provider be the model under test.
 docs/                        # SPEC, guides, and maintainer design notes (design/core.md = architecture)
 ```
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "build": "tsc -p tsconfig.build.json",
     "prepack": "npm run build",
     "test": "vitest --run",
+    "test:live": "vitest --run --config vitest.live.config.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src test && node scripts/check-doc-links.mjs && knip",
     "format": "biome check --write src test",

--- a/test/live/docker.live.test.ts
+++ b/test/live/docker.live.test.ts
@@ -1,0 +1,96 @@
+/**
+ * A definition on disk → a real container serving real turns, driven through the CLI a user runs.
+ * This is the probe for everything the offline deploy tests fake at the `CliRunner` seam: the
+ * generated Dockerfile actually builds, the image boots, the credential carry arrives, `/health` and
+ * `POST /invoke` answer, and the state volume outlives the container.
+ *
+ * Needs a model credential the way the product needs one: a provider env key in the environment, or
+ * `FASTAGENT_AUTH_PATH` pointing at a stored auth.json. Without either, `--run` gates before it
+ * builds and this test fails with that gate's own message.
+ */
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { waitForHealth } from "../../src/channels/wait-health.ts";
+import { requireEnv } from "./env.ts";
+
+// A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-build.
+const run = (file: string, args: string[], cwd: string) =>
+  promisify(execFile)(file, args, { cwd, maxBuffer: 64 << 20 });
+const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+const COMPOSE = "fastagent/fastagent.compose.yml";
+
+let workspace = "";
+let port = 0;
+
+/** A port the container will publish on 127.0.0.1 — taken and released, so parallel runs do not collide. */
+async function freePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port: taken } = server.address() as { port: number };
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return taken;
+}
+
+const compose = (args: string[]) => run("docker", ["compose", "-f", COMPOSE, ...args], workspace);
+
+beforeAll(async () => {
+  port = await freePort();
+  workspace = await mkdtemp(join(tmpdir(), "fa-live-docker-"));
+  const agent = join(workspace, "fastagent");
+  await mkdir(agent, { recursive: true });
+  await writeFile(join(agent, "persona.md"), "You are terse. Answer in as few words as possible.\n");
+  await writeFile(
+    join(agent, "fastagent.config.mjs"),
+    `export default { model: ${JSON.stringify(MODEL)}, http: { port: ${port} } };\n`,
+  );
+  // No package.json on purpose: that is the markdown/skills agent path, whose image installs the
+  // PUBLISHED CLI at this checkout's version — so the container runs the same artifact the registry
+  // probe installs, and the build needs no lockfile.
+});
+
+afterAll(async () => {
+  // Always tear down, including the volume: a leaked probe deployment is a leaked model credential.
+  if (workspace) await compose(["down", "-v"]).catch(() => {});
+});
+
+/** POST one turn and return the SSE body (the built-in `/invoke`, mounted because no channel is declared). */
+async function invoke(session: string, text: string): Promise<string> {
+  const response = await fetch(`http://127.0.0.1:${port}/invoke`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ session, text }),
+  });
+  expect(response.status).toBe(200);
+  return await response.text();
+}
+
+describe("deploy docker --run: a definition serving real turns in a container", () => {
+  it("builds, boots, answers, and keeps its sessions across a restart", async () => {
+    // Every gate in the driver exits non-zero, so a refusal surfaces here as this call's rejection,
+    // carrying the gate's own remediation text.
+    await run(process.execPath, [CLI, "deploy", "docker", "--run"], workspace);
+
+    expect(await fetch(`http://127.0.0.1:${port}/health`).then((r) => r.text())).toBe("ok\n");
+
+    const session = "live-docker";
+    expect(await invoke(session, "Remember this number: 47. Reply with just: ok")).toContain('"type":"completed"');
+
+    // The state volume is the deployment's continuity. Restarting the container drops every bit of
+    // in-process state, so what answers afterwards can only have come off the volume.
+    await compose(["restart", "agent"]);
+    expect(await waitForHealth(`http://127.0.0.1:${port}/health`, 60_000, 500)).toBe(true);
+    const listed = await compose(["exec", "-T", "agent", "ls", "/data/.state/sessions"]);
+    expect(listed.stdout.trim()).not.toBe("");
+
+    const second = await invoke(session, "What number did I ask you to remember? Reply with digits only.");
+    expect(second).toContain('"type":"completed"');
+    expect(second).toContain("47");
+  });
+});

--- a/test/live/docker.live.test.ts
+++ b/test/live/docker.live.test.ts
@@ -16,7 +16,9 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AgentEvent } from "../../src/agent.ts";
 import { waitForHealth } from "../../src/channels/wait-health.ts";
+import { exists } from "../../src/paths.ts";
 import { liveVersion, requireEnv } from "./env.ts";
 
 // A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-build.
@@ -67,24 +69,37 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // Always tear down, including the volume: a leaked probe deployment is a leaked model credential.
-  // Swallowed on purpose — `down` also runs when the deploy never got as far as writing a Compose
-  // file, and rethrowing from a hook would replace the real test failure with this one. REPORTED on
-  // purpose too: the case this catch exists to absorb looks identical to a daemon that refused to
-  // remove a running container, and that one leaves CI's credential live in it.
-  if (workspace) await compose(["down", "-v"]).catch((error) => console.error(`[live] teardown failed: ${error}`));
+  // Tear down whatever the deploy created, volume included: a leaked probe deployment is a leaked
+  // model credential. The one expected failure — `down` when the deploy never got as far as writing a
+  // Compose file — is ruled out by asking whether that file exists, so nothing here needs absorbing:
+  // a `down` that fails now is a daemon refusing to remove a container that holds CI's credential,
+  // and a run that ends green while that container keeps running is the outcome worth failing over.
+  if (workspace && (await exists(join(workspace, COMPOSE)))) await compose(["down", "-v"]);
 });
 
-/** POST one turn and return the SSE body (the built-in `/invoke`, mounted because no channel is declared). */
-async function invoke(session: string, text: string): Promise<string> {
+/** POST one turn and return its SSE events (the built-in `/invoke`, mounted because no channel is
+ *  declared). Same reduction test/http.test.ts uses; `JSON.parse` is deliberately unguarded, since a
+ *  payload that is not an event is a broken wire format, not a case to absorb. */
+async function invoke(session: string, text: string): Promise<AgentEvent[]> {
   const response = await fetch(`http://127.0.0.1:${port}/invoke`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ session, text }),
   });
   expect(response.status).toBe(200);
-  return await response.text();
+  return (await response.text())
+    .split("\n\n")
+    .filter((block) => block.startsWith("data: "))
+    .map((block) => JSON.parse(block.slice("data: ".length)) as AgentEvent);
 }
+
+/**
+ * The ANSWER, and only it. Asserting on the raw SSE text would be wrong in both directions: a
+ * provider that splits `47` into two tokens never spells it literally, and a `thinking` delta that
+ * reasoned about the number would satisfy the assertion even when the answer got it wrong.
+ */
+const answerOf = (events: AgentEvent[]): string =>
+  events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
 
 describe("deploy docker --run: a definition serving real turns in a container", () => {
   it("builds, boots, answers, and keeps its sessions across a restart", async () => {
@@ -95,7 +110,7 @@ describe("deploy docker --run: a definition serving real turns in a container", 
     expect(await fetch(`http://127.0.0.1:${port}/health`).then((r) => r.text())).toBe("ok\n");
 
     const session = "live-docker";
-    expect(await invoke(session, "Remember this number: 47. Reply with just: ok")).toContain('"type":"completed"');
+    expect((await invoke(session, "Remember this number: 47. Reply with just: ok")).at(-1)?.type).toBe("completed");
 
     // The state volume is the deployment's continuity. Restarting the container drops every bit of
     // in-process state, so what answers afterwards can only have come off the volume.
@@ -105,7 +120,7 @@ describe("deploy docker --run: a definition serving real turns in a container", 
     expect(listed.stdout.trim()).not.toBe("");
 
     const second = await invoke(session, "What number did I ask you to remember? Reply with digits only.");
-    expect(second).toContain('"type":"completed"');
-    expect(second).toContain("47");
+    expect(second.at(-1)?.type).toBe("completed");
+    expect(answerOf(second)).toContain("47");
   });
 });

--- a/test/live/docker.live.test.ts
+++ b/test/live/docker.live.test.ts
@@ -17,13 +17,14 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { waitForHealth } from "../../src/channels/wait-health.ts";
-import { requireEnv } from "./env.ts";
+import { liveVersion, requireEnv } from "./env.ts";
 
 // A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-build.
 const run = (file: string, args: string[], cwd: string) =>
   promisify(execFile)(file, args, { cwd, maxBuffer: 64 << 20 });
 const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+const VERSION = await liveVersion();
 const COMPOSE = "fastagent/fastagent.compose.yml";
 
 let workspace = "";
@@ -50,14 +51,28 @@ beforeAll(async () => {
     join(agent, "fastagent.config.mjs"),
     `export default { model: ${JSON.stringify(MODEL)}, http: { port: ${port} } };\n`,
   );
-  // No package.json on purpose: that is the markdown/skills agent path, whose image installs the
-  // PUBLISHED CLI at this checkout's version — so the container runs the same artifact the registry
-  // probe installs, and the build needs no lockfile.
+  // The agent declares the fastagent version it runs, so the image installs the SAME artifact the
+  // registry probe does. Without this the generated Dockerfile takes the markdown-agent path and
+  // bakes `npm i -g @fastagent-sh/fastagent@<this checkout>` (src/deploy/container.ts), which no
+  // environment variable can redirect: a dispatch pinning FASTAGENT_LIVE_VERSION would then move the
+  // registry probe alone, and the two would report on two different artifacts.
+  await writeFile(
+    join(agent, "package.json"),
+    `${JSON.stringify(
+      { name: "live-docker-probe", private: true, dependencies: { "@fastagent-sh/fastagent": VERSION } },
+      null,
+      2,
+    )}\n`,
+  );
 });
 
 afterAll(async () => {
   // Always tear down, including the volume: a leaked probe deployment is a leaked model credential.
-  if (workspace) await compose(["down", "-v"]).catch(() => {});
+  // Swallowed on purpose — `down` also runs when the deploy never got as far as writing a Compose
+  // file, and rethrowing from a hook would replace the real test failure with this one. REPORTED on
+  // purpose too: the case this catch exists to absorb looks identical to a daemon that refused to
+  // remove a running container, and that one leaves CI's credential live in it.
+  if (workspace) await compose(["down", "-v"]).catch((error) => console.error(`[live] teardown failed: ${error}`));
 });
 
 /** POST one turn and return the SSE body (the built-in `/invoke`, mounted because no channel is declared). */

--- a/test/live/docker.live.test.ts
+++ b/test/live/docker.live.test.ts
@@ -9,7 +9,7 @@
  * builds and this test fails with that gate's own message.
  */
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -32,7 +32,10 @@ const COMPOSE = "fastagent/fastagent.compose.yml";
 let workspace = "";
 let port = 0;
 
-/** A port the container will publish on 127.0.0.1 — taken and released, so parallel runs do not collide. */
+/** An ephemeral port for the container to publish on 127.0.0.1: taken to learn a free number, then
+ *  released — nothing holds it until the container binds it. What keeps concurrent runs apart is
+ *  `fileParallelism: false` plus the per-run Compose project name; losing the race in between surfaces
+ *  as `docker compose up` failing to bind, never as two probes on one port. */
 async function freePort(): Promise<number> {
   const server = createServer();
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -74,7 +77,11 @@ afterAll(async () => {
   // Compose file — is ruled out by asking whether that file exists, so nothing here needs absorbing:
   // a `down` that fails now is a daemon refusing to remove a container that holds CI's credential,
   // and a run that ends green while that container keeps running is the outcome worth failing over.
-  if (workspace && (await exists(join(workspace, COMPOSE)))) await compose(["down", "-v"]);
+  // `--rmi local`: the Compose project name carries this run's mkdtemp suffix, so the built image is
+  // unique per run and nothing else can reuse it. Without this every local `npm run test:live` leaves
+  // another node:22-slim + full pi dependency tree behind.
+  if (workspace && (await exists(join(workspace, COMPOSE)))) await compose(["down", "-v", "--rmi", "local"]);
+  if (workspace) await rm(workspace, { recursive: true });
 });
 
 /** POST one turn and return its SSE events (the built-in `/invoke`, mounted because no channel is
@@ -110,7 +117,12 @@ describe("deploy docker --run: a definition serving real turns in a container", 
     expect(await fetch(`http://127.0.0.1:${port}/health`).then((r) => r.text())).toBe("ok\n");
 
     const session = "live-docker";
-    expect((await invoke(session, "Remember this number: 47. Reply with just: ok")).at(-1)?.type).toBe("completed");
+    // toMatchObject, not `.at(-1)?.type`: a `failed` terminal carries `details`/`retryable` (SPEC
+    // MUST 2), and a mismatch prints the whole event. Nobody is watching a nightly run, so a bare
+    // `expected 'failed' to be 'completed'` costs a full re-run to learn why.
+    expect((await invoke(session, "Remember this number: 47. Reply with just: ok")).at(-1)).toMatchObject({
+      type: "completed",
+    });
 
     // The state volume is the deployment's continuity. Restarting the container drops every bit of
     // in-process state, so what answers afterwards can only have come off the volume.
@@ -120,7 +132,7 @@ describe("deploy docker --run: a definition serving real turns in a container", 
     expect(listed.stdout.trim()).not.toBe("");
 
     const second = await invoke(session, "What number did I ask you to remember? Reply with digits only.");
-    expect(second.at(-1)?.type).toBe("completed");
+    expect(second.at(-1)).toMatchObject({ type: "completed" });
     expect(answerOf(second)).toContain("47");
   });
 });

--- a/test/live/env.ts
+++ b/test/live/env.ts
@@ -11,15 +11,14 @@ export function requireEnv(name: string, hint: string): string {
 }
 
 /**
- * The published version under probe: the workflow's input when it carries one, else this checkout's
- * (after a release, the version just published). Read HERE rather than per probe, because the
- * registry install and the container image must resolve the same one — a dispatch that pins a version
- * for one of them and not the other would report on two different artifacts.
+ * The published version under probe, read the same way by every probe: `FASTAGENT_LIVE_VERSION` when
+ * it carries one — CI resolves the registry's current `latest` to an exact version ONCE and exports it
+ * (.github/workflows/live.yml), so the registry install and the container image cannot report on two
+ * artifacts — else this checkout's version, which is what a local run means.
  *
- * `||`, never `??`: an optional `workflow_dispatch` input left blank — and EVERY `schedule` run —
- * arrives as an empty string, which `??` would keep. That installs `@fastagent-sh/fastagent@` (npm
- * resolves the empty range to `latest`) and then asserts the CLI reports `""`, so the nightly path
- * would fail every night while never once probing this checkout.
+ * `||`, never `??`: an exported-but-empty variable is not a pin, and `??` would keep it. That installs
+ * `@fastagent-sh/fastagent@` (npm resolves the empty range to `latest`) and then asserts the CLI
+ * reports `""` — a probe that fails without ever naming the version it meant to check.
  */
 export async function liveVersion(): Promise<string> {
   return process.env.FASTAGENT_LIVE_VERSION || (await fastagentVersion());

--- a/test/live/env.ts
+++ b/test/live/env.ts
@@ -1,0 +1,10 @@
+/**
+ * Live probes fail loudly on missing configuration instead of skipping: `npm run test:live` is an
+ * explicit opt-in, so an unset variable is a broken run, not an absent capability. (A platform that
+ * is genuinely DOWN is a different case — that belongs in the probe that talks to it.)
+ */
+export function requireEnv(name: string, hint: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`live probes need ${name} (${hint})`);
+  return value;
+}

--- a/test/live/env.ts
+++ b/test/live/env.ts
@@ -3,8 +3,24 @@
  * explicit opt-in, so an unset variable is a broken run, not an absent capability. (A platform that
  * is genuinely DOWN is a different case — that belongs in the probe that talks to it.)
  */
+import { fastagentVersion } from "../../src/version.ts";
 export function requireEnv(name: string, hint: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`live probes need ${name} (${hint})`);
   return value;
+}
+
+/**
+ * The published version under probe: the workflow's input when it carries one, else this checkout's
+ * (after a release, the version just published). Read HERE rather than per probe, because the
+ * registry install and the container image must resolve the same one — a dispatch that pins a version
+ * for one of them and not the other would report on two different artifacts.
+ *
+ * `||`, never `??`: an optional `workflow_dispatch` input left blank — and EVERY `schedule` run —
+ * arrives as an empty string, which `??` would keep. That installs `@fastagent-sh/fastagent@` (npm
+ * resolves the empty range to `latest`) and then asserts the CLI reports `""`, so the nightly path
+ * would fail every night while never once probing this checkout.
+ */
+export async function liveVersion(): Promise<string> {
+  return process.env.FASTAGENT_LIVE_VERSION || (await fastagentVersion());
 }

--- a/test/live/model.live.test.ts
+++ b/test/live/model.live.test.ts
@@ -34,6 +34,17 @@ import { installProxyFetch } from "../../src/proxy.ts";
 import { describeSpecConformance } from "../spec-conformance.ts";
 import { requireEnv } from "./env.ts";
 
+// The `failing` subject's endpoint is on loopback, and undici's EnvHttpProxyAgent exempts nothing by
+// itself ("Always proxy if NO_PROXY is not set or empty") — on a machine with a proxy set, that
+// request would be dialed through it and the subject would fail for a reason unrelated to what it
+// probes. The agent reads `no_proxy` BEFORE `NO_PROXY`, so the merged value goes into both spellings:
+// writing only the upper-case one is a no-op wherever the lower-case one is set.
+const noProxy = [process.env.no_proxy ?? process.env.NO_PROXY ?? "", "127.0.0.1", "localhost"]
+  .filter(Boolean)
+  .join(",");
+process.env.no_proxy = noProxy;
+process.env.NO_PROXY = noProxy;
+
 // What every CLI entry does before it reaches a provider. This probe assembles the engine directly,
 // so it owes the same call: without it, a machine behind a proxy sees each turn time out.
 installProxyFetch();

--- a/test/live/model.live.test.ts
+++ b/test/live/model.live.test.ts
@@ -1,42 +1,40 @@
 /**
- * The SPEC conformance suite (spec-conformance.ts) against a REAL provider, over the same per-invoke
- * `AgentSession` L0 the serving path binds. The offline twin (test/conformance-session.test.ts) proves
- * the contract holds over a faux model; this one proves it still holds when the stream, the errors and
- * the cancellation are a real provider's.
+ * A definition directory served by a REAL provider, opened the way the product opens one.
  *
- * `FASTAGENT_LIVE_MODEL` selects the model ("provider/modelId"); credentials resolve exactly as the
- * product resolves them — `FASTAGENT_AUTH_PATH` or the agent's own auth.json, then the provider's env
- * key. An OAuth provider (openai-codex) has only the first, so point the variable at a logged-in file.
+ * The probe drives `createPiAgentFromDir` — the same opener `dev`, `start` and `invoke` drive — and
+ * observes only from outside: what the turn answers, and what a failing one reports. It deliberately
+ * does NOT reach for the `AgentSession` L0 underneath, even though that layer offers observation
+ * points this file cannot have (intercepting `session.abort`, for one). Rebuilding the opener to get
+ * at them means re-doing everything it does — proxy install, credential resolution, pinning pi's own
+ * agent dir away from `~/.pi/agent` — and every one of those was missed at least once here. A probe
+ * that rebuilds the assembly measures the rebuild's fidelity, not the product.
  *
- * The `failing` subject is the one deliberate stand-in: it points a definition-local models.json at a
- * local endpoint that answers 400, because the assertion is how a real HTTP error travels through pi's
- * provider stack into our terminal mapping — not which prose the vendor puts in it. MUST 6 has no
- * subject here either: the suite's `pair` probe needs to read the second instance's ANSWER, which is
- * the continuity test below, written once.
+ * SPEC conformance therefore stays where it can be asserted honestly: test/conformance-session.test.ts
+ * runs the full suite (MUST 1/2/3/6) against the L0 on a faux model. Cancellation in particular gains
+ * nothing from a live provider — the assertion is that the engine's abort ran, which is identical in
+ * both worlds. What only a real provider can settle is here: a real stream completes, a real HTTP
+ * error becomes a `failed` terminal with the right `retryable`, and a real record carries a
+ * conversation across two independent instances.
+ *
+ * `FASTAGENT_LIVE_MODEL` selects the model ("provider/modelId"); credentials resolve as the product
+ * resolves them — `FASTAGENT_AUTH_PATH`, else the agent's own `.secrets/auth.json`, else the
+ * provider's env key. An OAuth provider (openai-codex) has only the first, so point the variable at a
+ * logged-in file.
  */
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  type AgentSession,
-  createAgentSessionFromServices,
-  createAgentSessionServices,
-} from "@earendil-works/pi-coding-agent";
 import { afterAll, describe, expect, it } from "vitest";
-import type { Agent } from "../../src/agent.ts";
+import type { AgentEvent } from "../../src/agent.ts";
 import { collect } from "../../src/collect.ts";
-import { resolveAuthPath, resolveModel } from "../../src/engines/pi/config.ts";
-import { type PiAgentSessionFactory, createPiAgentFromSession } from "../../src/engines/pi/invoke-session.ts";
-import { createPiModelRuntime } from "../../src/engines/pi/models.ts";
-import { piInMemorySessionRecordStore, piSessionRecordStore } from "../../src/engines/pi/session-store.ts";
+import { createPiAgentFromDir } from "../../src/engines/pi/open.ts";
 import { installProxyFetch } from "../../src/proxy.ts";
-import { describeSpecConformance } from "../spec-conformance.ts";
 import { requireEnv } from "./env.ts";
 
-// The `failing` subject's endpoint is on loopback, and undici's EnvHttpProxyAgent exempts nothing by
+// The refusing endpoint below is on loopback, and undici's EnvHttpProxyAgent exempts nothing by
 // itself ("Always proxy if NO_PROXY is not set or empty") — on a machine with a proxy set, that
-// request would be dialed through it and the subject would fail for a reason unrelated to what it
+// request would be dialed through it and the test would fail for a reason unrelated to what it
 // probes. The agent reads `no_proxy` BEFORE `NO_PROXY`, so the merged value goes into both spellings:
 // writing only the upper-case one is a no-op wherever the lower-case one is set.
 const noProxy = [process.env.no_proxy ?? process.env.NO_PROXY ?? "", "127.0.0.1", "localhost"]
@@ -45,8 +43,9 @@ const noProxy = [process.env.no_proxy ?? process.env.NO_PROXY ?? "", "127.0.0.1"
 process.env.no_proxy = noProxy;
 process.env.NO_PROXY = noProxy;
 
-// What every CLI entry does before it reaches a provider. This probe assembles the engine directly,
-// so it owes the same call: without it, a machine behind a proxy sees each turn time out.
+// Every CLI entry calls this before it reaches a provider, and the LIBRARY opener does not — proxy
+// wiring belongs to the process, not to the assembly. An embedder owes the same call, and so does
+// this probe: without it, a machine behind a proxy sees each turn time out.
 installProxyFetch();
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
@@ -56,62 +55,31 @@ afterAll(async () => {
   for (const cleanup of cleanups) await cleanup();
 });
 
-/** An empty agent dir: no models.json, so the real provider registry and real credentials are in play. */
-const agentDir = (): Promise<string> => mkdtemp(join(tmpdir(), "fa-live-model-"));
-
 /**
- * A per-invoke `AgentSession` factory on the REAL model runtime — the same shape the offline
- * conformance subject builds, with pi's own resource loading turned off so the probe measures the
- * engine and the provider, not this machine's pi setup. `dir` makes the record durable; without it
- * each turn gets a fresh in-memory session.
+ * An agent directory as an author would write one: a persona and a config naming the model. The
+ * directory IS the agent (no nesting), so the opener resolves it as both agent dir and workspace.
  */
-async function sessionFactory(options: {
-  agentDir: string;
-  model: string;
-  dir?: string;
-}): Promise<PiAgentSessionFactory> {
-  const cwd = options.agentDir;
-  // Credentials resolve the way the opener resolves them (FASTAGENT_AUTH_PATH > the agent's own
-  // .secrets/auth.json), NOT the credential store's bare default: an OAuth provider has no env key to
-  // fall back to, so a probe that skipped this knob could only ever be run against an API-key provider.
-  const modelRuntime = await createPiModelRuntime({
-    agentDir: options.agentDir,
-    authPath: resolveAuthPath(options.agentDir, undefined),
-  });
-  const model = resolveModel(modelRuntime, options.model);
-  const services = await createAgentSessionServices({
-    cwd,
-    modelRuntime,
-    resourceLoaderOptions: {
-      noExtensions: true,
-      noPromptTemplates: true,
-      noContextFiles: true,
-      systemPromptOverride: () => "Answer in as few words as possible.",
-      appendSystemPromptOverride: () => [],
-      skillsOverride: (base) => ({ skills: [], diagnostics: base.diagnostics }),
-    },
-  });
-  const store =
-    options.dir === undefined ? piInMemorySessionRecordStore({ cwd }) : piSessionRecordStore({ dir: options.dir, cwd });
-  return async (sessionId) => {
-    const sessionManager = await store.openOrCreate(sessionId);
-    const { session } = await createAgentSessionFromServices({
-      services,
-      sessionManager,
-      model,
-      noTools: "builtin", // a protocol subject, not an agent: the coding tools stay off
-    });
-    return session;
-  };
+async function agentDirectory(model: string, files: Record<string, string> = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "fa-live-model-"));
+  await writeFile(join(dir, "persona.md"), "You are terse. Answer in as few words as possible.\n");
+  await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(model)} };\n`);
+  for (const [name, content] of Object.entries(files)) {
+    await mkdir(join(dir, name, ".."), { recursive: true });
+    await writeFile(join(dir, name), content);
+  }
+  return dir;
 }
 
-async function liveAgent(dir?: string): Promise<Agent> {
-  const factory = await sessionFactory({ agentDir: await agentDir(), model: MODEL, ...(dir ? { dir } : {}) });
-  return createPiAgentFromSession({ sessionFactory: factory });
+/** Drain a turn without letting a `failed` terminal throw — the SPEC's own discipline (MUST 2). */
+async function drain(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
 }
 
-/** An agent dir whose models.json points at a local endpoint that answers 400 to every request. */
-async function refusingEndpointAgent(): Promise<Agent> {
+/** A definition whose models.json points at a local endpoint that answers 400 to every request.
+ *  models.json is definition data, so this failure arrives through the product's own path. */
+async function refusingDefinition(): Promise<string> {
   const server = createServer((_req, res) => {
     res.writeHead(400, { "content-type": "application/json" });
     res.end(JSON.stringify({ error: { message: "live probe: endpoint refuses this request", type: "bad_request" } }));
@@ -119,10 +87,8 @@ async function refusingEndpointAgent(): Promise<Agent> {
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
   const { port } = server.address() as { port: number };
-  const dir = await agentDir();
-  await writeFile(
-    join(dir, "models.json"),
-    JSON.stringify({
+  return agentDirectory("refusing/refuses", {
+    "models.json": JSON.stringify({
       providers: {
         refusing: {
           baseUrl: `http://127.0.0.1:${port}/v1`,
@@ -132,49 +98,39 @@ async function refusingEndpointAgent(): Promise<Agent> {
         },
       },
     }),
-  );
-  return createPiAgentFromSession({
-    sessionFactory: await sessionFactory({ agentDir: dir, model: "refusing/refuses" }),
   });
 }
 
-describeSpecConformance(`pi AgentSession over ${MODEL} (live)`, {
-  completing: () => liveAgent(),
-
-  failing: () => refusingEndpointAgent(),
-
-  hanging: async (onCleanup) => {
-    const factory = await sessionFactory({ agentDir: await agentDir(), model: MODEL });
-    // The engine's cancel cleanup is session.abort() — intercepted as the probe, exactly as the
-    // offline subject does it. What is live here is that a real streaming HTTP response is what gets
-    // torn down, which is the half a faux provider cannot exercise.
-    return createPiAgentFromSession({
-      sessionFactory: async (sessionId) => {
-        const session = await factory(sessionId);
-        const abort = session.abort.bind(session);
-        (session as { abort: AgentSession["abort"] }).abort = async () => {
-          onCleanup();
-          return abort();
-        };
-        return session;
-      },
-    });
-  },
-});
-
 describe(`live model: ${MODEL}`, () => {
+  it("a real stream reaches a completed terminal with an answer", async () => {
+    const { agent } = await createPiAgentFromDir(await agentDirectory(MODEL));
+    const { text } = await collect(agent.invoke({ session: "live-answer" }, { text: "Reply with just: ok" }));
+    expect(text.trim()).not.toBe("");
+  });
+
   it("MUST 6 portable — a second instance over the same record continues the conversation", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-live-pair-"));
+    // One directory, opened twice: two agent instances sharing nothing in process but the disk, which
+    // is what a horizontally-scaled deployment is.
+    const dir = await agentDirectory(MODEL);
     const session = "-1001234567890"; // a telegram group id: pi refuses it verbatim
-    const first = await liveAgent(dir);
+    const { agent: first } = await createPiAgentFromDir(dir);
     await collect(first.invoke({ session }, { text: "Remember this number: 47. Reply with just: ok" }));
 
-    // A second agent instance over the same directory — nothing shared in process but the disk. The
-    // witness is a literal crossing the instance boundary, never the model's phrasing.
-    const second = await liveAgent(dir);
+    const { agent: second } = await createPiAgentFromDir(dir);
     const { text } = await collect(
       second.invoke({ session }, { text: "What number did I ask you to remember? Reply with digits only." }),
     );
+    // The witness is a literal crossing the instance boundary, never the model's phrasing.
     expect(text).toContain("47");
+  });
+
+  it("a real HTTP error becomes a failed terminal, classified non-retryable", async () => {
+    const { agent } = await createPiAgentFromDir(await refusingDefinition());
+    // MUST 2: iteration must not throw — a rejection here is the violation, not a failed event.
+    const events = await drain(agent.invoke({ session: "live-refused" }, { text: "go" }));
+    // 400 is decisive: re-sending it would fail identically, and `retryable` is what a caller branches
+    // on. This is the half a faux provider cannot settle — the shape of a real provider error as it
+    // travels through pi's stack into our classifier.
+    expect(events.at(-1)).toMatchObject({ type: "failed", retryable: false });
   });
 });

--- a/test/live/model.live.test.ts
+++ b/test/live/model.live.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The SPEC conformance suite (spec-conformance.ts) against a REAL provider, over the same per-invoke
+ * `AgentSession` L0 the serving path binds. The offline twin (test/conformance-session.test.ts) proves
+ * the contract holds over a faux model; this one proves it still holds when the stream, the errors and
+ * the cancellation are a real provider's.
+ *
+ * `FASTAGENT_LIVE_MODEL` selects the model ("provider/modelId"); credentials resolve exactly as the
+ * product resolves them — `FASTAGENT_AUTH_PATH` or the agent's own auth.json, then the provider's env
+ * key. An OAuth provider (openai-codex) has only the first, so point the variable at a logged-in file.
+ *
+ * The `failing` subject is the one deliberate stand-in: it points a definition-local models.json at a
+ * local endpoint that answers 400, because the assertion is how a real HTTP error travels through pi's
+ * provider stack into our terminal mapping — not which prose the vendor puts in it. MUST 6 has no
+ * subject here either: the suite's `pair` probe needs to read the second instance's ANSWER, which is
+ * the continuity test below, written once.
+ */
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type AgentSession,
+  createAgentSessionFromServices,
+  createAgentSessionServices,
+} from "@earendil-works/pi-coding-agent";
+import { afterAll, describe, expect, it } from "vitest";
+import type { Agent } from "../../src/agent.ts";
+import { collect } from "../../src/collect.ts";
+import { resolveAuthPath, resolveModel } from "../../src/engines/pi/config.ts";
+import { type PiAgentSessionFactory, createPiAgentFromSession } from "../../src/engines/pi/invoke-session.ts";
+import { createPiModelRuntime } from "../../src/engines/pi/models.ts";
+import { piInMemorySessionRecordStore, piSessionRecordStore } from "../../src/engines/pi/session-store.ts";
+import { installProxyFetch } from "../../src/proxy.ts";
+import { describeSpecConformance } from "../spec-conformance.ts";
+import { requireEnv } from "./env.ts";
+
+// What every CLI entry does before it reaches a provider. This probe assembles the engine directly,
+// so it owes the same call: without it, a machine behind a proxy sees each turn time out.
+installProxyFetch();
+
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+
+const cleanups: (() => Promise<void>)[] = [];
+afterAll(async () => {
+  for (const cleanup of cleanups) await cleanup();
+});
+
+/** An empty agent dir: no models.json, so the real provider registry and real credentials are in play. */
+const agentDir = (): Promise<string> => mkdtemp(join(tmpdir(), "fa-live-model-"));
+
+/**
+ * A per-invoke `AgentSession` factory on the REAL model runtime — the same shape the offline
+ * conformance subject builds, with pi's own resource loading turned off so the probe measures the
+ * engine and the provider, not this machine's pi setup. `dir` makes the record durable; without it
+ * each turn gets a fresh in-memory session.
+ */
+async function sessionFactory(options: {
+  agentDir: string;
+  model: string;
+  dir?: string;
+}): Promise<PiAgentSessionFactory> {
+  const cwd = options.agentDir;
+  // Credentials resolve the way the opener resolves them (FASTAGENT_AUTH_PATH > the agent's own
+  // .secrets/auth.json), NOT the credential store's bare default: an OAuth provider has no env key to
+  // fall back to, so a probe that skipped this knob could only ever be run against an API-key provider.
+  const modelRuntime = await createPiModelRuntime({
+    agentDir: options.agentDir,
+    authPath: resolveAuthPath(options.agentDir, undefined),
+  });
+  const model = resolveModel(modelRuntime, options.model);
+  const services = await createAgentSessionServices({
+    cwd,
+    modelRuntime,
+    resourceLoaderOptions: {
+      noExtensions: true,
+      noPromptTemplates: true,
+      noContextFiles: true,
+      systemPromptOverride: () => "Answer in as few words as possible.",
+      appendSystemPromptOverride: () => [],
+      skillsOverride: (base) => ({ skills: [], diagnostics: base.diagnostics }),
+    },
+  });
+  const store =
+    options.dir === undefined ? piInMemorySessionRecordStore({ cwd }) : piSessionRecordStore({ dir: options.dir, cwd });
+  return async (sessionId) => {
+    const sessionManager = await store.openOrCreate(sessionId);
+    const { session } = await createAgentSessionFromServices({
+      services,
+      sessionManager,
+      model,
+      noTools: "builtin", // a protocol subject, not an agent: the coding tools stay off
+    });
+    return session;
+  };
+}
+
+async function liveAgent(dir?: string): Promise<Agent> {
+  const factory = await sessionFactory({ agentDir: await agentDir(), model: MODEL, ...(dir ? { dir } : {}) });
+  return createPiAgentFromSession({ sessionFactory: factory });
+}
+
+/** An agent dir whose models.json points at a local endpoint that answers 400 to every request. */
+async function refusingEndpointAgent(): Promise<Agent> {
+  const server = createServer((_req, res) => {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: { message: "live probe: endpoint refuses this request", type: "bad_request" } }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
+  const { port } = server.address() as { port: number };
+  const dir = await agentDir();
+  await writeFile(
+    join(dir, "models.json"),
+    JSON.stringify({
+      providers: {
+        refusing: {
+          baseUrl: `http://127.0.0.1:${port}/v1`,
+          api: "openai-completions",
+          apiKey: "live-probe",
+          models: [{ id: "refuses" }],
+        },
+      },
+    }),
+  );
+  return createPiAgentFromSession({
+    sessionFactory: await sessionFactory({ agentDir: dir, model: "refusing/refuses" }),
+  });
+}
+
+describeSpecConformance(`pi AgentSession over ${MODEL} (live)`, {
+  completing: () => liveAgent(),
+
+  failing: () => refusingEndpointAgent(),
+
+  hanging: async (onCleanup) => {
+    const factory = await sessionFactory({ agentDir: await agentDir(), model: MODEL });
+    // The engine's cancel cleanup is session.abort() — intercepted as the probe, exactly as the
+    // offline subject does it. What is live here is that a real streaming HTTP response is what gets
+    // torn down, which is the half a faux provider cannot exercise.
+    return createPiAgentFromSession({
+      sessionFactory: async (sessionId) => {
+        const session = await factory(sessionId);
+        const abort = session.abort.bind(session);
+        (session as { abort: AgentSession["abort"] }).abort = async () => {
+          onCleanup();
+          return abort();
+        };
+        return session;
+      },
+    });
+  },
+});
+
+describe(`live model: ${MODEL}`, () => {
+  it("MUST 6 portable — a second instance over the same record continues the conversation", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-pair-"));
+    const session = "-1001234567890"; // a telegram group id: pi refuses it verbatim
+    const first = await liveAgent(dir);
+    await collect(first.invoke({ session }, { text: "Remember this number: 47. Reply with just: ok" }));
+
+    // A second agent instance over the same directory — nothing shared in process but the disk. The
+    // witness is a literal crossing the instance boundary, never the model's phrasing.
+    const second = await liveAgent(dir);
+    const { text } = await collect(
+      second.invoke({ session }, { text: "What number did I ask you to remember? Reply with digits only." }),
+    );
+    expect(text).toContain("47");
+  });
+});

--- a/test/live/registry.live.test.ts
+++ b/test/live/registry.live.test.ts
@@ -5,7 +5,9 @@
  * the tarball makes `init` produce a half-empty agent, and every offline test stays green.
  *
  * Defaults to this checkout's version — after a release, that is the version just published.
- * `FASTAGENT_LIVE_VERSION` points it at any other (a dist-tag works too).
+ * `FASTAGENT_LIVE_VERSION` points it at any other EXACT version. Not a dist-tag: `--version` reports
+ * what a tag resolved to, never the tag, and the container image resolves the same tag a second time
+ * — the two probes would stop being about one artifact.
  */
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile } from "node:fs/promises";

--- a/test/live/registry.live.test.ts
+++ b/test/live/registry.live.test.ts
@@ -4,10 +4,10 @@
  * the postbuild asset copy (scripts/copy-scaffold-assets.mjs): a scaffold payload that never reaches
  * the tarball makes `init` produce a half-empty agent, and every offline test stays green.
  *
- * Defaults to this checkout's version — after a release, that is the version just published.
- * `FASTAGENT_LIVE_VERSION` points it at any other EXACT version. Not a dist-tag: `--version` reports
- * what a tag resolved to, never the tag, and the container image resolves the same tag a second time
- * — the two probes would stop being about one artifact.
+ * `FASTAGENT_LIVE_VERSION` names the version (CI resolves the registry's `latest` into it; a local run
+ * without it probes this checkout's version). Always EXACT, never a dist-tag: `--version` reports what
+ * a tag resolved to, never the tag, and the container image resolves the same tag a second time — the
+ * two probes would stop being about one artifact.
  */
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile } from "node:fs/promises";

--- a/test/live/registry.live.test.ts
+++ b/test/live/registry.live.test.ts
@@ -8,22 +8,17 @@
  * `FASTAGENT_LIVE_VERSION` points it at any other (a dist-tag works too).
  */
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { fastagentVersion } from "../../src/version.ts";
+import { exists } from "../../src/paths.ts";
+import { liveVersion } from "./env.ts";
 
 const run = promisify(execFile);
-const VERSION = process.env.FASTAGENT_LIVE_VERSION ?? (await fastagentVersion());
+const VERSION = await liveVersion();
 const PACKAGE = "@fastagent-sh/fastagent";
-
-const exists = (path: string): Promise<boolean> =>
-  stat(path).then(
-    () => true,
-    () => false,
-  );
 
 describe(`published ${PACKAGE}@${VERSION}`, () => {
   it("installs from the registry and scaffolds a complete agent", async () => {

--- a/test/live/registry.live.test.ts
+++ b/test/live/registry.live.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The PUBLISHED artifact, installed from the registry — the one thing CI's `npm pack` smoke cannot
+ * see. Between a green pack job and a user's `npm i` sit the `files` field, the publish pipeline and
+ * the postbuild asset copy (scripts/copy-scaffold-assets.mjs): a scaffold payload that never reaches
+ * the tarball makes `init` produce a half-empty agent, and every offline test stays green.
+ *
+ * Defaults to this checkout's version — after a release, that is the version just published.
+ * `FASTAGENT_LIVE_VERSION` points it at any other (a dist-tag works too).
+ */
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { fastagentVersion } from "../../src/version.ts";
+
+const run = promisify(execFile);
+const VERSION = process.env.FASTAGENT_LIVE_VERSION ?? (await fastagentVersion());
+const PACKAGE = "@fastagent-sh/fastagent";
+
+const exists = (path: string): Promise<boolean> =>
+  stat(path).then(
+    () => true,
+    () => false,
+  );
+
+describe(`published ${PACKAGE}@${VERSION}`, () => {
+  it("installs from the registry and scaffolds a complete agent", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-registry-"));
+    await run("npm", ["init", "-y"], { cwd: dir });
+    // --ignore-scripts: a consumer install runs no build of ours, so the tarball must already be whole.
+    await run("npm", ["install", `${PACKAGE}@${VERSION}`, "--ignore-scripts"], { cwd: dir });
+
+    const cli = join(dir, "node_modules", ".bin", "fastagent");
+    const { stdout } = await run(cli, ["--version"], { cwd: dir });
+    expect(stdout.trim()).toBe(VERSION);
+
+    // --no-install: the scaffold's own npm install would re-fetch the same package for nothing.
+    await run(cli, ["init", "demo", "--no-install"], { cwd: dir });
+    const agent = join(dir, "demo", "fastagent");
+    for (const file of ["persona.md", "fastagent.config.mjs", "package.json", "tools/fetch-url.ts"]) {
+      expect(await exists(join(agent, file)), `init did not produce ${file}`).toBe(true);
+    }
+    // The skill is a DIRECTORY in the payload — the shape most likely to be lost by a copy step.
+    expect(await exists(join(agent, "skills", "writing-great-skills", "SKILL.md"))).toBe(true);
+    expect(await readFile(join(agent, "persona.md"), "utf8")).not.toBe("");
+
+    // Channel bundles are copied by the same postbuild step, from a different source root
+    // (src/channels/<kind>/scaffold). `add <kind>` for slack/feishu/lark talks to the platform, so
+    // the payload is asserted where it lands rather than through an onboarding flow.
+    const dist = join(dir, "node_modules", PACKAGE, "dist");
+    for (const kind of ["telegram", "slack", "feishu", "lark", "github"]) {
+      expect(await exists(join(dist, "channels", kind, "scaffold")), `${kind} scaffold missing from the tarball`).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defaultExclude, defineConfig } from "vitest/config";
 
 // A handful of CLI e2e tests spawn `node src/cli.ts <cmd>` subprocesses that each cold-start the full
 // engine import graph (~0.7s+, measured; the pi packages, not TS stripping). They are deliberately few
@@ -23,5 +23,8 @@ export default defineConfig({
     pool: "forks",
     testTimeout: 30000,
     hookTimeout: 30000,
+    // test/live/ talks to real providers, the registry and Docker; it runs only under
+    // `npm run test:live` (vitest.live.config.ts), never as part of `npm test`.
+    exclude: [...defaultExclude, "test/live/**"],
   },
 });

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * The live probes (`npm run test:live`): real providers, the real registry, a real container — so a
+ * container build and a registry install get minutes, not the offline suite's seconds. Serial by file,
+ * because these probes compete for the Docker daemon and one provider's rate limit.
+ *
+ * Standalone rather than merged with vitest.config.ts: `mergeConfig` CONCATENATES include/exclude, and
+ * the whole point of the split is that each config runs the other's files not at all.
+ */
+export default defineConfig({
+  test: {
+    include: ["test/live/*.live.test.ts"],
+    pool: "forks",
+    fileParallelism: false,
+    testTimeout: 600_000,
+    hookTimeout: 600_000,
+  },
+});


### PR DESCRIPTION
The offline suite is ~33k lines and fakes every external system: `globalThis.fetch` in 13 files, a faux model provider, a `CliRunner` seam standing in for docker/flyctl/railway/aws. That covers the logic. It cannot cover whether the assumptions those fakes encode are still true.

`test/live/` holds probes for exactly that, and nothing else — no re-running of logic that already has an offline test.

| Probe | Assumption it checks | What breaks silently without it |
|---|---|---|
| `registry.live.test.ts` | the PUBLISHED tarball is whole | a scaffold payload that misses `files`/postbuild makes `init` produce a half-empty agent; CI's `npm pack` smoke never sees it |
| `model.live.test.ts` | a real provider's stream and errors still satisfy the contract | terminal discipline and error classification are asserted against a faux stream today |
| `docker.live.test.ts` | the generated Dockerfile builds, boots and keeps state | every deploy test fakes the CLI seam, so a broken artifact stays green |

**Each probe drives a product entry and observes from outside it** — `npm install` + `fastagent init`, `createPiAgentFromDir`, `deploy docker --run`. This is the load-bearing constraint, not a style preference: a probe that rebuilds the assembly to reach a better observation point ends up measuring the rebuild's fidelity, and the entry's own steps go missing one at a time (`installProxyFetch`, which the CLI calls and the library deliberately does not; credential resolution; pinning pi's agent dir away from `~/.pi/agent`). Unit tests reach into the `AgentSession` layer freely and correctly — the rule is `test/live/`'s alone, because only these files claim to report on the real thing.

That constraint decides what the model probe asserts. SPEC conformance stays on the faux L0 (`test/conformance-session.test.ts`, MUST 1/2/3/6), which can assert it honestly; cancellation in particular gains nothing from a real provider, since the assertion is that the engine's abort ran and that is identical in both worlds. Live asserts only what a real provider can settle: a stream completes, a real HTTP 400 becomes a `failed` terminal classified non-retryable, and one record carries a conversation across two independent instances (MUST 6).

Structure:

- Excluded from `npm test`. `npm run test:live` (`vitest.live.config.ts`) opts in, with minutes-long timeouts and no file parallelism — these probes compete for the Docker daemon and one provider's rate limit. The live config is standalone rather than `mergeConfig`'d, because `mergeConfig` concatenates include/exclude and the whole point of the split is that each config runs the other's files not at all.
- A missing credential FAILS rather than skips: `test:live` is a deliberate opt-in, so an unset variable is a broken run, not an absent capability.
- Credentials arrive the product's way — `FASTAGENT_AUTH_PATH` → an auth.json — which is what lets an OAuth-only provider (`openai-codex`) be the model under test.
- Assertions are facts (terminal type and `retryable`, HTTP status, a file on the volume), never model wording. The one exception is a literal crossing an instance boundary, which is what MUST 6 *is*.
- One version reaches both artifacts: CI resolves the registry's `latest` to an exact version once and exports it, so the registry install and the container image cannot report on two different things. Resolving `latest` rather than taking this checkout's version keeps the nightly from being red for every release window, which is how a nightly gets ignored.

`live.yml` runs nightly and on demand, never on a PR: an external contributor has no credentials, and a platform's bad night must not read as a broken pull request. The credential it stages is a grant minted for CI alone — pi persists a new refresh token on every refresh, so a grant shared with a maintainer's machine would go stale the moment either side used it.

Verified end to end against `openai-codex` OAuth and a real Docker daemon: 3 files, 5 tests. Each assertion was also checked against a deliberately broken premise (severed session record, inverted `retryable`, wrong container session path, missing scaffold file) to confirm it fails when it should.
