### PR TITLE
fix(deploy/fly): allocate an ingress address, plus the live probes that found it missing

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -133,7 +133,27 @@ jobs:
           # refreshed pair, so a rotating credential would be revoked by its own first refresh.
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_TEST_CHANNEL: ${{ secrets.SLACK_TEST_CHANNEL }}
-          # READ-ONLY use: the fly probe runs `auth whoami` and two `list --json` commands. Nothing it
-          # does creates, deploys or bills.
+          # WRITE scope. `vitest.live.config.ts` includes the whole test/live directory, so this ONE
+          # token serves both fly probes: fly.live.test.ts only reads, but fly-deploy.live.test.ts
+          # creates a real app + volume, stages secrets, runs a remote build and destroys it again.
+          # A read-only token makes the nightly red at `apps create`; a write token bills every night.
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: npm run test:live
+
+      # The deploy probe destroys its own app in afterAll, which a job timeout or a cancelled run
+      # never reaches — and what it leaves behind is a running Fly app holding the model credential
+      # that was staged into it, with nothing else in the world collecting it. `always()` still
+      # reaches this step on cancellation, so the sweep lives here rather than in the probe.
+      #
+      # Scoped to the name the probe mints (`fastagent-live-<uuid8>`, see test/live/fly-deploy) and
+      # serialized by the `live` concurrency group, so it cannot destroy another CI run's app. A
+      # LOCAL probe run against this same org at this same moment is the one case it would.
+      - name: Destroy leftover live Fly apps
+        if: always()
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl apps list --json \
+            | jq -r '.[] | (.Name // .name) | select(test("^fastagent-live-[0-9a-f]{8}$"))' \
+            | tee /dev/stderr \
+            | xargs -r -n1 -I{} flyctl apps destroy {} --yes

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -153,6 +153,10 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
+          # Without this the pipeline's exit code is `xargs`'s, which is 0 on empty input: a failed
+          # `apps list` (expired token, Fly 5xx) or a `jq` error would report a clean sweep having
+          # deleted nothing. The default shell here is `bash -e {0}` — `-o pipefail` is NOT included.
+          set -o pipefail
           flyctl apps list --json \
             | jq -r '.[] | (.Name // .name) | select(test("^fastagent-live-[0-9a-f]{8}$"))' \
             | tee /dev/stderr \

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
 
+      # The driver spawns `fly`, the short name Fly's own installer also provides; this action ships
+      # only `flyctl`. Without the alias `deploy fly --run` fails with "flyctl not found" on a runner
+      # that demonstrably has it.
+      - name: Provide the `fly` alias the driver spawns
+        run: |
+          sudo ln -sf "$(command -v flyctl)" /usr/local/bin/fly
+          fly version
+
       # ONE credential mechanism for both probes: an auth.json, named by the product's own
       # FASTAGENT_AUTH_PATH. It carries an OAuth grant (openai-codex) as readily as an API key, and
       # `deploy docker --run` turns the same file into the container's FASTAGENT_AUTH_SEED.

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -61,6 +61,12 @@ jobs:
           sudo apt-get install -y cloudflared
           cloudflared --version
 
+      # The Fly probe shells out to `flyctl`, the same binary `deploy fly --run` drives. Pinned to a
+      # commit like every other action here; it only installs the CLI, which then reads FLY_API_TOKEN
+      # from the environment below.
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
+
       # ONE credential mechanism for both probes: an auth.json, named by the product's own
       # FASTAGENT_AUTH_PATH. It carries an OAuth grant (openai-codex) as readily as an API key, and
       # `deploy docker --run` turns the same file into the container's FASTAGENT_AUTH_SEED.
@@ -119,4 +125,7 @@ jobs:
           # refreshed pair, so a rotating credential would be revoked by its own first refresh.
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_TEST_CHANNEL: ${{ secrets.SLACK_TEST_CHANNEL }}
+          # READ-ONLY use: the fly probe runs `auth whoami` and two `list --json` commands. Nothing it
+          # does creates, deploys or bills.
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: npm run test:live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,13 +264,14 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # it was handed and Feishu CALLING one with a challenge (telegram/feishu —
                              # registration only; delivery needs a human to type), and Slack's Bot API
                              # answering our pipeline (slack — OUTBOUND only: its inbound half needs a
-                             # 12h App Configuration Token, which no nightly can hold), and `flyctl`
-                             # still printing what the Fly driver reads (fly — READ-ONLY: the write
-                             # steps are what cost money, the read steps are where the parsing lives).
+                             # 12h App Configuration Token, which no nightly can hold), `flyctl` still
+                             # printing what the Fly driver reads (fly — read-only), and a REAL Fly app
+                             # provisioned then destroyed (fly-deploy — which is how #425 was found: a
+                             # deploy whose every step succeeded, serving on a URL that had no IP).
                              # Each one drives a PRODUCT ENTRY (`createPiAgentFromDir`,
-                             # `deploy docker --run`, `npm install`, `startCloudflareTunnel`,
-                             # `startSchedules`, `registerTelegramWebhook`, `registerFeishuWebhook`,
-                             # `createSlackApi`, `listHasName`)
+                             # `deploy docker --run`, `deploy fly --run`, `npm install`,
+                             # `startCloudflareTunnel`, `startSchedules`, `registerTelegramWebhook`,
+                             # `registerFeishuWebhook`, `createSlackApi`, `listHasName`)
                              # and observes from OUTSIDE it
                              # — a probe that rebuilds the assembly to get a better observation point
                              # measures the rebuild, and the entry's own steps (installProxyFetch,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,8 +271,10 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # Each one drives a PRODUCT ENTRY (`createPiAgentFromDir`,
                              # `deploy docker --run`, `deploy fly --run`, `npm install`,
                              # `startCloudflareTunnel`, `startSchedules`, `registerTelegramWebhook`,
-                             # `registerFeishuWebhook`, `createSlackApi`, `listHasName`)
-                             # and observes from OUTSIDE it
+                             # `registerFeishuWebhook`, `createSlackApi`) and observes from OUTSIDE it
+                             # — except the read-only fly probe, which checks a real `flyctl`'s output
+                             # against the driver's PARSING assumptions about it (`listHasName`,
+                             # `hasIngressAddress`): the belief a faked CliRunner cannot test
                              # — a probe that rebuilds the assembly to get a better observation point
                              # measures the rebuild, and the entry's own steps (installProxyFetch,
                              # credential resolution, pinning pi's agent dir) go missing one at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,7 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # `registerFeishuWebhook`, `createSlackApi`) and observes from OUTSIDE it
                              # — except the read-only fly probe, which checks a real `flyctl`'s output
                              # against the driver's PARSING assumptions about it (`listHasName`,
-                             # `hasIngressAddress`): the belief a faked CliRunner cannot test
+                             # `ingressAddresses`): the belief a faked CliRunner cannot test
                              # — a probe that rebuilds the assembly to get a better observation point
                              # measures the rebuild, and the entry's own steps (installProxyFetch,
                              # credential resolution, pinning pi's agent dir) go missing one at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,10 +264,13 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # it was handed and Feishu CALLING one with a challenge (telegram/feishu —
                              # registration only; delivery needs a human to type), and Slack's Bot API
                              # answering our pipeline (slack — OUTBOUND only: its inbound half needs a
-                             # 12h App Configuration Token, which no nightly can hold). Each one drives
-                             # a PRODUCT ENTRY (`createPiAgentFromDir`, `deploy docker --run`,
-                             # `npm install`, `startCloudflareTunnel`, `startSchedules`,
-                             # `registerTelegramWebhook`, `registerFeishuWebhook`, `createSlackApi`)
+                             # 12h App Configuration Token, which no nightly can hold), and `flyctl`
+                             # still printing what the Fly driver reads (fly — READ-ONLY: the write
+                             # steps are what cost money, the read steps are where the parsing lives).
+                             # Each one drives a PRODUCT ENTRY (`createPiAgentFromDir`,
+                             # `deploy docker --run`, `npm install`, `startCloudflareTunnel`,
+                             # `startSchedules`, `registerTelegramWebhook`, `registerFeishuWebhook`,
+                             # `createSlackApi`, `listHasName`)
                              # and observes from OUTSIDE it
                              # — a probe that rebuilds the assembly to get a better observation point
                              # measures the rebuild, and the entry's own steps (installProxyFetch,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,16 @@ src/
 │       └── scaffold/        # `add lark` bundle
 ├── deploy/                  # `deploy docker|fly|railway|agentcore`: host artifacts + runbook + `--run` CLI drive (docs/design/core.md §9)
 │   │                        # LAYOUT: neutral kernel at top (horizontal) + one dir per host (vertical) — new host = new dir, copy fly/.
