### PR TITLE
chore: fill the issue and PR sidebar automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,10 @@
 # Ownership map for review routing. Maintainer-authored PRs do not require a second maintainer approval.
 
+# Fallback so every PR arrives with a reviewer requested. Branch protection does
+# not require code-owner approval, so a later, narrower rule still decides who
+# actually owns a path — this only fills the sidebar.
+*                        @kid7st @Sukitly
+
 # The locked contract and its types.
 /docs/SPEC.md            @kid7st @Sukitly
 /src/agent.ts            @kid7st @Sukitly

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report something that is broken or behaving unexpectedly.
 title: "bug: "
+type: Bug
 labels: [bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature request
 description: Propose a new capability or product change.
 title: "feat: "
+type: Feature
 labels: [enhancement]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -2,6 +2,7 @@ name: Task
 description: Track internal work — refactor, chore, CI, test, or release follow-up.
 title: "task: "
 type: Task
+labels: [chore]
 body:
   - type: textarea
     id: goal

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,24 @@
+name: Task
+description: Track internal work — refactor, chore, CI, test, or release follow-up.
+title: "task: "
+type: Task
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be true when this is done?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which files, commands, or docs does this touch? Name what is explicitly out of scope.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: How will the change be proven — tests, a command to run, an observable behavior?

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,8 @@
 bug:
   - head-branch: ['^fix/']
 enhancement:
-  - head-branch: ['^feature/']
+  # `feat/` is a fifth of this repo's feature branches, despite the documented prefix.
+  - head-branch: ['^feat(ure)?/']
 documentation:
   - head-branch: ['^docs/']
 refactor:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+# One label per PR, from the branch prefix CONTRIBUTING.md already requires.
+# Path-based rules are deliberately absent: they double-label a branch that
+# touches docs on the way to a fix, and the prefix is the author's own claim
+# about what the change is.
+bug:
+  - head-branch: ['^fix/']
+enhancement:
+  - head-branch: ['^feature/']
+documentation:
+  - head-branch: ['^docs/']
+refactor:
+  - head-branch: ['^refactor/']
+chore:
+  - head-branch: ['^chore/']
+ci:
+  - head-branch: ['^ci/']
+test:
+  - head-branch: ['^test/']

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,12 @@
+<!--
+Labels come from the branch prefix and reviewers from CODEOWNERS — both automatic.
+Still yours: the assignee (`gh pr create --assignee @me`) and the issue link below.
+-->
+
 ## Summary
 
 <!-- What changed, and why? -->
+<!-- Add `Closes #<issue>` here when one exists — that is what carries Projects/Milestone/Priority over. -->
 
 ## Validation
 
@@ -11,6 +17,7 @@
 
 ## Checklist
 
+- [ ] Assignee is set, and the branch uses a prefix so the labeler can label it
 - [ ] Public-facing text is in English
 - [ ] Errors fail visibly; no silent fallbacks or swallowed exceptions
 - [ ] No secrets, local paths, or machine-specific state were committed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 <!--
 Labels come from the branch prefix and reviewers from CODEOWNERS — both automatic.
-Still yours: the assignee (`gh pr create --assignee @me`) and the issue link below.
+Still yours: the issue link below, and the assignee if you have push access (`gh pr create --assignee @me`).
 -->
 
 ## Summary
 
 <!-- What changed, and why? -->
-<!-- Add `Closes #<issue>` here when one exists — that is what carries Projects/Milestone/Priority over. -->
+<!-- Add `Closes #<issue>` here when one exists — it closes the issue on merge. Board fields stay manual. -->
 
 ## Validation
 
@@ -17,7 +17,7 @@ Still yours: the assignee (`gh pr create --assignee @me`) and the issue link bel
 
 ## Checklist
 
-- [ ] Assignee is set, and the branch uses a prefix so the labeler can label it
+- [ ] The PR carries a label — from the branch prefix, or added by hand
 - [ ] Public-facing text is in English
 - [ ] Errors fail visibly; no silent fallbacks or swallowed exceptions
 - [ ] No secrets, local paths, or machine-specific state were committed

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+name: Labeler
+
+# pull_request_target, not pull_request: the fork-PR token is read-only, so a
+# fork's PR would never get labelled. Safe here only because this job never
+# checks out or runs the PR's code.
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: Label from branch prefix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # labeler reads .github/labeler.yml through the API
+      pull-requests: write
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,7 @@ Full version: `CONTRIBUTING.md`. The essentials:
    ```bash
    npm run lint && npm run typecheck && npm test
    ```
-2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`.
+2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`. The prefix is also what labels the PR (`.github/labeler.yml`), and CODEOWNERS requests the reviewer — so `gh pr create --base main --assignee @me` is enough. `gh issue create` is the exception: a bare `--title` skips the templates and files an issue with no type and no label, so always pass `--template bug_report.yml` (or `feature_request.yml` / `task.yml`).
 3. **Squash merge only** (repo settings enforce it): one PR = one commit on `main`; curate the PR title/body — they become the commit message. Branch commits are working state, the PR is the design asset: put the durable *why* there, not in per-commit narration. `main` enforces linear history; force-push is forbidden.
 4. **Review policy.** Merging is a maintainer's decision, never an agent's. Green CI makes a PR eligible; report "ready to merge" and stop — merge only when told to. External-contributor PRs are reviewed and merged by a maintainer.
 5. **After merge:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,7 @@ Full version: `CONTRIBUTING.md`. The essentials:
    ```bash
    npm run lint && npm run typecheck && npm test
    ```
-2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`. The prefix is also what labels the PR (`.github/labeler.yml`), and CODEOWNERS requests the reviewer — so `gh pr create --base main --assignee @me` is enough. `gh issue create` is the exception: a bare `--title` skips the templates and files an issue with no type and no label, so always pass `--template bug_report.yml` (or `feature_request.yml` / `task.yml`).
+2. **Branch → PR → CI → merge.** Never commit directly to `main`. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `ci/`, `test/`. The prefix is also what labels the PR (`.github/labeler.yml`), and CODEOWNERS requests the reviewer — so `gh pr create --base main --assignee @me` is enough. `gh issue create` is the exception: it cannot read the issue forms (`--template` only sees Markdown templates), so pass the fields it would have set — `--type Bug --label bug` (or `Feature`/`enhancement`, `Task`/`chore`).
 3. **Squash merge only** (repo settings enforce it): one PR = one commit on `main`; curate the PR title/body — they become the commit message. Branch commits are working state, the PR is the design asset: put the durable *why* there, not in per-commit narration. `main` enforces linear history; force-push is forbidden.
 4. **Review policy.** Merging is a maintainer's decision, never an agent's. Green CI makes a PR eligible; report "ready to merge" and stop — merge only when told to. External-contributor PRs are reviewed and merged by a maintainer.
 5. **After merge:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,31 @@ Tests use faux models by default, so they validate serving mechanics without net
 2. ... change code, iterate locally ...
 3. npm run lint && npm run typecheck && npm test
 4. git push -u origin feature/<thing>
-5. gh pr create --base main           # fill in the PR template
+5. gh pr create --base main --assignee @me   # fill in the PR template
 6. CI green → merge (see "Merge strategy")
 7. After merge: clean up local + remote tracking branches
 ```
+
+### Issue and PR metadata
+
+Most of the sidebar fills itself; the rest is one flag. What is automatic and what is not:
+
+| Field | Issues | Pull requests |
+| --- | --- | --- |
+| Type (`Bug` / `Feature` / `Task`) | Automatic — each issue form declares one | Not applicable |
+| Labels | Automatic — the form's `labels:` | Automatic — the branch prefix, via `.github/labeler.yml` |
+| Reviewer | Not applicable | Automatic — CODEOWNERS |
+| Assignee | Whoever picks it up | `--assignee @me` |
+| Projects, Priority, Milestone | Board fields; set them on the board | Follows the linked issue — write `Closes #<n>` |
+
+The one thing that defeats all of it is `gh issue create` with a bare `--title`: the CLI skips the templates entirely, so the issue lands with no type and no label. Name the template instead:
+
+```bash
+gh issue create --template bug_report.yml       # or feature_request.yml, task.yml
+gh pr create --base main --assignee @me        # labels and reviewers are added for you
+```
+
+A PR whose branch does not carry one of the prefixes above gets no label — that is the prefix convention failing loudly, not the labeler.
 
 ### After a PR merges
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Tests use faux models by default, so they validate serving mechanics without net
 2. ... change code, iterate locally ...
 3. npm run lint && npm run typecheck && npm test
 4. git push -u origin feature/<thing>
-5. gh pr create --base main --assignee @me   # fill in the PR template
+5. gh pr create --base main --assignee @me   # drop --assignee without push access
 6. CI green → merge (see "Merge strategy")
 7. After merge: clean up local + remote tracking branches
 ```
@@ -43,20 +43,22 @@ Most of the sidebar fills itself; the rest is one flag. What is automatic and wh
 
 | Field | Issues | Pull requests |
 | --- | --- | --- |
-| Type (`Bug` / `Feature` / `Task`) | Automatic — each issue form declares one | Not applicable |
-| Labels | Automatic — the form's `labels:` | Automatic — the branch prefix, via `.github/labeler.yml` |
+| Type (`Bug` / `Feature` / `Task`) | Automatic in the browser — each issue form declares one | Not applicable |
+| Labels | Automatic in the browser — the form's `labels:` (Task files as `chore`) | Automatic — the branch prefix, via `.github/labeler.yml` |
 | Reviewer | Not applicable | Automatic — CODEOWNERS |
-| Assignee | Whoever picks it up | `--assignee @me` |
-| Projects, Priority, Milestone | Board fields; set them on the board | Follows the linked issue — write `Closes #<n>` |
+| Assignee | Whoever picks it up | `--assignee @me`, and only with push access |
+| Projects, Priority, Milestone | Board fields; set them on the board | Board fields too — `Closes #<n>` closes the issue, it does not carry them over |
 
-The one thing that defeats all of it is `gh issue create` with a bare `--title`: the CLI skips the templates entirely, so the issue lands with no type and no label. Name the template instead:
+The forms fill the sidebar only in the browser — which is where contributors without push access should open issues, since the API silently drops `--type` and `--label` for them. `gh issue create` cannot use the forms at all: it discovers templates through GraphQL `repository.issueTemplates`, which does not return issue forms ([cli/cli#5865](https://github.com/cli/cli/issues/5865)). With push access, pass the two fields explicitly:
 
 ```bash
-gh issue create --template bug_report.yml       # or feature_request.yml, task.yml
+gh issue create --title "bug: <what>" --body "<detail>" --type Bug --label bug   # Feature/enhancement, Task/chore
 gh pr create --base main --assignee @me        # labels and reviewers are added for you
 ```
 
-A PR whose branch does not carry one of the prefixes above gets no label — that is the prefix convention failing loudly, not the labeler.
+Without push access, drop `--assignee`: `gh` resolves the login against the repository's assignable users and aborts with `'<login>' not found` before the pull request is created.
+
+A PR whose branch prefix matches no rule in `.github/labeler.yml` gets no label, and nothing says so: the job stays green and the label field is silently empty.
 
 ### After a PR merges
 


### PR DESCRIPTION
Issues and PRs were landing with an empty sidebar — no type, no label, and for CLI-created issues not even the ones the templates already declared. Three different causes, three different fixes.

**Issue type.** The org defines `Bug`/`Feature`/`Task`, but nothing ever set it. Issue forms take a top-level `type:`, so the two existing forms now declare theirs. A third form (`task.yml`) exists at all because blank issues are disabled: internal refactor/chore/CI work had no form to file under and was going through a bare `gh issue create`, which is exactly the path that sets nothing.

**PR labels.** No repository setting can do this — a markdown PR template carries no metadata, so the sidebar stays empty unless every author remembers `--label`. `actions/labeler` reads the branch prefix that `CONTRIBUTING.md` already requires, which makes the label a consequence of a convention we enforce anyway rather than a second thing to remember. Deliberately no path-based rules: a `fix/` branch that touches a doc on the way would come out labelled both. `pull_request_target` is what lets a fork PR be labelled at all (the fork token is read-only); it is safe here only because the job never checks out the PR's code. Four labels were created to match the prefixes that had none: `refactor`, `chore`, `ci`, `test`.

**Reviewers.** CODEOWNERS covered a handful of paths, so a PR touching anything else arrived with none. A `*` fallback fills it. Branch protection does not require code-owner approval, so this requests review without gating merges, and the narrower rules below it still decide real ownership.

What stays manual, and why automating it costs more than it returns: `Priority` is a Projects v2 single-select, and the built-in project workflows can only set `Status` — automating it means an Action calling GraphQL for one dropdown. `Projects` and `Milestone` are manual too: a closing keyword links and closes an issue, it does not carry the linked issue's board fields onto the PR.

`CONTRIBUTING.md`, `AGENTS.md`, and the PR template now state which fields are automatic and where the automation stops at the CLI. `gh issue create` cannot use the forms at all — it discovers templates through GraphQL `repository.issueTemplates`, which does not return issue forms (cli/cli#5865) — so the docs pass `--type`/`--label` explicitly, and note that the API silently drops both for anyone without push access, who should use the browser form instead. `gh pr create` resolves `--assignee` before creating the PR and aborts with `'<login>' not found` when the login is not assignable, so that flag is marked push-access-only.

## Validation

- `npm run lint` clean
- All five YAML files parse; the labeler config matches `feature/` and `feat/` (a fifth of this repo's feature branches) and no other prefix
- This PR cannot test itself: `pull_request_target` workflows and CODEOWNERS are both read from the default branch, so the labeler first runs on the PR after this one. Its reviewer request here came from the existing `/.github/workflows/` rule.

