### PR TITLE
test(live): probes for the tunnel, a schedule's fire, and Telegram's webhook verification

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -103,4 +103,7 @@ jobs:
         env:
           FASTAGENT_LIVE_MODEL: ${{ vars.FASTAGENT_LIVE_MODEL }}
           FASTAGENT_AUTH_PATH: ${{ runner.temp }}/secrets/auth.json
+          # A bot of the probe's OWN: it sets and then deletes that bot's webhook, which would take
+          # down whatever traffic a shared bot was serving.
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         run: npm run test:live

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -43,6 +43,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The tunnel probe needs the binary `dev --tunnel` shells out to. Deliberately the LATEST
+      # release, not the version deploy/docker/plan.ts pins for generated Compose: that pin exists so a
+      # deployment does not move under its operator, while this probe exists to find out when the tool
+      # we shell out to changes. Pinning it here would retire the only check that would notice.
+      - name: Install cloudflared
+        run: |
+          curl -fsSL -o /tmp/cloudflared.deb \
+            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+          sudo dpkg -i /tmp/cloudflared.deb
+          cloudflared --version
+
       # ONE credential mechanism for both probes: an auth.json, named by the product's own
       # FASTAGENT_AUTH_PATH. It carries an OAuth grant (openai-codex) as readily as an API key, and
       # `deploy docker --run` turns the same file into the container's FASTAGENT_AUTH_SEED.

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -47,11 +47,18 @@ jobs:
       # release, not the version deploy/docker/plan.ts pins for generated Compose: that pin exists so a
       # deployment does not move under its operator, while this probe exists to find out when the tool
       # we shell out to changes. Pinning it here would retire the only check that would notice.
+      #
+      # Through Cloudflare's apt repo rather than a raw .deb from releases/latest: still that latest
+      # build, but signed and verified by apt — this job stages an OAuth grant on the same runner.
       - name: Install cloudflared
         run: |
-          curl -fsSL -o /tmp/cloudflared.deb \
-            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
-          sudo dpkg -i /tmp/cloudflared.deb
+          sudo mkdir -p --mode=0755 /usr/share/keyrings
+          curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
+            | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main' \
+            | sudo tee /etc/apt/sources.list.d/cloudflared.list
+          sudo apt-get update
+          sudo apt-get install -y cloudflared
           cloudflared --version
 
       # ONE credential mechanism for both probes: an auth.json, named by the product's own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,10 +259,12 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # check an assumption about a system we do not own, never to re-run logic:
                              # the published tarball (registry), a real provider's stream and errors
                              # (model), a real container build + boot + state volume (docker), a real
-                             # Quick Tunnel carrying a request home (tunnel), and a cron on disk firing
-                             # a real turn into the audit log (schedule). Each one drives a PRODUCT
-                             # ENTRY (`createPiAgentFromDir`, `deploy docker --run`, `npm install`,
-                             # `startCloudflareTunnel`, `startSchedules`) and observes from OUTSIDE it
+                             # Quick Tunnel carrying a request home (tunnel), a cron on disk firing a
+                             # real turn into the audit log (schedule), and Telegram VERIFYING a webhook
+                             # URL it was handed (telegram — registration only; delivery needs a human
+                             # to type). Each one drives a PRODUCT ENTRY (`createPiAgentFromDir`,
+                             # `deploy docker --run`, `npm install`, `startCloudflareTunnel`,
+                             # `startSchedules`, `registerTelegramWebhook`) and observes from OUTSIDE it
                              # — a probe that rebuilds the assembly to get a better observation point
                              # measures the rebuild, and the entry's own steps (installProxyFetch,
                              # credential resolution, pinning pi's agent dir) go missing one at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,14 +258,16 @@ test/                        # vitest; faux models by default + reusable SPEC co
 └── live/                   # the probes for what the offline suite FAKES — every file here exists to
                              # check an assumption about a system we do not own, never to re-run logic:
                              # the published tarball (registry), a real provider's stream and errors
