### PR TITLE
docs: retire stale file/section references and the phase table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,9 @@ src/
 │       ├── onboard.ts       # unbound launcher + credentials + manual config fallback
 │       └── scaffold/        # `add lark` bundle
 ├── deploy/                  # `deploy docker|fly|railway|agentcore`: host artifacts + runbook + `--run` CLI drive (docs/design/core.md §9)
-│   │                        # LAYOUT: neutral kernel at top (horizontal) + one dir per host (vertical) — new host = new dir, copy fly/.
+│   │                        # LAYOUT: neutral kernel at top (horizontal) + one dir per host (vertical). A new host is
+│   │                        # a new dir (copy fly/) PLUS its branch in cli/commands/deploy.ts (kept-artifact semantics,
+│   │                        # gates, the `runDeployX` glue), a row in `isOurArtifact`, and the `<host>` choice in program.ts.
 │   │                        # BEFORE writing one: READ that host's docs for what it does NOT do implicitly
 │   │                        # — above all, whether a created resource is REACHABLE without a further
 │   │                        # step. Fly taught this eight rounds in a row: `[http_service]` declares a

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -32,6 +32,6 @@ Do **not** keep private strategy here: market positioning, competitor analysis, 
 | Document | Purpose |
 |---|---|
 | [core.md](core.md) | Current architecture of the pi reference implementation. |
-| [conformance-levels.md](conformance-levels.md) | Where a session's state lives, and which engine class serves it: two independent deployment axes, the postures that pin them, and what each owes. |
+| [conformance-levels.md](conformance-levels.md) | Where a session's state lives: the deployment axis, the postures that pin it, and what each owes. |
 | [participant-model.md](participant-model.md) | How a chat bot behaves in a collaboration tool: the participant axiom and the summon/placement/memory rules derived from it. |
 | [session-control.md](session-control.md) | Session control plane beside `invoke`: observe a session, act on its run, set its properties, and manage the deployment's sessions. |

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -8,8 +8,8 @@ status: current
 
 ## 1. Decision
 
-**Where a session's state lives is an explicit deployment choice, and the engine class that serves it
-is a separate one.** Neither is a property of "fastagent"; both are properties of a deployment.
+**Where a session's state lives is an explicit deployment choice** — a property of a deployment, not
+of "fastagent". Which engine class serves it is a separate question, and it is settled.
 
 The protocol says so already. [SPEC](../SPEC.md) §6, under *Portable conformance (optional; required
 for Agents claiming serverless portability)*:
@@ -22,9 +22,10 @@ for Agents claiming serverless portability)*:
 A resident Agent is permitted, the cost is named, and the level is optional. `test/spec-conformance.ts`
 encodes the same shape: `pair?()` is an OPTIONAL subject capability, because MUST 6 is optional.
 
-The engine question is separate from the level: `invoke` runs on pi's `AgentSession`
-(pi-coding-agent), the class pi itself consumes (its TUI, RPC and SDK all run on it) — being the
-sole consumer of a surface nobody dogfoods is a position, not an architecture. That choice is §2.
+`invoke` runs on pi's `AgentSession` (pi-coding-agent), the class pi itself consumes (its TUI, RPC
+and SDK all run on it); the serving path moved there off the former `AgentHarness` (pi-agent-core),
+because being the sole consumer of a surface nobody dogfoods is a position, not an architecture.
+That leaves one axis: §2.
 
 ## 2. The axis
 

--- a/docs/design/conformance-levels.md
+++ b/docs/design/conformance-levels.md
@@ -1,6 +1,6 @@
 ---
 title: Conformance levels
-description: "Where a session's state lives is a deployment choice the SPEC already defines — not an implementation detail. Two axes (state locality × engine class), the postures that pin them, and what each owes."
+description: "Where a session's state lives is a deployment choice the SPEC already defines — not an implementation detail. The axis, the postures that pin it, and what each owes."
 status: current
 ---
 
@@ -22,24 +22,19 @@ for Agents claiming serverless portability)*:
 A resident Agent is permitted, the cost is named, and the level is optional. `test/spec-conformance.ts`
 encodes the same shape: `pair?()` is an OPTIONAL subject capability, because MUST 6 is optional.
 
-The recurring question — "should `invoke` be built on pi's `AgentSession` instead of its
-`AgentHarness`?" — used to be malformed, because it conflated the level with the engine. It has since
-been answered by the engine itself: §2.
+The engine question is separate from the level: `invoke` runs on pi's `AgentSession`
+(pi-coding-agent), the class pi itself consumes (its TUI, RPC and SDK all run on it) — being the
+sole consumer of a surface nobody dogfoods is a position, not an architecture. That choice is §2.
 
-## 2. One axis now
+## 2. The axis
 
 | Axis | Values | What it decides |
 |---|---|---|
 | **State locality** | `per-invoke` \| `resident` | SPEC MUST 6. Whether a turn may require the previous turn's process. |
 
-There used to be a second axis — which pi class ran the turn, `AgentHarness` (pi-agent-core) or
-`AgentSession` (pi-coding-agent) — and the interesting cell was `per-invoke × session`: portable AND
-extension-hosting. That cell is now the only one, for a reason outside this repo: pi 0.84 replaced
-`AgentHarness` with an unimplemented lane-based skeleton, and pi does not consume that class itself
-(its TUI, RPC and SDK all run on `AgentSession`). Being the sole consumer of a surface nobody
-dogfoods is a position, not an architecture, so the serving path moved.
+The serving cell is `per-invoke` on `AgentSession`: portable AND extension-hosting.
 
-What made the move affordable, measured on the way through:
+What makes per-invoke binding affordable on that class, measured:
 
 - **The expensive half is shareable.** Services (the `ResourceLoader`, settings, model runtime) build
   once at ~23 ms; binding a session to a record costs ~0.6 ms per turn.
@@ -116,8 +111,7 @@ gates them is wiring, not class:
   exposes an injectable `bindExtensions({ uiContext, mode })` seam for exactly that, the same door its
   RPC mode uses.
 - **`commands()` stays a listing**, not a dispatch surface: the data plane takes prompts as text, so
