### PR TITLE
refactor(engines/pi): the assembly is a value, and one bind for both session shapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,10 @@ src/
 │   ├── discover.ts          # channels/ filesystem discovery (ChannelModule → Routes) — engine-neutral,
 │   │                     # so it lives here and not under engines/ (#365)
 │   ├── body.ts, respond.ts  # channel-authoring kit (body cap, responses)
+│   ├── secret.ts            # the ONE constant-time comparison every shared-secret gate reads through
+│   │                     # (control bearer token, telegram secret token, slack signature, feishu
+│   │                     # verification token/signature, agentcore envelope secret). An EMPTY expected
+│   │                     # value never matches: an unconfigured gate must not be passable by sending none
 │   ├── wait-health.ts       # readiness probe for a server THIS process reaches directly (deploy's
 │   │                     # published local port). NOT for a public URL a platform must reach: the
 │   │                     # registrars let the platform's own URL verification be the probe (#421)
@@ -211,6 +215,9 @@ src/
 │   │                     # the container reads them back with. The read side lived in fly/run.ts, which
 │   │                     # `start` had to reach into to deploy nothing on Fly.
 │   ├── runner.ts            # the shared host-CLI dispatcher seam (CliRunner + spawnRunner; faked in tests)
+│   ├── hosts.ts             # the deploy targets as a value (DEPLOY_HOSTS): the CLI's `<host>` choices and
+│   │                     # HOST_ONLY_FLAGS's exhaustiveness both read it. Dependency-free, so
+│   │                     # `cli/program.ts` imports it at load time without pulling a command module
 │   ├── docker/    { plan.ts, run.ts }  # Local Docker: Compose topology (agent + optional Quick Tunnel) + `--run` compose driver
 │   ├── fly/       { plan.ts, run.ts }  # Fly: PLAN (artifacts + runbook, pure) + `--run` driver (drives flyctl behind the runner seam)
 │   ├── railway/   { plan.ts, run.ts }  # Railway: same two roles — NOT a copy of Fly (thin config, minted URL, no scriptable scale-to-zero)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,10 @@ src/
     ├── service.ts           # createAgentService: the public one-call shortcut = this engine's opener +
     │                         # the neutral mountAgentService. Here, not in src/service.ts, because
     │                         # opening a DIRECTORY is the only pi-specific part of it
-    ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt
+    ├── create.ts            # reusable assembly ladder L1–L2 + engine assets/prompt. Every rung builds a
+    │                         # PiAssembly VALUE (lease, store, session factory, engine thunk) and puts the
+    │                         # L0 over it; the opener takes the value itself, since the control plane
+    │                         # must contend on the same lease and validate against the same registry
     ├── turn-kit.ts          # the turn mechanism's pi-CLASS-neutral half: lease (single-writer
     │                         # floor), terminals (settled message/thrown error → SPEC terminal +
     │                         # retryable), EventQueue (push→pull), prompt image prep, the SPEC
@@ -243,7 +246,9 @@ src/
     │                         # controls, and exactly one settlement
     ├── agent-session-factory.ts # the engine binding: the assembly (model/prompt/skills/tools) bound
     │                         # to one record per invoke. services shared, session per turn. Carries
-    │                         # the adaptations pi's TUI origins require — see its header
+    │                         # the adaptations pi's TUI origins require — see its header. bindPiSession
+    │                         # is the ONE binding of tools + turn context + deferral to a pi session;
+    │                         # chat's session-builder binds through it too (recordActivations: false)
     ├── session-store.ts     # session records on pi's SessionManager: Caller ids encoded into names
     │                         # pi accepts, a record published on create (pi buffers until the first
     │                         # assistant message), crash reconciliation for interrupted tool calls

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -401,9 +401,6 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       model,
       thinkingLevel: thinkingLevel ?? DEFAULT_THINKING_LEVEL,
     });
-    // An extension handler that throws is otherwise dropped: pi fans errors out to registered
-    // listeners and has none by default, which on a server means a broken extension looks like an
-    // extension that simply did nothing.
     const { session } = await bindPiSession({
       services: await services,
       sessionManager,

--- a/src/engines/pi/agent-session-factory.ts
+++ b/src/engines/pi/agent-session-factory.ts
@@ -157,6 +157,100 @@ function toolDefinitions(tools: MountedTool[], env: ExecutionEnv, bound: { conte
   })) as unknown as ToolDefinition[];
 }
 
