### PR TITLE
fix(feishu): every created app can configure itself, plus a live probe for the challenge round trip

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -110,4 +110,8 @@ jobs:
           FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
           FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
           FEISHU_VERIFICATION_TOKEN: ${{ secrets.FEISHU_VERIFICATION_TOKEN }}
+          # A LONG-LIVED xoxb- (token rotation off): a runner has no durable volume to catch a
+          # refreshed pair, so a rotating credential would be revoked by its own first refresh.
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_TEST_CHANNEL: ${{ secrets.SLACK_TEST_CHANNEL }}
         run: npm run test:live

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -110,6 +110,11 @@ jobs:
           FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
           FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
           FEISHU_VERIFICATION_TOKEN: ${{ secrets.FEISHU_VERIFICATION_TOKEN }}
+          # OPTIONAL, unlike the three above, because the platform's Encrypt Key is: set it only if the
+          # probe's app has one configured, and the channel then decrypts the url_verification
+          # challenge instead of refusing it. An unset secret expands to "", which the channel file's
+          # `|| undefined` reads as absent — the same reason env.ts prefers `||` over `??`.
+          FEISHU_ENCRYPT_KEY: ${{ secrets.FEISHU_ENCRYPT_KEY }}
           # A LONG-LIVED xoxb- (token rotation off): a runner has no durable volume to catch a
           # refreshed pair, so a rotating credential would be revoked by its own first refresh.
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -106,4 +106,8 @@ jobs:
           # A bot of the probe's OWN: it sets and then deletes that bot's webhook, which would take
           # down whatever traffic a shared bot was serving.
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          # Likewise an app of the probe's own: registering rewrites its event Request URL.
+          FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
+          FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+          FEISHU_VERIFICATION_TOKEN: ${{ secrets.FEISHU_VERIFICATION_TOKEN }}
         run: npm run test:live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # real turn into the audit log (schedule), Telegram VERIFYING a webhook URL
                              # it was handed and Feishu CALLING one with a challenge (telegram/feishu —
                              # registration only; delivery needs a human to type), and Slack's Bot API
-                             # answering our claude codepeline (slack — OUTBOUND only: its inbound half needs a
+                             # answering our pipeline (slack — OUTBOUND only: its inbound half needs a
                              # 12h App Configuration Token, which no nightly can hold). Each one drives
                              # a PRODUCT ENTRY (`createPiAgentFromDir`, `deploy docker --run`,
                              # `npm install`, `startCloudflareTunnel`, `startSchedules`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,11 +260,15 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # the published tarball (registry), a real provider's stream and errors
                              # (model), a real container build + boot + state volume (docker), a real
                              # Quick Tunnel carrying a request home (tunnel), a cron on disk firing a
-                             # real turn into the audit log (schedule), and Telegram VERIFYING a webhook
-                             # URL it was handed (telegram — registration only; delivery needs a human
-                             # to type). Each one drives a PRODUCT ENTRY (`createPiAgentFromDir`,
-                             # `deploy docker --run`, `npm install`, `startCloudflareTunnel`,
-                             # `startSchedules`, `registerTelegramWebhook`) and observes from OUTSIDE it
+                             # real turn into the audit log (schedule), Telegram VERIFYING a webhook URL
+                             # it was handed and Feishu CALLING one with a challenge (telegram/feishu —
+                             # registration only; delivery needs a human to type), and Slack's Bot API
+                             # answering our claude codepeline (slack — OUTBOUND only: its inbound half needs a
+                             # 12h App Configuration Token, which no nightly can hold). Each one drives
+                             # a PRODUCT ENTRY (`createPiAgentFromDir`, `deploy docker --run`,
+                             # `npm install`, `startCloudflareTunnel`, `startSchedules`,
+                             # `registerTelegramWebhook`, `registerFeishuWebhook`, `createSlackApi`)
+                             # and observes from OUTSIDE it
                              # — a probe that rebuilds the assembly to get a better observation point
                              # measures the rebuild, and the entry's own steps (installProxyFetch,
                              # credential resolution, pinning pi's agent dir) go missing one at a time.

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -95,9 +95,10 @@ device-authorization grant) as its default behavior. The CLI opens a one-time co
 printed, so you can open it in the app or scan it as a QR code instead — and you confirm; the platform
 creates an app from its agent template—bot capability, messaging scopes, and event subscriptions
 pre-configured—and adds `im.message.receive_v1`. Onboarding requests
