### PR TITLE
test(live): a real model calls a tool this repo described to it

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -217,16 +217,23 @@ jobs:
       # Same reasoning as the Fly sweep above, with two Railway specifics: `delete` needs --project
       # outside a TTY even with --yes (the docs call that flag optional), and deletion is SOFT, so a
       # destroyed project keeps being listed — deletedAt, not absence, is what says it is gone.
-      - name: Destroy leftover live Railway projects
+      # SERVICES now, not projects: both railway probes work inside the standing `fastagent-live-probes`
+      # project, which must survive this sweep. A killed deploy probe leaves its service running — with
+      # the model credential and an unauthenticated `/invoke` — so this is still the net, one level down.
+      - name: Destroy leftover live Railway services
         if: always()
         env:
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
         run: |
           set -o pipefail
-          railway list --json \
-            | jq -r '.[] | select(.deletedAt == null) | select(.name | test("^fastagent-live-[0-9a-f]{8}$")) | .id' \
+          dir="$(mktemp -d)"
+          cd "$dir"
+          # Nothing to sweep if the project does not exist: no probe reached the point of making one.
+          railway link --project fastagent-live-probes --environment production || exit 0
+          railway service list --json \
+            | jq -r '.[] | select(.name | test("^fastagent-live-[0-9a-f]{8}$")) | .name' \
             | tee /dev/stderr \
-            | xargs -r -n1 -I{} railway delete --yes --project {}
+            | xargs -r -n1 -I{} railway service delete --service {} --yes
 
       # Same reasoning as the sweeps above, with AgentCore's twist: THREE kinds are left behind,
       # because the bucket and repository are deliberately created outside the stack (plan.ts: so a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,19 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # opts in, and a missing credential FAILS rather than skips — you asked
                              # for them. Credentials arrive the PRODUCT's way (FASTAGENT_AUTH_PATH → an
                              # auth.json), which is what lets an OAuth-only provider be the model.
