### PR TITLE
fix(deploy): registration budget outlasts a host's start-up, and four retry loops become one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,12 @@ src/
 │   ├── wait-health.ts       # readiness probe for a server THIS process reaches directly (deploy's
 │   │                     # published local port). NOT for a public URL a platform must reach: the
 │   │                     # registrars let the platform's own URL verification be the probe (#421)
-│   ├── registration.ts      # SHARED registrar outcome (registered|manual|failed) + the one warm-up
-│   │                     # budget every registrar spends on the platform's own URL check — same reason
+│   ├── registration.ts      # SHARED registrar outcome (registered|manual|failed) + the ONE retry loop
+│   │                     # every registrar spends its warm-up budget through (retryWhile). Each platform
+│   │                     # keeps only what differs: which errors mean "not reachable YET" and what a
+│   │                     # final failure MEANS (one's terminal state is another's `manual`). Two budgets,
+│   │                     # because a tunnel is live when its URL prints and a deploy is not — a registrar
+│   │                     # that gives up first GATES the deploy (#428) — same reason
 │   ├── kit/                 # WRITING a channel — the parts every chat platform needs and none should
 │   │   │                     # reinvent. The split from the mechanism beside it is a FACT about
 │   │   │                     # imports, asserted in package-boundary.test.ts: every file here has

--- a/src/channels/feishu/register-webhook.ts
+++ b/src/channels/feishu/register-webhook.ts
@@ -27,8 +27,9 @@ import { createFeishuApi, isFeishuConfigApiMissing, isTransientFeishuRegistratio
 
 /**
  * Register `<baseUrl>/<kind>` as the app's event Request URL (webhook mode). Missing credentials print
- * the manual instruction instead of failing. `opts` exist for tests: the attempt budget + `apiBase` (a
- * fake platform — production derives it from the kind).
+ * the manual instruction instead of failing. `opts` carries the attempt budget — `--tunnel` takes the
+ * default, `deploy --run` passes `DEPLOY_REGISTRATION_ATTEMPTS` (a host starts slower than a tunnel) —
+ * plus `apiBase`, which is a test's fake platform (production derives it from the kind).
  *
  * Reports its outcome as a {@link RegistrationOutcome} fact; gating policy belongs to the caller.
  */

--- a/src/channels/feishu/register-webhook.ts
+++ b/src/channels/feishu/register-webhook.ts
@@ -20,9 +20,8 @@
  * platform ships it, registration starts working with no change here) and names the real cause in the
  * fallback instead of blaming the app's scopes.
  */
-import { setTimeout as sleep } from "node:timers/promises";
 import { log } from "../../log.ts";
-import { REGISTRATION_ATTEMPTS, REGISTRATION_RETRY_MS, type RegistrationOutcome } from "../registration.ts";
+import { retryWhile, type RegistrationOutcome } from "../registration.ts";
 import { type FeishuCloudKind, cloudFor } from "./cloud.ts";
 import { createFeishuApi, isFeishuConfigApiMissing, isTransientFeishuRegistrationError } from "./feishu-api.ts";
 
