### PR TITLE
test(live): the railway CLI still prints what its driver reads, and a real project round trip

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -70,17 +70,32 @@ jobs:
       # The driver spawns `fly`, the short name Fly's own installer also provides; this action ships
       # only `flyctl`. Without the alias `deploy fly --run` fails with "flyctl not found" on a runner
       # that demonstrably has it.
-      # The railway probes shell out to `railway`, the same binary `deploy railway --run` drives.
-      # Railway publishes no pinned action; the install script is their documented path.
-      - name: Install the Railway CLI
-        run: |
-          curl -fsSL https://railway.com/install.sh | sh
-          echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
-
       - name: Provide the `fly` alias the driver spawns
         run: |
           sudo ln -sf "$(command -v flyctl)" /usr/local/bin/fly
           fly version
+
+      # The railway probes shell out to `railway`, the same binary `deploy railway --run` drives.
+      # Railway publishes no pinned action; the install script is their documented path.
+      #
+      # The VERSION comes from the npm registry, not from the script's own lookup. Unpinned, that
+      # lookup is an unauthenticated api.github.com call the script itself calls out as "rate limited
+      # to 60/hour per source IP, which shared CI runners exhaust" — and it exits 1 when the limit is
+      # hit, turning a nightly red for someone else's traffic. `@railway/cli` is published from the
+      # same release (its postinstall pulls releases/download/v<its own version>), so `latest` there
+      # is the same build, resolved through a registry this job already depends on. Still LATEST, for
+      # the cloudflared reason: this probe exists to find out when the CLI drifts, and a pin retires it.
+      - name: Install the Railway CLI
+        run: |
+          # Without pipefail a failed `curl` feeds `sh` an empty script, which exits 0 — the step goes
+          # green and the suite fails twenty minutes later with `spawn railway ENOENT`. The default
+          # shell here is `bash -e {0}`; `-o pipefail` is NOT included.
+          set -o pipefail
+          RAILWAY_VERSION="$(npm view @railway/cli version)"
+          test -n "$RAILWAY_VERSION" || { echo "could not resolve a Railway CLI version from npm"; exit 1; }
+          curl -fsSL https://railway.com/install.sh | RAILWAY_VERSION="$RAILWAY_VERSION" sh
+          echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
+          "$HOME/.railway/bin/railway" --version
 
       # ONE credential mechanism for both probes: an auth.json, named by the product's own
       # FASTAGENT_AUTH_PATH. It carries an OAuth grant (openai-codex) as readily as an API key, and
@@ -146,8 +161,9 @@ jobs:
           # A read-only token makes the nightly red at `apps create`; a write token bills every night.
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           # ACCOUNT-scoped, NOT the project-scoped RAILWAY_TOKEN a project hands out: the deploy probe
-          # creates a project, which a project token cannot do. Nothing in src/ names either variable —
-          # the driver assumes an operator who ran `railway login`, and CI has no such session.
+          # creates a project, which a project token cannot do. The driver never reads it — it assumes
+          # an operator who ran `railway login` and only names the variable in its gate message, so
+          # here the token stands in for the session CI has no way to hold.
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
         run: npm run test:live
 

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -70,6 +70,13 @@ jobs:
       # The driver spawns `fly`, the short name Fly's own installer also provides; this action ships
       # only `flyctl`. Without the alias `deploy fly --run` fails with "flyctl not found" on a runner
       # that demonstrably has it.
+      # The railway probes shell out to `railway`, the same binary `deploy railway --run` drives.
+      # Railway publishes no pinned action; the install script is their documented path.
+      - name: Install the Railway CLI
+        run: |
+          curl -fsSL https://railway.com/install.sh | sh
+          echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
+
       - name: Provide the `fly` alias the driver spawns
         run: |
           sudo ln -sf "$(command -v flyctl)" /usr/local/bin/fly
@@ -138,6 +145,10 @@ jobs:
           # creates a real app + volume, stages secrets, runs a remote build and destroys it again.
           # A read-only token makes the nightly red at `apps create`; a write token bills every night.
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          # ACCOUNT-scoped, NOT the project-scoped RAILWAY_TOKEN a project hands out: the deploy probe
+          # creates a project, which a project token cannot do. Nothing in src/ names either variable —
+          # the driver assumes an operator who ran `railway login`, and CI has no such session.
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
         run: npm run test:live
 
       # The deploy probe destroys its own app in afterAll, which a job timeout or a cancelled run
@@ -161,3 +172,17 @@ jobs:
             | jq -r '.[] | (.Name // .name) | select(test("^fastagent-live-[0-9a-f]{8}$"))' \
             | tee /dev/stderr \
             | xargs -r -n1 -I{} flyctl apps destroy {} --yes
