### PR TITLE
test(live): AgentCore — CloudFormation accepts the generated template, and a real stack round trip

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -85,6 +85,14 @@ jobs:
       # same release (its postinstall pulls releases/download/v<its own version>), so `latest` there
       # is the same build, resolved through a registry this job already depends on. Still LATEST, for
       # the cloudflared reason: this probe exists to find out when the CLI drifts, and a pin retires it.
+      # The AgentCore image must be linux/arm64 (the runtime's only architecture), which the driver
+      # cross-builds with `docker buildx`. Ubuntu runners ship docker, and this adds the plugin plus
+      # the QEMU emulation an arm64 build needs on an x86 runner.
+      - name: Set up QEMU and buildx for the arm64 image
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
       - name: Install the Railway CLI
         run: |
           # Without pipefail a failed `curl` feeds `sh` an empty script, which exits 0 — the step goes
@@ -165,6 +173,13 @@ jobs:
           # an operator who ran `railway login` and only names the variable in its gate message, so
           # here the token stands in for the session CI has no way to hold.
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          # Scoped to the `fastagent-live-probe-*` namespace by an inline IAM policy: the deploy probe
+          # creates a CloudFormation stack, an ECR repository and an S3 bucket, and destroys all three.
+          # The driver PREFIXES `fastagent-` onto the directory name, which is why the probe's
+          # directories are `live-probe-…` and the policy matches `fastagent-live-probe-*`.
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
         run: npm run test:live
 
       # The deploy probe destroys its own app in afterAll, which a job timeout or a cancelled run
@@ -202,3 +217,31 @@ jobs:
             | jq -r '.[] | select(.deletedAt == null) | select(.name | test("^fastagent-live-[0-9a-f]{8}$")) | .id' \
             | tee /dev/stderr \
             | xargs -r -n1 -I{} railway delete --yes --project {}
+
+      # Same reasoning as the sweeps above, with AgentCore's twist: THREE kinds are left behind,
+      # because the bucket and repository are deliberately created outside the stack (plan.ts: so a
+      # `delete-stack` cannot take the agent's memory with it). The bucket is versioned, so every
+      # version goes before the bucket will.
+      #
+      # It reads names from a FILE the probe appends to, not from `list-stacks`: the IAM policy scopes
+      # this credential to `fastagent-live-probe-*` and account-wide listing is exactly what that
+      # refuses. Widening the policy to enumerate every stack in the account, so a cleanup can find
+      # the two it owns, is the wrong trade.
+      - name: Destroy leftover live AgentCore resources
+        if: always()
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set -o pipefail
+          [ -f "$RUNNER_TEMP/agentcore-probe-names" ] || { echo "no probe ran"; exit 0; }
+          account=$(aws sts get-caller-identity --query Account --output text)
+          sort -u "$RUNNER_TEMP/agentcore-probe-names" | tee /dev/stderr | while read -r name; do
+            [ -n "$name" ] || continue
+            aws cloudformation delete-stack --stack-name "fastagent-$name" || true
+            aws cloudformation wait stack-delete-complete --stack-name "fastagent-$name" || true
+            aws s3 rm "s3://fa-$name-$account" --recursive || true
+            aws s3api delete-bucket --bucket "fa-$name-$account" || true
+            aws ecr delete-repository --repository-name "fastagent/$name" --force || true
+          done

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -27,7 +27,13 @@ jobs:
     # vitest's own ceiling covers the tests; `npm ci` and a container build sit outside it. Nobody is
     # watching a nightly run, and the 6h default would hold the next one behind it (the group does not
     # cancel in progress).
-    timeout-minutes: 60
+    #
+    # 120, not 60: the probes run SERIALLY (`fileParallelism: false`) and their own budgets already add
+    # up past an hour — the AgentCore deploy alone declares 30 minutes for the stack plus 15 for its
+    # teardown, on top of the fly and railway deploys and a container build. At 60 this job would hit
+    # the ceiling on a normal-but-slow night, and it would hit it DURING the most expensive probe, in
+    # the one place where the sweeps below are all that stand between a kill and a billing leak.
+    timeout-minutes: 120
     environment: live # holds FASTAGENT_LIVE_MODEL and the provider key
     steps:
       - name: Check out repository
@@ -85,14 +91,6 @@ jobs:
       # same release (its postinstall pulls releases/download/v<its own version>), so `latest` there
       # is the same build, resolved through a registry this job already depends on. Still LATEST, for
       # the cloudflared reason: this probe exists to find out when the CLI drifts, and a pin retires it.
-      # The AgentCore image must be linux/arm64 (the runtime's only architecture), which the driver
-      # cross-builds with `docker buildx`. Ubuntu runners ship docker, and this adds the plugin plus
-      # the QEMU emulation an arm64 build needs on an x86 runner.
-      - name: Set up QEMU and buildx for the arm64 image
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
       - name: Install the Railway CLI
         run: |
           # Without pipefail a failed `curl` feeds `sh` an empty script, which exits 0 — the step goes
@@ -104,6 +102,14 @@ jobs:
           curl -fsSL https://railway.com/install.sh | RAILWAY_VERSION="$RAILWAY_VERSION" sh
           echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
           "$HOME/.railway/bin/railway" --version
+
+      # The AgentCore image must be linux/arm64 (the runtime's only architecture), which the driver
+      # cross-builds with `docker buildx`. Ubuntu runners ship docker, and this adds the plugin plus
+      # the QEMU emulation an arm64 build needs on an x86 runner.
+      - name: Set up QEMU and buildx for the arm64 image
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       # ONE credential mechanism for both probes: an auth.json, named by the product's own
       # FASTAGENT_AUTH_PATH. It carries an OAuth grant (openai-codex) as readily as an API key, and
@@ -173,10 +179,14 @@ jobs:
           # an operator who ran `railway login` and only names the variable in its gate message, so
           # here the token stands in for the session CI has no way to hold.
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
-          # Scoped to the `fastagent-live-probe-*` namespace by an inline IAM policy: the deploy probe
-          # creates a CloudFormation stack, an ECR repository and an S3 bucket, and destroys all three.
-          # The driver PREFIXES `fastagent-` onto the directory name, which is why the probe's
-          # directories are `live-probe-…` and the policy matches `fastagent-live-probe-*`.
+          # Scoped by an inline IAM policy to the resources the deploy probe creates and destroys: a
+          # CloudFormation stack, an ECR repository, an S3 bucket and an AgentCore runtime. The policy
+          # needs FOUR patterns, not one — the driver derives each name differently from the same
+          # `live-probe-<uuid8>` directory, and only the stack wears the `fastagent-` prefix:
+          #   stack `fastagent-live-probe-*` / bucket `fa-live-probe-*-<account>` /
+          #   repository `fastagent/live-probe-*` (slash) / runtime `live_probe_*` (underscores).
+          # A policy written for the stack pattern alone denies the other three, and does it only after
+          # the image is built and pushed. test/live/agentcore-deploy.live.test.ts carries the same map.
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -221,7 +231,14 @@ jobs:
       # Same reasoning as the sweeps above, with AgentCore's twist: THREE kinds are left behind,
       # because the bucket and repository are deliberately created outside the stack (plan.ts: so a
       # `delete-stack` cannot take the agent's memory with it). The bucket is versioned, so every
