### PR TITLE
fix(feishu): default the ingress menu to webhook

### DIFF
--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -226,13 +226,15 @@ async function resolveIngress(
   }
   const answer = await select<FeishuSubscriptionMode>({
     message: `How should ${kind === "feishu" ? "Feishu" : "Lark"} deliver events?`,
-    // Webhook leads because the menu's default must match the non-interactive one above, and because
-    // websocket -> webhook is a migration this command refuses (see existsAlready) while the reverse costs nothing.
+    // The default must match the non-interactive branch above. Webhook is the cheaper side to be
+    // wrong on: its credentials are a superset of websocket's (App ID/Secret plus the Verification
+    // Token), and that token has no read API — a websocket app moving to webhook must re-acquire it.
+    initialValue: "webhook",
     options: [
       {
         value: "webhook",
         label: "Webhook endpoint",
-        hint: "works on every deploy target; scales to zero; requires a public HTTPS URL",
+        hint: "works on every deploy target; supports scale-to-zero; requires a public HTTPS URL",
       },
       {
         value: "websocket",

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -226,16 +226,18 @@ async function resolveIngress(
   }
   const answer = await select<FeishuSubscriptionMode>({
     message: `How should ${kind === "feishu" ? "Feishu" : "Lark"} deliver events?`,
+    // Webhook leads because the menu's default must match the non-interactive one above, and because
+    // websocket -> webhook is a migration this command refuses (see existsAlready) while the reverse costs nothing.
     options: [
-      {
-        value: "websocket",
-        label: "WebSocket long connection",
-        hint: "no public URL; requires an always-on process",
-      },
       {
         value: "webhook",
         label: "Webhook endpoint",
-        hint: "supports scale-to-zero; requires a public HTTPS URL",
+        hint: "works on every deploy target; scales to zero; requires a public HTTPS URL",
+      },
+      {
+        value: "websocket",
+        label: "WebSocket long connection",
+        hint: "no public URL; needs an always-on process (not on AgentCore)",
       },
     ],
   });


### PR DESCRIPTION
Closes #423.

`add feishu` picked the ingress two different ways: the interactive menu defaulted to `websocket` (first option, no `initialValue`), while the non-interactive branch hard-coded `webhook`. One command, two architectures, decided by whether stdout is a TTY.

Webhook wins the tie because it is the cheaper side to be wrong on: a webhook app's credentials are a superset of a websocket one's (App ID/Secret plus the Verification Token), and that token has no read API — a websocket app moving to webhook has to re-acquire it. Websocket also rules out AgentCore entirely and forbids scale-to-zero on Fly/Railway.

Websocket keeps its place as an option — no public URL is the only choice on some networks — and its hint states the AgentCore constraint as a fact, since learning it at `deploy agentcore` time is worse.

The menu now names its default with `initialValue`, the way `resolveGroupBehavior` beside it already does, so the agreement with the non-interactive branch survives a future reordering. Lark shares the resolver and moves with it.