@@ -89,53 +88,49 @@ export async function registerFeishuWebhook(
   // with a challenge DURING the call, so its 210042 "request_url validation failed" is the readiness
   // signal and is retried with backoff, alongside transient network errors. Only a permanent config
   // error (missing scope, app under review, the intl 404) is reported once with the manual path.
-  const attempts = opts.attempts ?? REGISTRATION_ATTEMPTS;
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    if (attempt > 0) await sleep(opts.retryMs ?? REGISTRATION_RETRY_MS);
-    try {
-      await api.updateEventSubscription(appId, { subscriptionType: "webhook", requestUrl });
-      log.info(`[fastagent] ${kind}: event Request URL registered → ${requestUrl}`);
-      // Field-tested: a URL change applies immediately, but the MODE flip (the template's long
-      // connection → webhook) only takes effect when a version is published — the dispatcher serves
-      // the published snapshot, and version publishing has no open API. One console click, once.
-      log.info(
-        `[fastagent] ${kind}: if messages do not arrive, publish a version (one click, prompted) — the switch to webhook mode takes effect on publish: ${versionUrl}`,
+  try {
+    await retryWhile(
+      () => api.updateEventSubscription(appId, { subscriptionType: "webhook", requestUrl }),
+      isTransientFeishuRegistrationError,
+      {
+        attempts: opts.attempts,
+        retryMs: opts.retryMs,
+        onRetry: ({ attempt, attempts }) =>
+          log.info(
+            `[fastagent] ${kind}: the platform cannot verify ${requestUrl} yet (attempt ${attempt}/${attempts}); retrying…`,
+          ),
+      },
+    );
+    log.info(`[fastagent] ${kind}: event Request URL registered → ${requestUrl}`);
+    // Field-tested: a URL change applies immediately, but the MODE flip (the template's long
+    // connection → webhook) only takes effect when a version is published — the dispatcher serves
+    // the published snapshot, and version publishing has no open API. One console click, once.
+    log.info(
+      `[fastagent] ${kind}: if messages do not arrive, publish a version (one click, prompted) — the switch to webhook mode takes effect on publish: ${versionUrl}`,
+    );
+    return "registered";
+  } catch (e) {
+    // A 404 on the config route is the CLOUD lagging, not this app's configuration: the v7 API is
+    // live on open.feishu.cn but not yet on open.larksuite.com. Name that — "check your scopes"
+    // would send the operator hunting for a problem they cannot fix. It stays WARN: on that cloud the
+    // manual path is the known norm, not an exceptional failure.
+    if (isFeishuConfigApiMissing(e)) {
+      log.warn(
+        `[fastagent] ${kind}: this cloud (${apiBase}) returned HTTP 404 for the app-config API — ` +
+          `manual registration is required`,
       );
-      return "registered";
-    } catch (e) {
-      // A 404 on the config route is the CLOUD lagging, not this app's configuration: the v7 API is
-      // live on open.feishu.cn but not yet on open.larksuite.com. Name that — "check your scopes"
-      // would send the operator hunting for a problem they cannot fix.
-      if (isFeishuConfigApiMissing(e)) {
-        log.warn(
-          `[fastagent] ${kind}: this cloud (${apiBase}) returned HTTP 404 for the app-config API — ` +
-            `manual registration is required`,
-        );
-        manualRegistration();
-        return "manual"; // that cloud has no config API — the manual path is the norm there
-      }
-      if (!isTransientFeishuRegistrationError(e)) {
-        log.error(
-          `[fastagent] ${kind}: could not register the event URL (${String(e)}). ` +
-            `The app may lack the "application:application:patch" scope (console → Permissions) or be under review; manual registration is available below.`,
-        );
-        manualRegistration();
-        return "failed";
-      }
-      // The wait is otherwise silent for over a minute, which reads as a hang (`dev --tunnel`).
-      if (attempt + 1 < attempts) {
-        log.info(
-          `[fastagent] ${kind}: the platform cannot verify ${requestUrl} yet (attempt ${attempt + 1}/${attempts}); retrying…`,
-        );
-      }
+      manualRegistration();
+      return "manual"; // that cloud has no config API — the manual path is the norm there
     }
+    // Exhausted retries end in the same state as a permanent config error (event URL not registered,
+    // manual action required) — report at the same level.
+    log.error(
+      isTransientFeishuRegistrationError(e)
+        ? `[fastagent] ${kind}: the platform could not verify ${requestUrl} after retries — manual registration is required`
+        : `[fastagent] ${kind}: could not register the event URL (${String(e)}). ` +
+            `The app may lack the "application:application:patch" scope (console → Permissions) or be under review; manual registration is available below.`,
+    );
+    manualRegistration();
+    return "failed";
   }
-  // Exhausted retries end in the same state as a permanent error (event URL not registered, manual
-  // action required) — report at the same level. The cloud-lag 404 above stays warn: on that cloud the
-  // manual path is the known norm, not an exceptional failure.
-  log.error(
-    `[fastagent] ${kind}: the platform could not verify ${requestUrl} after retries — manual registration is required`,
-  );
-  manualRegistration();
-  return "failed";
 }

--- a/src/channels/registration.ts
+++ b/src/channels/registration.ts
@@ -31,8 +31,16 @@ export const REGISTRATION_RETRY_MS = 10_000;
  * domain's DNS all happen after that, and railway-deploy.live.test.ts allows 180s for exactly this.
  * Registration failure GATES the deploy (registration-gate.ts), so a budget shorter than the host's
  * own start-up turns a working deployment into a re-run instruction.
+ *
+ * N attempts buy (N - 1) waits — {@link retryWhile} only waits BETWEEN calls — so 180s of patience is
+ * 19, not 18. At 18 the last call went out at t=170s and a host that started answering in the final
+ * ten seconds was still reported as a deploy to re-run.
  */
-export const DEPLOY_REGISTRATION_ATTEMPTS = 18;
+export const DEPLOY_REGISTRATION_ATTEMPTS = 19;
+
+/** Sleep on the GLOBAL timer (not `node:timers/promises`) so tests can drive it with fake timers — the
+ *  same reason feishu-api.ts does. What must happen BEFORE this wait is the point of `onRetry`. */
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Call, and while `retryable` says the failure is the platform not reaching the URL YET, call again —
@@ -44,10 +52,6 @@ export const DEPLOY_REGISTRATION_ATTEMPTS = 18;
  * `add slack` also drops its duplicate-guard marker so it never spans a sleep. The last error is
  * thrown, so a caller can tell "still unreachable" from "a config error" in one place.
  */
-/** Sleep on the GLOBAL timer (not `node:timers/promises`) so tests can drive it with fake timers — the
- *  same reason feishu-api.ts does. What must happen BEFORE this wait is the point of `onRetry`. */
-const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
 export async function retryWhile<T>(
   call: () => Promise<T>,
   retryable: (error: unknown) => boolean,

--- a/src/channels/registration.ts
+++ b/src/channels/registration.ts
@@ -10,15 +10,62 @@
  *   unreachable) and a cloud without the config API (the Lark cloud-lag 404 — no re-run can ever
  *   register it; the console is the only path).
  * - "failed": this run ends with the webhook NOT registered, and acting + re-running can fix it
- *   (health timeout, a permanent config error, exhausted retries).
+ *   (a permanent config error, or the platform still unable to reach the URL when the retries ran out).
  */
 export type RegistrationOutcome = "registered" | "manual" | "failed";
 
 /**
- * SHARED: how long a registrar waits for the PLATFORM to be able to reach a freshly minted public URL
- * — 8 attempts 10s apart, so 70s of waiting. One judgement (a new tunnel/container's warm-up), so one
- * pair of numbers: telegram, feishu, slack registration and `add slack` all spend the same budget, and
- * it is part of `deploy --run`'s wall clock once per channel.
+ * SHARED: how long a registrar waits for the PLATFORM to be able to reach a freshly minted public URL.
+ * One judgement (a new tunnel's warm-up), so one pair of numbers — telegram, feishu, slack registration
+ * and `add slack` all spend it.
+ *
+ * Sized for a tunnel, which is live before its URL is printed, and applied by {@link retryWhile} as its
+ * default. A DEPLOY is slower and its callers pass {@link DEPLOY_REGISTRATION_ATTEMPTS} instead.
  */
-export const REGISTRATION_ATTEMPTS = 8;
+const REGISTRATION_ATTEMPTS = 8;
 export const REGISTRATION_RETRY_MS = 10_000;
+
+/**
+ * What `deploy --run` spends instead: 180s, because a host CLI returns before the deployment serves.
+ * `railway up --ci` returns when the BUILD ends — container start, healthcheck and a freshly minted
+ * domain's DNS all happen after that, and railway-deploy.live.test.ts allows 180s for exactly this.
+ * Registration failure GATES the deploy (registration-gate.ts), so a budget shorter than the host's
+ * own start-up turns a working deployment into a re-run instruction.
+ */
+export const DEPLOY_REGISTRATION_ATTEMPTS = 18;
+
+/**
+ * Call, and while `retryable` says the failure is the platform not reaching the URL YET, call again —
+ * the one retry loop every registrar spends {@link REGISTRATION_ATTEMPTS} through. Retryability and
+ * what a final failure MEANS stay with each platform (their vocabularies differ, and one registrar's
+ * terminal state is another's `"manual"`); the counting, the announcement and the wait do not.
+ *
+ * `onRetry` runs BEFORE the wait — registrars announce there (a silent minute reads as a hang), and
+ * `add slack` also drops its duplicate-guard marker so it never spans a sleep. The last error is
+ * thrown, so a caller can tell "still unreachable" from "a config error" in one place.
+ */
+/** Sleep on the GLOBAL timer (not `node:timers/promises`) so tests can drive it with fake timers — the
+ *  same reason feishu-api.ts does. What must happen BEFORE this wait is the point of `onRetry`. */
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function retryWhile<T>(
+  call: () => Promise<T>,
+  retryable: (error: unknown) => boolean,
+  options: {
+    attempts?: number;
+    retryMs?: number;
+    onRetry?: (info: { attempt: number; attempts: number; error: unknown }) => void;
+  } = {},
+): Promise<T> {
+  const attempts = options.attempts ?? REGISTRATION_ATTEMPTS;
+  const retryMs = options.retryMs ?? REGISTRATION_RETRY_MS;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await call();
+    } catch (error) {
+      if (attempt >= attempts || !retryable(error)) throw error;
+      options.onRetry?.({ attempt, attempts, error });
+      await wait(retryMs);
+    }
+  }
+}