-  what typing `/name` means belongs to the client. That was a `harness`-era constraint that has become
-  a deliberate contract line.
+  what typing `/name` means belongs to the client — a deliberate contract line.
 
 What has NOT changed is the level: `per-invoke` remains the serving posture, and residency remains a
 deployment choice with the bill in §5. The engine swap moved which class runs a turn, not where the

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -446,8 +446,8 @@ implementation lives in `src/channels/feishu/`: `feishu.ts` wiring, `parse.ts` p
 `feishu-api.ts` transport/token pipeline, `crypto.ts` security math, `card.ts` builders, and registration
 automation. Shared mechanisms (`turn-queue` / generic `turn-store` / generic `context-buffer` /
 `invoke-turn-kit` / `state`) live in `channels/kit/`, whose defining property is that its consumers
-are only platform directories like this one (`wait-health` and `registration` sit one level up because
-deploy/ and cli/ use them too).
+are only platform directories like this one — `wait-health` (deploy/) and `registration` (deploy/ and
+cli/ as well as platform dirs) sit one level up because theirs are not.
 
 **Feishu is the design center; Lark is a compatibility profile.** The clouds share event/card/crypto
 wire formats, but Lark international trails Feishu in app creation and application-config APIs.
@@ -484,7 +484,7 @@ a stable hand-authored surface. What is platform-different:
 - **Session partitioning follows the place, not the ask.** A chat is one session
   (`<kind>:<chat_id>`) and a thread is another (`<kind>:<chat_id>:<thread_id>`) — branded with the
   channel kind because session ids share ONE namespace across every channel in a deployment. The id
-  becomes a percent-encoded jsonl filename, so its real bound is the filesystem's 255 bytes, which
+  becomes an escaped jsonl filename (`piSessionId`), so its real bound is the filesystem's 255 bytes, which
   platform ids do not come close to. A room keeps one memory that everyone in it shares and a
   side conversation keeps its own. Keyed by `thread_id`, never `root_id`: the platform's `root_id`
   tracks the reply chain and can differ between messages of one thread, which would split a side

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -380,13 +380,13 @@ Telegram is the stateful channel reference. Its modules separate:
 | Module | Responsibility |
 |---|---|
 | `parse.ts` | pure update/message parsing and summon policy |
-| `invoke-turn.ts` | attachment resolution and one Agent invocation (busy-retry loop + manifest wording shared via `../invoke-turn-kit.ts`) |
-| `../turn-queue.ts` | per-session FIFO, different sessions concurrent (shared with Feishu) |
-| `turn-store.ts` | telegram's record + ordering over the shared generic `../turn-store.ts` (pre-ACK persisted turn intent, crash replay) |
-| `context-buffer.ts` | telegram's entry shape + attachment selection over the shared generic `../context-buffer.ts` (durable un-summoned group context, peek→completed→commit) |
+| `invoke-turn.ts` | attachment resolution and one Agent invocation (busy-retry loop + manifest wording shared via `../kit/invoke-turn-kit.ts`) |
+| `../kit/turn-queue.ts` | per-session FIFO, different sessions concurrent (shared with Slack and Feishu) |
+| `turn-store.ts` | telegram's record + ordering over the shared generic `../kit/turn-store.ts` (pre-ACK persisted turn intent, crash replay) |
+| `context-buffer.ts` | telegram's entry shape + attachment selection over the shared generic `../kit/context-buffer.ts` (durable un-summoned group context, peek→completed→commit) |
 | `preview.ts` | live preview and terminal write policy |
 | `telegram-api.ts` | Bot API timeouts/retries and HTML-aware splitting |
-| `../state.ts` | atomic small JSON state files (shared with Feishu) |
+| `../kit/state.ts` | atomic small JSON state files (shared with Slack and Feishu) |
 
 Telegram turn replay is at-least-once. A crash can re-run side-effecting tools, and a narrow pre-ACK
 window can run a delivery twice. Exactly-once execution needs a different backend/resume model.
@@ -445,8 +445,9 @@ implementation lives in `src/channels/feishu/`: `feishu.ts` wiring, `parse.ts` p
 `thread-participants.ts` thread-participation cache, shared `../kit/seen.ts` bounded delivery dedup,
 `feishu-api.ts` transport/token pipeline, `crypto.ts` security math, `card.ts` builders, and registration
 automation. Shared mechanisms (`turn-queue` / generic `turn-store` / generic `context-buffer` /
-`invoke-turn-kit` / `state` / `wait-health`) live in `channels/kit/`, whose defining property is that
-its consumers are only platform directories like this one.
+`invoke-turn-kit` / `state`) live in `channels/kit/`, whose defining property is that its consumers
+are only platform directories like this one (`wait-health` and `registration` sit one level up because
+deploy/ and cli/ use them too).
 
 **Feishu is the design center; Lark is a compatibility profile.** The clouds share event/card/crypto
 wire formats, but Lark international trails Feishu in app creation and application-config APIs.

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -210,7 +210,7 @@ compromise — it is the same social rule:
 - separate conversations are parallel: threads proceed independently.
 
 Two turns in one place must therefore serialize (`channels/kit/turn-queue.ts` FIFO, and the engine's
-single-writer lease in `engines/pi/invoke.ts`). Two turns in different places run concurrently
+single-writer lease in `engines/pi/turn-kit.ts`). Two turns in different places run concurrently
 because they are different sessions.
 
 Finer-grained concurrency (parallel turns *inside* one session, branching the session tree per turn)

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -8,9 +8,9 @@ updated: 2026-07-20
 
 # Session control plane
 
-This document is the serving-extension design for FastAgent. Everything it describes is implemented
-(a subprocess transport adapter stays demand-driven). It is a companion to, not a replacement for,
-the locked [Agent Handler SPEC v0.1](../SPEC.md).
+This document is the serving-extension design for FastAgent. Everything below is implemented except
+the demand-driven follow-ons named in §15 (a subprocess transport adapter among them). It is a
+companion to, not a replacement for, the locked [Agent Handler SPEC v0.1](../SPEC.md).
 
 The whole design reduces to one sentence: **`invoke` is the only data plane; the session control
 plane observes and modulates the runs that `invoke` drives.** A client uses `invoke` to make the
