### PR TITLE
refactor(channels): the durable-turn lifecycle lives in the kit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,11 @@ src/
 │   │   │                     # discover have none there. Neither side may reach for the other.
 │   │   ├── preview-kit.ts   # turn-view reducer (event → view state + line renderers) + preview policies
 │   │   ├── invoke-turn-kit.ts # busy-retry stream loop around agent.invoke (onCompleted commit point)
-│   │   ├── turn-queue.ts    # in-memory per-session serial turns (FIFO; telegram + slack + feishu)
+│   │   ├── turn-runner.ts   # THE durable-turn lifecycle (accept → dequeue → execute → end) over the
+│   │   │                     # queue + store + buffer; a channel supplies only what names a platform
+│   │   │                     # object (notice, prompt, attachments, the dropped-turn line). Three
+│   │   │                     # channels wrote it out and drifted in ways that were not decisions
+│   │   ├── turn-queue.ts    # in-memory per-session serial turns (FIFO; the runner's)
 │   │   ├── turn-store.ts    # generic durable turn intent (L1) — record shape/validator/order injected
 │   │   ├── context-buffer.ts# generic durable un-summoned-discussion buffer (peek→completed→commit)
 │   │   ├── thread-participants.ts # who the agent has HEARD in a thread (the summon rule)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,9 @@ src/
 │   │                        # branches and drifted) — that is HOST_ONLY_FLAGS, one row per host-only flag
 │   │                        # that only WARNS elsewhere. `--tunnel` is host-only too and stays a usage GATE
 │   │                        # in runDeploy (exit 2): a refusal is not a row, and tabling it would make it advice.
+│   ├── hosts.ts             # DEPLOY_HOSTS, the deploy targets as a value: the CLI's `<host>` choices and
+│   │                        # HOST_ONLY_FLAGS's exhaustiveness check read this one copy. Dependency-free,
+│   │                        # so cli/program.ts imports it without pulling a command module
 │   ├── channel-ingress.ts   # HOW A RUNNING CHANNEL IS REACHED: default route, who can set that URL
 │   │                     # end-to-end, the words when nobody can. The ONE answer to "which channels
 │   │                     # have a webhook" — it was written per host (3 runbooks, 3 --run drivers, a

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -381,7 +381,7 @@ Telegram is the stateful channel reference. Its modules separate:
 |---|---|
 | `parse.ts` | pure update/message parsing and summon policy |
 | `invoke-turn.ts` | attachment resolution and one Agent invocation (busy-retry loop + manifest wording shared via `../kit/invoke-turn-kit.ts`) |
-| `../kit/turn-queue.ts` | per-session FIFO, different sessions concurrent (shared with Slack and Feishu) |
+| `../kit/turn-runner.ts` | the durable-turn lifecycle over the queue + store + buffer (shared with Slack and Feishu); `../kit/turn-queue.ts` is its per-session FIFO |
 | `turn-store.ts` | telegram's record + ordering over the shared generic `../kit/turn-store.ts` (pre-ACK persisted turn intent, crash replay) |
 | `context-buffer.ts` | telegram's entry shape + attachment selection over the shared generic `../kit/context-buffer.ts` (durable un-summoned group context, peek→completed→commit) |
 | `preview.ts` | live preview and terminal write policy |

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -19,11 +19,12 @@ import { createTaskTracker } from "../kit/tasks.ts";
 import { ensureStateHome, loadStateFile, saveStateFile } from "../kit/state.ts";
 import { signatureIsFresh } from "../kit/signature.ts";
 import { dispatchStop, isStopText } from "../kit/stop-command.ts";