+│   │                        # BEFORE writing one: READ that host's docs for what it does NOT do implicitly
+│   │                        # — above all, whether a created resource is REACHABLE without a further
+│   │                        # step. Fly taught this eight rounds in a row: `[http_service]` declares a
+│   │                        # service and allocates no address, so every step succeeded and the URL had
+│   │                        # no DNS record (#425); v4 and v6 are separate free commands, so an app with
+│   │                        # only v6 is unreachable from an IPv4-only webhook sender. Five of the eight
+│   │                        # defects were sitting in Fly's own docs or fly-go's source; each was instead
+│   │                        # bought with a real deploy or a red nightly. A parser's judgement must also
+│   │                        # match the GRANULARITY of the action it drives (one question per command),
+│   │                        # and "we could not read the host" is a third answer, never "absent".
 │   │                        # The CLI branch that picks between them is cli/commands/deploy.ts; what it may NOT
 │   │                        # hold is a fact about ANOTHER host ("--into-linked is railway's" lived in three
 │   │                        # branches and drifted) — that is HOST_ONLY_FLAGS, one row per host-only flag

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -103,9 +103,10 @@ Generates `fly.toml`, `Dockerfile`, `.dockerignore`, then prints a first-deploy 
 
 1. `fly apps create <name>` — one-time (Fly app names are globally unique; if taken, edit `app` in `fly.toml` and re-run `deploy`).
 2. `fly volumes create data --region <region> --size 1` — one-time; the region **must** match `primary_region` in `fly.toml`.
-3. `fly secrets set …` — the model key + each channel's secrets, with `<value>` placeholders to fill.
-4. `fly deploy` — build and ship. **A redeploy is this step alone.**
-5. Register each route channel's webhook at the live URL. Locally onboarded Slack updates its App Manifest from the builder machine; scaffold-only/manual Slack prints the console URL. WebSocket long-connection channels make no registration call.
+3. `fly ips allocate-v4 --shared` + `fly ips allocate-v6` — one-time, free. `[http_service]` declares a service; it does not allocate an address to reach it on. `fly deploy` does that on a *first* deploy only, and just warns when it fails — leaving a machine that serves and a `https://<name>.fly.dev` with no DNS record. Skip if `fly ips list` already shows one.
+4. `fly secrets set …` — the model key + each channel's secrets, with `<value>` placeholders to fill.
+5. `fly deploy` — build and ship. **A redeploy is this step alone.**
+6. Register each route channel's webhook at the live URL. Locally onboarded Slack updates its App Manifest from the builder machine; scaffold-only/manual Slack prints the console URL. WebSocket long-connection channels make no registration call.
 
 Or let the CLI do all of it:
 