-`application:application:patch` when it must configure webhook mode or the recommended group-context
-scope. The CLI immediately persists App ID/Secret to `.secrets/.env` before starting later network
-work.
+`application:application:patch` for every app it creates, whichever ingress you pick: only webhook uses
+it on day one, but a WebSocket app that later moves to webhook cannot acquire it in passing, because
+changing mode is a migration the CLI refuses to perform. The CLI immediately persists App ID/Secret to
+`.secrets/.env` before starting later network work.
 
 For WebSocket, those two values are the complete runtime credential set. For webhook, the platform-
 generated Verification Token has no read API; its only programmatic delivery is the `url_verification`

--- a/src/channels/feishu/setup-mode.ts
+++ b/src/channels/feishu/setup-mode.ts
@@ -6,6 +6,38 @@ export type FeishuSubscriptionMode = "webhook" | "websocket";
  * are delivered. */
 export type FeishuGroupBehavior = "context" | "mentions";
 
+/**
+ * Configuring THIS app: what every v7 config PATCH needs — registering a webhook Request URL, and
+ * adding a scope to the app draft during context-aware group setup.
+ *
+ * Requested at creation for BOTH ingress modes, though only webhook uses it on day one. A WebSocket
+ * app that later wants webhook delivery cannot acquire it in passing: changing mode is a migration
+ * the CLI deliberately refuses to perform (`resolveIngress`), so the app would have to be recreated
+ * or the scope added by hand in the console after a failed PATCH. It is not a data scope — it reads
+ * and writes this app's own configuration — so carrying it costs an app nothing and keeps the one
+ * door open that the alternative nails shut.
+ */
+export const FEISHU_APP_CONFIG_SCOPE = "application:application:patch";
+
+/** The one event an agent app cannot serve without: an inbound message. */
+export const FEISHU_MESSAGE_RECEIVE_EVENT = "im.message.receive_v1";
+
+/**
+ * What a created app carries on top of the platform's agent template, for EITHER ingress — the
+ * `addons` merged onto the confirm page. Here rather than inline at the call site because it is a
+ * policy decision (which capabilities an app is born with), and the CLI layer that requests it is
+ * terminal wiring with no seam to test through.
+ */
+export function feishuAppAddons(): {
+  scopes: { tenant: string[] };
+  events: { items: { tenant: string[] } };
+} {
+  return {
+    scopes: { tenant: [FEISHU_APP_CONFIG_SCOPE] },
+    events: { items: { tenant: [FEISHU_MESSAGE_RECEIVE_EVENT] } },
+  };
+}
+
 /** The sensitive tenant scope behind both bare replies in the agent's threads and group context buffering. */
 export const FEISHU_GROUP_CONTEXT_SCOPE = "im:message.group_msg";
 

