### PR TITLE
refactor: drop five back-compat shims

### DIFF
--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -424,20 +424,20 @@ coupled three independent axes — session identity, reply placement, and the su
 who wanted room-level sessions was forced to also give up mention-free thread continuations. The
 model above sets each axis on its own principle, which leaves nothing for the modes to select.
 
-For Feishu/Lark, `buffers.json` buckets keyed `<chat>:root:<id>` are dropped at load — the re-keying
-means no place key can produce that shape again, so nothing could ever fold or clear them. That drop
-is permanent code: those buckets hold chat content, and an upgrade that skips several releases would
-never run an expired copy of the cleanup.
+For Feishu/Lark, `buffers.json` buckets keyed `<chat>:root:<id>` are never read again — the re-keying
+means no place key can produce that shape again, so nothing can fold or clear them. Nothing deletes
+them either: they hold chat content and stay on disk, bounded and never growing, until an operator
+removes them.
 
 `owned-threads.json` was deleted on the next start by 0.16 and 0.17 only — a pure index, so its
 removal was tidiness, not migration, and the code expired with 0.18 (test/migration-deadline.test.ts,
 now retired with it). Upgrading straight from 0.15 or earlier leaves the file behind, unread by
 anything; delete it if you want the state directory clean.
 
-That discards real content, once: the retired shape covered EVERY thread bucket and every main-chat
+That strands real content, once: the retired shape covered EVERY thread bucket and every main-chat
 quoted-reply bucket, so buffered discussion in threads does not survive the upgrade (a chat's own
 `<chat>` bucket does). A turn that was in flight across the upgrade loses its buffered context too —
-its `bufferKey` was persisted under the old shape. Both are one-time, and the dropped count is logged.
+its `bufferKey` was persisted under the old shape. Both are one-time.
 
 Breaking changes for existing Feishu/Lark deployments:
 
@@ -461,8 +461,8 @@ there, which restores the mention requirement. `owned-threads.json` is left behi
 
 Breaking changes for existing Slack deployments:
 
-- `directMessageSession` and `groupMessageSession` are removed. Passing either now fails at startup
-  rather than being ignored — placement and session identity follow from Slack's own primitives (§5),
-  which leaves nothing for the options to select;
+- `directMessageSession` and `groupMessageSession` are removed — placement and session identity follow
+  from Slack's own primitives (§5), which leaves nothing for the options to select. TypeScript refuses
+  them; a JavaScript channel file that still passes either has it silently ignored;
 - a deployment that set either to `continuous` therefore changes both where answers land and how
   sessions are keyed. Existing history is not migrated, for the same reason as Feishu's re-keying above.

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -489,9 +489,9 @@ carries.
 
 `list` answers in CALLER ids, never storage names. The pi implementation encodes a Caller's id into a
 name pi accepts (`-1001234567890` → `s-1001234567890`), and that encoding is storage detail: a listing
