### PR TITLE
fix(deploy): docker names a tunnel that never connected, like its sibling does

### DIFF
--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -40,11 +40,18 @@ export type DockerRunOutcome =
 type DockerAnnounce = (baseUrl: string) => Promise<{ kind: string; outcome: RegistrationOutcome }[]>;
 
 export type DockerHealthProbe = (healthUrl: string) => Promise<boolean>;
+/** A published Quick Tunnel URL, and whether its tunnel ever reported an edge connection. Both, because
+ *  a URL that never connected still gets served (retrying meets the same network) and the operator has
+ *  to be told which of the two they are looking at. */
+export interface ComposeTunnel {
+  url: string;
+  connected: boolean;
+}
 export type DockerTunnelUrlProbe = (
   docker: CliRunner,
   composeFile: string,
   env: NodeJS.ProcessEnv,
-) => Promise<string | undefined>;
+) => Promise<ComposeTunnel | undefined>;
 
 /** Resolve Docker Compose's `host:port` output to a loopback URL (safe for 0.0.0.0/[::] bindings too). */
 export function localUrlFromComposePort(stdout: string): string | undefined {
@@ -64,14 +71,15 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
  * reports an edge connection. Waiting for the second is the same requirement `startCloudflareTunnel`
  * has and for the same reason — the hostname does not exist until then (#435), and this driver hands
  * the URL straight to `announce`. Returns a URL that never connected rather than nothing: the
- * registrars downstream report their own outcome, and a gate saying "no URL" would misname it.
+ * registrars downstream report their own outcome, and a gate saying "no URL" would misname it — but it
+ * says WHICH it is returning, because the caller owes the operator that sentence.
  */
 export async function waitForComposeTunnelUrl(
   docker: CliRunner,
   composeFile: string,
   env: NodeJS.ProcessEnv,
   options: { attempts?: number; intervalMs?: number; sleep?: (ms: number) => Promise<void> } = {},
-): Promise<string | undefined> {
+): Promise<ComposeTunnel | undefined> {
   const compose = ["compose", "-f", composeFile];
   const attempts = options.attempts ?? 60;
   let assigned: string | undefined;
@@ -81,12 +89,12 @@ export async function waitForComposeTunnelUrl(
       assigned ??= parseTunnelUrl(logs.stdout);
       if (assigned && hasTunnelConnection(logs.stdout)) {
         await (options.sleep ?? sleep)(TUNNEL_DNS_LAG_MS);
-        return assigned;
+        return { url: assigned, connected: true };
       }
     }
     if (attempt + 1 < attempts) await (options.sleep ?? sleep)(options.intervalMs ?? 500);
   }
-  return assigned;
+  return assigned ? { url: assigned, connected: false } : undefined;
 }
 
 const defaultTunnelUrlProbe: DockerTunnelUrlProbe = (docker, composeFile, env) =>
@@ -203,12 +211,24 @@ export async function deployDockerRun(
 
   if (!hasTunnel) return { ok: true, url };
   log("waiting for the Compose tunnel service to publish its Quick Tunnel URL…");
-  const tunnelUrl = await tunnelUrlProbe(docker, plan.composeFile, env);
-  if (!tunnelUrl) {
+  const tunnel = await tunnelUrlProbe(docker, plan.composeFile, env);
+  if (!tunnel) {
     return gate(
       `tunnel did not publish a Quick Tunnel URL — inspect \`docker compose -f ${plan.composeFile} logs tunnel\``,
     );
   }
+  // The same sentence `startCloudflareTunnel` prints for the same state, and needed MORE here: this
+  // cloudflared runs in a container, so the author cannot see the logs that would explain the
+  // registration failures about to follow. Silence sends them to debug the platform for what is a
+  // local tunnel that never came up.
+  if (!tunnel.connected) {
+    log(
+      `warn: the tunnel service never reported an edge connection for ${tunnel.url} — announcing it anyway. ` +
+        `Nothing reaches a tunnel that has not connected, so a webhook registration that cannot resolve the ` +
+        `host is this, not the platform. Inspect \`docker compose -f ${plan.composeFile} logs tunnel\`.`,
+    );
+  }
+  const tunnelUrl = tunnel.url;
   // Registration lives HERE, like every other host's driver, and not at the CLI: this is the layer
   // that owns the outcome, so it is the layer that can gate on one. While it sat above, docker was
   // the one target whose `--run` could exit 0 with a webhook that never registered.

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -72,7 +72,7 @@ describe("deploy/docker/run: local Compose journey", () => {
       docker,
       () => {},
       healthy,
-      async () => "https://blue-cat.trycloudflare.com",
+      async () => ({ url: "https://blue-cat.trycloudflare.com", connected: true }),
     );
     expect(out).toEqual({
       ok: true,
@@ -109,7 +109,7 @@ describe("deploy/docker/run: local Compose journey", () => {
       docker,
       () => {},
       healthy,
-      async () => "https://blue-cat.trycloudflare.com",
+      async () => ({ url: "https://blue-cat.trycloudflare.com", connected: true }),
     );
     expect(gated.ok).toBe(false);
     if (!gated.ok) {
@@ -131,9 +131,52 @@ describe("deploy/docker/run: local Compose journey", () => {
       docker,
       () => {},
       healthy,
-      async () => "https://blue-cat.trycloudflare.com",
+      async () => ({ url: "https://blue-cat.trycloudflare.com", connected: true }),
     );
     expect(out.ok).toBe(true);
+  });
+
+  // The sibling of the warning `startCloudflareTunnel` prints, and load-bearing for a sharper reason:
+  // this cloudflared runs in a CONTAINER, so its logs are not in front of the author. Without this
+  // line the deploy announces a URL nothing can reach and the only visible symptom is a platform
+  // refusing to register — which sends the author to debug the platform.
+  it("names a tunnel that never connected, rather than announcing it silently", async () => {
+    const { docker } = fakeDocker((args) => {
+      if (args.includes("--services")) return { stdout: "agent\ntunnel\n" };
+      if (args.includes("port")) return { stdout: "127.0.0.1:8787\n" };
+      return {};
+    });
+    const lines: string[] = [];
+    const out = await deployDockerRun(
+      plan({ requireTunnel: true, announce: async () => [{ kind: "github", outcome: "manual" }] }),
+      docker,
+      (message) => lines.push(message),
+      healthy,
+      async () => ({ url: "https://blue-cat.trycloudflare.com", connected: false }),
+    );
+    expect(out.ok).toBe(true);
+    const warned = lines.find((line) => line.startsWith("warn:"));
+    expect(warned, `no warning among: ${lines.join(" | ")}`).toBeDefined();
+    // The URL and the remedy, because the author cannot reach these container logs on their own.
+    expect(warned).toContain("https://blue-cat.trycloudflare.com");
+    expect(warned).toContain("logs tunnel");
+  });
+
+  it("a connected tunnel says nothing — the warning must not fire on the normal path", async () => {
+    const { docker } = fakeDocker((args) => {
+      if (args.includes("--services")) return { stdout: "agent\ntunnel\n" };
+      if (args.includes("port")) return { stdout: "127.0.0.1:8787\n" };
+      return {};
+    });
+    const lines: string[] = [];
+    await deployDockerRun(
+      plan({ requireTunnel: true, announce: async () => [{ kind: "github", outcome: "manual" }] }),
+      docker,
+      (message) => lines.push(message),
+      healthy,
+      async () => ({ url: "https://blue-cat.trycloudflare.com", connected: true }),
+    );
+    expect(lines.filter((line) => line.startsWith("warn:"))).toEqual([]);
   });
 
   it("passes secret values through the child environment, never argv", async () => {
@@ -256,9 +299,10 @@ describe("deploy/docker/run: parsers", () => {
         },
       },
     );
-    // Neither poll carries a connection line, so the budget runs out — and the URL is still returned.
-    // The registrars downstream report their own outcome; a "no URL" gate would misname this one.
-    expect(url).toBe("https://blue-cat.trycloudflare.com");
+    // Neither poll carries a connection line, so the budget runs out — and the URL is still returned,
+    // marked as never having connected. The registrars downstream report their own outcome; a "no URL"
+    // gate would misname this one, and an unmarked URL would leave the driver unable to say which it is.
+    expect(url).toEqual({ url: "https://blue-cat.trycloudflare.com", connected: false });
     expect(sleeps).toEqual([7]);
   });
 
@@ -286,7 +330,7 @@ describe("deploy/docker/run: parsers", () => {
         },
       },
     );
-    expect(url).toBe("https://blue-cat.trycloudflare.com");
+    expect(url).toEqual({ url: "https://blue-cat.trycloudflare.com", connected: true });
     expect(calls, "the URL was there on poll 1; it kept polling for the connection").toBe(2);
     expect(sleeps).toEqual([7, TUNNEL_DNS_LAG_MS]);
   });


### PR DESCRIPTION
Follow-up to #437, from reviewing it.

That PR taught both tunnel consumers to wait for cloudflared's edge connection, and gave both the same fallback: serve a URL that never connected, since retrying meets the same network. `startCloudflareTunnel` explains that state:

> cloudflared never reported an edge connection for … — serving it anyway. Nothing reaches a tunnel that has not connected, so a webhook registration that cannot resolve the host is this, not the platform.

`waitForComposeTunnelUrl` made the same decision and said nothing. One concept, two implementations, one of them careful — the shape AGENTS.md lists first for this repo.

The sentence is worth **more** on the Compose path: that cloudflared runs in a container, so its logs are not in front of the author. Their only symptom is a platform refusing to register, which sends them to debug the platform for a local tunnel that never came up. #437's own test comment states the reasoning ("Silence here would send the author to debug the platform for a local tunnel failure") — it just did not reach this caller.

The probe returns `{ url, connected }` rather than logging itself: the driver already holds the operator's log channel and the `warn:` prefix convention `railway/run.ts` uses, and the probe stays free of output. Two tests cover both directions, and deleting the line turns one red.