-import { createTurnQueue } from "../kit/turn-queue.ts";
-import { commitAnsweredTurn, createTurnStore } from "../kit/turn-store.ts";
+import { createTurnRunner } from "../kit/turn-runner.ts";
+import { createTurnStore } from "../kit/turn-store.ts";
 import { discussionBlock } from "../kit/context-buffer.ts";
 import { FEISHU_CLOUD, type FeishuCloudProfile } from "./cloud.ts";
 import {
+  type FeishuBufferEntry,
   collectFeishuBufferedAttachments,
   createFeishuContextBuffer,
   feishuBufferPlaceKey,
@@ -363,11 +364,6 @@ function createFeishuRuntimeFactory(
     const seen = createSeenRing(join(stateHome, "seen.json"), label);
     // Side tasks (stop feedback) run off the ingress path but drain in turnsIdle.
     const sideTasks = createTaskTracker(label);
-    const toStored = (r: PendingFeishuTurn): StoredFeishuTurn => {
-      const { preview: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
-      return { ...intent, attempts: 0 };
-    };
-
     const targetOf = (r: PendingFeishuTurn): FeishuTarget => ({
       chatId: r.chatId,
       replyTo: r.replyTo,
@@ -379,18 +375,31 @@ function createFeishuRuntimeFactory(
       replyInThread: r.replyInThread,
     });
 
-    // In-memory: the pending queue-preview mount per turn. Immediate by default; with an explicit delay,
-    // it mounts only if the turn is still waiting when the timer fires and is cancelled unsent otherwise.
-    // `done` settles either way, awaited at dequeue so the runner reliably receives the mounted preview
-    // instead of racing it and double-posting.
-    const notices = new Map<string, { cancel: () => void; done: Promise<void> }>();
-    const queue = createTurnQueue<PendingFeishuTurn>({
+    // Tell the asker when a turn is dropped at the execution ceiling: the chain's end needs a signal,
+    // not just an operator log line. Take over its queue preview in place if present (else send fresh) —
+    // leaving it pinned at "Queued" while sending a separate failure would double-post.
+    const notifyDropped = (r: PendingFeishuTurn): void => {
+      const body = "⚠️ I couldn’t complete an earlier request — please ask again.";
+      void settleFeishuPreview(api, targetOf(r), r.preview, body).catch((e) =>
+        log.warn(`${label} could not notify a dropped turn (session=${r.session}): ${String(e)}`),
+      );
+    };
+
+    const runner = createTurnRunner<PendingFeishuTurn, StoredFeishuTurn, FeishuBufferEntry>({
       label,
-      // Queue feedback: when this session already has a turn running/queued, a silent wait reads as
-      // "the bot ignored me" once the current turn runs long — mount that turn's preview early with a
-      // queue status. It reply-quotes the exact source message (including p2p), then the runner mutates
-      // the SAME card/text into Thinking → final answer. Best-effort and post-ACK: a failed mount is a
-      // log line, never a failed event delivery; the turn later mounts its normal preview.
+      store,
+      buffer,
+      seen,
+      toStored: ({ preview: _live, ...intent }) => ({ ...intent, attempts: 0 }),
+      fromStored: ({ attempts: _a, ...intent }) => ({ ...intent, preview: undefined }),
+      bufferKey: (rec) => rec.bufferKey,
+      where: (rec) => `chat=${rec.chatId}`,
+      // Queue feedback: mount that turn's preview early with a queue status. It reply-quotes the exact
+      // source message (including p2p), then the runner mutates the SAME card/text into Thinking →
+      // final answer. Immediate by default; with an explicit delay it mounts only if the turn is still
+      // waiting when the timer fires and is cancelled unsent otherwise. Best-effort and post-ACK: a
+      // failed mount is a log line, never a failed event delivery; the turn later mounts its normal
+      // preview.
       onQueuedBehind: (rec) => {
         let fired = false;
         let settle: () => void = () => {};
@@ -410,130 +419,71 @@ function createFeishuRuntimeFactory(
         };
         const timer = queueNoticeDelayMs > 0 ? setTimeout(mount, queueNoticeDelayMs) : undefined;
         if (timer === undefined) mount();
-        notices.set(rec.id, {
-          // Cancel is a no-op once mounting started — the send is in flight and `done` settles with it.
+        return {
+          done,
+          // A no-op once mounting started — the send is in flight and `done` settles with it.
           cancel: () => {
             if (!fired) {
               if (timer !== undefined) clearTimeout(timer);
               settle();
             }
           },
-          done,
-        });
+        };
       },
-      run: async (rec) => {
-        // Runs at DEQUEUE time (serialized). The turn's queue wait is over: cancel a not-yet-mounted
-        // preview (fast turnover skips the Queued frame), then settle so rec.preview is final — in the
-        // common path this await is instant. BEFORE the ceiling check so drop/defer can take it over too.
-        const notice = notices.get(rec.id);
-        notice?.cancel();
-        await notice?.done;
-        notices.delete(rec.id);
-        // Count this execution against the durable record (poison-turn ceiling) before running it again.
-        const decision = store.startAttempt(rec.id);
-        if (decision === "exceeded") {
-          notifyDropped(rec);
-          return;
+      // Do not recall an existing queue preview (the client exposes a confusing tombstone): settle it in
+      // place to an honest delayed status. The eventual replay mounts a fresh preview.
+      onDeferred: (rec) => {
+        if (rec.preview !== undefined) {
+          void settleFeishuPreview(api, targetOf(rec), rec.preview, DEFERRED_PLACEHOLDER).catch((e) =>
+            log.warn(`${label} could not update a deferred turn's queue preview: ${String(e)}`),
+          );
         }
-        if (decision === "defer") {
-          // Couldn't record the attempt (disk failure): skip this cycle; a restart replays it. Do not
-          // recall an existing queue preview (the client exposes a confusing tombstone): settle it in
-          // place to an honest delayed status. The eventual replay mounts a fresh preview.
-          if (rec.preview !== undefined) {
-            void settleFeishuPreview(api, targetOf(rec), rec.preview, DEFERRED_PLACEHOLDER).catch((e) =>
-              log.warn(`${label} could not update a deferred turn's queue preview: ${String(e)}`),
-            );
-          }
-          return;
-        }
-        const startedAt = Date.now();
-        log.info(`${label} turn start: turn=${rec.id} session=${rec.session} chat=${rec.chatId}`);
-        // Snapshot background discussion at dequeue. Commit only this snapshot on `completed`, so a
-        // message arriving while the turn runs remains buffered for the next answered turn.
-        // ponytail: independent threaded roots in one main chat dequeue concurrently and may both fold
-        // this snapshot before either commits it. That fan-out loses nothing; claiming by buffer key
-        // would instead couple otherwise-independent root sessions and require failure rollback.
-        const { text: recent, consumed } = buffer.peek(rec.bufferKey);
+      },
+      notifyDropped,
+      execute: (rec, discussion, onCompleted) => {
         // PEEK and never commit: the room still owes this discussion to its OWN memory (§8).
+        // ponytail: independent threaded roots in one main chat dequeue concurrently and may both fold
+        // the thread's snapshot before either commits it. That fan-out loses nothing; claiming by buffer
+        // key would instead couple otherwise-independent root sessions and require failure rollback.
         const room = rec.roomBufferKey !== undefined ? buffer.peek(rec.roomBufferKey) : undefined;
         const roomBlock = room?.text
           ? `[recent discussion in the room this thread branched from — not yet answered there:\n${room.text}\n]\n\n`
           : "";
-        const prompt = `${roomBlock}${discussionBlock(recent)}${rec.baseText}`;
+        const prompt = `${roomBlock}${discussionBlock(discussion.text)}${rec.baseText}`;
         // Room entries FIRST: the collector keeps the TAIL under its cap, so the thread's own
         // attachments win the slots.
-        const buffered = collectFeishuBufferedAttachments([...(room?.consumed ?? []), ...consumed], {
+        const buffered = collectFeishuBufferedAttachments([...(room?.consumed ?? []), ...discussion.consumed], {
           images: rec.images.map((ref) => ({ messageId: ref.msg, key: ref.key })),
           files: rec.files.map((ref) => ({ messageId: ref.msg, key: ref.key, name: ref.name })),
         });
         // Recorded at ingress (see submit) — never re-derived from the session key, which may be a
         // routed OPAQUE id that only looks like a place key.
         const parentSession = rec.parentSession;
-        try {
-          await streamFeishuReply(
-            invokeFeishuTurn(
-              agent,
-              rec.session,
-              prompt,
-              {
-                api,
-                chatId: rec.chatId,
-                filesDir: join(stateHome, "files"),
-                label,
-                appId,
-                ...(parentSession !== undefined ? { parentSession } : {}),
-              },
-              { primary: { images: rec.images, files: rec.files, parentId: rec.parentId }, buffered },
-              () => commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey: rec.bufferKey, consumed }),
-            ),
-            api,
-            targetOf(rec),
-            formatError,
-            rec.preview,
-            label,
-          );
-          log.info(`${label} turn done: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms)`);
-        } catch (error) {
-          log.error(
-            `${label} turn failed: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms): ${String(error)}`,
-          );
-        } finally {
-          // Fallback removal for the caught-error paths (a `failed` event or a transport throw): those
-          // never reach the completed hook above. Idempotent — a second remove is a no-op. Only an
-          // INTERRUPTED run (this finally never runs — a crash or SIGTERM deploy) leaves the record for
-          // replay; a transport throw is dropped, not retried (safe retry needs an L2 delivery key).
-          store.remove(rec.id);
-        }
+        return streamFeishuReply(
+          invokeFeishuTurn(
+            agent,
+            rec.session,
+            prompt,
+            {
+              api,
+              chatId: rec.chatId,
+              filesDir: join(stateHome, "files"),
+              label,
+              appId,
+              ...(parentSession !== undefined ? { parentSession } : {}),
+            },
+            { primary: { images: rec.images, files: rec.files, parentId: rec.parentId }, buffered },
+            onCompleted,
+          ),
+          api,
+          targetOf(rec),
+          formatError,
+          rec.preview,
+          label,
+        );
       },
     });
-
-    // Accept a turn: persist its intent before the ACK, then record the platform delivery id and enqueue
-    // it. The ordering is deliberate: recording first could turn a failed intent write into silent loss
-    // when the platform redelivers. Recovery re-enqueues a crash survivor without re-persisting it.
-    const submit = (rec: PendingFeishuTurn, persist: boolean): void => {
-      if (persist) {
-        store.add(toStored(rec)); // failed write → HTTP/WS 500 → platform re-push
-        seen.add(rec.id); // post-persist, best-effort protection from documented duplicate pushes
-      }
-      queue.accept(rec);
-    };
-
-    // Tell the asker when a turn is dropped at the execution ceiling: the chain's end needs a signal,
-    // not just an operator log line. Take over its queue preview in place if present (else send fresh) —
-    // leaving it pinned at "Queued" while sending a separate failure would double-post.
-    const notifyDropped = (r: PendingFeishuTurn): void => {
-      const body = "⚠️ I couldn’t complete an earlier request — please ask again.";
-      void settleFeishuPreview(api, targetOf(r), r.preview, body).catch((e) =>
-        log.warn(`${label} could not notify a dropped turn (session=${r.session}): ${String(e)}`),
-      );
-    };
-
-    // Re-enqueue turns a prior crash left mid-flight (ACKed but unfinished). Synchronous at construction:
-    // the queue runs them on the next tick. The execution ceiling is enforced per turn at dequeue.
-    const recovered = store.recover();
-    if (recovered.length > 0) log.info(`${label} recovering ${recovered.length} unfinished turn(s) from a prior run`);
-    let seqCounter = recovered.reduce((max, r) => Math.max(max, r.seq), 0);
-    for (const { attempts: _a, ...intent } of recovered) submit({ ...intent, preview: undefined }, false);
+    let seqCounter = runner.recover().reduce((max, r) => Math.max(max, r.seq), 0);
 
     // Who the agent has heard in a thread decides whether a bare message addresses it (participant
     // model §3), and it comes from what this channel observed — see thread-participants.ts.
@@ -692,7 +642,7 @@ function createFeishuRuntimeFactory(
       const baseText = r.text ?? cloudEnvelope(event, kind);
       if (baseText.trim() === "" && images.length === 0 && files.length === 0) return;
 
-      submit(
+      runner.submit(
         {
           id: m.message_id,
           seq: ++seqCounter, // arrival order; the turn store replays by it
@@ -750,7 +700,7 @@ function createFeishuRuntimeFactory(
       }
     };
 
-    return { acceptEvent, turnsIdle: () => Promise.all([queue.idle(), sideTasks.drain()]).then(() => undefined) };
+    return { acceptEvent, turnsIdle: () => Promise.all([runner.idle(), sideTasks.drain()]).then(() => undefined) };
   };
 }
 

--- a/src/channels/kit/turn-runner.ts
+++ b/src/channels/kit/turn-runner.ts
@@ -1,0 +1,133 @@
+/**
+ * The durable-turn LIFECYCLE the stateful chat channels share, over the kit's parts: accept
+ * (persist pre-ACK, dedup, enqueue) → dequeue (settle the queue notice, count the attempt against
+ * the poison ceiling, fold the buffered discussion) → execute → end (log, drop the intent). Telegram,
+ * Slack and Feishu each wrote this out; the copies had already drifted in small ways that were not
+ * decisions (which one deletes its notice on defer, which one logs the duration on failure).
+ *
+ * What stays with the platform is everything that names a platform object: how a queue notice is
+ * mounted and taken over, what the prompt looks like, how attachments resolve, what a dropped turn
+ * says and where. Those arrive as hooks; the ORDER they run in is this module's.
+ */
+import { log } from "../../log.ts";
+import type { ContextBuffer } from "./context-buffer.ts";
+import { createTurnQueue } from "./turn-queue.ts";
+import { type TurnRecordBase, type TurnStore, commitAnsweredTurn } from "./turn-store.ts";
+
+/** A pending turn is the persisted intent minus its attempt count, plus live-only fields the
+ *  channel adds (a notice's message id) — never persisted, reconstructed fresh on replay. */
+export type PendingBase<S extends TurnRecordBase> = Omit<S, "attempts">;
+
+export interface TurnRunnerOptions<R extends PendingBase<S>, S extends TurnRecordBase, E> {
+  label: string;
+  store: TurnStore<S>;
+  buffer: ContextBuffer<E>;
+  /** Delivery dedup by platform id, recorded post-persist (Slack, Feishu). */
+  seen?: { add(id: string): void };
+  /** The persisted intent for a pending turn — drops the live-only fields. */
+  toStored(rec: R): S;
+  /** A recovered intent as a pending turn — live-only fields start absent. */
+  fromStored(stored: S): R;
+  /** The context-buffer bucket this turn folds. */
+  bufferKey(rec: R): string;
+  /** The place, for the lifecycle log line (`chat=… thread=…`). */
+  where(rec: R): string;
+  /** Queue feedback when a turn is scheduled BEHIND an active one. Returns what the runner awaits at
+   *  dequeue (so the turn reliably takes the notice over instead of racing it) and, optionally, how
+   *  to cancel a notice that has not fired yet. */
+  onQueuedBehind?(rec: R): { done: Promise<void>; cancel?: () => void };
+  /** Runs before the attempt is counted. Answer false to leave the intent untouched for a later run
+   *  (Slack: its transport is known to be down, so an Agent turn now would have nowhere to answer). */
+  beforeRun?(rec: R): Promise<boolean>;
+  /** The attempt could not be recorded (disk failure): a restart replays the turn, so say so on any
+   *  notice it holds rather than leaving it pinned at "Queued". */
+  onDeferred(rec: R): void;
+  /** The turn started the ceiling's worth of times without finishing: tell the asker. */
+  notifyDropped(rec: R): void;
+  /** Run the turn. `onCompleted` is the durable-commit point (the turn's `completed` event): it drops
+   *  the intent and commits the folded discussion, in that order. A throw is logged as the turn's
+   *  failure; the intent is dropped either way. */
+  execute(rec: R, discussion: { text: string; consumed: E[] }, onCompleted: () => void): Promise<void>;
+}
+
+export interface TurnRunner<R, S> {
+  /** Accept a turn: persist its intent (pre-ACK — a failed write throws so the platform redelivers),
+   *  record the delivery id, enqueue. Recovery re-enqueues without re-persisting. */
+  submit(rec: R, persist: boolean): void;
+  /** Re-enqueue the turns a prior crash left mid-flight; returns them so a channel can continue its
+   *  arrival counter. */
+  recover(): S[];
+  /** Resolve once no turn is in flight — the test/observability seam. */
+  idle(): Promise<void>;
+}
+
+export function createTurnRunner<
+  R extends PendingBase<S> & { id: string; session: string },
+  S extends TurnRecordBase,
+  E,
+>(options: TurnRunnerOptions<R, S, E>): TurnRunner<R, S> {
+  const { label, store, buffer, seen, onQueuedBehind } = options;
+  const notices = new Map<string, { done: Promise<void>; cancel?: () => void }>();
+  const queue = createTurnQueue<R>({
+    label,
+    onQueuedBehind: onQueuedBehind && ((rec) => notices.set(rec.id, onQueuedBehind(rec))),
+    run: async (rec) => {
+      // Runs at DEQUEUE time (serialized). The queue wait is over: cancel a notice that has not
+      // fired, then settle so the turn's preview handle is final — in the common path this await is
+      // instant. BEFORE the ceiling check so a dropped or deferred turn can take the notice over too.
+      const notice = notices.get(rec.id);
+      notice?.cancel?.();
+      await notice?.done;
+      notices.delete(rec.id);
+      if (options.beforeRun && !(await options.beforeRun(rec))) return;
+      const decision = store.startAttempt(rec.id);
+      if (decision === "exceeded") {
+        options.notifyDropped(rec);
+        return;
+      }
+      if (decision === "defer") {
+        options.onDeferred(rec);
+        return;
+      }
+      const startedAt = Date.now();
+      log.info(`${label} turn start: turn=${rec.id} session=${rec.session} ${options.where(rec)}`);
+      // Snapshot the discussion at dequeue; commit only this snapshot on `completed`, so a message
+      // arriving while the turn runs stays buffered for the next answered turn.
+      const bufferKey = options.bufferKey(rec);
+      const discussion = buffer.peek(bufferKey);
+      try {
+        await options.execute(rec, discussion, () =>
+          commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey, consumed: discussion.consumed }),
+        );
+        log.info(`${label} turn done: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms)`);
+      } catch (error) {
+        log.error(
+          `${label} turn failed: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms): ${String(error)}`,
+        );
+      } finally {
+        // Fallback removal for the caught-error paths (a `failed` event or a transport throw): those
+        // never reach the completed hook. Idempotent. Only an INTERRUPTED run (this finally never
+        // runs — a crash or SIGTERM deploy) leaves the record for replay; a transport throw is
+        // dropped, not retried (safe retry needs an L2 delivery key).
+        store.remove(rec.id);
+      }
+    },
+  });
+  const submit = (rec: R, persist: boolean): void => {
+    if (persist) {
+      store.add(options.toStored(rec)); // pre-ACK: a failed write throws → 500 → redelivery
+      seen?.add(rec.id); // post-persist — recording first could turn a failed write into silent loss
+    }
+    queue.accept(rec);
+  };
+  return {
+    submit,
+    recover() {
+      const recovered = store.recover();
+      if (recovered.length > 0) log.info(`${label} recovering ${recovered.length} unfinished turn(s) from a prior run`);
+      for (const stored of recovered) submit(options.fromStored(stored), false);
+      return recovered;
+    },
+    idle: () => queue.idle(),
+  };
+}

--- a/src/channels/kit/turn-runner.ts
+++ b/src/channels/kit/turn-runner.ts
@@ -34,7 +34,8 @@ export interface TurnRunnerOptions<R extends PendingBase<S>, S extends TurnRecor
   where(rec: R): string;
   /** Queue feedback when a turn is scheduled BEHIND an active one. Returns what the runner awaits at
    *  dequeue (so the turn reliably takes the notice over instead of racing it) and, optionally, how
-   *  to cancel a notice that has not fired yet. */
+   *  to cancel a notice that has not fired yet. `done` may reject — posting the notice is a platform
+   *  call — and the runner logs that and runs the turn anyway. */
   onQueuedBehind?(rec: R): { done: Promise<void>; cancel?: () => void };
   /** Runs before the attempt is counted. Answer false to leave the intent untouched for a later run
    *  (Slack: its transport is known to be down, so an Agent turn now would have nowhere to answer). */
@@ -77,7 +78,12 @@ export function createTurnRunner<
       // instant. BEFORE the ceiling check so a dropped or deferred turn can take the notice over too.
       const notice = notices.get(rec.id);
       notice?.cancel?.();
-      await notice?.done;
+      // The notice is the PLATFORM's feedback, not the turn: a failed post must not throw out of the
+      // run, which would leak the persisted intent (removed only below) into a replay that burns an
+      // attempt against the ceiling. Logged, then the turn proceeds without its handle.
+      await notice?.done.catch((error) =>
+        log.warn(`${label} queue notice failed: turn=${rec.id} session=${rec.session}: ${String(error)}`),
+      );
       notices.delete(rec.id);
       if (options.beforeRun && !(await options.beforeRun(rec))) return;
       const decision = store.startAttempt(rec.id);

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -13,11 +13,11 @@ import { createTaskTracker } from "../kit/tasks.ts";
 import { ensureStateHome } from "../kit/state.ts";
 import { dispatchStop, isStopText } from "../kit/stop-command.ts";
 import { codePointPrefix } from "../kit/text.ts";
-import { createTurnQueue } from "../kit/turn-queue.ts";
-import { commitAnsweredTurn, createTurnStore } from "../kit/turn-store.ts";
+import { createTurnRunner } from "../kit/turn-runner.ts";
+import { createTurnStore } from "../kit/turn-store.ts";
 import { discussionBlock } from "../kit/context-buffer.ts";
 import { createSlackBotTokenProvider } from "./bot-auth.ts";
-import { collectSlackBufferedFiles, createSlackContextBuffer } from "./context-buffer.ts";
+import { type SlackBufferEntry, collectSlackBufferedFiles, createSlackContextBuffer } from "./context-buffer.ts";
 import { invokeSlackTurn } from "./invoke-turn.ts";
 import {
   type SlackEventEnvelope,
@@ -271,10 +271,6 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
       order: (a, b) => a.seq - b.seq,
     });
     const decide = route ?? defaultSlackRoute;
-    const toStored = (turn: PendingSlackTurn): StoredSlackTurn => {
-      const { previewTs: _preview, nativeQueueStatus: _status, ...intent } = turn;
-      return { ...intent, attempts: 0 };
-    };
     const targetOf = (turn: PendingSlackTurn): SlackTarget => ({
       channelId: turn.channelId,
       threadTs: turn.threadTs,
@@ -282,15 +278,31 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
       recipientTeamId: turn.teamId,
     });
 
-    const notices = new Map<string, Promise<void>>();
-    const queue = createTurnQueue<PendingSlackTurn>({
+    const notifyDropped = (turn: PendingSlackTurn): void => {
+      const target = targetOf(turn);
+      if (turn.nativeQueueStatus) void api.setThreadStatus(target, "").catch(() => {});
+      void settleSlackPreview(
+        api,
+        target,
+        turn.previewTs,
+        "⚠️ I couldn’t complete an earlier request — please ask again.",
+      ).catch((error) => log.warn(`${label} could not notify a dropped turn: ${String(error)}`));
+    };
+
+    const runner = createTurnRunner<PendingSlackTurn, StoredSlackTurn, SlackBufferEntry>({
       label,
+      store,
+      buffer,
+      seen,
+      toStored: ({ previewTs: _preview, nativeQueueStatus: _status, ...intent }) => ({ ...intent, attempts: 0 }),
+      fromStored: ({ attempts: _attempts, ...intent }) => ({ ...intent }),
+      bufferKey: (turn) => turn.bufferKey,
+      where: (turn) => `channel=${turn.channelId}`,
       onQueuedBehind(turn) {
         const nativeDmStatus = rendering === "native" && turn.threadTs && turn.channelId.startsWith("D");
         if (nativeDmStatus) turn.nativeQueueStatus = true;
-        notices.set(
-          turn.id,
-          authentication
+        return {
+          done: authentication
             .then(() =>
               nativeDmStatus
                 ? api.setThreadStatus(targetOf(turn), "is queued behind an earlier request…")
@@ -299,42 +311,33 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
                   }),
             )
             .catch((error) => log.warn(`${label} queue preview failed (the turn stays durable): ${String(error)}`)),
-        );
+        };
       },
-      run: async (turn) => {
-        await notices.get(turn.id);
-        notices.delete(turn.id);
+      // Leave the intent untouched when Slack auth failed. A fixed token + restart replays it;
+      // running now would execute an Agent turn whose only customer-facing transport is known to be
+      // unavailable.
+      beforeRun: async (turn) => {
         try {
           await authentication;
+          return true;
         } catch (error) {
-          // Leave the intent untouched. A fixed token + restart replays it; running now would execute an
-          // Agent turn whose only customer-facing transport is known to be unavailable.
           log.error(`${label} deferring durable turn ${turn.id} because Slack authentication failed: ${String(error)}`);
-          return;
+          return false;
         }
-        const attempt = store.startAttempt(turn.id);
-        if (attempt === "exceeded") {
-          notifyDropped(turn);
-          return;
+      },
+      onDeferred: (turn) => {
+        if (turn.nativeQueueStatus) {
+          void api
+            .setThreadStatus(targetOf(turn), "is delayed by a temporary system issue and will retry after restart…")
+            .catch((error) => log.warn(`${label} could not update a deferred Agent status: ${String(error)}`));
+        } else if (turn.previewTs) {
+          void settleSlackPreview(api, targetOf(turn), turn.previewTs, DEFERRED_PLACEHOLDER).catch((error) =>
+            log.warn(`${label} could not update a deferred queue preview: ${String(error)}`),
+          );
         }
-        if (attempt === "defer") {
-          if (turn.nativeQueueStatus) {
-            void api
-              .setThreadStatus(targetOf(turn), "is delayed by a temporary system issue and will retry after restart…")
-              .catch((error) => log.warn(`${label} could not update a deferred Agent status: ${String(error)}`));
-          } else if (turn.previewTs) {
-            void settleSlackPreview(api, targetOf(turn), turn.previewTs, DEFERRED_PLACEHOLDER).catch((error) =>
-              log.warn(`${label} could not update a deferred queue preview: ${String(error)}`),
-            );
-          }
-          return;
-        }
-
-        const startedAt = Date.now();
-        log.info(`${label} turn start: turn=${turn.id} session=${turn.session} channel=${turn.channelId}`);
-        const { text: recent, consumed } = buffer.peek(turn.bufferKey);
-        const prompt = `${discussionBlock(recent)}${turn.baseText}`;
-        const buffered = collectSlackBufferedFiles(consumed, new Set(turn.fileIds));
+      },
+      notifyDropped,
+      execute: async (turn, discussion, onCompleted) => {
         const messageRef = messageRefOf(turn.id);
         const reaction =
           reactionEmojis && messageRef
@@ -351,10 +354,13 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
             invokeSlackTurn(
               agent,
               turn.session,
-              prompt,
+              `${discussionBlock(discussion.text)}${turn.baseText}`,
               { api, channelId: turn.channelId, filesDir: join(stateHome, "files"), label },
-              { primaryFileIds: turn.fileIds, buffered },
-              () => commitAnsweredTurn(store, buffer, { id: turn.id, bufferKey: turn.bufferKey, consumed }),
+              {
+                primaryFileIds: turn.fileIds,
+                buffered: collectSlackBufferedFiles(discussion.consumed, new Set(turn.fileIds)),
+              },
+              onCompleted,
             ),
             api,
             targetOf(turn),
@@ -367,40 +373,14 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
               label,
             },
           );
-          log.info(`${label} turn done: turn=${turn.id} session=${turn.session} (${Date.now() - startedAt}ms)`);
-          await reaction?.complete();
         } catch (error) {
-          log.error(`${label} turn failed: turn=${turn.id} session=${turn.session}: ${String(error)}`);
           await reaction?.remove();
-        } finally {
-          store.remove(turn.id);
+          throw error;
         }
+        await reaction?.complete();
       },
     });
-
-    const notifyDropped = (turn: PendingSlackTurn): void => {
-      const target = targetOf(turn);
-      if (turn.nativeQueueStatus) void api.setThreadStatus(target, "").catch(() => {});
-      void settleSlackPreview(
-        api,
-        target,
-        turn.previewTs,
-        "⚠️ I couldn’t complete an earlier request — please ask again.",
-      ).catch((error) => log.warn(`${label} could not notify a dropped turn: ${String(error)}`));
-    };
-
-    const submit = (turn: PendingSlackTurn, persist: boolean): void => {
-      if (persist) {
-        store.add(toStored(turn));
-        seen.add(turn.id);
-      }
-      queue.accept(turn);
-    };
-
-    const recovered = store.recover();
-    if (recovered.length) log.info(`${label} recovering ${recovered.length} unfinished turn(s) from a prior run`);
-    let seq = recovered.reduce((maximum, turn) => Math.max(maximum, turn.seq), 0);
-    for (const { attempts: _attempts, ...intent } of recovered) submit({ ...intent }, false);
+    let seq = runner.recover().reduce((maximum, turn) => Math.max(maximum, turn.seq), 0);
 
     // Acceptance touches no network, so it stays synchronous inside Slack's ACK window and the
     // delivery dedup ring alone is enough — there is no await for a duplicate delivery to race
@@ -513,7 +493,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
           ? codePointPrefix(stripSlackMentions(slackMessageText(event), "").replace(/\s+/g, " ").trim(), 80)
           : undefined;
 
-      submit(
+      runner.submit(
         {
           id: logicalId,
           seq: ++seq,
@@ -633,7 +613,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
       return new Response(null, { status: 200 });
     };
     (handler as typeof handler & { turnsIdle?: () => Promise<void> }).turnsIdle = () =>
-      Promise.all([queue.idle(), sideTasks.drain()]).then(() => undefined);
+      Promise.all([runner.idle(), sideTasks.drain()]).then(() => undefined);
     return { "POST /slack": handler };
   };
 }

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -9,7 +9,7 @@
  * Every other concern lives in its own module, each owning its invariants:
  *   - parse.ts          pure message parsing: field extraction, prompt envelope, summon/route policy
  *   - invoke-turn.ts    run one turn: assemble inputs (resolve attachments) + stream `agent.invoke`
- *   - turn-queue.ts     in-memory per-session serial execution (FIFO; one turn at a time per session)
+ *   - kit/turn-runner.ts the durable-turn lifecycle (accept → dequeue → execute → end) over the queue + store
  *   - turn-store.ts     durable turn intent (L1): pre-ACK persist, replay a crash-surviving turn
  *   - context-buffer.ts un-summoned group discussion, folded into the next answered turn
  *   - preview.ts        the live-preview pump ("💭 Thinking…" → edits → final answer) + terminal writes
@@ -29,7 +29,7 @@ import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { secretEquals } from "../secret.ts";
 import { invokeTurn } from "./invoke-turn.ts";
-import { collectAttachments, createContextBuffer } from "./context-buffer.ts";
+import { type BufferEntry, collectAttachments, createContextBuffer } from "./context-buffer.ts";
 import {
   type TelegramMessage,
   type TelegramRoute,
@@ -50,8 +50,7 @@ import { type TelegramFailure, defaultErrorMessage, streamReply } from "./previe
 import { ensureStateHome } from "../kit/state.ts";
 import { dispatchStop } from "../kit/stop-command.ts";
 import { type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
-import { createTurnQueue } from "../kit/turn-queue.ts";
-import { commitAnsweredTurn } from "../kit/turn-store.ts";
+import { createTurnRunner } from "../kit/turn-runner.ts";
 import { discussionBlock } from "../kit/context-buffer.ts";
 import { type StoredTurn, createTurnStore } from "./turn-store.ts";
 
@@ -171,138 +170,7 @@ export function telegramChannel({
     // Durable turn intent (L1): persist an accepted turn pre-ACK, remove it when the turn ends; a crash
     // leaves it for replay on the next start. See turn-store.ts for the at-least-once semantics.
     const store = createTurnStore(join(stateHome, "turns.json"));
-    const toStored = (r: PendingTurn): StoredTurn => {
-      const { previewId: _live, ...intent } = r; // drop the live-only field; TS enforces the rest is complete
-      return { ...intent, attempts: 0 };
-    };
-
-    // In-memory: the in-flight "⏳ queued" notice per turn, awaited at dequeue so the turn reliably takes
-    // the notice message over (rec.previewId) instead of racing it and orphaning a late-arriving notice.
-    const notices = new Map<string, Promise<void>>();
-    const queue = createTurnQueue<PendingTurn>({
-      label: "[telegram]",
-      // Queue feedback: when this session already has a turn running/queued, a silent wait reads as "the
-      // bot ignored me" once the current turn runs long — tell the asker NOW (reply-quoted, so it is
-      // clear whose ask is queued). Best-effort and post-ACK: a failed notice is a log line, never a
-      // failed update. The turn's live preview then edits this same message in place.
-      onQueuedBehind: (rec) => {
-        const target: Target = {
-          chatId: rec.chatId,
-          threadId: rec.threadId,
-          replyTo: rec.replyTo,
-        };
-        notices.set(
-          rec.id,
-          sendMessage(apiBaseUrl, botToken, target, "⏳ Queued — I’ll start once the current task finishes.", {
-            html: false,
-          }).then(
-            // The runner holds this same `rec` object, so mutating it here (gated by the notices await at
-            // dequeue below) is what hands the turn its preview message id.
-            (id) => {
-              if (id !== undefined) rec.previewId = id;
-            },
-            (e) => log.warn(`[telegram] queue notice failed (the turn still runs): ${String(e)}`),
-          ),
-        );
-      },
-      run: async (rec) => {
-        // Runs at DEQUEUE time (serialized), so the lifecycle log and engine turn reflect the actual
-        // execution order rather than arrival.
-        // Settle the queue notice (if any) so rec.previewId is final. NOT free: a slow (not failed)
-        // notice delays this turn's start by up to the API timeout — accepted, because racing it would
-        // orphan the ⏳ message and double-post a placeholder; in the common path the notice resolved
-        // while the previous turn was still running, so this await is instant. BEFORE the ceiling check
-        // so a dropped turn's notice is settled/cleared too (rec.previewId lets notifyDropped take it over).
-        await notices.get(rec.id);
-        notices.delete(rec.id);
-        // Count this execution against the durable record (poison-turn ceiling) before running it again.
-        const decision = store.startAttempt(rec.id);
-        if (decision === "exceeded") {
-          // Started the ceiling's worth of times without finishing (turn-store.ts MAX_TURN_ATTEMPTS) —
-          // tell the asker (reusing its ⏳ notice if any), drop it.
-          notifyDropped(rec);
-          return;
-        }
-        if (decision === "defer") {
-          // Couldn't record the attempt (disk failure): skip this cycle. A restart replays it, so no notify
-          // (telling the asker to re-ask would double-answer once the deferred turn runs). Two accepted
-          // edges of this rare disk-failure corner: (1) the session chain proceeds to the next queued turn,
-          // so a deferred turn can replay AFTER its successors — a per-session FIFO reorder; (2) its ⏳ notice
-          // (if it was queued behind another turn) now falsely reads "Queued", so delete it best-effort — the
-          // eventual replay sends a fresh preview, and leaving it would orphan a stale message above that.
-          if (rec.previewId !== undefined) {
-            void callApi(apiBaseUrl, botToken, "deleteMessage", {
-              chat_id: rec.chatId,
-              message_id: rec.previewId,
-            }).catch(() => {});
-          }
-          return;
-        }
-        const startedAt = Date.now();
-        const where = `chat=${rec.chatId}${rec.threadId !== undefined ? ` thread=${rec.threadId}` : ""}`;
-        log.info(`[telegram] turn start: turn=${rec.id} session=${rec.session} ${where}`);
-        // Fold the un-summoned discussion since the last answered turn into the prompt; it is cleared
-        // only when the turn COMPLETES (then it lives in the session).
-        const { text: recent, consumed } = buffer.peek(rec.placeKey);
-        const prompt = `${discussionBlock(recent)}${rec.baseText}`;
-        const buffered = collectAttachments(consumed, {
-          files: new Set(rec.fileIds),
-          images: new Set(rec.imageFileIds),
-        });
-        const target: Target = {
-          chatId: rec.chatId,
-          threadId: rec.threadId,
-          replyTo: rec.replyTo,
-        };
-        try {
-          await streamReply(
-            invokeTurn(
-              agent,
-              rec.session,
-              prompt,
-              {
-                api: apiBaseUrl,
-                botToken,
-                chatId: rec.chatId,
-                filesDir: join(stateHome, "files"),
-              },
-              {
-                primary: {
-                  imageFileIds: rec.imageFileIds,
-                  fileIds: rec.fileIds,
-                },
-                buffered,
-              },
-              () => commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey: rec.placeKey, consumed }),
-            ),
-            apiBaseUrl,
-            botToken,
-            target,
-            formatError,
-            rec.previewId,
-          );
-          log.info(`[telegram] turn done: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms)`);
-        } catch (error) {
-          log.error(
-            `[telegram] turn failed: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms): ${String(error)}`,
-          );
-        } finally {
-          // Fallback removal for the caught-error paths (a `failed` event or a transport throw): those
-          // never reach the completed hook above, which is where a completed turn removes its intent in
-          // order. Idempotent — a second remove after the completed hook is a no-op. Only an INTERRUPTED run
-          // (this finally never runs — a crash or a SIGTERM deploy, no graceful drain) leaves the record for
-          // replay; a transport throw is dropped, not retried (safe retry needs an L2 delivery key).
-          store.remove(rec.id);
-        }
-      },
-    });
-
-    // Accept a turn: persist its intent before the ACK (durable), then enqueue it. Recovery re-enqueues a
-    // crash-surviving turn WITHOUT re-persisting (it is already on disk with a bumped attempt count).
-    const submit = (rec: PendingTurn, persist: boolean): void => {
-      if (persist) store.add(toStored(rec)); // pre-ACK: a failed write throws → webhook 500 → redeliver
-      queue.accept(rec);
-    };
+    const targetOf = (r: PendingTurn): Target => ({ chatId: r.chatId, threadId: r.threadId, replyTo: r.replyTo });
 
     // Tell the asker when a turn is dropped at the execution ceiling: the chain's end needs a signal, not
     // just an operator log line. Take over the ⏳ "Queued" notice in place if the turn had one (else send
@@ -310,30 +178,79 @@ export function telegramChannel({
     // effort, like the queue notices.
     const notifyDropped = (r: PendingTurn): void => {
       const body = "⚠️ I couldn’t complete an earlier request — please ask again.";
-      const target: Target = {
-        chatId: r.chatId,
-        threadId: r.threadId,
-        replyTo: r.replyTo,
-      };
       const sent =
         r.previewId !== undefined
-          ? editMessageText(apiBaseUrl, botToken, target, r.previewId, body, {
-              html: false,
-            })
-          : sendMessage(apiBaseUrl, botToken, target, body, {
-              html: false,
-            }).then(() => {});
+          ? editMessageText(apiBaseUrl, botToken, targetOf(r), r.previewId, body, { html: false })
+          : sendMessage(apiBaseUrl, botToken, targetOf(r), body, { html: false }).then(() => {});
       void sent.catch((e) =>
         log.warn(`[telegram] could not notify a dropped turn (session=${r.session}): ${String(e)}`),
       );
     };
 
-    // Re-enqueue turns a prior crash left mid-flight (ACKed but unfinished). Synchronous at construction:
-    // the queue runs them on the next tick, once this factory returns and the event loop turns. The
-    // execution ceiling is enforced per turn at dequeue (run), not here — a never-run turn keeps its budget.
-    const recovered = store.recover();
-    if (recovered.length > 0) log.info(`[telegram] recovering ${recovered.length} unfinished turn(s) from a prior run`);
-    for (const { attempts: _a, ...intent } of recovered) submit({ ...intent, previewId: undefined }, false);
+    const runner = createTurnRunner<PendingTurn, StoredTurn, BufferEntry>({
+      label: "[telegram]",
+      store,
+      buffer,
+      toStored: ({ previewId: _live, ...intent }) => ({ ...intent, attempts: 0 }),
+      fromStored: ({ attempts: _a, ...intent }) => ({ ...intent, previewId: undefined }),
+      bufferKey: (rec) => rec.placeKey,
+      where: (rec) => `chat=${rec.chatId}${rec.threadId !== undefined ? ` thread=${rec.threadId}` : ""}`,
+      // Queue feedback: when this session already has a turn running/queued, a silent wait reads as "the
+      // bot ignored me" once the current turn runs long — tell the asker NOW (reply-quoted, so it is
+      // clear whose ask is queued). Best-effort and post-ACK: a failed notice is a log line, never a
+      // failed update. The turn's live preview then edits this same message in place. The runner holds
+      // this same `rec` object, so mutating it here (awaited at dequeue) hands the turn its preview id.
+      onQueuedBehind: (rec) => ({
+        done: sendMessage(
+          apiBaseUrl,
+          botToken,
+          targetOf(rec),
+          "⏳ Queued — I’ll start once the current task finishes.",
+          {
+            html: false,
+          },
+        ).then(
+          (id) => {
+            if (id !== undefined) rec.previewId = id;
+          },
+          (e) => log.warn(`[telegram] queue notice failed (the turn still runs): ${String(e)}`),
+        ),
+      }),
+      // Its ⏳ notice (if any) now falsely reads "Queued": delete it best-effort — the eventual replay
+      // sends a fresh preview, and leaving it would orphan a stale message above that.
+      onDeferred: (rec) => {
+        if (rec.previewId !== undefined) {
+          void callApi(apiBaseUrl, botToken, "deleteMessage", {
+            chat_id: rec.chatId,
+            message_id: rec.previewId,
+          }).catch(() => {});
+        }
+      },
+      notifyDropped,
+      execute: (rec, discussion, onCompleted) =>
+        streamReply(
+          invokeTurn(
+            agent,
+            rec.session,
+            `${discussionBlock(discussion.text)}${rec.baseText}`,
+            { api: apiBaseUrl, botToken, chatId: rec.chatId, filesDir: join(stateHome, "files") },
+            {
+              primary: { imageFileIds: rec.imageFileIds, fileIds: rec.fileIds },
+              buffered: collectAttachments(discussion.consumed, {
+                files: new Set(rec.fileIds),
+                images: new Set(rec.imageFileIds),
+              }),
+            },
+            onCompleted,
+          ),
+          apiBaseUrl,
+          botToken,
+          targetOf(rec),
+          formatError,
+          rec.previewId,
+        ),
+    });
+    runner.recover();
 
     const handler = async (req: Request): Promise<Response> => {
       if (req.method !== "POST") return text("POST only\n", 405);
@@ -413,7 +330,7 @@ export function telegramChannel({
       const fileIds = extractFiles(m);
       if (baseText.trim() !== "" || imageFileIds.length > 0 || fileIds.length > 0) {
         // Everything the turn needs, as a plain record; persisted pre-ACK then run serially per session.
-        submit(
+        runner.submit(
           {
             id: `${update.update_id}`,
             session,
@@ -433,7 +350,7 @@ export function telegramChannel({
     // Test/observability seam: await the fire-and-forget turns this handler enqueues. Inert in production
     // (nothing reads it; the runtime never drains — see turn-queue), it lets a test await a turn
     // deterministically instead of polling for side effects to settle.
-    (handler as typeof handler & { turnsIdle?: () => Promise<void> }).turnsIdle = () => queue.idle();
+    (handler as typeof handler & { turnsIdle?: () => Promise<void> }).turnsIdle = () => runner.idle();
     return { "POST /telegram": handler };
   };
 }

--- a/test/turn-runner.test.ts
+++ b/test/turn-runner.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { ContextBuffer } from "../src/channels/kit/context-buffer.ts";
+import { createTurnRunner } from "../src/channels/kit/turn-runner.ts";
+import type { TurnRecordBase, TurnStore } from "../src/channels/kit/turn-store.ts";
+
+interface Stored extends TurnRecordBase {
+  text: string;
+}
+interface Pending extends Omit<Stored, "attempts"> {
+  notice?: string;
+}
+
+/** A store that records what the runner asks of it, with a scripted answer per attempt. */
+function fakeStore(decisions: Record<string, "run" | "exceeded" | "defer"> = {}) {
+  const calls: string[] = [];
+  const recovered: Stored[] = [];
+  const store: TurnStore<Stored> = {
+    add: (rec) => {
+      calls.push(`add ${rec.id}`);
+    },
+    remove: (id) => {
+      calls.push(`remove ${id}`);
+    },
+    recover: () => recovered,
+    startAttempt: (id) => {
+      calls.push(`attempt ${id}`);
+      return decisions[id] ?? "run";
+    },
+  };
+  return { store, calls, recovered };
+}
+
+function fakeBuffer(calls: string[]): ContextBuffer<string> {
+  return {
+    push: () => {},
+    peek: (key) => {
+      calls.push(`peek ${key}`);
+      return { text: "earlier", consumed: ["e1"] };
+    },
+    commit: (key, consumed) => {
+      calls.push(`commit ${key} ${consumed.join(",")}`);
+    },
+  } as unknown as ContextBuffer<string>;
+}
+
+function runner(
+  store: TurnStore<Stored>,
+  calls: string[],
+  overrides: Partial<Parameters<typeof createTurnRunner<Pending, Stored, string>>[0]> = {},
+) {
+  return createTurnRunner<Pending, Stored, string>({
+    label: "[t]",
+    store,
+    buffer: fakeBuffer(calls),
+    seen: { add: (id) => calls.push(`seen ${id}`) },
+    toStored: ({ notice: _n, ...intent }) => ({ ...intent, attempts: 0 }),
+    fromStored: ({ attempts: _a, ...intent }) => ({ ...intent, notice: undefined }),
+    bufferKey: (rec) => `place:${rec.session}`,
+    where: (rec) => `session=${rec.session}`,
+    onDeferred: (rec) => calls.push(`deferred ${rec.id}`),
+    notifyDropped: (rec) => calls.push(`dropped ${rec.id}`),
+    execute: async (rec, discussion, onCompleted) => {
+      calls.push(`execute ${rec.id} notice=${rec.notice ?? "-"} text=${discussion.text}`);
+      onCompleted();
+    },
+    ...overrides,
+  });
+}
+
+describe("turn runner: the lifecycle order every chat channel shares", () => {
+  it("accepts, settles the queue notice, counts the attempt, folds, executes, commits, and drops the intent", async () => {
+    const { store, calls } = fakeStore();
+    const r = runner(store, calls, {
+      onQueuedBehind: (rec) => ({
+        done: Promise.resolve().then(() => {
+          rec.notice = "n1";
+          calls.push(`notice ${rec.id}`);
+        }),
+      }),
+    });
+    r.submit({ id: "a", session: "s", text: "one" }, true);
+    r.submit({ id: "b", session: "s", text: "two" }, true); // queued behind a → gets the notice
+    await r.idle();
+    expect(calls).toEqual([
+      "add a",
+      "seen a",
+      "add b",
+      "seen b",
+      "notice b", // fired on acceptance, settled BEFORE b's attempt is counted — b holds its preview handle
+      "attempt a",
+      "peek place:s",
+      "execute a notice=- text=earlier",
+      "remove a",
+      "commit place:s e1",
+      "remove a",
+      "attempt b",
+      "peek place:s",
+      "execute b notice=n1 text=earlier",
+      "remove b",
+      "commit place:s e1",
+      "remove b",
+    ]);
+  });
+
+  it("a turn at the ceiling is dropped and told; a deferred one is left for the next start", async () => {
+    const { store, calls } = fakeStore({ x: "exceeded", d: "defer" });
+    const r = runner(store, calls);
+    r.submit({ id: "x", session: "s1", text: "" }, false);
+    r.submit({ id: "d", session: "s2", text: "" }, false);
+    await r.idle();
+    expect(calls.filter((c) => !c.startsWith("attempt"))).toEqual(["dropped x", "deferred d"]);
+  });
+
+  it("beforeRun false leaves the intent untouched — nothing counted, nothing run, nothing removed", async () => {
+    const { store, calls } = fakeStore();
+    const r = runner(store, calls, { beforeRun: async () => false });
+    r.submit({ id: "a", session: "s", text: "" }, false);
+    await r.idle();
+    expect(calls).toEqual([]);
+  });
+
+  it("a failed execute still drops the intent, and a recovered turn is re-enqueued without re-persisting", async () => {
+    const { store, calls, recovered } = fakeStore();
+    recovered.push({ id: "r", session: "s", text: "again", attempts: 1 });
+    const r = runner(store, calls, {
+      execute: async (rec) => {
+        calls.push(`execute ${rec.id}`);
+        throw new Error("transport down");
+      },
+    });
+    expect(r.recover()).toHaveLength(1);
+    await r.idle();
+    expect(calls).toEqual(["attempt r", "peek place:s", "execute r", "remove r"]);
+  });
+});

--- a/test/turn-runner.test.ts
+++ b/test/turn-runner.test.ts
@@ -33,11 +33,11 @@ function fakeStore(decisions: Record<string, "run" | "exceeded" | "defer"> = {})
 function fakeBuffer(calls: string[]): ContextBuffer<string> {
   return {
     push: () => {},
-    peek: (key) => {
+    peek: (key: string) => {
       calls.push(`peek ${key}`);
       return { text: "earlier", consumed: ["e1"] };
     },
-    commit: (key, consumed) => {
+    commit: (key: string, consumed: string[]) => {
       calls.push(`commit ${key} ${consumed.join(",")}`);
     },
   } as unknown as ContextBuffer<string>;

--- a/test/turn-runner.test.ts
+++ b/test/turn-runner.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ContextBuffer } from "../src/channels/kit/context-buffer.ts";
 import { createTurnRunner } from "../src/channels/kit/turn-runner.ts";
 import type { TurnRecordBase, TurnStore } from "../src/channels/kit/turn-store.ts";
+import { log } from "../src/log.ts";
 
 interface Stored extends TurnRecordBase {
   text: string;
@@ -40,7 +41,7 @@ function fakeBuffer(calls: string[]): ContextBuffer<string> {
     commit: (key: string, consumed: string[]) => {
       calls.push(`commit ${key} ${consumed.join(",")}`);
     },
-  } as unknown as ContextBuffer<string>;
+  };
 }
 
 function runner(
@@ -117,6 +118,28 @@ describe("turn runner: the lifecycle order every chat channel shares", () => {
     r.submit({ id: "a", session: "s", text: "" }, false);
     await r.idle();
     expect(calls).toEqual([]);
+  });
+
+  it("a rejected queue notice does not abort the turn, so the intent is still counted, run and dropped", async () => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      const { store, calls } = fakeStore();
+      const r = runner(store, calls, { onQueuedBehind: () => ({ done: Promise.reject(new Error("post failed")) }) });
+      r.submit({ id: "a", session: "s", text: "one" }, false);
+      r.submit({ id: "b", session: "s", text: "two" }, false); // queued behind a → gets the failing notice
+      await r.idle();
+      expect(calls.filter((c) => c.endsWith(" b") || c.startsWith("execute b"))).toEqual([
+        "attempt b",
+        "execute b notice=- text=earlier",
+        "remove b",
+        "remove b",
+      ]);
+      // Swallowing it is the point, so the swallow owes a signal: without this the catch could go
+      // silent and every assertion above would still pass.
+      expect(warn.mock.calls.flat().join(" ")).toContain("turn=b");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("a failed execute still drops the intent, and a recovered turn is re-enqueued without re-persisting", async () => {


### PR DESCRIPTION
## What

`channels/kit/turn-runner.ts` owns the durable-turn lifecycle the three stateful chat channels share: accept (persist pre-ACK, record the delivery id, enqueue) → dequeue (settle the queue notice, count the attempt against the poison ceiling, fold the buffered discussion) → execute → end (log, drop the intent). Telegram, Slack and Feishu each wrote it out — ~120 lines each, same comments — and the copies had drifted in ways that were not decisions (Slack's failure log had no duration; Telegram deleted its notice on defer where the others settled it).

What stays with a platform arrives as hooks, and is everything that names a platform object: how a queue notice is mounted and taken over (`onQueuedBehind`, with Feishu's cancellable delayed mount), what the prompt and attachments look like (`execute`), what a dropped or deferred turn says and where (`notifyDropped`, `onDeferred`), and Slack's auth gate (`beforeRun`). The ORDER they run in is the runner's.

One hook needed a contract the copies never had to state. `onQueuedBehind` hands back a promise the runner awaits at dequeue, and posting that notice is a platform call that can fail. Awaiting it bare would throw out of the run and skip the intent's removal, leaving a record in `turns.json` to replay and burn an attempt against the ceiling. The runner catches it, logs it with the turn id, and runs the turn without its notice handle — the notice is the platform's feedback, not the turn.

`test/turn-runner.test.ts` pins that order with a fake store and buffer: notice before attempt, commit before the fallback remove, a ceiling hit drops and tells, a defer leaves the intent, `beforeRun: false` counts nothing, a failed execute still drops the intent, recovery re-enqueues without re-persisting, and a rejected notice still counts, runs and drops its turn — asserting the warn as well, since a swallow that goes silent is the way that guard would rot. The three channel suites cover each platform's hooks end to end as before.

## Why

The kit had every part (queue, store, buffer, seen, invoke-turn kit) and no skeleton; #413 ("three turn-lifecycle facts the three chat channels each restated") fixed three facts and left the other ten in place.
