### PR TITLE
fix(tunnel): wait for cloudflared's edge connection, not just its URL

### DIFF
--- a/src/channels/registration.ts
+++ b/src/channels/registration.ts
@@ -19,14 +19,21 @@ export type RegistrationOutcome = "registered" | "manual" | "failed";
  * One judgement (a new tunnel's warm-up), so one pair of numbers — telegram, feishu, slack registration
  * and `add slack` all spend it.
  *
- * Sized for a tunnel, which is live before its URL is printed, and applied by {@link retryWhile} as its
- * default. A DEPLOY is slower and its callers pass {@link DEPLOY_REGISTRATION_ATTEMPTS} instead.
+ * Sized for a tunnel, which is live before its URL is HANDED OVER — not before it is printed, which is
+ * what this budget once had to absorb: a quick tunnel's hostname is published when the tunnel registers
+ * an edge connection, seconds after cloudflared prints it, and no budget covers a platform that already
+ * answered "cannot resolve" (#435). `startCloudflareTunnel` waits for that connection, so what is left
+ * here is the platform's own warm-up. Applied by {@link retryWhile} as its default; a DEPLOY is slower
+ * and its callers pass {@link DEPLOY_REGISTRATION_ATTEMPTS} instead.
  */
 const REGISTRATION_ATTEMPTS = 8;
 export const REGISTRATION_RETRY_MS = 10_000;
 
 /**
- * What `deploy --run` spends instead: 180s, because a host CLI returns before the deployment serves.
+ * What `deploy --run` spends instead: 180s, because a host CLI returns before the deployment serves —
+ * the same gap a tunnel has, on a scale no local signal reports (`docker compose --tunnel` is the one
+ * host whose ingress does report it, and its driver waits on it the way the tunnel does).
+ *
  * `railway up --ci` returns when the BUILD ends — container start, healthcheck and a freshly minted
  * domain's DNS all happen after that, and railway-deploy.live.test.ts allows 180s for exactly this.
  * Registration failure GATES the deploy (registration-gate.ts), so a budget shorter than the host's

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -4,7 +4,7 @@
  * carry through the child environment (never argv), and a readiness check on the published loopback port.
  */
 import { waitForHealth } from "../../channels/wait-health.ts";
-import { parseTunnelUrl } from "../../tunnel.ts";
+import { TUNNEL_DNS_LAG_MS, hasTunnelConnection, parseTunnelUrl } from "../../tunnel.ts";
 import type { RegistrationOutcome } from "../../channels/registration.ts";
 import { registrationGate } from "../registration-gate.ts";
 import { MIN_DOCKER_COMPOSE_VERSION } from "./plan.ts";
@@ -59,7 +59,13 @@ export function localUrlFromComposePort(stdout: string): string | undefined {
 const defaultHealthProbe: DockerHealthProbe = (healthUrl) => waitForHealth(healthUrl, 30_000, 500);
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-/** Poll the detached cloudflared service's logs until its assigned Quick Tunnel URL appears. */
+/**
+ * Poll the detached cloudflared service's logs until its Quick Tunnel URL is assigned AND the tunnel
+ * reports an edge connection. Waiting for the second is the same requirement `startCloudflareTunnel`
+ * has and for the same reason — the hostname does not exist until then (#435), and this driver hands
+ * the URL straight to `announce`. Returns a URL that never connected rather than nothing: the
+ * registrars downstream report their own outcome, and a gate saying "no URL" would misname it.
+ */
 export async function waitForComposeTunnelUrl(
   docker: CliRunner,
   composeFile: string,
@@ -68,13 +74,19 @@ export async function waitForComposeTunnelUrl(
 ): Promise<string | undefined> {
   const compose = ["compose", "-f", composeFile];
   const attempts = options.attempts ?? 60;
+  let assigned: string | undefined;
   for (let attempt = 0; attempt < attempts; attempt++) {
     const logs = await docker([...compose, "logs", "--no-color", "tunnel"], { capture: true, env });
-    const url = logs.code === 0 ? parseTunnelUrl(logs.stdout) : undefined;
-    if (url) return url;
+    if (logs.code === 0) {
+      assigned ??= parseTunnelUrl(logs.stdout);
+      if (assigned && hasTunnelConnection(logs.stdout)) {
+        await (options.sleep ?? sleep)(TUNNEL_DNS_LAG_MS);
+        return assigned;
+      }
+    }
     if (attempt + 1 < attempts) await (options.sleep ?? sleep)(options.intervalMs ?? 500);
   }
-  return undefined;
+  return assigned;
 }
 
 const defaultTunnelUrlProbe: DockerTunnelUrlProbe = (docker, composeFile, env) =>

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -33,6 +33,31 @@ export function parseTunnelUrl(chunk: string): string | undefined {
   return chunk.match(TUNNEL_URL_RE)?.[0];
 }
 
+/**
+ * cloudflared's line for an established edge connection. THIS, not the URL, is when the hostname
+ * begins to exist: `*.trycloudflare.com` is no wildcard, and a quick tunnel's record is published
+ * once the tunnel registers a connection — so the URL is printed while the name is still NXDOMAIN.
+ * A platform told about it inside that window answers "Failed to resolve host" and goes on answering
+ * it far longer than any registrar's retry budget (#435); the record going live seconds later does
+ * not undo the answer it already gave, which is why more retries were never the fix.
+ *
+ * Measured over 7 quick tunnels: the URL at +0s, this line at +1.1-1.9s, the record 0.5-3.9s later.
+ */
+const TUNNEL_CONNECTED_RE = /Registered tunnel connection/i;
+
+/** Whether cloudflared's output so far reports an edge connection — see {@link TUNNEL_CONNECTED_RE}. */
+export function hasTunnelConnection(output: string): boolean {
+  return TUNNEL_CONNECTED_RE.test(output);
+}
+
+/**
+ * How long after that connection to hand the URL over. The one number here that is not observed: 5s
+ * covers the widest of the 7 measured gaps (3.9s), all taken over cloudflared's http2 transport
+ * because this network blocks its QUIC. Costs a beat of `dev --tunnel` start-up; buys the first
+ * registration attempt landing on a name that resolves.
+ */
+export const TUNNEL_DNS_LAG_MS = 5000;
+
 /** Global timer (rather than timers/promises) so timeout/retry behavior is deterministic under fake timers. */
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -52,12 +77,13 @@ type TunnelSpawn =
   | { tunnel?: undefined; fatal: false; detail?: string };
 
 /**
- * Start a Cloudflare quick tunnel to localhost:`port`, resolving once its public URL appears.
- * cloudflared sometimes exits before printing a URL (a transient trycloudflare API error), so retry a
- * few times. ALWAYS resolves to undefined WITH an operator log saying why — missing binary, the exit
- * reason, or "gave up after retries" — never silently; serving continues without a tunnel either way.
- * (Edge warmup AFTER the URL appears is handled downstream: each registrar retries while the platform
- * reports it cannot yet verify the URL, so a not-yet-routable tunnel delays registration, not fails it.)
+ * Start a Cloudflare quick tunnel to localhost:`port`, resolving once its public URL is assigned AND
+ * the tunnel has an edge connection — the URL is printed first and is not usable yet
+ * ({@link hasTunnelConnection}). cloudflared sometimes exits before printing a URL (a transient
+ * trycloudflare API error), so retry a few times. ALWAYS resolves to undefined WITH an operator log
+ * saying why — missing binary, the exit reason, or "gave up after retries" — never silently; serving
+ * continues without a tunnel either way. What remains after this is the PLATFORM's own warm-up, which
+ * each registrar absorbs by retrying while the platform reports it cannot yet verify the URL.
  */
 export async function startCloudflareTunnel(
   port: number,
@@ -81,23 +107,31 @@ export async function startCloudflareTunnel(
   return undefined;
 }
 
-/** One cloudflared launch: a Tunnel on the first URL, or a failure (missing binary / exit before a URL). */
+/** One cloudflared launch: a Tunnel once its URL is assigned AND the edge connection is up, or a
+ *  failure (missing binary / exit before a URL). */
 function spawnTunnelOnce(port: number, spawnFn: SpawnCloudflared, timeoutMs: number): Promise<TunnelSpawn> {
   return new Promise((resolve) => {
     const child = spawnFn(port);
     let settled = false;
     let timer: NodeJS.Timeout | undefined;
+    let handOver: NodeJS.Timeout | undefined;
     let tail = ""; // recent output, surfaced as the failure reason
+    let assigned: string | undefined; // printed well before the tunnel can carry anything
     const finish = (result: TunnelSpawn): void => {
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
+      if (handOver) clearTimeout(handOver);
       resolve(result);
     };
+    const handOverNow = (url: string): void => finish({ tunnel: { url, close: () => child.kill("SIGTERM") } });
     const onChunk = (buf: Buffer): void => {
       tail = (tail + String(buf)).slice(-600);
-      const url = parseTunnelUrl(String(buf));
-      if (url) finish({ tunnel: { url, close: () => child.kill("SIGTERM") } });
+      assigned ??= parseTunnelUrl(String(buf));
+      if (!assigned || handOver || !hasTunnelConnection(tail)) return;
+      const url = assigned;
+      handOver = setTimeout(() => handOverNow(url), TUNNEL_DNS_LAG_MS);
+      handOver.unref();
     };
     child.stdout?.on("data", onChunk);
     child.stderr?.on("data", onChunk); // cloudflared prints the URL (and its errors) on stderr
@@ -114,6 +148,17 @@ function spawnTunnelOnce(port: number, spawnFn: SpawnCloudflared, timeoutMs: num
     });
     child.on("exit", () => finish({ fatal: false, detail: lastErrorLine(tail) }));
     timer = setTimeout(() => {
+      // A URL whose tunnel never connected is not worth a fresh one — the next attempt meets the same
+      // network. Serve it and name what is wrong, rather than retrying into the same wall.
+      if (assigned) {
+        log.warn(
+          `[fastagent] --tunnel: cloudflared never reported an edge connection for ${assigned} within ` +
+            `${Math.round(timeoutMs / 1000)}s — serving it anyway. Nothing reaches a tunnel that has not ` +
+            "connected, so a webhook registration that cannot resolve the host is this, not the platform.",
+        );
+        handOverNow(assigned);
+        return;
+      }
       child.kill("SIGTERM");
       finish({ fatal: false, detail: `timed out after ${Math.round(timeoutMs / 1000)}s waiting for a public URL` });
     }, timeoutMs);

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -6,6 +6,7 @@ import {
   waitForComposeTunnelUrl,
 } from "../src/deploy/docker/run.ts";
 import type { CliRunner } from "../src/deploy/runner.ts";
+import { TUNNEL_DNS_LAG_MS } from "../src/tunnel.ts";
 
 function fakeDocker(script: (args: string[]) => { code?: number; stdout?: string } = () => ({})) {
   const calls: { args: string[]; env?: NodeJS.ProcessEnv }[] = [];
@@ -255,8 +256,39 @@ describe("deploy/docker/run: parsers", () => {
         },
       },
     );
+    // Neither poll carries a connection line, so the budget runs out — and the URL is still returned.
+    // The registrars downstream report their own outcome; a "no URL" gate would misname this one.
     expect(url).toBe("https://blue-cat.trycloudflare.com");
     expect(sleeps).toEqual([7]);
+  });
+
+  // #435, the same requirement startCloudflareTunnel has: a quick tunnel's hostname is published when
+  // the tunnel registers an edge connection, so the URL alone is a name that does not resolve yet —
+  // and this driver hands it straight to `announce`.
+  it("waits for the edge connection, not just the URL, before handing the tunnel over", async () => {
+    let calls = 0;
+    const { docker } = fakeDocker(() => {
+      calls++;
+      return calls === 1
+        ? { stdout: "INF https://blue-cat.trycloudflare.com ready\n" }
+        : { stdout: "INF https://blue-cat.trycloudflare.com ready\nINF Registered tunnel connection connIndex=0\n" };
+    });
+    const sleeps: number[] = [];
+    const url = await waitForComposeTunnelUrl(
+      docker,
+      "fastagent.compose.yml",
+      {},
+      {
+        attempts: 5,
+        intervalMs: 7,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+      },
+    );
+    expect(url).toBe("https://blue-cat.trycloudflare.com");
+    expect(calls, "the URL was there on poll 1; it kept polling for the connection").toBe(2);
+    expect(sleeps).toEqual([7, TUNNEL_DNS_LAG_MS]);
   });
 
   it("normalizes Compose port output to a loopback URL", () => {

--- a/test/live/tunnel.live.test.ts
+++ b/test/live/tunnel.live.test.ts
@@ -9,13 +9,13 @@
  * Drives `startCloudflareTunnel`, the same function `dev --tunnel` and `deploy docker --tunnel` use.
  * Needs the `cloudflared` binary on PATH and no credentials: a Quick Tunnel is anonymous.
  */
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createServer } from "node:http";
 import { randomUUID } from "node:crypto";
 import { afterAll, describe, expect, it } from "vitest";
 import { waitForHealth } from "../../src/channels/wait-health.ts";
 import { installProxyFetch } from "../../src/proxy.ts";
-import { startCloudflareTunnel } from "../../src/tunnel.ts";
+import { hasTunnelConnection, startCloudflareTunnel } from "../../src/tunnel.ts";
 
 // Node's fetch ignores HTTPS_PROXY; reaching the tunnel's public URL from a proxied machine needs the
 // same call every CLI entry makes. See model.live.test.ts for why the library opener does not make it.
@@ -66,4 +66,32 @@ describe("cloudflare quick tunnel", () => {
     expect(await waitForHealth(tunnel.url, 60_000, 1000), `${tunnel.url} never became reachable`).toBe(true);
     expect(await fetch(tunnel.url).then((r) => r.text())).toBe(token);
   });
+
+  /**
+   * The one assumption behind #435 that lives in another project's source: cloudflared announces its
+   * first edge connection in words {@link hasTunnelConnection} knows, and the DNS record follows THAT,
+   * not the URL. Asserted here because a change to it degrades the product INVISIBLY — nothing fails,
+   * every tunnel is just handed over a connect-timeout late with a warning about a tunnel that is
+   * fine. Same shape as the fly/railway CLI probes: a real tool's output against this repo's reading
+   * of it, which is the belief a faked child process cannot test.
+   */
+  it("cloudflared still announces its edge connection in the words the hand-over waits for", async () => {
+    const child = spawn("cloudflared", ["tunnel", "--url", "http://localhost:9"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    cleanups.push(() => child.kill("SIGTERM"));
+    const connected = await new Promise<boolean>((resolve) => {
+      let output = "";
+      const timer = setTimeout(() => resolve(false), 90_000);
+      const onChunk = (buf: Buffer): void => {
+        output += String(buf);
+        if (!hasTunnelConnection(output)) return;
+        clearTimeout(timer);
+        resolve(true);
+      };
+      child.stdout?.on("data", onChunk);
+      child.stderr?.on("data", onChunk); // cloudflared logs to stderr
+    });
+    expect(connected, "cloudflared printed no line hasTunnelConnection recognises").toBe(true);
+  }, 120_000);
 });

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -8,7 +8,13 @@ import { newSlackOnboardingState } from "../src/channels/slack/onboard.ts";
 import { writeSlackOnboardingState } from "../src/channels/slack/onboarding-state.ts";
 import { declaredChannels } from "../src/channels/discover.ts";
 import { REGISTRATION_RETRY_MS } from "../src/channels/registration.ts";
-import { announceWebhooks, parseTunnelUrl, startCloudflareTunnel } from "../src/tunnel.ts";
+import {
+  TUNNEL_DNS_LAG_MS,
+  announceWebhooks,
+  hasTunnelConnection,
+  parseTunnelUrl,
+  startCloudflareTunnel,
+} from "../src/tunnel.ts";
 
 // Mirrors TUNNEL_RETRY_MS in tunnel.ts (the constant is not exported).
 const TUNNEL_RETRY_MS = 2000;
@@ -62,13 +68,41 @@ async function workspace(channels: string[]): Promise<string> {
 }
 
 describe("tunnel: startCloudflareTunnel", () => {
-  it("resolves a tunnel on the first URL cloudflared prints", async () => {
+  // #435: the URL is printed while the hostname is still NXDOMAIN, and a platform told about it in
+  // that window keeps answering "cannot resolve" long past any registrar's retry budget. The record
+  // follows the edge connection, so that line — not the URL — is when the tunnel can be handed over.
+  it("resolves a tunnel once the URL is assigned AND the edge connection is up", async () => {
+    vi.useFakeTimers();
     const child = fakeCloudflared();
-    const p = startCloudflareTunnel(8800, () => child);
+    let handedOut: string | undefined;
+    const p = startCloudflareTunnel(8800, () => child).then((t) => {
+      handedOut = t?.url;
+      return t;
+    });
     await Promise.resolve(); // let the listeners attach
     child.stderr?.emit("data", Buffer.from("INF +-+ https://blue-cat-42.trycloudflare.com +-+\n"));
-    const t = await p;
-    expect(t?.url).toBe("https://blue-cat-42.trycloudflare.com");
+
+    await vi.advanceTimersByTimeAsync(TUNNEL_DNS_LAG_MS * 2);
+    expect(handedOut, "a URL whose tunnel has not connected must not reach a registrar").toBeUndefined();
+
+    child.stderr?.emit("data", Buffer.from("INF Registered tunnel connection connIndex=0 ip=198.41.200.63\n"));
+    await vi.advanceTimersByTimeAsync(TUNNEL_DNS_LAG_MS);
+    expect((await p)?.url).toBe("https://blue-cat-42.trycloudflare.com");
+  });
+
+  // Retrying would meet the same network with a new hostname, so the URL is served and the cause
+  // named. Silence here would send the author to debug the platform for a local tunnel failure.
+  it("serves a URL whose tunnel never connected, naming that as the fault", async () => {
+    vi.useFakeTimers();
+    const errs = captureErrors();
+    const child = fakeCloudflared();
+    const p = startCloudflareTunnel(8800, () => child, 100);
+    await Promise.resolve();
+    child.stderr?.emit("data", Buffer.from("INF |  https://blue-cat-42.trycloudflare.com  |\n"));
+    await vi.advanceTimersByTimeAsync(100);
+    expect((await p)?.url).toBe("https://blue-cat-42.trycloudflare.com");
+    expect(errs.some((e) => /never reported an edge connection/.test(e))).toBe(true);
+    expect(child.kill, "the tunnel is served, not killed").not.toHaveBeenCalled();
   });
 
   it("does not retry a missing cloudflared (ENOENT); logs the install hint", async () => {
@@ -124,6 +158,23 @@ describe("tunnel: startCloudflareTunnel", () => {
     expect(spawns).toBe(3); // retried, not a single silent attempt
     expect(errs.some((e) => /exited before a public URL/.test(e) && /retrying/.test(e))).toBe(true);
     expect(errs.some((e) => /Serving without a tunnel/.test(e))).toBe(true);
+  });
+});
+
+describe("tunnel: hasTunnelConnection", () => {
+  it("recognises cloudflared's edge-connection line", () => {
+    expect(hasTunnelConnection("2026 INF Registered tunnel connection connIndex=0 ip=198.41.200.63")).toBe(true);
+  });
+
+  it("never reads the URL banner or a failed dial as a connection", () => {
+    expect(hasTunnelConnection("INF |  https://blue-cat-42.trycloudflare.com  |")).toBe(false);
+    // Seen live on a network that blocks cloudflared's QUIC: it retries this forever, never connects,
+    // and the hostname is never published — the case the timeout branch exists to name.
+    expect(
+      hasTunnelConnection(
+        '2026 ERR Failed to dial a quic connection error="failed to dial to edge with quic: timeout" connIndex=0',
+      ),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #435. Replaces #436, which asked DNS whether the hostname existed — a probe that publishes the
negative answer it then reads back.

## Root cause

`*.trycloudflare.com` is not a wildcard. Each quick tunnel gets its own record, and **the record is
published when the tunnel registers an edge connection**, not when the hostname is assigned. cloudflared
prints the URL before that:

| | measured over 7 tunnels |
|---|---|
| cloudflared prints the URL | +0s |
| `Registered tunnel connection` | +1.1–1.9s |
| the DNS record resolves | +1.9–5.6s |
| Telegram's first `setWebhook` | **+0.1–0.5s** (109 / 304 / 471ms in the three failing runs) |

Every registrar spoke inside that window. Telegram then answered `Failed to resolve host` for all 8
attempts — 80s against a name that went live in under 4 — because the answer it already gave outlives
the window that produced it. That is also why a bigger `REGISTRATION_ATTEMPTS` was never the fix: the
variable is the start time, not the length.

## Why this shape

The signal was already on a stream we read. `spawnTunnelOnce` was parsing cloudflared's output for the
URL and stopping one line short of the line that says the tunnel works. Reading it costs nothing, has
no side effect, and is the only observation here that cannot poison what it observes — asking DNS
whether a name exists is what teaches a resolver that it does not.

It also turns the failure into a diagnosis. Because the record follows the connection, a tunnel that
never connects (a network that drops cloudflared's QUIC) never publishes a hostname, and the timeout
branch can now say *that* instead of blaming DNS or the platform. It serves the URL anyway and warns:
a new tunnel would meet the same network, so retrying is not the answer.

The wait lives at the one place that produces a URL rather than at each place that consumes one.
`announceWebhooks`, `add slack` and `add feishu` all hand a fresh hostname to a platform as their next
move, so a per-consumer opt-in would be a convention with three enforcers and no way to see a missing
one. The cost is a few seconds of `dev --tunnel` start-up.

## The sibling caller

`deploy docker --tunnel` reads the same cloudflared output through `docker compose logs` and had the
same bug: `waitForComposeTunnelUrl` returned on the URL and the driver handed it straight to
`announce`. It now waits for the same line, through the same predicate. A tunnel that never connects
still returns its URL rather than nothing — the registrars downstream report their own outcome, and a
"no URL" gate would misname it.

## A premise #432 was resting on

`REGISTRATION_ATTEMPTS` is documented as "sized for a tunnel, which is live before its URL is printed".
That is the claim #435 disproves — the URL is printed while the hostname is still NXDOMAIN, and part of
what the budget was absorbing was this gap rather than the platform's warm-up. The second commit
corrects the wording to what now holds: live before its URL is *handed over*.

## Verified

`lint` + `typecheck` + `test` (1619). Three offline checks, each confirmed red without the change: the
URL is withheld until the connection line arrives (tunnel + docker), and the timeout branch still
serves *and* names the tunnel as the fault.

Live, against real tunnels:

- normal path — handed over at 11.4s, and `resolve4` on the returned hostname answers **at hand-over**;
- timeout path — a real child that assigns a URL and never connects: warned, served the URL, and
  `close()` left no orphan process;
- `hasTunnelConnection` is asserted against real cloudflared output in `tunnel.live.test.ts`. That
  assumption lives in another project's source, and a change to its wording degrades this **invisibly**
  — nothing fails, every tunnel is just handed over a connect-timeout late — so it is asserted rather
  than left to be inferred from a slow run. Same shape as the fly/railway CLI probes.

## Not established

Why Telegram keeps answering `Failed to resolve host` for 80s after the record is live. Its own
resolver's negative cache fits (the zone's SOA sets a 1800s negative TTL) but the major public
resolvers demonstrably do not honour it, so this is not proven. The fix does not depend on knowing:
not speaking before the name exists is correct whichever side holds the answer.

The 5s margin between the connection and the record is the one number here that is not observed —
it covers the widest measured gap (3.9s), and all 7 samples were taken over cloudflared's http2
transport because the measuring machine's network blocks its QUIC.