--- a/src/cli/add-feishu.ts
+++ b/src/cli/add-feishu.ts
@@ -16,6 +16,7 @@ import {
   FEISHU_GROUP_CONTEXT_SCOPE,
   FEISHU_CONTEXT_ONBOARDING_SCOPES,
   FEISHU_MESSAGE_READ_SCOPE,
+  feishuAppAddons,
   scopeSatisfied,
   type FeishuGroupBehavior,
   type FeishuSubscriptionMode,
@@ -316,16 +317,9 @@ async function createFeishuAppFlow(
     const app = await registerFeishuApp({
       name: "{user}'s agent", // the platform expands {user} to the confirming user's name; editable on the page
       desc: "Served by fastagent",
-      // The agent template alone is not enough to SERVE: v7 config PATCHes (webhook registration and
-      // context-aware group scope setup) demand application:application:patch, and the app must subscribe
-      // the receive event. Addons merge those BASE capabilities onto the confirm page; sensitive group
+      // The agent template alone is not enough to SERVE (see feishuAppAddons). Sensitive group
       // permission approval and version publishing remain explicit console work.
-      addons: {
-        ...(ingress === "webhook" || (groupBehavior.behavior === "context" && groupBehavior.explicit)
-          ? { scopes: { tenant: ["application:application:patch"] } }
-          : {}),
-        events: { items: { tenant: ["im.message.receive_v1"] } },
-      },
+      addons: feishuAppAddons(),
       onVerificationUrl: ({ url, expiresInS }) => {
         console.error(
           `\n  Opening the confirmation link in your browser (or open it in Feishu / render it as a QR code) — valid for ${Math.round(expiresInS / 60)} minutes:\n\n    ${url}\n\n  waiting for confirmation… (keep this running — the credentials are delivered here)`,

--- a/test/feishu-onboard.test.ts
+++ b/test/feishu-onboard.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { configureGroupBehavior } from "../src/cli/add-feishu.ts";
 import type { FeishuAppScope, FeishuApi } from "../src/channels/feishu/feishu-api.ts";
+import {
+  FEISHU_APP_CONFIG_SCOPE,
+  FEISHU_MESSAGE_RECEIVE_EVENT,
+  feishuAppAddons,
+} from "../src/channels/feishu/setup-mode.ts";
 
 function fixture(scopes: FeishuAppScope[] = []): {
   api: Pick<FeishuApi, "listAppScopes" | "addAppScopes">;
@@ -173,5 +178,18 @@ describe("Feishu/Lark group-behavior onboarding", () => {
     expect(result).toEqual({ publishReady: false });
     expect(fx.notes.join("\n")).toMatch(/could not add.*add it manually before publishing/);
     expect(fx.opened).toEqual(["https://open.larksuite.com/app/cli_l/permission"]);
+  });
+});
+
+describe("Feishu app creation addons", () => {
+  it("requests the app-config scope for either ingress — a WebSocket app can still move to webhook", () => {
+    // The scope only webhook USES on day one, requested for both: changing ingress is a migration the
+    // CLI refuses to perform, so an app that was not born with it has to be recreated or repaired by
+    // hand in the console after a PATCH already failed.
+    expect(feishuAppAddons().scopes.tenant).toContain(FEISHU_APP_CONFIG_SCOPE);
+  });
+
+  it("subscribes the inbound message event — an app that cannot hear one serves nothing", () => {
+    expect(feishuAppAddons().events.items.tenant).toContain(FEISHU_MESSAGE_RECEIVE_EVENT);
   });
 });

--- a/test/live/feishu.live.test.ts
+++ b/test/live/feishu.live.test.ts
@@ -31,6 +31,7 @@ installProxyFetch();
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 requireEnv("FEISHU_APP_ID", "an app of this probe's OWN, from `fastagent add feishu`");
 requireEnv("FEISHU_APP_SECRET", "the app secret that came with FEISHU_APP_ID");
+requireEnv("FEISHU_VERIFICATION_TOKEN", "console → Events & Callbacks; `add feishu --ingress webhook` captures it");
 
 // Every cleanup runs, in reverse, and failures surface together — a loop that stops at the first
 // failure would leave a public *.trycloudflare.com URL pointed at this service.
@@ -64,11 +65,14 @@ describe("feishu: registering an event URL the platform verifies by calling it",
         `export default feishuChannel({\n` +
         `  appId: process.env.FEISHU_APP_ID ?? "",\n` +
         `  appSecret: process.env.FEISHU_APP_SECRET ?? "",\n` +
+        `  verificationToken: process.env.FEISHU_VERIFICATION_TOKEN ?? "",\n` +
         `});\n`,
     );
 
     const service = await createAgentService(dir);
-    expect(service.channels.routes, "channels/feishu.ts did not mount a route").toContain("POST /feishu");
+    // `service.routes` is the literal route table; `channels.routes` next to it is the channel FILE
+    // names. The platform is about to call this path, so assert the path.
+    expect(Object.keys(service.routes), "channels/feishu.ts did not mount POST /feishu").toContain("POST /feishu");
 
     const server = serveNode(service.handler, { port: 0, host: "127.0.0.1" });
     cleanups.push(() => server.close());

--- a/test/live/feishu.live.test.ts
+++ b/test/live/feishu.live.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Feishu verifies an event Request URL by CALLING it: the `PATCH` that sets the URL makes the platform
+ * POST a `url_verification` challenge, and the URL is only stored if our handler echoes the challenge
+ * back. That is a real inbound round trip — platform → our route → platform — which is one step past
+ * what the telegram probe can reach (Telegram only checks that the URL answers).
+ *
+ * The chain is all product entries: `createAgentService` mounts `channels/feishu.ts` at `POST /feishu`
+ * and serves `/health` → `serveNode` binds it → `startCloudflareTunnel` publishes it →
+ * `registerFeishuWebhook` waits for readiness, PATCHes the subscription, and reports what the platform
+ * answered. A `registered` outcome IS the platform's verdict on that round trip.
+ *
+ * Needs `FEISHU_APP_ID` + `FEISHU_APP_SECRET` for an app of its own — this probe REWRITES that app's
+ * event Request URL, so pointing it at an app serving real traffic would take that traffic down.
+ * `fastagent add feishu` creates one in a scan-to-confirm flow.
+ */
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+import { serveNode } from "../../src/channels/serve.ts";
+import { registerFeishuWebhook } from "../../src/channels/feishu/register-webhook.ts";
+import { createAgentService } from "../../src/engines/pi/service.ts";
+import { installProxyFetch } from "../../src/proxy.ts";
+import { startCloudflareTunnel } from "../../src/tunnel.ts";
+import { requireEnv } from "./env.ts";
+
+// Node's fetch ignores HTTPS_PROXY; the registrar's PATCH and the readiness poll both need this.
+installProxyFetch();
+
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+requireEnv("FEISHU_APP_ID", "an app of this probe's OWN, from `fastagent add feishu`");
+requireEnv("FEISHU_APP_SECRET", "the app secret that came with FEISHU_APP_ID");
+
+// Every cleanup runs, in reverse, and failures surface together — a loop that stops at the first
+// failure would leave a public *.trycloudflare.com URL pointed at this service.
+const cleanups: (() => Promise<void> | void)[] = [];
+afterAll(async () => {
+  const errors: unknown[] = [];
+  for (const cleanup of cleanups.reverse()) {
+    try {
+      await cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) throw new AggregateError(errors, "cleanup failed");
+});
+
+describe("feishu: registering an event URL the platform verifies by calling it", () => {
+  it("the platform's challenge reaches our route and the subscription is stored", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-feishu-"));
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+    await mkdir(join(dir, "channels"), { recursive: true });
+    // The scaffold's own import is the package name, which resolves through the agent dir's
+    // node_modules; a throwaway directory has none. Importing this checkout by path loads the same
+    // `feishuChannel` the scaffold would, which is what mounts POST /feishu — the route the platform
+    // is about to call.
+    const feishuModule = fileURLToPath(new URL("../../src/feishu.ts", import.meta.url));
+    await writeFile(
+      join(dir, "channels", "feishu.ts"),
+      `import { feishuChannel } from ${JSON.stringify(feishuModule)};\n` +
+        `export default feishuChannel({\n` +
+        `  appId: process.env.FEISHU_APP_ID ?? "",\n` +
+        `  appSecret: process.env.FEISHU_APP_SECRET ?? "",\n` +
+        `});\n`,
+    );
+
+    const service = await createAgentService(dir);
+    expect(service.channels.routes, "channels/feishu.ts did not mount a route").toContain("POST /feishu");
+
+    const server = serveNode(service.handler, { port: 0, host: "127.0.0.1" });
+    cleanups.push(() => server.close());
+    const port = await server.listening;
+
+    const tunnel = await startCloudflareTunnel(port);
+    expect(tunnel, "cloudflared did not yield a quick-tunnel URL").toBeDefined();
+    if (!tunnel) return;
+    cleanups.push(() => tunnel.close());
+
+    // The PATCH triggers the platform's url_verification challenge against `${tunnel.url}/feishu`.
+    // "registered" means the platform called us, our handler echoed the challenge, and it stored the
+    // URL — the round trip, not our own opinion of it.
+    const outcome = await registerFeishuWebhook(tunnel.url, "feishu");
+    expect(outcome, "feishu did not store the event URL (see the registrar's log line for its reason)").toBe(
+      "registered",
+    );
+  });
+});

--- a/test/live/feishu.live.test.ts
+++ b/test/live/feishu.live.test.ts
@@ -12,6 +12,12 @@
  * Needs `FEISHU_APP_ID` + `FEISHU_APP_SECRET` for an app of its own — this probe REWRITES that app's
  * event Request URL, so pointing it at an app serving real traffic would take that traffic down.
  * `fastagent add feishu` creates one in a scan-to-confirm flow.
+ *
+ * It does NOT restore the subscription afterwards, unlike the telegram probe's `deleteWebhook`. The
+ * app is left pointing at a closed `*.trycloudflare.com` until the next run rewrites it, which is
+ * inert for an app of the probe's own and is the state a failed run would leave anyway. Restoring
+ * would mean flipping the app back to `websocket` — a second mode change per run, on the very
+ * migration path this probe exists to verify — for no observable gain.
  */
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -66,6 +72,11 @@ describe("feishu: registering an event URL the platform verifies by calling it",
         `  appId: process.env.FEISHU_APP_ID ?? "",\n` +
         `  appSecret: process.env.FEISHU_APP_SECRET ?? "",\n` +
         `  verificationToken: process.env.FEISHU_VERIFICATION_TOKEN ?? "",\n` +
+        // The scaffold carries this and the console flow marks it RECOMMENDED, so a probe app created
+        // that way HAS an Encrypt Key. Omitting it here would make the platform's url_verification
+        // arrive encrypted at a handler that refuses it (401), surfacing as a bare `registered`
+        // assertion failure with the real reason buried in the channel's own log.
+        `  encryptKey: process.env.FEISHU_ENCRYPT_KEY || undefined,\n` +
         `});\n`,
     );
 

--- a/test/live/slack.live.test.ts
+++ b/test/live/slack.live.test.ts
@@ -1,5 +1,5 @@
 /**
- * The Slack Bot API contract, against the real API. `slack-api.ts` is our own claude codepeline over a
+ * The Slack Bot API contract, against the real API. `slack-api.ts` is our own pipeline over a
  * surface Slack owns — argument spelling, response shape, the `ok:false` error envelope — and the
  * offline tests (slack-api.test.ts) drive it against a fake `fetch` that answers what we believe
  * today. This probe is the part that notices when that belief stops matching.
@@ -18,7 +18,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { afterAll, describe, expect, it } from "vitest";
-import { createSlackApi } from "../../src/channels/slack/slack-api.ts";
+import { createSlackApi, SlackApiError } from "../../src/channels/slack/slack-api.ts";
 import { installProxyFetch } from "../../src/proxy.ts";
 import { requireEnv } from "./env.ts";
 
@@ -65,17 +65,26 @@ describe("slack Bot API contract", () => {
     await api.updateMessage(CHANNEL, ts, `fastagent live probe ${marker} (edited)`);
   });
 
-  it("posts markdown through the blocks path", async () => {
-    // postMarkdown builds a different request body than postMessage (blocks, not text), and it is the
-    // one every agent reply actually goes through.
+  it("posts markdown through the markdown_text path", async () => {
+    // postMarkdown builds a different request body than postMessage (markdown_text, not text), and it
+    // is the one every agent reply actually goes through.
     const ts = await api.postMarkdown({ channelId: CHANNEL }, `**fastagent** live probe \`${randomUUID()}\``);
     posted.push(ts);
     expect(ts).toMatch(/^\d+\.\d+$/);
   });
 
   it("surfaces an API rejection as an error instead of a silent no-op", async () => {
-    // Slack answers `{ ok: false, error: "channel_not_found" }` with HTTP 200. A claude codepeline that only
+    // Slack answers `{ ok: false, error: "channel_not_found" }` with HTTP 200. A pipeline that only
     // checked the status would treat this as success and lose every message sent to a bad channel.
-    await expect(api.postMessage({ channelId: "C000000000000" }, "should not arrive")).rejects.toThrow();
+    // Asserted on the ENVELOPE, not merely on "it threw": a transport failure (an unreachable proxy,
+    // a timeout) arrives as status 0 or as something that is not a SlackApiError at all, and a bare
+    // `rejects.toThrow()` would count those as coverage. Not pinned to the literal `channel_not_found`
+    // — Slack may answer a malformed id with another code, and an `ok:false` code on HTTP 200 is the
+    // whole claim. A dead TOKEN still satisfies this shape (`invalid_auth` rides the same envelope);
+    // the three tests above are what fail then, and that is the right division of labour.
+    const error = await api.postMessage({ channelId: "C000000000000" }, "should not arrive").catch((e) => e);
+    expect(error, "a Slack rejection must arrive as SlackApiError").toBeInstanceOf(SlackApiError);
+    expect(error.status, "the ok:false envelope rides on HTTP 200").toBe(200);
+    expect(error.slackError, "no Slack error code on the rejection").toBeTruthy();
   });
 });

--- a/test/live/slack.live.test.ts
+++ b/test/live/slack.live.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The Slack Bot API contract, against the real API. `slack-api.ts` is our own claude codepeline over a
+ * surface Slack owns — argument spelling, response shape, the `ok:false` error envelope — and the
+ * offline tests (slack-api.test.ts) drive it against a fake `fetch` that answers what we believe
+ * today. This probe is the part that notices when that belief stops matching.
+ *
+ * SCOPE: OUTBOUND only, and deliberately narrower than the telegram and feishu probes. Those two
+ * assert that the platform calls US (setWebhook verification, url_verification challenge). The
+ * equivalent for Slack is the Events API, whose Request URL is registered with an App Configuration
+ * Token — which expires in 12h and revokes its predecessor on every rotation, so a nightly built on
+ * one is red by its second run. Inbound Slack (signature verification, url_verification, delivery)
+ * therefore stays offline-only, and this file says so rather than implying coverage it does not have.
+ *
+ * Needs a bot token WITHOUT token rotation (`createSlackBotTokenProvider` takes the long-lived path
+ * when the four rotation fields are absent) and a channel the bot has joined. Rotation is covered
+ * offline: slack-bot-auth.test.ts asserts the refresh, its single-flight and its 0600 persistence —
+ * CI has no durable volume to catch a refreshed pair, which is exactly why this uses a static token.
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, describe, expect, it } from "vitest";
+import { createSlackApi } from "../../src/channels/slack/slack-api.ts";
+import { installProxyFetch } from "../../src/proxy.ts";
+import { requireEnv } from "./env.ts";
+
+// Node's fetch ignores HTTPS_PROXY; every call below is an outbound HTTPS request.
+installProxyFetch();
+
+const BOT_TOKEN = requireEnv("SLACK_BOT_TOKEN", "a long-lived xoxb- token for this probe's OWN app");
+const CHANNEL = requireEnv("SLACK_TEST_CHANNEL", "a channel id (C…) the probe's bot has been invited to");
+
+const api = createSlackApi({ botToken: BOT_TOKEN });
+
+/** Messages this run posted, removed however it ends — a probe must not leave a channel full of noise. */
+const posted: string[] = [];
+afterAll(async () => {
+  const errors: unknown[] = [];
+  for (const ts of posted.reverse()) {
+    try {
+      await api.deleteMessage(CHANNEL, ts);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) throw new AggregateError(errors, "could not delete every probe message");
+});
+
+describe("slack Bot API contract", () => {
+  it("authenticates and reports this bot's identity", async () => {
+    const who = await api.authTest();
+    // The fields the channel actually consumes downstream: a response that stopped carrying them
+    // would break routing long before anyone noticed a schema change.
+    expect(who.teamId, "auth.test returned no team id").toBeTruthy();
+    expect(who.userId, "auth.test returned no bot user id").toBeTruthy();
+  });
+
+  it("posts a message and gets back a timestamp that addresses it", async () => {
+    const marker = randomUUID();
+    const ts = await api.postMessage({ channelId: CHANNEL }, `fastagent live probe ${marker}`);
+    posted.push(ts);
+    // A Slack ts is `<seconds>.<microseconds>` and is the message's address for every later call.
+    expect(ts, `unexpected ts shape: ${ts}`).toMatch(/^\d+\.\d+$/);
+
+    // Prove the ts really addresses that message rather than merely looking well-formed: editing
+    // through it is the same round trip the live preview makes on every streamed turn.
+    await api.updateMessage(CHANNEL, ts, `fastagent live probe ${marker} (edited)`);
+  });
+
+  it("posts markdown through the blocks path", async () => {
+    // postMarkdown builds a different request body than postMessage (blocks, not text), and it is the
+    // one every agent reply actually goes through.
+    const ts = await api.postMarkdown({ channelId: CHANNEL }, `**fastagent** live probe \`${randomUUID()}\``);
+    posted.push(ts);
+    expect(ts).toMatch(/^\d+\.\d+$/);
+  });
+
+  it("surfaces an API rejection as an error instead of a silent no-op", async () => {
+    // Slack answers `{ ok: false, error: "channel_not_found" }` with HTTP 200. A claude codepeline that only
+    // checked the status would treat this as success and lose every message sent to a bad channel.
+    await expect(api.postMessage({ channelId: "C000000000000" }, "should not arrive")).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Two changes that came out of building the Feishu live probe.

## Every created app can configure itself

`add feishu` requested `application:application:patch` only for webhook ingress. Minimal-privilege reasoning, but it makes the WebSocket path a one-way door: a WebSocket app that later wants webhook delivery cannot pick the scope up in passing, because changing ingress is a migration the CLI deliberately refuses to perform (`resolveIngress` fails with *"changing mode is a migration"*). The app has to be recreated, or repaired by hand in the console after a PATCH has already failed.

The scope reads and writes the app's **own** configuration — not a data scope — so carrying it costs an app nothing and keeps that door open.

The addons are now a named policy function (`feishuAppAddons`) beside the other scope constants, where they can be asserted. The CLI layer that requests them is terminal wiring with no seam to test through, which is why the decision did not belong there.

Verified against the platform, not just in a unit test: an app created by this branch comes back with `application:application:patch` granted at credential-delivery time, with no manual console visit.

```
T+0s  scopes=37  patch=true
```

## A probe for the round trip Feishu makes us complete

`feishu.live.test.ts`. The PATCH that registers a Request URL makes the platform POST a `url_verification` challenge, and the URL is stored **only if** our handler echoes it back. That is a real inbound round trip — platform → our route → platform — one step past what the telegram probe can reach (Telegram only checks that the URL answers).

All product entries: `createAgentService` mounts `channels/feishu.ts` at `POST /feishu`, `serveNode` binds it, `startCloudflareTunnel` publishes it, and `registerFeishuWebhook` reports what the platform answered. A `registered` outcome is the platform's verdict on that round trip, not ours.

Needs an app of the probe's own (`secrets.FEISHU_APP_ID` / `FEISHU_APP_SECRET` / `FEISHU_VERIFICATION_TOKEN`), since registering rewrites that app's event Request URL.

Verified on CI (run 33527034861): 7 files, 9 tests, 117s — feishu 26.8s.
