### PR TITLE
test(live): an agent schedules itself, and the deployment turns that into an EventBridge one-shot

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -29,10 +29,12 @@ jobs:
     # cancel in progress).
     #
     # 120, not 60: the probes run SERIALLY (`fileParallelism: false`) and their own budgets already add
-    # up past an hour — the AgentCore deploy alone declares 30 minutes for the stack plus 15 for its
-    # teardown, on top of the fly and railway deploys and a container build. At 60 this job would hit
-    # the ceiling on a normal-but-slow night, and it would hit it DURING the most expensive probe, in
-    # the one place where the sweeps below are all that stand between a kill and a billing leak.
+    # up past an hour — the TWO AgentCore deploys (agentcore-deploy and agentcore-wake) each declare 30
+    # minutes for the stack plus 15 for teardown, and the wake probe additionally waits out a 90s wake
+    # delay plus up to 5 more for the fire, on top of the fly and railway deploys and a container build.
+    # At 60 this job would hit the ceiling on a normal-but-slow night, and it would hit it DURING the
+    # most expensive probe, in the one place where the sweeps below are all that stand between a kill
+    # and a billing leak. Observed run time is ~20 minutes; the gap is worst-case ceilings, not slack.
     timeout-minutes: 120
     environment: live # holds FASTAGENT_LIVE_MODEL and the provider key
     steps:
@@ -179,7 +181,7 @@ jobs:
           # an operator who ran `railway login` and only names the variable in its gate message, so
           # here the token stands in for the session CI has no way to hold.
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
-          # Scoped by an inline IAM policy to the resources the deploy probe creates and destroys: a
+          # Scoped by an inline IAM policy to the resources the AgentCore probes create and destroy: a
           # CloudFormation stack, an ECR repository, an S3 bucket and an AgentCore runtime. The policy
           # needs FOUR patterns, not one — the driver derives each name differently from the same
           # `live-probe-<uuid8>` directory, and only the stack wears the `fastagent-` prefix:
@@ -187,6 +189,17 @@ jobs:
           #   repository `fastagent/live-probe-*` (slash) / runtime `live_probe_*` (underscores).
           # A policy written for the stack pattern alone denies the other three, and does it only after
           # the image is built and pushed. test/live/agentcore-deploy.live.test.ts carries the same map.
+          #
+          # agentcore-wake needs MORE, and its failures land the same way — after the push:
+          #   scheduler:ListSchedules   RESOURCE-LESS, so it can only be granted on `*` (the probe reads
+          #                             the alarm back; teardown and the sweep below both list too)
+          #   scheduler:GetSchedule     the expression + completion action, which the summary omits
+          #   scheduler:DeleteSchedule  teardown here and the sweep step below
+          # It is also the first `selfSchedule: true` fixture, i.e. the first deployment with
+          # `needsForwarder` true: the forwarder Lambda + its Function URL, the wake role
+          # (iam:CreateRole / PassRole / AttachRolePolicy / DetachRolePolicy) and a VERSIONED state
+          # bucket (s3:PutBucketVersioning, s3:PutLifecycleConfiguration) exist in no other probe.
+          # The policy itself lives in AWS and cannot be verified from this repo.
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -283,11 +296,21 @@ jobs:
             # at runtime, into the `default` Scheduler group, and `ActionAfterCompletion: DELETE` only
             # runs once a schedule FIRES. A probe killed between the wake call and the fire leaves one
             # pending; after `delete-stack` its target is gone and it retries into nothing for weeks.
-            aws scheduler list-schedules --name-prefix "fa-$name-wk-" \
-              --query 'Schedules[].Name' --output text 2>/dev/null | tr '\t' '\n' | while read -r alarm; do
-              [ -n "$alarm" ] || continue
+            #
+            # Command substitution, NOT a pipe into `while`, for both reasons this step already knows:
+            # a piped loop is a subshell that discards `failed=1`, and an un-`if`-guarded pipeline under
+            # `bash -e` + `pipefail` would abort the WHOLE sweep at the first list failure (missing IAM,
+            # expired credentials, throttling) — skipping this name's stack, bucket and repository and
+            # every name after it, with the reason discarded down /dev/null.
+            if ! alarms=$(aws scheduler list-schedules --name-prefix "fa-$name-wk-" \
+              --query 'Schedules[].Name' --output text 2>&1); then
+              echo "::error::list-schedules fa-$name-wk- failed: $alarms"
+              failed=1
+              alarms=""
+            fi
+            for alarm in $alarms; do
               echo "deleting wake alarm $alarm" >&2
-              aws scheduler delete-schedule --name "$alarm" || echo "::error::could not delete wake alarm $alarm"
+              attempt "delete-schedule $alarm" aws scheduler delete-schedule --name "$alarm"
             done
             attempt "delete-stack $name" aws cloudformation delete-stack --stack-name "fastagent-$name"
             attempt "wait stack-delete $name" aws cloudformation wait stack-delete-complete --stack-name "fastagent-$name"

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -279,6 +279,16 @@ jobs:
           while read -r name; do
             [ -n "$name" ] || continue
             bucket="fa-$name-$account"
+            # BEFORE the stack, because these are not stack resources: the forwarder creates wake alarms
+            # at runtime, into the `default` Scheduler group, and `ActionAfterCompletion: DELETE` only
+            # runs once a schedule FIRES. A probe killed between the wake call and the fire leaves one
+            # pending; after `delete-stack` its target is gone and it retries into nothing for weeks.
+            aws scheduler list-schedules --name-prefix "fa-$name-wk-" \
+              --query 'Schedules[].Name' --output text 2>/dev/null | tr '\t' '\n' | while read -r alarm; do
+              [ -n "$alarm" ] || continue
+              echo "deleting wake alarm $alarm" >&2
+              aws scheduler delete-schedule --name "$alarm" || echo "::error::could not delete wake alarm $alarm"
+            done
             attempt "delete-stack $name" aws cloudformation delete-stack --stack-name "fastagent-$name"
             attempt "wait stack-delete $name" aws cloudformation wait stack-delete-complete --stack-name "fastagent-$name"
             # `s3 rm` does not empty a versioned bucket — it writes a delete marker per object, and a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,8 +293,10 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # check that the template parses)
                              # plus a REAL stack + ECR repo + S3 bucket provisioned and destroyed
                              # (agentcore-deploy — no public URL exists, so it proves the deployment
-                             # works through InvokeAgentRuntime; teardown is THREE places because the
-                             # bucket and repo live outside the stack on purpose), and an agent
+                             # works through InvokeAgentRuntime; teardown is FOUR places because the
+                             # bucket, repo and runtime-created wake alarms all live outside the stack
+                             # on purpose, and it is ONE shared function in test/live/env.ts because a
+                             # second copy of cleanup code drifts where nobody looks), and an agent
                              # SCHEDULING ITSELF on a host with no resident process (agentcore-wake —
                              # the wake tool's write becomes a POST to the forwarder becomes an
                              # EventBridge one-shot, three systems that must be simultaneously right

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,12 @@ test/                        # vitest; faux models by default + reusable SPEC co
                              # plus a REAL stack + ECR repo + S3 bucket provisioned and destroyed
                              # (agentcore-deploy — no public URL exists, so it proves the deployment
                              # works through InvokeAgentRuntime; teardown is THREE places because the
