### PR TITLE
fix(tunnel): hold a quick-tunnel URL back until its hostname is in DNS

### DIFF
--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -7,6 +7,7 @@
  * Process orchestration, not assembly — lives outside the engine, beside dev-supervisor.ts.
  */
 import { type ChildProcess, spawn } from "node:child_process";
+import { resolve4 } from "node:dns/promises";
 import type { RegistrationOutcome } from "./channels/registration.ts";
 import type { DeclaredChannel } from "./channels/discover.ts";
 import { registerFeishuWebhook } from "./channels/feishu/register-webhook.ts";
@@ -40,6 +41,52 @@ const TUNNEL_ATTEMPTS = 3;
 const TUNNEL_RETRY_MS = 2000;
 /** cloudflared can stay alive without ever receiving/printing an assigned quick-tunnel URL. */
 const TUNNEL_START_TIMEOUT_MS = 30_000;
+/** Budget for the assigned hostname to appear in DNS — see {@link waitForTunnelDns} for what it buys. */
+const TUNNEL_DNS_TIMEOUT_MS = 30_000;
+const TUNNEL_DNS_INTERVAL_MS = 500;
+
+/** A host's A records; injectable so tests need no real DNS. */
+type ResolveHost = (host: string) => Promise<unknown>;
+
+/**
+ * Hold the URL back until its hostname RESOLVES. `*.trycloudflare.com` is not a wildcard — each quick
+ * tunnel gets its own record, published only once the tunnel's first connection registers with the
+ * edge, which is AFTER cloudflared prints the URL (measured: connection at +1.5s, record at +3-6s). A
+ * platform handed the URL inside that window answers NXDOMAIN and then keeps answering it for far
+ * longer than any registrar's budget, so all 8 retries fail against a hostname that went live seconds
+ * in (#435). Every registrar is downstream of this function, so waiting once here covers them all.
+ *
+ * That ordering also makes an unresolvable hostname a real diagnosis and not just a slow one: the
+ * record is missing because the tunnel never connected (a network that drops cloudflared's QUIC, say),
+ * so nothing will reach this URL until that is fixed.
+ *
+ * NOT the local-reachability gate #421 removed: this asks whether a GLOBAL record exists (`resolve4`
+ * queries the configured nameservers through c-ares, so each poll really re-queries instead of reading
+ * a cache), never whether this machine can reach the origin — and it is bounded and never fatal, so a
+ * resolver that cannot see the record delays the URL rather than withholding it.
+ */
+async function waitForTunnelDns(host: string, resolveHost: ResolveHost): Promise<void> {
+  const deadline = Date.now() + TUNNEL_DNS_TIMEOUT_MS;
+  for (;;) {
+    // The rejection IS the signal (NXDOMAIN while the record is unpublished), not an error to report.
+    // Exhausting the budget is, and it warns below.
+    try {
+      await resolveHost(host);
+      return;
+    } catch {
+      /* not published yet */
+    }
+    if (Date.now() >= deadline) {
+      log.warn(
+        `[fastagent] --tunnel: ${host} is still not in DNS after ${Math.round(TUNNEL_DNS_TIMEOUT_MS / 1000)}s — ` +
+          "the tunnel likely never connected to Cloudflare's edge. Nothing will reach this URL, " +
+          "webhook registration included.",
+      );
+      return;
+    }
+    await sleep(TUNNEL_DNS_INTERVAL_MS);
+  }
+}
 
 /** How cloudflared is launched; injectable so tests can drive the child without a real process. */
 type SpawnCloudflared = (port: number) => ChildProcess;
@@ -56,17 +103,22 @@ type TunnelSpawn =
  * cloudflared sometimes exits before printing a URL (a transient trycloudflare API error), so retry a
  * few times. ALWAYS resolves to undefined WITH an operator log saying why — missing binary, the exit
  * reason, or "gave up after retries" — never silently; serving continues without a tunnel either way.