-that leaked it would hand a client strings it cannot dial back. Records written before this store
-existed use an older spelling that cannot be decoded, so they are OMITTED from a listing rather than
-reported under a name nobody can use — they are still opened and continued by id.
+that leaked it would hand a client strings it cannot dial back. A name this store did not write
+cannot be decoded, so it is OMITTED from a listing rather than reported under a name nobody can use.
+Records written before this store existed lie outside its directory and are not read at all.
 
 The pi implementation may use pi's richer session repository internally for stable entry ids
 and session reconstruction; both views point at the same durable root, and all writers share the

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -340,11 +340,11 @@ The channel persists its state under `<state root>/channels/<kind>/` (`channels/
 - `buffers.json` — unsummoned human group/thread discussion, persisted before the transport ACK and consumed only after an Agent turn completes,
 - `files/c-<chat>/` — downloaded inbound files, one directory per chat.
 
-An upgrade from the earlier session-mode model cleans itself up on the next start: the obsolete
-`owned-threads.json` is removed, and `buffers.json` buckets keyed `<chat>:root:<id>` are dropped at
-load, since the re-keying means nothing can ever fold or clear them again. That old shape covered every
-thread bucket, so **buffered discussion in threads does not survive the upgrade** — a chat's own bucket
-does. The dropped count is logged.
+An upgrade from the earlier session-mode model leaves its state behind, unread: `owned-threads.json`
+and the `buffers.json` buckets keyed `<chat>:root:<id>`, which the re-keying means nothing can ever
+fold or clear again. That old shape covered every thread bucket, so **buffered discussion in threads
+does not survive the upgrade** — a chat's own bucket does. Nothing deletes either one; they are
+bounded and never grow, so removing them is optional cleanup.
 
 The seen ring is bounded, best-effort delivery dedup rather than exactly-once execution. It is written
 after the turn/buffer state so a failed pre-ACK state write can still be redelivered safely; a crash
@@ -378,9 +378,9 @@ Three behaviour changes, none of them opt-in:
   Scaffolded files are copies, so an existing workspace keeps the old text — see the send-tool section
   above for the one-line fix.
 
-State cleans itself up on the first start: `owned-threads.json` is removed, and `buffers.json` buckets
-under the retired key shape are dropped — which means **buffered discussion in threads does not survive
-the upgrade** (a chat's own bucket does). The dropped count is logged.
+State from the earlier model stays on disk, unread: `owned-threads.json` and the `buffers.json`
+buckets under the retired key shape — which means **buffered discussion in threads does not survive
+the upgrade** (a chat's own bucket does). Delete them if you want the state directory clean.
 
 Derivation in [design/participant-model.md](design/participant-model.md) §3 and §12.
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -324,10 +324,10 @@ manual console step. Mount `FASTAGENT_STATE_DIR` on durable storage and keep one
 
 ## Upgrading from the session-mode releases
 
-`directMessageSession` and `groupMessageSession` are **removed**, and passing either now fails at
-startup rather than being ignored — placement and session identity follow from Slack's own primitives
-(an answer goes in a thread on the ask, and that thread is the session), which leaves nothing for the
-options to select. Delete them from `channels/slack.ts`.
+`directMessageSession` and `groupMessageSession` are **removed** — placement and session identity
+follow from Slack's own primitives (an answer goes in a thread on the ask, and that thread is the
+session), which leaves nothing for the options to select. Delete them from `channels/slack.ts`:
+TypeScript refuses them, but a JavaScript channel file that still passes either is silently ignored.
 
 If either was set to `continuous`, both where answers land and how sessions are keyed change with the
 removal, and **existing conversation history is not migrated** — every thread starts fresh. The obsolete

--- a/src/channels/feishu/context-buffer.ts
+++ b/src/channels/feishu/context-buffer.ts
@@ -4,14 +4,12 @@
  * buffered-resource selection. Entries are bucketed by conversation place (main chat, or one
  * concrete thread root) and folded into the next answered turn in that place.
  */
-import { log } from "../../log.ts";
 import {
   BUFFER_ATTACH_MAX,
   BUFFER_LINE_MAX_CHARS,
   type ContextBuffer,
   createContextBuffer as createGenericContextBuffer,
 } from "../kit/context-buffer.ts";
-import { loadStateFile, saveStateFile } from "../kit/state.ts";
 import { truncateCodePointPrefix } from "../kit/text.ts";
 import type { NormalizedFeishuMessage } from "./model.ts";
 
@@ -128,41 +126,7 @@ function isEntry(value: unknown): value is FeishuBufferEntry {
   );
 }
 
-/**
- * Buckets from the pre-participant-model keying (`<chat>:root:<root_id>`) can never be produced again —
- * a place is `<chat>` or `<chat>:thread:<thread_id>` — so nothing could ever fold or clear them, and
- * they would hold chat content on disk forever. Dropped here, before the buffer loads, so the shared
- * kernel never learns about a key shape one channel retired.
- *
- * TWO one-time losses, both accepted and both logged by count. (1) The retired shape covered every
- * thread bucket and every main-chat quoted-reply bucket, so buffered discussion in threads does not
- * survive the upgrade — it becomes unreachable BECAUSE of the re-keying, not before it. (2)
- * `turns.json` persists each in-flight turn's `bufferKey` verbatim and this runs before turn recovery,
- * so a turn spanning the upgrade finds its bucket already gone. Sparing referenced keys would couple
- * the buffer to the turn store to protect a single upgrade, and would not help (1) at all.
- *
- * PERMANENT, unlike the `owned-threads.json` cleanup it otherwise resembles. That one leaves an inert
- * orphan file, so deleting it a release later is free; this one is what stops user chat content
- * lingering, and a deployment that skips from before the model to well after it would never run an
- * expired version of this code. The standing cost is one key scan at load, and nothing when no retired
- * key is present.
- */
-function dropRetiredBuckets(path: string, label: string): void {
-  const raw = loadStateFile(path);
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return;
-  const live = Object.entries(raw).filter(([placeKey]) => !placeKey.includes(":root:"));
-  const dropped = Object.keys(raw).length - live.length;
-  if (dropped === 0) return;
-  log.info(`${label} dropped ${dropped} context bucket(s) with a retired key shape`);
-  try {
-    saveStateFile(path, Object.fromEntries(live));
-  } catch (error) {
-    log.warn(`${label} could not rewrite ${path} after dropping retired buckets: ${String(error)}`);
-  }
-}
-
 export function createFeishuContextBuffer(path: string, label: string): FeishuContextBuffer {
-  dropRetiredBuckets(path, label);
   return createGenericContextBuffer({
     path,
     label,

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -201,21 +201,6 @@ interface FeishuRuntime {
   turnsIdle(): Promise<void>;
 }
 
-/** The participant model removed the session modes (docs/design/participant-model.md §12). An upgraded
- *  workspace still passing one would otherwise start fine and silently get different placement AND a
- *  different memory boundary — the one breaking change most likely to be hit, and invisible. */
-function rejectRemovedSessionOptions(opts: FeishuChannelBaseOptions, factoryName: string): void {
-  const removed = ["directMessageSession", "groupMessageSession"].filter(
-    (name) => (opts as unknown as Record<string, unknown>)[name] !== undefined,
-  );
-  if (removed.length > 0) {
-    throw new Error(
-      `${factoryName} no longer accepts ${removed.join(" / ")}: a chat is one session and a thread is another, ` +
-        "and the summon rule no longer depends on the mode — remove the option (see docs/design/participant-model.md)",
-    );
-  }
-}
-
 function createFeishuRuntimeFactory(
   profile: FeishuCloudProfile,
   opts: FeishuChannelBaseOptions,
@@ -878,7 +863,6 @@ export function buildFeishuChannel(
   opts: FeishuChannelOptions,
   factoryName: string,
 ): ChannelModule {
-  rejectRemovedSessionOptions(opts, factoryName);
   const createRuntime = createFeishuRuntimeFactory(profile, opts, factoryName);
   return (ctx) => {
     if (!opts.verificationToken) {
@@ -894,7 +878,6 @@ export function buildFeishuWebSocketChannel(
   factoryName: string,
   deps: FeishuWebSocketChannelDeps = {},
 ): LongConnectionChannelModule {
-  rejectRemovedSessionOptions(opts, factoryName);
   const createRuntime = createFeishuRuntimeFactory(profile, opts, factoryName);
   return {
     name: `${profile.kind} websocket`,

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -182,19 +182,6 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
     apiBaseUrl = "https://slack.com/api",
   } = options;
 
-  // The participant model derives placement instead of selecting it: Slack has no quote primitive, so
-  // answering in place means answering in a thread on the ask, whichever renderer draws it. An
-  // upgraded workspace still passing one of the removed modes would otherwise start fine and silently
-  // get a different placement AND a different memory boundary.
-  const removedModes = ["directMessageSession", "groupMessageSession"].filter(
-    (name) => (options as unknown as Record<string, unknown>)[name] !== undefined,
-  );
-  if (removedModes.length > 0) {
-    throw new Error(
-      `slackChannel no longer accepts ${removedModes.join(" / ")}: an answer goes in a thread on the ask, and ` +
-        "that thread is the session — see docs/design/participant-model.md",
-    );
-  }
   if (!(["context", "mentions"] as const).includes(groupBehavior)) {
     throw new Error('slackChannel groupBehavior must be "context" or "mentions"');
   }

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -29,7 +29,7 @@ import { failStartup, failUsage, placementOrExit } from "../fail.ts";
 export async function runAddChannel(
   channelKind: ChannelKind,
   dirArg: string,
-  opts: { createApp?: boolean; ingress?: string; groupBehavior?: string; onboard?: boolean; replaceConfig?: boolean },
+  opts: { ingress?: string; groupBehavior?: string; onboard?: boolean; replaceConfig?: boolean },
 ): Promise<void> {
   // The channel (glue + companion tool + secrets) is agent surface — everything lands in the
   // AGENT DIR (`fastagent/`), the same place dev/start discover channels/.
@@ -49,21 +49,6 @@ export async function runAddChannel(
   const inAgent = (p: string): string => (agentFromCwd === undefined ? p : join(agentFromCwd, p));
   const envPath = dotEnvPath(target);
   const envLabel = isUnderDir(envPath, target) ? inAgent(relative(target, envPath)) : envPath;
-  // App creation is not a flag — it is what `add feishu` IS (the scan-to-create flow is the default
-  // and only path there). The retired --create-app spelling gets a pointer, not silence.
-  if (opts.createApp) {
-    if (channelKind === "feishu") {
-      console.error(`[fastagent] note: --create-app is retired — \`add feishu\` creates the app by default`);
-    } else if (channelKind === "lark") {
-      failStartup(
-        new Error(
-          "--create-app is retired — `add lark` now opens the developer console and guides credential setup by default",
-        ),
-      );
-    } else {
-      failStartup(new Error("--create-app is retired — app creation is the default behavior of `add feishu`"));
-    }
-  }
   // Preconditions before the write, so a refusal is side-effect-free. slack/feishu/lark are exceptions:
   // their add is scaffold + ONBOARD THE APP, so an existing scaffold skips the write and continues (a
   // failed/cancelled app or OAuth flow must be re-runnable without hand-deleting authored glue).