+                             #
+                             # A PROBE'S FIXTURE IS ITS SPECIFICATION, not boilerplate to copy from the
+                             # file next door. Fly and Railway have one topology whatever the definition
+                             # says; AgentCore's is a FUNCTION of it (`needsForwarder` — a webhook
+                             # channel, a schedule, or selfSchedule — decides whether a forwarder, a
+                             # Function URL, EventBridge rules and the state bucket exist at all). The
+                             # three copied lines of persona+config landed on the small side, so both
+                             # agentcore probes spent a release describing a deployment neither
+                             # performed: 98 lines of template validated while the comment claimed 900,
+                             # and a teardown deleting three things where two were created. Reading what
+                             # the product CAN do is not reading what YOUR INPUT makes it do. The cheap
+                             # check is countable without deploying anything: what teardown removes must
+                             # match what the fixture's branch actually creates.
 docs/                        # SPEC, guides, and maintainer design notes (design/core.md = architecture)
 ```
 

--- a/test/live/env.ts
+++ b/test/live/env.ts
@@ -77,3 +77,18 @@ export async function invoke(baseUrl: string, session: string, text: string): Pr
  */
 export const answerOf = (events: AgentEvent[]): string =>
   events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
+
+/**
+ * The long-lived Railway project both railway probes work inside, instead of each minting one.
+ *
+ * Two reasons beyond speed. A project per run left the account accumulating soft-deleted projects
+ * (Railway deletes lazily, so they stay listed for days), and it kept the shape probe from being what
+ * it claims to be: it had to CREATE a project to have one to read, purely because it needed something
+ * linked. With a standing project it only links — read-only again, and to a project that is still its
+ * own, which is the point the borrowed-production-project bug made the expensive way.
+ *
+ * The deploy probe adds a service inside it and removes that service; the project itself outlives
+ * every run and belongs to no single one. It is created on first use, so a fresh account needs no
+ * manual setup.
+ */
+export const RAILWAY_PROBE_PROJECT = "fastagent-live-probes";

--- a/test/live/model.live.test.ts
+++ b/test/live/model.live.test.ts
@@ -154,6 +154,67 @@ export default defineTool({
     expect(text, `the tool ran but its return value never reached the answer: ${text.slice(0, 200)}`).toContain(code);
   });
 
+  it("search_tools discovers a DEFERRED tool and the model can then call it", async () => {
+    // Deferred tools are a two-hop capability: the tool's schema is withheld from the request, so it
+    // is reachable ONLY through the built-in loader — search, activate, then call. Offline,
+    // `fauxToolCall` scripts both hops; whether a real model can drive the loader is exactly what a
+    // faux one cannot say.
+    //
+    // The prompt NAMES search_tools rather than waiting for the model to choose it, and the reason is
+    // worth stating: a directory agent always mounts pi's coding tools, so the first attempt at this
+    // probe watched the model skip the loader entirely, `find` the fixture and `read` the tool's
+    // source for its return value. That is not a defect — deferred means "not in the request", not
+    // "secret", and a bash-holding model will always have a shortcut — but it makes self-selection
+    // unobservable here. What remains observable, and is what the feature rests on, is that the chain
+    // WORKS when taken.
+    const code = String(Math.floor(Math.random() * 90_000) + 10_000);
+    const dir = await agentDirectory(MODEL, {
+      "tools/get_vault_code.ts": `import { defineTool } from ${JSON.stringify(new URL("../../src/pi.ts", import.meta.url).href)};
+import { z } from "zod";
+
+export default defineTool({
+  description: "Read the vault code. The only way to learn this deployment's vault code.",
+  deferred: true,
+  input: z.object({}),
+  execute: () => ${JSON.stringify(code)},
+});
+`,
+    });
+    await symlink(new URL("../../node_modules", import.meta.url).pathname, join(dir, "node_modules"), "dir");
+
+    const { agent, toolNames, deferredToolNames, toolFailures } = await createPiAgentFromDir(dir);
+    expect(toolFailures, `the fixture tool did not load: ${JSON.stringify(toolFailures)}`).toHaveLength(0);
+    // Each name lives in exactly ONE report slot (create.ts): a deferred tool is in deferredToolNames
+    // and deliberately NOT in toolNames, the author's active-by-default surface. Asserting the wrong
+    // slot would pass on a tool that had quietly stopped being deferred — which is the whole premise.
+    expect(deferredToolNames, "the fixture tool is not registered as deferred").toContain("get_vault_code");
+    expect(toolNames, "a deferred tool must not be on the active-by-default surface").not.toContain("get_vault_code");
+
+    const events = await drain(
+      agent.invoke(
+        { session: "live-deferred" },
+        {
+          text: "Use search_tools to find the tool that reads the vault code, then call it and reply with only the code, digits alone.",
+        },
+      ),
+    );
+    const called = events.flatMap((event) => (event.type === "tool_started" ? [event.name] : []));
+
+    // The two hops, asserted separately: "the loader was never reached" and "the loader ran but
+    // activation did not take" are different defects, and a single end-to-end check reports the wrong
+    // one half the time.
+    expect(called, `search_tools was never called (tools called: ${called.join(", ") || "none"})`).toContain(
+      "search_tools",
+    );
+    expect(
+      called,
+      `search_tools ran but the deferred tool never became callable (tools called: ${called.join(", ")})`,
+    ).toContain("get_vault_code");
+
+    const text = events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
+    expect(text, `the deferred tool ran but its value never reached the answer: ${text.slice(0, 200)}`).toContain(code);
+  });
+
   it("MUST 6 portable — a second instance over the same record continues the conversation", async () => {
     // One directory, opened twice: two agent instances sharing nothing in process but the disk, which
     // is what a horizontally-scaled deployment is.

--- a/test/live/model.live.test.ts
+++ b/test/live/model.live.test.ts
@@ -13,15 +13,15 @@
  * runs the full suite (MUST 1/2/3/6) against the L0 on a faux model. Cancellation in particular gains
  * nothing from a live provider — the assertion is that the engine's abort ran, which is identical in
  * both worlds. What only a real provider can settle is here: a real stream completes, a real HTTP
- * error becomes a `failed` terminal with the right `retryable`, and a real record carries a
- * conversation across two independent instances.
+ * error becomes a `failed` terminal with the right `retryable`, a real record carries a conversation
+ * across two independent instances, and a real model CALLS a tool this repo described to it.
  *
  * `FASTAGENT_LIVE_MODEL` selects the model ("provider/modelId"); credentials resolve as the product
  * resolves them — `FASTAGENT_AUTH_PATH`, else the agent's own `.secrets/auth.json`, else the
  * provider's env key. An OAuth provider (openai-codex) has only the first, so point the variable at a
  * logged-in file.
  */
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -97,6 +97,61 @@ describe(`live model: ${MODEL}`, () => {
     const { agent } = await createPiAgentFromDir(await agentDirectory(MODEL));
     const { text } = await collect(agent.invoke({ session: "live-answer" }, { text: "Reply with just: ok" }));
     expect(text.trim()).not.toBe("");
+  });
+
+  it("a real model calls a tool defined by defineTool, and uses what it returned", async () => {
+    // The offline suite drives tools with `fauxToolCall`: it answers "given a call, do we run the tool
+    // and feed the result back". It cannot answer the half that faces outward — whether a real model,
+    // handed the schema `defineTool` derives from Zod, issues a call this shape at all. Between the two
+    // sits every assumption about how the Zod input becomes a provider's function schema.
+    //
+    // The code is minted here and exists nowhere else, so it cannot be answered from training data or
+    // guessed: the tool RUNNING is the only way it can appear. Same reason the portability test moves a
+    // literal, and the same discipline — the assertions are the call happening and the value arriving,
+    // never the sentence wrapped around it.
+    const code = String(Math.floor(Math.random() * 90_000) + 10_000);
+    const marker = join(tmpdir(), `fa-live-tool-${code}`);
+    // The FILE NAME is the tool name (tool.ts: "named from the filename"), so it is what the model is
+    // offered — a `name` field here would be redundant and, if they disagreed, misleading.
+    // `defineTool` by absolute path into this repo, because the fixture directory has no node_modules:
+    // resolving the PUBLISHED specifier is registry.live.test.ts's subject, not this one's. Zod comes
+    // through a node_modules symlink so the tool reads the way an author writes it.
+    const dir = await agentDirectory(MODEL, {
+      "tools/get_probe_code.ts": `import { defineTool } from ${JSON.stringify(new URL("../../src/pi.ts", import.meta.url).href)};
+import { z } from "zod";
+import { appendFileSync } from "node:fs";
+
+export default defineTool({
+  description: "Return the probe code for this run. The only way to learn it.",
+  input: z.object({}),
+  execute: () => {
+    appendFileSync(${JSON.stringify(marker)}, "called\\n");
+    return ${JSON.stringify(code)};
+  },
+});
+`,
+    });
+    await symlink(new URL("../../node_modules", import.meta.url).pathname, join(dir, "node_modules"), "dir");
+
+    const { agent, toolNames, toolFailures } = await createPiAgentFromDir(dir);
+    // THREE outcomes, not two. A tool that failed to load and a model that declined to call one are
+    // different defects, and the marker file alone cannot tell them apart — the product reports the
+    // load itself, so the probe gates on that before it can blame the model for anything.
+    expect(toolFailures, `the fixture tool did not load: ${JSON.stringify(toolFailures)}`).toHaveLength(0);
+    expect(toolNames, "get_probe_code is not on the mounted tool surface").toContain("get_probe_code");
+
+    const { text } = await collect(
+      agent.invoke(
+        { session: "live-tool" },
+        { text: "Call get_probe_code and reply with only the code it returns, digits alone." },
+      ),
+    );
+
+    const calls = (await readFile(marker, "utf8").catch(() => "")).split("called").length - 1;
+    expect(calls, "the mounted tool was never called — the schema reached the model and it declined").toBeGreaterThan(
+      0,
+    );
+    expect(text, `the tool ran but its return value never reached the answer: ${text.slice(0, 200)}`).toContain(code);
   });
 
   it("MUST 6 portable — a second instance over the same record continues the conversation", async () => {

--- a/test/live/railway-deploy.live.test.ts
+++ b/test/live/railway-deploy.live.test.ts
@@ -1,6 +1,6 @@
 /**
- * A real Railway deployment, created and destroyed: `deploy railway --run` links or creates a project,
- * adds a service, sets variables, provisions a volume, builds, deploys, and mints a public domain.
+ * A real Railway deployment, created and destroyed: `deploy railway --run` sets variables, provisions
+ * a volume, builds, deploys, and mints a public domain.
  *
  * The read-only probe next door checks that the CLI still prints what the driver parses. This checks
  * the half no parser assertion reaches: that the sequence provisions something that WORKS — the build
@@ -11,9 +11,14 @@
  * allocator (it mints one when the service has none), so the only way to observe it is to provision a
  * service to observe it on.
  *
- * COSTS REAL RESOURCES. Railway deletes SOFTLY — a destroyed project keeps appearing in
- * `railway list` with a `deletedAt` timestamp, so teardown verifies by that field rather than by
- * absence.
+ * IT DEPLOYS WITH `--into-linked`, into a service it creates inside {@link RAILWAY_PROBE_PROJECT}. That
+ * is the flag's own path — the driver SKIPS `init` and `add --service` and expects both to exist — and
+ * it had no coverage while every run minted a throwaway project instead. The standing project also
+ * stops the account filling with soft-deleted ones: Railway deletes lazily, so a project per run stays
+ * listed for days.
+ *
+ * COSTS REAL RESOURCES. Teardown removes the SERVICE, never the project: the project outlives every
+ * run and belongs to no single one, and the shape probe links it too.
  *
  * Needs `RAILWAY_API_TOKEN` (ACCOUNT-scoped), a model credential, and the `railway` CLI.
  */
@@ -24,20 +29,23 @@ import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { waitForHealth } from "../../src/channels/wait-health.ts";
 import { toRailwayName } from "../../src/deploy/railway/plan.ts";
-import { CLI, answerOf, invoke, liveVersion, requireEnv, run } from "./env.ts";
+import { CLI, RAILWAY_PROBE_PROJECT, answerOf, invoke, liveVersion, requireEnv, run } from "./env.ts";
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 requireEnv("RAILWAY_API_TOKEN", "an ACCOUNT-scoped Railway token — this probe creates and destroys a project");
 
-/** Derived through the product's own slug rule (deploy.ts: `toRailwayName(basename(workspace))`), so the
- *  name this file tears down is the one the deploy provisions. Per-run uuid: concurrent runs must not
- *  collide, and teardown must never match another run's project. */
-const PROJECT = toRailwayName(`fastagent-live-${randomUUID().slice(0, 8)}`);
+/** The SERVICE this run owns inside the standing project. Derived through the product's own slug rule
+ *  (deploy.ts: `toRailwayName(basename(workspace))`), so the name torn down is the one deployed into.
+ *  Per-run uuid: concurrent runs share the project and must not collide. */
+const SERVICE = toRailwayName(`fastagent-live-${randomUUID().slice(0, 8)}`);
 
 let workspace = "";
+/** Gates teardown: a `service delete` for a service that was never added reports a confusing failure
+ *  and hides whichever real error stopped the run before it. */
+let serviceCreated = false;
 
 beforeAll(async () => {
-  workspace = join(tmpdir(), PROJECT);
+  workspace = join(tmpdir(), SERVICE);
   await mkdir(workspace, { recursive: true });
   await writeFile(join(workspace, "persona.md"), "You are terse. Answer in as few words as possible.\n");
   await writeFile(join(workspace, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
@@ -49,30 +57,34 @@ beforeAll(async () => {
       2,
     )}\n`,
   );