-                             # (model), a real container build + boot + state volume (docker). Each one
-                             # drives a PRODUCT ENTRY (`createPiAgentFromDir`, `deploy docker --run`,
-                             # `npm install`) and observes from OUTSIDE it — a probe that rebuilds the
-                             # assembly to get a better observation point measures the rebuild, and the
-                             # entry's own steps (installProxyFetch, credential resolution, pinning pi's
-                             # agent dir) go missing one at a time. Unit tests below DO reach into that
-                             # layer, correctly — the rule is this directory's, because only these files
-                             # claim to report on the real thing.
+                             # (model), a real container build + boot + state volume (docker), a real
+                             # Quick Tunnel carrying a request home (tunnel), and a cron on disk firing
+                             # a real turn into the audit log (schedule). Each one drives a PRODUCT
+                             # ENTRY (`createPiAgentFromDir`, `deploy docker --run`, `npm install`,
+                             # `startCloudflareTunnel`, `startSchedules`) and observes from OUTSIDE it
+                             # — a probe that rebuilds the assembly to get a better observation point
+                             # measures the rebuild, and the entry's own steps (installProxyFetch,
+                             # credential resolution, pinning pi's agent dir) go missing one at a time.
+                             # Unit tests below DO reach into that layer, correctly — the rule is this
+                             # directory's, because only these files claim to report on the real thing.
                              # Excluded from `npm test`; `npm run test:live` (vitest.live.config.ts)
                              # opts in, and a missing credential FAILS rather than skips — you asked
                              # for them. Credentials arrive the PRODUCT's way (FASTAGENT_AUTH_PATH → an