-      # version goes before the bucket will.
+      # version AND every delete marker goes before the bucket will.
+      #
+      # Fail-loud like the two sweeps above, and for a sharper reason: this step is the net under a
+      # probe that was KILLED, so the run it reports into is already red or cancelled and nobody will
+      # read its log. A swallowed `delete-stack` failure (DELETE_FAILED) or a bucket that refuses to go
+      # is a Bedrock runtime, a Lambda, an image and a credential-bearing bucket still billing, with
+      # nothing else in the world collecting them. Every deletion is still ATTEMPTED even after one
+      # fails; "already gone" is the goal state, not a failure.
       #
       # It reads names from a FILE the probe appends to, not from `list-stacks`: the IAM policy scopes
       # this credential to `fastagent-live-probe-*` and account-wide listing is exactly what that
@@ -237,11 +254,43 @@ jobs:
           set -o pipefail
           [ -f "$RUNNER_TEMP/agentcore-probe-names" ] || { echo "no probe ran"; exit 0; }
           account=$(aws sts get-caller-identity --query Account --output text)
-          sort -u "$RUNNER_TEMP/agentcore-probe-names" | tee /dev/stderr | while read -r name; do
+          failed=0
+          # Tolerates only the goal state; anything else is reported and fails the step.
+          attempt() {
+            label="$1"; shift
+            if ! out=$("$@" 2>&1); then
+              case "$out" in
+                *"does not exist"*|*NotFound*|*NoSuchBucket*) ;;
+                *) echo "::error::$label failed: $out"; failed=1 ;;
+              esac
+            fi
+          }
+          # A FILE, not a pipe into `while`: a piped loop runs in a subshell, where every `failed=1`
+          # would be discarded at the `done` and this step would go green having reported errors.
+          sort -u "$RUNNER_TEMP/agentcore-probe-names" > "$RUNNER_TEMP/agentcore-sweep"
+          cat "$RUNNER_TEMP/agentcore-sweep" >&2
+          while read -r name; do
             [ -n "$name" ] || continue
-            aws cloudformation delete-stack --stack-name "fastagent-$name" || true
-            aws cloudformation wait stack-delete-complete --stack-name "fastagent-$name" || true
-            aws s3 rm "s3://fa-$name-$account" --recursive || true
-            aws s3api delete-bucket --bucket "fa-$name-$account" || true
-            aws ecr delete-repository --repository-name "fastagent/$name" --force || true
-          done
+            bucket="fa-$name-$account"
+            attempt "delete-stack $name" aws cloudformation delete-stack --stack-name "fastagent-$name"
+            attempt "wait stack-delete $name" aws cloudformation wait stack-delete-complete --stack-name "fastagent-$name"
+            # `s3 rm` does not empty a versioned bucket — it writes a delete marker per object, and a
+            # marker comes back under DeleteMarkers, not Versions. Deleting only Versions leaves the
+            # bucket non-empty and `delete-bucket` answers BucketNotEmpty.
+            attempt "s3 rm $bucket" aws s3 rm "s3://$bucket" --recursive
+            if objects=$(aws s3api list-object-versions --bucket "$bucket" --output json 2>&1); then
+              payload=$(printf '%s' "$objects" \
+                | jq -c '{Objects: [(.Versions // []) + (.DeleteMarkers // [])] | flatten | map({Key, VersionId})}')
+              if [ "$(printf '%s' "$payload" | jq '.Objects | length')" -gt 0 ]; then
+                attempt "delete-objects $bucket" aws s3api delete-objects --bucket "$bucket" --delete "$payload"
+              fi
+            else
+              case "$objects" in
+                *NoSuchBucket*) ;;
+                *) echo "::error::list-object-versions $bucket failed: $objects"; failed=1 ;;
+              esac
+            fi
+            attempt "delete-bucket $bucket" aws s3api delete-bucket --bucket "$bucket"
+            attempt "delete-repository $name" aws ecr delete-repository --repository-name "fastagent/$name" --force
+          done < "$RUNNER_TEMP/agentcore-sweep"
+          exit "$failed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,8 +282,9 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # file that dates the `Verified against CLI 5.15.0` claims in run.ts) plus
                              # a REAL Railway project provisioned and destroyed (railway-deploy — the
                              # only way to observe `railway domain`, which MINTS one when absent),
-                             # CloudFormation ACCEPTING the ~900 lines of YAML this repo emits by hand
-                             # (agentcore — read-only, free, and the only check that the template parses)
+                             # CloudFormation ACCEPTING the YAML this repo emits by hand, forwarder and
+                             # schedule branches included (agentcore — read-only, free, and the only
+                             # check that the template parses)
                              # plus a REAL stack + ECR repo + S3 bucket provisioned and destroyed
                              # (agentcore-deploy — no public URL exists, so it proves the deployment
                              # works through InvokeAgentRuntime; teardown is THREE places because the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,12 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # file that dates the `Verified against CLI 5.15.0` claims in run.ts) plus
                              # a REAL Railway project provisioned and destroyed (railway-deploy — the
                              # only way to observe `railway domain`, which MINTS one when absent),