@@ -718,8 +718,8 @@ What each part of the plane settled on, where the reason is not obvious from the
   landed; a session with no compactable history rejects `nothing_to_compact` (a no-op, like
   `no_active_run`). An in-flight compaction is abortable — run/compaction symmetry: both are model
   calls a client must be able to stop — and converges as `compaction_finished{aborted}`.
-- **The leaf is movable.** `navigate` moves it through pi's `SessionManager.branch()` (a pointer move,
-  no record written) under the same lease; an unknown `targetId` rejects `invalid_command`; the move
+- **The leaf is movable.** `update({ leafEntryId })` moves it through pi's `SessionManager.branch()` (a
+  pointer move, no record written) under the same lease; an unknown target rejects `invalid_command`; the move
   rides out as `state_changed{leafEntryId, model, thinkingLevel}`. Every last-wins read — the
   activation/override walk, `state()`, the update gate — therefore reads the ACTIVE PATH, not the
   flat journal. An unreadable chain never resolves silently to assembly defaults: `state()` stays
@@ -743,11 +743,12 @@ What each part of the plane settled on, where the reason is not obvious from the
   `GET /control/sessions` is the first read that MAY reject — a store that cannot be enumerated
   answers `sessions_unavailable` + 503.
 
-Demand-driven follow-ons, explicitly not prerequisites: blocking interactions (typed
-confirm/select/input gates that suspend a run), definition reload, export, and channel upgrades — a
-chat channel becoming an events consumer for message-boundary delivery (enabling an opt-in
-follow_up/steer policy for mid-run messages) or, once interactions exist, an interaction responder
-(e.g. Telegram inline keyboards). The extension unlocks those options; it does not mandate them.
+Demand-driven follow-ons, explicitly not prerequisites: a subprocess transport adapter beside the
+HTTP+SSE one, blocking interactions (typed confirm/select/input gates that suspend a run), definition
+reload, export, and channel upgrades — a chat channel becoming an events consumer for
+message-boundary delivery (enabling an opt-in follow_up/steer policy for mid-run messages) or, once
+interactions exist, an interaction responder (e.g. Telegram inline keyboards). The extension unlocks
+those options; it does not mandate them.
 
 Considered and rejected — **replacing the chat channels' queued-turn path with `steer`/`follow_up`**:
 the stateful channels persist each accepted turn intent BEFORE the transport ACK (L1, at-least-once,

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -8,9 +8,9 @@ updated: 2026-07-20
 
 # Session control plane
 
-This document is the serving-extension design for FastAgent. Phases 0–3 (§15) are implemented
-(Phase 3's subprocess adapter stays demand-driven). It is a companion to, not a replacement
-for, the locked [Agent Handler SPEC v0.1](../SPEC.md).
+This document is the serving-extension design for FastAgent. Everything it describes is implemented
+(a subprocess transport adapter stays demand-driven). It is a companion to, not a replacement for,
+the locked [Agent Handler SPEC v0.1](../SPEC.md).
 
 The whole design reduces to one sentence: **`invoke` is the only data plane; the session control
 plane observes and modulates the runs that `invoke` drives.** A client uses `invoke` to make the
@@ -336,7 +336,7 @@ interface SessionState {
 }
 ```
 
-`compacting` refers to Phase 2 manual compaction at a session boundary; automatic overflow
+`compacting` refers to manual compaction (`compact`) at a session boundary; automatic overflow
 compaction happens inside a run's activity window (before its `run_settled`) and reports as
 `running` — the observation plane's "running" window equals the data plane's lease window, so
 `state()` never says idle while an invoke would still be rejected `session_busy`.
@@ -433,7 +433,7 @@ FastAgent prompt assembly, definition-local skills and tools, the same deferred-
 FastAgent auth (never implicit `~/.pi` state), model policy from config, and host-owned working
 directory and session repository — never client-provided paths.
 
-The shared builder `src/engines/pi/session-builder.ts` (Phase 0, extracted from the TUI launcher)
+The shared builder `src/engines/pi/session-builder.ts` (extracted from the TUI launcher)
 proves this assembly seam: it builds a resident pi `AgentSessionRuntime` with FastAgent's prompt,
 skills, tools, auth, and agent boundary; the TUI (`chat.ts`) is one consumer of it. The
 formerly TUI-only `~/.pi` auth divergence was eliminated in place, not inherited.
@@ -688,24 +688,66 @@ filesystem paths; audit records for accepted commands. The control plane does no
 safe for untrusted users; `ExecutionEnv` is still not a complete sandbox boundary
 ([core design §5](core.md#5-tools-skills-and-execution-environment)).
 
-## 15. Implementation sequence
+## 15. Decisions on the record
 
-| Phase | Work | Done when |
-|---|---|---|
-| 0 | **Done.** The definition-aware session builder is extracted (`session-builder.ts`); the TUI-only `~/.pi` auth divergence is eliminated in place; `runPiChat` is one consumer. | Chat assembly semantics unchanged; auth source and `thinkingLevel` deliberately converged to serving; builder independently instantiable. |
-| 1 | **Done.** Observation plane: pi events translate ONCE to `SessionEvent` inside the invoke path (`toSessionEvent`), `AgentEvent` is its projection (`projectAgentEvent`); the `session` subpath types + pi `createPiSessionControl` (`state`/`entries`/`events` over the store's read-only `openIfExists`); conformance tests for projection fidelity, run boundaries (incl. cancellation → exactly-one `run_settled{aborted}`), reconnect, and single-writer. | An L0 client can watch and reconnect to any invoke-driven run. |
-| 2a | **Done.** Run modulation: the session's actions route `steer`/`follow_up`/`abort` to the live run via {@link RunControls} registered with `run_started`; the settle window spans steered/queued continuations inside one invoke (pi's agent loop drains both queues within one `prompt()`); `queue_changed` + live `pending` in state; a control-plane abort terminates as `failed{code: "aborted"}` / `run_settled{aborted}`; idle-session run actions reject `no_active_run` before acceptance. | L1 clients. |
-| 2b | **Done.** Boundary mutations under the lease: `set_model`/`set_thinking` append durable session overrides (validated against the registry / the MODEL's own thinking levels — `reasoning` + `thinkingLevelMap`, not the bare scale; `invalid_command` before acceptance) and the per-invoke resolve (`resolveSessionSettings`, the active-tools precedent) applies them on every later turn — a registry change across deploys falls back to the default with a deduped warn instead of bricking the session. `compact` is ACCEPT-FAST (§5.2 has no exceptions: a summarization is a full model call, so the dispatch answers on admission — lease held, session bound — and the outcome travels as `compaction_finished{summary|error|aborted}`, emitted after the lease frees); pre-acceptance failures (binding the session and the local preparation — admission ends where the work becomes a model call) reject `boundary_command_failed` with nothing durable landed, and a session with no compactable history rejects `nothing_to_compact` (a no-op, not a failure — the `no_active_run` pattern: re-dispatch once the session grows); an in-flight compaction is abortable — `abort` during `compacting` aborts the summarization's controller (run/compaction symmetry: both are model calls a client must be able to stop) and converges as `compaction_finished{aborted}` with the lease released, mirroring `run_settled{aborted}`. Mutations contend on the SAME lease as runs (`session_busy` when busy); capabilities report `allowedModels` from the live wiring (`PiBoundaryWiring`, a lazy thunk — the hub exists before the assembly that produces the parts), while the session's model, executing level and available levels come from ONE resolution (`resolveSessionSettings`) that `state()`, the `set_thinking` gate and the per-invoke resolve all read — model and thinking level are one setting, so deriving them separately is what let the surfaces disagree. `navigate` moves the leaf through pi's `SessionManager.branch()` (a pointer move that writes no record) under the same lease — an unknown `targetId` rejects `invalid_command` before it, and the move rides out as `state_changed{leafEntryId, model, thinkingLevel}` (a move can change which settings apply). Because the leaf is now MOVABLE, every last-wins read — the per-invoke activation/override walk, `state()`, the `set_thinking` gate — reads the ACTIVE PATH rather than the flat journal: a record on an abandoned branch no longer governs the session. An unreadable chain never resolves silently to the assembly defaults: `state()` stays TOTAL but leaves the settings pair ABSENT, and the fault surfaces where an error code exists — the next invoke's `failed` event and a boundary dispatch's `boundary_command_failed`. | L2 clients. |
-| 3 | **Done** (HTTP+SSE; subprocess adapter stays demand-driven). One transport serves every remote consumer — Web panel, desktop app, `fastagent attach`: `createControlPlane` (engine-neutral, bearer-token REQUIRED) serves the RESTful surface in §13, with the envelope born at the wire (`{sessionId, epoch, seq, event}` per SSE message; HTTP itself is the request correlation). `connectSessionControl` re-exposes the SAME `SessionControl` interface and consumes the envelope internally — a seq gap ends the iterator into the standard reconnect steps; a server restart is covered by the same rule (its connections drop), and `epoch` is informational for consumers correlating ACROSS connections — within one connection it cannot change, so the client does not compare it. The DATA plane travels too: `POST /control/invoke` (the standard invoke handler behind the same token, mounted when the serve wires an agent) + `connectAgent` client-side — a remote consumer holds a full fastagent instance through the same two contracts local code uses. Serve wiring: `config.sessionControl: true` → dev/start mount the routes, mint a per-boot token, and write `<stateRoot>/control.json` (0600) for local discovery; product runners still own real authentication, idempotency, event persistence, and routing (§14). | Remote `SessionControl` is isomorphic to local (conformance-tested). |
-| 4 | **Done.** Session lifecycle, and the reshaping it forced. `sessions.list()` is the deployment's conversation list in CALLER ids (a facade must not expose it); `fork` is idempotent (the id is the caller's, the record carries its provenance, a repeat writes nothing); `delete` ends the session's live streams rather than holding connections open on a record that is gone. No `create` (an empty session is the data plane's job, and `invoke` already does it) and no `clone` (it is `fork` at the leaf). Adding three commands to a ten-variant `dispatch` union is what exposed the shape problem: four of those variants RECORD a property, so they became `update(patch)`; the rest are actions on a run; the collection is its own thing. The interface is now a collection + a pure-binding handle (§5), the transport is REST (§13), and `capabilities` gates by the names a client actually writes. `GET /control/sessions` is the first read that MAY reject — a store that cannot be enumerated answers `sessions_unavailable` + 503, and the client reads the code. | A GUI can show, name, branch and remove the deployment's conversations, and reads like one API rather than two. |
+What each part of the plane settled on, where the reason is not obvious from the interface:
 
-Phase 1 modifies the existing invoke pipeline incrementally (translation + projection); it does not
-build a parallel runtime that later needs reconciling. Demand-driven follow-ons, explicitly not
-prerequisites: blocking interactions (typed confirm/select/input gates that suspend a
-run), definition reload, export, and channel upgrades — a chat channel becoming an events consumer
-for message-boundary delivery (enabling an opt-in follow_up/steer policy for mid-run messages) or,
-once interactions exist, an interaction responder (e.g. Telegram inline keyboards). The extension
-unlocks those options; it does not mandate them.
+- **Definition fidelity for chat.** The definition-aware session builder (`session-builder.ts`) is
+  independently instantiable and `runPiChat` is one consumer; the TUI-only `~/.pi` auth divergence
+  was eliminated in place, and auth source and `thinkingLevel` converged to serving.
+- **Observation.** pi events translate ONCE to `SessionEvent` inside the invoke path
+  (`toSessionEvent`); `AgentEvent` is its projection (`projectAgentEvent`). `state`/`entries`/`events`
+  read the store's read-only `openIfExists`. Conformance tests cover projection fidelity, run
+  boundaries (cancellation → exactly one `run_settled{aborted}`), reconnect, and single-writer.
+- **Run modulation.** `steer`/`follow_up`/`abort` reach the live run via the `RunControls` registered
+  with `run_started`; the settle window spans steered/queued continuations inside one invoke (pi's
+  loop drains both queues within one `prompt()`); a control-plane abort terminates as
+  `failed{code: "aborted"}` / `run_settled{aborted}`; idle-session run actions reject `no_active_run`
+  before acceptance.
+- **Boundary mutations under the lease.** `update({ model | thinkingLevel })` appends durable session
+  overrides, validated against the registry and the MODEL's own thinking levels (`reasoning` +
+  `thinkingLevelMap`, not the bare scale; `invalid_command` before acceptance). The per-invoke resolve
+  (`resolveSessionSettings`) applies them on every later turn; a registry change across deploys falls
+  back to the default with a deduped warn instead of bricking the session. `state()`, the update gate
+  and the per-invoke binding all read that ONE resolution — model and thinking level are one setting,
+  so deriving them separately is what let the surfaces disagree.
+- **`compact` is accept-fast.** §5.2 has no exceptions: a summarization is a full model call, so the
+  dispatch answers on admission (lease held, session bound) and the outcome travels as
+  `compaction_finished{summary|error|aborted}`, emitted after the lease frees. Pre-acceptance failures
+  (binding the session, local preparation) reject `boundary_command_failed` with nothing durable
+  landed; a session with no compactable history rejects `nothing_to_compact` (a no-op, like
+  `no_active_run`). An in-flight compaction is abortable — run/compaction symmetry: both are model
+  calls a client must be able to stop — and converges as `compaction_finished{aborted}`.
+- **The leaf is movable.** `navigate` moves it through pi's `SessionManager.branch()` (a pointer move,
+  no record written) under the same lease; an unknown `targetId` rejects `invalid_command`; the move
+  rides out as `state_changed{leafEntryId, model, thinkingLevel}`. Every last-wins read — the
+  activation/override walk, `state()`, the update gate — therefore reads the ACTIVE PATH, not the
+  flat journal. An unreadable chain never resolves silently to assembly defaults: `state()` stays
+  total but leaves the settings pair absent, and the fault surfaces where an error code exists (the
+  next invoke's `failed`, a boundary dispatch's `boundary_command_failed`).
+- **Transport.** `createControlPlane` (engine-neutral, bearer token REQUIRED) serves the RESTful
+  surface in §13 with the envelope born at the wire (`{sessionId, epoch, seq, event}` per SSE
+  message; HTTP itself is the request correlation). `connectSessionControl` re-exposes the SAME
+  `SessionControl` and consumes the envelope internally — a seq gap ends the iterator into the
+  standard reconnect steps; a server restart is the same rule (its connections drop); `epoch` is
+  informational across connections and never compared within one. The data plane travels too:
+  `POST /control/invoke` + `connectAgent`. `config.sessionControl: true` makes dev/start mount the
+  routes, mint a per-boot token and write `<stateRoot>/control.json` (0600); product runners own
+  real authentication, idempotency, event persistence and routing (§14).
+- **Lifecycle.** `sessions.list()` is the deployment's conversation list in CALLER ids (a facade must
+  not expose it); `fork` is idempotent (the id is the caller's, the record carries its provenance, a
+  repeat writes nothing); `delete` ends the session's live streams rather than holding connections
+  open on a record that is gone. No `create` (an empty session is the data plane's job) and no
+  `clone` (it is `fork` at the leaf). Four of the former dispatch variants RECORDED a property, so
+  they became `update(patch)`; the rest are actions on a run; the collection is its own thing (§5).
+  `GET /control/sessions` is the first read that MAY reject — a store that cannot be enumerated
+  answers `sessions_unavailable` + 503.
+
+Demand-driven follow-ons, explicitly not prerequisites: blocking interactions (typed
+confirm/select/input gates that suspend a run), definition reload, export, and channel upgrades — a
+chat channel becoming an events consumer for message-boundary delivery (enabling an opt-in
+follow_up/steer policy for mid-run messages) or, once interactions exist, an interaction responder
+(e.g. Telegram inline keyboards). The extension unlocks those options; it does not mandate them.
 
 Considered and rejected — **replacing the chat channels' queued-turn path with `steer`/`follow_up`**:
 the stateful channels persist each accepted turn intent BEFORE the transport ACK (L1, at-least-once,

--- a/src/channels/control.ts
+++ b/src/channels/control.ts
@@ -1,5 +1,5 @@
 /**
- * The session control plane over HTTP + SSE — the Phase 3 transport (design §13). Engine-neutral:
+ * The session control plane over HTTP + SSE (docs/design/session-control.md §13). Engine-neutral:
  * consumes only the `SessionControl` contract. One transport serves every remote consumer (Web
  * panel, desktop app, `fastagent attach`); the embedded API stays semantic-only and the ENVELOPE
  * lives here: `id` (request correlation — implicit in HTTP), `epoch` (serving-process incarnation

--- a/src/channels/feishu/parse.ts
+++ b/src/channels/feishu/parse.ts
@@ -59,8 +59,8 @@ export function senderId(sender: FeishuSender | undefined): string | undefined {
  *
  * Branded with the channel kind, like Slack's twin, because session ids share ONE namespace across
  * every channel in a deployment: without it a `feishu` and a `lark` chat carrying the same platform id
- * would answer into the same memory. The length bound is the FILENAME the id becomes (sessions.ts
- * percent-encodes it, so each `:` costs three), and the worst case here — brand + a 35-char chat id +
+ * would answer into the same memory. The length bound is the FILENAME the id becomes (session-store.ts
+ * `piSessionId` percent-encodes it, so each `:` costs three), and the worst case here — brand + a 35-char chat id +
  * a 36-char thread id — encodes to well under 100 bytes against the filesystem's 255.
  */
 export function placeKey(kind: string, message: Pick<FeishuMessage, "chat_id" | "thread_id">): string {
@@ -84,7 +84,7 @@ export function cloudEnvelope(event: FeishuMessageEvent, tag: FeishuCloudKind): 
     from ? `from ${from}` : undefined,
     // The message's own id is LOAD-BEARING, not decoration: it is the only way this message's id
     // enters the session transcript, and session inheritance locates a thread's branch point by
-    // searching the parent transcript for exactly these ids (scope.branchHints — sessions.ts).
+    // searching the parent transcript for exactly these ids (scope.branchHints — session-inheritance.ts).
     // Remove it and every thread quietly inherits from the room's present instead of the branch
     // point. It also lets the model name what it is answering in a busy chat.
     `msg ${message.message_id}`,

--- a/src/channels/feishu/parse.ts
+++ b/src/channels/feishu/parse.ts
@@ -60,8 +60,9 @@ export function senderId(sender: FeishuSender | undefined): string | undefined {
  * Branded with the channel kind, like Slack's twin, because session ids share ONE namespace across
  * every channel in a deployment: without it a `feishu` and a `lark` chat carrying the same platform id
  * would answer into the same memory. The length bound is the FILENAME the id becomes (session-store.ts
- * `piSessionId` percent-encodes it, so each `:` costs three), and the worst case here — brand + a 35-char chat id +
- * a 36-char thread id — encodes to well under 100 bytes against the filesystem's 255.
+ * `piSessionId` escapes every character outside `[A-Za-z0-9.-]` as `_XX` / `_uXXXX`, so each `:` costs
+ * three), and the worst case here — brand + a 35-char chat id + a 36-char thread id — encodes to well
+ * under 100 bytes against the filesystem's 255.
  */
 export function placeKey(kind: string, message: Pick<FeishuMessage, "chat_id" | "thread_id">): string {
   const chat = `${kind}:${message.chat_id}`;

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -152,7 +152,7 @@ export async function preflightDeploy(input: {
         `same value to callers: attach --url <public-url> --token …. Unset, the box mints its own per boot — ` +
         `readable only by shelling in (\`docker compose exec\`/\`fly ssh console\`: <stateRoot>/control.json, whose ` +
         `url field is container-loopback) and replaced on every restart. Front the endpoint with real auth for ` +
-        `anything wider (design §14)`,
+        `anything wider (docs/design/session-control.md §14)`,
     });
   }
 

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -48,7 +48,7 @@ export interface FastagentConfig {
    * per-boot bearer token and write `<stateRoot>/control.json` for local discovery. The serve
    * binds all interfaces by default, so the routes are LAN-reachable with the token as the only
    * protection — bind loopback (`--bind 127.0.0.1`; not `http.host`, which travels into a deployed
-   * image), firewall the port, or wrap it for real exposure (design §14).
+   * image), firewall the port, or wrap it for real exposure (docs/design/session-control.md §14).
    */
   sessionControl?: boolean;
   /** Deploy-time declarations for what the agent needs on the box, so real agents don't hand-write a

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -191,7 +191,7 @@ export function piBasePrompt(options: { tools?: MountedTool[]; persona?: string 
   const toolsList =
     tools.length > 0 ? tools.map((t) => `- ${t.name}: ${(t.description ?? "").split("\n")[0]}`).join("\n") : "(none)";
   // Segment ① identity: an authored persona (persona.md) replaces the default engine identity line
-  // (core.md §11), keeping the tools list + guidelines below. Preserve pi's coding identity only for
+  // (core.md §2), keeping the tools list + guidelines below. Preserve pi's coding identity only for
   // the full coding surface; a partial/empty surface must not claim machine capabilities it lacks.
   // The four this sentence NAMES — reading, executing, editing, writing. Searching is not part of the
   // claim, so requiring it would demote an agent that can do everything the identity says it can.

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -60,8 +60,8 @@ export interface CreatePiAgentFromDirOptions {
   sessionControl?: boolean;
   /** Additional raw tap with the FULL vocabulary: run events composed after the
    *  {@link sessionControl} hub's observer, plus the hub's own boundary-mutation events
-   *  (`state_changed`/`compaction_*`) via the hub's tap. TRUSTED seam: since Phase 2a an observer
-   *  receives each run's live modulation handles (see `SessionObserver`) — for read-only consumers
+   *  (`state_changed`/`compaction_*`) via the hub's tap. TRUSTED seam: an observer receives each
+   *  run's live modulation handles (see `SessionObserver`) — for read-only consumers
    *  use the hub's `events()` stream instead. */
   observer?: SessionObserver;
 }

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -1,10 +1,9 @@
 /**
  * The shared definition-aware session builder: open a directory's assembled agent as a resident pi
- * `AgentSessionRuntime`. Extracted from chat.ts (session-control Phase 0) as the proof of the
- * assembly seam — independently instantiable, running the SAME agent that `dev`/`start` serve. The
- * TUI (chat.ts) is its one consumer: the session control plane (Phases 1–3) was built on the invoke
- * pipeline instead of this resident runtime, so control-plane observation covers invoke-driven runs
- * and deliberately not chat sessions (design §10/§15).
+ * `AgentSessionRuntime`, running the SAME agent that `dev`/`start` serve. The TUI (chat.ts) is its
+ * one consumer: the session control plane was built on the invoke pipeline instead of this resident
+ * runtime, so control-plane observation covers invoke-driven runs and deliberately not chat sessions
+ * (docs/design/session-control.md §10).
  *
  * FIDELITY: pi's vanilla discovery (AGENTS.md walk to repo root, machine-global skills/extensions)
  * is suppressed; fastagent's assembly is INJECTED into pi's session:

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -3,7 +3,7 @@
  * `AgentSessionRuntime`, running the SAME agent that `dev`/`start` serve. The TUI (chat.ts) is its
  * one consumer: the session control plane was built on the invoke pipeline instead of this resident
  * runtime, so control-plane observation covers invoke-driven runs and deliberately not chat sessions
- * (docs/design/session-control.md §10).
+ * (docs/design/session-control.md §10, §15).
  *
  * FIDELITY: pi's vanilla discovery (AGENTS.md walk to repo root, machine-global skills/extensions)
  * is suppressed; fastagent's assembly is INJECTED into pi's session:

--- a/src/engines/pi/session-store.ts
+++ b/src/engines/pi/session-store.ts
@@ -172,10 +172,9 @@ export function callerSessionId(recordId: string): string | undefined {
  * the serving path provides — the single-writer lease is taken before any store call, so no two
  * turns of one conversation reach this at once. What it does NOT do is arbitrate a FIRST open racing
  * across processes: two instances that scan before either writes will both create, and the
- * conversation forks into two records. sessions.ts states the same boundary for the same reason
- * ("the serving path serializes it with the single-writer lease before reaching any store"), and a
- * horizontally-scaled deployment that wants more owes a lease that spans its instances — an
- * in-process one cannot arbitrate between them, and a file lock here would only look like it could.
+ * conversation forks into two records. A horizontally-scaled deployment that wants more owes a lease
+ * that spans its instances — an in-process one cannot arbitrate between them, and a file lock here
+ * would only look like it could.
  */
 export function piSessionRecordStore(options: { dir: string; cwd?: string }): PiSessionRecordStore {
   const cwd = options.cwd ?? process.cwd();

--- a/src/engines/pi/tool-context.ts
+++ b/src/engines/pi/tool-context.ts
@@ -95,9 +95,9 @@ export interface TurnContext {
   cwd?: string;
   /** Current conversation manager. Absent outside a FastAgent-managed agent turn. */
   sessionManager?: ReadonlySessionManager;
-  /** Tool activation for the current turn. Two producers, one consumer surface: invoke.ts bridges the
-   *  served session; chat.ts bridges the resident one (chat emulates deferral — same loader, same
-   *  semantics). Absent only outside any turn (a bare `fastagent tool` run). */
+  /** Tool activation for the current turn. Two producers, one consumer surface: agent-session-factory.ts
+   *  bridges the served session; session-builder.ts bridges the resident one (chat emulates deferral —
+   *  same loader, same semantics). Absent only outside any turn (a bare `fastagent tool` run). */
   tools?: ToolActivation;
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -220,14 +220,14 @@ export function mountSessionControl(
         log.warn(
           `[fastagent] the port binds ${bind === "wildcard" ? "all interfaces" : `${options.host} (off this machine)`}: ` +
             "/control/* is reachable on your LAN, protected only by the bearer token — bind loopback " +
-            "(--bind 127.0.0.1), firewall the port, or wrap it for real exposure (docs: design §14)",
+            "(--bind 127.0.0.1), firewall the port, or wrap it for real exposure (docs/design/session-control.md §14)",
         );
       }
       if (options.tunnel) {
         // Local trust = the token + its file permissions; --tunnel takes the whole port PUBLIC.
         log.warn(
           "[fastagent] --tunnel exposes /control/* (steer, stop, rewrite or delete a session) at the public tunnel URL, " +
-            "protected ONLY by the bearer token — wrap it with real auth before sharing that URL (docs: design §14)",
+            "protected ONLY by the bearer token — wrap it with real auth before sharing that URL (docs/design/session-control.md §14)",
         );
       }
       // Removed on shutdown so a stale file cannot point a client at a dead port: `attach` then

--- a/src/session-remote.ts
+++ b/src/session-remote.ts
@@ -1,5 +1,6 @@
 /**
- * The remote `SessionControl` — the client half of the Phase 3 transport (design §13). Engine- and
+ * The remote `SessionControl` — the client half of the HTTP + SSE transport (docs/design/session-control.md
+ * §13). Engine- and
  * server-neutral: speaks only the wire protocol `createControlPlane` serves (HTTP JSON + SSE with the
  * {sessionId, epoch, seq, event} envelope) and re-exposes the SAME `SessionControl` interface, so
  * local and remote consumers are isomorphic — client code does not change when the agent moves out

--- a/src/session-remote.ts
+++ b/src/session-remote.ts
@@ -1,10 +1,9 @@
 /**
- * The remote `SessionControl` — the client half of the HTTP + SSE transport (docs/design/session-control.md
- * §13). Engine- and
- * server-neutral: speaks only the wire protocol `createControlPlane` serves (HTTP JSON + SSE with the
- * {sessionId, epoch, seq, event} envelope) and re-exposes the SAME `SessionControl` interface, so
- * local and remote consumers are isomorphic — client code does not change when the agent moves out
- * of process.
+ * The remote `SessionControl` — the client half of the HTTP + SSE transport
+ * (docs/design/session-control.md §13). Engine- and server-neutral: speaks only the wire protocol
+ * `createControlPlane` serves (HTTP JSON + SSE with the {sessionId, epoch, seq, event} envelope) and
+ * re-exposes the SAME `SessionControl` interface, so local and remote consumers are isomorphic —
+ * client code does not change when the agent moves out of process.
  *
  * Envelope consumption is internal: a seq gap (loss in transit on this connection) — and any
  * mid-stream transport failure, a server restart included (its connections drop) — THROWS from

--- a/src/session.ts
+++ b/src/session.ts
@@ -300,7 +300,7 @@ export interface SessionState {
   /** Set by `update({ name })`, so a client that opens a session directly gets the same label the list
    *  showed. */
   name?: string;
-  /** `compacting` refers to Phase 2 MANUAL compaction at a session boundary. Automatic overflow
+  /** `compacting` refers to MANUAL compaction (`compact`) at a session boundary. Automatic overflow
    *  compaction happens inside a run's activity window and reports as `running`. */
   status: "idle" | "running" | "compacting";
   activeRunId?: string;

--- a/test/control-http.test.ts
+++ b/test/control-http.test.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 3 transport conformance — docs/design/session-control.md §13: the HTTP+SSE wire protocol
+ * Transport conformance — docs/design/session-control.md §13: the HTTP+SSE wire protocol
  * (`createControlPlane`) and the remote client (`connectSessionControl`) are exercised TOGETHER over a
  * real node:http server against a real hub + faux agent: local and remote `SessionControl` must be
  * isomorphic (same interface, same answers), the envelope must be consumed internally (epoch/seq
@@ -80,7 +80,7 @@ async function drain(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   return out;
 }
 
-describe("session control over HTTP (Phase 3)", () => {
+describe("session control over HTTP", () => {
   it("fails closed: no/wrong token is 401 on every route, and connect() rejects", async () => {
     const served = await serveControl();
     try {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -9,6 +9,7 @@ import { type FeishuChannelOptions, feishuChannel as buildFeishuChannel } from "
 import { larkChannel } from "../src/lark.ts";
 import { eventSignature } from "../src/channels/feishu/crypto.ts";
 import { cardSummary } from "../src/channels/feishu/card.ts";
+import { piSessionId } from "../src/engines/pi/session-store.ts";
 import { log } from "../src/log.ts";
 
 const TOKEN = "verif-token";
@@ -535,10 +536,10 @@ describe("turn flow", () => {
 
     // Rule 3 (memory follows the place): both messages share the chat session — no per-ask session.
     expect(calls.map((call) => call.scope.session)).toEqual(["feishu:oc_1", "feishu:oc_1"]);
-    // The id becomes a percent-encoded jsonl filename, so the bound that matters is the filesystem's,
+    // The id becomes an escaped jsonl filename, so the bound that matters is the filesystem's,
     // not a round number: worst-case platform ids stay far under it.
     const worstCase = `feishu:oc_${"a".repeat(32)}:omt_${"b".repeat(32)}`;
-    expect(encodeURIComponent(worstCase).length).toBeLessThan(255);
+    expect(piSessionId(worstCase).length).toBeLessThan(255);
     expect(calls[0]?.prompt.text).toContain("[feishu: chat oc_1 (p2p), from user ou_alice, msg om_dm1]");
     expect(calls[0]?.prompt.text).toContain("hello there");
     // The reply contract rides every chat prompt: the channel owns delivery — no send-tool answering.

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -1,5 +1,5 @@
 /**
- * Session control plane, Phase 1 (observation plane) conformance — docs/design/session-control.md:
+ * Session control plane, observation-plane conformance — docs/design/session-control.md:
  * projection fidelity (AgentEvent is a projection of the rich stream), ordering, run boundaries
  * (exactly one run_settled per run_started, incl. caller cancellation), reconnect (entries cursor +
  * state), read-only observation (no session creation), and acceptance-vs-outcome on dispatch.
@@ -71,7 +71,7 @@ async function watchUntilSettled(control: SessionControl, session: string) {
   return seen;
 }
 
-describe("session control (Phase 1): observation plane", () => {
+describe("session control: observation plane", () => {
   it("run boundaries + projection fidelity: the invoke stream is a projection of the rich stream", async () => {
     const { agent, control } = await makeObserved([
       fauxAssistantMessage([fauxThinking("hmm"), { type: "text", text: "answer" }]),
@@ -503,7 +503,7 @@ async function waitForToolStarted(control: SessionControl, session: string) {
   }
 }
 
-describe("session control (Phase 2a): run modulation", () => {
+describe("session control: run modulation", () => {
   it("steer joins the active run: accepted with its runId, delivered before the next model call, settle window spans it", async () => {
     const { agent, control, gate } = await makeGated([
       fauxAssistantMessage(fauxToolCall("gate", {}, { id: "g1" })),
@@ -789,7 +789,7 @@ async function makeBoundary(responses: FauxResponseStep[], tools: AgentTool[] = 
   return { ...built, spec: `${model.provider}/${model.id}` };
 }
 
-describe("session control (Phase 2b): boundary mutations", () => {
+describe("session control: boundary mutations", () => {
   it("capabilities carry only what is SESSIONLESS: the registry has a list, thinking levels do not", async () => {
     const { control, sessions, spec } = await makeBoundary([]);
     const caps = control.capabilities();
@@ -1850,7 +1850,7 @@ describe("session control (Phase 2b): boundary mutations", () => {
   });
 });
 
-describe("session control (Phase 4): session lifecycle", () => {
+describe("session control: session lifecycle", () => {
   it("sessions.list() reports the deployment's conversations, with the name update({ name }) gave them", async () => {
     const { control, sessions } = await makeBoundary([]);
     await sessions.openOrCreate("room-a");


### PR DESCRIPTION
## What

- Design docs and source comments referenced files that moved or no longer exist (`../turn-queue.ts` et al. → `channels/kit/`, `engines/pi/invoke.ts`, `sessions.ts`) and section numbers `core.md` does not have (§11, §14 — the latter meant `session-control.md`). Every reference now names the file and the document it means.
- `docs/design/session-control.md` §15 was an implementation-sequence table with "Done." markers inside a `status: current` document. It is now "Decisions on the record": the same durable decisions, without the phase framing. The other "Phase N" mentions (doc + `src/` + test describes) follow, and the opening scope statement now bounds itself by §15's follow-on list rather than by phase numbers.
- `docs/design/conformance-levels.md` §2 narrated the removed engine axis; it states the one axis and the class the serving path runs on. §1 keeps naming `AgentHarness` once, because §4 and §6 still reason about the swap.
- Two mechanism descriptions were wrong, not just misplaced: `piSessionId` escapes non-`[A-Za-z0-9.-]` characters as `_XX` / `_uXXXX`, it does not percent-encode; and `channels/kit/`'s neighbours sit one level up per file (`wait-health` for deploy/, `registration` for deploy/ and cli/), not as one group.
- `AGENTS.md`'s deploy layout line claimed "new host = new dir, copy fly/"; it now lists what adding a host actually touches.

## Why

Risk shape #4 in AGENTS.md (a comment that describes code that no longer exists) and rule 9 (process docs are scaffolding).

One assertion changes with it. `test/feishu.test.ts` bounded a session id's filename length through `encodeURIComponent`, an encoding the product never applies — the comment above it named the same wrong mechanism. It now calls `piSessionId`, so the check measures the encoding that actually produces the filename. No other behaviour change.