-                             # bucket and repo live outside the stack on purpose),
+                             # bucket and repo live outside the stack on purpose), and an agent
+                             # SCHEDULING ITSELF on a host with no resident process (agentcore-wake —
+                             # the wake tool's write becomes a POST to the forwarder becomes an
+                             # EventBridge one-shot, three systems that must be simultaneously right
+                             # and all silent from inside the agent when they are not; the FIRE is
+                             # only weakly checked, via a self-deleting alarm's disappearance),
                              # `flyctl` still printing what the Fly driver reads (fly — read-only), and
                              # a REAL Fly app provisioned then destroyed (fly-deploy — which is how
                              # #425 was found: a deploy whose every step succeeded, serving on a URL

--- a/test/live/agentcore-deploy.live.test.ts
+++ b/test/live/agentcore-deploy.live.test.ts
@@ -15,11 +15,10 @@
  * check that the deployment WORKS goes through that API — an `invoke` envelope, not the driver's
  * `checkpoint`; the reason it cannot be a checkpoint is on the assertion itself.
  *
- * TEARDOWN IS THREE PLACES, and the product offers none of them: `delete-stack` is used only to clear
- * a ROLLBACK_COMPLETE husk. The state bucket and the ECR repository are created OUTSIDE the stack on
- * purpose — `plan.ts` says why: so a `delete-stack` "cannot take the agent's memory with it". Correct
- * for an operator, which makes cleanup this probe's own job: stack, then bucket, then repository (with
- * its images).
+ * TEARDOWN, which the product offers none of, is {@link destroyAgentcoreDeployment} — shared with the
+ * wake probe, and shared deliberately: it is cleanup code, so a second copy drifts unnoticed until it
+ * has been leaking. It sweeps more than this fixture creates (wake alarms, a versioned bucket), which
+ * is the point: one line here (a channel, a schedule, `selfSchedule`) turns those on.
  *
  * COSTS REAL RESOURCES and is the slowest probe here — a stack create plus delete is minutes.
  *
@@ -36,13 +35,13 @@
  * The directory name carries no `fastagent-` prefix of its own: the driver adds one.
  */
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { agentcoreName, ingressSessionId, stateBucketName } from "../../src/deploy/agentcore/plan.ts";
+import { agentcoreName } from "../../src/deploy/agentcore/plan.ts";
 import { parseStackOutputs } from "../../src/deploy/agentcore/run.ts";
-import { CLI, aws, liveVersion, requireEnv, run } from "./env.ts";
+import { CLI, aws, destroyAgentcoreDeployment, invokeAgentcore, liveVersion, requireEnv, run } from "./env.ts";
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 requireEnv("AWS_ACCESS_KEY_ID", "an AWS key scoped to fastagent-live-probe-* (this probe creates real resources)");
@@ -53,7 +52,6 @@ requireEnv("AWS_REGION", "a region where Bedrock AgentCore is available, e.g. us
  *  all of them inside the IAM policy's namespace once the driver prefixes `fastagent-`. */
 const NAME = agentcoreName(`live-probe-${randomUUID().slice(0, 8)}`);
 const STACK = `fastagent-${NAME}`;
-const REPO = `fastagent/${NAME}`;
 
 let workspace = "";
 let account = "";
@@ -83,67 +81,11 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // Three deletions, each attempted even if an earlier one failed, and every failure reported: what
-  // survives a silent teardown here is a Bedrock runtime, a Lambda with a public Function URL, an
-  // image in ECR and a bucket holding the model credential seed — all of them billing.
-  const errors: unknown[] = [];
-  const attempt = async (label: string, args: string[]) => {
-    const { code, stderr } = await aws(args);
-    // "already gone" is the goal state, not a failure: a probe whose deploy never got that far, or a
-    // re-run after a partial teardown, both land here.
-    if (code !== 0 && !/does not exist|NotFound|NoSuchBucket/i.test(stderr)) {
-      errors.push(new Error(`${label} failed: ${stderr.slice(0, 500)}`));
-    }
-  };
-
-  await attempt("delete-stack", ["cloudformation", "delete-stack", "--stack-name", STACK]);
-  await attempt("wait stack-delete-complete", [
-    "cloudformation",
-    "wait",
-    "stack-delete-complete",
-    "--stack-name",
-    STACK,
-  ]);
-  if (account) {
-    // UNREACHED BY THIS FIXTURE: with `needsForwarder` false the driver creates no bucket, so every
-    // call below answers NoSuchBucket and the emptying path never runs. It is kept because the name is
-    // deterministic and one line in the fixture (a channel, a schedule, `selfSchedule`) turns the
-    // bucket on — at which point a teardown that had not been written would leak it silently.
-    //
-    // What it must do then: the bucket has versioning ON (run.ts enables it), so `s3 rm` does not empty
-    // it — it writes a DELETE MARKER per object. Markers are not Versions (they come back under their
-    // own key), and a bucket still holding either refuses to go with BucketNotEmpty, which is not one
-    // of the tolerated patterns above. Both lists, or the bucket leaks holding the model credential seed.
-    const bucket = stateBucketName(NAME, account);
-    await attempt("s3 rm", ["s3", "rm", `s3://${bucket}`, "--recursive"]);
-    const listed = await aws(["s3api", "list-object-versions", "--bucket", bucket, "--output", "json"]);
-    if (listed.code === 0) {
-      const payload = JSON.parse(listed.stdout) as {
-        Versions?: { Key: string; VersionId: string }[];
-        DeleteMarkers?: { Key: string; VersionId: string }[];
-      };
-      const objects = [...(payload.Versions ?? []), ...(payload.DeleteMarkers ?? [])].map(({ Key, VersionId }) => ({
-        Key,
-        VersionId,
-      }));
-      if (objects.length > 0) {
-        await attempt("s3api delete-objects", [
-          "s3api",
-          "delete-objects",
-          "--bucket",
-          bucket,
-          "--delete",
-          JSON.stringify({ Objects: objects }),
-        ]);
-      }
-    }
-    await attempt("s3 rb", ["s3api", "delete-bucket", "--bucket", bucket]);
-  }
-  await attempt("ecr delete-repository", ["ecr", "delete-repository", "--repository-name", REPO, "--force"]);
-
-  if (workspace) await rm(workspace, { recursive: true, force: true }).catch((e: unknown) => errors.push(e));
-  if (errors.length > 0) {
-    throw new AggregateError(errors, `teardown failed — check stack ${STACK}, bucket fa-${NAME}-*, repo ${REPO}`);
+  // `finally`, not a catch: the AWS failure still throws, and the temp directory still goes.
+  try {
+    await destroyAgentcoreDeployment(NAME, account);
+  } finally {
+    if (workspace) await rm(workspace, { recursive: true, force: true });
   }
 }, 900_000);
 