+
+      # Same reasoning as the Fly sweep above, with two Railway specifics: `delete` needs --project
+      # outside a TTY even with --yes (the docs call that flag optional), and deletion is SOFT, so a
+      # destroyed project keeps being listed — deletedAt, not absence, is what says it is gone.
+      - name: Destroy leftover live Railway projects
+        if: always()
+        env:
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+        run: |
+          set -o pipefail
+          railway list --json \
+            | jq -r '.[] | select(.deletedAt == null) | select(.name | test("^fastagent-live-[0-9a-f]{8}$")) | .id' \
+            | tee /dev/stderr \
+            | xargs -r -n1 -I{} railway delete --yes --project {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,16 +279,18 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # file that dates the `Verified against CLI 5.15.0` claims in run.ts) plus
                              # a REAL Railway project provisioned and destroyed (railway-deploy — the
                              # only way to observe `railway domain`, which MINTS one when absent),
-                             # `flyctl` still printing what the Fly driver reads (fly — read-only), and a REAL Fly app
-                             # provisioned then destroyed (fly-deploy — which is how #425 was found: a
-                             # deploy whose every step succeeded, serving on a URL that had no IP).
-                             # Each one drives a PRODUCT ENTRY (`createPiAgentFromDir`,
-                             # `deploy docker --run`, `deploy fly --run`, `npm install`,
-                             # `startCloudflareTunnel`, `startSchedules`, `registerTelegramWebhook`,
-                             # `registerFeishuWebhook`, `createSlackApi`) and observes from OUTSIDE it
-                             # — except the read-only fly probe, which checks a real `flyctl`'s output
-                             # against the driver's PARSING assumptions about it (`listHasName`,
-                             # `ingressAddresses`): the belief a faked CliRunner cannot test
+                             # `flyctl` still printing what the Fly driver reads (fly — read-only), and
+                             # a REAL Fly app provisioned then destroyed (fly-deploy — which is how
+                             # #425 was found: a deploy whose every step succeeded, serving on a URL
+                             # that had no IP). Each one drives a PRODUCT ENTRY (`createPiAgentFromDir`,
+                             # `deploy docker --run`, `deploy fly --run`, `deploy railway --run`,
+                             # `npm install`, `startCloudflareTunnel`, `startSchedules`,
+                             # `registerTelegramWebhook`, `registerFeishuWebhook`, `createSlackApi`)
+                             # and observes from OUTSIDE it — except the two read-only CLI probes
+                             # (fly, railway), which check what a real host CLI prints against the
+                             # driver's PARSING assumptions about it (`listHasName`,
+                             # `ingressAddresses`, `isLinked`, `linkedName`, `parseHasVolume`): the
+                             # belief a faked CliRunner cannot test
                              # — a probe that rebuilds the assembly to get a better observation point
                              # measures the rebuild, and the entry's own steps (installProxyFetch,
                              # credential resolution, pinning pi's agent dir) go missing one at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,8 +274,12 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # it was handed and Feishu CALLING one with a challenge (telegram/feishu —
                              # registration only; delivery needs a human to type), and Slack's Bot API
                              # answering our pipeline (slack — OUTBOUND only: its inbound half needs a
-                             # 12h App Configuration Token, which no nightly can hold), `flyctl` still
-                             # printing what the Fly driver reads (fly — read-only), and a REAL Fly app
+                             # 12h App Configuration Token, which no nightly can hold), the `railway`
+                             # CLI still printing what its driver reads (railway — read-only, and the
+                             # file that dates the `Verified against CLI 5.15.0` claims in run.ts) plus
+                             # a REAL Railway project provisioned and destroyed (railway-deploy — the
+                             # only way to observe `railway domain`, which MINTS one when absent),
+                             # `flyctl` still printing what the Fly driver reads (fly — read-only), and a REAL Fly app
                              # provisioned then destroyed (fly-deploy — which is how #425 was found: a
                              # deploy whose every step succeeded, serving on a URL that had no IP).
                              # Each one drives a PRODUCT ENTRY (`createPiAgentFromDir`,

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -43,7 +43,12 @@ import {
 } from "../../deploy/fly/plan.ts";
 import { deployFlyRun } from "../../deploy/fly/run.ts";
 import { preflightDeploy } from "../../deploy/preflight.ts";
-import { dockerfilePathVar, isGeneratedRailwayJson, planRailwayDeploy } from "../../deploy/railway/plan.ts";
+import {
+  dockerfilePathVar,
+  isGeneratedRailwayJson,
+  planRailwayDeploy,
+  toRailwayName,
+} from "../../deploy/railway/plan.ts";
 import { deployRailwayRun } from "../../deploy/railway/run.ts";
 import { spawnRunner } from "../../deploy/runner.ts";
 import { assembleSecrets } from "../../deploy/secrets.ts";
@@ -306,12 +311,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
   // Railway: thin config file, scale-to-zero is a manual dashboard step, the URL is minted (see
   // planRailwayDeploy). --run drives the railway CLI to completion; otherwise print the runbook.
   if (host === "railway") {
-    // Railway service names are project-scoped (not globally unique like a Fly app); slug the dir
-    // basename so a name with spaces/odd chars can't break the `railway add --service <name>` command.
-    const serviceName =
-      basename(workspace)
-        .replace(/[^a-zA-Z0-9-]+/g, "-")
-        .replace(/^-+|-+$/g, "") || "agent";
+    const serviceName = toRailwayName(basename(workspace));
     const plan = planRailwayDeploy({
       serviceName,
       modelAuth,

--- a/src/deploy/railway/plan.ts
+++ b/src/deploy/railway/plan.ts
@@ -63,6 +63,14 @@ const MOUNT = "/data";
  *  convention); two mechanisms, two documented spellings, one fact each. */
 export const dockerfilePathVar = (prefix: string): string => `/${prefix}Dockerfile`;
 
+/** The name this tool gives BOTH the project and the service, derived from the workspace directory.
+ *  Railway names are project-scoped (not globally unique like a Fly app), so this only has to survive
+ *  the command — slug anything that would break `railway add --service <name>`, and name the fallback
+ *  rather than emitting an empty argument. Shared so the live probe tears down what the CLI creates. */
+export function toRailwayName(basename: string): string {
+  return basename.replace(/[^a-zA-Z0-9-]+/g, "-").replace(/^-+|-+$/g, "") || "agent";
+}
+
 /** railway.json is JSON, so its ownership marker is a KEY rather than a comment line. Railway ignores
  *  unknown keys; the predicate below is what lets `--force` reset OUR file and keep a hand-written one. */
 const GENERATED_RAILWAY_KEY = "x-generated-by";

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -21,7 +21,8 @@
  *
  * Secrets go in one-per-`variable set --stdin` (value on stdin, never argv/process listing — Railway has
  * no bulk stdin import like Fly's `secrets import`). Auth needs an ACCOUNT credential (login or
- * `RAILWAY_API_KEY`), not a project token: `init` creates a project that a project token can't predate.
+ * `RAILWAY_API_TOKEN`), not the project-scoped `RAILWAY_TOKEN`: `init` creates a project that a project
+ * token can't predate.
  */
 import { type Registrars, registerWebhooks } from "../channel-ingress.ts";
 import type { DeclaredChannel } from "../../channels/discover.ts";
@@ -141,11 +142,11 @@ export async function deployRailwayRun(
   // side effect. (Pre-checking the name means walking status's nested multi-service shape — not worth it.)
   const svc = ["--service", plan.name];
 
-  // 1. Auth needs an ACCOUNT credential (browser login or RAILWAY_API_KEY) — a project token can't
-  //    predate the project `init` creates. `whoami` succeeds with either.
+  // 1. Auth needs an ACCOUNT credential (browser login or RAILWAY_API_TOKEN) — the project-scoped
+  //    RAILWAY_TOKEN can't predate the project `init` creates. `whoami` succeeds with either.
   if ((await railway(["whoami"], { capture: true })).code !== 0) {
     return gate(
-      "not logged in to Railway — run `railway login`, or set RAILWAY_API_KEY (an account token), then re-run",
+      "not logged in to Railway — run `railway login`, or set RAILWAY_API_TOKEN (an account token), then re-run",
     );
   }
 

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -314,7 +314,7 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
   it("gate: not logged in → stops before any side effect", async () => {
     const { railway, cmds } = fakeRailway((a) => (a[0] === "whoami" ? { code: 1 } : {}));
     const out = await run(plan(), railway);
-    expect(out).toEqual({ ok: false, gate: expect.stringMatching(/railway login|RAILWAY_API_KEY/) });
+    expect(out).toEqual({ ok: false, gate: expect.stringMatching(/railway login|RAILWAY_API_TOKEN/) });
     expect(cmds()).toEqual(["whoami"]); // nothing after the gate
   });
 

--- a/test/deploy-railway.test.ts
+++ b/test/deploy-railway.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { planRailwayDeploy } from "../src/deploy/railway/plan.ts";
+import { planRailwayDeploy, toRailwayName } from "../src/deploy/railway/plan.ts";
 import { declaredChannels } from "../src/channels/discover.ts";
 
 const json = (p: ReturnType<typeof planRailwayDeploy>) =>
@@ -206,6 +206,13 @@ describe("deploy/railway: planRailwayDeploy", () => {
         }),
       ),
     ).toContain("do NOT enable App Sleeping");
+  });
+
+  it("toRailwayName survives `railway add --service <name>` — and never yields an empty argument", () => {
+    // The live probe tears down the project by the name the CLI creates, so both go through this.
+    expect(toRailwayName("fastagent-live-a1b2c3d4")).toBe("fastagent-live-a1b2c3d4"); // the probe's own
+    expect(toRailwayName("My Agent (v2)")).toBe("My-Agent-v2");
+    expect(toRailwayName("___")).toBe("agent"); // nothing left to name it with
   });
 
   it("turns a non-env auth label into guidance, not a variable (shared secret logic)", () => {

--- a/test/live/docker.live.test.ts
+++ b/test/live/docker.live.test.ts
@@ -8,29 +8,22 @@
  * `FASTAGENT_AUTH_PATH` pointing at a stored auth.json. Without either, `--run` gates before it
  * builds and this test fails with that gate's own message.
  */
-import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { AgentEvent } from "../../src/agent.ts";
 import { waitForHealth } from "../../src/channels/wait-health.ts";
 import { exists } from "../../src/paths.ts";
-import { liveVersion, requireEnv } from "./env.ts";
+import { CLI, answerOf, invoke, liveVersion, requireEnv, run } from "./env.ts";
 
-// A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-build.
-const run = (file: string, args: string[], cwd: string) =>
-  promisify(execFile)(file, args, { cwd, maxBuffer: 64 << 20 });
-const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 const VERSION = await liveVersion();
 const COMPOSE = "fastagent/fastagent.compose.yml";
 
 let workspace = "";
 let port = 0;
+let baseUrl = "";
 
 /** An ephemeral port for the container to publish on 127.0.0.1: taken to learn a free number, then
  *  released — nothing holds it until the container binds it. What keeps concurrent runs apart is
@@ -48,6 +41,7 @@ const compose = (args: string[]) => run("docker", ["compose", "-f", COMPOSE, ...
 
 beforeAll(async () => {
   port = await freePort();
+  baseUrl = `http://127.0.0.1:${port}`;
   workspace = await mkdtemp(join(tmpdir(), "fa-live-docker-"));
   const agent = join(workspace, "fastagent");
   await mkdir(agent, { recursive: true });
@@ -84,54 +78,30 @@ afterAll(async () => {
   if (workspace) await rm(workspace, { recursive: true });
 });
 
-/** POST one turn and return its SSE events (the built-in `/invoke`, mounted because no channel is
- *  declared). Same reduction test/http.test.ts uses; `JSON.parse` is deliberately unguarded, since a
- *  payload that is not an event is a broken wire format, not a case to absorb. */
-async function invoke(session: string, text: string): Promise<AgentEvent[]> {
-  const response = await fetch(`http://127.0.0.1:${port}/invoke`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ session, text }),
-  });
-  expect(response.status).toBe(200);
-  return (await response.text())
-    .split("\n\n")
-    .filter((block) => block.startsWith("data: "))
-    .map((block) => JSON.parse(block.slice("data: ".length)) as AgentEvent);
-}
-
-/**
- * The ANSWER, and only it. Asserting on the raw SSE text would be wrong in both directions: a
- * provider that splits `47` into two tokens never spells it literally, and a `thinking` delta that
- * reasoned about the number would satisfy the assertion even when the answer got it wrong.
- */
-const answerOf = (events: AgentEvent[]): string =>
-  events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
-
 describe("deploy docker --run: a definition serving real turns in a container", () => {
   it("builds, boots, answers, and keeps its sessions across a restart", async () => {
     // Every gate in the driver exits non-zero, so a refusal surfaces here as this call's rejection,
     // carrying the gate's own remediation text.
     await run(process.execPath, [CLI, "deploy", "docker", "--run"], workspace);
 
-    expect(await fetch(`http://127.0.0.1:${port}/health`).then((r) => r.text())).toBe("ok\n");
+    expect(await fetch(`${baseUrl}/health`).then((r) => r.text())).toBe("ok\n");
 
     const session = "live-docker";
     // toMatchObject, not `.at(-1)?.type`: a `failed` terminal carries `details`/`retryable` (SPEC
     // MUST 2), and a mismatch prints the whole event. Nobody is watching a nightly run, so a bare
     // `expected 'failed' to be 'completed'` costs a full re-run to learn why.
-    expect((await invoke(session, "Remember this number: 47. Reply with just: ok")).at(-1)).toMatchObject({
+    expect((await invoke(baseUrl, session, "Remember this number: 47. Reply with just: ok")).at(-1)).toMatchObject({
       type: "completed",
     });
 
     // The state volume is the deployment's continuity. Restarting the container drops every bit of
     // in-process state, so what answers afterwards can only have come off the volume.
     await compose(["restart", "agent"]);
-    expect(await waitForHealth(`http://127.0.0.1:${port}/health`, 60_000, 500)).toBe(true);
+    expect(await waitForHealth(`${baseUrl}/health`, 60_000, 500)).toBe(true);
     const listed = await compose(["exec", "-T", "agent", "ls", "/data/.state/sessions"]);
     expect(listed.stdout.trim()).not.toBe("");
 
-    const second = await invoke(session, "What number did I ask you to remember? Reply with digits only.");
+    const second = await invoke(baseUrl, session, "What number did I ask you to remember? Reply with digits only.");
     expect(second.at(-1)).toMatchObject({ type: "completed" });
     expect(answerOf(second)).toContain("47");
   });

--- a/test/live/env.ts
+++ b/test/live/env.ts
@@ -1,8 +1,16 @@
 /**
+ * What every live probe shares: the configuration rule, and the three platform-neutral moves a deploy
+ * probe makes (drive the CLI, POST a turn, read the answer out of the stream).
+ *
  * Live probes fail loudly on missing configuration instead of skipping: `npm run test:live` is an
  * explicit opt-in, so an unset variable is a broken run, not an absent capability. (A platform that
  * is genuinely DOWN is a different case — that belongs in the probe that talks to it.)
  */
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { expect } from "vitest";
+import type { AgentEvent } from "../../src/agent.ts";
 import { fastagentVersion } from "../../src/version.ts";
 export function requireEnv(name: string, hint: string): string {
   const value = process.env[name];
@@ -23,3 +31,36 @@ export function requireEnv(name: string, hint: string): string {
 export async function liveVersion(): Promise<string> {
   return process.env.FASTAGENT_LIVE_VERSION || (await fastagentVersion());
 }
+
+/** One spawned command. A container build's log is megabytes; execFile's 1 MB default would abort the
+ *  deploy mid-flight. */
+export const run = (file: string, args: string[], cwd?: string) =>
+  promisify(execFile)(file, args, { ...(cwd ? { cwd } : {}), maxBuffer: 64 << 20 });
+
+/** The product entry every deploy probe drives, spawned as `process.execPath [CLI, …]`. */
+export const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
+
+/** POST one turn to a deployed agent and return its SSE events (the built-in `/invoke`, mounted
+ *  because no channel is declared). Same reduction test/http.test.ts uses; `JSON.parse` is
+ *  deliberately unguarded, since a payload that is not an event is a broken wire format, not a case to
+ *  absorb. */
+export async function invoke(baseUrl: string, session: string, text: string): Promise<AgentEvent[]> {
+  const response = await fetch(`${baseUrl}/invoke`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ session, text }),
+  });
+  expect(response.status).toBe(200);
+  return (await response.text())
+    .split("\n\n")
+    .filter((block) => block.startsWith("data: "))
+    .map((block) => JSON.parse(block.slice("data: ".length)) as AgentEvent);
+}
+
+/**
+ * The ANSWER, and only it. Asserting on the raw SSE text would be wrong in both directions: a
+ * provider that splits `47` into two tokens never spells it literally, and a `thinking` delta that
+ * reasoned about the number would satisfy the assertion even when the answer got it wrong.
+ */
+export const answerOf = (events: AgentEvent[]): string =>
+  events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");

--- a/test/live/fly-deploy.live.test.ts
+++ b/test/live/fly-deploy.live.test.ts
@@ -14,24 +14,15 @@
  *
  * Needs `FLY_API_TOKEN` with write scope, a model credential (`FASTAGENT_AUTH_PATH`), and `flyctl`.
  */
-import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { AgentEvent } from "../../src/agent.ts";
 import { waitForHealth } from "../../src/channels/wait-health.ts";
 import { toFlyAppName } from "../../src/deploy/fly/plan.ts";
 import { listHasName } from "../../src/deploy/fly/run.ts";
-import { liveVersion, requireEnv } from "./env.ts";
-
-// A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-flight.
-const run = (file: string, args: string[], cwd?: string) =>
-  promisify(execFile)(file, args, { ...(cwd ? { cwd } : {}), maxBuffer: 64 << 20 });
-const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
+import { CLI, answerOf, invoke, liveVersion, requireEnv, run } from "./env.ts";
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 requireEnv("FLY_API_TOKEN", "a Fly API token WITH write scope — this probe creates and destroys an app");
@@ -97,23 +88,6 @@ afterAll(async () => {
   if (errors.length > 0) throw new AggregateError(errors, `teardown failed — check whether app ${APP} still exists`);
 }, 300_000);
 
-/** POST one turn and return its SSE events (the built-in `/invoke`, mounted because no channel is declared). */
-async function invoke(session: string, text: string): Promise<AgentEvent[]> {
-  const response = await fetch(`${URL_BASE}/invoke`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ session, text }),
-  });
-  expect(response.status).toBe(200);
-  return (await response.text())
-    .split("\n\n")
-    .filter((block) => block.startsWith("data: "))
-    .map((block) => JSON.parse(block.slice("data: ".length)) as AgentEvent);
-}
-
-const answerOf = (events: AgentEvent[]): string =>
-  events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
-
 describe("deploy fly --run: a real app, provisioned and destroyed", () => {
   it("provisions, boots, and serves a turn on its fly.dev URL", async () => {
     // Every gate in the driver exits non-zero, so a refusal surfaces here as this call's rejection.
@@ -131,7 +105,7 @@ describe("deploy fly --run: a real app, provisioned and destroyed", () => {
     expect(await waitForHealth(`${URL_BASE}/health`, 180_000, 3_000), `${URL_BASE}/health never came up`).toBe(true);
 
     const session = "live-fly";
-    const first = await invoke(session, "Remember this number: 47. Reply with just: ok");
+    const first = await invoke(URL_BASE, session, "Remember this number: 47. Reply with just: ok");
     expect(first.at(-1)).toMatchObject({ type: "completed" });
 
     // Restart BETWEEN the turns, which is what makes the next answer evidence about the VOLUME rather
@@ -142,7 +116,7 @@ describe("deploy fly --run: a real app, provisioned and destroyed", () => {
     await run("flyctl", ["apps", "restart", APP]);
     expect(await waitForHealth(`${URL_BASE}/health`, 180_000, 3_000), `${URL_BASE}/health never came back`).toBe(true);
 
-    const second = await invoke(session, "What number did I ask you to remember? Reply with digits only.");
+    const second = await invoke(URL_BASE, session, "What number did I ask you to remember? Reply with digits only.");
     expect(second.at(-1)).toMatchObject({ type: "completed" });
     expect(answerOf(second)).toContain("47");
   }, 900_000);

--- a/test/live/railway-deploy.live.test.ts
+++ b/test/live/railway-deploy.live.test.ts
@@ -1,0 +1,135 @@
+/**
+ * A real Railway deployment, created and destroyed: `deploy railway --run` links or creates a project,
+ * adds a service, sets variables, provisions a volume, builds, deploys, and mints a public domain.
+ *
+ * The read-only probe next door checks that the CLI still prints what the driver parses. This checks
+ * the half no parser assertion reaches: that the sequence provisions something that WORKS — the build
+ * accepts our generated Dockerfile via `railway.json`, the volume mounts where FASTAGENT_STATE_DIR
+ * expects it, the model credential arrives, and the minted domain actually serves.
+ *
+ * It also covers a step with no read-only equivalent: `railway domain` is the driver's getter AND its
+ * allocator (it mints one when the service has none), so the only way to observe it is to provision a
+ * service to observe it on.
+ *
+ * COSTS REAL RESOURCES. Railway deletes SOFTLY — a destroyed project keeps appearing in
+ * `railway list` with a `deletedAt` timestamp, so teardown verifies by that field rather than by
+ * absence.
+ *
+ * Needs `RAILWAY_API_TOKEN` (ACCOUNT-scoped), a model credential, and the `railway` CLI.
+ */
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AgentEvent } from "../../src/agent.ts";
+import { waitForHealth } from "../../src/channels/wait-health.ts";
+import { liveVersion, requireEnv } from "./env.ts";
+
+// A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-flight.
+const run = (file: string, args: string[], cwd?: string) =>
+  promisify(execFile)(file, args, { ...(cwd ? { cwd } : {}), maxBuffer: 64 << 20 });
+const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
+
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+requireEnv("RAILWAY_API_TOKEN", "an ACCOUNT-scoped Railway token — this probe creates and destroys a project");
+
+/** The project name the driver derives from the directory (`toRailwayName(basename(workspace))`), so the
+ *  name this file tears down is the one the deploy provisions. Per-run uuid: concurrent runs must not
+ *  collide, and teardown must never match another run's project. */
+const PROJECT = `fastagent-live-${randomUUID().slice(0, 8)}`;
+
+let workspace = "";
+
+beforeAll(async () => {
+  workspace = join(tmpdir(), PROJECT);
+  await mkdir(workspace, { recursive: true });
+  await writeFile(join(workspace, "persona.md"), "You are terse. Answer in as few words as possible.\n");
+  await writeFile(join(workspace, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+  await writeFile(
+    join(workspace, "package.json"),
+    `${JSON.stringify(
+      { name: "live-railway-probe", private: true, dependencies: { "@fastagent-sh/fastagent": await liveVersion() } },
+      null,
+      2,
+    )}\n`,
+  );
+});
+
+afterAll(async () => {
+  const errors: unknown[] = [];
+  try {
+    // `--project` is REQUIRED here even with `--yes`: outside a TTY the CLI refuses to infer which
+    // project it is deleting (the docs call the flag optional). Measured, not read.
+    const { stdout } = await run("railway", ["list", "--json"]);
+    const projects = JSON.parse(stdout) as { id?: string; name?: string; deletedAt?: string | null }[];
+    const mine = projects.find((p) => p.name === PROJECT && p.deletedAt === null);
+    if (mine?.id) await run("railway", ["delete", "--yes", "--project", mine.id]);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (workspace) await rm(workspace, { recursive: true, force: true }).catch((e: unknown) => errors.push(e));
+  if (errors.length > 0) throw new AggregateError(errors, `teardown failed — check whether project ${PROJECT} lives`);
+}, 300_000);
+
+/** POST one turn and return its SSE events (the built-in `/invoke`, mounted because no channel is declared). */
+async function invoke(url: string, session: string, text: string): Promise<AgentEvent[]> {
+  const response = await fetch(`${url}/invoke`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ session, text }),
+  });
+  expect(response.status).toBe(200);
+  return (await response.text())
+    .split("\n\n")
+    .filter((block) => block.startsWith("data: "))
+    .map((block) => JSON.parse(block.slice("data: ".length)) as AgentEvent);
+}
+
+const answerOf = (events: AgentEvent[]): string =>
+  events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
+
+describe("deploy railway --run: a real project, provisioned and destroyed", () => {
+  it("provisions, mints a domain, and serves a turn on it", async () => {
+    let output: string;
+    try {
+      // flyctl's lesson: execFile's error carries the CLI's output but its message does not, and
+      // "Command failed" is all an unattended nightly would otherwise report.
+      const result = await run(process.execPath, [CLI, "deploy", "railway", "--run"], workspace);
+      // BOTH streams: fastagent's own progress and result lines go to stderr (console.error), the
+      // railway CLI's build log to stdout. The minted URL is on the former.
+      output = result.stdout + result.stderr;
+    } catch (error) {
+      const e = error as { stderr?: string; stdout?: string };
+      throw new Error(`deploy railway --run failed for ${PROJECT}:\n${(e.stderr || e.stdout || "").slice(-4000)}`);
+    }
+
+    // Railway's URL is MINTED, not derived from the name the way Fly's is — the driver reports the
+    // one it got back, so the probe reads it from there rather than constructing it.
+    const url = output.match(/https:\/\/[a-z0-9-]+\.up\.railway\.app/i)?.[0];
+    expect(url, `no minted domain in the deploy output:\n${output.slice(-1500)}`).toBeTruthy();
+
+    expect(await waitForHealth(`${url}/health`, 180_000, 3_000), `${url}/health never came up`).toBe(true);
+
+    const session = "live-railway";
+    expect(
+      (await invoke(url as string, session, "Remember this number: 47. Reply with just: ok")).at(-1),
+    ).toMatchObject({
+      type: "completed",
+    });
+
+    // Session continuity on the deployed service. Unlike the fly probe this does NOT restart first:
+    // `railway redeploy` replaces the machine but the CLI offers no wait-for-ready, so a restart
+    // here would race the next request rather than prove anything about the volume.
+    const second = await invoke(
+      url as string,
+      session,
+      "What number did I ask you to remember? Reply with digits only.",
+    );
+    expect(second.at(-1)).toMatchObject({ type: "completed" });
+    expect(answerOf(second)).toContain("47");
+  }, 900_000);
+});

--- a/test/live/railway-deploy.live.test.ts
+++ b/test/live/railway-deploy.live.test.ts
@@ -17,30 +17,22 @@
  *
  * Needs `RAILWAY_API_TOKEN` (ACCOUNT-scoped), a model credential, and the `railway` CLI.
  */
-import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { AgentEvent } from "../../src/agent.ts";
 import { waitForHealth } from "../../src/channels/wait-health.ts";
-import { liveVersion, requireEnv } from "./env.ts";
-
-// A container build's log is megabytes; execFile's 1 MB default would abort the deploy mid-flight.
-const run = (file: string, args: string[], cwd?: string) =>
-  promisify(execFile)(file, args, { ...(cwd ? { cwd } : {}), maxBuffer: 64 << 20 });
-const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
+import { toRailwayName } from "../../src/deploy/railway/plan.ts";
+import { CLI, answerOf, invoke, liveVersion, requireEnv, run } from "./env.ts";
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 requireEnv("RAILWAY_API_TOKEN", "an ACCOUNT-scoped Railway token — this probe creates and destroys a project");
 
-/** The project name the driver derives from the directory (`toRailwayName(basename(workspace))`), so the
+/** Derived through the product's own slug rule (deploy.ts: `toRailwayName(basename(workspace))`), so the
  *  name this file tears down is the one the deploy provisions. Per-run uuid: concurrent runs must not
  *  collide, and teardown must never match another run's project. */
-const PROJECT = `fastagent-live-${randomUUID().slice(0, 8)}`;
+const PROJECT = toRailwayName(`fastagent-live-${randomUUID().slice(0, 8)}`);
 
 let workspace = "";
 
@@ -66,7 +58,15 @@ afterAll(async () => {
     // project it is deleting (the docs call the flag optional). Measured, not read.
     const { stdout } = await run("railway", ["list", "--json"]);
     const projects = JSON.parse(stdout) as { id?: string; name?: string; deletedAt?: string | null }[];
-    const mine = projects.find((p) => p.name === PROJECT && p.deletedAt === null);
+    // Refuse a list we cannot read, which is what makes asking safe at all: "not mine" now only ever
+    // means the account said so. A renamed field would otherwise match nothing, skip the delete
+    // silently, and leak a billing project holding the model credential and serving `/invoke`
+    // unauthenticated — the failure fly-deploy's throwing `listHasName` exists to prevent.
+    if (!Array.isArray(projects) || projects.some((p) => typeof p.name !== "string"))
+      throw new Error(`\`railway list --json\` is no longer a list of named projects: ${stdout.slice(0, 300)}`);
+    // `== null`, not `=== null`: a MISSING deletedAt must read as alive, so an absent field ends in a
+    // delete attempt that fails loudly rather than in a silent skip.
+    const mine = projects.find((p) => p.name === PROJECT && p.deletedAt == null);
     if (mine?.id) await run("railway", ["delete", "--yes", "--project", mine.id]);
   } catch (error) {
     errors.push(error);
@@ -74,23 +74,6 @@ afterAll(async () => {
   if (workspace) await rm(workspace, { recursive: true, force: true }).catch((e: unknown) => errors.push(e));
   if (errors.length > 0) throw new AggregateError(errors, `teardown failed — check whether project ${PROJECT} lives`);
 }, 300_000);
-
-/** POST one turn and return its SSE events (the built-in `/invoke`, mounted because no channel is declared). */
-async function invoke(url: string, session: string, text: string): Promise<AgentEvent[]> {
-  const response = await fetch(`${url}/invoke`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ session, text }),
-  });
-  expect(response.status).toBe(200);
-  return (await response.text())
-    .split("\n\n")
-    .filter((block) => block.startsWith("data: "))
-    .map((block) => JSON.parse(block.slice("data: ".length)) as AgentEvent);
-}
-
-const answerOf = (events: AgentEvent[]): string =>
-  events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
 
 describe("deploy railway --run: a real project, provisioned and destroyed", () => {
   it("provisions, mints a domain, and serves a turn on it", async () => {

--- a/test/live/railway.live.test.ts
+++ b/test/live/railway.live.test.ts
@@ -1,0 +1,117 @@
+/**
+ * What the `railway` CLI actually prints, checked against the assumptions the Railway driver makes
+ * about it. `deploy-railway-run.test.ts` drives the whole deploy against a fake `CliRunner` answering
+ * what we believe it prints; that covers the orchestration and cannot cover the belief.
+ *
+ * The beliefs here are DATED: `isLinked`/`linkedName` carry "Verified against CLI 5.15.0" in their
+ * comments, and the CLI is past 5.45. A version pin in a comment is exactly the kind of claim that
+ * stops being true without anything going red — this file is what makes it go red.
+ *
+ * READ-ONLY. The write half lives in railway-deploy.live.test.ts, because `railway domain` MINTS a
+ * domain when the service has none (it is the driver's getter and its allocator at once), so there is
+ * no way to observe that one without provisioning something to observe it on.
+ *
+ * Needs `RAILWAY_API_TOKEN` — the ACCOUNT-scoped token, not the project-scoped `RAILWAY_TOKEN` a
+ * Railway project hands out. Nothing in `src/` names either variable: the driver assumes an operator
+ * who ran `railway login`, and CI has no such session.
+ */
+import { execFile } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { isLinked, linkedName, parseHasVolume } from "../../src/deploy/railway/run.ts";
+import { requireEnv } from "./env.ts";
+
+const run = promisify(execFile);
+
+requireEnv("RAILWAY_API_TOKEN", "an ACCOUNT-scoped Railway token (Account Settings → Tokens)");
+
+/** One railway invocation from `cwd`, capturing both streams and the exit code — none of the three is
+ *  incidental here: the driver reads stdout only, and this file is what proves that is still right. */
+async function railway(args: string[], cwd: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await run("railway", args, { cwd, maxBuffer: 64 << 20 });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+/** Parse, or fail with what was actually printed. A bare `SyntaxError: Unexpected token` names neither
+ *  the command nor the output, and this probe has already seen one transient non-JSON answer. */
+function parseJson<T>(stdout: string, what: string): T {
+  try {
+    return JSON.parse(stdout) as T;
+  } catch (error) {
+    throw new Error(`\`railway ${what}\` did not return JSON (${String(error)}): ${stdout.slice(0, 300)}`);
+  }
+}
+
+describe("railway CLI output still matches what the Railway driver reads", () => {
+  it("an UNLINKED directory leaves stdout empty — the whole basis of isLinked", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
+    const { code, stdout, stderr } = await railway(["status", "--json"], dir);
+
+    // THE assertion. `isLinked` is `stdout.trim() !== ""`, so an unlinked directory that started
+    // printing anything to stdout would read as linked and the driver would refuse to provision,
+    // telling the operator their fresh directory belongs to a project.
+    expect(stdout.trim(), "an unlinked `railway status --json` now writes to stdout").toBe("");
+    expect(isLinked(stdout)).toBe(false);
+    expect(stderr.trim(), "the unlinked message no longer goes to stderr").not.toBe("");
+
+    // The comment on `isLinked` says the exit code "is 0 either way, so it can't be the signal".
+    // Measured on 5.45.2 it is NOT 0 — which does not break the driver (it reads stdout alone) and is
+    // recorded here so the reasoning stays honest rather than the conclusion staying lucky.
+    expect([0, 1], `unexpected exit code ${code} for an unlinked status`).toContain(code);
+  });
+
+  it("`list --json` is an array of projects carrying id, name and deletedAt", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
+    const { stdout } = await railway(["list", "--json"], dir);
+    const projects = parseJson<{ id?: string; name?: string; deletedAt?: string | null }[]>(stdout, "list --json");
+    expect(Array.isArray(projects), "`railway list --json` is no longer an array").toBe(true);
+
+    // Teardown in the deploy probe needs all three: the name to find its own project, the id because
+    // `delete` takes one, and deletedAt because Railway deletes SOFTLY — a destroyed project keeps
+    // being listed, so "still present" is not evidence of a leak.
+    for (const project of projects) {
+      expect(typeof project.name, `a project entry carries no name: ${JSON.stringify(project)}`).toBe("string");
+      expect(typeof project.id, `project ${project.name} carries no id`).toBe("string");
+      expect(project, `project ${project.name} carries no deletedAt`).toHaveProperty("deletedAt");
+    }
+  });
+
+  it("`linkedName` and `parseHasVolume` read a linked project's shape", async () => {
+    // Against a project this probe did NOT create: both readers are pure, and linking is local state
+    // (a file in the directory), so nothing here writes to the account.
+    const projects = parseJson<{ name?: string; deletedAt?: string | null }[]>(
+      (await railway(["list", "--json"], tmpdir())).stdout,
+      "list --json",
+    );
+    const alive = projects.find((p) => p.deletedAt === null && typeof p.name === "string")?.name;
+    expect(alive, "this Railway account holds no live project to read against — create one").toBeTruthy();
+
+    const dir = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
+    expect((await railway(["link", "--project", alive as string], dir)).code, `could not link ${alive}`).toBe(0);
+
+    const status = await railway(["status", "--json"], dir);
+    expect(isLinked(status.stdout), "a linked directory reads as unlinked").toBe(true);
+    // `linkedName` only feeds a gate message, but a rename would make that message say "(name
+    // unreadable)" about a project the operator can see by name in their dashboard.
+    expect(linkedName(status.stdout), "`name` is no longer at the top level of status --json").toBe(alive);
+
+    // `parseHasVolume` is shape-agnostic (any JSON string equal to the mount path), so what it needs is
+    // for mount paths to keep appearing as strings at all. Asserted in both directions against the
+    // volumes this project really has.
+    const volumes = await railway(["volume", "list", "--json"], dir);
+    const mounts =
+      parseJson<{ volumes?: { mountPath?: string }[] }>(volumes.stdout, "volume list --json").volumes ?? [];
+    for (const { mountPath } of mounts) {
+      expect(parseHasVolume(volumes.stdout, mountPath as string), `mount ${mountPath} unreadable`).toBe(true);
+    }
+    expect(parseHasVolume(volumes.stdout, "/definitely-not-a-mount-path")).toBe(false);
+  });
+});

--- a/test/live/railway.live.test.ts
+++ b/test/live/railway.live.test.ts
@@ -12,8 +12,9 @@
  * no way to observe that one without provisioning something to observe it on.
  *
  * Needs `RAILWAY_API_TOKEN` — the ACCOUNT-scoped token, not the project-scoped `RAILWAY_TOKEN` a
- * Railway project hands out. Nothing in `src/` names either variable: the driver assumes an operator
- * who ran `railway login`, and CI has no such session.
+ * Railway project hands out. The driver never reads it: it assumes an operator who ran `railway login`
+ * and only NAMES the variable in its gate message (`run.ts`), so in CI the token stands in for that
+ * session.
  */
 import { execFile } from "node:child_process";
 import { mkdtemp } from "node:fs/promises";
@@ -95,7 +96,11 @@ describe("railway CLI output still matches what the Railway driver reads", () =>
     expect(alive, "this Railway account holds no live project to read against — create one").toBeTruthy();
 
     const dir = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
-    expect((await railway(["link", "--project", alive as string], dir)).code, `could not link ${alive}`).toBe(0);
+    // `--environment` too: interactive `link` prompts for workspace, project AND environment, and the
+    // docs' non-interactive form passes both. `production` is the environment Railway gives every new
+    // project — a project that renamed it fails here by name rather than by an unreadable prompt.
+    const link = await railway(["link", "--project", alive as string, "--environment", "production"], dir);
+    expect(link.code, `could not link ${alive}: ${link.stderr.trim()}`).toBe(0);
 
     const status = await railway(["status", "--json"], dir);
     expect(isLinked(status.stdout), "a linked directory reads as unlinked").toBe(true);
@@ -107,8 +112,14 @@ describe("railway CLI output still matches what the Railway driver reads", () =>
     // for mount paths to keep appearing as strings at all. Asserted in both directions against the
     // volumes this project really has.
     const volumes = await railway(["volume", "list", "--json"], dir);
-    const mounts =
-      parseJson<{ volumes?: { mountPath?: string }[] }>(volumes.stdout, "volume list --json").volumes ?? [];
+    // The `volumes` key must EXIST. `?? []` would have folded "the field is gone" into "this project
+    // has no volumes": the loop runs zero times, only the always-false negative assertion is left, and
+    // the shape change this file exists to catch goes green.
+    const mounts = parseJson<{ volumes?: { mountPath?: string }[] }>(volumes.stdout, "volume list --json").volumes;
+    if (!Array.isArray(mounts))
+      throw new Error(
+        `\`railway volume list --json\` no longer carries a volumes array: ${volumes.stdout.slice(0, 300)}`,
+      );
     for (const { mountPath } of mounts) {
       expect(parseHasVolume(volumes.stdout, mountPath as string), `mount ${mountPath} unreadable`).toBe(true);
     }


### PR DESCRIPTION
Phase 4's second host, and the first written under the "read before writing" note this repo added after Fly (`deploy/` in AGENTS.md).

## Two probes

**`railway.live.test.ts` — read-only.** `deploy-railway-run.test.ts` drives the whole deploy against a fake `CliRunner` answering what we believe the CLI prints; that covers the orchestration and cannot cover the belief. Here the beliefs are DATED: `isLinked` and `linkedName` both carry *"Verified against CLI 5.15.0"* in their comments, and the CLI is past 5.45. A version pin in a comment is exactly the claim that stops being true with nothing going red.

**`railway-deploy.live.test.ts` — the real thing.** Provisions a project, deploys, reads the minted domain, serves two turns, destroys it. There is no read-only version of this one: `railway domain` is the driver's getter AND its allocator (it mints a domain when the service has none), so observing it requires a service to observe it on.

## What reading first produced

Eight facts, before writing a line of probe:

| Fact | How |
|---|---|
| CI needs `RAILWAY_API_TOKEN` (account-scoped); the project-scoped `RAILWAY_TOKEN` cannot create a project, and nothing in `src/` names either — the driver assumes an operator who ran `railway login` | measured |
| `status --json` on an unlinked directory exits **1**, while `isLinked`'s comment says the code *"is 0 either way, so it can't be the signal"* | measured |
| The driver reads stdout alone, so that conclusion held while its stated reason went stale | read the code |
| `railway delete --yes` requires `--project` outside a TTY; the docs call the flag optional | measured |
| Deletion is **soft** — a destroyed project keeps appearing in `railway list` with a `deletedAt` timestamp | measured |
| Railway mints a reachable domain in one step, so it has **no equivalent of Fly's #425** | real deploy + curl |
| `railway add --service` does not stall on a prompt (railwayapp/cli#816 risk) | real deploy |
| `railway.json` is retired on 2026-12-01, and `deploy railway` generates exactly it | the CLI says so on every invocation → #429 |

The last one is filed rather than fixed: Railway's TypeScript SDK has no `dockerfilePath` (their own migration tool comments it out instead of translating), the IaC API is documented as beta, and it would add an npm dependency to the user's agent directory. #429 records the evidence and the date.

## What did not need fixing

The prediction going in was that Railway would repeat Fly's defects. It does not. All three of its parsers degrade in the SAFE direction — `isLinked` reads unreadable output as *linked*, which refuses rather than provisioning a duplicate, and its comment says so. Fly's `listHasName` degraded the other way and created a second volume. Nothing in `railway/run.ts` changed in this PR.

## Verification

CI run 33614848114: 12 files, 22 tests, 263s — `railway-deploy` 55s, `railway` 2.5s. Both hosts provision and destroy real infrastructure every run; leaked projects and apps verified at 0 after.

The workflow installs the Railway CLI and sweeps leftovers with `always()`, matching the Fly sweep. Its jq filter was checked in both directions: empty against the real account, and selecting only live probe projects out of a fixture holding a soft-deleted one and an unrelated user project.
