### PR TITLE
refactor(cli): one prelude and one serve tail for the model-running commands

### DIFF
--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -424,20 +424,16 @@ coupled three independent axes — session identity, reply placement, and the su
 who wanted room-level sessions was forced to also give up mention-free thread continuations. The
 model above sets each axis on its own principle, which leaves nothing for the modes to select.
 
-For Feishu/Lark, `buffers.json` buckets keyed `<chat>:root:<id>` are never read again — the re-keying
+For Feishu/Lark, `buffers.json` buckets keyed `<chat>:root:<id>` become unreachable — the re-keying
 means no place key can produce that shape again, so nothing can fold or clear them. Nothing deletes
-them either: they hold chat content and stay on disk, bounded and never growing, until an operator
-removes them.
+them either, and nothing deletes the obsolete `owned-threads.json`: both cleanups were migration code,
+which this repo does not carry. They are the operator's to remove, with the process stopped.
 
-`owned-threads.json` was deleted on the next start by 0.16 and 0.17 only — a pure index, so its
-removal was tidiness, not migration, and the code expired with 0.18 (test/migration-deadline.test.ts,
-now retired with it). Upgrading straight from 0.15 or earlier leaves the file behind, unread by
-anything; delete it if you want the state directory clean.
-
-That strands real content, once: the retired shape covered EVERY thread bucket and every main-chat
-quoted-reply bucket, so buffered discussion in threads does not survive the upgrade (a chat's own
-`<chat>` bucket does). A turn that was in flight across the upgrade loses its buffered context too —
-its `bufferKey` was persisted under the old shape. Both are one-time.
+The buffered content is lost to the agent either way: the retired shape covered EVERY thread bucket and
+every main-chat quoted-reply bucket, so buffered discussion in threads does not survive the upgrade (a
+chat's own `<chat>` bucket does), and a turn in flight across the upgrade loses its buffered context too
+— `turns.json` persisted its `bufferKey` under the old shape. What differs from a drop is only where it
+rests: those buckets sit in `buffers.json` holding chat content until someone removes them.
 
 Breaking changes for existing Feishu/Lark deployments:
 
@@ -456,13 +452,15 @@ Breaking changes for existing Feishu/Lark deployments:
 
 For Slack, placement and sessions are unchanged **under the default configuration**; what changes is
 the summon rule: a thread the agent has answered in admits bare replies until a second human is heard
-there, which restores the mention requirement. `owned-threads.json` is left behind by an upgrade from
-0.15 or earlier (see above); nothing reads it.
+there, which restores the mention requirement. `owned-threads.json` is left behind by the upgrade (see
+above); nothing reads it.
 
 Breaking changes for existing Slack deployments:
 
 - `directMessageSession` and `groupMessageSession` are removed — placement and session identity follow
-  from Slack's own primitives (§5), which leaves nothing for the options to select. TypeScript refuses
-  them; a JavaScript channel file that still passes either has it silently ignored;
+  from Slack's own primitives (§5), which leaves nothing for the options to select. Delete them by
+  hand: a workspace's `channels/slack.ts` is loaded as ESM, not type-checked, so a leftover option is
+  ignored in silence while placement and the memory boundary change underneath it. Feishu/Lark options
+  are the same;
 - a deployment that set either to `continuous` therefore changes both where answers land and how
   sessions are keyed. Existing history is not migrated, for the same reason as Feishu's re-keying above.

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -340,11 +340,12 @@ The channel persists its state under `<state root>/channels/<kind>/` (`channels/
 - `buffers.json` — unsummoned human group/thread discussion, persisted before the transport ACK and consumed only after an Agent turn completes,
 - `files/c-<chat>/` — downloaded inbound files, one directory per chat.
 
-An upgrade from the earlier session-mode model leaves its state behind, unread: `owned-threads.json`
-and the `buffers.json` buckets keyed `<chat>:root:<id>`, which the re-keying means nothing can ever
-fold or clear again. That old shape covered every thread bucket, so **buffered discussion in threads
-does not survive the upgrade** — a chat's own bucket does. Nothing deletes either one; they are
-bounded and never grow, so removing them is optional cleanup.
+An upgrade from the earlier session-mode model leaves two dead things behind, and nothing removes them:
+the obsolete `owned-threads.json`, and `buffers.json` buckets keyed `<chat>:root:<id>`. The re-keying
+means no place key can produce that shape again, so those buckets can never be folded or cleared —
+**buffered discussion in threads does not survive the upgrade** (a chat's own bucket does), and it stays
+on disk holding that chat content until you delete it. Remove the file and those keys by hand, with the
+process stopped.
 
 The seen ring is bounded, best-effort delivery dedup rather than exactly-once execution. It is written
 after the turn/buffer state so a failed pre-ACK state write can still be redelivered safely; a crash
@@ -378,9 +379,10 @@ Three behaviour changes, none of them opt-in:
   Scaffolded files are copies, so an existing workspace keeps the old text — see the send-tool section
   above for the one-line fix.
 
-State from the earlier model stays on disk, unread: `owned-threads.json` and the `buffers.json`
-buckets under the retired key shape — which means **buffered discussion in threads does not survive
-the upgrade** (a chat's own bucket does). Delete them if you want the state directory clean.
+State does not clean itself up: `owned-threads.json` and the `buffers.json` buckets under the retired
+key shape are both left in place, unread and unreachable — which means **buffered discussion in threads
+does not survive the upgrade** (a chat's own bucket does), while its content stays on disk. Delete both
+by hand with the process stopped (see State & restarts above).
 
 Derivation in [design/participant-model.md](design/participant-model.md) §3 and §12.
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -326,12 +326,13 @@ manual console step. Mount `FASTAGENT_STATE_DIR` on durable storage and keep one
 
 `directMessageSession` and `groupMessageSession` are **removed** — placement and session identity
 follow from Slack's own primitives (an answer goes in a thread on the ask, and that thread is the
-session), which leaves nothing for the options to select. Delete them from `channels/slack.ts`:
-TypeScript refuses them, but a JavaScript channel file that still passes either is silently ignored.
+session), which leaves nothing for the options to select. Delete them from `channels/slack.ts`
+yourself: nothing rejects them at startup, and the file is loaded as ESM rather than type-checked, so a
+leftover option is ignored in silence while placement and the memory boundary change underneath it.
 
 If either was set to `continuous`, both where answers land and how sessions are keyed change with the
 removal, and **existing conversation history is not migrated** — every thread starts fresh. The obsolete
-`owned-threads.json` is deleted on the first start; nothing else needs cleaning up.
+`owned-threads.json` is left behind, unread by anything; delete it if you want the state directory clean.
 
 Slack's scaffolded `slack-send` already carried the "do not use this to answer the current turn"
 boundary its Feishu and Telegram siblings gained this release, so nothing to paste here.

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -1,19 +1,12 @@
 /** `fastagent chat [dir]`: open the SAME assembled agent in pi's interactive TUI. */
-import { resolve } from "node:path";
-import { loadDotEnv } from "../../env.ts";
-
-import { installProxyFetch } from "../../proxy.ts";
-import { failStartup, placementOrExit } from "../fail.ts";
-import { resolveFirstRunModel } from "../shared.ts";
+import { failStartup } from "../fail.ts";
+import { enterAgentCommand } from "../shared.ts";
 
 export async function runChat(dirArg: string, opts: { model?: string; authPath?: string }): Promise<void> {
-  const placement = placementOrExit(resolve(dirArg));
-  loadDotEnv(placement.agentDir);
-  installProxyFetch(); // model calls (and the login dialog) must go through the proxy too
-  // First-run funnel, FULL picker: chat authenticates through fastagent's credential store like every
-  // other command (the shared session builder injects it — see engines/pi/session-builder.ts), so the
-  // credential-annotated catalog and inline login apply here too.
-  await resolveFirstRunModel(placement.agentDir, { model: opts.model, authPath: opts.authPath });
+  // Chat authenticates through fastagent's credential store like every other command (the shared
+  // session builder injects it — see engines/pi/session-builder.ts), so the first-run picker and its
+  // inline login apply here too.
+  const placement = await enterAgentCommand(dirArg, opts);
   // Run the chat process AT the workspace: pi resolves a session's cwd as `header.cwd ?? process.cwd()`,
   // so aligning process.cwd() with the workspace keeps a cwd-less session on it. Paths are absolute.
   process.chdir(placement.workspace);

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -11,7 +11,7 @@ import { MAX_WEBHOOK_BODY_BYTES } from "../../channels/agentcore-limits.ts";
 import type { DeclaredChannel } from "../../channels/discover.ts";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { registerFeishuWebhook } from "../../channels/feishu/register-webhook.ts";
 import { DEPLOY_REGISTRATION_ATTEMPTS } from "../../channels/registration.ts";
 import { readSlackBotAuthEnv } from "../../channels/slack/bot-auth.ts";
@@ -54,15 +54,13 @@ import { deployRailwayRun } from "../../deploy/railway/run.ts";
 import type { DeployHost } from "../../deploy/hosts.ts";
 import { spawnRunner } from "../../deploy/runner.ts";
 import { assembleSecrets } from "../../deploy/secrets.ts";
-import { loadDotEnv } from "../../env.ts";
 import { loadConfig, resolveModelSpec } from "../../engines/pi/config.ts";
 import { type ResolvedPlacement, resolveStateRoot, exists, readTextIfExists } from "../../paths.ts";
 import { loadSchedules } from "../../schedule/discover.ts";
-import { installProxyFetch } from "../../proxy.ts";
 import { openExternalUrl } from "../../open-url.ts";
 import { announceWebhooks } from "../../tunnel.ts";
-import { failStartup, failUsage, placementOrExit } from "../fail.ts";
-import { resolveFirstRunModel } from "../shared.ts";
+import { failStartup, failUsage } from "../fail.ts";
+import { enterAgentCommand } from "../shared.ts";
 
 export interface DeployOptions {
   run?: boolean;
@@ -219,19 +217,16 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
   // ONE deploy semantic: bake the WORKSPACE (WYSIWYG). Artifacts land under the agent dir
   // (`fastagent/`) plus the one workspace-root `.dockerignore` the packers require; host CLIs run
   // from the workspace, which is the build context.
-  const placement = placementOrExit(resolve(dirArg));
-  const { agentDir, workspace } = placement;
   if (opts.tunnel && host !== "docker") {
     // A flag/host combination the parser cannot see (host is an argument) — usage class, exit 2.
     failUsage(`deploy stopped: --tunnel is supported only by the local Docker target`);
   }
-  loadDotEnv(agentDir); // a custom provider/tool may read a key at config load
-  installProxyFetch(); // post-deploy channel API calls must honor HTTP(S)_PROXY under Node
-  // First-run funnel, FULL picker: the write-back lands the model in fastagent.config.* — exactly what
-  // the model-travel gate below requires (--model/env don't reach the deployed box) — and an inline
-  // login stores the credential `--run` then carries. Runs BEFORE loadConfig; the read-back sees the
-  // rewritten file because loadConfig cache-busts on mtime (a failed write-back still gates, correctly).
-  await resolveFirstRunModel(agentDir, { model: opts.model, authPath: opts.authPath, input: opts.input });
+  // The picker's write-back lands the model in fastagent.config.* — exactly what the model-travel
+  // gate below requires (--model/env don't reach the deployed box) — and an inline login stores the
+  // credential `--run` then carries. Runs BEFORE loadConfig; the read-back sees the rewritten file
+  // because loadConfig cache-busts on mtime (a failed write-back still gates, correctly).
+  const placement = await enterAgentCommand(dirArg, opts);
+  const { agentDir, workspace } = placement;
   const { config } = await loadConfig(agentDir).catch(failStartup);
   const modelSpec = resolveModelSpec(opts.model, config);
   // The host-neutral pre-flight (model-travel gate, channel discovery, model-auth probe, container facts +

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -214,9 +214,6 @@ function gateOnModelCredential(needsModelCredential: boolean): void {
 }
 
 export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOptions): Promise<void> {
-  // ONE deploy semantic: bake the WORKSPACE (WYSIWYG). Artifacts land under the agent dir
-  // (`fastagent/`) plus the one workspace-root `.dockerignore` the packers require; host CLIs run
-  // from the workspace, which is the build context.
   if (opts.tunnel && host !== "docker") {
     // A flag/host combination the parser cannot see (host is an argument) — usage class, exit 2.
     failUsage(`deploy stopped: --tunnel is supported only by the local Docker target`);
@@ -226,6 +223,9 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
   // credential `--run` then carries. Runs BEFORE loadConfig; the read-back sees the rewritten file
   // because loadConfig cache-busts on mtime (a failed write-back still gates, correctly).
   const placement = await enterAgentCommand(dirArg, opts);
+  // ONE deploy semantic: bake the WORKSPACE (WYSIWYG). Artifacts land under the agent dir
+  // (`fastagent/`) plus the one workspace-root `.dockerignore` the packers require; host CLIs run
+  // from the workspace, which is the build context.
   const { agentDir, workspace } = placement;
   const { config } = await loadConfig(agentDir).catch(failStartup);
   const modelSpec = resolveModelSpec(opts.model, config);

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -3,26 +3,15 @@
  * assemble + serve, restarting it on agent edits. A fresh process per reload means what is served
  * is always the latest code, including modules a tool/config imports.
  */
-import { resolve } from "node:path";
 import { runDevSupervisor } from "../../dev-supervisor.ts";
-import { loadDotEnv } from "../../env.ts";
-
 import { setLogLevel } from "../../log.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { mountAgentService } from "../../service.ts";
 import { logAgentLoop } from "../../observe.ts";
-import { installProxyFetch } from "../../proxy.ts";
-import { bindAddress } from "../../bind.ts";
-import { failStartup, placementOrExit } from "../fail.ts";
-import {
-  SHUTDOWN_GRACE_MS,
-  announceControl,
-  assertTunnelBindable,
-  maybeTunnel,
-  reportServing,
-  serve,
-} from "../serve.ts";
-import { parseBind, parsePort, reportAssembly, resolveFirstRunModel } from "../shared.ts";
+import type { ResolvedPlacement } from "../../paths.ts";
+import { failStartup } from "../fail.ts";
+import { assertTunnelBindable, cliMountOptions, resolveBindHost, serveService } from "../serve.ts";
+import { enterAgentCommand, parseBind, parsePort, reportAssembly } from "../shared.ts";
 
 export interface DevOptions {
   port?: string;
@@ -37,21 +26,13 @@ export interface DevOptions {
 }
 
 export async function runDev(dirArg: string, opts: DevOptions): Promise<void> {
-  const dir = resolve(dirArg);
-  const placement = placementOrExit(dir);
   setLogLevel("debug"); // dev posture: verbose, includes the debug turn trace (content) — supervisor and worker both
   const isWorker = process.env.FASTAGENT_DEV_WORKER === "1";
-  // Pick a model interactively once, in the parent (both watch and --no-watch have a TTY); a spawned
-  // watch worker inherits the choice via FASTAGENT_MODEL, so it must not prompt again. Load .env and
-  // the proxy FIRST (as invoke/start do): the picker reads FASTAGENT_MODEL and provider keys from
-  // .env, and getAuth's OAuth refresh must go through HTTPS_PROXY. The worker re-loads both in serveOnce.
-  if (!isWorker) {
-    loadDotEnv(placement.agentDir);
-    installProxyFetch();
-    await resolveFirstRunModel(placement.agentDir, opts);
-  }
+  // The model is picked ONCE, in the supervisor (a TTY, before any worker exists); the worker inherits
+  // the choice through FASTAGENT_MODEL and must not prompt even when the pick was cancelled.
+  const placement = await enterAgentCommand(dirArg, { ...opts, input: isWorker ? false : opts.input });
   if (isWorker || opts.watch === false) {
-    await serveOnce(dir, opts);
+    await serveOnce(placement, opts);
     return;
   }
   parsePort(opts.port, "--port", "flag"); // flag-shape checks before spawning
@@ -62,51 +43,27 @@ export async function runDev(dirArg: string, opts: DevOptions): Promise<void> {
 }
 
 /** Assemble the agent and serve it once (the dev worker; also the --no-watch path). */
-async function serveOnce(dir: string, opts: DevOptions): Promise<void> {
+async function serveOnce(placement: ResolvedPlacement, opts: DevOptions): Promise<void> {
   const portFlag = parsePort(opts.port, "--port", "flag");
   const bindFlag = parseBind(opts.bind);
-  loadDotEnv(placementOrExit(dir).agentDir);
-  installProxyFetch();
-
-  const a = await createPiAgentFromDir(dir, {
+  const tunnel = opts.tunnel ?? false;
+  const a = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
     authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
     serving: true, // long-running serve: the scheduler poller runs (wake mounts iff config.selfSchedule)
   }).catch(failStartup);
   // The same report `start` prints; `config:` is dev's own extra (see reportAssembly on the asymmetry).
   await reportAssembly(a, { beforeModel: [["config", a.configPath ?? "(none)"]] });
-  // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
-  // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
-  const configured = a.config.http?.host;
-  const host = bindFlag ?? (configured === undefined ? undefined : bindAddress(configured));
-  assertTunnelBindable(host, opts.tunnel ?? false, bindFlag ? "flag" : "config");
+  const host = resolveBindHost(bindFlag, a.config.http?.host, tunnel);
   // The SAME assembly an embedder gets from `createAgentService` — channels, control plane,
   // schedules, long connections. `dev` opens the directory itself only because its startup report
-  // prints the opened values before anything mounts.
-  const service = await mountAgentService(a, {
-    // Trace each turn's agent loop (tool calls + reply) to the log at debug level — shown in dev,
-    // gated out in start (level info), keeping end-user content out of production logs.
-    wrapAgent: logAgentLoop,
-    closeTimeoutMs: SHUTDOWN_GRACE_MS,
-    onChannelClosed: (name, error) =>
-      failStartup(new Error(`${name} ${error === undefined ? "closed unexpectedly" : `failed: ${String(error)}`}`)),
-  }).catch(failStartup);
-  const tunnel = opts.tunnel ?? false;
-  let unannounce = (): void => {};
-  serve(
-    service.handler,
+  // prints the opened values before anything mounts. The turn trace (tool calls + reply) logs at
+  // debug level: shown here, gated out in start (level info), keeping end-user content out of
+  // production logs.
+  const service = await mountAgentService(a, cliMountOptions(logAgentLoop)).catch(failStartup);
+  serveService(
+    service,
     { port: portFlag ?? a.config.http?.port ?? 8787, host },
-    {
-      ready: service.ready,
-      onListening: (p) => {
-        reportServing(service, host, p);
-        unannounce = announceControl(service, a.stateRoot, { host, tunnel }, p);
-        maybeTunnel(a.agentDir, service.channels.routes, p, tunnel, a.stateRoot);
-      },
-      onShutdown: () => {
-        unannounce();
-        return service.close();
-      },
-    },
+    { tunnel, agentDir: a.agentDir, stateRoot: a.stateRoot },
   );
 }

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -28,8 +28,9 @@ export interface DevOptions {
 export async function runDev(dirArg: string, opts: DevOptions): Promise<void> {
   setLogLevel("debug"); // dev posture: verbose, includes the debug turn trace (content) — supervisor and worker both
   const isWorker = process.env.FASTAGENT_DEV_WORKER === "1";
-  // The model is picked ONCE, in the supervisor (a TTY, before any worker exists); the worker inherits
-  // the choice through FASTAGENT_MODEL and must not prompt even when the pick was cancelled.
+  // The model is picked ONCE, in the parent process (a TTY; watch and --no-watch both); a spawned
+  // worker inherits the choice through FASTAGENT_MODEL and must not prompt even when the pick was
+  // cancelled.
   const placement = await enterAgentCommand(dirArg, { ...opts, input: isWorker ? false : opts.input });
   if (isWorker || opts.watch === false) {
     await serveOnce(placement, opts);

--- a/src/cli/commands/fire.ts
+++ b/src/cli/commands/fire.ts
@@ -4,17 +4,15 @@
  * the schedule's stable session (faithful to the served behavior). Does NOT advance the schedule's fire
  * state — a test run must never make the scheduler skip the real next run.
  */
-import { join, resolve } from "node:path";
-import { loadDotEnv } from "../../env.ts";
+import { join } from "node:path";
 import { displayPath } from "../../paths.ts";
 import { reportModuleLoadFailures } from "../../log.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { runInvokeStream } from "../invoke-stream.ts";
-import { installProxyFetch } from "../../proxy.ts";
 import { loadSchedules } from "../../schedule/discover.ts";
 import { scheduleSession } from "../../schedule/scheduler.ts";
-import { failStartup, placementOrExit } from "../fail.ts";
-import { reportAuth, resolveFirstRunModel } from "../shared.ts";
+import { failStartup } from "../fail.ts";
+import { enterAgentCommand, reportAuth } from "../shared.ts";
 
 export interface FireOptions {
   model?: string;
@@ -24,11 +22,7 @@ export interface FireOptions {
 }
 
 export async function runFire(name: string, dirArg: string, opts: FireOptions): Promise<void> {
-  const fireDir = resolve(dirArg);
-  const placement = placementOrExit(fireDir);
-  loadDotEnv(placement.agentDir);
-  installProxyFetch();
-  await resolveFirstRunModel(placement.agentDir, opts);
+  const placement = await enterAgentCommand(dirArg, opts);
   // Schedules are agent surface — discover them where dev/start/`schedule list` do (the agent
   // dir), so `fire` sees the same set the scheduler serves.
   const { schedules, failures } = await loadSchedules(placement.agentDir).catch(failStartup);
@@ -44,7 +38,7 @@ export async function runFire(name: string, dirArg: string, opts: FireOptions): 
       ),
     );
   }
-  const { agent, modelSpec, authPath } = await createPiAgentFromDir(fireDir, {
+  const { agent, modelSpec, authPath } = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
     authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
   }).catch(failStartup);

--- a/src/cli/commands/invoke.ts
+++ b/src/cli/commands/invoke.ts
@@ -1,13 +1,9 @@
 /** `fastagent invoke <message> [dir]`: run ONE turn against the assembled agent, then exit. */
 import { randomUUID } from "node:crypto";
-import { resolve } from "node:path";
-import { loadDotEnv } from "../../env.ts";
-
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { runInvokeStream } from "../invoke-stream.ts";
-import { installProxyFetch } from "../../proxy.ts";
-import { failStartup, placementOrExit } from "../fail.ts";
-import { reportAuth, resolveFirstRunModel } from "../shared.ts";
+import { failStartup } from "../fail.ts";
+import { enterAgentCommand, reportAuth } from "../shared.ts";
 
 export interface InvokeOptions {
   model?: string;
@@ -17,12 +13,8 @@ export interface InvokeOptions {
 }
 
 export async function runInvoke(message: string, dirArg: string, opts: InvokeOptions): Promise<void> {
-  const invokeDir = resolve(dirArg);
-  const placement = placementOrExit(invokeDir);
-  loadDotEnv(placement.agentDir);
-  installProxyFetch();
-  await resolveFirstRunModel(placement.agentDir, opts);
-  const { agent, modelSpec, authPath } = await createPiAgentFromDir(invokeDir, {
+  const placement = await enterAgentCommand(dirArg, opts);
+  const { agent, modelSpec, authPath } = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
     authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
   }).catch(failStartup);

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -2,32 +2,21 @@
  * `fastagent start [dir]`: run the agent in production posture — the SAME assembly as dev (your
  * directory is the agent), just no file-watching. No build step: start reads the definition directly.
  */
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 import { writeFileAtomic } from "../../atomic-write.ts";
 import { authSeedBytes, collectAuthSeed } from "../../deploy/secrets.ts";
-import { loadDotEnv } from "../../env.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
 import { SECRET_FILE_MODE, ensureSecretsDir, resolveSecretsDir, isUnderDir, exists } from "../../paths.ts";
 import { log, setLogLevel } from "../../log.ts";
 import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { mountAgentService } from "../../service.ts";
 import { logAgentLoop } from "../../observe.ts";
-import { installProxyFetch } from "../../proxy.ts";
-import { bindAddress } from "../../bind.ts";
-
 import { isAgentcoreRuntime, mountAgentcoreService } from "../../channels/agentcore-service.ts";
 import { createWakeAlarmSink } from "../../schedule/wake-alarm.ts";
 import { setWakeupsSink } from "../../schedule/wakeups.ts";
-import { failStartup, placementOrExit } from "../fail.ts";
-import {
-  SHUTDOWN_GRACE_MS,
-  announceControl,
-  assertTunnelBindable,
-  maybeTunnel,
-  reportServing,
-  serve,
-} from "../serve.ts";
-import { parseBind, parsePort, reportAssembly, resolveFirstRunModel } from "../shared.ts";
+import { failStartup } from "../fail.ts";
+import { cliMountOptions, resolveBindHost, serveService } from "../serve.ts";
+import { enterAgentCommand, parseBind, parsePort, reportAssembly } from "../shared.ts";
 
 export interface StartOptions {
   port?: string;
@@ -41,16 +30,13 @@ export interface StartOptions {
 }
 
 export async function runStart(dirArg: string, opts: StartOptions): Promise<void> {
-  const dir = resolve(dirArg);
   // Flag validation first: a bad --port is a USAGE error (exit 2), and reporting it must not depend on
   // the directory being an agent (which is a runtime/environment failure, exit 1).
   const portFlag = parsePort(opts.port, "--port", "flag");
   const bindFlag = parseBind(opts.bind);
-  const placement = placementOrExit(dir);
+  const tunnel = opts.tunnel ?? false;
   setLogLevel("info"); // production posture: info+, the debug turn trace (and its end-user content) gated out
-  loadDotEnv(placement.agentDir);
-  installProxyFetch();
-  await resolveFirstRunModel(placement.agentDir, opts);
+  const placement = await enterAgentCommand(dirArg, opts);
 
   // A `deploy --run` may carry the operator's local credential as FASTAGENT_AUTH_SEED —
   // materialize it into the writable secrets dir BEFORE the opener resolves auth (once, absent-only).
@@ -58,8 +44,12 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   await maybeSeedAuth(resolveAuthPath(placement.agentDir, opts.authPath));
 
   // The same opener dev uses (single assembly source), just no watch.
-  const sessionsDirOverride = resolveSessionsDirOverride(opts.sessionsDir);
-  const opened = await openStartDir(dir, opts, sessionsDirOverride);
+  const opened = await createPiAgentFromDir(placement.workspace, {
+    model: opts.model,
+    sessionsDir: resolveSessionsDirOverride(opts.sessionsDir),
+    authPath: opts.authPath,
+    serving: true, // long-running serve: the scheduler poller runs (wake mounts iff config.selfSchedule)
+  }).catch(failStartup);
   const { agent, agentDir, config, stateRoot, sessionsDir } = opened;
 
   // The same report `dev` prints; `state:`/`sessions:` are start's own extras, and the persistence
@@ -93,14 +83,9 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
     );
   }
 
-  // Same debug turn trace as dev; gated out here by the info level (see dev.ts serveOnce).
+  // Same debug turn trace as dev; gated out here by the info level.
   const traced = logAgentLoop(agent);
-  // `http.host` enters here the way the flag enters `parseBind` — through `bindAddress`, so a
-  // configured `localhost` is an ADDRESS by the time anything binds, renders or dials it.
-  const configured = config.http?.host;
-  const host = bindFlag ?? (configured === undefined ? undefined : bindAddress(configured));
-  const tunnel = opts.tunnel ?? false;
-  assertTunnelBindable(host, tunnel, bindFlag ? "flag" : "config");
+  const host = resolveBindHost(bindFlag, config.http?.host, tunnel);
   // ONE branch for the whole posture. AgentCore assembles differently — lazy channels over a
   // pre-restore state mount, an external clock, no resident connections — but it yields the same
   // AgentService, so everything below this point is common.
@@ -110,44 +95,20 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   const onStateReady = isAgentcoreRuntime() && config.selfSchedule ? armWakeAlarms(stateRoot) : undefined;
   const service = await (isAgentcoreRuntime()
     ? mountAgentcoreService(opened, { wrapAgent: () => traced, onStateReady })
-    : mountAgentService(opened, {
-        wrapAgent: () => traced,
-        closeTimeoutMs: SHUTDOWN_GRACE_MS,
-        onChannelClosed: (name, error) =>
-          failStartup(new Error(`${name} ${error === undefined ? "closed unexpectedly" : `failed: ${String(error)}`}`)),
-      })
+    : mountAgentService(
+        opened,
+        cliMountOptions(() => traced),
+      )
   ).catch(failStartup);
-  let unannounce = (): void => {};
-  serve(
-    service.handler,
+  serveService(
+    service,
     { port: portFlag ?? parsePort(process.env.PORT, "PORT env", "env") ?? config.http?.port ?? 8787, host },
-    {
-      ready: service.ready,
-      onListening: (p) => {
-        reportServing(service, host, p);
-        unannounce = announceControl(service, stateRoot, { host, tunnel }, p);
-        maybeTunnel(agentDir, service.channels.routes, p, tunnel, stateRoot);
-      },
-      onShutdown: () => {
-        unannounce();
-        return service.close();
-      },
-    },
+    { tunnel, agentDir, stateRoot },
   );
   // No graceful drain: webhook turns run fire-and-forget; SIGTERM just exits mid-turn. Whether an
   // in-flight turn is LOST depends on the channel: the Telegram channel persists turn intent pre-ACK
   // and replays it next start (turn-store.ts, L1 durable execution, at-least-once); HTTP and other
   // channels have no such layer, so their in-flight turns are still lost (the asker re-invokes).
-}
-
-/** The opener, kept as its own call so `opened` can also feed the shared assembly below. */
-function openStartDir(dir: string, opts: StartOptions, sessionsDir: string | undefined) {
-  return createPiAgentFromDir(dir, {
-    model: opts.model,
-    sessionsDir,
-    authPath: opts.authPath,
-    serving: true, // long-running serve: the scheduler poller runs (wake mounts iff config.selfSchedule)
-  }).catch(failStartup);
 }
 
 /**

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -8,10 +8,11 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { INVOKE_EXAMPLE_BODY } from "../channels/http.ts";
-import { answersLocalhost, bindLabel, classifyBind, clientHost } from "../bind.ts";
+import { answersLocalhost, bindAddress, bindLabel, classifyBind, clientHost } from "../bind.ts";
 import { writeFileAtomic } from "../atomic-write.ts";
+import type { Agent } from "../agent.ts";
 import type { ChannelHandler } from "../channel.ts";
-import type { AgentService } from "../service.ts";
+import type { AgentService, MountAgentServiceOptions } from "../service.ts";
 import { serveNode } from "../channels/serve.ts";
 import { log } from "../log.ts";
 import { openExternalUrl } from "../open-url.ts";
@@ -39,6 +40,57 @@ export function assertTunnelBindable(host: string | undefined, tunnel: boolean, 
   const message = `--tunnel reaches the serve by dialing localhost, which the bind address ${host} does not answer — ${fix}`;
   if (source === "flag") failUsage(message);
   failStartup(new Error(message));
+}
+
+/**
+ * The bind address a serve uses: the flag, else `http.host` from the config — through `bindAddress`,
+ * so a configured `localhost` is an ADDRESS by the time anything binds, renders or dials it — checked
+ * against `--tunnel` with the exit code the SOURCE of the value earns (serve.ts assertTunnelBindable).
+ */
+export function resolveBindHost(
+  bindFlag: string | undefined,
+  configured: string | undefined,
+  tunnel: boolean,
+): string | undefined {
+  const host = bindFlag ?? (configured === undefined ? undefined : bindAddress(configured));
+  assertTunnelBindable(host, tunnel, bindFlag ? "flag" : "config");
+  return host;
+}
+
+/** What the CLI adds to the assembly: its shutdown grace, and exit on a connection that drops. */
+export function cliMountOptions(wrapAgent: (agent: Agent) => Agent): MountAgentServiceOptions {
+  return {
+    wrapAgent,
+    closeTimeoutMs: SHUTDOWN_GRACE_MS,
+    onChannelClosed: (name, error) =>
+      failStartup(new Error(`${name} ${error === undefined ? "closed unexpectedly" : `failed: ${String(error)}`}`)),
+  };
+}
+
+/**
+ * Bind, report, announce the control plane, open the tunnel, and close in order on a signal — the
+ * tail dev's worker and start share once the service is assembled.
+ */
+export function serveService(
+  service: AgentService,
+  bind: { port: number; host?: string },
+  posture: { tunnel: boolean; agentDir: string; stateRoot: string },
+): void {
+  const { host } = bind;
+  const { tunnel, agentDir, stateRoot } = posture;
+  let unannounce = (): void => {};
+  serve(service.handler, bind, {
+    ready: service.ready,
+    onListening: (p) => {
+      reportServing(service, host, p);
+      unannounce = announceControl(service, stateRoot, { host, tunnel }, p);
+      maybeTunnel(agentDir, service.channels.routes, p, tunnel, stateRoot);
+    },
+    onShutdown: () => {
+      unannounce();
+      return service.close();
+    },
+  });
 }
 
 /**
@@ -128,7 +180,7 @@ export function announceControl(
 
 /** What the CLI gives a service to stop in, and the hard exit that follows it. The order matters:
  *  a forced exit before the service answers would report a clean shutdown over a stuck channel. */
-export const SHUTDOWN_GRACE_MS = 800;
+const SHUTDOWN_GRACE_MS = 800;
 const FORCED_EXIT_MS = 1_500;
 
 /**
@@ -137,7 +189,7 @@ const FORCED_EXIT_MS = 1_500;
  * awaits `hooks.ready` (mountAgentService owns the connections themselves) before announcing
  * anything. Signals are the sole clean-shutdown command; `host` unset binds all interfaces.
  */
-export function serve(
+function serve(
   handler: ChannelHandler,
   bind: { port: number; host?: string },
   hooks: {
@@ -214,7 +266,7 @@ export function serve(
 }
 
 /** Start a Cloudflare tunnel for route channels only. */
-export function maybeTunnel(
+function maybeTunnel(
   agentDir: string,
   routeChannels: string[],
   boundPort: number,

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -84,7 +84,7 @@ export function serveService(
     ready: service.ready,
     onListening: (p) => {
       reportServing(service, host, p);
-      unannounce = announceControl(service, stateRoot, { host, tunnel }, p);
+      unannounce = announceControl(service.control, stateRoot, { host, tunnel }, p);
       maybeTunnel(agentDir, service.channels.routes, p, tunnel, stateRoot);
     },
     onShutdown: () => {
@@ -141,17 +141,17 @@ export function readyAddressLines(host: string | undefined, boundPort: number, b
  * operator finds and protects the plane. An embedder distributes `service.control` itself.
  */
 export function announceControl(
-  service: AgentService,
+  control: { token: string; prefix: string } | undefined,
   stateRoot: string,
   bind: { host?: string; tunnel: boolean },
   boundPort: number,
 ): () => void {
-  if (!service.control) return () => {};
+  if (!control) return () => {};
   mkdirSync(stateRoot, { recursive: true, mode: 0o700 });
   const path = join(stateRoot, "control.json");
   const url = `http://${clientHost(bind.host)}:${boundPort}`;
-  writeFileAtomic(path, `${JSON.stringify({ url, token: service.control.token })}\n`, 0o600);
-  log.info(`[fastagent] session control on ${service.control.prefix}/* (token in ${path})`);
+  writeFileAtomic(path, `${JSON.stringify({ url, token: control.token })}\n`, 0o600);
+  log.info(`[fastagent] session control on ${control.prefix}/* (token in ${path})`);
   // LAN-reachable with the bearer token as the only protection — the tunnel and deploy paths warn
   // loudly, and the LAN path must not be the silent third way past the local trust story. A
   // loopback bind closes exactly that reach, so it earns silence.

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,9 +1,10 @@
 /**
  * What `dev` (its worker) and `start` need beyond the service itself: binding a port, the shutdown
- * order, the startup report, and the optional Cloudflare quick tunnel.
+ * order, the startup report, the optional Cloudflare quick tunnel, and the options the CLI hands the
+ * assembly (`cliMountOptions`, `resolveBindHost` — policy ABOUT the assembly, decided per command).
  *
- * The ASSEMBLY is not here — it lives in `src/service.ts`, which a public entry may import and this
- * directory may not be (it decides process-level things: `fail.ts` calls `process.exit`).
+ * The ASSEMBLY itself is not here — it lives in `src/service.ts`, which a public entry may import and
+ * this directory may not be (it decides process-level things: `fail.ts` calls `process.exit`).
  */
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -4,7 +4,7 @@
  * module-scoped flag access (`values.*`) became parameters.
  */
 import { readFile, writeFile } from "node:fs/promises";
-import { relative } from "node:path";
+import { relative, resolve } from "node:path";
 import { autocomplete, isCancel, log as clackLog, password, select, text as clackText } from "@clack/prompts";
 import type { Models } from "@earendil-works/pi-ai";
 import { buildModelPickerOptions } from "./models-view.ts";
@@ -33,11 +33,30 @@ import type { LoadedDefinition } from "../engines/pi/definition.ts";
 import type { ModuleLoadFailure } from "../loader.ts";
 import type { ToolCollision } from "../engines/pi/tool.ts";
 import { reportFindingsIfChanged, reportToolCollisions } from "../engines/pi/report.ts";
-import { workspaceHint } from "../paths.ts";
+import { type ResolvedPlacement, workspaceHint } from "../paths.ts";
 import { log, reportModuleLoadFailures } from "../log.ts";
+import { loadDotEnv } from "../env.ts";
 import { openExternalUrl } from "../open-url.ts";
+import { installProxyFetch } from "../proxy.ts";
 import { bindAddress, isBindAddress } from "../bind.ts";
-import { failStartup, failUsage } from "./fail.ts";
+import { failStartup, failUsage, placementOrExit } from "./fail.ts";
+
+/**
+ * How every command that runs the model enters its agent directory, in the one order that works:
+ * placement decides whose `.env` to read; `.env` may carry the proxy and the provider keys the
+ * picker's auth probe needs; the picker runs last. Six commands wrote these steps out by hand, and
+ * one carried the order as a comment. The result is the placement every later step reads.
+ */
+export async function enterAgentCommand(
+  dirArg: string,
+  opts: { model?: string; authPath?: string; input?: boolean },
+): Promise<ResolvedPlacement> {
+  const placement = placementOrExit(resolve(dirArg));
+  loadDotEnv(placement.agentDir);
+  installProxyFetch();
+  await resolveFirstRunModel(placement.agentDir, opts);
+  return placement;
+}
 
 /**
  * The padded label writer for the STARTUP report (`dev`/`start`, stderr via the log level). Hand-spaced
@@ -188,7 +207,7 @@ export async function reportAuth(agentDir: string, modelSpec: string, authPath: 
  * and best-effort written back to the config so the next run is quiet. `agentDir` is the resolved
  * AGENT DIR (resolvePlacement().agentDir) — config and auth both live there.
  */
-export async function resolveFirstRunModel(
+async function resolveFirstRunModel(
   agentDir: string,
   options: { model?: string; authPath?: string; input?: boolean } = {},
 ): Promise<void> {

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -7,7 +7,7 @@ import { announceControl, reportServing } from "../src/cli/serve.ts";
 import { mountAgentcore } from "../src/channels/agentcore-service.ts";
 import { agentcoreRoutes } from "../src/channels/agentcore.ts";
 import { beginWork } from "../src/channels/busy.ts";
-import { type AgentService, mountSessionControl, routesFor } from "../src/service.ts";
+import { mountSessionControl, routesFor } from "../src/service.ts";
 import { log } from "../src/log.ts";
 import { router } from "../src/channels/serve.ts";
 import { text } from "../src/channels/respond.ts";
@@ -200,8 +200,12 @@ describe("cli: the assembled serving surface", () => {
   it("announceControl writes the 0600 discovery file under a fresh state root and removes it on cleanup", async () => {
     const root = await mkdtemp(join(tmpdir(), "fa-cli-announce-"));
     const stateRoot = join(root, "nested", ".fastagent"); // deliberately not pre-created
-    const service = { control: { token: "tok-1", prefix: "/control" } } as AgentService;
-    const cleanup = announceControl(service, stateRoot, { host: "127.0.0.1", tunnel: false }, 12345);
+    const cleanup = announceControl(
+      { token: "tok-1", prefix: "/control" },
+      stateRoot,
+      { host: "127.0.0.1", tunnel: false },
+      12345,
+    );
     const path = join(stateRoot, "control.json");
     expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ url: "http://127.0.0.1:12345", token: "tok-1" });
     // The file IS the credential: anything readable by other users on the box is a handover of the
@@ -210,16 +214,16 @@ describe("cli: the assembled serving surface", () => {
     cleanup();
     await expect(readFile(path, "utf8")).rejects.toThrow(/ENOENT/);
     // No plane: nothing written, nothing to remove.
-    announceControl({} as AgentService, stateRoot, { tunnel: false }, 1)();
+    announceControl(undefined, stateRoot, { tunnel: false }, 1)();
     await expect(readFile(path, "utf8")).rejects.toThrow(/ENOENT/);
   });
 
   it("a bind address lands in the discovery url and a loopback bind drops the LAN warning", async () => {
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
     const root = await mkdtemp(join(tmpdir(), "fa-cli-bind-"));
-    const service = { control: { token: "t", prefix: "/control" } } as AgentService;
+    const control = { token: "t", prefix: "/control" };
     const url = async (host: string | undefined, stateRoot: string) => {
-      announceControl(service, stateRoot, { host, tunnel: false }, 9000);
+      announceControl(control, stateRoot, { host, tunnel: false }, 9000);
       return (JSON.parse(await readFile(join(stateRoot, "control.json"), "utf8")) as { url: string }).url;
     };
     try {
@@ -233,7 +237,7 @@ describe("cli: the assembled serving surface", () => {
       expect(await url(undefined, join(root, "c"))).toBe("http://127.0.0.1:9000"); // wildcard accepts loopback
       expect(warn.mock.calls.flat().join(" ")).toContain("binds all interfaces");
       expect(warn).toHaveBeenCalledTimes(2);
-      announceControl(service, join(root, "d"), { host: "127.0.0.1", tunnel: true }, 9000);
+      announceControl(control, join(root, "d"), { host: "127.0.0.1", tunnel: true }, 9000);
       expect(warn.mock.calls.flat().join(" ")).toContain("--tunnel exposes /control/*");
     } finally {
       warn.mockRestore();

--- a/test/cli-shared.test.ts
+++ b/test/cli-shared.test.ts
@@ -7,6 +7,10 @@ import { setLogLevel } from "../src/log.ts";
 import { LoginCancelled, type LoginMethod } from "../src/engines/pi/login.ts";
 import * as models from "../src/engines/pi/models.ts";
 
+// enterAgentCommand installs the proxy fetch, and undici.install() swaps this process's fetch/Response/
+// Headers/FormData/WebSocket with no way back. Keep the side effect out of the test process.
+vi.mock("../src/proxy.ts", () => ({ installProxyFetch: vi.fn() }));
+
 /** Record every flow call's (provider, method) and pop canned results/verdicts in order. */
 function fakes(
   results: Array<{ provider: string; method: LoginMethod }>,
@@ -144,6 +148,7 @@ describe("enterAgentCommand: --no-input never reaches the picker", () => {
     for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
     process.stdin.isTTY = undefined as unknown as boolean;
     process.stdout.isTTY = undefined as unknown as boolean;
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -159,6 +164,9 @@ describe("enterAgentCommand: --no-input never reaches the picker", () => {
   // The guard is resolveFirstRunModel returning BEFORE isInteractive(), so a worker that inherits a
   // terminal still stays silent — which is exactly the case a TTY-less test would pass either way.
   it("returns without building a model runtime, even when stdin and stdout are terminals", async () => {
+    // A model from the environment satisfies resolveFirstRunModel before it reads `input`, so leaving
+    // FASTAGENT_MODEL set would pass this test without ever running the guard.
+    vi.stubEnv("FASTAGENT_MODEL", undefined);
     const runtime = vi.spyOn(models, "createPiModelRuntime");
     process.stdin.isTTY = true;
     process.stdout.isTTY = true;

--- a/test/cli-shared.test.ts
+++ b/test/cli-shared.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
-import { loginWithKeyCheck, reportAssembly } from "../src/cli/shared.ts";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { enterAgentCommand, loginWithKeyCheck, reportAssembly } from "../src/cli/shared.ts";
 import { setLogLevel } from "../src/log.ts";
 import { LoginCancelled, type LoginMethod } from "../src/engines/pi/login.ts";
+import * as models from "../src/engines/pi/models.ts";
 
 /** Record every flow call's (provider, method) and pop canned results/verdicts in order. */
 function fakes(
@@ -131,5 +135,38 @@ describe("reportAssembly (the startup report dev and start share)", () => {
     expect(start.indexOf("state")).toBeGreaterThan(start.indexOf("codingTools"));
     expect(start.slice(-2)).toEqual(["state", "sessions"]);
     expect(start).not.toContain("config"); // start's report has never named it
+  });
+});
+
+describe("enterAgentCommand: --no-input never reaches the picker", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    process.stdin.isTTY = undefined as unknown as boolean;
+    process.stdout.isTTY = undefined as unknown as boolean;
+    vi.restoreAllMocks();
+  });
+
+  /** An agent with NO model set, so the picker is the only thing that could answer. */
+  const modellessAgent = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "fastagent-prelude-"));
+    dirs.push(dir);
+    writeFileSync(join(dir, "fastagent.config.mjs"), "export default {};\n");
+    return dir;
+  };
+
+  // `dev`'s worker passes input:false so the supervisor's pick is not re-asked in a child process.
+  // The guard is resolveFirstRunModel returning BEFORE isInteractive(), so a worker that inherits a
+  // terminal still stays silent — which is exactly the case a TTY-less test would pass either way.
+  it("returns without building a model runtime, even when stdin and stdout are terminals", async () => {
+    const runtime = vi.spyOn(models, "createPiModelRuntime");
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+
+    const dir = modellessAgent();
+    const placement = await enterAgentCommand(dir, { input: false });
+
+    expect(placement.agentDir).toBe(dir);
+    expect(runtime).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

`dev`, `start`, `invoke`, `fire`, `chat` and `deploy` each spelled the same four steps — placement, `.env`, proxy, first-run model pick — and `dev` carried the order as a comment ("Load .env and the proxy FIRST (as invoke/start do)"). `enterAgentCommand` (cli/shared.ts) is those steps in the one order that works.

`dev`'s worker and `start` also shared ~70% of the tail after the assembly: host resolution + `--tunnel` check, the mount options, bind, report, control-plane announce, tunnel, shutdown order. `resolveBindHost` / `cliMountOptions` / `serveService` (cli/serve.ts) are that tail. `start` keeps what is its own: `PORT`, the auth seed, the AgentCore branch, the two persistence notes. `announceControl` takes the control plane rather than the whole `AgentService`, which is all it ever read.

`dev` runs the prelude once per process: the supervisor's picker prompts before a worker exists, and the worker passes `input: false` so a cancelled pick cannot prompt a second time from the child. Previously `--no-watch` ran `.env` + proxy twice in one process.

That worker guard is the one new branch, and `dev`'s two-process path has no e2e — so it gets a unit check: with both streams set to TTY, `enterAgentCommand(dir, { input: false })` must build no model runtime. The test clears `FASTAGENT_MODEL` first, because `resolveFirstRunModel` returns on an environment model before it ever reads `input` — without that, the check passes on a developer's shell whether or not the guard exists.

## Docs

The upgrade notes described migration code this repo no longer carries, and one claim was wrong in a way an operator would act on:

- Feishu/Lark's retired `<chat>:root:<id>` buffer buckets and `owned-threads.json` are no longer dropped at load. They stay on disk holding chat content, unreachable, until someone removes them with the process stopped — the notes said the state cleaned itself up and logged a dropped count.
- A removed session-mode option is ignored in silence, not refused at startup. A workspace's `channels/slack.ts` is loaded as ESM by `src/loader.ts`, so nothing type-checks it either — the earlier wording implied TypeScript would catch it.
- The `owned-threads.json` narration by release (0.15 → 0.18) is gone: nothing deletes it on any version now.

## Why

A convention with six enforcers (AGENTS.md); `start.ts` was the most-changed file of the last 80 commits and half of those changes were the same edit made twice. #411 ("dev and start print one report, not two copies") was the last symptom.

## Observable change

One, and it is an exit code. `deploy`'s `--tunnel`/host gate now runs before placement resolves, so `fastagent deploy fly ./not-an-agent --tunnel` exits 2 ("--tunnel is supported only by the local Docker target") where it used to exit 1 ("not a fastagent agent"). This follows `fail.ts` — exit codes follow responsibility, not the layer that happens to discover the problem first, and an unsupported flag/host pair is a usage error whatever the directory holds.