--- a/src/deploy/fly/plan.ts
+++ b/src/deploy/fly/plan.ts
@@ -163,6 +163,13 @@ export function planFlyDeploy(input: FlyPlanInput): FlyPlan {
     `# <region> MUST equal primary_region in fly.toml (a volume in another region can't mount) — fly.toml`,
     `# is the single source for the region; skip this if the volume exists (fly volumes list --app ${appName}):`,
     `fly volumes create data --app ${appName} --region <region> --size 1`,
+    ``,
+    `# An address to be reached ON: [http_service] declares a service, it does not allocate an IP.`,
+    `# \`fly deploy\` allocates one on a FIRST deploy only, and merely WARNS when that fails — which`,
+    `# leaves the machine serving and https://${appName}.fly.dev with no DNS record at all. Both are`,
+    `# free; skip if \`fly ips list --app ${appName}\` already shows a v4/v6/shared_v4 address:`,
+    `fly ips allocate-v4 --shared --app ${appName}`,
+    `fly ips allocate-v6 --app ${appName}`,
   ];
 
   if (requiredSecrets.length > 0) {

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -41,25 +41,33 @@ export interface FlyRunPlan {
 /** Done, or a gate the operator must clear before re-running (printed + non-zero exit by the CLI). */
 export type FlyRunOutcome = { ok: true } | { ok: false; gate: string };
 
-/** The `Type` values that put an app on `https://<app>.fly.dev`. The rest of flyctl's vocabulary —
- *  `private_v6` (Flycast), `egress_v4`, `egress_v6`, `egress_pair` — is internal or outbound. */
-const PUBLIC_IP_TYPES = new Set(["v4", "v6", "shared_v4"]);
+/** The `Type` values that put an app on `https://<app>.fly.dev`, BY FAMILY — one entry per allocate
+ *  command, because that is the granularity the answer is acted on at. The rest of flyctl's
+ *  vocabulary — `private_v6` (Flycast), `egress_v4`, `egress_v6`, `egress_pair` — is internal or
+ *  outbound. */
+const INGRESS_TYPES = { v4: ["v4", "shared_v4"], v6: ["v6"] } as const;
 
 /**
- * Whether `fly ips list --json` shows a PUBLIC ingress address. The list is EVERY assignment the app
- * holds, and a Flycast or egress address carries a non-empty `Address` too — reading one as routable
- * reproduces #425 on an app that has one, and pre-empts flyctl's own first-deploy fallback, which
- * returns early once any assignment exists.
+ * Which PUBLIC ingress families `fly ips list --json` shows — asked per family, because "has an
+ * ingress address" is not the question the two allocate commands answer. An app holding only a `v6`
+ * passes the coarse test and still resolves `<app>.fly.dev` to an AAAA record alone, so an IPv4-only
+ * webhook sender (Telegram, GitHub) reproduces #425 against it.
+ *
+ * The list is EVERY assignment the app holds, and a Flycast or egress address carries a non-empty
+ * `Address` too — reading one as routable pre-empts flyctl's own first-deploy fallback, which returns
+ * early once any assignment exists.
  *
  * Output that is not a JSON array THROWS rather than reading as "no address": the caller turns that
  * into a gate, because a list we cannot read is not a state we can act on.
  */
-export function hasIngressAddress(stdout: string): boolean {
+export function ingressAddresses(stdout: string): { v4: boolean; v6: boolean } {
   const entries: unknown = JSON.parse(stdout);
   if (!Array.isArray(entries)) throw new Error(`expected a JSON array, got ${typeof entries}`);
-  return (entries as { Address?: unknown; Type?: unknown }[]).some(
-    (entry) => typeof entry?.Address === "string" && entry.Address !== "" && PUBLIC_IP_TYPES.has(entry.Type as string),
-  );
+  const has = (types: readonly string[]) =>
+    (entries as { Address?: unknown; Type?: unknown }[]).some(
+      (entry) => typeof entry?.Address === "string" && entry.Address !== "" && types.includes(entry.Type as string),
+    );
+  return { v4: has(INGRESS_TYPES.v4), v6: has(INGRESS_TYPES.v6) };
 }
 
 /**
@@ -67,7 +75,7 @@ export function hasIngressAddress(stdout: string): boolean {
  * both). Exported for the same reason railway's parsers are: what it encodes is an assumption about
  * another tool's output, and the live probe checks that assumption against the real `flyctl`.
  *
- * THROWS on output that is not a JSON array, for the same reason {@link hasIngressAddress} does —
+ * THROWS on output that is not a JSON array, for the same reason {@link ingressAddresses} does —
  * `false` here means "the host does not have it", and answering that for a list nobody could read
  * creates a SECOND volume, or in teardown destroys nothing at all.
  */
@@ -85,20 +93,25 @@ export function listHasName(stdout: string, name: string): boolean {
  * unreadable, or the host gave a verdict. Collapsing the middle one into `false` is what shipped #425
  * and what would have skipped a teardown.
  */
-async function readList(
+async function readList<T>(
   fly: CliRunner,
   args: string[],
-  label: string,
-  read: (stdout: string) => boolean,
-): Promise<{ value: boolean } | { gate: string }> {
+  read: (stdout: string) => T,
+): Promise<{ value: T } | { gate: string }> {
+  // The command as RUN, not a restatement of it: a gate that tells the operator to run it themselves
+  // has to name one that works from their cwd, and `fly ips list --json` without `-a <app>` does not
+  // (fly.toml lives under the agent prefix, so flyctl finds no app).
+  const cmd = `fly ${args.join(" ")}`;
   const result = await fly(args, { capture: true });
-  if (result.code !== 0) return { gate: `\`fly ${label}\` failed — see the flyctl output above; fix and re-run` };
+  if (result.code !== 0) return { gate: `\`${cmd}\` failed — see the flyctl output above; fix and re-run` };
   try {
     return { value: read(result.stdout) };
   } catch (error) {
+    // The one place a parse failure is allowed to stop being an exception: this IS the boundary that
+    // turns it into the operator's gate (printed + non-zero exit), never a default answer.
     return {
       gate:
-        `\`fly ${label} --json\` was unreadable (${error instanceof Error ? error.message : String(error)}) — ` +
+        `\`${cmd}\` was unreadable (${error instanceof Error ? error.message : String(error)}) — ` +
         `run it yourself and check the flyctl version; fix and re-run`,
     };
   }
@@ -134,9 +147,7 @@ export async function deployFlyRun(
   // 3. App — idempotent (create only if absent; a taken global name is a gate). An unusable list is its
   //    own gate ({@link readList}): inferring "absent" from a query nobody could read would then
   //    misreport the create as a name clash.
-  const appExists = await readList(fly, ["apps", "list", "--json"], "apps list", (out) =>
-    listHasName(out, plan.appName),
-  );
+  const appExists = await readList(fly, ["apps", "list", "--json"], (out) => listHasName(out, plan.appName));
   if ("gate" in appExists) return gate(appExists.gate);
   if (appExists.value) {
     log(`app ${plan.appName} exists — skipping create`);
@@ -152,7 +163,7 @@ export async function deployFlyRun(
 
   // 4. Volume — idempotent; region comes from fly.toml (must match the machine's region). A failed list
   //    gates for the same reason as the app list above.
-  const volumeExists = await readList(fly, ["volumes", "list", "-a", plan.appName, "--json"], "volumes list", (out) =>
+  const volumeExists = await readList(fly, ["volumes", "list", "-a", plan.appName, "--json"], (out) =>
     listHasName(out, "data"),
   );
   if ("gate" in volumeExists) return gate(volumeExists.gate);
@@ -172,22 +183,25 @@ export async function deployFlyRun(
   //    to reach it on. `fly launch` allocates one as part of its flow, and this driver does not use it,
   //    so without this step the deploy succeeds, the machine serves, and `https://<app>.fly.dev` has no
   //    DNS record at all — reported as a healthy deploy, and handed to the webhook registrars as a URL
-  //    they then fail to reach. Check-then-act like the volume above; both allocations are free.
-  const addressExists = await readList(fly, ["ips", "list", "-a", plan.appName, "--json"], "ips list", (out) =>
-    hasIngressAddress(out),
-  );
-  if ("gate" in addressExists) return gate(addressExists.gate);
-  if (addressExists.value) {
-    log("public address exists — skipping allocate");
-  } else {
-    log("allocating a public address…");
-    // v4 SHARED (free, and what every client can reach) plus v6. A dedicated v4 is billed, so it stays
-    // an operator decision — `fly ips allocate-v4 -a <app>` after the fact, which this step then skips.
-    if ((await fly(["ips", "allocate-v4", "--shared", "-a", plan.appName])).code !== 0) {
-      return gate("`fly ips allocate-v4 --shared` failed — see the flyctl output above");
+  //    they then fail to reach.
+  const addresses = await readList(fly, ["ips", "list", "-a", plan.appName, "--json"], ingressAddresses);
+  if ("gate" in addresses) return gate(addresses.gate);
+  // Check-then-act PER FAMILY: an app that already holds one must still be given the other, or the
+  // gate between the two allocations below heals into a permanent half-state — the re-run the gate
+  // asks for sees the v4 it just made, skips, and reports success on an app with no v6 (and, the way
+  // that matters, no v4). v4 SHARED and v6 are both free; a dedicated v4 is billed, so it stays an
+  // operator decision — `fly ips allocate-v4 -a <app>` after the fact, which this step reads as v4.
+  for (const [family, allocate] of [
+    ["v4", ["ips", "allocate-v4", "--shared", "-a", plan.appName]],
+    ["v6", ["ips", "allocate-v6", "-a", plan.appName]],
+  ] as const) {
+    if (addresses.value[family]) {
+      log(`public ${family} address exists — skipping allocate`);
+      continue;
     }
-    if ((await fly(["ips", "allocate-v6", "-a", plan.appName])).code !== 0) {
-      return gate("`fly ips allocate-v6` failed — see the flyctl output above");
+    log(`allocating a public ${family} address…`);
+    if ((await fly([...allocate])).code !== 0) {
+      return gate(`\`fly ${allocate.join(" ")}\` failed — see the flyctl output above`);
     }
   }
 

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -41,32 +41,66 @@ export interface FlyRunPlan {
 /** Done, or a gate the operator must clear before re-running (printed + non-zero exit by the CLI). */
 export type FlyRunOutcome = { ok: true } | { ok: false; gate: string };
 
+/** The `Type` values that put an app on `https://<app>.fly.dev`. The rest of flyctl's vocabulary —
+ *  `private_v6` (Flycast), `egress_v4`, `egress_v6`, `egress_pair` — is internal or outbound. */
+const PUBLIC_IP_TYPES = new Set(["v4", "v6", "shared_v4"]);
+
 /**
- * Whether `fly ips list --json` shows a public ingress address. Entries carry `Address` plus a `Type`
- * (`v6`, `shared_v4`, …); any non-empty address means the app is routable, which is the only question
- * the deploy has to answer.
+ * Whether `fly ips list --json` shows a PUBLIC ingress address. The list is EVERY assignment the app
+ * holds, and a Flycast or egress address carries a non-empty `Address` too — reading one as routable
+ * reproduces #425 on an app that has one, and pre-empts flyctl's own first-deploy fallback, which
+ * returns early once any assignment exists.
+ *
+ * Output that is not a JSON array THROWS rather than reading as "no address": the caller turns that
+ * into a gate, because a list we cannot read is not a state we can act on.
  */
 export function hasIngressAddress(stdout: string): boolean {
-  try {
-    const arr = JSON.parse(stdout) as { Address?: unknown }[];
-    return Array.isArray(arr) && arr.some((entry) => typeof entry?.Address === "string" && entry.Address !== "");
-  } catch {
-    return false;
-  }
+  const entries: unknown = JSON.parse(stdout);
+  if (!Array.isArray(entries)) throw new Error(`expected a JSON array, got ${typeof entries}`);
+  return (entries as { Address?: unknown; Type?: unknown }[]).some(
+    (entry) => typeof entry?.Address === "string" && entry.Address !== "" && PUBLIC_IP_TYPES.has(entry.Type as string),
+  );
 }
 
-/** Whether a `fly … list --json` array contains an object named `name` (Fly capitalizes `Name`; accept both).
- *  Exported for the same reason railway's parsers are: what it encodes is an assumption about another
- *  tool's output, and the live probe checks that assumption against the real `flyctl`. */
+/**
+ * Whether a `fly … list --json` array contains an object named `name` (Fly capitalizes `Name`; accept
+ * both). Exported for the same reason railway's parsers are: what it encodes is an assumption about
+ * another tool's output, and the live probe checks that assumption against the real `flyctl`.
+ *
+ * THROWS on output that is not a JSON array, for the same reason {@link hasIngressAddress} does —
+ * `false` here means "the host does not have it", and answering that for a list nobody could read
+ * creates a SECOND volume, or in teardown destroys nothing at all.
+ */
 export function listHasName(stdout: string, name: string): boolean {
+  const entries: unknown = JSON.parse(stdout);
+  if (!Array.isArray(entries)) throw new Error(`expected a JSON array, got ${typeof entries}`);
+  return entries.some(
+    (o) => (o as { Name?: string; name?: string }).Name === name || (o as { name?: string }).name === name,
+  );
+}
+
+/**
+ * A read-only `fly … list --json`, reduced to the question the next step asks of it — or the gate for
+ * a list we cannot act on. THE place the three answers stay three: the command failed, the output was
+ * unreadable, or the host gave a verdict. Collapsing the middle one into `false` is what shipped #425
+ * and what would have skipped a teardown.
+ */
+async function readList(
+  fly: CliRunner,
+  args: string[],
+  label: string,
+  read: (stdout: string) => boolean,
+): Promise<{ value: boolean } | { gate: string }> {
+  const result = await fly(args, { capture: true });
+  if (result.code !== 0) return { gate: `\`fly ${label}\` failed — see the flyctl output above; fix and re-run` };
   try {
-    const arr = JSON.parse(stdout) as unknown;
-    return (
-      Array.isArray(arr) &&
-      arr.some((o) => (o as { Name?: string; name?: string }).Name === name || (o as { name?: string }).name === name)
-    );
-  } catch {
-    return false;
+    return { value: read(result.stdout) };
+  } catch (error) {
+    return {
+      gate:
+        `\`fly ${label} --json\` was unreadable (${error instanceof Error ? error.message : String(error)}) — ` +
+        `run it yourself and check the flyctl version; fix and re-run`,
+    };
   }
 }
 
@@ -97,11 +131,14 @@ export async function deployFlyRun(
     );
   }
 
-  // 3. App — idempotent (create only if absent; a taken global name is a gate). A FAILED list is its own
-  //    gate: inferring "absent" from an errored query would then misreport the create as a name clash.
-  const appsList = await fly(["apps", "list", "--json"], { capture: true });
-  if (appsList.code !== 0) return gate("`fly apps list` failed — see the flyctl output above; fix and re-run");
-  if (listHasName(appsList.stdout, plan.appName)) {
+  // 3. App — idempotent (create only if absent; a taken global name is a gate). An unusable list is its
+  //    own gate ({@link readList}): inferring "absent" from a query nobody could read would then
+  //    misreport the create as a name clash.
+  const appExists = await readList(fly, ["apps", "list", "--json"], "apps list", (out) =>
+    listHasName(out, plan.appName),
+  );
+  if ("gate" in appExists) return gate(appExists.gate);
+  if (appExists.value) {
     log(`app ${plan.appName} exists — skipping create`);
   } else {
     log(`creating app ${plan.appName}…`);
@@ -115,9 +152,11 @@ export async function deployFlyRun(
 
   // 4. Volume — idempotent; region comes from fly.toml (must match the machine's region). A failed list
   //    gates for the same reason as the app list above.
-  const volList = await fly(["volumes", "list", "-a", plan.appName, "--json"], { capture: true });
-  if (volList.code !== 0) return gate("`fly volumes list` failed — see the flyctl output above; fix and re-run");
-  if (listHasName(volList.stdout, "data")) {
+  const volumeExists = await readList(fly, ["volumes", "list", "-a", plan.appName, "--json"], "volumes list", (out) =>
+    listHasName(out, "data"),
+  );
+  if ("gate" in volumeExists) return gate(volumeExists.gate);
+  if (volumeExists.value) {
     log(`volume data exists — skipping create`);
   } else {
     log(`creating volume data in ${plan.region}…`);
@@ -134,9 +173,11 @@ export async function deployFlyRun(
   //    so without this step the deploy succeeds, the machine serves, and `https://<app>.fly.dev` has no
   //    DNS record at all — reported as a healthy deploy, and handed to the webhook registrars as a URL
   //    they then fail to reach. Check-then-act like the volume above; both allocations are free.
-  const ipList = await fly(["ips", "list", "-a", plan.appName, "--json"], { capture: true });
-  if (ipList.code !== 0) return gate("`fly ips list` failed — see the flyctl output above; fix and re-run");
-  if (hasIngressAddress(ipList.stdout)) {
+  const addressExists = await readList(fly, ["ips", "list", "-a", plan.appName, "--json"], "ips list", (out) =>
+    hasIngressAddress(out),
+  );
+  if ("gate" in addressExists) return gate(addressExists.gate);
+  if (addressExists.value) {
     log("public address exists — skipping allocate");
   } else {
     log("allocating a public address…");

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -41,8 +41,10 @@ export interface FlyRunPlan {
 /** Done, or a gate the operator must clear before re-running (printed + non-zero exit by the CLI). */
 export type FlyRunOutcome = { ok: true } | { ok: false; gate: string };
 
-/** Whether a `fly … list --json` array contains an object named `name` (Fly capitalizes `Name`; accept both). */
-function listHasName(stdout: string, name: string): boolean {
+/** Whether a `fly … list --json` array contains an object named `name` (Fly capitalizes `Name`; accept both).
+ *  Exported for the same reason railway's parsers are: what it encodes is an assumption about another
+ *  tool's output, and the live probe checks that assumption against the real `flyctl`. */
+export function listHasName(stdout: string, name: string): boolean {
   try {
     const arr = JSON.parse(stdout) as unknown;
     return (

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -41,6 +41,20 @@ export interface FlyRunPlan {
 /** Done, or a gate the operator must clear before re-running (printed + non-zero exit by the CLI). */
 export type FlyRunOutcome = { ok: true } | { ok: false; gate: string };
 
+/**
+ * Whether `fly ips list --json` shows a public ingress address. Entries carry `Address` plus a `Type`
+ * (`v6`, `shared_v4`, …); any non-empty address means the app is routable, which is the only question
+ * the deploy has to answer.
+ */
+export function hasIngressAddress(stdout: string): boolean {
+  try {
+    const arr = JSON.parse(stdout) as { Address?: unknown }[];
+    return Array.isArray(arr) && arr.some((entry) => typeof entry?.Address === "string" && entry.Address !== "");
+  } catch {
+    return false;
+  }
+}
+
 /** Whether a `fly … list --json` array contains an object named `name` (Fly capitalizes `Name`; accept both).
  *  Exported for the same reason railway's parsers are: what it encodes is an assumption about another
  *  tool's output, and the live probe checks that assumption against the real `flyctl`. */
@@ -115,7 +129,28 @@ export async function deployFlyRun(
     }
   }
 
-  // 5. Secrets — staged (no deploy yet; we deploy with fly.toml next). Values over stdin, not argv.
+  // 5. Ingress address — `[http_service]` in fly.toml DECLARES a service; it does not create an address
+  //    to reach it on. `fly launch` allocates one as part of its flow, and this driver does not use it,
+  //    so without this step the deploy succeeds, the machine serves, and `https://<app>.fly.dev` has no
+  //    DNS record at all — reported as a healthy deploy, and handed to the webhook registrars as a URL
+  //    they then fail to reach. Check-then-act like the volume above; both allocations are free.
+  const ipList = await fly(["ips", "list", "-a", plan.appName, "--json"], { capture: true });
+  if (ipList.code !== 0) return gate("`fly ips list` failed — see the flyctl output above; fix and re-run");
+  if (hasIngressAddress(ipList.stdout)) {
+    log("public address exists — skipping allocate");
+  } else {
+    log("allocating a public address…");
+    // v4 SHARED (free, and what every client can reach) plus v6. A dedicated v4 is billed, so it stays
+    // an operator decision — `fly ips allocate-v4 -a <app>` after the fact, which this step then skips.
+    if ((await fly(["ips", "allocate-v4", "--shared", "-a", plan.appName])).code !== 0) {
+      return gate("`fly ips allocate-v4 --shared` failed — see the flyctl output above");
+    }
+    if ((await fly(["ips", "allocate-v6", "-a", plan.appName])).code !== 0) {
+      return gate("`fly ips allocate-v6` failed — see the flyctl output above");
+    }
+  }
+
+  // 6. Secrets — staged (no deploy yet; we deploy with fly.toml next). Values over stdin, not argv.
   const keys = Object.keys(plan.secrets);
   if (keys.length > 0) {
     log(`setting ${keys.length} secret(s): ${keys.join(", ")}`);
@@ -125,7 +160,7 @@ export async function deployFlyRun(
     }
   }
 
-  // 6. Deploy — remote builder (no local Docker), one machine. Context + Dockerfile are passed
+  // 7. Deploy — remote builder (no local Docker), one machine. Context + Dockerfile are passed
   //    explicitly (the workspace root is the context; the Dockerfile lives under fastagent/).
   log("deploying (remote build)…");
   const deployArgs = [
@@ -145,7 +180,7 @@ export async function deployFlyRun(
     return gate("`fly deploy` failed — see the flyctl output above; fix and re-run");
   }
 
-  // 7. Post-deploy webhook — which channels, in what words, and the gate policy are all the shared
+  // 8. Post-deploy webhook — which channels, in what words, and the gate policy are all the shared
   //    kernel's; Fly contributes its deterministic URL and how to retry.
   const registrationGateMsg = await registerWebhooks({
     baseUrl: `https://${plan.appName}.fly.dev`,

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -32,9 +32,11 @@ const run = (p: FlyRunPlan, fly: CliRunner, tg = vi.fn(async (): Promise<Registr
   deployFlyRun(p, fly, () => {}, { telegram: tg });
 
 describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
-  it("happy path: auth → create app+volume → set secrets → deploy → telegram webhook", async () => {
-    // Fresh account: apps/volumes lists are empty, everything succeeds.
-    const { fly, cmds } = fakeFly((a) => (a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {}));
+  it("happy path: auth → create app+volume+address → set secrets → deploy → telegram webhook", async () => {
+    // Fresh account: apps/volumes/ips lists are empty, everything succeeds.
+    const { fly, cmds } = fakeFly((a) =>
+      a[0] === "apps" || a[0] === "volumes" || a[0] === "ips" ? { stdout: "[]" } : {},
+    );
     const tg = vi.fn(async (): Promise<RegistrationOutcome> => "registered");
     const out = await run(
       plan({
@@ -52,10 +54,37 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
       "apps create bot",
       "volumes list -a bot --json",
       "volumes create data -a bot --region iad --size 1 --yes",
+      "ips list -a bot --json",
+      "ips allocate-v4 --shared -a bot",
+      "ips allocate-v6 -a bot",
       "secrets import --stage -a bot",
       "deploy . -a bot -c fastagent/fly.toml --dockerfile fastagent/Dockerfile --remote-only --yes --ha=false",
     ]);
     expect(tg).toHaveBeenCalledWith("https://bot.fly.dev"); // telegram end-to-end
+  });
+
+  it("an app that already has an address is not allocated a second one", async () => {
+    // The shape `fly ips list --json` really returns (Address + Type), from a deployed app.
+    const existing = JSON.stringify([{ ID: "ip_x", Address: "66.241.124.150", Type: "shared_v4" }]);
+    const { fly, cmds } = fakeFly((a) => {
+      if (a[0] === "ips") return { stdout: existing };
+      return a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {};
+    });
+
+    expect(await run(plan(), fly)).toEqual({ ok: true });
+    expect(cmds()).toContain("ips list -a bot --json");
+    expect(cmds().some((c) => c.startsWith("ips allocate"))).toBe(false);
+  });
+
+  it("gate: a failed `ips list` stops before deploying something unreachable", async () => {
+    // Without an address the machine serves and https://<app>.fly.dev has no DNS record at all, so a
+    // list we cannot read must not be treated as "probably fine" (#425).
+    const { fly } = fakeFly((a) => {
+      if (a[0] === "ips") return { code: 1 };
+      return a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {};
+    });
+
+    expect(await run(plan(), fly)).toEqual({ ok: false, gate: expect.stringContaining("ips list") });
   });
 
   it("dispatches Feishu and Lark registration through the per-kind seam", async () => {

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -12,7 +12,9 @@ function fakeFly(script: (args: string[]) => { code?: number; stdout?: string } 
   const fly: CliRunner = async (args, opts) => {
     calls.push({ args, input: opts?.input });
     const r = script(args);
-    return { code: r.code ?? 0, stdout: r.stdout ?? "" };
+    // An unscripted `--json` command answers an EMPTY LIST, not an empty string: flyctl cannot print
+    // the latter, and the driver's parse gates correctly refuse it. Scripting stays per-test.
+    return { code: r.code ?? 0, stdout: r.stdout ?? (args.includes("--json") ? "[]" : "") };
   };
   return { fly, calls, cmds: () => calls.map((c) => c.args.join(" ")) };
 }
@@ -76,6 +78,25 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     expect(cmds().some((c) => c.startsWith("ips allocate"))).toBe(false);
   });
 
+  it("allocates for an app whose only addresses are Flycast and egress", async () => {
+    // Every one of these carries a non-empty Address and NONE of them answers https://<app>.fly.dev.
+    // Treating them as ingress is #425 again, and it also stops flyctl's own first-deploy fallback,
+    // which returns early as soon as the app holds any assignment at all.
+    const internal = JSON.stringify([
+      { Address: "fdaa:0:1::3", Type: "private_v6" },
+      { Address: "66.241.125.9", Type: "egress_v4" },
+      { Address: "2a09:8280:1::5", Type: "egress_v6" },
+    ]);
+    const { fly, cmds } = fakeFly((a) => {
+      if (a[0] === "ips") return { stdout: internal };
+      return a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {};
+    });
+
+    expect(await run(plan(), fly)).toEqual({ ok: true });
+    expect(cmds()).toContain("ips allocate-v4 --shared -a bot");
+    expect(cmds()).toContain("ips allocate-v6 -a bot");
+  });
+
   it("gate: a failed `ips list` stops before deploying something unreachable", async () => {
     // Without an address the machine serves and https://<app>.fly.dev has no DNS record at all, so a
     // list we cannot read must not be treated as "probably fine" (#425).
@@ -85,6 +106,38 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     });
 
     expect(await run(plan(), fly)).toEqual({ ok: false, gate: expect.stringContaining("ips list") });
+  });
+
+  // Exit 0 with unreadable output is a THIRD answer, and every list gates on it rather than reading it
+  // as "absent". flyctl has dropped `--json` before (superfly/flyctl#1967), and each collapse has its
+  // own damage: a second volume, a create misreported as a name clash, an unreachable deploy (#425).
+  for (const [label, args] of [
+    ["apps list", ["apps"]],
+    ["volumes list", ["volumes"]],
+    ["ips list", ["ips"]],
+  ] as const) {
+    it(`gate: \`${label}\` exiting 0 with non-JSON is not read as "absent"`, async () => {
+      const { fly, cmds } = fakeFly((a) => {
+        if (a[0] === args[0]) return { stdout: "NAME\tSTATUS\nbot\tdeployed\n" }; // the pre-#1967 table
+        return a[0] === "apps" || a[0] === "volumes" || a[0] === "ips" ? { stdout: "[]" } : {};
+      });
+
+      expect(await run(plan(), fly)).toEqual({ ok: false, gate: expect.stringContaining(label) });
+      // Gated BEFORE the write it would otherwise have guessed its way into.
+      expect(cmds().some((c) => c.startsWith(`${args[0]} create`) || c.startsWith(`${args[0]} allocate`))).toBe(false);
+    });
+  }
+
+  it("gate: `ips list` that exits 0 with unparseable output stops too", async () => {
+    // The other half of the same rule: exit 0 does not mean the answer was readable, and silently
+    // reading "no address" out of it would allocate a second one on every run.
+    const { fly, cmds } = fakeFly((a) => {
+      if (a[0] === "ips") return { stdout: "NAME\tTYPE\n" };
+      return a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {};
+    });
+
+    expect(await run(plan(), fly)).toEqual({ ok: false, gate: expect.stringContaining("unreadable") });
+    expect(cmds().some((c) => c.startsWith("ips allocate"))).toBe(false);
   });
 
   it("dispatches Feishu and Lark registration through the per-kind seam", async () => {

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -65,9 +65,12 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     expect(tg).toHaveBeenCalledWith("https://bot.fly.dev"); // telegram end-to-end
   });
 
-  it("an app that already has an address is not allocated a second one", async () => {
+  it("an app that already has both families is not allocated a second address", async () => {
     // The shape `fly ips list --json` really returns (Address + Type), from a deployed app.
-    const existing = JSON.stringify([{ ID: "ip_x", Address: "66.241.124.150", Type: "shared_v4" }]);
+    const existing = JSON.stringify([
+      { ID: "ip_x", Address: "66.241.124.150", Type: "shared_v4" },
+      { ID: "ip_y", Address: "2a09:8280:1::1:2", Type: "v6" },
+    ]);
     const { fly, cmds } = fakeFly((a) => {
       if (a[0] === "ips") return { stdout: existing };
       return a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {};
@@ -77,6 +80,25 @@ describe("deploy/fly/run: the coding-agent deploy journey (benchmark)", () => {
     expect(cmds()).toContain("ips list -a bot --json");
     expect(cmds().some((c) => c.startsWith("ips allocate"))).toBe(false);
   });
+
+  // The check is per family because the ACTION is: "has an ingress address" would read either of
+  // these as done. The v6-only app is #425 itself — it resolves, to an AAAA record alone, which an
+  // IPv4-only webhook sender (Telegram, GitHub) cannot reach. The v4-only app is how it gets there:
+  // allocate-v4 succeeds, allocate-v6 gates, and the re-run the gate asks for sees v4 and skips.
+  for (const [held, missing, expected] of [
+    [{ ID: "ip_y", Address: "2a09:8280:1::1:2", Type: "v6" }, "v4", "ips allocate-v4 --shared -a bot"],
+    [{ ID: "ip_x", Address: "66.241.124.150", Type: "shared_v4" }, "v6", "ips allocate-v6 -a bot"],
+  ] as const) {
+    it(`allocates the missing ${missing} for an app that holds only the other family`, async () => {
+      const { fly, cmds } = fakeFly((a) => {
+        if (a[0] === "ips") return { stdout: JSON.stringify([held]) };
+        return a[0] === "apps" || a[0] === "volumes" ? { stdout: "[]" } : {};
+      });
+
+      expect(await run(plan(), fly)).toEqual({ ok: true });
+      expect(cmds().filter((c) => c.startsWith("ips allocate"))).toEqual([expected]);
+    });
+  }
 
   it("allocates for an app whose only addresses are Flycast and egress", async () => {
     // Every one of these carries a non-empty Address and NONE of them answers https://<app>.fly.dev.

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -84,6 +84,15 @@ describe("deploy/fly: planFlyDeploy", () => {
     expect(def).toContain("min_machines_running = 0");
   });
 
+  it("gives the runbook an address to be reached on, both families", () => {
+    // The runbook is the DEFAULT path (`--run` is opt-in), so #425 reaches an operator through it
+    // first. `[http_service]` declares a service without allocating an address, and both commands
+    // are needed: an AAAA-only app is unreachable to IPv4-only webhook senders.
+    const out = runbook(planFlyDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: [] }));
+    expect(out).toContain("fly ips allocate-v4 --shared --app bot");
+    expect(out).toContain("fly ips allocate-v6 --app bot");
+  });
+
   it("computes the secret list from the model key + discovered channels + config deploy.secrets", () => {
     const out = runbook(
       planFlyDeploy({

--- a/test/live/fly-deploy.live.test.ts
+++ b/test/live/fly-deploy.live.test.ts
@@ -25,6 +25,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { AgentEvent } from "../../src/agent.ts";
 import { waitForHealth } from "../../src/channels/wait-health.ts";
 import { toFlyAppName } from "../../src/deploy/fly/plan.ts";
+import { listHasName } from "../../src/deploy/fly/run.ts";
 import { liveVersion, requireEnv } from "./env.ts";
 
 // A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-flight.
@@ -61,12 +62,14 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // Unconditional: a deploy that failed after `apps create` still leaves an app holding the staged
-  // model credential. Destroying a name that was never created exits non-zero and is reported, not
-  // swallowed — silence here is how a paid resource outlives the run that made it.
+  // Ask before destroying: a deploy that failed BEFORE `apps create` has nothing to remove, and an
+  // unconditional destroy answers `Could not find App` — a teardown error loud enough to bury the
+  // real failure it followed. A deploy that failed AFTER it still holds the staged model credential,
+  // so the destroy itself stays mandatory and its failure is reported.
   const errors: unknown[] = [];
   try {
-    await run("flyctl", ["apps", "destroy", APP, "--yes"]);
+    const { stdout } = await run("flyctl", ["apps", "list", "--json"]);
+    if (listHasName(stdout, APP)) await run("flyctl", ["apps", "destroy", APP, "--yes"]);
   } catch (error) {
     errors.push(error);
   }
@@ -93,9 +96,15 @@ const answerOf = (events: AgentEvent[]): string =>
 
 describe("deploy fly --run: a real app, provisioned and destroyed", () => {
   it("provisions, boots, and serves a turn on its fly.dev URL", async () => {
-    // Every gate in the driver exits non-zero, so a refusal surfaces here as this call's rejection,
-    // carrying the gate's own remediation text.
-    await run(process.execPath, [CLI, "deploy", "fly", "--run"], workspace);
+    // Every gate in the driver exits non-zero, so a refusal surfaces here as this call's rejection.
+    // flyctl's own output is spliced in: execFile's error carries stderr but its message does not,
+    // and "Command failed" is all an unattended nightly would otherwise report.
+    try {
+      await run(process.execPath, [CLI, "deploy", "fly", "--run"], workspace);
+    } catch (error) {
+      const { stderr, stdout } = error as { stderr?: string; stdout?: string };
+      throw new Error(`deploy fly --run failed for ${APP}:\n${(stderr || stdout || String(error)).slice(-4000)}`);
+    }
 
     // The URL is deterministic (run.ts builds it the same way), so reaching it proves the machine
     // is up under the name the driver provisioned — not merely that some deploy succeeded.

--- a/test/live/fly-deploy.live.test.ts
+++ b/test/live/fly-deploy.live.test.ts
@@ -1,0 +1,114 @@
+/**
+ * A real Fly deployment, created and destroyed: `deploy fly --run` provisions an app, a volume and
+ * secrets, builds on Fly's remote builder, boots the machine, and then this tears all of it down.
+ *
+ * The read-only probe next door (fly.live.test.ts) checks that `flyctl` still prints what the driver
+ * parses. This one checks the half no parser assertion can reach: that the sequence actually
+ * provisions a working deployment — the remote build accepts our generated Dockerfile, the volume
+ * mounts where the state root expects it, the secrets arrive so the container can reach a model, and
+ * the machine answers on its deterministic `https://<app>.fly.dev`.
+ *
+ * COSTS REAL RESOURCES. The app name carries a per-run uuid because Fly app names are GLOBALLY
+ * unique, and teardown runs even when the deploy failed — a half-provisioned app still holds the
+ * model credential that `fly secrets import` just staged into it.
+ *
+ * Needs `FLY_API_TOKEN` with write scope, a model credential (`FASTAGENT_AUTH_PATH`), and `flyctl`.
+ */
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AgentEvent } from "../../src/agent.ts";
+import { waitForHealth } from "../../src/channels/wait-health.ts";
+import { toFlyAppName } from "../../src/deploy/fly/plan.ts";
+import { liveVersion, requireEnv } from "./env.ts";
+
+// A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-flight.
+const run = (file: string, args: string[], cwd?: string) =>
+  promisify(execFile)(file, args, { ...(cwd ? { cwd } : {}), maxBuffer: 64 << 20 });
+const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
+
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+requireEnv("FLY_API_TOKEN", "a Fly API token WITH write scope — this probe creates and destroys an app");
+
+/** Globally unique: Fly rejects a name another tenant already holds, and a collision here would make
+ *  this probe destroy an app it did not create. Derived through the product's own slug rule so the
+ *  name this file destroys is the one the deploy provisions. */
+const APP = toFlyAppName(`fastagent-live-${randomUUID().slice(0, 8)}`);
+const URL_BASE = `https://${APP}.fly.dev`;
+
+let workspace = "";
+
+beforeAll(async () => {
+  // basename(workspace) IS the app name (deploy.ts: toFlyAppName(basename(workspace))), so the
+  // directory is named deliberately rather than by mkdtemp.
+  workspace = join(tmpdir(), APP);
+  await mkdir(workspace, { recursive: true });
+  await writeFile(join(workspace, "persona.md"), "You are terse. Answer in as few words as possible.\n");
+  await writeFile(join(workspace, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+  await writeFile(
+    join(workspace, "package.json"),
+    `${JSON.stringify(
+      { name: "live-fly-probe", private: true, dependencies: { "@fastagent-sh/fastagent": await liveVersion() } },
+      null,
+      2,
+    )}\n`,
+  );
+});
+
+afterAll(async () => {
+  // Unconditional: a deploy that failed after `apps create` still leaves an app holding the staged
+  // model credential. Destroying a name that was never created exits non-zero and is reported, not
+  // swallowed — silence here is how a paid resource outlives the run that made it.
+  const errors: unknown[] = [];
+  try {
+    await run("flyctl", ["apps", "destroy", APP, "--yes"]);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (workspace) await rm(workspace, { recursive: true, force: true }).catch((e: unknown) => errors.push(e));
+  if (errors.length > 0) throw new AggregateError(errors, `teardown failed — check whether app ${APP} still exists`);
+}, 300_000);
+
+/** POST one turn and return its SSE events (the built-in `/invoke`, mounted because no channel is declared). */
+async function invoke(session: string, text: string): Promise<AgentEvent[]> {
+  const response = await fetch(`${URL_BASE}/invoke`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ session, text }),
+  });
+  expect(response.status).toBe(200);
+  return (await response.text())
+    .split("\n\n")
+    .filter((block) => block.startsWith("data: "))
+    .map((block) => JSON.parse(block.slice("data: ".length)) as AgentEvent);
+}
+
+const answerOf = (events: AgentEvent[]): string =>
+  events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
+
+describe("deploy fly --run: a real app, provisioned and destroyed", () => {
+  it("provisions, boots, and serves a turn on its fly.dev URL", async () => {
+    // Every gate in the driver exits non-zero, so a refusal surfaces here as this call's rejection,
+    // carrying the gate's own remediation text.
+    await run(process.execPath, [CLI, "deploy", "fly", "--run"], workspace);
+
+    // The URL is deterministic (run.ts builds it the same way), so reaching it proves the machine
+    // is up under the name the driver provisioned — not merely that some deploy succeeded.
+    expect(await waitForHealth(`${URL_BASE}/health`, 180_000, 3_000), `${URL_BASE}/health never came up`).toBe(true);
+
+    const session = "live-fly";
+    const first = await invoke(session, "Remember this number: 47. Reply with just: ok");
+    expect(first.at(-1)).toMatchObject({ type: "completed" });
+
+    // The volume is the deployment's continuity, and on Fly it is the one piece the driver had to
+    // create separately — a machine that came up without it answers this turn from nothing.
+    const second = await invoke(session, "What number did I ask you to remember? Reply with digits only.");
+    expect(second.at(-1)).toMatchObject({ type: "completed" });
+    expect(answerOf(second)).toContain("47");
+  }, 900_000);
+});

--- a/test/live/fly-deploy.live.test.ts
+++ b/test/live/fly-deploy.live.test.ts
@@ -69,6 +69,10 @@ afterAll(async () => {
   const errors: unknown[] = [];
   try {
     const { stdout } = await run("flyctl", ["apps", "list", "--json"]);
+    // `listHasName` THROWS on output it cannot read, which is what makes asking safe here: the answer
+    // "not listed" now only ever means the host said so. Were it to answer `false` for an unreadable
+    // list, a flyctl that renamed a field would skip the destroy, report nothing, and leak a running
+    // app holding the model credential and serving `/invoke` unauthenticated.
     if (listHasName(stdout, APP)) await run("flyctl", ["apps", "destroy", APP, "--yes"]);
   } catch (error) {
     errors.push(error);

--- a/test/live/fly-deploy.live.test.ts
+++ b/test/live/fly-deploy.live.test.ts
@@ -61,6 +61,22 @@ beforeAll(async () => {
   );
 });
 
+/**
+ * A teardown flyctl call, retried once. Fly's API returns a bare
+ * `Post "https://api.fly.io/graphql": EOF` often enough that a single attempt makes the nightly red
+ * for a transient with nothing wrong behind it — the exact way an unattended check trains people to
+ * ignore it. Only the CLEANUP path retries: a flaky answer inside the test body is a result, not an
+ * obstacle, and a second failure here still surfaces.
+ */
+async function flyctlForTeardown(args: string[]): Promise<{ stdout: string }> {
+  try {
+    return await run("flyctl", args);
+  } catch {
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+    return await run("flyctl", args);
+  }
+}
+
 afterAll(async () => {
   // Ask before destroying: a deploy that failed BEFORE `apps create` has nothing to remove, and an
   // unconditional destroy answers `Could not find App` — a teardown error loud enough to bury the
@@ -68,12 +84,12 @@ afterAll(async () => {
   // so the destroy itself stays mandatory and its failure is reported.
   const errors: unknown[] = [];
   try {
-    const { stdout } = await run("flyctl", ["apps", "list", "--json"]);
+    const { stdout } = await flyctlForTeardown(["apps", "list", "--json"]);
     // `listHasName` THROWS on output it cannot read, which is what makes asking safe here: the answer
     // "not listed" now only ever means the host said so. Were it to answer `false` for an unreadable
     // list, a flyctl that renamed a field would skip the destroy, report nothing, and leak a running
     // app holding the model credential and serving `/invoke` unauthenticated.
-    if (listHasName(stdout, APP)) await run("flyctl", ["apps", "destroy", APP, "--yes"]);
+    if (listHasName(stdout, APP)) await flyctlForTeardown(["apps", "destroy", APP, "--yes"]);
   } catch (error) {
     errors.push(error);
   }

--- a/test/live/fly-deploy.live.test.ts
+++ b/test/live/fly-deploy.live.test.ts
@@ -118,8 +118,14 @@ describe("deploy fly --run: a real app, provisioned and destroyed", () => {
     const first = await invoke(session, "Remember this number: 47. Reply with just: ok");
     expect(first.at(-1)).toMatchObject({ type: "completed" });
 
-    // The volume is the deployment's continuity, and on Fly it is the one piece the driver had to
-    // create separately — a machine that came up without it answers this turn from nothing.
+    // Restart BETWEEN the turns, which is what makes the next answer evidence about the VOLUME rather
+    // than about the record store: a rolling restart replaces the machine's filesystem, so anything
+    // that survives came off the `data` volume mounted at /data (fly.toml's `[mounts]`, the one piece
+    // this driver creates in a step of its own). Without it both turns hit one running machine and a
+    // container-local store would answer identically — the same reason docker.live.test.ts restarts.
+    await run("flyctl", ["apps", "restart", APP]);
+    expect(await waitForHealth(`${URL_BASE}/health`, 180_000, 3_000), `${URL_BASE}/health never came back`).toBe(true);
+
     const second = await invoke(session, "What number did I ask you to remember? Reply with digits only.");
     expect(second.at(-1)).toMatchObject({ type: "completed" });
     expect(answerOf(second)).toContain("47");

--- a/test/live/fly.live.test.ts
+++ b/test/live/fly.live.test.ts
@@ -19,7 +19,7 @@ import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { hasIngressAddress, listHasName } from "../../src/deploy/fly/run.ts";
+import { ingressAddresses, listHasName } from "../../src/deploy/fly/run.ts";
 import { requireEnv } from "./env.ts";
 
 const run = promisify(execFile);
@@ -90,10 +90,16 @@ describe("flyctl output still matches what the Fly driver reads", () => {
 
     // An account's first app is one this probe did not create, so it may legitimately have no public
     // address; assert the reader agrees with the payload either way rather than assuming a state.
-    const isPublic = (ip: { Address?: string; Type?: string }) =>
-      typeof ip.Address === "string" && ip.Address !== "" && ["v4", "v6", "shared_v4"].includes(ip.Type as string);
-    expect(hasIngressAddress(stdout)).toBe(ips.some(isPublic));
-    expect(hasIngressAddress("[]"), "an app with no addresses must read as unallocated").toBe(false);
+    const holds = (types: string[]) => (ip: { Address?: string; Type?: string }) =>
+      typeof ip.Address === "string" && ip.Address !== "" && types.includes(ip.Type as string);
+    expect(ingressAddresses(stdout)).toEqual({
+      v4: ips.some(holds(["v4", "shared_v4"])),
+      v6: ips.some(holds(["v6"])),
+    });
+    expect(ingressAddresses("[]"), "an app with no addresses must read as unallocated").toEqual({
+      v4: false,
+      v6: false,
+    });
   });
 
   it("`volumes list --json` parses through the same reader", async () => {

--- a/test/live/fly.live.test.ts
+++ b/test/live/fly.live.test.ts
@@ -1,0 +1,76 @@
+/**
+ * What `flyctl` actually prints, checked against the assumptions the Fly driver makes about it.
+ *
+ * `deploy-fly-run.test.ts` drives the whole deploy against a fake `CliRunner` that answers what we
+ * believe `flyctl` prints today. That covers the orchestration — the order of operations, the gates,
+ * which failure stops what — and cannot cover the belief itself. When Fly ships a CLI that renames a
+ * field or stops emitting JSON, every one of those tests stays green while `deploy fly --run` starts
+ * misreading its own tooling.
+ *
+ * READ-ONLY, on purpose. The driver's write steps (`apps create`, `volumes create`, `secrets import`,
+ * `deploy`) are what cost money and leave resources behind; its read steps are where the parsing
+ * assumptions live, and they are free. What a real deploy would add on top of this — that pushing an
+ * image succeeds — is largely covered by docker.live.test.ts, which builds and boots the SAME
+ * generated Dockerfile through the SAME serving path.
+ *
+ * Needs `FLY_API_TOKEN` (`flyctl auth token`) and `flyctl` on PATH. No write scope is exercised.
+ */
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { listHasName } from "../../src/deploy/fly/run.ts";
+import { requireEnv } from "./env.ts";
+
+const run = promisify(execFile);
+
+// flyctl reads this itself; the probe only asserts it is present so a missing token fails by name
+// rather than as an opaque `auth whoami` exit code.
+requireEnv("FLY_API_TOKEN", "a Fly API token from `flyctl auth token`");
+
+/** One read-only flyctl invocation, failing loudly: a non-zero exit is a broken assumption, not a case
+ *  to absorb. `maxBuffer` because an account with many apps prints more than the 1 MB default. */
+async function flyctl(args: string[]): Promise<string> {
+  const { stdout } = await run("flyctl", args, { maxBuffer: 64 << 20 });
+  return stdout;
+}
+
+describe("flyctl output still matches what the Fly driver reads", () => {
+  it("authenticates with the token the driver expects to inherit", async () => {
+    // The driver's first gate is `auth whoami`; it only reads the exit code, so this asserts the same
+    // thing it does — that the ambient token works — before anything downstream is meaningful.
+    const who = await flyctl(["auth", "whoami"]);
+    expect(who.trim(), "auth whoami printed nothing").not.toBe("");
+  });
+
+  it("`apps list --json` parses, and listHasName agrees with it in both directions", async () => {
+    const stdout = await flyctl(["apps", "list", "--json"]);
+    const apps = JSON.parse(stdout) as { Name?: string; name?: string }[];
+    expect(Array.isArray(apps), "apps list --json is no longer a JSON array").toBe(true);
+
+    // The negative direction holds on any account, empty or not.
+    expect(listHasName(stdout, `fastagent-live-absent-${randomUUID()}`)).toBe(false);
+
+    // The positive direction is what pins the FIELD NAME — the driver accepts `Name` or `name`, and a
+    // rename to anything else would silently make every app look absent, sending the driver into
+    // `apps create` for an app that already exists.
+    const first = apps[0];
+    if (first) {
+      const name = first.Name ?? first.name;
+      expect(name, "an app entry carries neither Name nor name").toBeTruthy();
+      expect(listHasName(stdout, name as string), "listHasName cannot find an app that is listed").toBe(true);
+    }
+  });
+
+  it("`volumes list --json` parses through the same reader", async () => {
+    // listHasName serves BOTH lists, so a divergence between the two shapes would break volume
+    // detection while apps still worked — the driver would try to create an existing volume.
+    const apps = JSON.parse(await flyctl(["apps", "list", "--json"])) as { Name?: string; name?: string }[];
+    const app = apps[0]?.Name ?? apps[0]?.name;
+    if (!app) return; // nothing to list against; the apps assertions above already covered the reader
+
+    const stdout = await flyctl(["volumes", "list", "-a", app, "--json"]);
+    expect(Array.isArray(JSON.parse(stdout)), "volumes list --json is no longer a JSON array").toBe(true);
+    expect(listHasName(stdout, `absent-${randomUUID()}`)).toBe(false);
+  });
+});

--- a/test/live/fly.live.test.ts
+++ b/test/live/fly.live.test.ts
@@ -19,7 +19,7 @@ import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { listHasName } from "../../src/deploy/fly/run.ts";
+import { hasIngressAddress, listHasName } from "../../src/deploy/fly/run.ts";
 import { requireEnv } from "./env.ts";
 
 const run = promisify(execFile);
@@ -60,6 +60,22 @@ describe("flyctl output still matches what the Fly driver reads", () => {
       expect(name, "an app entry carries neither Name nor name").toBeTruthy();
       expect(listHasName(stdout, name as string), "listHasName cannot find an app that is listed").toBe(true);
     }
+  });
+
+  it("`ips list --json` still carries Address, which decides whether the deploy allocates one", async () => {
+    // The newest parsing assumption here (#425): reading this wrong in the "has an address" direction
+    // ships an app nobody can reach, and in the other direction allocates a second address every run.
+    const apps = JSON.parse(await flyctl(["apps", "list", "--json"])) as { Name?: string; name?: string }[];
+    const app = apps[0]?.Name ?? apps[0]?.name;
+    if (!app) return; // no app to inspect; the shape below is what an empty account would answer anyway
+
+    const stdout = await flyctl(["ips", "list", "-a", app, "--json"]);
+    const ips = JSON.parse(stdout) as { Address?: string }[];
+    expect(Array.isArray(ips), "ips list --json is no longer a JSON array").toBe(true);
+    // An account's first app is one this probe did not create, so it may legitimately have no address;
+    // assert the reader agrees with the payload either way rather than assuming a state.
+    expect(hasIngressAddress(stdout)).toBe(ips.some((ip) => typeof ip.Address === "string" && ip.Address !== ""));
+    expect(hasIngressAddress("[]"), "an app with no addresses must read as unallocated").toBe(false);
   });
 
   it("`volumes list --json` parses through the same reader", async () => {

--- a/test/live/fly.live.test.ts
+++ b/test/live/fly.live.test.ts
@@ -35,6 +35,16 @@ async function flyctl(args: string[]): Promise<string> {
   return stdout;
 }
 
+/** The app the per-app readers run against. An EMPTY org is a failure, not a case to return from:
+ *  these assertions would then pass while checking nothing, which is exactly what test/live/env.ts
+ *  refuses. The deploy probe destroys the app it creates, so a dedicated org needs one app of its
+ *  own kept around — any app will do; nothing here writes to it. */
+function requireApp(apps: { Name?: string; name?: string }[]): string {
+  const app = apps[0]?.Name ?? apps[0]?.name;
+  expect(app, "this Fly org holds no app to read against — create one (any app) so these assertions run").toBeTruthy();
+  return app as string;
+}
+
 describe("flyctl output still matches what the Fly driver reads", () => {
   it("authenticates with the token the driver expects to inherit", async () => {
     // The driver's first gate is `auth whoami`; it only reads the exit code, so this asserts the same
@@ -62,19 +72,27 @@ describe("flyctl output still matches what the Fly driver reads", () => {
     }
   });
 
-  it("`ips list --json` still carries Address, which decides whether the deploy allocates one", async () => {
+  it("`ips list --json` still carries Address AND Type, which decide whether the deploy allocates", async () => {
     // The newest parsing assumption here (#425): reading this wrong in the "has an address" direction
     // ships an app nobody can reach, and in the other direction allocates a second address every run.
     const apps = JSON.parse(await flyctl(["apps", "list", "--json"])) as { Name?: string; name?: string }[];
-    const app = apps[0]?.Name ?? apps[0]?.name;
-    if (!app) return; // no app to inspect; the shape below is what an empty account would answer anyway
+    const app = requireApp(apps);
 
     const stdout = await flyctl(["ips", "list", "-a", app, "--json"]);
-    const ips = JSON.parse(stdout) as { Address?: string }[];
+    const ips = JSON.parse(stdout) as { Address?: string; Type?: string }[];
     expect(Array.isArray(ips), "ips list --json is no longer a JSON array").toBe(true);
-    // An account's first app is one this probe did not create, so it may legitimately have no address;
-    // assert the reader agrees with the payload either way rather than assuming a state.
-    expect(hasIngressAddress(stdout)).toBe(ips.some((ip) => typeof ip.Address === "string" && ip.Address !== ""));
+
+    // `Type` is HALF the reading, and the half a non-empty `Address` hides: Flycast (`private_v6`)
+    // and egress addresses are assignments that reach nothing. A renamed or dropped Type would make
+    // every one of them read as ingress, which is #425 on an app that already has an address.
+    const known = ["v4", "v6", "shared_v4", "private_v6", "egress_v4", "egress_v6", "egress_pair"];
+    for (const ip of ips) expect(known, `ips list --json carries an unknown Type ${ip.Type}`).toContain(ip.Type);
+
+    // An account's first app is one this probe did not create, so it may legitimately have no public
+    // address; assert the reader agrees with the payload either way rather than assuming a state.
+    const isPublic = (ip: { Address?: string; Type?: string }) =>
+      typeof ip.Address === "string" && ip.Address !== "" && ["v4", "v6", "shared_v4"].includes(ip.Type as string);
+    expect(hasIngressAddress(stdout)).toBe(ips.some(isPublic));
     expect(hasIngressAddress("[]"), "an app with no addresses must read as unallocated").toBe(false);
   });
 
@@ -82,8 +100,7 @@ describe("flyctl output still matches what the Fly driver reads", () => {
     // listHasName serves BOTH lists, so a divergence between the two shapes would break volume
     // detection while apps still worked — the driver would try to create an existing volume.
     const apps = JSON.parse(await flyctl(["apps", "list", "--json"])) as { Name?: string; name?: string }[];
-    const app = apps[0]?.Name ?? apps[0]?.name;
-    if (!app) return; // nothing to list against; the apps assertions above already covered the reader
+    const app = requireApp(apps);
 
     const stdout = await flyctl(["volumes", "list", "-a", app, "--json"]);
     expect(Array.isArray(JSON.parse(stdout)), "volumes list --json is no longer a JSON array").toBe(true);


### PR DESCRIPTION
Phase 4's first host, and the first product defect a live probe has found.

## The bug

`deploy fly --run` completed, printed `deployed → https://<app>.fly.dev`, and that URL was never reachable — the app had **no public IP**, so the hostname had no DNS record at all. The remote build succeeded, the machine booted, the volume mounted, and the container logged its own readiness. It was only unreachable from outside.

`[http_service]` in fly.toml *declares* a service; it does not create an address to reach it on. `fly launch` allocates one as part of its flow, and this driver does not use it — `apps create` → `volumes create` → `secrets import` → `deploy` allocates nothing (flyctl 0.4.95).

Nothing failed, so the driver returned `ok` and the CLI printed the URL. The blast radius is bigger than a wrong success line: `registerWebhooks` waits on `<baseUrl>/health` and then hands that URL to Telegram/Feishu, so a deployment *with* channels fails as a readiness gate that never names the real cause, while a channel-less one reports success and the operator finds out when they open the link.

Fixed with the same check-then-act shape the volume step above it uses. Both allocations are free; a dedicated v4 is billed and stays an operator decision. A failed `ips list` gates rather than guessing — guessing wrong ships an unreachable app in one direction and allocates a second address every run in the other.

## Two probes

**`fly.live.test.ts` — read-only.** `deploy-fly-run.test.ts` drives the whole deploy against a fake `CliRunner` answering what we believe `flyctl` prints today; that covers the orchestration and cannot cover the belief. This feeds the *real* CLI's output to the real parsers (`listHasName` for apps and volumes, `hasIngressAddress` for ips). Free, seconds, no writes.

**`fly-deploy.live.test.ts` — the real thing.** Provisions an app, deploys, serves two turns (the second checks the volume carried the conversation), destroys it. The app name carries a per-run uuid because Fly names are globally unique, and teardown runs even when the deploy failed — a half-provisioned app still holds the model credential `secrets import` staged into it.

The read-only probe could never have found #425: every command it inspects returns perfectly well-formed output. It took a real deploy, timing out on health while the container logs showed a healthy process.

## Verification

Same probe, before and after the fix:

```
before   305s, failed:  https://<app>.fly.dev/health never came up
after    100s, passed:  health → turn → turn, "47" recalled across the volume
```

Teardown verified clean after every run (`leaked probe apps: 0`, `leaked temp dirs: 0`). Offline suite: `deploy-fly-run.test.ts` 27 → 29 tests, covering the skip-when-allocated and gate-on-unreadable-list branches.

`FLY_API_TOKEN` is a new `live` environment secret. The read-only probe needs no write scope; the deploy probe does.