+                             # CloudFormation ACCEPTING the ~900 lines of YAML this repo emits by hand
+                             # (agentcore — read-only, free, and the only check that the template parses)
+                             # plus a REAL stack + ECR repo + S3 bucket provisioned and destroyed
+                             # (agentcore-deploy — no public URL exists, so it proves the deployment
+                             # works through InvokeAgentRuntime; teardown is THREE places because the
+                             # bucket and repo live outside the stack on purpose),
                              # `flyctl` still printing what the Fly driver reads (fly — read-only), and
                              # a REAL Fly app provisioned then destroyed (fly-deploy — which is how
                              # #425 was found: a deploy whose every step succeeded, serving on a URL

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -489,6 +489,8 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
 describe("deploy/agentcore/run: helpers", () => {
   it("parseStackOutputs tolerates garbage and partial shapes", () => {
     expect(parseStackOutputs("not json")).toEqual({});
+    // A stack with no Outputs answers `null`, which must read as "no RuntimeArn" (the driver gates).
+    expect(parseStackOutputs("null")).toEqual({});
     expect(parseStackOutputs(JSON.stringify([{ OutputKey: "A", OutputValue: "1" }, { OutputKey: 2 }]))).toEqual({
       A: "1",
     });

--- a/test/live/agentcore-deploy.live.test.ts
+++ b/test/live/agentcore-deploy.live.test.ts
@@ -1,0 +1,199 @@
+/**
+ * A real AgentCore deployment, created and destroyed: `deploy agentcore --run` builds and pushes an
+ * image to ECR, creates the state bucket, and converges a CloudFormation stack holding a Bedrock
+ * AgentCore runtime, a forwarder Lambda with a Function URL, its IAM roles, and any schedule rules.
+ *
+ * This host shares nothing with the fly/railway probes but the intent. There is NO public URL to curl:
+ * AgentCore exposes `POST /invocations` behind `InvokeAgentRuntime`, an IAM-signed AWS API. So the
+ * check that the deployment WORKS is the one the driver itself makes — a `checkpoint` envelope through
+ * `aws bedrock-agentcore invoke-agent-runtime`, read back with the driver's own `parseCheckpointReply`.
+ *
+ * TEARDOWN IS THREE PLACES, and the product offers none of them: `delete-stack` is used only to clear
+ * a ROLLBACK_COMPLETE husk. The state bucket and the ECR repository are created OUTSIDE the stack on
+ * purpose — `plan.ts` says why: so a `delete-stack` "cannot take the agent's memory with it". Correct
+ * for an operator, which makes cleanup this probe's own job: stack, then bucket (versioned, so every
+ * version must go before the bucket will), then repository (with its images).
+ *
+ * COSTS REAL RESOURCES and is the slowest probe here — a stack create plus delete is minutes.
+ *
+ * Needs AWS credentials scoped to the `fastagent-live-probe-*` namespace (see the IAM policy in the
+ * `live` environment), a model credential, and the `aws` CLI. The directory name carries NO
+ * `fastagent-` prefix: the driver adds one to every resource it names.
+ */
+import { randomUUID } from "node:crypto";
+import { appendFile, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { agentcoreName, ingressSessionId, stateBucketName } from "../../src/deploy/agentcore/plan.ts";
+import { parseStackOutputs } from "../../src/deploy/agentcore/run.ts";
+import { CLI, liveVersion, requireEnv, run } from "./env.ts";
+
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+requireEnv("AWS_ACCESS_KEY_ID", "an AWS key scoped to fastagent-live-probe-* (this probe creates real resources)");
+requireEnv("AWS_SECRET_ACCESS_KEY", "the secret for AWS_ACCESS_KEY_ID");
+requireEnv("AWS_REGION", "a region where Bedrock AgentCore is available, e.g. us-east-1");
+
+/** The directory basename IS the agent name; every AWS resource derives from it. `live-probe-` keeps
+ *  all of them inside the IAM policy's namespace once the driver prefixes `fastagent-`. */
+const NAME = agentcoreName(`live-probe-${randomUUID().slice(0, 8)}`);
+const STACK = `fastagent-${NAME}`;
+const REPO = `fastagent/${NAME}`;
+
+let workspace = "";
+let account = "";
+
+async function aws(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await run("aws", args);
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+beforeAll(async () => {
+  const identity = await aws(["sts", "get-caller-identity", "--output", "json"]);
+  expect(identity.code, `sts get-caller-identity failed: ${identity.stderr}`).toBe(0);
+  account = (JSON.parse(identity.stdout) as { Account: string }).Account;
+
+  // Registered BEFORE anything is created, so the workflow sweep can still find these resources if
+  // this process is killed mid-deploy (a job timeout, a cancelled run) and afterAll never runs. The
+  // IAM policy forbids account-wide listing, which is what makes a written name the only way.
+  if (process.env.RUNNER_TEMP) await appendFile(join(process.env.RUNNER_TEMP, "agentcore-probe-names"), `${NAME}\n`);
+
+  workspace = join(tmpdir(), NAME);
+  await mkdir(workspace, { recursive: true });
+  await writeFile(join(workspace, "persona.md"), "You are terse. Answer in as few words as possible.\n");
+  await writeFile(join(workspace, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+  await writeFile(
+    join(workspace, "package.json"),
+    `${JSON.stringify(
+      { name: "live-agentcore-probe", private: true, dependencies: { "@fastagent-sh/fastagent": await liveVersion() } },
+      null,
+      2,
+    )}\n`,
+  );
+});
+
+afterAll(async () => {
+  // Three deletions, each attempted even if an earlier one failed, and every failure reported: what
+  // survives a silent teardown here is a Bedrock runtime, a Lambda with a public Function URL, an
+  // image in ECR and a bucket holding the model credential seed — all of them billing.
+  const errors: unknown[] = [];
+  const attempt = async (label: string, args: string[]) => {
+    const { code, stderr } = await aws(args);
+    // "already gone" is the goal state, not a failure: a probe whose deploy never got that far, or a
+    // re-run after a partial teardown, both land here.
+    if (code !== 0 && !/does not exist|NotFound|NoSuchBucket/i.test(stderr)) {
+      errors.push(new Error(`${label} failed: ${stderr.slice(0, 500)}`));
+    }
+  };
+
+  await attempt("delete-stack", ["cloudformation", "delete-stack", "--stack-name", STACK]);
+  await attempt("wait stack-delete-complete", [
+    "cloudformation",
+    "wait",
+    "stack-delete-complete",
+    "--stack-name",
+    STACK,
+  ]);
+  if (account) {
+    // The bucket has versioning ON (run.ts enables it), so `rb --force` alone leaves delete markers
+    // behind and the bucket refuses to go. Object versions must be removed first.
+    const bucket = stateBucketName(NAME, account);
+    await attempt("s3 rm", ["s3", "rm", `s3://${bucket}`, "--recursive"]);
+    const versions = await aws([
+      "s3api",
+      "list-object-versions",
+      "--bucket",
+      bucket,
+      "--query",
+      "{Objects: Versions[].{Key:Key,VersionId:VersionId}}",
+      "--output",
+      "json",
+    ]);
+    if (versions.code === 0) {
+      const payload = JSON.parse(versions.stdout) as { Objects?: unknown[] | null };
+      if (Array.isArray(payload.Objects) && payload.Objects.length > 0) {
+        await attempt("s3api delete-objects", [
+          "s3api",
+          "delete-objects",
+          "--bucket",
+          bucket,
+          "--delete",
+          JSON.stringify({ Objects: payload.Objects }),
+        ]);
+      }
+    }
+    await attempt("s3 rb", ["s3api", "delete-bucket", "--bucket", bucket]);
+  }
+  await attempt("ecr delete-repository", ["ecr", "delete-repository", "--repository-name", REPO, "--force"]);
+
+  if (workspace) await rm(workspace, { recursive: true, force: true }).catch((e: unknown) => errors.push(e));
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `teardown failed — check stack ${STACK}, bucket fa-${NAME}-*, repo ${REPO}`);
+  }
+}, 900_000);
+
+describe("deploy agentcore --run: a real stack, provisioned and destroyed", () => {
+  it("converges the stack and the runtime answers a checkpoint", async () => {
+    try {
+      await run(process.execPath, [CLI, "deploy", "agentcore", "--run"], workspace);
+    } catch (error) {
+      const e = error as { stderr?: string; stdout?: string };
+      throw new Error(`deploy agentcore --run failed for ${STACK}:\n${(e.stderr || e.stdout || "").slice(-4000)}`);
+    }
+
+    // The stack's own Outputs, read through the driver's parser: RuntimeArn is what every later call
+    // addresses, and the driver gates when it is absent.
+    const outputs = await aws([
+      "cloudformation",
+      "describe-stacks",
+      "--stack-name",
+      STACK,
+      "--query",
+      "Stacks[0].Outputs",
+      "--output",
+      "json",
+    ]);
+    expect(outputs.code, `describe-stacks failed: ${outputs.stderr}`).toBe(0);
+    const runtimeArn = parseStackOutputs(outputs.stdout).RuntimeArn;
+    expect(runtimeArn, `the converged stack has no RuntimeArn output:\n${outputs.stdout.slice(0, 500)}`).toBeTruthy();
+
+    // THE assertion that the deployment WORKS, and the only one this host allows: there is no public
+    // URL, so it goes through `InvokeAgentRuntime`. The envelope is `invoke` rather than the driver's
+    // `checkpoint` because this agent declares no channel — no channel means no forwarder, no forwarder
+    // means no FASTAGENT_INGRESS_SECRET (deploy.ts mints it only when one is needed), and without that
+    // secret the adapter serves the PUBLIC kind alone: "Undefined = nothing can be trusted, so only the
+    // public `invoke` kind is served" (agentcore.ts). A checkpoint here answers 403 from the container.
+    // It is also the better assertion: `invoke` runs a real turn, the same thing the fly and railway
+    // probes POST for.
+    const payload = join(workspace, "invoke.json");
+    await writeFile(
+      payload,
+      `${JSON.stringify({ kind: "invoke", session: "live-agentcore", text: "Reply with just: ok" })}\n`,
+    );
+    const reply = await aws([
+      "bedrock-agentcore",
+      "invoke-agent-runtime",
+      "--agent-runtime-arn",
+      runtimeArn as string,
+      "--runtime-session-id",
+      ingressSessionId(NAME),
+      "--payload",
+      `file://${payload}`,
+      "--cli-binary-format",
+      "raw-in-base64-out",
+      "/dev/stdout",
+    ]);
+    expect(reply.code, `invoke-agent-runtime failed:\n${reply.stderr.slice(-2000)}`).toBe(0);
+
+    // The reply is the invoke stream in AgentCore's streaming form — the HTTP channel's SSE, reused
+    // wholesale (agentcore.ts). A turn that reached a terminal is what proves the container served.
+    expect(reply.stdout, `the runtime returned no completed terminal:\n${reply.stdout.slice(0, 600)}`).toContain(
+      '"type":"completed"',
+    );
+  }, 1_800_000);
+});

--- a/test/live/agentcore-deploy.live.test.ts
+++ b/test/live/agentcore-deploy.live.test.ts
@@ -1,24 +1,39 @@
 /**
  * A real AgentCore deployment, created and destroyed: `deploy agentcore --run` builds and pushes an
- * image to ECR, creates the state bucket, and converges a CloudFormation stack holding a Bedrock
- * AgentCore runtime, a forwarder Lambda with a Function URL, its IAM roles, and any schedule rules.
+ * image to ECR, then converges a CloudFormation stack holding a Bedrock AgentCore runtime and its
+ * execution role.
+ *
+ * THE FIXTURE DECLARES NO CHANNEL AND NO SCHEDULE, and that is what the topology follows from: with
+ * `needsForwarder` false (deploy.ts) there is no forwarder Lambda, no Function URL, no EventBridge
+ * rule and no state bucket — the driver skips creating one. The template's forwarder half is proven
+ * to PARSE by agentcore.live.test.ts, whose fixture turns it on; what this probe adds is that the
+ * minimal stack really converges and really serves. Teardown still sweeps the bucket, because the
+ * name is deterministic and a topology change here must not start leaking one.
  *
  * This host shares nothing with the fly/railway probes but the intent. There is NO public URL to curl:
  * AgentCore exposes `POST /invocations` behind `InvokeAgentRuntime`, an IAM-signed AWS API. So the
- * check that the deployment WORKS is the one the driver itself makes — a `checkpoint` envelope through
- * `aws bedrock-agentcore invoke-agent-runtime`, read back with the driver's own `parseCheckpointReply`.
+ * check that the deployment WORKS goes through that API — an `invoke` envelope, not the driver's
+ * `checkpoint`; the reason it cannot be a checkpoint is on the assertion itself.
  *
  * TEARDOWN IS THREE PLACES, and the product offers none of them: `delete-stack` is used only to clear
  * a ROLLBACK_COMPLETE husk. The state bucket and the ECR repository are created OUTSIDE the stack on
  * purpose — `plan.ts` says why: so a `delete-stack` "cannot take the agent's memory with it". Correct
- * for an operator, which makes cleanup this probe's own job: stack, then bucket (versioned, so every
- * version must go before the bucket will), then repository (with its images).
+ * for an operator, which makes cleanup this probe's own job: stack, then bucket, then repository (with
+ * its images).
  *
  * COSTS REAL RESOURCES and is the slowest probe here — a stack create plus delete is minutes.
  *
- * Needs AWS credentials scoped to the `fastagent-live-probe-*` namespace (see the IAM policy in the
- * `live` environment), a model credential, and the `aws` CLI. The directory name carries NO
- * `fastagent-` prefix: the driver adds one to every resource it names.
+ * Needs AWS credentials, a model credential, and the `aws` CLI. The IAM policy in the `live`
+ * environment must cover FOUR name shapes, because the driver derives each differently from the same
+ * directory name (`live-probe-<uuid8>`) — a policy written for the stack pattern alone rejects the
+ * bucket, the repository or the runtime, and does it only AFTER the image is built and pushed:
+ *
+ *   stack       `fastagent-live-probe-*`      (the driver prefixes `fastagent-`)
+ *   bucket      `fa-live-probe-*-<account>`   (stateBucketName: `fa-` prefix, account suffix)
+ *   repository  `fastagent/live-probe-*`      (a SLASH, not a hyphen)
+ *   runtime     `live_probe_*`                (toRuntimeName: underscores, no prefix at all)
+ *
+ * The directory name carries no `fastagent-` prefix of its own: the driver adds one.
  */
 import { randomUUID } from "node:crypto";
 import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -27,7 +42,7 @@ import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { agentcoreName, ingressSessionId, stateBucketName } from "../../src/deploy/agentcore/plan.ts";
 import { parseStackOutputs } from "../../src/deploy/agentcore/run.ts";
-import { CLI, liveVersion, requireEnv, run } from "./env.ts";
+import { CLI, aws, liveVersion, requireEnv, run } from "./env.ts";
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 requireEnv("AWS_ACCESS_KEY_ID", "an AWS key scoped to fastagent-live-probe-* (this probe creates real resources)");
@@ -42,16 +57,6 @@ const REPO = `fastagent/${NAME}`;
 
 let workspace = "";
 let account = "";
-
-async function aws(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
-  try {
-    const { stdout, stderr } = await run("aws", args);
-    return { code: 0, stdout, stderr };
-  } catch (error) {
-    const e = error as { code?: number; stdout?: string; stderr?: string };
-    return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
-  }
-}
 
 beforeAll(async () => {
   const identity = await aws(["sts", "get-caller-identity", "--output", "json"]);
@@ -100,30 +105,35 @@ afterAll(async () => {
     STACK,
   ]);
   if (account) {
-    // The bucket has versioning ON (run.ts enables it), so `rb --force` alone leaves delete markers
-    // behind and the bucket refuses to go. Object versions must be removed first.
+    // UNREACHED BY THIS FIXTURE: with `needsForwarder` false the driver creates no bucket, so every
+    // call below answers NoSuchBucket and the emptying path never runs. It is kept because the name is
+    // deterministic and one line in the fixture (a channel, a schedule, `selfSchedule`) turns the
+    // bucket on — at which point a teardown that had not been written would leak it silently.
+    //
+    // What it must do then: the bucket has versioning ON (run.ts enables it), so `s3 rm` does not empty
+    // it — it writes a DELETE MARKER per object. Markers are not Versions (they come back under their
+    // own key), and a bucket still holding either refuses to go with BucketNotEmpty, which is not one
+    // of the tolerated patterns above. Both lists, or the bucket leaks holding the model credential seed.
     const bucket = stateBucketName(NAME, account);
     await attempt("s3 rm", ["s3", "rm", `s3://${bucket}`, "--recursive"]);
-    const versions = await aws([
-      "s3api",
-      "list-object-versions",
-      "--bucket",
-      bucket,
-      "--query",
-      "{Objects: Versions[].{Key:Key,VersionId:VersionId}}",
-      "--output",
-      "json",
-    ]);
-    if (versions.code === 0) {
-      const payload = JSON.parse(versions.stdout) as { Objects?: unknown[] | null };
-      if (Array.isArray(payload.Objects) && payload.Objects.length > 0) {
+    const listed = await aws(["s3api", "list-object-versions", "--bucket", bucket, "--output", "json"]);
+    if (listed.code === 0) {
+      const payload = JSON.parse(listed.stdout) as {
+        Versions?: { Key: string; VersionId: string }[];
+        DeleteMarkers?: { Key: string; VersionId: string }[];
+      };
+      const objects = [...(payload.Versions ?? []), ...(payload.DeleteMarkers ?? [])].map(({ Key, VersionId }) => ({
+        Key,
+        VersionId,
+      }));
+      if (objects.length > 0) {
         await attempt("s3api delete-objects", [
           "s3api",
           "delete-objects",
           "--bucket",
           bucket,
           "--delete",
-          JSON.stringify({ Objects: payload.Objects }),
+          JSON.stringify({ Objects: objects }),
         ]);
       }
     }

--- a/test/live/agentcore-deploy.live.test.ts
+++ b/test/live/agentcore-deploy.live.test.ts
@@ -21,7 +21,7 @@
  * `fastagent-` prefix: the driver adds one to every resource it names.
  */
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -170,6 +170,9 @@ describe("deploy agentcore --run: a real stack, provisioned and destroyed", () =
     // public `invoke` kind is served" (agentcore.ts). A checkpoint here answers 403 from the container.
     // It is also the better assertion: `invoke` runs a real turn, the same thing the fly and railway
     // probes POST for.
+    // A real file, NOT /dev/stdout: this CLI writes the response body to the positional argument, and
+    // on a runner whose stdout is a pipe Actions owns, opening it answers "No such device or address".
+    const out = join(workspace, "invoke-reply.json");
     const payload = join(workspace, "invoke.json");
     await writeFile(
       payload,
@@ -186,14 +189,13 @@ describe("deploy agentcore --run: a real stack, provisioned and destroyed", () =
       `file://${payload}`,
       "--cli-binary-format",
       "raw-in-base64-out",
-      "/dev/stdout",
+      out,
     ]);
     expect(reply.code, `invoke-agent-runtime failed:\n${reply.stderr.slice(-2000)}`).toBe(0);
+    const body = await readFile(out, "utf8");
 
     // The reply is the invoke stream in AgentCore's streaming form — the HTTP channel's SSE, reused
     // wholesale (agentcore.ts). A turn that reached a terminal is what proves the container served.
-    expect(reply.stdout, `the runtime returned no completed terminal:\n${reply.stdout.slice(0, 600)}`).toContain(
-      '"type":"completed"',
-    );
+    expect(body, `the runtime returned no completed terminal:\n${body.slice(0, 600)}`).toContain('"type":"completed"');
   }, 1_800_000);
 });

--- a/test/live/agentcore.live.test.ts
+++ b/test/live/agentcore.live.test.ts
@@ -1,0 +1,116 @@
+/**
+ * What AWS actually answers, checked against the assumptions the AgentCore driver makes about it.
+ * `deploy-agentcore-run.test.ts` drives the whole deploy against a fake `CliRunner`; that covers the
+ * orchestration and cannot cover the belief.
+ *
+ * READ-ONLY, and unlike the fly/railway pair this one carries real weight on its own: the generated
+ * CloudFormation template is ~900 lines of YAML this repo emits by hand, and `validate-template` is
+ * CloudFormation's own parser saying whether it would accept it — for free, in a second, without
+ * creating anything. The deploy probe next door proves the stack CONVERGES; this proves the template
+ * is well-formed even when nobody wants to wait eight minutes.
+ *
+ * Needs `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` and the `aws` CLI. Nothing here
+ * creates a resource: STS identity, a template validation, and two describes against names that do
+ * not exist.
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { parseCheckpointReply, parseStackOutputs } from "../../src/deploy/agentcore/run.ts";
+import { TEMPLATE_FILE, agentcoreName, stateBucketName } from "../../src/deploy/agentcore/plan.ts";
+import { CLI, run, requireEnv } from "./env.ts";
+
+requireEnv("AWS_ACCESS_KEY_ID", "an AWS key for an account that can reach Bedrock AgentCore");
+requireEnv("AWS_SECRET_ACCESS_KEY", "the secret for AWS_ACCESS_KEY_ID");
+requireEnv("AWS_REGION", "a region where Bedrock AgentCore is available, e.g. us-east-1");
+
+/** One aws invocation, capturing the exit code rather than throwing: several assertions below are
+ *  ABOUT the failure (a name that does not exist must answer "not found", never "access denied"). */
+async function aws(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await run("aws", args);
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+/** Generated artifact dirs, removed however the run ends: this probe writes a template per run and
+ *  creates nothing in AWS, so the only thing it can leak is disk. */
+const dirs: string[] = [];
+afterAll(async () => {
+  for (const dir of dirs) await rm(dir, { recursive: true, force: true });
+});
+
+describe("aws CLI output still matches what the AgentCore driver reads", () => {
+  it("`sts get-caller-identity --output json` carries the Account the driver reads", async () => {
+    const { code, stdout } = await aws(["sts", "get-caller-identity", "--output", "json"]);
+    expect(code, `sts get-caller-identity failed: ${stdout}`).toBe(0);
+
+    // run.ts parses this inline (`JSON.parse(identity.stdout).Account`) and gates on a non-string.
+    // The account id is not cosmetic — it suffixes the state bucket, whose name is global.
+    const account = (JSON.parse(stdout) as { Account?: unknown }).Account;
+    expect(typeof account, "get-caller-identity no longer returns a string Account").toBe("string");
+    expect(stateBucketName(agentcoreName("fastagent-live-probe"), account as string)).toMatch(/^fa-[a-z0-9-]+-\d+$/);
+  });
+
+  it("CloudFormation accepts the template this repo generates", async () => {
+    // The generated template is emitted line by line in plan.ts. Offline tests assert what it
+    // CONTAINS; only CloudFormation can say whether it parses — and a template that does not is a
+    // deploy that fails after the image is already built and pushed.
+    // `live-probe-` and NOT `fastagent-`: the driver prefixes the directory name for every resource
+    // it creates (stack `fastagent-<name>`, repo `fastagent/<name>`, lambda
+    // `fastagent-<name>-forwarder`), so a directory already called `fastagent-...` yields
+    // `fastagent-fastagent-...` and escapes the IAM policy that scopes this credential.
+    const dir = await mkdtemp(join(tmpdir(), "live-probe-"));
+    dirs.push(dir);
+    await writeFile(join(dir, "persona.md"), "You are terse.\n");
+    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+    await writeFile(join(dir, "package.json"), `${JSON.stringify({ name: "p", private: true }, null, 2)}\n`);
+    // Generation only: `deploy agentcore` without --run writes artifacts and touches no AWS API.
+    const generated = await run(process.execPath, [CLI, "deploy", "agentcore"], dir);
+    expect(generated.stderr, "generation did not write a template").toContain(TEMPLATE_FILE);
+
+    const validated = await aws([
+      "cloudformation",
+      "validate-template",
+      "--template-body",
+      `file://${join(dir, TEMPLATE_FILE)}`,
+    ]);
+    expect(validated.code, `CloudFormation rejected the generated template:\n${validated.stderr}`).toBe(0);
+  });
+
+  it("a stack and a repository that do not exist answer 'not found', not 'denied'", async () => {
+    // The driver's check-then-act reads these two failures as "absent, go create". If the credential
+    // ever loses the permission instead, the same non-zero exit would send it into create — so what
+    // the failure SAYS is what separates a first deploy from a broken key.
+    const stack = await aws(["cloudformation", "describe-stacks", "--stack-name", "fastagent-live-probe-absent"]);
+    expect(stack.code).not.toBe(0);
+    expect(stack.stderr, `describe-stacks on a missing stack now says: ${stack.stderr}`).toMatch(
+      /does not exist|ValidationError/i,
+    );
+
+    const repo = await aws(["ecr", "describe-repositories", "--repository-names", "fastagent/live-probe-absent"]);
+    expect(repo.code).not.toBe(0);
+    expect(repo.stderr, `describe-repositories on a missing repo now says: ${repo.stderr}`).toMatch(
+      /RepositoryNotFound/i,
+    );
+  });
+
+  it("the two output readers hold their shapes", async () => {
+    // `describe-stacks --query "Stacks[0].Outputs"` on a real stack is the deploy probe's business;
+    // here the readers are pinned against the shapes AWS documents, including the empty answers the
+    // driver must not mistake for success.
+    expect(parseStackOutputs('[{"OutputKey":"RuntimeArn","OutputValue":"arn:aws:x"}]')).toEqual({
+      RuntimeArn: "arn:aws:x",
+    });
+    // A stack with no Outputs answers `null`, which must read as "no RuntimeArn" (the driver gates).
+    expect(parseStackOutputs("null")).toEqual({});
+    expect(parseCheckpointReply('{"written":true}')).toEqual({ written: true, reason: undefined });
+    // Malformed must NOT read as a successful checkpoint — the comment on it says exactly this.
+    expect(parseCheckpointReply("not json")).toBeUndefined();
+    expect(parseCheckpointReply('{"ok":true}')).toBeUndefined();
+  });
+});

--- a/test/live/agentcore.live.test.ts
+++ b/test/live/agentcore.live.test.ts
@@ -3,39 +3,26 @@
  * `deploy-agentcore-run.test.ts` drives the whole deploy against a fake `CliRunner`; that covers the
  * orchestration and cannot cover the belief.
  *
- * READ-ONLY, and unlike the fly/railway pair this one carries real weight on its own: the generated
- * CloudFormation template is ~900 lines of YAML this repo emits by hand, and `validate-template` is
- * CloudFormation's own parser saying whether it would accept it — for free, in a second, without
- * creating anything. The deploy probe next door proves the stack CONVERGES; this proves the template
- * is well-formed even when nobody wants to wait eight minutes.
+ * READ-ONLY, and unlike the fly/railway pair this one carries real weight on its own: the CloudFormation
+ * template is YAML this repo emits line by line, and `validate-template` is CloudFormation's own parser
+ * saying whether it would accept it — for free, in a second, without creating anything. The deploy probe
+ * next door proves the stack CONVERGES; this proves the template is well-formed even when nobody wants
+ * to wait eight minutes.
  *
  * Needs `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` and the `aws` CLI. Nothing here
  * creates a resource: STS identity, a template validation, and two describes against names that do
  * not exist.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { parseCheckpointReply, parseStackOutputs } from "../../src/deploy/agentcore/run.ts";
 import { TEMPLATE_FILE, agentcoreName, stateBucketName } from "../../src/deploy/agentcore/plan.ts";
-import { CLI, run, requireEnv } from "./env.ts";
+import { CLI, aws, run, requireEnv } from "./env.ts";
 
 requireEnv("AWS_ACCESS_KEY_ID", "an AWS key for an account that can reach Bedrock AgentCore");
 requireEnv("AWS_SECRET_ACCESS_KEY", "the secret for AWS_ACCESS_KEY_ID");
 requireEnv("AWS_REGION", "a region where Bedrock AgentCore is available, e.g. us-east-1");
-
-/** One aws invocation, capturing the exit code rather than throwing: several assertions below are
- *  ABOUT the failure (a name that does not exist must answer "not found", never "access denied"). */
-async function aws(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
-  try {
-    const { stdout, stderr } = await run("aws", args);
-    return { code: 0, stdout, stderr };
-  } catch (error) {
-    const e = error as { code?: number; stdout?: string; stderr?: string };
-    return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
-  }
-}
 
 /** Generated artifact dirs, removed however the run ends: this probe writes a template per run and
  *  creates nothing in AWS, so the only thing it can leak is disk. */
@@ -67,7 +54,18 @@ describe("aws CLI output still matches what the AgentCore driver reads", () => {
     const dir = await mkdtemp(join(tmpdir(), "live-probe-"));
     dirs.push(dir);
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+    // selfSchedule AND a schedule file, so the branch that carries the YAML most likely to be wrong is
+    // the one CloudFormation reads: a bare agent emits ~100 lines and NONE of the forwarder Lambda, its
+    // Function URL, the two Lambda permissions, the wake/scheduler IAM roles or an
+    // `AWS::Scheduler::Schedule`. This fixture emits all of them and still creates nothing.
+    await writeFile(
+      join(dir, "fastagent.config.mjs"),
+      `export default { model: "openai-codex/gpt-5.5", selfSchedule: true };\n`,
+    );
+    // A plain default export, not `defineSchedule(...)`: loadSchedules validates the SHAPE, and this
+    // fixture has no node_modules to import the package's helper from.
+    await mkdir(join(dir, "schedules"), { recursive: true });
+    await writeFile(join(dir, "schedules", "nightly.mjs"), `export default { cron: "0 3 * * *", prompt: "probe" };\n`);
     await writeFile(join(dir, "package.json"), `${JSON.stringify({ name: "p", private: true }, null, 2)}\n`);
     // Generation only: `deploy agentcore` without --run writes artifacts and touches no AWS API.
     const generated = await run(process.execPath, [CLI, "deploy", "agentcore"], dir);
@@ -97,20 +95,5 @@ describe("aws CLI output still matches what the AgentCore driver reads", () => {
     expect(repo.stderr, `describe-repositories on a missing repo now says: ${repo.stderr}`).toMatch(
       /RepositoryNotFound/i,
     );
-  });
-
-  it("the two output readers hold their shapes", async () => {
-    // `describe-stacks --query "Stacks[0].Outputs"` on a real stack is the deploy probe's business;
-    // here the readers are pinned against the shapes AWS documents, including the empty answers the
-    // driver must not mistake for success.
-    expect(parseStackOutputs('[{"OutputKey":"RuntimeArn","OutputValue":"arn:aws:x"}]')).toEqual({
-      RuntimeArn: "arn:aws:x",
-    });
-    // A stack with no Outputs answers `null`, which must read as "no RuntimeArn" (the driver gates).
-    expect(parseStackOutputs("null")).toEqual({});
-    expect(parseCheckpointReply('{"written":true}')).toEqual({ written: true, reason: undefined });
-    // Malformed must NOT read as a successful checkpoint — the comment on it says exactly this.
-    expect(parseCheckpointReply("not json")).toBeUndefined();
-    expect(parseCheckpointReply('{"ok":true}')).toBeUndefined();
   });
 });

--- a/test/live/env.ts
+++ b/test/live/env.ts
@@ -40,6 +40,19 @@ export const run = (file: string, args: string[], cwd?: string) =>
 /** The product entry every deploy probe drives, spawned as `process.execPath [CLI, …]`. */
 export const CLI = fileURLToPath(new URL("../../src/cli.ts", import.meta.url));
 
+/** One `aws` invocation, returning the exit code instead of throwing on it. The AgentCore probes both
+ *  need that: several assertions are ABOUT the failure (a name that does not exist must answer "not
+ *  found", never "access denied"), and teardown must attempt every deletion even after one fails. */
+export async function aws(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await run("aws", args);
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
 /** POST one turn to a deployed agent and return its SSE events (the built-in `/invoke`, mounted
  *  because no channel is declared). Same reduction test/http.test.ts uses; `JSON.parse` is
  *  deliberately unguarded, since a payload that is not an event is a broken wire format, not a case to

--- a/test/live/railway.live.test.ts
+++ b/test/live/railway.live.test.ts
@@ -64,8 +64,17 @@ let createdProject = "";
 
 afterAll(async () => {
   if (!createdProject) return;
-  const deleted = await railway(["delete", "--yes", "--project", createdProject], tmpdir());
-  // Loud: a project left behind is one an operator has to find and remove by hand.
+  // `delete --project` takes an ID, not a name (the assertion below says so, and railway-deploy's
+  // teardown and the workflow sweep both resolve one first) — so the id is looked up here too.
+  // `== null`, not `=== null`: a MISSING deletedAt must read as alive, so it ends in a delete attempt
+  // that fails loudly rather than in a silent skip.
+  const listed = await railway(["list", "--json"], tmpdir());
+  const projects = parseJson<{ id?: string; name?: string; deletedAt?: string | null }[]>(listed.stdout, "list --json");
+  const mine = projects.find((p) => p.name === createdProject && p.deletedAt == null);
+  // Loud in both directions: a project left behind is one an operator has to find and remove by hand,
+  // and a list this probe cannot find its own project in is the same leak wearing a clean exit.
+  if (!mine?.id) throw new Error(`could not find ${createdProject} to delete: ${listed.stdout.slice(0, 300)}`);
+  const deleted = await railway(["delete", "--yes", "--project", mine.id], tmpdir());
   if (deleted.code !== 0) throw new Error(`could not delete ${createdProject}: ${deleted.stderr.trim()}`);
 }, 120_000);
 

--- a/test/live/railway.live.test.ts
+++ b/test/live/railway.live.test.ts
@@ -7,9 +7,15 @@
  * comments, and the CLI is past 5.45. A version pin in a comment is exactly the kind of claim that
  * stops being true without anything going red — this file is what makes it go red.
  *
- * READ-ONLY. The write half lives in railway-deploy.live.test.ts, because `railway domain` MINTS a
- * domain when the service has none (it is the driver's getter and its allocator at once), so there is
- * no way to observe that one without provisioning something to observe it on.
+ * The shape half. The DEPLOY half lives in railway-deploy.live.test.ts, because `railway domain`
+ * MINTS a domain when the service has none (it is the driver's getter and its allocator at once), so
+ * there is no way to observe that one without provisioning something to observe it on.
+ *
+ * This one creates an EMPTY project — no service, no build, no deploy — reads the shapes against it,
+ * and deletes it. It used to link whatever live project the account happened to hold, to stay purely
+ * read-only. That is a probe reaching for something that is not its own: once the account held no
+ * leftover probe project, it linked the operator's REAL one and failed against it. A probe owns what
+ * it asserts against.
  *
  * Needs `RAILWAY_API_TOKEN` — the ACCOUNT-scoped token, not the project-scoped `RAILWAY_TOKEN` a
  * Railway project hands out. The driver never reads it: it assumes an operator who ran `railway login`
@@ -17,11 +23,12 @@
  * session.
  */
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { isLinked, linkedName, parseHasVolume } from "../../src/deploy/railway/run.ts";
 import { requireEnv } from "./env.ts";
 
@@ -50,6 +57,17 @@ function parseJson<T>(stdout: string, what: string): T {
     throw new Error(`\`railway ${what}\` did not return JSON (${String(error)}): ${stdout.slice(0, 300)}`);
   }
 }
+
+/** The empty project the shape test owns. Named like the deploy probe's so one sweep finds both. */
+const shapeProject = `fastagent-live-${randomUUID().slice(0, 8)}`;
+let createdProject = "";
+
+afterAll(async () => {
+  if (!createdProject) return;
+  const deleted = await railway(["delete", "--yes", "--project", createdProject], tmpdir());
+  // Loud: a project left behind is one an operator has to find and remove by hand.
+  if (deleted.code !== 0) throw new Error(`could not delete ${createdProject}: ${deleted.stderr.trim()}`);
+}, 120_000);
 
 describe("railway CLI output still matches what the Railway driver reads", () => {
   it("an UNLINKED directory leaves stdout empty — the whole basis of isLinked", async () => {
@@ -86,27 +104,26 @@ describe("railway CLI output still matches what the Railway driver reads", () =>
   });
 
   it("`linkedName` and `parseHasVolume` read a linked project's shape", async () => {
-    // Against a project this probe did NOT create: both readers are pure, and linking is local state
-    // (a file in the directory), so nothing here writes to the account.
-    const projects = parseJson<{ name?: string; deletedAt?: string | null }[]>(
-      (await railway(["list", "--json"], tmpdir())).stdout,
-      "list --json",
-    );
-    const alive = projects.find((p) => p.deletedAt === null && typeof p.name === "string")?.name;
-    expect(alive, "this Railway account holds no live project to read against — create one").toBeTruthy();
+    // `init` both creates and links, in the directory it runs from.
+    const created = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
+    const init = await railway(["init", "--name", shapeProject], created);
+    expect(init.code, `could not create ${shapeProject}: ${init.stderr.trim()}`).toBe(0);
+    createdProject = shapeProject;
 
+    // A SECOND directory, so `link` is exercised as its own command — it is what the driver runs, and
+    // the directory `init` linked would answer for it without it ever being called.
     const dir = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
     // `--environment` too: interactive `link` prompts for workspace, project AND environment, and the
     // docs' non-interactive form passes both. `production` is the environment Railway gives every new
     // project — a project that renamed it fails here by name rather than by an unreadable prompt.
-    const link = await railway(["link", "--project", alive as string, "--environment", "production"], dir);
-    expect(link.code, `could not link ${alive}: ${link.stderr.trim()}`).toBe(0);
+    const link = await railway(["link", "--project", shapeProject, "--environment", "production"], dir);
+    expect(link.code, `could not link ${shapeProject}: ${link.stderr.trim()}`).toBe(0);
 
     const status = await railway(["status", "--json"], dir);
     expect(isLinked(status.stdout), "a linked directory reads as unlinked").toBe(true);
     // `linkedName` only feeds a gate message, but a rename would make that message say "(name
     // unreadable)" about a project the operator can see by name in their dashboard.
-    expect(linkedName(status.stdout), "`name` is no longer at the top level of status --json").toBe(alive);
+    expect(linkedName(status.stdout), "`name` is no longer at the top level of status --json").toBe(shapeProject);
 
     // `parseHasVolume` is shape-agnostic (any JSON string equal to the mount path), so what it needs is
     // for mount paths to keep appearing as strings at all. Asserted in both directions against the


### PR DESCRIPTION
Phase 4's last host. AgentCore shares nothing with fly and railway but the intent: there is no public URL — it serves `POST /invocations` behind `InvokeAgentRuntime`, an IAM-signed AWS API — and the product offers no destroy entry point at all, because the state bucket and the ECR repository are created OUTSIDE the CloudFormation stack on purpose (`plan.ts`: so a `delete-stack` "cannot take the agent's memory with it"). Correct for an operator; this probe's own job here.

**`agentcore.live.test.ts`** (read-only, ~4s) carries weight on its own. The generated template is ~900 lines of YAML this repo emits line by line; offline tests assert what it CONTAINS, and only CloudFormation can say whether it parses. `validate-template` answers that for free, creating nothing — and a template that does not parse is a deploy that fails after the image is built and pushed.

**`agentcore-deploy.live.test.ts`** provisions the stack, the ECR repository and the state bucket, runs a turn through `InvokeAgentRuntime`, and destroys all three. The bucket is versioned, so every version goes before the bucket will.

Three things only running it could find:

- **`docker push` needs `ecr:BatchGetImage` and `ecr:GetDownloadUrlForLayer`.** It HEADs the manifest before pushing. Those calls belong to the registry API, not to us, so no reading of `run.ts` would have listed them.
- **The probe sends an `invoke` envelope, not the driver's `checkpoint`.** An agent with no channel gets no forwarder, and without a forwarder there is no `FASTAGENT_INGRESS_SECRET`; the adapter then serves the public kind alone ("Undefined = nothing can be trusted"). A checkpoint answers 403 from the container. `invoke` is also the better assertion — it runs a real turn.
- **`/dev/stdout` cannot be opened on a runner** whose stdout Actions owns. The driver passes it to `invoke-agent-runtime`, which writes the response body to that path; the probe writes to a file in its workspace instead.

The workflow sweep reads names the probe writes BEFORE creating anything, rather than listing stacks: the IAM policy scopes this credential to `fastagent-live-probe-*`, and widening it to enumerate every stack in the account so a cleanup can find its own two is the wrong trade.

**Also here:** the railway shape probe now owns the project it reads. It used to link whatever live project the account happened to hold, to stay purely read-only — which held only while there was a leftover probe project to borrow. Once the deploy probe's cleanup caught up, the newest live project was the operator's real one, and the probe linked that and failed against it. It now creates an empty project (no service, no build, no deploy), reads against it, and deletes it.

CI: 14 files / 27 tests green, 553s.