- * (Edge warmup AFTER the URL appears is handled downstream: each registrar retries while the platform
- * reports it cannot yet verify the URL, so a not-yet-routable tunnel delays registration, not fails it.)
+ * The URL is held back until its hostname resolves ({@link waitForTunnelDns}); the edge warm-up AFTER
+ * that is handled downstream — each registrar retries while the platform reports it cannot yet verify
+ * the URL, so a not-yet-routable tunnel delays registration, not fails it.
  */
 export async function startCloudflareTunnel(
   port: number,
   spawnFn: SpawnCloudflared = spawnCloudflared,
   attemptTimeoutMs: number = TUNNEL_START_TIMEOUT_MS,
+  resolveHost: ResolveHost = resolve4,
 ): Promise<Tunnel | undefined> {
   for (let attempt = 1; attempt <= TUNNEL_ATTEMPTS; attempt++) {
     const r = await spawnTunnelOnce(port, spawnFn, attemptTimeoutMs);
-    if (r.tunnel) return r.tunnel;
+    if (r.tunnel) {
+      await waitForTunnelDns(new URL(r.tunnel.url).hostname, resolveHost);
+      return r.tunnel;
+    }
     if (r.fatal) {
       log.error(r.message); // missing binary — retrying cannot help
       return undefined;

--- a/test/live/tunnel.live.test.ts
+++ b/test/live/tunnel.live.test.ts
@@ -10,6 +10,7 @@
  * Needs the `cloudflared` binary on PATH and no credentials: a Quick Tunnel is anonymous.
  */
 import { spawnSync } from "node:child_process";
+import { resolve4 } from "node:dns/promises";
 import { createServer } from "node:http";
 import { randomUUID } from "node:crypto";
 import { afterAll, describe, expect, it } from "vitest";
@@ -58,6 +59,12 @@ describe("cloudflare quick tunnel", () => {
     if (!tunnel) return;
     cleanups.push(() => tunnel.close());
     expect(tunnel.url).toMatch(/^https:\/\/[a-z0-9-]+\.trycloudflare\.com$/i);
+
+    // A URL is only handed out once its hostname EXISTS in DNS (#435) — cloudflared prints it before
+    // the record is published, and a platform asked to verify it inside that window answers NXDOMAIN
+    // for longer than any registrar's budget. Not a tautology despite the product polling the same
+    // call: the wait is bounded, and this is what catches the URL escaping through its timeout.
+    await expect(resolve4(new URL(tunnel.url).hostname)).resolves.not.toHaveLength(0);
 
     // A fresh hostname can take a minute to become resolvable FROM HERE — and on a machine whose
     // resolver or proxy is slow about it, longer than this budget (#421). That is why the webhook

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -9,8 +9,10 @@ import { writeSlackOnboardingState } from "../src/channels/slack/onboarding-stat
 import { declaredChannels } from "../src/channels/discover.ts";
 import { announceWebhooks, parseTunnelUrl, startCloudflareTunnel } from "../src/tunnel.ts";
 
-// Mirrors TUNNEL_RETRY_MS in tunnel.ts (the constant is not exported).
+// Mirror tunnel.ts's constants (they are not exported).
 const TUNNEL_RETRY_MS = 2000;
+const TUNNEL_DNS_INTERVAL_MS = 500;
+const TUNNEL_DNS_TIMEOUT_MS = 30_000;
 
 /** A fake cloudflared child: EventEmitter with stdout/stderr emitters, drivable from a test. */
 function fakeCloudflared(): ChildProcess {
@@ -63,11 +65,68 @@ async function workspace(channels: string[]): Promise<string> {
 describe("tunnel: startCloudflareTunnel", () => {
   it("resolves a tunnel on the first URL cloudflared prints", async () => {
     const child = fakeCloudflared();
-    const p = startCloudflareTunnel(8800, () => child);
+    const p = startCloudflareTunnel(
+      8800,
+      () => child,
+      undefined,
+      async () => ["104.16.0.1"],
+    );
     await Promise.resolve(); // let the listeners attach
     child.stderr?.emit("data", Buffer.from("INF +-+ https://blue-cat-42.trycloudflare.com +-+\n"));
     const t = await p;
     expect(t?.url).toBe("https://blue-cat-42.trycloudflare.com");
+  });
+
+  // #435: cloudflared prints the URL before the hostname's DNS record is published, and a platform
+  // told about it in that window answers NXDOMAIN for far longer than any registrar's retry budget.
+  it("holds the URL back until its hostname resolves", async () => {
+    vi.useFakeTimers();
+    const child = fakeCloudflared();
+    let published = false;
+    let handedOut: string | undefined;
+    const p = startCloudflareTunnel(
+      8800,
+      () => child,
+      undefined,
+      async (host: string) => {
+        if (!published) throw new Error(`queryA ENOTFOUND ${host}`);
+        return ["104.16.0.1"];
+      },
+    ).then((t) => {
+      handedOut = t?.url;
+      return t;
+    });
+    await Promise.resolve();
+    child.stderr?.emit("data", Buffer.from("https://blue-cat-42.trycloudflare.com\n"));
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(handedOut, "a URL no resolver knows yet must not reach a registrar").toBeUndefined();
+
+    published = true;
+    await vi.advanceTimersByTimeAsync(TUNNEL_DNS_INTERVAL_MS);
+    expect((await p)?.url).toBe("https://blue-cat-42.trycloudflare.com");
+  });
+
+  // The record is published once the tunnel's first connection registers, so a hostname that never
+  // appears means the tunnel never connected (a network dropping cloudflared's QUIC, say). Serving
+  // continues either way, but silence there would leave the author debugging the wrong end.
+  it("says so, and still serves, when the hostname never appears in DNS", async () => {
+    vi.useFakeTimers();
+    const errs = captureErrors();
+    const child = fakeCloudflared();
+    const p = startCloudflareTunnel(
+      8800,
+      () => child,
+      undefined,
+      async () => {
+        throw new Error("queryA ENOTFOUND");
+      },
+    );
+    await Promise.resolve();
+    child.stderr?.emit("data", Buffer.from("https://blue-cat-42.trycloudflare.com\n"));
+    await vi.advanceTimersByTimeAsync(TUNNEL_DNS_TIMEOUT_MS + TUNNEL_DNS_INTERVAL_MS);
+    expect((await p)?.url).toBe("https://blue-cat-42.trycloudflare.com");
+    expect(errs.some((e) => /still not in DNS/.test(e) && /never connected/.test(e))).toBe(true);
   });
 
   it("does not retry a missing cloudflared (ENOENT); logs the install hint", async () => {


### PR DESCRIPTION
Closes #435.

## The bug

A quick tunnel's hostname does not exist in DNS when cloudflared prints it. `*.trycloudflare.com` is
not a wildcard — each tunnel gets its own record, published only once the tunnel's **first connection
registers with the edge**, which is after the URL appears:

| | measured |
|---|---|
| cloudflared prints the URL | +0s |
| first connection registers | +1.5s |
| the record is published | +3–6s (0.2–4s over QUIC) |
| Telegram's first `setWebhook` | **+0.1–0.5s** (109ms / 304ms / 471ms across the three failing runs) |

Every registrar opens its mouth inside that window. Telegram then keeps answering `Failed to resolve
host` for all 8 attempts — 80s against a hostname that went live in under 4.

## Why the retry loop cannot save it

It is not the budget. Attempt 8 lands at t+80s, long after the record is live, and still gets
NXDOMAIN; no budget short of Telegram's own cache expiry would help. The variable is the **start
time**, not the length.

## The fix

`startCloudflareTunnel` does not hand the URL out until its hostname resolves — bounded at 30s, never
fatal. Every registrar is downstream of that one function, so waiting once covers Telegram, Feishu,
Lark, Slack and `add feishu`/`add slack` alike.

This is not the local-reachability gate #421 removed. That one asked whether *this machine* could
reach the origin, which a proxy or a slow resolver can make false for minutes while the platform
reaches it fine. This asks whether a **global DNS record exists** — `resolve4` goes to the configured
nameservers through c-ares, so each poll really re-queries — and on timeout it warns and serves
anyway.

The timeout also became a diagnosis rather than a shrug: because the record follows the connection, a
hostname that never appears means the tunnel never connected (a network dropping cloudflared's QUIC,
say), and nothing will reach that URL at all. The warning says that instead of blaming DNS.

## Two corrections to the issue

- **It is a regression from #428**, though not from its retry loop, which does exactly what it was
  written to do. #428 removed the `waitForHealth` gate, and on a runner with no proxy that gate was
  incidentally supplying the several seconds that kept the first platform call out of this window.
  Three consecutive live failures on commits containing #428; zero before.
- **It is not Telegram-specific.** In run 33651121643 — one of the two the issue cites — **feishu
  failed identically**, 8 attempts of `cannot verify`. Feishu survives when it happens to spend a few
  seconds on token and scope calls before its PATCH. Whoever speaks first loses, which is also why
  `REGISTRATION_ATTEMPTS` stays shared: the platforms do not differ, their warm-up time does.

## Verified

`lint` + `typecheck` + `test` (1617). Two offline checks, both red without the change: the URL is
withheld while DNS says NXDOMAIN, and the timeout path still serves *and* says why. Live, against a
real tunnel: held back 3.6s, and `resolve4` on the returned URL answers immediately — plus a run
where the tunnel never connected, which took the 30s branch and printed the warning.
`test/live/tunnel.live.test.ts` now asserts the returned hostname resolves, which is what catches a
URL escaping through that timeout.