@@ -180,29 +122,14 @@ describe("deploy agentcore --run: a real stack, provisioned and destroyed", () =
     // public `invoke` kind is served" (agentcore.ts). A checkpoint here answers 403 from the container.
     // It is also the better assertion: `invoke` runs a real turn, the same thing the fly and railway
     // probes POST for.
-    // A real file, NOT /dev/stdout: this CLI writes the response body to the positional argument, and
-    // on a runner whose stdout is a pipe Actions owns, opening it answers "No such device or address".
-    const out = join(workspace, "invoke-reply.json");
-    const payload = join(workspace, "invoke.json");
-    await writeFile(
-      payload,
-      `${JSON.stringify({ kind: "invoke", session: "live-agentcore", text: "Reply with just: ok" })}\n`,
-    );
-    const reply = await aws([
-      "bedrock-agentcore",
-      "invoke-agent-runtime",
-      "--agent-runtime-arn",
-      runtimeArn as string,
-      "--runtime-session-id",
-      ingressSessionId(NAME),
-      "--payload",
-      `file://${payload}`,
-      "--cli-binary-format",
-      "raw-in-base64-out",
-      out,
-    ]);
-    expect(reply.code, `invoke-agent-runtime failed:\n${reply.stderr.slice(-2000)}`).toBe(0);
-    const body = await readFile(out, "utf8");
+    const body = await invokeAgentcore({
+      runtimeArn: runtimeArn as string,
+      name: NAME,
+      session: "live-agentcore",
+      text: "Reply with just: ok",
+      dir: workspace,
+      label: "invoke",
+    });
 
     // The reply is the invoke stream in AgentCore's streaming form — the HTTP channel's SSE, reused
     // wholesale (agentcore.ts). A turn that reached a terminal is what proves the container served.

--- a/test/live/agentcore-wake.live.test.ts
+++ b/test/live/agentcore-wake.live.test.ts
@@ -86,9 +86,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // Same three places as agentcore-deploy, and here the bucket is REAL: `selfSchedule` turns the
-  // forwarder on, which is what makes the driver create a state bucket. The alarms need no cleanup —
-  // one-shots self-delete after firing, and the stack's Scheduler group goes with the stack.
+  // FOUR places, not the three agentcore-deploy has. The alarms are the extra one, and they are the
+  // easiest to get wrong: the forwarder creates them at RUNTIME with the SDK, into the `default`
+  // Scheduler group, so they are not stack resources and `delete-stack` does not take them. Nor do
+  // they reliably remove themselves — `ActionAfterCompletion: DELETE` runs after a schedule FIRES, and
+  // any failure between the wake call and the fire (a failed assertion, a killed job) leaves one
+  // pending, aimed at a forwarder this teardown is about to delete. That is precisely the orphan shape
+  // found in this account: a schedule outliving its target, retrying into nothing, for weeks.
+  //
+  // They go FIRST, while the stack still stands: after `delete-stack` the forwarder is gone and the
+  // alarm is a leak nothing is left to explain.
   const errors: unknown[] = [];
   const attempt = async (label: string, args: string[]) => {
     const { code, stderr } = await aws(args);
@@ -96,6 +103,17 @@ afterAll(async () => {
       errors.push(new Error(`${label} failed: ${stderr.slice(0, 500)}`));
     }
   };
+
+  const pending = await aws(["scheduler", "list-schedules", "--name-prefix", ALARM_PREFIX, "--output", "json"]);
+  if (pending.code === 0) {
+    for (const alarm of (JSON.parse(pending.stdout) as { Schedules?: { Name: string }[] }).Schedules ?? []) {
+      await attempt(`scheduler delete-schedule ${alarm.Name}`, ["scheduler", "delete-schedule", "--name", alarm.Name]);
+    }
+  } else {
+    // Not fatal to the rest of teardown, but never silent: an unreadable list is indistinguishable
+    // from an empty one, and the difference is whether something is still out there firing.
+    errors.push(new Error(`could not list wake alarms under ${ALARM_PREFIX}: ${pending.stderr.slice(0, 300)}`));
+  }
 
   await attempt("delete-stack", ["cloudformation", "delete-stack", "--stack-name", STACK]);
   await attempt("wait stack-delete-complete", [

--- a/test/live/agentcore-wake.live.test.ts
+++ b/test/live/agentcore-wake.live.test.ts
@@ -1,0 +1,262 @@
+/**
+ * The wake-alarm mechanism against real AWS: an agent schedules its own follow-up, and the deployment
+ * turns that into an EventBridge one-shot that will poke it back awake.
+ *
+ * WHY THIS NEEDS A LIVE PROBE. On a host with no resident process, a `wake` is not a timer someone is
+ * holding — it is a round trip through three systems (wake-alarm.ts):
+ *
+ *   wake tool → wakeups store → the sink → POST the full pending set to the forwarder's reserved path
+ *   → the forwarder (AWS SDK + IAM role) mirrors each wake-up into a one-shot `at(fireAt)` schedule
+ *   → EventBridge pokes the forwarder at the instant → InvokeAgentRuntime wakes the container
+ *   → the boot / 30s pump finds the due entry and fires it
+ *
+ * Offline, every arrow but the first is a stub. The one this probe is FOR is the middle one: the
+ * container POSTing to its own forwarder, and the forwarder having exactly the IAM it needs to create
+ * a schedule. Three things have to be simultaneously right (the wake secret both sides received, the
+ * forwarder's role, the Scheduler API call), none of them is exercised by any other test, and the
+ * failure mode is silent — a pending wake-up with no alarm behind it, which is the reliability hole
+ * this whole mechanism exists to close.
+ *
+ * WHERE THE ASSERTIONS STOP, and why. Creating the alarm is checked directly. The FIRE is checked
+ * weakly — the schedule carries `ActionAfterCompletion: DELETE`, so its disappearance is evidence it
+ * ran, but disappearance has other causes and this probe cannot tell them apart. The last two arrows
+ * (poke → container awake → pump fires the turn) are NOT covered: observing them means pulling the
+ * state snapshot out of S3 and reading session records, which costs more than it settles here — that
+ * half is AWS delivering a schedule it accepted, where the half above is our code and our IAM.
+ *
+ * COSTS REAL RESOURCES (a full AgentCore stack) and is the slowest probe in the suite: a deploy plus
+ * MIN_WAKE_MS plus a teardown. Needs the same AWS credentials as agentcore-deploy, plus
+ * `scheduler:ListSchedules` / `scheduler:GetSchedule` — ListSchedules is resource-less, so it must be
+ * granted on `*`.
+ */
+import { randomUUID } from "node:crypto";
+import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { agentcoreName, ingressSessionId, stateBucketName } from "../../src/deploy/agentcore/plan.ts";
+import { parseStackOutputs } from "../../src/deploy/agentcore/run.ts";
+import { MIN_WAKE_MS } from "../../src/schedule/wakeups.ts";
+import { CLI, aws, liveVersion, requireEnv, run } from "./env.ts";
+
+const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
+requireEnv("AWS_ACCESS_KEY_ID", "an AWS key scoped to fastagent-live-probe-* (this probe creates real resources)");
+requireEnv("AWS_SECRET_ACCESS_KEY", "the secret for AWS_ACCESS_KEY_ID");
+requireEnv("AWS_REGION", "a region where Bedrock AgentCore is available, e.g. us-east-1");
+
+const NAME = agentcoreName(`live-probe-${randomUUID().slice(0, 8)}`);
+const STACK = `fastagent-${NAME}`;
+const REPO = `fastagent/${NAME}`;
+/** The forwarder names every alarm `WAKE_PREFIX + sha256(wakeId)[:16]` (plan.ts). The prefix is all
+ *  this probe can predict — the id is minted inside the container. */
+const ALARM_PREFIX = `fa-${NAME}-wk-`;
+
+let workspace = "";
+let account = "";
+
+beforeAll(async () => {
+  const identity = await aws(["sts", "get-caller-identity", "--output", "json"]);
+  expect(identity.code, `sts get-caller-identity failed: ${identity.stderr}`).toBe(0);
+  account = (JSON.parse(identity.stdout) as { Account: string }).Account;
+
+  if (process.env.RUNNER_TEMP) await appendFile(join(process.env.RUNNER_TEMP, "agentcore-probe-names"), `${NAME}\n`);
+
+  workspace = join(tmpdir(), NAME);
+  await mkdir(workspace, { recursive: true });
+  await writeFile(join(workspace, "persona.md"), "You are terse. Answer in as few words as possible.\n");
+  // `selfSchedule` is what puts the whole mechanism in the deployment: it mounts the `wake` tool in the
+  // container (open.ts, serving + selfSchedule), and it puts the forwarder, its Function URL and the
+  // wake/scheduler IAM into the template. Without it there is no chain to test.
+  await writeFile(
+    join(workspace, "fastagent.config.mjs"),
+    `export default { model: ${JSON.stringify(MODEL)}, selfSchedule: true };\n`,
+  );
+  await writeFile(
+    join(workspace, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "live-agentcore-wake-probe",
+        private: true,
+        dependencies: { "@fastagent-sh/fastagent": await liveVersion() },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+});
+
+afterAll(async () => {
+  // Same three places as agentcore-deploy, and here the bucket is REAL: `selfSchedule` turns the
+  // forwarder on, which is what makes the driver create a state bucket. The alarms need no cleanup —
+  // one-shots self-delete after firing, and the stack's Scheduler group goes with the stack.
+  const errors: unknown[] = [];
+  const attempt = async (label: string, args: string[]) => {
+    const { code, stderr } = await aws(args);
+    if (code !== 0 && !/does not exist|NotFound|NoSuchBucket/i.test(stderr)) {
+      errors.push(new Error(`${label} failed: ${stderr.slice(0, 500)}`));
+    }
+  };
+
+  await attempt("delete-stack", ["cloudformation", "delete-stack", "--stack-name", STACK]);
+  await attempt("wait stack-delete-complete", [
+    "cloudformation",
+    "wait",
+    "stack-delete-complete",
+    "--stack-name",
+    STACK,
+  ]);
+  if (account) {
+    const bucket = stateBucketName(NAME, account);
+    await attempt("s3 rm", ["s3", "rm", `s3://${bucket}`, "--recursive"]);
+    const listed = await aws(["s3api", "list-object-versions", "--bucket", bucket, "--output", "json"]);
+    if (listed.code === 0) {
+      const payload = JSON.parse(listed.stdout) as {
+        Versions?: { Key: string; VersionId: string }[];
+        DeleteMarkers?: { Key: string; VersionId: string }[];
+      };
+      const objects = [...(payload.Versions ?? []), ...(payload.DeleteMarkers ?? [])].map(({ Key, VersionId }) => ({
+        Key,
+        VersionId,
+      }));
+      if (objects.length > 0) {
+        await attempt("s3api delete-objects", [
+          "s3api",
+          "delete-objects",
+          "--bucket",
+          bucket,
+          "--delete",
+          JSON.stringify({ Objects: objects }),
+        ]);
+      }
+    }
+    await attempt("s3 rb", ["s3api", "delete-bucket", "--bucket", bucket]);
+  }
+  await attempt("ecr delete-repository", ["ecr", "delete-repository", "--repository-name", REPO, "--force"]);
+
+  if (workspace) await rm(workspace, { recursive: true, force: true }).catch((e: unknown) => errors.push(e));
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `teardown failed — check stack ${STACK}, bucket fa-${NAME}-*, repo ${REPO}`);
+  }
+}, 900_000);
+
+/** One `invoke` envelope through the runtime, returning the stream body. */
+async function invokeRuntime(runtimeArn: string, text: string, label: string): Promise<string> {
+  const payload = join(workspace, `${label}.json`);
+  const out = join(workspace, `${label}-reply.json`);
+  await writeFile(payload, `${JSON.stringify({ kind: "invoke", session: "live-wake", text })}\n`);
+  const reply = await aws([
+    "bedrock-agentcore",
+    "invoke-agent-runtime",
+    "--agent-runtime-arn",
+    runtimeArn,
+    "--runtime-session-id",
+    ingressSessionId(NAME),
+    "--payload",
+    `file://${payload}`,
+    "--cli-binary-format",
+    "raw-in-base64-out",
+    out,
+  ]);
+  expect(reply.code, `invoke-agent-runtime (${label}) failed:\n${reply.stderr.slice(-2000)}`).toBe(0);
+  return await readFile(out, "utf8");
+}
+
+/** What ListSchedules actually returns per entry: a SUMMARY. Measured against the API, not assumed —
+ *  there is no `ScheduleExpression` on it, which is why that assertion goes through {@link getAlarm}. */
+interface AlarmSummary {
+  Name: string;
+  State?: string;
+  Target?: { Arn?: string };
+}
+
+async function listAlarms(): Promise<AlarmSummary[]> {
+  const listed = await aws(["scheduler", "list-schedules", "--name-prefix", ALARM_PREFIX, "--output", "json"]);
+  expect(listed.code, `scheduler list-schedules failed: ${listed.stderr}`).toBe(0);
+  return (JSON.parse(listed.stdout) as { Schedules?: AlarmSummary[] }).Schedules ?? [];
+}
+
+/** The full schedule: only `get-schedule` carries the expression and the completion action. */
+async function getAlarm(name: string): Promise<{ ScheduleExpression?: string; ActionAfterCompletion?: string }> {
+  const got = await aws(["scheduler", "get-schedule", "--name", name, "--output", "json"]);
+  expect(got.code, `scheduler get-schedule ${name} failed: ${got.stderr}`).toBe(0);
+  return JSON.parse(got.stdout) as { ScheduleExpression?: string; ActionAfterCompletion?: string };
+}
+
+describe("agentcore wake alarms: a self-scheduled wake-up becomes an EventBridge one-shot", () => {
+  it("the container registers an alarm with the forwarder, and it fires", async () => {
+    try {
+      await run(process.execPath, [CLI, "deploy", "agentcore", "--run"], workspace);
+    } catch (error) {
+      const e = error as { stderr?: string; stdout?: string };
+      throw new Error(`deploy agentcore --run failed for ${STACK}:\n${(e.stderr || e.stdout || "").slice(-4000)}`);
+    }
+
+    const outputs = await aws([
+      "cloudformation",
+      "describe-stacks",
+      "--stack-name",
+      STACK,
+      "--query",
+      "Stacks[0].Outputs",
+      "--output",
+      "json",
+    ]);
+    expect(outputs.code, `describe-stacks failed: ${outputs.stderr}`).toBe(0);
+    const runtimeArn = parseStackOutputs(outputs.stdout).RuntimeArn;
+    expect(runtimeArn, `the converged stack has no RuntimeArn output:\n${outputs.stdout.slice(0, 500)}`).toBeTruthy();
+
+    // Nothing has asked for a wake-up yet. Asserted so the alarm found below is THIS run's doing and
+    // not a leftover the name prefix happened to match.
+    expect(await listAlarms(), "an alarm existed before any wake-up was requested").toHaveLength(0);
+
+    // The delay is the product's floor (MIN_WAKE_MS): shorter is rejected by the guardrail, and
+    // longer only makes the probe wait. The tool is NAMED because self-selection is not what this
+    // probe is about — see the deferred-tool probe for that distinction.
+    const seconds = Math.round(MIN_WAKE_MS / 1000);
+    const body = await invokeRuntime(
+      runtimeArn as string,
+      `Call the wake tool to wake yourself in ${seconds} seconds, then reply with just: scheduled`,
+      "wake",
+    );
+    expect(body, `the wake turn did not complete:\n${body.slice(0, 600)}`).toContain('"type":"completed"');
+
+    // THE assertion. Everything between the tool call and this line is the chain that has no other
+    // test: the store write, the sink, the authenticated POST to the forwarder's reserved path, and
+    // the forwarder's own IAM creating a schedule. A pending wake-up with no alarm is exactly the
+    // silent failure the mechanism exists to prevent.
+    const alarms = await listAlarms();
+    expect(
+      alarms,
+      "the wake-up never became an EventBridge alarm — the container's POST to the forwarder, its wake " +
+        "secret, or the forwarder's scheduler IAM is broken (all three are silent from inside the agent)",
+    ).toHaveLength(1);
+    // It must target THIS deployment's forwarder: the poke goes wherever this points, and the name
+    // prefix alone would be satisfied by an alarm aimed anywhere.
+    expect(alarms[0]?.Target?.Arn, `the alarm targets something else: ${alarms[0]?.Target?.Arn}`).toContain(
+      `${STACK}-forwarder`,
+    );
+
+    const alarm = await getAlarm(alarms[0]?.Name as string);
+    // `at(...)` and nothing else: a rate/cron expression here would mean a one-shot became recurring,
+    // which on this path is an agent poking itself forever.
+    expect(alarm.ScheduleExpression, `not a one-shot: ${alarm.ScheduleExpression}`).toMatch(/^at\(/);
+    // What makes the disappearance below mean anything at all.
+    expect(alarm.ActionAfterCompletion, "a fired alarm would not clean itself up").toBe("DELETE");
+
+    // The weak half, stated as such in the header: `ActionAfterCompletion: DELETE` means a fired
+    // schedule removes itself, so disappearance is evidence it ran — evidence this probe cannot
+    // separate from other causes. Worth the wait anyway: an alarm that is still there well past its
+    // instant means EventBridge never delivered, and nothing else in the suite would say so.
+    const deadline = Date.now() + MIN_WAKE_MS + 240_000;
+    let remaining = await listAlarms();
+    while (remaining.length > 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 15_000));
+      remaining = await listAlarms();
+    }
+    expect(
+      remaining,
+      `the alarm was still registered ${Math.round((Date.now() - (deadline - MIN_WAKE_MS - 240_000)) / 1000)}s later — ` +
+        "EventBridge did not deliver it, or the forwarder rejected the poke",
+    ).toHaveLength(0);
+  }, 1_800_000);
+});

--- a/test/live/agentcore-wake.live.test.ts
+++ b/test/live/agentcore-wake.live.test.ts
@@ -25,19 +25,28 @@
  * half is AWS delivering a schedule it accepted, where the half above is our code and our IAM.
  *
  * COSTS REAL RESOURCES (a full AgentCore stack) and is the slowest probe in the suite: a deploy plus
- * MIN_WAKE_MS plus a teardown. Needs the same AWS credentials as agentcore-deploy, plus
- * `scheduler:ListSchedules` / `scheduler:GetSchedule` — ListSchedules is resource-less, so it must be
- * granted on `*`.
+ * the wake delay plus a teardown. It also needs MORE IAM than agentcore-deploy, in two ways that both
+ * fail late — after the image is built and pushed — so they are listed where a policy author will see
+ * them (.github/workflows/live.yml carries the same list):
+ *
+ *   scheduler:ListSchedules   reading the alarm back, and the teardown. RESOURCE-LESS: `*` or nothing.
+ *   scheduler:GetSchedule     the expression and completion action, which the list summary omits.
+ *   scheduler:DeleteSchedule  teardown, here and in the workflow sweep.
+ *
+ * And this is the first fixture with `selfSchedule: true`, i.e. the first `needsForwarder` deployment:
+ * the forwarder Lambda, its Function URL, the wake role (iam:CreateRole / PassRole / AttachRolePolicy)
+ * and a VERSIONED state bucket (s3:PutBucketVersioning, PutLifecycleConfiguration) are all created
+ * here and nowhere else in the suite.
  */
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { agentcoreName, ingressSessionId, stateBucketName } from "../../src/deploy/agentcore/plan.ts";
+import { agentcoreName } from "../../src/deploy/agentcore/plan.ts";
 import { parseStackOutputs } from "../../src/deploy/agentcore/run.ts";
 import { MIN_WAKE_MS } from "../../src/schedule/wakeups.ts";
-import { CLI, aws, liveVersion, requireEnv, run } from "./env.ts";
+import { CLI, aws, destroyAgentcoreDeployment, invokeAgentcore, liveVersion, requireEnv, run } from "./env.ts";
 
 const MODEL = requireEnv("FASTAGENT_LIVE_MODEL", 'the model under test, e.g. "anthropic/claude-sonnet-4-5"');
 requireEnv("AWS_ACCESS_KEY_ID", "an AWS key scoped to fastagent-live-probe-* (this probe creates real resources)");
@@ -46,10 +55,17 @@ requireEnv("AWS_REGION", "a region where Bedrock AgentCore is available, e.g. us
 
 const NAME = agentcoreName(`live-probe-${randomUUID().slice(0, 8)}`);
 const STACK = `fastagent-${NAME}`;
-const REPO = `fastagent/${NAME}`;
 /** The forwarder names every alarm `WAKE_PREFIX + sha256(wakeId)[:16]` (plan.ts). The prefix is all
  *  this probe can predict — the id is minted inside the container. */
 const ALARM_PREFIX = `fa-${NAME}-wk-`;
+
+/** ABOVE the floor, never ON it. `wake` reads the clock TWICE — `new Date(now() + ms)`, then
+ *  `addWakeup(…, now())` — and the guardrail compares them strictly (`fireAt < now + MIN_WAKE_MS`), so
+ *  asking for exactly MIN_WAKE_MS is a coin flip on a millisecond boundary. Losing it is worse than it
+ *  sounds: the turn still completes, and the rejection surfaces on the alarm assertion below, which
+ *  blames the wake secret and the forwarder's IAM. Half a minute of clearance costs the probe nothing
+ *  against a 240s poll budget. */
+const WAKE_MS = MIN_WAKE_MS + 30_000;
 
 let workspace = "";
 let account = "";
@@ -86,98 +102,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // FOUR places, not the three agentcore-deploy has. The alarms are the extra one, and they are the
-  // easiest to get wrong: the forwarder creates them at RUNTIME with the SDK, into the `default`
-  // Scheduler group, so they are not stack resources and `delete-stack` does not take them. Nor do
-  // they reliably remove themselves — `ActionAfterCompletion: DELETE` runs after a schedule FIRES, and
-  // any failure between the wake call and the fire (a failed assertion, a killed job) leaves one
-  // pending, aimed at a forwarder this teardown is about to delete. That is precisely the orphan shape
-  // found in this account: a schedule outliving its target, retrying into nothing, for weeks.
-  //
-  // They go FIRST, while the stack still stands: after `delete-stack` the forwarder is gone and the
-  // alarm is a leak nothing is left to explain.
-  const errors: unknown[] = [];
-  const attempt = async (label: string, args: string[]) => {
-    const { code, stderr } = await aws(args);
-    if (code !== 0 && !/does not exist|NotFound|NoSuchBucket/i.test(stderr)) {
-      errors.push(new Error(`${label} failed: ${stderr.slice(0, 500)}`));
-    }
-  };
-
-  const pending = await aws(["scheduler", "list-schedules", "--name-prefix", ALARM_PREFIX, "--output", "json"]);
-  if (pending.code === 0) {
-    for (const alarm of (JSON.parse(pending.stdout) as { Schedules?: { Name: string }[] }).Schedules ?? []) {
-      await attempt(`scheduler delete-schedule ${alarm.Name}`, ["scheduler", "delete-schedule", "--name", alarm.Name]);
-    }
-  } else {
-    // Not fatal to the rest of teardown, but never silent: an unreadable list is indistinguishable
-    // from an empty one, and the difference is whether something is still out there firing.
-    errors.push(new Error(`could not list wake alarms under ${ALARM_PREFIX}: ${pending.stderr.slice(0, 300)}`));
-  }
-
-  await attempt("delete-stack", ["cloudformation", "delete-stack", "--stack-name", STACK]);
-  await attempt("wait stack-delete-complete", [
-    "cloudformation",
-    "wait",
-    "stack-delete-complete",
-    "--stack-name",
-    STACK,
-  ]);
-  if (account) {
-    const bucket = stateBucketName(NAME, account);
-    await attempt("s3 rm", ["s3", "rm", `s3://${bucket}`, "--recursive"]);
-    const listed = await aws(["s3api", "list-object-versions", "--bucket", bucket, "--output", "json"]);
-    if (listed.code === 0) {
-      const payload = JSON.parse(listed.stdout) as {
-        Versions?: { Key: string; VersionId: string }[];
-        DeleteMarkers?: { Key: string; VersionId: string }[];
-      };
-      const objects = [...(payload.Versions ?? []), ...(payload.DeleteMarkers ?? [])].map(({ Key, VersionId }) => ({
-        Key,
-        VersionId,
-      }));
-      if (objects.length > 0) {
-        await attempt("s3api delete-objects", [
-          "s3api",
-          "delete-objects",
-          "--bucket",
-          bucket,
-          "--delete",
-          JSON.stringify({ Objects: objects }),
-        ]);
-      }
-    }
-    await attempt("s3 rb", ["s3api", "delete-bucket", "--bucket", bucket]);
-  }
-  await attempt("ecr delete-repository", ["ecr", "delete-repository", "--repository-name", REPO, "--force"]);
-
-  if (workspace) await rm(workspace, { recursive: true, force: true }).catch((e: unknown) => errors.push(e));
-  if (errors.length > 0) {
-    throw new AggregateError(errors, `teardown failed — check stack ${STACK}, bucket fa-${NAME}-*, repo ${REPO}`);
+  // FOUR places, not the three this fixture's resources suggest — the wake alarms are the extra one,
+  // and {@link destroyAgentcoreDeployment} takes all four (it sweeps alarms for every fixture, which
+  // is why this probe adds no teardown of its own). `finally`, not a catch: the AWS failure still
+  // throws, and the temp directory still goes.
+  try {
+    await destroyAgentcoreDeployment(NAME, account);
+  } finally {
+    if (workspace) await rm(workspace, { recursive: true, force: true });
   }
 }, 900_000);
-
-/** One `invoke` envelope through the runtime, returning the stream body. */
-async function invokeRuntime(runtimeArn: string, text: string, label: string): Promise<string> {
-  const payload = join(workspace, `${label}.json`);
-  const out = join(workspace, `${label}-reply.json`);
-  await writeFile(payload, `${JSON.stringify({ kind: "invoke", session: "live-wake", text })}\n`);
-  const reply = await aws([
-    "bedrock-agentcore",
-    "invoke-agent-runtime",
-    "--agent-runtime-arn",
-    runtimeArn,
-    "--runtime-session-id",
-    ingressSessionId(NAME),
-    "--payload",
-    `file://${payload}`,
-    "--cli-binary-format",
-    "raw-in-base64-out",
-    out,
-  ]);
-  expect(reply.code, `invoke-agent-runtime (${label}) failed:\n${reply.stderr.slice(-2000)}`).toBe(0);
-  return await readFile(out, "utf8");
-}
 
 /** What ListSchedules actually returns per entry: a SUMMARY. Measured against the API, not assumed —
  *  there is no `ScheduleExpression` on it, which is why that assertion goes through {@link getAlarm}. */
@@ -227,22 +161,40 @@ describe("agentcore wake alarms: a self-scheduled wake-up becomes an EventBridge
     // not a leftover the name prefix happened to match.
     expect(await listAlarms(), "an alarm existed before any wake-up was requested").toHaveLength(0);
 
-    // The delay is the product's floor (MIN_WAKE_MS): shorter is rejected by the guardrail, and
-    // longer only makes the probe wait. The tool is NAMED because self-selection is not what this
-    // probe is about — see the deferred-tool probe for that distinction.
-    const seconds = Math.round(MIN_WAKE_MS / 1000);
-    const body = await invokeRuntime(
-      runtimeArn as string,
-      `Call the wake tool to wake yourself in ${seconds} seconds, then reply with just: scheduled`,
-      "wake",
-    );
+    // The wake tool is NAMED because self-selection is not what this probe is about — see the
+    // deferred-tool probe for that distinction. The woken turn's `prompt` is DICTATED for a sharper
+    // reason: it is free text the model chooses, and a model that echoes this instruction into it
+    // arms a SECOND wake-up when the first fires. That one is created after teardown has listed the
+    // alarms, so it outlives the forwarder it points at — the orphan this suite already grew once.
+    const seconds = Math.round(WAKE_MS / 1000);
+    const body = await invokeAgentcore({
+      runtimeArn: runtimeArn as string,
+      name: NAME,
+      session: "live-wake",
+      text:
+        `Call the wake tool exactly once, with in: ${seconds} and prompt: "Reply with just: awake". ` +
+        "Then reply with just: scheduled",
+      dir: workspace,
+      label: "wake",
+    });
     expect(body, `the wake turn did not complete:\n${body.slice(0, 600)}`).toContain('"type":"completed"');
 
     // THE assertion. Everything between the tool call and this line is the chain that has no other
     // test: the store write, the sink, the authenticated POST to the forwarder's reserved path, and
     // the forwarder's own IAM creating a schedule. A pending wake-up with no alarm is exactly the
     // silent failure the mechanism exists to prevent.
-    const alarms = await listAlarms();
+    //
+    // POLLED, not read once. The alarm trails the reply: the sink is fire-and-forget (`void
+    // reconcile(…)` in wake-alarm.ts, retrying at 2s/4s/6s) and the SSE stream this invoke consumes
+    // does not wait for in-flight work, so `invoke-agent-runtime` can return before a cold forwarder
+    // Lambda has created anything. A single read would report that race in the words below — sending
+    // whoever reads it after the IAM and the wake secret, neither of which was wrong.
+    const appearBy = Date.now() + 60_000;
+    let alarms = await listAlarms();
+    while (alarms.length === 0 && Date.now() < appearBy) {
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      alarms = await listAlarms();
+    }
     expect(
       alarms,
       "the wake-up never became an EventBridge alarm — the container's POST to the forwarder, its wake " +
@@ -265,7 +217,8 @@ describe("agentcore wake alarms: a self-scheduled wake-up becomes an EventBridge
     // schedule removes itself, so disappearance is evidence it ran — evidence this probe cannot
     // separate from other causes. Worth the wait anyway: an alarm that is still there well past its
     // instant means EventBridge never delivered, and nothing else in the suite would say so.
-    const deadline = Date.now() + MIN_WAKE_MS + 240_000;
+    const waitStarted = Date.now();
+    const deadline = waitStarted + WAKE_MS + 240_000;
     let remaining = await listAlarms();
     while (remaining.length > 0 && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 15_000));
@@ -273,7 +226,7 @@ describe("agentcore wake alarms: a self-scheduled wake-up becomes an EventBridge
     }
     expect(
       remaining,
-      `the alarm was still registered ${Math.round((Date.now() - (deadline - MIN_WAKE_MS - 240_000)) / 1000)}s later — ` +
+      `the alarm was still registered ${Math.round((Date.now() - waitStarted) / 1000)}s later — ` +
         "EventBridge did not deliver it, or the forwarder rejected the poke",
     ).toHaveLength(0);
   }, 1_800_000);

--- a/test/live/env.ts
+++ b/test/live/env.ts
@@ -1,16 +1,22 @@
 /**
- * What every live probe shares: the configuration rule, and the three platform-neutral moves a deploy
- * probe makes (drive the CLI, POST a turn, read the answer out of the stream).
+ * What every live probe shares: the configuration rule, the platform-neutral moves a deploy probe
+ * makes (drive the CLI, POST a turn, read the answer out of the stream), and the moves that only ONE
+ * platform has but SEVERAL probes make — an `aws` call, AgentCore's teardown, the standing Railway
+ * project. Those belong here for the reason the duplicated teardown proved: a second copy drifts, and
+ * it drifts in cleanup code nobody reads until it has been leaking for weeks.
  *
  * Live probes fail loudly on missing configuration instead of skipping: `npm run test:live` is an
  * explicit opt-in, so an unset variable is a broken run, not an absent capability. (A platform that
  * is genuinely DOWN is a different case — that belongs in the probe that talks to it.)
  */
 import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { expect } from "vitest";
 import type { AgentEvent } from "../../src/agent.ts";
+import { ingressSessionId, stateBucketName } from "../../src/deploy/agentcore/plan.ts";
 import { fastagentVersion } from "../../src/version.ts";
 export function requireEnv(name: string, hint: string): string {
   const value = process.env[name];
@@ -77,6 +83,126 @@ export async function invoke(baseUrl: string, session: string, text: string): Pr
  */
 export const answerOf = (events: AgentEvent[]): string =>
   events.flatMap((event) => (event.type === "text" ? [event.delta] : [])).join("");
+
+/**
+ * Everything one AgentCore probe created, destroyed in the order the dependencies demand — ONE copy,
+ * shared by every AgentCore probe, because each step is load-bearing in a way that is invisible when
+ * it is wrong. What survives a silent teardown is a Bedrock runtime, a Lambda with a public Function
+ * URL, an image in ECR and a bucket holding the model credential seed, all of them billing.
+ *
+ * WAKE ALARMS FIRST, while the stack still stands. The forwarder creates them at RUNTIME with the SDK
+ * into the `default` Scheduler group, so they are not stack resources and `delete-stack` does not take
+ * them; `ActionAfterCompletion: DELETE` only runs once a schedule FIRES, so anything killed between
+ * the wake call and the fire leaves one pending. After `delete-stack` its target is gone and it
+ * retries into nothing for weeks — the orphan shape this account actually grew. Swept for EVERY
+ * fixture, not only the one that asks for wake-ups: one line (`selfSchedule`, a channel, a schedule)
+ * turns the forwarder on, and a teardown that had to be extended first would leak before it was.
+ *
+ * THE BUCKET IS VERSIONED (run.ts enables it), so `s3 rm` does not empty it — it writes a DELETE
+ * MARKER per object, and a marker comes back under DeleteMarkers, not Versions. Deleting only Versions
+ * leaves the bucket non-empty and `delete-bucket` answers BucketNotEmpty. Both lists, or it leaks.
+ *
+ * The bucket and the repository are created OUTSIDE the stack on purpose (plan.ts: so a `delete-stack`
+ * "cannot take the agent's memory with it") — correct for an operator, which makes them a probe's own
+ * job. Every deletion is ATTEMPTED even after an earlier one fails, and every failure is collected
+ * into one throw: "already gone" is the goal state, not a failure.
+ */
+export async function destroyAgentcoreDeployment(name: string, account: string): Promise<void> {
+  const stack = `fastagent-${name}`;
+  const repo = `fastagent/${name}`;
+  const errors: unknown[] = [];
+  const attempt = async (label: string, args: string[]) => {
+    const { code, stderr } = await aws(args);
+    if (code !== 0 && !/does not exist|NotFound|NoSuchBucket/i.test(stderr)) {
+      errors.push(new Error(`${label} failed: ${stderr.slice(0, 500)}`));
+    }
+  };
+
+  // The forwarder names every alarm `WAKE_PREFIX + sha256(wakeId)[:16]` (plan.ts). The prefix is all a
+  // probe can predict — the id is minted inside the container.
+  const alarmPrefix = `fa-${name}-wk-`;
+  const pending = await aws(["scheduler", "list-schedules", "--name-prefix", alarmPrefix, "--output", "json"]);
+  if (pending.code === 0) {
+    for (const alarm of (JSON.parse(pending.stdout) as { Schedules?: { Name: string }[] }).Schedules ?? []) {
+      await attempt(`scheduler delete-schedule ${alarm.Name}`, ["scheduler", "delete-schedule", "--name", alarm.Name]);
+    }
+  } else {
+    // Not fatal to the rest of teardown, but never silent: an unreadable list is indistinguishable from
+    // an empty one, and the difference is whether something is still out there firing.
+    errors.push(new Error(`could not list wake alarms under ${alarmPrefix}: ${pending.stderr.slice(0, 300)}`));
+  }
+
+  await attempt("delete-stack", ["cloudformation", "delete-stack", "--stack-name", stack]);
+  await attempt("wait stack-delete-complete", [
+    "cloudformation",
+    "wait",
+    "stack-delete-complete",
+    "--stack-name",
+    stack,
+  ]);
+  if (account) {
+    const bucket = stateBucketName(name, account);
+    await attempt("s3 rm", ["s3", "rm", `s3://${bucket}`, "--recursive"]);
+    const listed = await aws(["s3api", "list-object-versions", "--bucket", bucket, "--output", "json"]);
+    if (listed.code === 0) {
+      const payload = JSON.parse(listed.stdout) as {
+        Versions?: { Key: string; VersionId: string }[];
+        DeleteMarkers?: { Key: string; VersionId: string }[];
+      };
+      const objects = [...(payload.Versions ?? []), ...(payload.DeleteMarkers ?? [])].map(({ Key, VersionId }) => ({
+        Key,
+        VersionId,
+      }));
+      if (objects.length > 0) {
+        const del = JSON.stringify({ Objects: objects });
+        await attempt("s3api delete-objects", ["s3api", "delete-objects", "--bucket", bucket, "--delete", del]);
+      }
+    }
+    await attempt("s3 rb", ["s3api", "delete-bucket", "--bucket", bucket]);
+  }
+  await attempt("ecr delete-repository", ["ecr", "delete-repository", "--repository-name", repo, "--force"]);
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `teardown failed — check stack ${stack}, bucket fa-${name}-*, repo ${repo}`);
+  }
+}
+
+/**
+ * One `invoke` envelope through a deployed AgentCore runtime, returning the raw stream body. There is
+ * no public URL on this host — `POST /invocations` sits behind `InvokeAgentRuntime`, an IAM-signed AWS
+ * API — so this is how every AgentCore probe asks the deployment to do something.
+ *
+ * `label` names two REAL FILES under `dir`, and the output one is why: this CLI writes the response
+ * body to its positional argument, and on a runner whose stdout is a pipe Actions owns, `/dev/stdout`
+ * answers "No such device or address".
+ */
+export async function invokeAgentcore(args: {
+  runtimeArn: string;
+  name: string;
+  session: string;
+  text: string;
+  dir: string;
+  label: string;
+}): Promise<string> {
+  const payload = join(args.dir, `${args.label}.json`);
+  const out = join(args.dir, `${args.label}-reply.json`);
+  await writeFile(payload, `${JSON.stringify({ kind: "invoke", session: args.session, text: args.text })}\n`);
+  const reply = await aws([
+    "bedrock-agentcore",
+    "invoke-agent-runtime",
+    "--agent-runtime-arn",
+    args.runtimeArn,
+    "--runtime-session-id",
+    ingressSessionId(args.name),
+    "--payload",
+    `file://${payload}`,
+    "--cli-binary-format",
+    "raw-in-base64-out",
+    out,
+  ]);
+  expect(reply.code, `invoke-agent-runtime (${args.label}) failed:\n${reply.stderr.slice(-2000)}`).toBe(0);
+  return await readFile(out, "utf8");
+}
 
 /**
  * The long-lived Railway project both railway probes work inside, instead of each minting one.


### PR DESCRIPTION
On a host with no resident process, a `wake` is not a timer someone holds. It is a round trip through three systems (`wake-alarm.ts`):

```
wake tool → wakeups store → the sink → POST the pending set to the forwarder's reserved path
  → the forwarder (AWS SDK + IAM role) creates a one-shot at(fireAt) schedule
  → EventBridge pokes the forwarder → InvokeAgentRuntime wakes the container
  → the boot / 30s pump finds the due entry and fires it
```

Offline, every arrow but the first is a stub. This probe is for the middle one — the container POSTing to its own forwarder, and the forwarder holding exactly the IAM it needs. Three things must be simultaneously right (the wake secret both sides received, the forwarder's role, the Scheduler call), none is exercised elsewhere, and the failure is **silent**: a pending wake-up with no alarm behind it, which is the reliability hole the whole mechanism exists to close.

The probe deploys with `selfSchedule` — which is what puts the forwarder, the wake IAM and the tool itself into the deployment — asks the agent to wake itself at `MIN_WAKE_MS`, and reads the alarm back: one schedule, targeting **this** stack's forwarder, `at(...)` rather than a rate, `ActionAfterCompletion: DELETE`.

**Where the assertions stop, and why.** The fire is checked weakly: a self-deleting schedule's disappearance is evidence it ran, and this probe cannot separate that from other causes. The last two hops (poke → container awake → pump fires the turn) are **not** covered — observing them means pulling the state snapshot from S3 and reading session records, which costs more than it settles here. That half is AWS delivering a schedule it accepted; the half above is our code and our IAM.

## What running it cost, and what that says

Three IAM gaps, all the same shape:

| missing | why nothing caught it |
|---|---|
| `s3:PutLifecycleConfiguration` | without a forwarder the driver skips the whole bucket-creation path |
| `iam:AttachRolePolicy` / `DetachRolePolicy` | only the forwarder's role uses `ManagedPolicyArns`; every other role is inline |
| `scheduler:ListSchedules` (resource-less, needs `*`) | nothing had ever read an alarm |

`needsForwarder` opens a region of the driver no previous probe reached, and the IAM policy had been written from what the product CAN do rather than what this fixture MAKES it do — the same lesson AGENTS.md records for the probes' comments, collected again one layer down.

One dependency correction: `ListSchedules` returns summaries with **no** `ScheduleExpression`. The expression and completion action are read through `get-schedule`.

Live: probe passes in ~600s; suite goes to ~19 min against a 120 min budget. Teardown is the same three places as agentcore-deploy, and here the bucket is real — `selfSchedule` is what makes the driver create one.