--- a/src/cli/kernel.ts
+++ b/src/cli/kernel.ts
@@ -27,8 +27,6 @@ interface ArgSpec {
 export interface FlagSpec {
   flags: string;
   description: string;
-  /** Parses but does not appear in help — for retired flags that should still explain themselves. */
-  hidden?: boolean;
   /** Mutually exclusive with these {@link optionKey} values — validated at build time. */
   conflicts?: string[];
 }
@@ -183,7 +181,6 @@ function register(parent: Command, spec: CommandSpec): void {
   }
   for (const f of spec.flags ?? []) {
     const opt = new Option(f.flags, f.description);
-    if (f.hidden) opt.hideHelp();
     if (f.conflicts) opt.conflicts(f.conflicts);
     cmd.addOption(opt);
   }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -295,8 +295,6 @@ const start: CommandSpec = {
     }),
 };
 
-/** The retired app-creation flag — parsed so it can explain itself, hidden from help. */
-const CREATE_APP: FlagSpec = { flags: "--create-app", description: "(retired)", hidden: true };
 const INGRESS: FlagSpec = {
   flags: "--ingress <mode>",
   description: "Feishu/Lark ingress: websocket or webhook (interactive when omitted)",
@@ -326,19 +324,16 @@ const channelSub = (
   summary,
   description,
   args: [DIR_ARG],
-  flags: [
-    CREATE_APP,
-    ...(kind === "feishu" || kind === "lark"
+  flags:
+    kind === "feishu" || kind === "lark"
       ? [INGRESS, GROUP_BEHAVIOR]
       : kind === "slack"
         ? [GROUP_BEHAVIOR, NO_ONBOARD, REPLACE_CONFIG]
-        : []),
-  ],
+        : [],
   examples: [{ cmd: `fastagent add ${kind}` }],
   ...(notes ? { notes } : {}),
   run: async (args, f) =>
     (await import("./commands/add.ts")).runAddChannel(kind, args[0] as string, {
-      createApp: f.createApp === true,
       ingress: f.ingress as string | undefined,
       groupBehavior: f.groupBehavior as string | undefined,
       onboard: f.onboard !== false,

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -27,7 +27,7 @@
  * workspace.
  */
 import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   type AgentSession,
@@ -44,8 +44,8 @@ import { definitionResourceLoaderOptions, reportExtensionErrors } from "./agent-
 import { resolveModel } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt } from "./create.ts";
 import { canonicalPath, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
-import { createPiModelRuntime, probeAuthSource } from "./models.ts";
-import { log, reportModuleLoadFailures } from "../../log.ts";
+import { createPiModelRuntime } from "./models.ts";
+import { reportModuleLoadFailures } from "../../log.ts";
 import {
   type ReadonlySessionManager,
   type ToolActivation,
@@ -138,7 +138,6 @@ export async function buildAgentSessionRuntime(
     return {
       modelRuntime,
       modelSpec,
-      authPath,
       // Serving honors config.thinkingLevel (config → L2); the resident session must too (fidelity).
       thinkingLevel: config.thinkingLevel,
       definition,
@@ -179,15 +178,10 @@ export async function buildAgentSessionRuntime(
     return assembly;
   };
 
-  // The credential hint belongs to the RUNTIME, not to each session it builds: model resolution
-  // moved into createRuntime (extensions must load first), and repeating this on every /new,
-  // /resume and fork would nag about a setting that did not change.
-  let credentialHintShown = false;
   const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
     const {
       modelRuntime,
       modelSpec,
-      authPath,
       thinkingLevel,
       definition,
       extensionPaths,
@@ -221,23 +215,6 @@ export async function buildAgentSessionRuntime(
     // services are built — resolving first fails a definition whose configured model comes from its
     // own extension with a bare "unknown model", after warning about credentials for a provider
     // that does not exist yet.
-    //
-    // MIGRATION HINT (deliberate breaking change): chat historically used pi's own `~/.pi` auth; it
-    // now reads the agent's credential file like every other command. Probe the RESOLVED model's
-    // provider through the normal resolution path (stored credential OR env var — an env-authed
-    // user is fine and must not be warned): only when that provider has no usable auth AND pi's old
-    // file exists does the bare provider error get its cause named.
-    if (
-      !credentialHintShown &&
-      (await probeAuthSource(modelRuntime, modelSpec)) === undefined &&
-      existsSync(join(getAgentDir(), "auth.json"))
-    ) {
-      credentialHintShown = true;
-      log.warn(
-        `[fastagent] no credentials for ${modelSpec} in ${authPath} — this runtime no longer reads ` +
-          `pi's ~/.pi auth; run \`fastagent login\` (or /login in the TUI) to store credentials for this agent`,
-      );
-    }
     const model = resolveModel(modelRuntime, modelSpec);
 
     const result = await createAgentSessionFromServices({

--- a/src/engines/pi/session-store.ts
+++ b/src/engines/pi/session-store.ts
@@ -100,10 +100,10 @@ interface AppliedProperties {
  * produce one output. `_` escapes itself for the same reason. A trailing `.` or `-` is legal
  * mid-name but not at the end, so it escapes too.
  *
- * Injective within this encoding — which is only sufficient because new records live in their own
- * directory. The older spelling draws names from the same character set (it stored a room literally
- * called `s42` as `s42`, which is also this encoding of `42`), so one directory would make some
- * names ambiguous no matter how either side spells them.
+ * Injective within this encoding — which is only sufficient because this store's records live in
+ * their own directory. A name this store did not write draws from the same character set and can
+ * still decode: a file called `s42` is also this encoding of `42`, so one directory would make some
+ * names ambiguous no matter how this side spells them.
  *
  * Readability is deliberate: `-1001234567890` becomes `s-1001234567890`, so an operator can still
  * tell which room a file belongs to.
@@ -154,15 +154,11 @@ export function callerSessionId(recordId: string): string | undefined {
  * each header and would make a renamed agent directory look like an empty store (see
  * {@link recordFiles}).
  *
- * NEW records live in a subdirectory of their own, because the two engines cannot share a namespace:
- * both spell ids into `[A-Za-z0-9._-]`, so neither can claim a prefix the other cannot produce, and
- * a directory holding both would have names that belong to two conversations at once — in whichever
- * direction it is read. Separate directories make each side's own injectivity sufficient.
- *
- * A PRE-EXISTING record is continued in place: looked up by the older spelling, which is injective
- * on its own terms, and appended to where it lies. Both spellings are the same v3 jsonl, so a
- * conversation started before this store keeps going rather than restarting empty. Nothing on disk
- * is rewritten.
+ * Records live in a subdirectory of their own, because a name this store did not write can still
+ * decode to a Caller id: a file called `s42` beside them is also this encoding of `42`, so a shared
+ * directory would answer `42` with a record it does not own. Only this directory is scanned, which
+ * makes this encoding's own injectivity sufficient — a record written before this store existed
+ * lies outside it and is never read.
  *
  * SCOPE OF "open-or-create": idempotent against a store that is serialized per session, which is what
  * the serving path provides — the single-writer lease is taken before any store call, so no two
@@ -283,8 +279,8 @@ export function piSessionRecordStore(options: { dir: string; cwd?: string }): Pi
       const rows: SessionSummary[] = [];
       const unreadable: string[] = [];
       for (const file of files) {
-        // A record this store did not write (the older spelling) cannot be decoded back to a Caller
-        // id, and a row nobody can dial is worse than a row that is missing. It stays openable BY id.
+        // A name this store did not write cannot be decoded back to a Caller id, and a row nobody
+        // can dial is worse than a row that is missing.
         const session = callerSessionId(file.id);
         if (!session) continue;
         try {

--- a/src/engines/pi/session-store.ts
+++ b/src/engines/pi/session-store.ts
@@ -1,10 +1,6 @@
 /**
  * Session persistence for the `AgentSession` L0 — open-or-create a durable record by the Caller's
  * opaque session id, on pi-coding-agent's `SessionManager` (the v3 jsonl every pi surface reads).
- *
- * Records written before this store existed (by the pi-agent-core `Session` the serving path used
- * to run on) are the same v3 jsonl and are continued in place — see `legacySessionId`. That is a
- * READ path for existing conversations, not a second engine.
  */
 import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -254,14 +250,11 @@ export function piSessionRecordStore(options: { dir: string; cwd?: string }): Pi
   /** The unreadable records the last listing reported, so a polled endpoint states the condition
    *  once rather than once a second. */
   let lastUnreadable = "";
-  /** WHERE a session's record is, under either spelling — the one lookup every caller shares, so a
-   *  fix to it (this store's own directory rather than pi's cwd-filtered listing) cannot reach three
-   *  of the four. */
+  /** WHERE a session's record is — the one lookup every caller shares, so a fix to it (this store's
+   *  own directory rather than pi's cwd-filtered listing) cannot reach three of the four. */
   const locate = (sessionId: string): { path: string; dir: string } | undefined => {
     const mine = recordFiles(own).find((f) => f.id === piSessionId(sessionId));
-    if (mine) return { path: mine.path, dir: own };
-    const legacy = recordFiles(root).find((f) => f.id === legacySessionId(sessionId));
-    return legacy ? { path: legacy.path, dir: root } : undefined;
+    return mine ? { path: mine.path, dir: own } : undefined;
   };
   /** Open an existing record, or undefined. A closure rather than a method call, so `fork` cannot be
    *  broken by a caller that spreads this object into another one. */
@@ -617,7 +610,7 @@ function reconcileInterruptedToolCalls(record: SessionManager): SessionManager {
   return record;
 }
 
-/** Where this engine's own records live, under the sessions directory both engines are pointed at. */
+/** Where the records live, under the sessions directory the store is pointed at. */
 const OWN_RECORDS_DIR = "agent-session";
 
 /**
@@ -724,14 +717,4 @@ export function piInMemorySessionRecordStore(options: { cwd?: string } = {}): Pi
       return live.delete(sessionId);
     },
   };
-}
-
-/** The spelling used before this store existed — read-only, so older records still resolve. */
-function legacySessionId(sessionId: string): string {
-  return sessionId.replace(/[^A-Za-z0-9._-]/g, (c) => {
-    const code = c.charCodeAt(0);
-    return code < 0x100
-      ? `%${code.toString(16).toUpperCase().padStart(2, "0")}`
-      : `%u${code.toString(16).toUpperCase().padStart(4, "0")}`;
-  });
 }

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -487,16 +487,6 @@ describe("ingress verification", () => {
 });
 
 describe("upgrade from the session-mode model", () => {
-  it("refuses a removed session option instead of silently changing behaviour under it", () => {
-    const opts = { appId: "app", appSecret: "secret", verificationToken: TOKEN } as FeishuChannelOptions;
-    expect(() => buildFeishuChannel({ ...opts, groupMessageSession: "continuous" } as never)).toThrow(
-      /groupMessageSession/,
-    );
-    expect(() => buildFeishuChannel({ ...opts, directMessageSession: "threaded" } as never)).toThrow(
-      /directMessageSession/,
-    );
-  });
-
   it("drops only the retired context buckets", async () => {
     feishuFetch();
     const root = mkdtempSync(join(tmpdir(), "feishu-upgrade-"));

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -486,34 +486,6 @@ describe("ingress verification", () => {
   });
 });
 
-describe("upgrade from the session-mode model", () => {
-  it("drops only the retired context buckets", async () => {
-    feishuFetch();
-    const root = mkdtempSync(join(tmpdir(), "feishu-upgrade-"));
-    tempRoots.push(root);
-    const home = join(root, "channels", "feishu");
-    mkdirSync(home, { recursive: true });
-    const entry = (body: string) => [{ sender: "user ou_alice", body, messageId: `om_${body}` }];
-    writeFileSync(
-      join(home, "buffers.json"),
-      JSON.stringify({
-        "oc_1:root:om_old": entry("retired"), // no place key can produce this shape any more
-        "oc_1:thread:omt_live": entry("live-thread"),
-        oc_1: entry("live-chat"),
-      }),
-    );
-
-    const { agent } = replyingAgent();
-    buildFeishuChannel({ appId: "app", appSecret: "secret", verificationToken: TOKEN, apiBaseUrl: BASE })({
-      agent,
-      stateRoot: root,
-    });
-
-    const buffers = JSON.parse(readFileSync(join(home, "buffers.json"), "utf8")) as Record<string, unknown[]>;
-    expect(Object.keys(buffers).sort()).toEqual(["oc_1", "oc_1:thread:omt_live"]);
-  });
-});
-
 describe("turn flow", () => {
   it("a direct message is one continuous conversation, answered in place", async () => {
     const fx = feishuFetch();

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -1,8 +1,8 @@
 /**
  * The AgentSession L0's session store: pi accepts the ids channels actually mint, two rooms never
- * share a record, and a conversation started by the harness path is continued rather than restarted.
+ * share a record.
  */
-import { symlinkSync, writeFileSync } from "node:fs";
+import { symlinkSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, rename, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -86,66 +86,6 @@ describe("piSessionRecordStore", () => {
     expect(after.getBranch().some((e) => JSON.stringify(e).includes("what did I ask?"))).toBe(true);
     // One conversation, one record - this engine keeps its own under a subdirectory of the store.
     expect((await SessionManager.list(cwd, join(dir, "agent-session"))).length).toBe(1);
-  });
-
-  it("does not hand a conversation the record another engine's spelling of its name produced", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-store-collide-"));
-    const cwd = process.cwd();
-    const store = piSessionRecordStore({ dir, cwd });
-
-    // The harness path stores raw ids, so a room literally called "s42" lands on disk as "s42" -
-    // which is also what this store's encoding produces for the DIFFERENT room "42".
-    writeFileSync(
-      join(dir, "2026-01-01T00-00-00-000Z_s42.jsonl"),
-      `${[
-        { type: "session", version: 3, id: "s42", timestamp: "2026-01-01T00:00:00.000Z", cwd },
-        {
-          type: "message",
-          id: "e1",
-          parentId: null,
-          timestamp: "2026-01-01T00:00:01.000Z",
-          message: { role: "user", content: "belongs to room s42" },
-        },
-      ]
-        .map((e) => JSON.stringify(e))
-        .join("\n")}\n`,
-    );
-
-    const other = await store.openOrCreate("42");
-
-    expect(other.getBranch().some((e) => JSON.stringify(e).includes("belongs to room s42"))).toBe(false);
-    // And the room that DOES own it still gets it.
-    expect(
-      (await store.openOrCreate("s42")).getBranch().some((e) => JSON.stringify(e).includes("belongs to room s42")),
-    ).toBe(true);
-  });
-
-  it("continues a record the harness path wrote, instead of restarting the conversation", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-store-legacy-"));
-    const cwd = process.cwd();
-    // Written the way the harness path writes it: sessions.ts keeps `[A-Za-z0-9._-]` verbatim, so a
-    // telegram group id lands on disk AS the id - a spelling pi itself refuses to mint, which is why
-    // this record has to be laid down by hand rather than through SessionManager.
-    const id = "-1001234567890";
-    writeFileSync(
-      join(dir, `2026-01-01T00-00-00-000Z_${id}.jsonl`),
-      `${[
-        { type: "session", version: 3, id, timestamp: "2026-01-01T00:00:00.000Z", cwd },
-        {
-          type: "message",
-          id: "e1",
-          parentId: null,
-          timestamp: "2026-01-01T00:00:01.000Z",
-          message: { role: "user", content: "written by the harness path" },
-        },
-      ]
-        .map((e) => JSON.stringify(e))
-        .join("\n")}\n`,
-    );
-
-    const reopened = await piSessionRecordStore({ dir, cwd }).openOrCreate(id);
-
-    expect(reopened.getBranch().some((e) => JSON.stringify(e).includes("written by the harness path"))).toBe(true);
   });
 });
 

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -139,7 +139,7 @@ describe("the lifecycle primitives (list / fork / delete)", () => {
     for (const id of ["42", "-1001234567890", "oc_9:thread/1", "a b", "emoji-🌤", "trailing-", "_", "s42"]) {
       expect(callerSessionId(piSessionId(id))).toBe(id);
     }
-    // Not ours to decode: the older spelling and anything else are left out of a listing rather
+    // Not ours to decode: a name this store did not write is left out of a listing rather
     // than reported under a name no client could dial.
     expect(callerSessionId("%2Dweird")).toBeUndefined();
     expect(callerSessionId("s_ZZ")).toBeUndefined();

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -279,17 +279,6 @@ describe("Slack signed ingress", () => {
     expect(verifySlackSignature(SECRET, timestamp, signature, body, 1_700_001_000_000)).toBe(false);
   });
 
-  it("refuses a removed session option instead of silently changing placement and memory under it", () => {
-    // The migration guarantee: an upgraded workspace still passing a mode fails loudly at construction
-    // rather than starting fine with a different place, a different session, and a different renderer.
-    expect(() =>
-      slackChannel({ botToken: "xoxb-test", signingSecret: SECRET, groupMessageSession: "continuous" } as never),
-    ).toThrow(/groupMessageSession/);
-    expect(() =>
-      slackChannel({ botToken: "xoxb-test", signingSecret: SECRET, directMessageSession: "threaded" } as never),
-    ).toThrow(/directMessageSession/);
-  });
-
   it("rejects invalid rendering, task-display, and reaction policies at construction", () => {
     expect(() =>
       slackChannel({


### PR DESCRIPTION
## What

Five back-compat shims:

- `cli`: the hidden, retired `--create-app` flag on `add <channel>` (three branches, three messages). Commander's unknown-option error is the answer now, and `FlagSpec.hidden` goes with its last producer.
- `channels`: `rejectRemovedSessionOptions` (feishu) and its inline copy (slack) — guards for `directMessageSession` / `groupMessageSession`, options that no longer exist in the types.
- `feishu`: `dropRetiredBuckets`, the one-time migration for the pre-participant-model `<chat>:root:<root_id>` bucket key.
- `session-store`: `legacySessionId` and the second `locate` branch that read records written by the pre-store engine at the sessions-dir root.
- `chat`: the `~/.pi/agent/auth.json` probe that named the old auth source when the agent's credential file was empty.

Each shim's test went with it, and so did its companion text: the upgrade notes in `docs/slack.md`, `docs/feishu.md`, `docs/design/participant-model.md` and `docs/design/session-control.md` described guards and cleanups that no longer run, and `piSessionRecordStore`'s docstring still explained how a pre-existing record is continued in place.

## Why

AGENTS.md: no backward compatibility, no migrations; keeping code clean is the priority. Every one of these existed to soften an already-shipped breaking change for a pre-release audience.

Deleting a mechanism without its description is the risk shape the same file names (#4): a comment that asserts a constraint argues the next reader into the wrong change, and an upgrade note that promises a guard is worse — it is read by someone who cannot check.

## Observable change

- `fastagent add feishu --create-app` → usage error (exit 2) instead of a note.
- A `.mjs` channel file still passing a removed session-mode option is silently ignored rather than refused (TypeScript authors are refused by the type). The upgrade notes now say so.
- Records under `<sessions>/agent-session/` are the only ones the store reads; a `.state/sessions/*.jsonl` written before the store existed is not found.
- Feishu's retired `<chat>:root:<id>` buffer buckets stay on disk unread instead of being dropped at load — bounded and never growing, but an operator who wants them gone deletes them.
