### PR TITLE
fix(test/live): the probe does not edit the runner's proxy environment

### DIFF
--- a/test/live/model.live.test.ts
+++ b/test/live/model.live.test.ts
@@ -32,20 +32,11 @@ import { createPiAgentFromDir } from "../../src/engines/pi/open.ts";
 import { installProxyFetch } from "../../src/proxy.ts";
 import { requireEnv } from "./env.ts";
 
-// The refusing endpoint below is on loopback, and undici's EnvHttpProxyAgent exempts nothing by
-// itself ("Always proxy if NO_PROXY is not set or empty") — on a machine with a proxy set, that
-// request would be dialed through it and the test would fail for a reason unrelated to what it
-// probes. The agent reads `no_proxy` BEFORE `NO_PROXY`, so the merged value goes into both spellings:
-// writing only the upper-case one is a no-op wherever the lower-case one is set.
-const noProxy = [process.env.no_proxy ?? process.env.NO_PROXY ?? "", "127.0.0.1", "localhost"]
-  .filter(Boolean)
-  .join(",");
-process.env.no_proxy = noProxy;
-process.env.NO_PROXY = noProxy;
-
-// Every CLI entry calls this before it reaches a provider, and the LIBRARY opener does not — proxy
-// wiring belongs to the process, not to the assembly. An embedder owes the same call, and so does
-// this probe: without it, a machine behind a proxy sees each turn time out.
+// Node's own fetch ignores HTTPS_PROXY, so a correctly configured machine still needs this call to
+// honour it. Every CLI entry makes it and the LIBRARY opener deliberately does not — proxy wiring
+// belongs to the process, not to the assembly — so an embedder owes it, and this probe is one.
+// Nothing beyond this line is the probe's business: whether a given host bypasses the proxy is the
+// runner's environment to get right, and a probe that edited NO_PROXY would be hiding that.
 installProxyFetch();
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');


### PR DESCRIPTION
The model probe rewrote `no_proxy` / `NO_PROXY` at module load so the loopback endpoint behind its `failed`-terminal test would bypass a configured proxy.

Two things are wrong with that. Whether a given host bypasses the proxy is the runner's environment to get right — a probe that edits it converts a misconfiguration into a silent pass. And it never had an effect: the suite passes with the lines removed, and passes with `no_proxy` deliberately set to exclude loopback. undici does route that request through the proxy, exactly as the code reading said; the proxy then completes it. The guard was written from that reading without once making its case happen.

`installProxyFetch()` stays and is not the same kind of thing: Node's `fetch` ignores `HTTPS_PROXY`, so honouring an already-configured proxy is the caller's job. Every CLI entry makes that call and the library opener deliberately does not — proxy wiring belongs to the process, not the assembly — so an embedder owes it, and the probe is one.

Verified against `openai-codex` OAuth in three environments: the lines present, removed with a correct `no_proxy`, and removed with `no_proxy` excluding loopback. All three green.