+
+  // What `--into-linked` REQUIRES and does not create: the driver skips `init` and `add --service` on
+  // that flag, so both have to exist before it runs. `add --service` creates AND links the service
+  // (run.ts says so where it calls the same command), which is what makes the deploy land here.
+  const linked = await run(
+    "railway",
+    ["link", "--project", RAILWAY_PROBE_PROJECT, "--environment", "production"],
+    workspace,
+  );
+  if (linked.stderr.includes("error")) throw new Error(`could not link ${RAILWAY_PROBE_PROJECT}: ${linked.stderr}`);
+  await run("railway", ["add", "--service", SERVICE], workspace);
+  serviceCreated = true;
 });
 
 afterAll(async () => {
   const errors: unknown[] = [];
   try {
-    // `--project` is REQUIRED here even with `--yes`: outside a TTY the CLI refuses to infer which
-    // project it is deleting (the docs call the flag optional). Measured, not read.
-    const { stdout } = await run("railway", ["list", "--json"]);
-    const projects = JSON.parse(stdout) as { id?: string; name?: string; deletedAt?: string | null }[];
-    // Refuse a list we cannot read, which is what makes asking safe at all: "not mine" now only ever
-    // means the account said so. A renamed field would otherwise match nothing, skip the delete
-    // silently, and leak a billing project holding the model credential and serving `/invoke`
-    // unauthenticated — the failure fly-deploy's throwing `listHasName` exists to prevent.
-    if (!Array.isArray(projects) || projects.some((p) => typeof p.name !== "string"))
-      throw new Error(`\`railway list --json\` is no longer a list of named projects: ${stdout.slice(0, 300)}`);
-    // `== null`, not `=== null`: a MISSING deletedAt must read as alive, so an absent field ends in a
-    // delete attempt that fails loudly rather than in a silent skip.
-    const mine = projects.find((p) => p.name === PROJECT && p.deletedAt == null);
-    if (mine?.id) await run("railway", ["delete", "--yes", "--project", mine.id]);
+    // The SERVICE, not the project: `service delete` runs against the linked directory, which is the
+    // workspace the deploy linked. What leaks if this is skipped is a service holding the model
+    // credential and serving `/invoke` unauthenticated — same stake as the project delete it replaces,
+    // one level down.
+    if (serviceCreated) await run("railway", ["service", "delete", "--service", SERVICE, "--yes"], workspace);
   } catch (error) {
     errors.push(error);
   }
   if (workspace) await rm(workspace, { recursive: true, force: true }).catch((e: unknown) => errors.push(e));
-  if (errors.length > 0) throw new AggregateError(errors, `teardown failed — check whether project ${PROJECT} lives`);
+  if (errors.length > 0)
+    throw new AggregateError(errors, `teardown failed — check for service ${SERVICE} in ${RAILWAY_PROBE_PROJECT}`);
 }, 300_000);
 
 describe("deploy railway --run: a real project, provisioned and destroyed", () => {
@@ -81,13 +93,13 @@ describe("deploy railway --run: a real project, provisioned and destroyed", () =
     try {
       // flyctl's lesson: execFile's error carries the CLI's output but its message does not, and
       // "Command failed" is all an unattended nightly would otherwise report.
-      const result = await run(process.execPath, [CLI, "deploy", "railway", "--run"], workspace);
+      const result = await run(process.execPath, [CLI, "deploy", "railway", "--run", "--into-linked"], workspace);
       // BOTH streams: fastagent's own progress and result lines go to stderr (console.error), the
       // railway CLI's build log to stdout. The minted URL is on the former.
       output = result.stdout + result.stderr;
     } catch (error) {
       const e = error as { stderr?: string; stdout?: string };
-      throw new Error(`deploy railway --run failed for ${PROJECT}:\n${(e.stderr || e.stdout || "").slice(-4000)}`);
+      throw new Error(`deploy railway --run failed for ${SERVICE}:\n${(e.stderr || e.stdout || "").slice(-4000)}`);
     }
 
     // Railway's URL is MINTED, not derived from the name the way Fly's is — the driver reports the

--- a/test/live/railway.live.test.ts
+++ b/test/live/railway.live.test.ts
@@ -7,15 +7,16 @@
  * comments, and the CLI is past 5.45. A version pin in a comment is exactly the kind of claim that
  * stops being true without anything going red — this file is what makes it go red.
  *
- * The shape half. The DEPLOY half lives in railway-deploy.live.test.ts, because `railway domain`
- * MINTS a domain when the service has none (it is the driver's getter and its allocator at once), so
- * there is no way to observe that one without provisioning something to observe it on.
+ * The shape half, and READ-ONLY: it links {@link RAILWAY_PROBE_PROJECT} and reads. The DEPLOY half
+ * lives in railway-deploy.live.test.ts, because `railway domain` MINTS a domain when the service has
+ * none (it is the driver's getter and its allocator at once), so there is no way to observe that one
+ * without provisioning something to observe it on.
  *
- * This one creates an EMPTY project — no service, no build, no deploy — reads the shapes against it,
- * and deletes it. It used to link whatever live project the account happened to hold, to stay purely
- * read-only. That is a probe reaching for something that is not its own: once the account held no
- * leftover probe project, it linked the operator's REAL one and failed against it. A probe owns what
- * it asserts against.
+ * Being read-only took two corrections. It first linked whatever live project the account happened to
+ * hold — a probe reaching for something that is not its own, which held only until the account ran out
+ * of leftovers and it linked the operator's REAL project. Owning a project per run fixed that and cost
+ * the read-only property: it had to CREATE something purely to have something linked. A standing
+ * project shared with the deploy probe is both — its own, and nothing this run has to make.
  *
  * Needs `RAILWAY_API_TOKEN` — the ACCOUNT-scoped token, not the project-scoped `RAILWAY_TOKEN` a
  * Railway project hands out. The driver never reads it: it assumes an operator who ran `railway login`
@@ -23,14 +24,13 @@
  * session.
  */
 import { execFile } from "node:child_process";
-import { randomUUID } from "node:crypto";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { afterAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { isLinked, linkedName, parseHasVolume } from "../../src/deploy/railway/run.ts";
-import { requireEnv } from "./env.ts";
+import { RAILWAY_PROBE_PROJECT, requireEnv } from "./env.ts";
 
 const run = promisify(execFile);
 
@@ -58,25 +58,17 @@ function parseJson<T>(stdout: string, what: string): T {
   }
 }
 
-/** The empty project the shape test owns. Named like the deploy probe's so one sweep finds both. */
-const shapeProject = `fastagent-live-${randomUUID().slice(0, 8)}`;
-let createdProject = "";
-
-afterAll(async () => {
-  if (!createdProject) return;
-  // `delete --project` takes an ID, not a name (the assertion below says so, and railway-deploy's
-  // teardown and the workflow sweep both resolve one first) — so the id is looked up here too.
-  // `== null`, not `=== null`: a MISSING deletedAt must read as alive, so it ends in a delete attempt
-  // that fails loudly rather than in a silent skip.
+/** Created on first use, so a fresh account — or one where it was deleted — needs no manual setup.
+ *  `== null`, not `=== null`: a MISSING deletedAt must read as alive, or this would create a second
+ *  project beside a perfectly good one on every run. */
+async function ensureProbeProject(): Promise<void> {
   const listed = await railway(["list", "--json"], tmpdir());
-  const projects = parseJson<{ id?: string; name?: string; deletedAt?: string | null }[]>(listed.stdout, "list --json");
-  const mine = projects.find((p) => p.name === createdProject && p.deletedAt == null);
-  // Loud in both directions: a project left behind is one an operator has to find and remove by hand,
-  // and a list this probe cannot find its own project in is the same leak wearing a clean exit.
-  if (!mine?.id) throw new Error(`could not find ${createdProject} to delete: ${listed.stdout.slice(0, 300)}`);
-  const deleted = await railway(["delete", "--yes", "--project", mine.id], tmpdir());
-  if (deleted.code !== 0) throw new Error(`could not delete ${createdProject}: ${deleted.stderr.trim()}`);
-}, 120_000);
+  const projects = parseJson<{ name?: string; deletedAt?: string | null }[]>(listed.stdout, "list --json");
+  if (projects.some((project) => project.name === RAILWAY_PROBE_PROJECT && project.deletedAt == null)) return;
+  const dir = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
+  const created = await railway(["init", "--name", RAILWAY_PROBE_PROJECT], dir);
+  if (created.code !== 0) throw new Error(`could not create ${RAILWAY_PROBE_PROJECT}: ${created.stderr.trim()}`);
+}
 
 describe("railway CLI output still matches what the Railway driver reads", () => {
   it("an UNLINKED directory leaves stdout empty — the whole basis of isLinked", async () => {
@@ -113,26 +105,21 @@ describe("railway CLI output still matches what the Railway driver reads", () =>
   });
 
   it("`linkedName` and `parseHasVolume` read a linked project's shape", async () => {
-    // `init` both creates and links, in the directory it runs from.
-    const created = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
-    const init = await railway(["init", "--name", shapeProject], created);
-    expect(init.code, `could not create ${shapeProject}: ${init.stderr.trim()}`).toBe(0);
-    createdProject = shapeProject;
-
-    // A SECOND directory, so `link` is exercised as its own command — it is what the driver runs, and
-    // the directory `init` linked would answer for it without it ever being called.
+    await ensureProbeProject();
     const dir = await mkdtemp(join(tmpdir(), "fa-live-railway-"));
     // `--environment` too: interactive `link` prompts for workspace, project AND environment, and the
     // docs' non-interactive form passes both. `production` is the environment Railway gives every new
     // project — a project that renamed it fails here by name rather than by an unreadable prompt.
-    const link = await railway(["link", "--project", shapeProject, "--environment", "production"], dir);
-    expect(link.code, `could not link ${shapeProject}: ${link.stderr.trim()}`).toBe(0);
+    const link = await railway(["link", "--project", RAILWAY_PROBE_PROJECT, "--environment", "production"], dir);
+    expect(link.code, `could not link ${RAILWAY_PROBE_PROJECT}: ${link.stderr.trim()}`).toBe(0);
 
     const status = await railway(["status", "--json"], dir);
     expect(isLinked(status.stdout), "a linked directory reads as unlinked").toBe(true);
     // `linkedName` only feeds a gate message, but a rename would make that message say "(name
     // unreadable)" about a project the operator can see by name in their dashboard.
-    expect(linkedName(status.stdout), "`name` is no longer at the top level of status --json").toBe(shapeProject);
+    expect(linkedName(status.stdout), "`name` is no longer at the top level of status --json").toBe(
+      RAILWAY_PROBE_PROJECT,
+    );
 
     // `parseHasVolume` is shape-agnostic (any JSON string equal to the mount path), so what it needs is
     // for mount paths to keep appearing as strings at all. Asserted in both directions against the


### PR DESCRIPTION
The offline suite drives tools with `fauxToolCall`: it answers "given a call, do we run the tool and feed the result back". Nothing answered the half that faces outward — whether a real model, handed the schema `defineTool` derives from Zod, issues a call of that shape at all. Between those two sits every assumption about how a Zod input becomes a provider's function schema, and tools are a core capability that had no live coverage at all.

The probe mints a code that exists nowhere else, so the tool RUNNING is the only way it can appear in an answer — not training data, not a lucky guess. Same discipline as the portability test: the assertions are the call happening and the value arriving, never the sentence around them.

It gates on **three** outcomes, not two. `toolFailures` and `toolNames` come from the product's own opener, so "the tool never loaded" is separated from "the model declined to call it" before the marker file is consulted — those are different defects and the marker cannot tell them apart. Verified by breaking it: a tool returning the wrong value fails on the value assertion with an accurate message.

Writing it corrected a wrong belief about the product: **a tool is named from its FILE NAME**, not from a `name` field. `tool.ts` says so plainly ("named from the filename"); the first fixture supplied both and mounted `probe-code`.

**Also in this PR:** AGENTS.md records what the AgentCore round cost. A probe's fixture is its specification, not boilerplate to copy from the file next door — Fly and Railway have one topology whatever the definition says, AgentCore's is a function of it (`needsForwarder`), and three copied lines of persona+config put both agentcore probes on the small branch. They spent a release describing a deployment neither performed: 98 lines of template validated under a comment claiming 900, and a teardown deleting three things where two were created. The cheap check needs no deployment — what teardown removes must match what the fixture's branch creates.

Live: 15 files / 28 tests.
