### PR TITLE
docs: serve.ts imports Hono's node adapter, not the framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,11 @@ src/
 │   │                     # semantics every collision check would then have to PREDICT. Prefix
 │   │                     # owners are a separate mount argument, not a key spelling. Plus the
 │   │                     # totality boundary and the node:http binding. Shared ground, NOT a
-│   │                     # deployment target: every host in deploy/ runs this same process. Hono
-│   │                     # lives INSIDE this file (overrideGlobalObjects: false keeps it there — an
-│   │                     # embedder's globals are not ours to swap); the types stay pure Fetch.
+│   │                     # deployment target: every host in deploy/ runs this same process. What is
+│   │                     # imported here is Hono's node ADAPTER (serve/getRequestListener), never the
+│   │                     # framework — the dispatch above is ours; overrideGlobalObjects: false keeps
+│   │                     # even the adapter inside the file, since an embedder's globals are not ours
+│   │                     # to swap. The types stay pure Fetch.
 │   ├── agentcore-service.ts # the AgentCore SERVING assembly — same product as service.ts, built
 │   │                     # differently because the host is: the adapter is the surface, channels are
 │   │                     # discovered LAZILY (the state mount at boot is pre-restore, so eager


### PR DESCRIPTION
The repo map in `AGENTS.md` described `channels/serve.ts` as the place "Hono lives INSIDE", which reads as the framework being used there.

It is not. The file imports exactly two functions from `@hono/node-server` — `serve` and `getRequestListener` — and the dispatch described two sentences earlier in the same entry is this repo's own map lookup over literal paths. `hono` appears in the tree only as that adapter's peer dependency; no source file imports it.

This is the fourth risk shape `AGENTS.md` lists for reviewing this repo: a comment asserting a mechanism that is not the one in the code. Here it would argue the next person into reaching for a Hono router that was never available.

The `overrideGlobalObjects: false` claim in the same sentence is accurate and stays — it is what keeps even the adapter from swapping an embedder's globals.