--- a/src/channels/slack/config-api.ts
+++ b/src/channels/slack/config-api.ts
@@ -9,6 +9,17 @@ interface SlackErrorShape {
   errors?: { message?: string; pointer?: string }[];
 }
 
+/** One `errors[]` entry that means "Slack could not verify this URL", by either signal it may carry.
+ *  The pointer is the precise one but an INFERENCE — the only reply captured from the real API is the
+ *  PERMANENT shape error, which reports on the parent pointer (`/settings/event_subscriptions`). If the
+ *  unverifiable case reports there too, a pointer-only check would retry zero times and gate the deploy
+ *  immediately, which is the failure this whole path exists to prevent. So a message about VERIFICATION
+ *  (challenge wording included) counts as well, while one that merely names the field does not — the
+ *  captured permanent error says "Event Subscription requires a Request URL". */
+const rejectsRequestUrl = (e: { message?: string; pointer?: string }): boolean =>
+  e.pointer?.endsWith("/request_url") === true ||
+  (/request.?url/i.test(e.message ?? "") && /verif|challenge/i.test(e.message ?? ""));
+
 export class SlackConfigApiError extends Error {
   readonly code: string;
   readonly status: number;
@@ -35,21 +46,18 @@ export class SlackConfigApiError extends Error {
  * poll precedes these calls (#421). Slack validates the manifest BEFORE acting on it, so a call that
  * ends here changed nothing and is safe to repeat.
  *
- * Read from the STRUCTURE (`invalid_manifest` + which field), not the message: matching `request_url`
- * anywhere in the formatted string also matched errors that merely mention the field, and the message
- * is Slack's prose to reword at will.
+ * Read from the rejected FIELD (`invalid_manifest` + {@link rejectsRequestUrl}), not from `request_url`
+ * appearing anywhere in the formatted string: that also matched errors which merely mention the field.
  *
  * KNOWN IMPRECISION: this cannot separate "not reachable yet" from "this URL is unacceptable" — both
- * arrive on the same pointer, and the wording that would tell them apart has not been observed against
- * the real API, so guessing at it would risk never retrying at all. A permanently bad URL therefore
- * costs the full budget before it is reported. Every URL here is a tunnel's or a host's, so it is
- * well-formed https by construction; narrow this the day a real rejection is captured.
+ * arrive the same way, and the wording that would tell them apart has not been observed against the
+ * real API, so guessing at it would risk never retrying at all. A permanently bad URL therefore costs
+ * the full budget before it is reported. Every URL here is a tunnel's or a host's, so it is well-formed
+ * https by construction; narrow this the day a real rejection is captured.
  */
 export function isSlackRequestUrlUnverified(error: unknown): boolean {
   return (
-    error instanceof SlackConfigApiError &&
-    error.code === "invalid_manifest" &&
-    error.errors.some((e) => e.pointer?.endsWith("/request_url"))
+    error instanceof SlackConfigApiError && error.code === "invalid_manifest" && error.errors.some(rejectsRequestUrl)
   );
 }
 

--- a/src/channels/slack/config-api.ts
+++ b/src/channels/slack/config-api.ts
@@ -12,6 +12,9 @@ interface SlackErrorShape {
 export class SlackConfigApiError extends Error {
   readonly code: string;
   readonly status: number;
+  /** Kept, not just formatted into the message: which FIELD Slack rejected is how a caller tells a
+   *  not-yet-reachable URL from a malformed one, and a message match cannot see the difference. */
+  readonly errors: { message?: string; pointer?: string }[];
 
   constructor(method: string, status: number, data: SlackErrorShape, fallback: string) {
     const code = data.error ?? fallback;
@@ -22,17 +25,32 @@ export class SlackConfigApiError extends Error {
     this.name = "SlackConfigApiError";
     this.code = code;
     this.status = status;
+    this.errors = data.errors ?? [];
   }
 }
 
 /**
  * Whether a manifest call failed because Slack could not verify the `request_url` it carries — the
  * platform's own readiness verdict on a freshly minted public URL, and the reason no local `/health`
- * poll precedes these calls (#421). Slack validates the manifest BEFORE acting on it, so a create that
- * ends here created nothing and is safe to retry.
+ * poll precedes these calls (#421). Slack validates the manifest BEFORE acting on it, so a call that
+ * ends here changed nothing and is safe to repeat.
+ *
+ * Read from the STRUCTURE (`invalid_manifest` + which field), not the message: matching `request_url`
+ * anywhere in the formatted string also matched errors that merely mention the field, and the message
+ * is Slack's prose to reword at will.
+ *
+ * KNOWN IMPRECISION: this cannot separate "not reachable yet" from "this URL is unacceptable" — both
+ * arrive on the same pointer, and the wording that would tell them apart has not been observed against
+ * the real API, so guessing at it would risk never retrying at all. A permanently bad URL therefore
+ * costs the full budget before it is reported. Every URL here is a tunnel's or a host's, so it is
+ * well-formed https by construction; narrow this the day a real rejection is captured.
  */
 export function isSlackRequestUrlUnverified(error: unknown): boolean {
-  return /request_url|verify_request_url|failed to verify/i.test(String(error));
+  return (
+    error instanceof SlackConfigApiError &&
+    error.code === "invalid_manifest" &&
+    error.errors.some((e) => e.pointer?.endsWith("/request_url"))
+  );
 }
 
 async function slackJson<T>(
@@ -88,7 +106,9 @@ interface CreateManifestResponse {
   };
 }
 
-/** Create is intentionally single-attempt: an ambiguous response may already have created the app. */
+/** Single-attempt BY DESIGN: an ambiguous response may already have created the app, so this never
+ *  retries itself. The one repeatable failure — a `request_url` Slack could not verify, which it
+ *  rejects before creating anything — is retried by the caller ({@link isSlackRequestUrlUnverified}). */
 export async function createSlackApp(
   configToken: string,
   manifest: SlackAppManifest,

--- a/src/channels/slack/onboard.ts
+++ b/src/channels/slack/onboard.ts
@@ -139,7 +139,15 @@ export async function onboardSlackApp(
   authorize.searchParams.set("scope", slackBotScopes(state.groupBehavior).join(","));
   authorize.searchParams.set("redirect_uri", input.redirectUrl);
   authorize.searchParams.set("state", oauthState);
-  io.note(`Approve the internal app installation in Slack: ${authorize}`);
+  // Approving redirects the browser to the TUNNEL hostname, which THIS machine has to resolve — the
+  // one thing #421 says it can be a minute slower at than Slack's own resolver was a moment ago. The
+  // wait below then looks like a hang sitting next to a broken page, so say it before it happens.
+  io.note(
+    `Approve the internal app installation in Slack: ${authorize}\n` +
+      "If the page Slack returns to does not load, reload it after a few seconds — this machine can be " +
+      "slower to resolve the just-created tunnel hostname than Slack was. The approval is not spent " +
+      "until that page loads, so nothing is lost by reloading.",
+  );
   io.openUrl(authorize.toString());
 
   const callback = await io.waitForOAuth();

--- a/src/channels/slack/onboard.ts
+++ b/src/channels/slack/onboard.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { setTimeout as sleep } from "node:timers/promises";
-import { REGISTRATION_ATTEMPTS, REGISTRATION_RETRY_MS } from "../registration.ts";
+import { retryWhile } from "../registration.ts";
 import {
   createSlackApp,
   exchangeSlackOAuthCode,
@@ -34,32 +33,6 @@ export interface SlackOnboardInput {
   redirectUrl: string;
 }
 
-/**
- * Repeat a manifest call while Slack reports it cannot VERIFY the request_url it carries. Slack
- * challenges that URL from its own network during the call — the readiness signal #421 is about; the
- * machine running `add slack` often cannot reach the fresh tunnel hostname at all, so it is not the one
- * asked — and validates the whole manifest BEFORE acting on it, so a call that ends this way did
- * nothing. `onAttemptFailed` runs before the wait, which is how the create path keeps its duplicate-guard
- * marker on for exactly one in-flight call and off during the sleep. Any other failure propagates.
- */
-async function retryWhileUnverified<T>(
-  io: Pick<SlackOnboardIO, "note">,
-  budget: { attempts: number; retryMs: number },
-  call: () => Promise<T>,
-  onAttemptFailed: () => void = () => {},
-): Promise<T> {
-  for (let attempt = 1; ; attempt++) {
-    try {
-      return await call();
-    } catch (error) {
-      if (!isSlackRequestUrlUnverified(error) || attempt >= budget.attempts) throw error;
-      onAttemptFailed();
-      io.note(`Slack cannot reach the temporary setup URL yet (attempt ${attempt}/${budget.attempts}); retrying…`);
-      await sleep(budget.retryMs);
-    }
-  }
-}
-
 /** Create/resume one internal Slack app and complete its workspace OAuth installation. */
 export async function onboardSlackApp(
   input: SlackOnboardInput,
@@ -76,7 +49,17 @@ export async function onboardSlackApp(
   let state = input.state;
   const current = await currentSlackConfigToken(input.stateRoot, state);
   state = current.state;
-  const budget = { attempts: deps.attempts ?? REGISTRATION_ATTEMPTS, retryMs: deps.retryMs ?? REGISTRATION_RETRY_MS };
+  /** Slack challenges request_url from ITS network during a manifest call and validates the whole
+   *  manifest before acting, so an unverifiable URL created nothing and the call is safe to repeat. */
+  const whileUnverified = <T>(call: () => Promise<T>, onRetry?: () => void): Promise<T> =>
+    retryWhile(call, isSlackRequestUrlUnverified, {
+      attempts: deps.attempts,
+      retryMs: deps.retryMs,
+      onRetry: ({ attempt, attempts }) => {
+        onRetry?.();
+        io.note(`Slack cannot reach the temporary setup URL yet (attempt ${attempt}/${attempts}); retrying…`);
+      },
+    });
   const manifest = buildSlackManifest({
     name: state.appName,
     groupBehavior: state.groupBehavior,
@@ -98,9 +81,7 @@ export async function onboardSlackApp(
     };
     let created: Awaited<ReturnType<typeof createSlackApp>>;
     try {
-      created = await retryWhileUnverified(
-        io,
-        budget,
+      created = await whileUnverified(
         () => {
           // Record BEFORE the non-idempotent API call. A transport/internal failure may have created the
           // app; refusing a blind retry is safer than silently producing duplicates. The marker spans
@@ -140,9 +121,7 @@ export async function onboardSlackApp(
     }
     const appId = state.appId;
     io.note(`Resuming Slack app ${appId}; refreshing its temporary setup URLs…`);
-    await retryWhileUnverified(io, budget, () =>
-      (deps.updateManifest ?? updateSlackAppManifest)(current.token, appId, manifest),
-    );
+    await whileUnverified(() => (deps.updateManifest ?? updateSlackAppManifest)(current.token, appId, manifest));
   }
 
   if (state.signingSecret) {

--- a/src/channels/slack/onboard.ts
+++ b/src/channels/slack/onboard.ts
@@ -139,15 +139,9 @@ export async function onboardSlackApp(
   authorize.searchParams.set("scope", slackBotScopes(state.groupBehavior).join(","));
   authorize.searchParams.set("redirect_uri", input.redirectUrl);
   authorize.searchParams.set("state", oauthState);
-  // Approving redirects the browser to the TUNNEL hostname, which THIS machine has to resolve — the
-  // one thing #421 says it can be a minute slower at than Slack's own resolver was a moment ago. The
-  // wait below then looks like a hang sitting next to a broken page, so say it before it happens.
-  io.note(
-    `Approve the internal app installation in Slack: ${authorize}\n` +
-      "If the page Slack returns to does not load, reload it after a few seconds — this machine can be " +
-      "slower to resolve the just-created tunnel hostname than Slack was. The approval is not spent " +
-      "until that page loads, so nothing is lost by reloading.",
-  );
+  // The redirect lands on the tunnel hostname, which THIS machine may not resolve yet (#421) — a broken
+  // page beside a terminal that looks hung, unless the reload is named before it happens.
+  io.note(`Click Allow in Slack to install the app: ${authorize}\nIf the page it returns to does not load, reload it.`);
   io.openUrl(authorize.toString());
 
   const callback = await io.waitForOAuth();

--- a/src/channels/slack/register-webhook.ts
+++ b/src/channels/slack/register-webhook.ts
@@ -1,5 +1,4 @@
-import { setTimeout as sleep } from "node:timers/promises";
-import { REGISTRATION_ATTEMPTS, REGISTRATION_RETRY_MS, type RegistrationOutcome } from "../registration.ts";
+import { retryWhile, type RegistrationOutcome } from "../registration.ts";
 import { isSlackRequestUrlUnverified, updateSlackAppManifest } from "./config-api.ts";
 import { buildSlackManifest } from "./manifest.ts";
 import { currentSlackConfigToken, readSlackOnboardingState } from "./onboarding-state.ts";
@@ -55,46 +54,42 @@ export async function registerSlackWebhook(
   // Slack verifies the new request_url with a challenge DURING apps.manifest.update, from Slack's own
   // network — that verdict IS the readiness signal, so it is retried while a fresh tunnel/container
   // warms up. No local `/health` poll precedes it: this machine's reach is the wrong question (#421).
-  const attempts = options.attempts ?? REGISTRATION_ATTEMPTS;
-  let lastUnverified = "unknown error";
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    if (attempt > 0) await sleep(options.retryMs ?? REGISTRATION_RETRY_MS);
-    try {
-      await updateSlackAppManifest(
-        current.token,
-        current.state.appId as string,
-        buildSlackManifest({
-          name: current.state.appName,
-          groupBehavior: current.state.groupBehavior,
-          requestUrl: `${publicBaseUrl}/slack`,
-          // Token-rotation manifests require at least one OAuth redirect URL even after installation.
-          // Actual reinstall flows replace this placeholder with their one-shot local setup callback.
-          redirectUrl: `${publicBaseUrl}/slack/oauth/callback`,
-        }),
-        { apiBaseUrl: options.apiBaseUrl, fetch: options.fetch },
-      );
-      note(`[fastagent] slack: Event Subscriptions Request URL registered → ${publicBaseUrl}/slack`);
-      return "registered";
-    } catch (error) {
-      if (!isSlackRequestUrlUnverified(error)) {
-        note(
-          `[fastagent] slack: automatic Request URL registration failed: ${String(error)} — ` +
+  try {
+    await retryWhile(
+      () =>
+        updateSlackAppManifest(
+          current.token,
+          current.state.appId as string,
+          buildSlackManifest({
+            name: current.state.appName,
+            groupBehavior: current.state.groupBehavior,
+            requestUrl: `${publicBaseUrl}/slack`,
+            // Token-rotation manifests require at least one OAuth redirect URL even after installation.
+            // Actual reinstall flows replace this placeholder with their one-shot local setup callback.
+            redirectUrl: `${publicBaseUrl}/slack/oauth/callback`,
+          }),
+          { apiBaseUrl: options.apiBaseUrl, fetch: options.fetch },
+        ),
+      isSlackRequestUrlUnverified,
+      {
+        attempts: options.attempts,
+        retryMs: options.retryMs,
+        onRetry: ({ attempt, attempts }) =>
+          note(
+            `[fastagent] slack: Slack cannot verify ${publicBaseUrl}/slack yet (attempt ${attempt}/${attempts}); retrying…`,
+          ),
+      },
+    );
+    note(`[fastagent] slack: Event Subscriptions Request URL registered → ${publicBaseUrl}/slack`);
+    return "registered";
+  } catch (error) {
+    note(
+      isSlackRequestUrlUnverified(error)
+        ? `[fastagent] slack: Slack could not verify ${publicBaseUrl}/slack after retries (last error: ${String(error)}) — ` +
+            `once the app is up, ${consoleFallback}`
+        : `[fastagent] slack: automatic Request URL registration failed: ${String(error)} — ` +
             `re-run \`fastagent add slack --replace-config\` to repair the configuration tokens, or ${consoleFallback}`,
-        );
-        return "failed";
-      }
-      lastUnverified = String(error);
-      // The wait is otherwise silent for over a minute, which reads as a hang.
-      if (attempt + 1 < attempts) {
-        note(
-          `[fastagent] slack: Slack cannot verify ${publicBaseUrl}/slack yet (attempt ${attempt + 1}/${attempts}); retrying…`,
-        );
-      }
-    }
+    );
+    return "failed";
   }
-  note(
-    `[fastagent] slack: Slack could not verify ${publicBaseUrl}/slack after retries (last error: ${lastUnverified}) — ` +
-      `once the app is up, ${consoleFallback}`,
-  );
-  return "failed";
 }

--- a/src/channels/telegram/register-webhook.ts
+++ b/src/channels/telegram/register-webhook.ts
@@ -22,8 +22,8 @@ import { callApi } from "./telegram-api.ts";
  * reach the webhook — which carries its connection layer's words verbatim (`Bad Request: bad webhook:
  * Connection timed out` / `Connection refused` for a host whose DNS answers before anything listens,
  * `Wrong response from the webhook: 530` for a tunnel edge without its origin). This is the ONLY gate
- * between "wait 70s" and "fail now", so it is wide on the reachability side. A permanent "bad webhook"
- * — an http:// URL, an unsupported port — matches nothing here and is reported.
+ * between "spend the caller's retry budget" and "fail now", so it is wide on the reachability side.
+ * A permanent "bad webhook" — an http:// URL, an unsupported port — matches nothing here and is reported.
  */
 function isTransientRegistrationError(error: string): boolean {
   return /resolve host|getaddrinfo|ENOTFOUND|fetch failed|ECONNRESET|timeout|timed out|connection refused|can't connect|connection to the host|wrong response from the webhook/i.test(
@@ -33,8 +33,9 @@ function isTransientRegistrationError(error: string): boolean {
 
 /**
  * Register `<baseUrl>/telegram` as the bot's webhook (with the .env secret). Missing tokens print the
- * manual instruction instead of failing. `opts` (attempt budget) exist for tests; production uses the
- * defaults.
+ * manual instruction instead of failing. `opts` carries the attempt budget: `--tunnel` takes the
+ * default, `deploy --run` passes `DEPLOY_REGISTRATION_ATTEMPTS` (a host starts slower than a tunnel),
+ * and tests shrink it.
  *
  * Reports its outcome as a {@link RegistrationOutcome} fact; gating policy belongs to the caller.
  */

--- a/src/channels/telegram/register-webhook.ts
+++ b/src/channels/telegram/register-webhook.ts
@@ -12,9 +12,8 @@
  * verdicts ("Failed to resolve host", "Wrong response from the webhook") are retried, and only a
  * configuration error the operator must fix is reported once.
  */
-import { setTimeout as sleep } from "node:timers/promises";
 import { log } from "../../log.ts";
-import { REGISTRATION_ATTEMPTS, REGISTRATION_RETRY_MS, type RegistrationOutcome } from "../registration.ts";
+import { retryWhile, type RegistrationOutcome } from "../registration.ts";
 import { callApi } from "./telegram-api.ts";
 
 /**
@@ -54,33 +53,31 @@ export async function registerTelegramWebhook(
   }
 
   log.info(`[fastagent] telegram: registering the webhook — Telegram verifies ${webhookUrl} as it does…`);
-  let lastTransientError = "unknown transport error";
-  const attempts = opts.attempts ?? REGISTRATION_ATTEMPTS;
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    if (attempt > 0) await sleep(opts.retryMs ?? REGISTRATION_RETRY_MS);
-    try {
-      await callApi("https://api.telegram.org", botToken, "setWebhook", { url: webhookUrl, secret_token: secret });
-      log.info(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
-      return "registered";
-    } catch (e) {
-      const error = String(e);
-      if (!isTransientRegistrationError(error)) {
-        log.error(`[fastagent] telegram: setWebhook failed (${error}). Register manually with url=${webhookUrl}`);
-        return "failed";
-      }
-      lastTransientError = error;
-      if (attempt + 1 < attempts) {
-        log.info(
-          `[fastagent] telegram: Telegram cannot reach ${webhookUrl} yet (attempt ${attempt + 1}/${attempts}); retrying…`,
-        );
-      }
-    }
+  try {
+    await retryWhile(
+      () => callApi("https://api.telegram.org", botToken, "setWebhook", { url: webhookUrl, secret_token: secret }),
+      (error) => isTransientRegistrationError(String(error)),
+      {
+        attempts: opts.attempts,
+        retryMs: opts.retryMs,
+        onRetry: ({ attempt, attempts }) =>
+          log.info(
+            `[fastagent] telegram: Telegram cannot reach ${webhookUrl} yet (attempt ${attempt}/${attempts}); retrying…`,
+          ),
+      },
+    );
+    log.info(`[fastagent] telegram: webhook registered → ${webhookUrl}`);
+    return "registered";
+  } catch (e) {
+    // Both endings leave the webhook unregistered and the operator with work to do, so both are ERROR;
+    // they differ only in what to do about it.
+    const error = String(e);
+    log.error(
+      isTransientRegistrationError(error)
+        ? `[fastagent] telegram: Telegram could not reach ${webhookUrl} after retries (last error: ${error}). ` +
+            `Once it is up, register manually: curl "https://api.telegram.org/bot<token>/setWebhook" -d url=${webhookUrl} -d secret_token=<secret>`
+        : `[fastagent] telegram: setWebhook failed (${error}). Register manually with url=${webhookUrl}`,
+    );
+    return "failed";
   }
-  // Exhausted retries end in the same state as a permanent error (webhook not registered, manual
-  // action required) — report at the same level.
-  log.error(
-    `[fastagent] telegram: Telegram could not reach ${webhookUrl} after retries (last error: ${lastTransientError}). ` +
-      `Once it is up, register manually: curl "https://api.telegram.org/bot<token>/setWebhook" -d url=${webhookUrl} -d secret_token=<secret>`,
-  );
-  return "failed";
 }

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -13,6 +13,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { registerFeishuWebhook } from "../../channels/feishu/register-webhook.ts";
+import { DEPLOY_REGISTRATION_ATTEMPTS } from "../../channels/registration.ts";
 import { readSlackBotAuthEnv } from "../../channels/slack/bot-auth.ts";
 import { registerSlackWebhook } from "../../channels/slack/register-webhook.ts";
 import { registerTelegramWebhook } from "../../channels/telegram/register-webhook.ts";
@@ -86,12 +87,18 @@ export interface DeployOptions {
 }
 
 /** The registrars every host driver gets. One wiring: a channel's credentials are the channel's, not
- *  the host's, so which of them can run end-to-end never varies by deployment target. */
+ *  the host's, so which of them can run end-to-end never varies by deployment target.
+ *
+ *  All three get {@link DEPLOY_REGISTRATION_ATTEMPTS} rather than the default: a host CLI returns
+ *  before the deployment answers, and a registration that gives up first GATES the deploy — reporting
+ *  a working deployment as one to re-run. `dev --tunnel` keeps the shorter default; it is a resident
+ *  process whose URL is live when it is printed. */
 function registrarsFor(agentDir: string): Registrars {
+  const attempts = DEPLOY_REGISTRATION_ATTEMPTS;
   return {
-    telegram: (baseUrl) => registerTelegramWebhook(baseUrl),
-    slack: (baseUrl) => registerSlackWebhook(baseUrl, { stateRoot: resolveStateRoot(agentDir) }),
-    feishu: (baseUrl, kind) => registerFeishuWebhook(baseUrl, kind),
+    telegram: (baseUrl) => registerTelegramWebhook(baseUrl, { attempts }),
+    slack: (baseUrl) => registerSlackWebhook(baseUrl, { stateRoot: resolveStateRoot(agentDir), attempts }),
+    feishu: (baseUrl, kind) => registerFeishuWebhook(baseUrl, kind, { attempts }),
   };
 }
 

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -92,7 +92,12 @@ export interface DeployOptions {
  *  All three get {@link DEPLOY_REGISTRATION_ATTEMPTS} rather than the default: a host CLI returns
  *  before the deployment answers, and a registration that gives up first GATES the deploy — reporting
  *  a working deployment as one to re-run. `dev --tunnel` keeps the shorter default; it is a resident
- *  process whose URL is live when it is printed. */
+ *  process whose URL is live when it is printed, as does `deploy docker --run` — it reuses that same
+ *  announcer, having already health-probed the container and waited for the Quick Tunnel URL.
+ *
+ *  Accepted cost: pointChannelsAt registers serially, so a deployment whose channels are ALL
+ *  unreachable spends the budget once per channel (3 x 180s) before it gates. Registering in parallel
+ *  would not shorten a single failing channel, and the failing case is the one nobody is waiting on. */
 function registrarsFor(agentDir: string): Registrars {
   const attempts = DEPLOY_REGISTRATION_ATTEMPTS;
   return {

--- a/test/registration-retry.test.ts
+++ b/test/registration-retry.test.ts
@@ -103,6 +103,9 @@ describe("registration budgets", () => {
     // railway-deploy.live.test.ts allows a real deployment 180s to answer /health, because
     // `railway up --ci` returns when the BUILD ends. Registration failure gates the deploy, so a
     // budget shorter than that reports a working deployment as one to re-run.
-    expect(DEPLOY_REGISTRATION_ATTEMPTS * REGISTRATION_RETRY_MS).toBeGreaterThanOrEqual(180_000);
+    //
+    // (N - 1), not N: the loop waits only BETWEEN calls, so the last attempt goes out one interval
+    // earlier than the attempt count suggests. Counting it as N kept this green at 170s of patience.
+    expect((DEPLOY_REGISTRATION_ATTEMPTS - 1) * REGISTRATION_RETRY_MS).toBeGreaterThanOrEqual(180_000);
   });
 });

--- a/test/registration-retry.test.ts
+++ b/test/registration-retry.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The one retry loop every webhook registrar spends its budget through. It was four copies until this
+ * file existed — same counting, same "attempt i/N" announcement, same wait — differing only in the
+ * predicate and in what a final failure means, which is what stayed with the platforms.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { DEPLOY_REGISTRATION_ATTEMPTS, REGISTRATION_RETRY_MS, retryWhile } from "../src/channels/registration.ts";
+
+const retryable = (error: unknown): boolean => String(error).includes("not yet");
+
+describe("retryWhile", () => {
+  it("repeats a retryable failure until the call succeeds", async () => {
+    let calls = 0;
+    const result = await retryWhile(
+      async () => {
+        if (++calls < 3) throw new Error("not yet");
+        return "ok";
+      },
+      retryable,
+      { retryMs: 1 },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  it("throws a non-retryable failure on the first attempt, without waiting or announcing", async () => {
+    const onRetry = vi.fn();
+    let calls = 0;
+    await expect(
+      retryWhile(
+        async () => {
+          calls++;
+          throw new Error("bad credentials");
+        },
+        retryable,
+        { retryMs: 60_000, onRetry }, // a wait this long would hang the test if it were reached
+      ),
+    ).rejects.toThrow(/bad credentials/);
+    expect(calls).toBe(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("throws the LAST error when the budget runs out — the caller reports what it was still failing on", async () => {
+    let calls = 0;
+    await expect(
+      retryWhile(
+        async () => {
+          throw new Error(`not yet #${++calls}`);
+        },
+        retryable,
+        { attempts: 3, retryMs: 1 },
+      ),
+    ).rejects.toThrow(/not yet #3/);
+    expect(calls).toBe(3);
+  });
+
+  it("announces BEFORE the wait — a caller may release state there that must not span the sleep", async () => {
+    // `add slack` drops its duplicate-guard marker in onRetry: an unverifiable URL created no app, and
+    // a Ctrl-C during the wait must not leave the next run refusing to create one.
+    vi.useFakeTimers();
+    try {
+      const onRetry = vi.fn();
+      const pending = retryWhile(
+        async () => {
+          throw new Error("not yet");
+        },
+        retryable,
+        { attempts: 2, retryMs: 10_000, onRetry },
+      );
+      pending.catch(() => {}); // the rejection is asserted below; this keeps it from going unhandled
+      await vi.advanceTimersByTimeAsync(0); // settle the first attempt without spending any of the wait
+      expect(onRetry).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(pending).rejects.toThrow(/not yet/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("announces every wait and only waits between attempts", async () => {
+    // A silent minute reads as a hang, and an announcement after the last attempt would promise a
+    // retry that never comes.
+    const announced: string[] = [];
+    await expect(
+      retryWhile(
+        async () => {
+          throw new Error("not yet");
+        },
+        retryable,
+        {
+          attempts: 3,
+          retryMs: 1,
+          onRetry: ({ attempt, attempts, error }) => announced.push(`${attempt}/${attempts} ${String(error)}`),
+        },
+      ),
+    ).rejects.toThrow();
+    expect(announced).toEqual(["1/3 Error: not yet", "2/3 Error: not yet"]);
+  });
+});
+
+describe("registration budgets", () => {
+  it("the deploy budget outlasts what a host takes to start serving", () => {
+    // railway-deploy.live.test.ts allows a real deployment 180s to answer /health, because
+    // `railway up --ci` returns when the BUILD ends. Registration failure gates the deploy, so a
+    // budget shorter than that reports a working deployment as one to re-run.
+    expect(DEPLOY_REGISTRATION_ATTEMPTS * REGISTRATION_RETRY_MS).toBeGreaterThanOrEqual(180_000);
+  });
+});

--- a/test/slack-onboard.test.ts
+++ b/test/slack-onboard.test.ts
@@ -101,7 +101,25 @@ describe("Slack internal-app manifest and control API", () => {
       },
       "unknown_error",
     );
+    // The `/request_url` pointer above is an inference — the captured reply is `badShape`, which
+    // reports on the PARENT pointer. If the unverifiable case reports there too, the pointer arm alone
+    // would retry zero times, so a verification-worded message on the parent pointer counts as well.
+    const unverifiedOnParentPointer = new SlackConfigApiError(
+      "apps.manifest.create",
+      200,
+      {
+        error: "invalid_manifest",
+        errors: [
+          {
+            pointer: "/settings/event_subscriptions",
+            message: "Your Request URL did not respond with the correct challenge value",
+          },
+        ],
+      },
+      "unknown_error",
+    );
     expect(isSlackRequestUrlUnverified(unverifiedUrl)).toBe(true);
+    expect(isSlackRequestUrlUnverified(unverifiedOnParentPointer)).toBe(true);
     expect(isSlackRequestUrlUnverified(badShape)).toBe(false);
     expect(isSlackRequestUrlUnverified(new Error("request_url something"))).toBe(false); // not Slack's
   });

--- a/test/slack-onboard.test.ts
+++ b/test/slack-onboard.test.ts
@@ -2,7 +2,12 @@ import { mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createSlackApp, exchangeSlackOAuthCode, SlackConfigApiError } from "../src/channels/slack/config-api.ts";
+import {
+  createSlackApp,
+  exchangeSlackOAuthCode,
+  isSlackRequestUrlUnverified,
+  SlackConfigApiError,
+} from "../src/channels/slack/config-api.ts";
 import { buildSlackManifest, slackBotEvents, slackBotScopes } from "../src/channels/slack/manifest.ts";
 import { newSlackOnboardingState, onboardSlackApp } from "../src/channels/slack/onboard.ts";
 import {
@@ -65,6 +70,40 @@ describe("Slack internal-app manifest and control API", () => {
       token_rotation_enabled: true,
       event_subscriptions: { request_url: "https://agent.test/slack" },
     });
+  });
+
+  it("only a rejected request_url is a retryable manifest error — read from the field, not the prose", async () => {
+    // Both are `invalid_manifest`; only one means "cannot reach it YET". The second is the real reply
+    // Slack gave a manifest that subscribed to events without a request_url — a permanent shape error
+    // that must be reported at once, not waited out. Matching the message text could not tell them
+    // apart: it mentions the Request URL either way.
+    const unverifiedUrl = new SlackConfigApiError(
+      "apps.manifest.create",
+      200,
+      {
+        error: "invalid_manifest",
+        errors: [{ pointer: "/settings/event_subscriptions/request_url", message: "failed to verify request url" }],
+      },
+      "unknown_error",
+    );
+    const badShape = new SlackConfigApiError(
+      "apps.manifest.create",
+      200,
+      {
+        error: "invalid_manifest",
+        errors: [
+          { pointer: "/settings/event_subscriptions", message: "Event Subscription requires a Request URL" },
+          {
+            pointer: "/settings/event_subscriptions",
+            message: "Event Subscription requires Socket Mode if no Request URL is provided",
+          },
+        ],
+      },
+      "unknown_error",
+    );
+    expect(isSlackRequestUrlUnverified(unverifiedUrl)).toBe(true);
+    expect(isSlackRequestUrlUnverified(badShape)).toBe(false);
+    expect(isSlackRequestUrlUnverified(new Error("request_url something"))).toBe(false); // not Slack's
   });
 
   it("sends manifest credentials only in headers/body and parses create + OAuth results", async () => {

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { newSlackOnboardingState } from "../src/channels/slack/onboard.ts";
 import { writeSlackOnboardingState } from "../src/channels/slack/onboarding-state.ts";
 import { declaredChannels } from "../src/channels/discover.ts";
+import { REGISTRATION_RETRY_MS } from "../src/channels/registration.ts";
 import { announceWebhooks, parseTunnelUrl, startCloudflareTunnel } from "../src/tunnel.ts";
 
 // Mirrors TUNNEL_RETRY_MS in tunnel.ts (the constant is not exported).
@@ -304,7 +305,7 @@ describe("tunnel: announceWebhooks", () => {
     vi.useFakeTimers();
 
     const p = announceWebhooks(dir, "https://x.trycloudflare.com", declaredChannels(["telegram"]));
-    await vi.advanceTimersByTimeAsync(6000); // past the 5s retry backoff
+    await vi.advanceTimersByTimeAsync(REGISTRATION_RETRY_MS); // spend the backoff without spending it
     await p;
 
     expect(setWebhookCount(fetchMock)).toBe(2); // retried once, then registered


### PR DESCRIPTION
Follow-up to #428, from its review. One behaviour fix and three cleanups it named.

## The fix: `deploy --run` was given a tunnel's patience

#428 replaced the local `/health` poll with retries of the platform call, and set one budget for
everyone: 8 x 10s = 70s. That is sized for a tunnel, which is **live before its URL is printed**. A
deploy is not: `railway up --ci` returns when the *build* ends — container start, healthcheck and a
freshly minted domain's DNS all happen after that, and `railway-deploy.live.test.ts` allows a real
deployment **180s** to answer `/health`. The old code spent up to 120s polling before it even called
setWebhook, so this was a real reduction on the deploy path.

Registration failure **gates** the deploy (`registration-gate.ts`), so a budget shorter than the host's
own start-up reports a working deployment as one to re-run with `--into-linked`.

`deploy` now passes `DEPLOY_REGISTRATION_ATTEMPTS` (18 x 10s = 180s) to all three registrars.
`dev --tunnel` keeps the shorter default — it is a resident process, and its URL is live when printed.
A test ties the deploy budget to the live probe's 180s so the two cannot drift apart silently.

## Four copies of one retry loop become one

telegram, feishu, slack registration and `add slack` each had the same loop: N attempts, a predicate,
`attempt i/N; retrying…`, announce only when another attempt follows, sleep. `retryWhile` in
`registration.ts` now owns that, beside the budget it spends. What stays with each platform is what
actually differs: which errors mean "not reachable yet", and what a final failure *means* — one
registrar's terminal state is another's `"manual"`.

`onRetry` runs **before** the wait. That is not cosmetic: `add slack` drops its duplicate-guard marker
there, so the marker never spans a sleep and a Ctrl-C mid-retry cannot wedge the next run on an app
that was never created.

## `isSlackRequestUrlUnverified` reads the field, not the prose

It matched `request_url` anywhere in the formatted error string, so any manifest error mentioning that
field bought a full retry budget. `SlackConfigApiError` now keeps its `errors` array, and the check is
`invalid_manifest` + a rejected `/request_url` pointer. A test pins it with the **real** reply Slack
gave a manifest that subscribed to events without a request_url — a permanent shape error, reported at
once, whose message mentions "Request URL" and would have matched the old regex.

Documented imprecision: this still cannot separate "not reachable yet" from "this URL is
unacceptable" — both land on that pointer, and the wording that would tell them apart has not been
observed against the real API. Guessing at it risks never retrying at all, so a permanently bad URL
costs the budget before being reported. Every URL here is a tunnel's or a host's, so it is well-formed
https by construction.

## Comments that had stopped being true

- `registration.ts`: `"failed"` still listed `health timeout` as a cause; #428 deleted every health poll.
- `config-api.ts`: `createSlackApp`'s "intentionally single-attempt" read as "never retried", while its
  caller now retries the one repeatable rejection. It says which, and why that one is safe.

## A test that was sleeping 10 real seconds

`retryWhile` waits on the global timer rather than `node:timers/promises`, the convention `feishu-api.ts`
already documents, so fake timers can drive it. That exposed `tunnel.test.ts`'s retry test: it called
`vi.useFakeTimers()` and advanced 6000ms "past the 5s retry backoff", but the backoff has been 10s and
the sleep was never fake-able — the test really slept, and its comment described a number that no
longer existed. It now advances `REGISTRATION_RETRY_MS`. That file went from 10s to 196ms.

## Verification

`npm run lint && npm run typecheck && npm test` (1622 passing). Each guard sabotaged, one test red:

| Sabotage | Red test |
|---|---|
| `onRetry` after the wait instead of before | "announces BEFORE the wait — a caller may release state there" |
| predicate ignored, everything retried | 6 tests across all four registrars |
| deploy budget back to the tunnel default | "the deploy budget outlasts what a host takes to start serving" |
| classifier ignores which field was rejected | "only a rejected request_url is a retryable manifest error" |

The first and last of those were written *because* the first sabotage pass found them green — the
retry-order and field-vs-prose behaviours had no coverage until then.

## Not done

The review's last P3: after `add slack` creates the app, the browser opens the OAuth redirect on the
*same* fresh tunnel hostname this PR's premise says the local machine often cannot resolve yet. The
code is unaffected (the callback is never consumed, a refresh recovers), so it is a wording question
on a path #428's own premise says is untested — left for whoever runs `add slack` on the machine from
#421.