+export interface BindPiSessionOptions {
+  services: AgentSessionServices;
+  sessionManager: SessionManager;
+  /** Chat only: pi's runtime hands the resumed/new session its start event. */
+  sessionStartEvent?: Parameters<typeof createAgentSessionFromServices>[0]["sessionStartEvent"];
+  model: AnyModel;
+  thinkingLevel: ThinkingLevel | undefined;
+  tools: MountedTool[];
+  env: ExecutionEnv;
+  /** The agent's working directory — what fastagent-defined tools see as `cwd`. */
+  cwd: string;
+  /** Built-ins omitted by an explicit lower-level tool list. */
+  excludedToolNames?: readonly string[];
+  /** The CALLER's session id — what a tool asking which conversation it is in hears. Defaults to
+   *  pi's own id, which is right where the caller has none (chat). */
+  sessionId?: string;
+  /** Record each discovered activation on the session, so the next bind restores it. Off for chat:
+   *  pi's own session has nowhere to put one, so a resumed chat re-discovers. */
+  recordActivations: boolean;
+}
+
+/**
+ * Bind ONE pi session to a record: the definition's tools as pi definitions over one turn context,
+ * pi's own tool copies kept off, and deferral applied. The per-invoke factory and the resident chat
+ * runtime both bind here — they differ in what they hand in (a shared vs a per-session `services`,
+ * record-resolved vs configured settings) and in whether a discovered activation has a record to
+ * land in, and in nothing else. Two copies of this drifted once (the tool adapter and the deferral
+ * narrowing each existed twice, identical but for those parameters).
+ */
+export async function bindPiSession(
+  options: BindPiSessionOptions,
+): Promise<Awaited<ReturnType<typeof createAgentSessionFromServices>> & { context: TurnContext }> {
+  const { services, sessionManager, model, thinkingLevel, tools, env, cwd, recordActivations } = options;
+  const excludedToolNames = options.excludedToolNames ?? [];
+  const deferred = tools.filter(isDeferredTool).map((t) => t.name);
+  const bound: { context?: TurnContext } = {};
+  const result = await createAgentSessionFromServices({
+    services,
+    sessionManager,
+    ...(options.sessionStartEvent ? { sessionStartEvent: options.sessionStartEvent } : {}),
+    model,
+    thinkingLevel,
+    // pi would otherwise mount its built-ins on top of fastagent's copies, offering duplicate names.
+    // Lower-level callers with an explicit list also rely on omitted built-ins staying omitted. And
+    // NO `tools` allowlist: it would freeze the set at bind time, while pi lets an extension register
+    // from `session_start` — `noTools: "builtin"` gives the guarantee the allowlist was there for.
+    noTools: "builtin",
+    ...(excludedToolNames.length > 0 ? { excludeTools: [...excludedToolNames] } : {}),
+    customTools: toolDefinitions(tools, env, bound),
+  });
+  const { session } = result;
+  const sessionId = options.sessionId ?? session.sessionManager.getSessionId();
+  // One context for the whole session: it describes the SESSION, not the call. The activation
+  // bridge above all — a tool call has to see what the previous one activated.
+  const context: TurnContext = {
+    cwd,
+    sessionManager: agentSessionManager(session, sessionId),
+    // A served session HAS somewhere to record the discovery, so it does: the delta is what makes
+    // the tool still callable next turn (see {@link TOOL_ACTIVATION_ENTRY}).
+    tools: sessionToolActivation(
+      session,
+      recordActivations
+        ? (added) => session.sessionManager.appendCustomEntry(TOOL_ACTIVATION_ENTRY, { names: added })
+        : undefined,
+    ),
+  };
+  bound.context = context;
+  // Deferral, then restoration: pi starts every mounted tool active, so narrow by SUBTRACTING the
+  // deferred names (robust to pi mounting tools of its own, unlike an exact-set replacement), then
+  // add back what THIS session has already discovered.
+  if (deferred.length > 0) {
+    const active = session.getActiveToolNames();
+    const mounted = new Set(session.getAllTools().map((tool) => tool.name));
+    const recorded = recordActivations ? recordedActivations(session) : [];
+    // A recorded name that is no longer mounted is dropped rather than replayed: pi's setter
+    // THROWS on an unknown name, so replaying one would brick every future turn of this session.
+    const restored = recorded.filter((name) => mounted.has(name));
+    const dropped = recorded.filter((name) => !mounted.has(name));
+    if (dropped.length > 0) {
+      const key = `${sessionId}\u0000${[...new Set(dropped)].sort().join(",")}`;
+      const emit = warnedDroppedActivations.has(key) ? log.debug : log.warn;
+      warnedDroppedActivations.add(key);
+      emit(
+        `[fastagent] session ${sessionId}: dropping recorded activation(s) no longer mounted: ${[...new Set(dropped)].join(", ")}`,
+      );
+    }
+    const next = [...new Set([...active.filter((name) => !deferred.includes(name)), ...restored])];
+    if (next.length !== active.length || next.some((name) => !active.includes(name))) {
+      session.setActiveToolsByName(next);
+    }
+  }
+  return { ...result, context };
+}
+
 /**
  * Announce extensions pi failed to load. pi collects them into `LoadExtensionsResult.errors` and
  * carries on with the rest — sound for a TUI that shows them, silent for a server that never looks.
@@ -230,7 +324,6 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
     );
   }
   const tools = options.tools ?? [];
-  const deferred = tools.filter(isDeferredTool).map((t) => t.name);
   // What the shared ResourceLoader serves, refreshed per turn before the session is built.
   let prompt = typeof options.systemPrompt === "function" ? options.systemPrompt() : options.systemPrompt;
   let skills = options.skills ?? [];
@@ -308,57 +401,21 @@ export function piAgentSessionFactory(options: PiAgentSessionFactoryOptions): Pi
       model,
       thinkingLevel: thinkingLevel ?? DEFAULT_THINKING_LEVEL,
     });
-    const bound: { context?: TurnContext } = {};
-    const { session } = await createAgentSessionFromServices({
+    // An extension handler that throws is otherwise dropped: pi fans errors out to registered
+    // listeners and has none by default, which on a server means a broken extension looks like an
+    // extension that simply did nothing.
+    const { session } = await bindPiSession({
       services: await services,
       sessionManager,
       model: settings.model,
       thinkingLevel: settings.thinkingLevel,
-      // pi would otherwise mount its built-ins on top of fastagent's copies, offering duplicate names.
-      // Lower-level callers with an explicit list also rely on omitted built-ins staying omitted.
-      noTools: "builtin",
-      ...(excludedToolNames.length > 0 ? { excludeTools: [...excludedToolNames] } : {}),
-      customTools: toolDefinitions(tools, env, bound),
-    });
-    // One context for the whole session: it describes the SESSION, not the call. The activation
-    // bridge above all — a tool call has to see what the previous one activated.
-    bound.context = {
+      tools,
+      env,
       cwd,
-      sessionManager: agentSessionManager(session, sessionId),
-      // A served session HAS somewhere to record the discovery, so it does: the delta is what makes
-      // the tool still callable next turn (see {@link TOOL_ACTIVATION_ENTRY}).
-      tools: sessionToolActivation(session, (added) =>
-        session.sessionManager.appendCustomEntry(TOOL_ACTIVATION_ENTRY, { names: added }),
-      ),
-    };
-    // An extension handler that throws is otherwise dropped: pi fans errors out to registered
-    // listeners and has none by default, which on a server means a broken extension looks like an
-    // extension that simply did nothing.
-    //
-    // Deferral, then restoration: pi starts every mounted tool active, so narrow by SUBTRACTING the
-    // deferred names (robust to pi mounting tools of its own, unlike an exact-set replacement), then
-    // add back what THIS session has already discovered.
-    if (deferred.length > 0) {
-      const active = session.getActiveToolNames();
-      const mounted = new Set(session.getAllTools().map((tool) => tool.name));
-      const recorded = recordedActivations(session);
-      // A recorded name that is no longer mounted is dropped rather than replayed: pi's setter
-      // THROWS on an unknown name, so replaying one would brick every future turn of this session.
-      const restored = recorded.filter((name) => mounted.has(name));
-      const dropped = recorded.filter((name) => !mounted.has(name));
-      if (dropped.length > 0) {
-        const key = `${sessionId}\u0000${[...new Set(dropped)].sort().join(",")}`;
-        const emit = warnedDroppedActivations.has(key) ? log.debug : log.warn;
-        warnedDroppedActivations.add(key);
-        emit(
-          `[fastagent] session ${sessionId}: dropping recorded activation(s) no longer mounted: ${[...new Set(dropped)].join(", ")}`,
-        );
-      }
-      const next = [...new Set([...active.filter((name) => !deferred.includes(name)), ...restored])];
-      if (next.length !== active.length || next.some((name) => !active.includes(name))) {
-        session.setActiveToolsByName(next);
-      }
-    }
+      excludedToolNames,
+      sessionId,
+      recordActivations: true,
+    });
     return session;
   };
 }

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -9,6 +9,11 @@
  * Above L2 sits the agent opener createPiAgentFromDir (open.ts), which both `dev` and
  * `start` drive. Each rung calls the one below; options narrow as you go up (L2 owns systemPrompt/skills —
  * they come from the definition; the openers own model/tools — from config resolution).
+ *
+ * Every rung assembles the same VALUE first — a {@link PiAssembly}: the lease, the store, the session
+ * factory and the engine thunk — and the agent is that value under the L0. The opener needs the value
+ * itself (the control plane contends on the same lease and validates against the same registry), so
+ * `assemblePiFromDefinition` hands it out and `createPiAgentFromDefinition` is it plus the L0.
  */
 import {
   formatSkillsForSystemPrompt,
@@ -253,11 +258,26 @@ export function assembleSystemPrompt(options: AssembleSystemPromptOptions): stri
 // ── §3 the reusable assembly ladder: L1 / L2 ────────────────────────────────
 
 /**
+ * The assembly, as a value: what every rung builds and what the agent runs on. The opener hands it to
+ * the control plane too — boundary mutations contend on the SAME lease and validate against the SAME
+ * registry the runs use, which is only true if there is one of each to hand over.
+ */
+export interface PiAssembly {
+  lease: Lease;
+  sessions: PiSessionRecordStore;
+  sessionFactory: PiAgentSessionFactory;
+  /** The registry and configured model, resolved on first use (a credential read is async). */
+  engine: () => Promise<{ modelRuntime: ModelRuntime; model: AnyModel }>;
+  /** The configured reasoning effort — the other half of the pair a session without overrides runs on. */
+  thinkingLevel: ThinkingLevel;
+}
+
+/**
  * Shared low-level wiring: resolve the model spec against the collection, default the K ports, build
- * the agent. Internal — the public rungs decide the systemPrompt (L1 from instructions, L2 from the
+ * the parts. Internal — the public rungs decide the systemPrompt (L1 from instructions, L2 from the
  * directory) and route through here.
  */
-function buildPiAgent(opts: {
+function assemblePi(opts: {
   model: string;
   thinkingLevel?: ThinkingLevel;
   providers?: Provider[];
@@ -285,19 +305,17 @@ function buildPiAgent(opts: {
    *  every one of those three must follow the workspace, not the loader. */
   cwd?: string;
   lease?: Lease;
-  observer?: SessionObserver;
-  onAssembly?: OnAssembly;
-}): Agent {
+}): PiAssembly {
   const env = opts.env ?? new NodeExecutionEnv({ cwd: process.cwd() });
   const cwd = opts.cwd ?? env.cwd;
-  // Materialized here (not defaulted inside the L0) so the exposed parts carry the SAME lease
-  // instance the agent runs under — boundary mutations must contend on it.
+  // Materialized here (not defaulted inside the L0) so the value carries the SAME lease instance the
+  // agent runs under — boundary mutations must contend on it.
   const lease = opts.lease ?? inProcessLease();
   const sessions = opts.sessions ?? piInMemorySessionRecordStore({ cwd });
   // The model and its runtime resolve on FIRST USE: building a ModelRuntime is async while
   // assembling an agent is not, so the credential read belongs on the first turn rather than in the
-  // caller's constructor. Memoized by the factory, and shared with the control plane below so a
-  // boundary mutation validates against the registry the runs actually use.
+  // caller's constructor. Memoized, and shared with the control plane so a boundary mutation
+  // validates against the registry the runs actually use.
   let engine: Promise<{ modelRuntime: ModelRuntime; model: AnyModel }> | undefined;
   const resolveEngine = () => {
     engine ??= (async () => {
@@ -327,34 +345,19 @@ function buildPiAgent(opts: {
     excludedToolNames: omittedBuiltinNames(opts.tools ?? [], cwd),
     env,
   });
-  opts.onAssembly?.({
+  return {
     lease,
+    sessions,
     sessionFactory,
-    // The control plane needs the registry and the configured pair as VALUES, and both only exist
-    // after the first credential read. Asking for them lazily keeps assembly synchronous without
-    // making the hub wait on a runtime it may never need (a control-less deployment never calls it).
     engine: resolveEngine,
     thinkingLevel: opts.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
-  });
-  return createPiAgentFromSession({ lease, observer: opts.observer, sessionFactory });
+  };
 }
 
-/**
- * INTERNAL seam (workspace ↔ assembly): hands the hub-wiring consumer the assembly's live parts —
- * the SAME session factory and lease the agent runs with, plus the model registry behind a thunk —
- * so boundary mutations (session-control.ts) contend on the real lease and validate against the real
- * registry. Called synchronously, exactly once, before the agent is returned. Not public surface.
- */
-export type PiAssemblyParts = {
-  lease: Lease;
-  sessionFactory: PiAgentSessionFactory;
-  /** The registry and configured model, resolved on first use (a credential read is async). */
-  engine: () => Promise<{ modelRuntime: ModelRuntime; model: AnyModel }>;
-  /** The configured reasoning effort — the other half of the pair a session without overrides runs on. */
-  thinkingLevel: ThinkingLevel;
-};
-
-type OnAssembly = (parts: PiAssemblyParts) => void;
+/** The agent an assembly runs as: the L0 over its lease and session factory. */
+export function agentOf(assembly: PiAssembly, observer?: SessionObserver): Agent {
+  return createPiAgentFromSession({ lease: assembly.lease, observer, sessionFactory: assembly.sessionFactory });
+}
 
 /**
  * L1 system prompt: `instructions` ARE the prompt (no engine base, no wrapping); the skills listing
@@ -427,20 +430,22 @@ export interface CreatePiAgentOptions {
 
 /** L1: assemble from typed parts. */
 export function createPiAgent(options: CreatePiAgentOptions): Agent {
-  return buildPiAgent({
-    model: options.model,
-    thinkingLevel: options.thinkingLevel,
-    providers: options.providers,
-    authPath: options.authPath,
-    systemPrompt: instructionsPrompt(options.instructions, options.skills),
-    // Deferred tools need their loader on every rung (idempotent; the caller's own search_tools wins).
-    tools: options.tools ? withSearchTool(options.tools) : options.tools,
-    skills: options.skills,
-    sessions: options.sessions,
-    env: options.env,
-    lease: options.lease,
-    observer: options.observer,
-  });
+  return agentOf(
+    assemblePi({
+      model: options.model,
+      thinkingLevel: options.thinkingLevel,
+      providers: options.providers,
+      authPath: options.authPath,
+      systemPrompt: instructionsPrompt(options.instructions, options.skills),
+      // Deferred tools need their loader on every rung (idempotent; the caller's own search_tools wins).
+      tools: options.tools ? withSearchTool(options.tools) : options.tools,
+      skills: options.skills,
+      sessions: options.sessions,
+      env: options.env,
+      lease: options.lease,
+    }),
+    options.observer,
+  );
 }
 
 /**
@@ -482,18 +487,17 @@ export interface CreatePiAgentFromDefinitionOptions {
   lease?: Lease;
   /** Observation-plane tap; see {@link CreatePiAgentOptions.observer}. */
   observer?: SessionObserver;
-  /** INTERNAL seam for hub wiring; see {@link OnAssembly}. */
-  onAssembly?: OnAssembly;
 }
 
 /**
- * L2: "point at a directory → agent": load + assemble (base + AGENTS.md + skills + env) + L1 in one
- * call. Returns the definition so callers can surface diagnostics/collisions.
+ * L2, as the value: load the directory (base + AGENTS.md + skills + env) and assemble. Returns the
+ * definition so callers can surface diagnostics/collisions. The opener consumes this form because
+ * the control plane needs the parts; {@link createPiAgentFromDefinition} is it plus the L0.
  */
-export async function createPiAgentFromDefinition(
+export async function assemblePiFromDefinition(
   dir: string,
-  options: CreatePiAgentFromDefinitionOptions,
-): Promise<{ agent: Agent; definition: LoadedDefinition }> {
+  options: Omit<CreatePiAgentFromDefinitionOptions, "observer">,
+): Promise<{ assembly: PiAssembly; definition: LoadedDefinition }> {
   // `dir` = the agent-definition dir (persona.md/skills/); `cwd` (default = dir) is the run root where
   // tools operate and whose ancestors are walked for ② context.
   const cwd = options.cwd ?? dir;
@@ -518,7 +522,7 @@ export async function createPiAgentFromDefinition(
   // Dir-aware default: the same secrets-dir-derived file the opener uses for this dir (the opener
   // passes an explicit authPath, so this only affects direct L2 callers).
   const authPath = options.authPath ?? defaultAuthPath(resolveSecretsDir(dir));
-  const agent = buildPiAgent({
+  const assembly = assemblePi({
     model: options.model,
     thinkingLevel: options.thinkingLevel,
     // THE directory rung's model surface: built-ins + the agent's own models.json (custom endpoints,
@@ -563,8 +567,15 @@ export async function createPiAgentFromDefinition(
     cwd,
     env,
     lease: options.lease,
-    observer: options.observer,
-    onAssembly: options.onAssembly,
   });
-  return { agent, definition };
+  return { assembly, definition };
+}
+
+/** L2: "point at a directory → agent": {@link assemblePiFromDefinition} under the L0. */
+export async function createPiAgentFromDefinition(
+  dir: string,
+  options: CreatePiAgentFromDefinitionOptions,
+): Promise<{ agent: Agent; definition: LoadedDefinition }> {
+  const { assembly, definition } = await assemblePiFromDefinition(dir, options);
+  return { agent: agentOf(assembly, options.observer), definition };
 }

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -10,8 +10,8 @@
  * `start` drive. Each rung calls the one below; options narrow as you go up (L2 owns systemPrompt/skills —
  * they come from the definition; the openers own model/tools — from config resolution).
  *
- * Every rung assembles the same VALUE first — a {@link PiAssembly}: the lease, the store, the session
- * factory and the engine thunk — and the agent is that value under the L0. The opener needs the value
+ * Every rung assembles the same VALUE first — a {@link PiAssembly}: the lease, the session factory
+ * and the engine thunk — and the agent is that value under the L0. The opener needs the value
  * itself (the control plane contends on the same lease and validates against the same registry), so
  * `assemblePiFromDefinition` hands it out and `createPiAgentFromDefinition` is it plus the L0.
  */
@@ -264,7 +264,6 @@ export function assembleSystemPrompt(options: AssembleSystemPromptOptions): stri
  */
 export interface PiAssembly {
   lease: Lease;
-  sessions: PiSessionRecordStore;
   sessionFactory: PiAgentSessionFactory;
   /** The registry and configured model, resolved on first use (a credential read is async). */
   engine: () => Promise<{ modelRuntime: ModelRuntime; model: AnyModel }>;
@@ -347,7 +346,6 @@ function assemblePi(opts: {
   });
   return {
     lease,
-    sessions,
     sessionFactory,
     engine: resolveEngine,
     thinkingLevel: opts.thinkingLevel ?? DEFAULT_THINKING_LEVEL,

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -20,9 +20,9 @@ import {
 } from "./config.ts";
 import { resolveStateRoot, resolvePlacement } from "../../paths.ts";
 import type { SessionControl } from "../../session.ts";
-import { type PiAssemblyParts, createPiAgentFromDefinition, resolveAgentTools } from "./create.ts";
+import { agentOf, assemblePiFromDefinition, resolveAgentTools } from "./create.ts";
 import type { SessionObserver } from "./turn-kit.ts";
-import { type PiBoundaryWiring, createPiSessionControl } from "./session-control.ts";
+import { createPiSessionControl } from "./session-control.ts";
 import { withWakeTool } from "./wake-tool.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
 import { type LoadedDefinition, loadAgentSkills } from "./definition.ts";
@@ -201,42 +201,59 @@ export async function createPiAgentFromDir(
   const sessionsDir = options.sessionsDir ?? defaultSessionsDir(stateRoot);
   await mkdir(sessionsDir, { recursive: true });
   const sessions = piSessionRecordStore({ dir: sessionsDir, cwd: workspace });
-  // The hub is wired HERE because the store is created here: chicken-and-egg otherwise (the hub
-  // needs the store; the agent needs the hub's observer). Boundary parts (factory/lease/registry)
-  // only exist after the assembly below — the hub takes them as a lazy thunk, filled by the
-  // assembly's onAssembly callback (assembly completes before this function returns, so every
-  // dispatch sees them). An extra caller observer composes after the hub's (TRUSTED seam).
-  let boundaryParts: PiBoundaryWiring | undefined;
-  let assembled: PiAssemblyParts | undefined;
+  const { assembly, definition } = await assemblePiFromDefinition(agentDir, {
+    model: modelSpec,
+    thinkingLevel: config.thinkingLevel,
+    cwd: workspace,
+    tools: mountedTools,
+    authPath,
+    // Skills are definition-only (the agent is its directory), so dev mirrors deployment exactly.
+    sessions,
+  });
+  // The hub is wired HERE because the store is created here (an external `createPiSessionControl`
+  // cannot exist before the store does). Its writes contend on the assembly's own lease and validate
+  // against its own registry — the value above is what makes "same" true. An extra caller observer
+  // composes after the hub's (TRUSTED seam).
   const caller = options.observer;
   const wantControl = options.sessionControl ?? (config.sessionControl === true && options.serving === true);
-  const hub = wantControl
-    ? createPiSessionControl({
-        sessions,
-        boundary: () => boundaryParts,
-        // Skills ARE the names a client offers — the resolved set, after collisions were decided
-        // first-wins, which a client cannot reconstruct from the directory. Read LIVE (the directory
-        // is the agent: a skill added while serving is in play on the next turn, so it must be
-        // listable now) and SKILLS-ONLY: this is called when a composer opens its completion list,
-        // and the full load's ② context walk buys nothing here.
-        commands: async () => {
-          const loaded = await loadAgentSkills(agentDir, { cwd: workspace });
-          // A skill whose frontmatter broke simply is not in `skills` — it would disappear from the
-          // author's composer with no signal anywhere. The memo is SHARED with the turn path (keyed
-          // by dir), so a finding is warned when it appears, not once per reader that notices it.
-          reportFindingsIfChanged(loaded.dir, loaded);
-          return loaded.skills.map((skill) => ({
-            name: skill.name,
-            description: skill.description,
-            source: "skill",
-          }));
-        },
-        // The caller tap's boundary-event half: state_changed/compaction_* originate in the hub
-        // and never cross the data plane's observer seam — without this, an audit tap wired here
-        // would miss exactly the mutations it most needs to see (`update({ model })`).
-        tap: caller ? (session, event) => caller(session, event) : undefined,
-      })
-    : undefined;
+  let hub: ReturnType<typeof createPiSessionControl> | undefined;
+  if (wantControl) {
+    // The hub's surface is synchronous (`capabilities()` lists the allowed models), while building
+    // the registry reads credentials and is not. Resolve it ONCE here — the opener is async anyway,
+    // and the first turn would have paid the same read — so every boundary mutation validates
+    // against the same registry the runs use.
+    const { modelRuntime, model } = await assembly.engine();
+    hub = createPiSessionControl({
+      sessions,
+      boundary: {
+        lease: assembly.lease,
+        models: modelRuntime,
+        sessionFactory: assembly.sessionFactory,
+        defaults: { model, thinkingLevel: assembly.thinkingLevel },
+      },
+      // Skills ARE the names a client offers — the resolved set, after collisions were decided
+      // first-wins, which a client cannot reconstruct from the directory. Read LIVE (the directory
+      // is the agent: a skill added while serving is in play on the next turn, so it must be
+      // listable now) and SKILLS-ONLY: this is called when a composer opens its completion list,
+      // and the full load's ② context walk buys nothing here.
+      commands: async () => {
+        const loaded = await loadAgentSkills(agentDir, { cwd: workspace });
+        // A skill whose frontmatter broke simply is not in `skills` — it would disappear from the
+        // author's composer with no signal anywhere. The memo is SHARED with the turn path (keyed
+        // by dir), so a finding is warned when it appears, not once per reader that notices it.
+        reportFindingsIfChanged(loaded.dir, loaded);
+        return loaded.skills.map((skill) => ({
+          name: skill.name,
+          description: skill.description,
+          source: "skill",
+        }));
+      },
+      // The caller tap's boundary-event half: state_changed/compaction_* originate in the hub
+      // and never cross the data plane's observer seam — without this, an audit tap wired here
+      // would miss exactly the mutations it most needs to see (`update({ model })`).
+      tap: caller ? (session, event) => caller(session, event) : undefined,
+    });
+  }
   const observer: SessionObserver | undefined = hub
     ? caller
       ? (session, event, run) => {
@@ -245,34 +262,7 @@ export async function createPiAgentFromDir(
         }
       : hub.observer
     : caller;
-  const { agent, definition } = await createPiAgentFromDefinition(agentDir, {
-    model: modelSpec,
-    thinkingLevel: config.thinkingLevel,
-    cwd: workspace,
-    tools: mountedTools,
-    authPath,
-    // Skills are definition-only (the agent is its directory), so dev mirrors deployment exactly.
-    sessions,
-    observer,
-    onAssembly: hub
-      ? (parts) => {
-          assembled = parts;
-        }
-      : undefined,
-  });
-  if (hub && assembled) {
-    // The hub's surface is synchronous (`capabilities()` lists the allowed models), while building
-    // the registry reads credentials and is not. Resolve it ONCE here — the opener is async anyway,
-    // and the first turn would have paid the same read — so every boundary mutation validates
-    // against the same registry the runs use.
-    const { modelRuntime, model } = await assembled.engine();
-    boundaryParts = {
-      lease: assembled.lease,
-      models: modelRuntime,
-      sessionFactory: assembled.sessionFactory,
-      defaults: { model, thinkingLevel: assembled.thinkingLevel },
-    };
-  }
+  const agent = agentOf(assembly, observer);
   return {
     agent,
     definition,

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -168,7 +168,9 @@ export async function buildAgentSessionRuntime(
       thinkingLevel,
       tools,
       env,
-      cwd,
+      // rootCwd, not the raw `cwd` pi hands the factory: `env` above is rooted at the canonical
+      // path, and a tool must not see two spellings of one directory under a symlinked workspace.
+      cwd: rootCwd,
       recordActivations: false,
     });
     return { ...result, services, diagnostics: services.diagnostics };

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -30,29 +30,19 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
-  type AgentSession,
   type AgentSessionRuntime,
   type CreateAgentSessionRuntimeFactory,
   SessionManager,
-  type ToolDefinition,
-  createAgentSessionFromServices,
   createAgentSessionRuntime,
   createAgentSessionServices,
   getAgentDir,
 } from "@earendil-works/pi-coding-agent";
-import { definitionResourceLoaderOptions, reportExtensionErrors } from "./agent-session-factory.ts";
+import { bindPiSession, definitionResourceLoaderOptions, reportExtensionErrors } from "./agent-session-factory.ts";
 import { resolveModel } from "./config.ts";
 import { assembleSystemPrompt, piBasePrompt } from "./create.ts";
 import { canonicalPath, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
 import { createPiModelRuntime } from "./models.ts";
 import { reportModuleLoadFailures } from "../../log.ts";
-import {
-  type ReadonlySessionManager,
-  type ToolActivation,
-  agentSessionManager,
-  sessionToolActivation,
-  turnContext,
-} from "./tool-context.ts";
 import { reportFindingsIfChanged, reportToolCollisions } from "./report.ts";
 import { resolveAgentAssembly } from "./open.ts";
 
@@ -80,12 +70,9 @@ export async function buildAgentSessionRuntime(
     // opener uses (open.ts); those inputs cannot drift between the two consumption shapes.
     // (Definition→prompt assembly is NOT shared: serving re-reads live per invoke, this runtime is a
     // startup snapshot and pi appends skills/env itself — see the header.) `tools` arrives with
-    // search_tools applied; deferral is EMULATED below like serving
-    // (what you iterate is what you serve): the initial active set excludes deferred tools (applied
-    // on the session in createRuntime — pi's session starts all-active), and the activation bridge
-    // above rides the same turn context, so the SAME search_tools works against pi's AgentSession
-    // instead of the served one.
-    const { config, modelSpec, agentDir, authPath, stateRoot, tools, deferredToolNames, toolCollisions, toolFailures } =
+    // search_tools applied; the bind below applies deferral like serving does (what you iterate is
+    // what you serve).
+    const { config, modelSpec, agentDir, authPath, stateRoot, tools, toolCollisions, toolFailures } =
       await resolveAgentAssembly(cwd, options);
     reportToolCollisions(toolCollisions);
     reportModuleLoadFailures(toolFailures);
@@ -99,34 +86,6 @@ export async function buildAgentSessionRuntime(
     // Assembly-time, like serving's: this whole function is memoized, so the scan and its warnings
     // happen once per runtime rather than per session rebuild (/new, /resume, fork).
     const extensionPaths = await loadExtensionPaths(agentDir, { cwd, env });
-    // fastagent mounts pi's complete coding set itself; `noTools: "builtin"` below keeps the runtime
-    // from adding duplicate copies.
-    // Adapt fastagent's AgentTool to pi's ToolDefinition (`parameters` is plain JSON-Schema; pi accepts
-    // it). Each execute runs inside the turn context with the CURRENT session's activation bridge — the
-    // assembly is memoized across /new//resume/fork rebuilds while the session changes, so the bridge
-    // resolves through sessionRef at call time, exactly like the serving path resolves its session.
-    const customToolDefs = tools.map((t) => ({
-      name: t.name,
-      label: t.name,
-      description: t.description ?? "",
-      parameters: t.parameters,
-      // Propagate the execution mode — an activating tool (the builtin loader) declares "sequential"
-      // so pi serializes its batch; without this, pi's outer active-set diff double-stamps parallels.
-      executionMode: t.executionMode,
-      execute: (id: string, params: unknown, signal: AbortSignal | undefined) => {
-        const bound = sessionRef.current;
-        // Unreachable by construction (createRuntime sets sessionRef before any turn can run a tool).
-        // Throw rather than silently run outside the turn context — that would disguise a broken
-        // session-lifecycle invariant as a normal out-of-turn call (fail visibly).
-        if (!bound) throw new Error("tool executed before its session was built (lifecycle invariant broken)");
-        return turnContext.run(
-          { cwd, sessionManager: bound.sessionManager, tools: bound.activation },
-          // Lower-level MountedTools may consume the fifth-argument env. Directory coding tools are
-          // cwd-bound and ignore it; authored tools read FastAgent's turnContext instead.
-          () => t.execute(id, params, signal, undefined, { env }) as Promise<unknown>,
-        );
-      },
-    })) as unknown as ToolDefinition[];
 
     // base + instructions ONLY — pi appends the skill section and env (cwd) itself (including
     // them here would duplicate them).
@@ -142,9 +101,8 @@ export async function buildAgentSessionRuntime(
       thinkingLevel: config.thinkingLevel,
       definition,
       extensionPaths,
-      customTools: tools,
-      customToolDefs,
-      deferredToolNames,
+      tools,
+      env,
       systemPrompt,
     };
   }
@@ -155,17 +113,6 @@ export async function buildAgentSessionRuntime(
   // load edits. And keep it workspace-scoped — `.env` is process-global, so a switch to another cwd
   // would leak env or require mutating global env at runtime.
   const rootCwd = canonicalPath(dir);
-  // The CURRENT pi session + its activation bridge, BOUND TOGETHER — rebuilt on /new//resume/fork
-  // while the memoized assembly (and its tool execute closures) stays. The bridge shares the
-  // session's lifetime because a tool call has to see what the previous one activated. Note on
-  // parallel batches: pi wraps SDK customTools in its own before/after active-set diff, so an
-  // activating tool must carry `executionMode: "sequential"` (the builtin loader does) — pi then runs
-  // the whole batch serially and the outer diff sees correct snapshots.
-  // NO activation record here: pi's chat session has nowhere to put one (see sessionToolActivation's
-  // `onActivated`), which is the documented divergence from serving — a resumed chat re-discovers.
-  const sessionRef: {
-    current?: { session: AgentSession; sessionManager: ReadonlySessionManager; activation: ToolActivation };
-  } = {};
   let assembly: Promise<Awaited<ReturnType<typeof resolveAssembly>>> | undefined;
   const assemblyFor = (cwd: string) => {
     // Canonical paths: pi's process.cwd() fallback is a realpath, so a symlinked workspace would
@@ -179,16 +126,8 @@ export async function buildAgentSessionRuntime(
   };
 
   const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
-    const {
-      modelRuntime,
-      modelSpec,
-      thinkingLevel,
-      definition,
-      extensionPaths,
-      customToolDefs,
-      deferredToolNames,
-      systemPrompt,
-    } = await assemblyFor(cwd);
+    const { modelRuntime, modelSpec, thinkingLevel, definition, extensionPaths, tools, env, systemPrompt } =
+      await assemblyFor(cwd);
 
     // Per session, NOT memoized with the assembly: pi replaces the session on /new, /resume and
     // fork, and its extension contract is that the replacement gets freshly loaded extensions
@@ -213,50 +152,25 @@ export async function buildAgentSessionRuntime(
     // AFTER the services, because an extension may be what defines the model. `registerProvider()`
     // is pi's documented way for one to add providers, and extensions do not execute until the
     // services are built — resolving first fails a definition whose configured model comes from its
-    // own extension with a bare "unknown model", after warning about credentials for a provider
-    // that does not exist yet.
+    // own extension with a bare "unknown model".
     const model = resolveModel(modelRuntime, modelSpec);
-
-    const result = await createAgentSessionFromServices({
+    // The same bind serving performs, minus the activation record: pi's chat session has nowhere to
+    // put one, which is the documented divergence — a resumed chat re-discovers via search_tools.
+    // NOT bound to the host here: InteractiveMode.bindCurrentSessionExtensions() calls
+    // session.bindExtensions() with the TUI's uiContext, abort handler and command actions — binding
+    // here too would emit session_start twice per chat, so an extension opening a resource on start
+    // would open two.
+    const { context: _context, ...result } = await bindPiSession({
       services,
       sessionManager,
       sessionStartEvent,
       model,
       thinkingLevel,
-      // NO `tools` allowlist. It would freeze the tool set at build time, and pi lets an extension
-      // register from `session_start`, a command, or any handler — those names would not be in a
-      // startup snapshot, so `refreshTools()` would filter them straight back out and the extension
-      // would look like it did nothing. `noTools: "builtin"` gets the same guarantee the allowlist
-      // was really there for (the machine's `defaultTools` setting cannot add pi's own copies on top
-      // of ours) without freezing anything.
-      noTools: "builtin",
-      customTools: customToolDefs,
+      tools,
+      env,
+      cwd,
+      recordActivations: false,
     });
-    sessionRef.current = {
-      session: result.session,
-      sessionManager: agentSessionManager(result.session, result.session.sessionManager.getSessionId()),
-      activation: sessionToolActivation(result.session),
-    };
-    // NOT bound here: the HOST does it. InteractiveMode.bindCurrentSessionExtensions() calls
-    // session.bindExtensions() with the TUI's uiContext, abort handler and command actions — binding
-    // here too would emit session_start twice per chat, so an extension opening a resource on start
-    // would open two.
-    // Deferral emulation: pi starts THIS agent's tools active — every coding tool it mounted, plus
-    // every custom and extension tool. So narrow by SUBTRACTING the deferred names from whatever is
-    // active, rather than stating a set: an exact-set-equality gate would silently stop narrowing the
-    // day pi activates one more.
-    //
-    // Applied on EVERY build including /resume: pi's chat session does not record activations (its
-    // SessionContext has no activeToolNames), so "restore prior activations" is not implementable
-    // here — deferral stays consistently ON and a resumed conversation re-discovers via search_tools
-    // (a documented divergence from serving, where activations persist in the session). The deferred
-    // SET comes from the shared assembly (one definition of "deferred"), never recomputed here.
-    if (deferredToolNames.length > 0) {
-      const active = result.session.getActiveToolNames();
-      if (deferredToolNames.some((n) => active.includes(n))) {
-        result.session.setActiveToolsByName(active.filter((n) => !deferredToolNames.includes(n)));
-      }
-    }
     return { ...result, services, diagnostics: services.diagnostics };
   };
 

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -191,15 +191,12 @@ export interface PiBoundaryWiring {
 export interface CreatePiSessionControlOptions {
   /** Read-only access to the durable session records (the same root the agent writes). */
   sessions: PiSessionRecordStore;
-  /** Boundary-mutation wiring, as a LAZY thunk: the hub's observer must exist before the agent
-   *  assembly that produces these parts, so the hub asks for them at dispatch time instead
-   *  (assembly completes before any dispatch can arrive). Absent / undefined → boundary commands
-   *  are gated off in `capabilities()` and rejected `unsupported_capability`. */
-  boundary?: () => PiBoundaryWiring | undefined;
-  /** The definition's names, as a LAZY thunk for the same reason {@link boundary} is one (the hub
-   *  exists before the assembly that can read a definition) — and async because the definition is
-   *  live: this must re-read it, not close over a boot snapshot, or `commands()` would advertise a
-   *  list the next turn no longer runs.
+  /** Boundary-mutation wiring — the assembly's own parts. Absent → boundary commands are gated off
+   *  in `capabilities()` and rejected `unsupported_capability`. */
+  boundary?: PiBoundaryWiring;
+  /** The definition's names, as an async thunk because the definition is live: this must re-read it,
+   *  not close over a boot snapshot, or `commands()` would advertise a list the next turn no longer
+   *  runs.
    *
    *  OPTIONAL because absence is a TRUE answer for the assembly that omits it: a hub over an L1
    *  agent (`createPiAgent({ model, instructions, tools })`) has no definition and therefore no
@@ -277,7 +274,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
     },
 
     capabilities: (): SessionCapabilities => {
-      const b = boundary?.();
+      const b = boundary;
       return {
         steering: true,
         followUp: true,
@@ -310,7 +307,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
       // channel to explain itself. The fault is not swallowed — it surfaces where codes exist: the
       // next invoke fails (binding a session walks the same chain) and a boundary dispatch answers
       // `boundary_command_failed`. Here it is a server-side warn.
-      const b = boundary?.();
+      const b = boundary;
       let settings: ReturnType<typeof resolveSessionSettings> | undefined;
       if (opened && b) {
         try {
@@ -533,7 +530,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
     }
     const fields = named.filter((f) => patch[f] !== undefined);
     if (fields.length === 0) return { ok: true }; // an empty patch asks for nothing, and gets it
-    const b = boundary?.();
+    const b = boundary;
     if (!b) return unsupported(`update(${fields.join(", ")})`);
 
     // PAYLOAD validation first — before the session is even opened, and long before the lease: an
@@ -679,7 +676,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
    * finished{error} dressed as a failure — pi reports it as a throw from compact(), too late.
    */
   const compactOf = async (session: string, instructions?: string): Promise<SessionResult> => {
-    const b = boundary?.();
+    const b = boundary;
     if (!b) return unsupported("compact()");
     const existing = await sessions.openIfExists(session);
     if (!existing) return noSuchSession(session);
@@ -819,7 +816,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
     /** WHICH fork this is: source + branch point. Two forks of one session at different entries are
      *  different requests, so a retry of one must not be answered by the other. */
     const provenance = `${from}@${at}`;
-    const b = boundary?.();
+    const b = boundary;
     if (!b) return unsupported("fork()");
     // An id no client could then open: the empty string, `.` and `..` are not URL path segments
     // (isAddressableSession), so minting one would put a row in list() that nothing can address —
@@ -879,7 +876,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
   };
 
   const deleteOf = async (session: string): Promise<SessionResult> => {
-    const b = boundary?.();
+    const b = boundary;
     if (!b) return unsupported("delete()");
     const existing = await sessions.openIfExists(session);
     if (!existing) return noSuchSession(session);

--- a/test/agent.ts
+++ b/test/agent.ts
@@ -111,12 +111,12 @@ export async function fauxControlledAgent(
     boundary:
       options.boundary === false
         ? undefined
-        : () => ({
+        : {
             lease,
             models: modelRuntime,
             sessionFactory,
             defaults: { model, thinkingLevel: options.thinkingLevel ?? "medium" },
-          }),
+          },
     ...(options.commands ? { commands: options.commands } : {}),
     ...(options.tap ? { tap: options.tap } : {}),
   });

--- a/test/definition.test.ts
+++ b/test/definition.test.ts
@@ -18,8 +18,8 @@ import {
 } from "../src/index.ts";
 import {
   CODING_TOOL_NAMES,
+  assemblePiFromDefinition,
   assembleSystemPrompt,
-  type PiAssemblyParts,
   piAllCodingTools,
   piBasePrompt,
 } from "../src/engines/pi/create.ts";
@@ -605,14 +605,10 @@ describe("create L2: explicit tools replace the coding defaults", () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-l2-tools-"));
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
     const { faux } = makeFaux();
-    let assembly!: PiAssemblyParts;
-    await createPiAgentFromDefinition(dir, {
+    const { assembly } = await assemblePiFromDefinition(dir, {
       model: "faux/faux-1",
       providers: [faux.provider],
       tools: piAllCodingTools(dir).filter((tool) => tool.name === "read"),
-      onAssembly: (parts) => {
-        assembly = parts;
-      },
     });
 
     const session = await assembly.sessionFactory("s");

--- a/test/session-builder.test.ts
+++ b/test/session-builder.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, realpathSync, symlinkSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -403,6 +403,64 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
         await expect(rt.fork("m1", { position: "at" })).resolves.toMatchObject({ cancelled: false });
         expect(rt.cwd).toBe(realDir);
       } finally {
+        rt.session.dispose?.();
+      }
+    } finally {
+      process.chdir(originalCwd);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("session builder: a tool sees one spelling of the workspace", () => {
+  it("binds the turn context to the canonical workspace when a resumed session records a symlinked one", async () => {
+    // pi hands the factory the session header's cwd, which is whatever spelling was recorded; the
+    // scope guard only canonicalizes to COMPARE. Passing that through put the tool's ctx.cwd and the
+    // ExecutionEnv (rooted at the canonical path) on two spellings of one directory.
+    const root = realpathSync(await mkdtemp(join(tmpdir(), "fa-chat-symlink-")));
+    const dir = join(root, "agent", "fastagent");
+    const observedKey = "__fastagent_chat_tool_cwd_test__";
+    const piUrl = new URL("../src/pi.ts", import.meta.url).href;
+    const originalCwd = process.cwd();
+    try {
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "persona.md"), "You are terse.\n");
+      await writeFile(
+        join(dir, "fastagent.config.mjs"),
+        `import { defineTool, z } from ${JSON.stringify(piUrl)};
+         export default {
+           model: "openai-codex/gpt-5.5",
+           tools: [defineTool({
+             name: "inspect_cwd",
+             description: "Report the workspace this turn runs in.",
+             input: z.object({}),
+             execute: async (_input, ctx) => {
+               globalThis[${JSON.stringify(observedKey)}] = ctx.cwd;
+               return "ok";
+             },
+           })],
+         };\n`,
+      );
+      // The same directory under a second name. A session recorded through it canonicalizes to the
+      // workspace, so the scope guard admits it — and the raw spelling reaches the bind.
+      symlinkSync(join(root, "agent"), join(root, "link"));
+      const linked = join(root, "link", "fastagent");
+      const recorded = join(root, "linked-session.jsonl");
+      await writeFile(
+        recorded,
+        `${JSON.stringify({ type: "session", version: 3, id: "linked", timestamp: new Date().toISOString(), cwd: linked })}\n`,
+      );
+
+      process.chdir(dir);
+      const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.create(dir, join(root, "sessions")));
+      try {
+        await expect(rt.importFromJsonl(recorded, linked)).resolves.toMatchObject({ cancelled: false });
+        const tool = rt.session.agent.state.tools.find((candidate) => candidate.name === "inspect_cwd");
+        expect(tool).toBeDefined();
+        await tool!.execute("inspect-cwd-1", {});
+        expect((globalThis as Record<string, unknown>)[observedKey]).toBe(dir);
+      } finally {
+        delete (globalThis as Record<string, unknown>)[observedKey];
         rt.session.dispose?.();
       }
     } finally {

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -1344,14 +1344,14 @@ describe("session control: boundary mutations", () => {
           throw new Error("validation rejects before any write is asked for");
         },
       },
-      boundary: () => ({
+      boundary: {
         lease: inProcessLease(),
         models,
         sessionFactory: (() => {
           throw new Error("unused");
         }) as never,
         defaults: { model: models.getProviders()[0]!.getModels()[0]!, thinkingLevel: "medium" },
-      }),
+      },
     });
     const state = await control.sessions.get("sBroken").state();
     expect(state.status).toBe("idle");
@@ -1405,14 +1405,14 @@ describe("session control: boundary mutations", () => {
           return { landed: ["leafEntryId" as const], leafEntryId: leafId };
         },
       },
-      boundary: () => ({
+      boundary: {
         lease: inProcessLease(),
         models,
         sessionFactory: (() => {
           throw new Error("unused");
         }) as never,
         defaults: { model: models.getProviders()[0]!.getModels()[0]!, thinkingLevel: "medium" },
-      }),
+      },
       tap: (_session, event) => seen.push(event),
     });
     expect(await control.sessions.get("sBrokenMove").update({ leafEntryId: "a" })).toEqual({ ok: true });
@@ -1732,7 +1732,7 @@ describe("session control: boundary mutations", () => {
         throw new Error("no session for you");
       },
     };
-    const { control: broken } = createPiSessionControl({ sessions, boundary: () => boundary });
+    const { control: broken } = createPiSessionControl({ sessions, boundary });
     const pre = await broken.sessions.get("sPre").compact();
     expect(pre.ok).toBe(false);
     if (!pre.ok) expect(pre.error.code).toBe(BOUNDARY_COMMAND_FAILED_CODE);


### PR DESCRIPTION
## What

Two seams.

**The assembly is a value.** Every rung built the same parts — lease, session factory, engine thunk — inside `buildPiAgent` and handed them out through an `onAssembly` callback, which the opener caught into a mutable variable so a lazy `boundary` thunk could read it at dispatch time (the comment called it chicken-and-egg). `PiAssembly` is those parts as a value: `assemblePi` builds it, `agentOf` puts the L0 over it, `assemblePiFromDefinition` is the L2 form the opener consumes. `createPiSessionControl` takes its boundary wiring as a value. The two mutable variables, the callback, the thunk and the `PiAssemblyParts` seam are gone.

**One bind for the served session and the chat session.** The tool adapter (`MountedTool` → pi `ToolDefinition` over the turn context) and the deferral narrowing existed twice — in `piAgentSessionFactory` and in `session-builder.ts` — identical but for whether a discovered activation has a record to land in. `bindPiSession` is the one binding; the factory hands it record-resolved settings and `recordActivations: true`, the chat runtime hands it its per-session services and `recordActivations: false`. The builder's `sessionRef` indirection goes with the copy.

## Observable change

Collapsing the two binds exposed a difference between them, and it is a fix. `chat`'s turn context took the raw `cwd` pi hands the factory — the session header's spelling, whatever was recorded — while its `ExecutionEnv` is rooted at the canonical path. Under a symlinked workspace (macOS `/tmp` → `/private/tmp`), a resumed session gave an authored tool a `ToolContext.cwd` that named the same directory differently from the env beside it. Both now take the canonical path; `test/session-builder.test.ts` resumes a session recorded through a symlink and asserts what the tool sees.

## Why

Every "what the agent is made of" change in the last 80 commits (#300, #310, #331, #333, #345, #350, #351, #365) touched four or five of these files together — the signature of a missing layer.

## Not done, deliberately

`info` still derives its report by hand rather than through `resolveAgentAssembly`: it must stay TOTAL on a broken agent (no model set, an unreadable `tools/`), while the assembly path fails visibly on both. That is a different posture, not a duplicate.