--- a/test/live/schedule.live.test.ts
+++ b/test/live/schedule.live.test.ts
@@ -27,6 +27,7 @@ installProxyFetch();
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 const SCHEDULE = "heartbeat";
+const BUDGET_MS = 480_000;
 
 const cleanups: (() => void)[] = [];
 afterAll(() => {
@@ -41,11 +42,10 @@ describe("schedules: a cron fire reaches the agent and the audit log", () => {
     await writeFile(join(dir, "persona.md"), "You are terse. Answer in as few words as possible.\n");
     await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
     await mkdir(join(dir, "schedules"), { recursive: true });
-    // A plain default export, not `defineSchedule(...)`: that import resolves through the agent dir's
-    // own node_modules, which a throwaway directory has none of (and vitest's alias does not reach a
-    // dynamic import). `defineSchedule` is an identity function, so the loaded shape is the same one
-    // either spelling produces. What that costs this probe is the module-resolution step, which is
-    // covered where it belongs — registry.live.test.ts asserts the scaffold that carries the dependency.
+    // A plain default export: `defineSchedule` is an identity function, so this is the shape the
+    // loader gets either way, and the file stays what an author's `schedules/*.ts` looks like rather
+    // than carrying an import path back into this checkout (the spelling schedule-discover.test.ts
+    // needs, since that one is testing the loader itself).
     await writeFile(
       join(dir, "schedules", `${SCHEDULE}.ts`),
       `export default { cron: "* * * * *", prompt: "Reply with just: tick" };\n`,
@@ -66,14 +66,19 @@ describe("schedules: a cron fire reaches the agent and the audit log", () => {
       "the schedules/ file did not load",
     ).toEqual([SCHEDULE]);
 
-    // The fire is a real model turn; poll the audit log rather than guessing a duration.
+    // The fire is a real model turn; poll the audit log rather than guessing a duration. The budget is
+    // the file timeout minus room for teardown, not an estimate of a turn: a queued or thinking model
+    // running long is the one thing this must not report as a schedule that never fired.
     let runs = readRuns(stateRoot, SCHEDULE);
-    for (let waited = 0; runs.length === 0 && waited < 120_000; waited += 500) {
+    for (let waited = 0; runs.length === 0 && waited < BUDGET_MS; waited += 500) {
       await sleep(500);
       runs = readRuns(stateRoot, SCHEDULE);
     }
 
-    expect(runs, "the overdue schedule never fired").toHaveLength(1);
+    expect(
+      runs,
+      `no run recorded in ${BUDGET_MS / 1000}s: the schedule never fired, or its turn is still running`,
+    ).toHaveLength(1);
     // toMatchObject: a `failed` record carries `error`, and printing it is the difference between
     // knowing why an unattended nightly went red and having to re-run it.
     expect(runs[0]).toMatchObject({ name: SCHEDULE, outcome: "completed" });

--- a/test/live/schedule.live.test.ts
+++ b/test/live/schedule.live.test.ts
@@ -18,9 +18,8 @@ import { afterAll, describe, expect, it } from "vitest";
 import { createPiAgentFromDir } from "../../src/engines/pi/open.ts";
 import { installProxyFetch } from "../../src/proxy.ts";
 import { readRuns } from "../../src/schedule/audit.ts";
-import { loadSchedules } from "../../src/schedule/discover.ts";
-import { createScheduler } from "../../src/schedule/scheduler.ts";
 import { saveFires } from "../../src/schedule/state.ts";
+import { startSchedules } from "../../src/service.ts";
 import { requireEnv } from "./env.ts";
 
 // Node's fetch ignores HTTPS_PROXY; the library opener deliberately leaves this to its caller.
@@ -53,17 +52,19 @@ describe("schedules: a cron fire reaches the agent and the audit log", () => {
     );
 
     const { agent, stateRoot } = await createPiAgentFromDir(dir, { serving: true });
-    const { schedules, failures } = await loadSchedules(dir);
-    expect(failures, "a schedules/ file failed to load").toEqual([]);
-    expect(schedules.map((s) => s.name)).toEqual([SCHEDULE]);
 
-    // Two minutes back: the next 1-minute slot after it is already in the past, so start() catches up
-    // instead of arming a timer.
+    // Two minutes back, seeded before the scheduler starts: the next 1-minute slot after it is already
+    // in the past, so start() catches up instead of arming a timer.
     saveFires(stateRoot, { [SCHEDULE]: new Date(Date.now() - 120_000).toISOString() });
 
-    const scheduler = createScheduler({ agent, stateRoot, schedules });
-    cleanups.push(() => scheduler.stop());
-    scheduler.start();
+    // The entry `dev`/`start` take — discovery, failure reporting, createScheduler, start() — rather
+    // than those four steps rebuilt here, which would measure the rebuild.
+    const { schedules, stop } = await startSchedules(dir, agent, stateRoot, false);
+    cleanups.push(stop);
+    expect(
+      schedules.map((s) => s.name),
+      "the schedules/ file did not load",
+    ).toEqual([SCHEDULE]);
 
     // The fire is a real model turn; poll the audit log rather than guessing a duration.
     let runs = readRuns(stateRoot, SCHEDULE);
@@ -76,7 +77,9 @@ describe("schedules: a cron fire reaches the agent and the audit log", () => {
     // toMatchObject: a `failed` record carries `error`, and printing it is the difference between
     // knowing why an unattended nightly went red and having to re-run it.
     expect(runs[0]).toMatchObject({ name: SCHEDULE, outcome: "completed" });
-    expect(runs[0]?.reply?.trim(), "a completed run must carry the turn's reply").not.toBe("");
+    // toBeTruthy, not `.not.toBe("")`: a MISSING reply is exactly the regression this guards, and
+    // `undefined?.trim()` is undefined, which is not "".
+    expect(runs[0]?.reply?.trim(), "a completed run must carry the turn's reply").toBeTruthy();
     // The session is derived from the schedule's name, not minted per fire — that is what makes a
     // schedule's turns one continuing conversation.
     expect(runs[0]?.session).toContain(SCHEDULE);

--- a/test/live/schedule.live.test.ts
+++ b/test/live/schedule.live.test.ts
@@ -1,0 +1,84 @@
+/**
+ * A schedule on disk fires a real turn and lands in the audit log — the whole chain, once, on a real
+ * model. Offline the pieces are covered separately and each against fakes: discovery reads a directory
+ * (schedule-discover.test.ts), the scheduler arms and claims against a fake clock
+ * (scheduler.test.ts), the audit appends a record (schedule-audit.test.ts). Nothing joins them, so a
+ * seam between two of them — a schedule that loads but never reaches the agent, a fire whose outcome
+ * never reaches `runs.jsonl` — is invisible to all three.
+ *
+ * The fire comes from the catch-up branch: `start()` anchors a never-fired schedule on `now` (so a new
+ * schedule cannot back-fire), which would mean waiting out a real cron instant. Seeding one past fire
+ * makes the next slot already due, so the probe exercises catch-up — a real behaviour worth asserting
+ * — instead of sleeping through a minute. The cron stays the documented 5-field form.
+ */
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { createPiAgentFromDir } from "../../src/engines/pi/open.ts";
+import { installProxyFetch } from "../../src/proxy.ts";
+import { readRuns } from "../../src/schedule/audit.ts";
+import { loadSchedules } from "../../src/schedule/discover.ts";
+import { createScheduler } from "../../src/schedule/scheduler.ts";
+import { saveFires } from "../../src/schedule/state.ts";
+import { requireEnv } from "./env.ts";
+
+// Node's fetch ignores HTTPS_PROXY; the library opener deliberately leaves this to its caller.
+installProxyFetch();
+
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+const SCHEDULE = "heartbeat";
+
+const cleanups: (() => void)[] = [];
+afterAll(() => {
+  for (const cleanup of cleanups) cleanup();
+});
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("schedules: a cron fire reaches the agent and the audit log", () => {
+  it("catches up an overdue slot, runs the turn, and records the outcome", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-schedule-"));
+    await writeFile(join(dir, "persona.md"), "You are terse. Answer in as few words as possible.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+    await mkdir(join(dir, "schedules"), { recursive: true });
+    // A plain default export, not `defineSchedule(...)`: that import resolves through the agent dir's
+    // own node_modules, which a throwaway directory has none of (and vitest's alias does not reach a
+    // dynamic import). `defineSchedule` is an identity function, so the loaded shape is the same one
+    // either spelling produces. What that costs this probe is the module-resolution step, which is
+    // covered where it belongs — registry.live.test.ts asserts the scaffold that carries the dependency.
+    await writeFile(
+      join(dir, "schedules", `${SCHEDULE}.ts`),
+      `export default { cron: "* * * * *", prompt: "Reply with just: tick" };\n`,
+    );
+
+    const { agent, stateRoot } = await createPiAgentFromDir(dir, { serving: true });
+    const { schedules, failures } = await loadSchedules(dir);
+    expect(failures, "a schedules/ file failed to load").toEqual([]);
+    expect(schedules.map((s) => s.name)).toEqual([SCHEDULE]);
+
+    // Two minutes back: the next 1-minute slot after it is already in the past, so start() catches up
+    // instead of arming a timer.
+    saveFires(stateRoot, { [SCHEDULE]: new Date(Date.now() - 120_000).toISOString() });
+
+    const scheduler = createScheduler({ agent, stateRoot, schedules });
+    cleanups.push(() => scheduler.stop());
+    scheduler.start();
+
+    // The fire is a real model turn; poll the audit log rather than guessing a duration.
+    let runs = readRuns(stateRoot, SCHEDULE);
+    for (let waited = 0; runs.length === 0 && waited < 120_000; waited += 500) {
+      await sleep(500);
+      runs = readRuns(stateRoot, SCHEDULE);
+    }
+
+    expect(runs, "the overdue schedule never fired").toHaveLength(1);
+    // toMatchObject: a `failed` record carries `error`, and printing it is the difference between
+    // knowing why an unattended nightly went red and having to re-run it.
+    expect(runs[0]).toMatchObject({ name: SCHEDULE, outcome: "completed" });
+    expect(runs[0]?.reply?.trim(), "a completed run must carry the turn's reply").not.toBe("");
+    // The session is derived from the schedule's name, not minted per fire — that is what makes a
+    // schedule's turns one continuing conversation.
+    expect(runs[0]?.session).toContain(SCHEDULE);
+  });
+});

--- a/test/live/telegram.live.test.ts
+++ b/test/live/telegram.live.test.ts
@@ -34,9 +34,22 @@ installProxyFetch();
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 const BOT_TOKEN = requireEnv("TELEGRAM_BOT_TOKEN", "a bot token of this probe's OWN bot, from @BotFather");
 
+// Every cleanup runs, in reverse, and failures surface together: the first one registered is a
+// network call to Telegram, and a plain loop would let its failure skip the two below it — leaving a
+// public *.trycloudflare.com URL pointed at this service's unauthenticated `POST /invoke`.
 const cleanups: (() => Promise<void> | void)[] = [];
 afterAll(async () => {
-  for (const cleanup of cleanups) await cleanup();
+  const errors: unknown[] = [];
+  for (const cleanup of cleanups.reverse()) {
+    // The only catch here, and it hides nothing: it holds one failure so the cleanups after it still
+    // run, then every one of them is rethrown together below.
+    try {
+      await cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) throw new AggregateError(errors, "cleanup failed");
 });
 
 /** One Bot API call, failing loudly: a non-ok body is a protocol answer, never something to absorb. */
@@ -54,9 +67,13 @@ async function botApi(method: string, body?: Record<string, unknown>): Promise<R
 describe("telegram: registering a webhook against a live tunnel", () => {
   it("Telegram verifies the tunnel URL and keeps the webhook we registered", async () => {
     // The bot's webhook is global state on Telegram's side — clear it however this test ends.
+    // `drop_pending_updates`, both here and before registering: Telegram queues updates for 24h while
+    // no webhook is set and delivers them the instant `setWebhook` succeeds. No `/telegram` route is
+    // mounted here, so a queued update would 404 and land in the `last_error_message` asserted below.
     cleanups.push(async () => {
-      await botApi("deleteWebhook");
+      await botApi("deleteWebhook", { drop_pending_updates: true });
     });
+    await botApi("deleteWebhook", { drop_pending_updates: true });
 
     const dir = await mkdtemp(join(tmpdir(), "fa-live-telegram-"));
     await writeFile(join(dir, "persona.md"), "You are terse.\n");

--- a/test/live/telegram.live.test.ts
+++ b/test/live/telegram.live.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Telegram accepts a webhook we register against a live tunnel — the one step of the Telegram path
+ * that no fake can stand in for, because Telegram itself decides it: `setWebhook` VERIFIES the URL
+ * (DNS, TLS, reachability) before it stores it. A mocked Bot API always says yes.
+ *
+ * The chain, all product entries: `createAgentService` composes the surface (its `/health` is what the
+ * registrar waits on) → `serveNode` binds it → `startCloudflareTunnel` publishes it →
+ * `registerTelegramWebhook` waits for readiness and calls `setWebhook` → Telegram's own
+ * `getWebhookInfo` is asked whether it kept what we sent.
+ *
+ * Scope: REGISTRATION, not delivery. A real inbound update needs a human to type into a chat, so the
+ * probe stops where automation honestly ends. The agent dir declares no channel, which means no
+ * `/telegram` route is mounted — Telegram verifies the URL at registration time and only POSTs to it
+ * when a message arrives, so nothing here depends on that route existing.
+ *
+ * Needs `TELEGRAM_BOT_TOKEN` (a bot of its own — this test SETS and then DELETES that bot's webhook,
+ * so pointing it at a bot serving real traffic would take that traffic down).
+ */
+import { randomBytes } from "node:crypto";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { serveNode } from "../../src/channels/serve.ts";
+import { registerTelegramWebhook } from "../../src/channels/telegram/register-webhook.ts";
+import { createAgentService } from "../../src/engines/pi/service.ts";
+import { installProxyFetch } from "../../src/proxy.ts";
+import { startCloudflareTunnel } from "../../src/tunnel.ts";
+import { requireEnv } from "./env.ts";
+
+// Node's fetch ignores HTTPS_PROXY; the Bot API calls below and the registrar's own both need this.
+installProxyFetch();
+
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+const BOT_TOKEN = requireEnv("TELEGRAM_BOT_TOKEN", "a bot token of this probe's OWN bot, from @BotFather");
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterAll(async () => {
+  for (const cleanup of cleanups) await cleanup();
+});
+
+/** One Bot API call, failing loudly: a non-ok body is a protocol answer, never something to absorb. */
+async function botApi(method: string, body?: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const response = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  const json = (await response.json()) as { ok: boolean; result?: unknown; description?: string };
+  if (!json.ok) throw new Error(`telegram ${method} failed: ${json.description ?? response.status}`);
+  return json.result as Record<string, unknown>;
+}
+
+describe("telegram: registering a webhook against a live tunnel", () => {
+  it("Telegram verifies the tunnel URL and keeps the webhook we registered", async () => {
+    // The bot's webhook is global state on Telegram's side — clear it however this test ends.
+    cleanups.push(async () => {
+      await botApi("deleteWebhook");
+    });
+
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-telegram-"));
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+
+    const service = await createAgentService(dir);
+    const server = serveNode(service.handler, { port: 0, host: "127.0.0.1" });
+    cleanups.push(() => server.close());
+    const port = await server.listening;
+
+    const tunnel = await startCloudflareTunnel(port);
+    expect(tunnel, "cloudflared did not yield a quick-tunnel URL").toBeDefined();
+    if (!tunnel) return;
+    cleanups.push(() => tunnel.close());
+
+    // The registrar reads both from the environment. The secret token is what the ingress compares on
+    // every inbound update; minted per run so a probe never reuses a value that reached Telegram before.
+    process.env.TELEGRAM_SECRET_TOKEN = randomBytes(16).toString("hex");
+
+    // Registration waits for /health through the tunnel, then calls setWebhook — Telegram verifies the
+    // URL itself, so "registered" is Telegram's verdict on the tunnel, not ours.
+    const outcome = await registerTelegramWebhook(tunnel.url);
+    expect(outcome, "telegram refused the webhook (see the registrar's log line for its reason)").toBe("registered");
+
+    // Ask Telegram what it stored: the round trip, not just our own return value.
+    const info = await botApi("getWebhookInfo");
+    expect(info.url).toBe(`${tunnel.url}/telegram`);
+    expect(info.last_error_message, "telegram recorded an error delivering to this URL").toBeUndefined();
+  });
+});

--- a/test/live/tunnel.live.test.ts
+++ b/test/live/tunnel.live.test.ts
@@ -1,0 +1,57 @@
+/**
+ * A Cloudflare Quick Tunnel, end to end: `--tunnel` is only worth anything if the URL it prints is
+ * reachable from the public internet and routes back to this process. The offline test
+ * (test/tunnel.test.ts) covers the parsing — which line of cloudflared's output is the URL, and which
+ * error line must NOT be mistaken for one — against a fake process. What it cannot cover is whether
+ * cloudflared still starts, still prints a URL in a shape the parser knows, and whether that URL
+ * actually carries a request home.
+ *
+ * Drives `startCloudflareTunnel`, the same function `dev --tunnel` and `deploy docker --tunnel` use.
+ * Needs the `cloudflared` binary on PATH and no credentials: a Quick Tunnel is anonymous.
+ */
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { afterAll, describe, expect, it } from "vitest";
+import { waitForHealth } from "../../src/channels/wait-health.ts";
+import { installProxyFetch } from "../../src/proxy.ts";
+import { startCloudflareTunnel } from "../../src/tunnel.ts";
+
+// Node's fetch ignores HTTPS_PROXY; reaching the tunnel's public URL from a proxied machine needs the
+// same call every CLI entry makes. See model.live.test.ts for why the library opener does not make it.
+installProxyFetch();
+
+const cleanups: (() => void)[] = [];
+afterAll(() => {
+  for (const cleanup of cleanups) cleanup();
+});
+
+describe("cloudflare quick tunnel", () => {
+  it("assigns a public URL that carries a request back to this process", async () => {
+    // A body only this run knows: proof the response came from OUR origin and not from a cached page,
+    // a captive portal, or another tunnel.
+    const token = randomUUID();
+    const origin = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(token);
+    });
+    // No host: cloudflared is pointed at `http://localhost:<port>` (src/tunnel.ts), and `localhost`
+    // resolves to ::1 before 127.0.0.1 on a dual-stack machine — an origin bound to 127.0.0.1 alone
+    // gets a tunnel that establishes and then cannot reach it.
+    await new Promise<void>((resolve) => origin.listen(0, resolve));
+    cleanups.push(() => origin.close());
+    const { port } = origin.address() as { port: number };
+
+    const tunnel = await startCloudflareTunnel(port);
+    // `undefined` is how the product reports "no tunnel" — every caller treats it as a hard stop, so
+    // a probe that let it through would be asserting nothing at all.
+    expect(tunnel, "cloudflared did not yield a quick-tunnel URL").toBeDefined();
+    if (!tunnel) return;
+    cleanups.push(() => tunnel.close());
+    expect(tunnel.url).toMatch(/^https:\/\/[a-z0-9-]+\.trycloudflare\.com$/i);
+
+    // A fresh hostname's DNS takes seconds to become resolvable — the same wait the webhook
+    // registrars do before handing a platform a URL to verify.
+    expect(await waitForHealth(tunnel.url, 60_000, 1000), `${tunnel.url} never became reachable`).toBe(true);
+    expect(await fetch(tunnel.url).then((r) => r.text())).toBe(token);
+  });
+});

--- a/test/live/tunnel.live.test.ts
+++ b/test/live/tunnel.live.test.ts
@@ -9,6 +9,7 @@
  * Drives `startCloudflareTunnel`, the same function `dev --tunnel` and `deploy docker --tunnel` use.
  * Needs the `cloudflared` binary on PATH and no credentials: a Quick Tunnel is anonymous.
  */
+import { spawnSync } from "node:child_process";
 import { createServer } from "node:http";
 import { randomUUID } from "node:crypto";
 import { afterAll, describe, expect, it } from "vitest";
@@ -27,6 +28,14 @@ afterAll(() => {
 
 describe("cloudflare quick tunnel", () => {
   it("assigns a public URL that carries a request back to this process", async () => {
+    // Checked first, and separately: startCloudflareTunnel reports a missing binary and a tunnel that
+    // failed to establish as the same `undefined`, and the two need opposite actions from whoever ran
+    // this. Same rule as env.ts — a missing precondition is named, not diagnosed from a symptom.
+    expect(
+      spawnSync("cloudflared", ["--version"]).error,
+      "live probes need cloudflared on PATH (e.g. `brew install cloudflared`)",
+    ).toBeUndefined();
+
     // A body only this run knows: proof the response came from OUR origin and not from a cached page,
     // a captive portal, or another tunnel.
     const token = randomUUID();

--- a/test/live/tunnel.live.test.ts
+++ b/test/live/tunnel.live.test.ts
@@ -43,9 +43,10 @@ describe("cloudflare quick tunnel", () => {
       res.writeHead(200, { "content-type": "text/plain" });
       res.end(token);
     });
-    // No host: cloudflared is pointed at `http://localhost:<port>` (src/tunnel.ts), and `localhost`
-    // resolves to ::1 before 127.0.0.1 on a dual-stack machine — an origin bound to 127.0.0.1 alone
-    // gets a tunnel that establishes and then cannot reach it.
+    // No host, so Node binds every interface: cloudflared is pointed at `http://localhost:<port>`
+    // (src/tunnel.ts) and this probe is about the tunnel, not about which address that name resolves
+    // to inside it. Whether a 127.0.0.1-only origin answers is the product's own question, settled by
+    // `answersLocalhost` (src/bind.ts) and exercised by telegram.live.test.ts, which binds one.
     await new Promise<void>((resolve) => origin.listen(0, resolve));
     cleanups.push(() => origin.close());
     const { port } = origin.address() as { port: number };


### PR DESCRIPTION
Three more systems the offline suite can only fake, following the existing rule: drive the function the CLI drives, observe from outside it.

| Probe | Assumption it checks | What the offline test cannot reach |
|---|---|---|
| `tunnel.live.test.ts` | `cloudflared` starts, prints a URL in the shape the parser knows, and that URL carries a request back to this process | `tunnel.test.ts` runs the parser against a fake child process — it settles which output line is the URL, never whether a tunnel exists |
| `schedule.live.test.ts` | a file in `schedules/` reaches the agent, and the turn's outcome reaches `runs.jsonl` | discovery, the scheduler and the audit are each covered against fakes; nothing joins them, so a seam between two is invisible to all three |
| `telegram.live.test.ts` | Telegram accepts a webhook URL we register | `setWebhook` is decided by Telegram, which resolves, TLS-handshakes and reaches the URL before storing it. A mocked Bot API always says yes |

The telegram probe runs the whole chain through product entries — `createAgentService` composes the surface whose `/health` the registrar waits on, `serveNode` binds it, `startCloudflareTunnel` publishes it, `registerTelegramWebhook` registers it — then asks `getWebhookInfo` what Telegram kept. It is REGISTRATION only: a real inbound update needs a human to type into a chat, so it stops where automation honestly ends. It needs a bot of its own (`secrets.TELEGRAM_BOT_TOKEN`), because it sets and then deletes that bot's webhook.

The schedule probe fires through the catch-up branch. `start()` anchors a never-fired schedule on `now`, so a new one cannot back-fire — asserting a real cron instant would mean sleeping through a minute. Seeding one past fire makes the next slot already due, exercising catch-up (a real behaviour worth asserting) with the cron in the documented 5-field form. Its `schedules/heartbeat.ts` default-exports a plain object rather than calling `defineSchedule`: that import resolves through the agent dir's own `node_modules`, which a throwaway directory has none of, and vitest's alias does not reach a dynamic import. `defineSchedule` is an identity function, so the loaded shape is identical; the module resolution it skips is covered by the scaffold assertion in `registry.live.test.ts`.

`live.yml` installs `cloudflared` from Cloudflare's signed apt repo — the latest build, deliberately not the version `deploy/docker/plan.ts` pins for generated Compose. That pin exists so a deployment does not move under its operator; this probe exists to notice when the tool we shell out to changes, and pinning it here would retire the only check that would see it. Signed rather than a raw `.deb`, since this job stages an OAuth grant on the same runner.

Verified on CI (run 33511602301): 6 files, 8 tests, 69.5s — telegram 9.9s, tunnel 7.9s, schedule 3.5s.
