### PR TITLE
fix: read FASTAGENT_LOG_LEVEL per emit so .secrets/.env carries it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -433,7 +433,7 @@ Log verbosity is an environment knob, not a config key. `FASTAGENT_LOG_LEVEL` (`
 FASTAGENT_LOG_LEVEL=debug fastagent start
 ```
 
-The value is read when a line is logged, so setting it in the agent's `.secrets/.env` works the same as setting it on the command line.
+The value is read when a line is logged, so setting it in the agent's `.secrets/.env` also takes effect locally (a real environment variable still wins over the file). `.secrets/` never enters a deploy image, so on a deployed agent set the variable on the host instead.
 
 ## What is deliberately not config
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -433,6 +433,8 @@ Log verbosity is an environment knob, not a config key. `FASTAGENT_LOG_LEVEL` (`
 FASTAGENT_LOG_LEVEL=debug fastagent start
 ```
 
+The value is read when a line is logged, so setting it in the agent's `.secrets/.env` works the same as setting it on the command line.
+
 ## What is deliberately not config
 
 The following are library API injection points rather than config keys:

--- a/src/log.ts
+++ b/src/log.ts
@@ -36,7 +36,7 @@ export function createLogger(opts: { level: LogLevel; sink?: (line: string) => v
 /**
  * `FASTAGENT_LOG_LEVEL` resolved PER EMIT, not at import: this module is imported transitively by every
  * command module, so an import-time read runs before any command reaches `loadDotEnv` and could never
- * see the agent's `.secrets/.env` — the one `FASTAGENT_*` key that file could not carry.
+ * see the agent's `.secrets/.env` — a key that file could not carry at all.
  *
  * Three states: a valid value wins over the posture; a present-but-invalid one warns (once per distinct
  * value) and is treated as absent, so a typo (meant to make logs louder) can never silently pin the

--- a/src/log.ts
+++ b/src/log.ts
@@ -34,32 +34,39 @@ export function createLogger(opts: { level: LogLevel; sink?: (line: string) => v
 }
 
 /**
- * `FASTAGENT_LOG_LEVEL` parsed to three states: a valid value locks the level (overrides posture); a
- * present-but-invalid value warns and is treated as absent, so a typo (meant to make logs louder) can
- * never silently pin the level to info nor kill the posture default; absent returns undefined. The
- * warning is raw — the singleton below is not built yet — but reuses `format` for the same shape.
+ * `FASTAGENT_LOG_LEVEL` resolved PER EMIT, not at import: this module is imported transitively by every
+ * command module, so an import-time read runs before any command reaches `loadDotEnv` and could never
+ * see the agent's `.secrets/.env` — the one `FASTAGENT_*` key that file could not carry.
+ *
+ * Three states: a valid value wins over the posture; a present-but-invalid one warns (once per distinct
+ * value) and is treated as absent, so a typo (meant to make logs louder) can never silently pin the
+ * level nor kill the posture default; absent leaves the posture. The warning is raw `console.error`
+ * because it is the logger reporting on its own gate, but reuses `format` for the same shape.
  */
-function parseEnvOverride(): LogLevel | undefined {
+let posture: LogLevel = "info";
+let warnedFor: string | undefined;
+
+function effectiveLevel(): LogLevel {
   const raw = process.env.FASTAGENT_LOG_LEVEL;
-  if (raw === undefined) return undefined;
+  if (raw === undefined) return posture;
   const value = raw.toLowerCase();
   if (isLevel(value)) return value;
-  console.error(format("warn", `[fastagent] unknown FASTAGENT_LOG_LEVEL "${raw}"; using the posture default`));
-  return undefined;
+  if (warnedFor !== raw) {
+    warnedFor = raw;
+    console.error(format("warn", `[fastagent] unknown FASTAGENT_LOG_LEVEL "${raw}"; using the posture default`));
+  }
+  return posture;
 }
 
-const override = parseEnvOverride();
-let currentLevel: LogLevel = override ?? "info";
-
-/** Set the posture default. A valid `FASTAGENT_LOG_LEVEL` override, if present, wins and is not changed. */
+/** Set the posture default. A valid `FASTAGENT_LOG_LEVEL` wins over it, whenever a line is emitted. */
 export function setLogLevel(level: LogLevel): void {
-  if (override === undefined) currentLevel = level;
+  posture = level;
 }
 
 const emit =
   (level: LogLevel) =>
   (msg: string): void => {
-    if (ORDER[level] >= ORDER[currentLevel]) console.error(format(level, msg));
+    if (ORDER[level] >= ORDER[effectiveLevel()]) console.error(format(level, msg));
   };
 
 /** The process logger. Runtime code imports this and calls `log.info(...)` etc. */

--- a/src/log.ts
+++ b/src/log.ts
@@ -40,15 +40,17 @@ export function createLogger(opts: { level: LogLevel; sink?: (line: string) => v
  *
  * Three states: a valid value wins over the posture; a present-but-invalid one warns (once per distinct
  * value) and is treated as absent, so a typo (meant to make logs louder) can never silently pin the
- * level nor kill the posture default; absent leaves the posture. The warning is raw `console.error`
- * because it is the logger reporting on its own gate, but reuses `format` for the same shape.
+ * level nor kill the posture default; absent leaves the posture. Empty is absent, matching
+ * `resolveOverridePath` — `KEY=` is how a `.env` parks a key it does not want set, not a typo to warn
+ * about. The warning is raw `console.error` because it is the logger reporting on its own gate, but
+ * reuses `format` for the same shape.
  */
 let posture: LogLevel = "info";
 let warnedFor: string | undefined;
 
 function effectiveLevel(): LogLevel {
   const raw = process.env.FASTAGENT_LOG_LEVEL;
-  if (raw === undefined) return posture;
+  if (!raw) return posture;
   const value = raw.toLowerCase();
   if (isLevel(value)) return value;
   if (warnedFor !== raw) {

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -78,12 +78,12 @@ describe("FASTAGENT_LOG_LEVEL override (read per emit)", () => {
   it("an invalid value warns once and falls back to the posture", () => {
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      vi.stubEnv("FASTAGENT_LOG_LEVEL", "trace");
+      vi.stubEnv("FASTAGENT_LOG_LEVEL", "verbose-typo"); // a value used nowhere else: the warn-once state is module-level and never reset
       setLogLevel("debug"); // the invalid value did not disable the posture default
       log.debug("[t] d2");
       log.debug("[t] d3");
       const lines = err.mock.calls.map((c) => String(c[0]));
-      expect(lines.filter((l) => /unknown FASTAGENT_LOG_LEVEL "trace"/.test(l))).toHaveLength(1);
+      expect(lines.filter((l) => /unknown FASTAGENT_LOG_LEVEL "verbose-typo"/.test(l))).toHaveLength(1);
       expect(lines.some((l) => l.includes("[t] d2"))).toBe(true);
     } finally {
       err.mockRestore();

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -52,22 +52,21 @@ describe("log singleton + setLogLevel", () => {
   });
 });
 
-describe("FASTAGENT_LOG_LEVEL override (parsed at module load)", () => {
-  // Each test re-imports a fresh log.ts so the load-time env parse runs under a stubbed value.
+describe("FASTAGENT_LOG_LEVEL override (read per emit)", () => {
+  // The env is stubbed AFTER log.ts is imported — the shape a `.secrets/.env` has (#451): the file lands
+  // in process.env long after every command module has pulled this one in.
   afterEach(() => {
     vi.unstubAllEnvs();
-    vi.resetModules();
+    setLogLevel("info"); // restore the default the other suites rely on
   });
 
-  it("a valid value locks the level — setLogLevel is a no-op", async () => {
-    vi.stubEnv("FASTAGENT_LOG_LEVEL", "error");
-    vi.resetModules();
-    const fresh = await import("../src/log.ts");
+  it("a valid value set after import wins over the posture", () => {
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      fresh.setLogLevel("debug"); // would normally show debug; the valid override wins
-      fresh.log.debug("[t] d");
-      fresh.log.error("[t] e");
+      setLogLevel("debug");
+      vi.stubEnv("FASTAGENT_LOG_LEVEL", "error");
+      log.debug("[t] d");
+      log.error("[t] e");
       const lines = err.mock.calls.map((c) => String(c[0]));
       expect(lines).toContain("ERROR [t] e");
       expect(lines.some((l) => l.includes("[t] d"))).toBe(false); // debug gated by the override
@@ -76,18 +75,16 @@ describe("FASTAGENT_LOG_LEVEL override (parsed at module load)", () => {
     }
   });
 
-  it("an invalid value warns at load and falls back to posture — setLogLevel still works", async () => {
-    vi.stubEnv("FASTAGENT_LOG_LEVEL", "trace");
-    vi.resetModules();
-    const err = vi.spyOn(console, "error").mockImplementation(() => {}); // before import — catch the load-time warn
+  it("an invalid value warns once and falls back to the posture", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      const fresh = await import("../src/log.ts");
-      expect(err.mock.calls.map((c) => String(c[0])).some((l) => /unknown FASTAGENT_LOG_LEVEL "trace"/.test(l))).toBe(
-        true,
-      );
-      fresh.setLogLevel("debug"); // the invalid value did not disable the posture default
-      fresh.log.debug("[t] d2");
-      expect(err.mock.calls.map((c) => String(c[0])).some((l) => l.includes("[t] d2"))).toBe(true);
+      vi.stubEnv("FASTAGENT_LOG_LEVEL", "trace");
+      setLogLevel("debug"); // the invalid value did not disable the posture default
+      log.debug("[t] d2");
+      log.debug("[t] d3");
+      const lines = err.mock.calls.map((c) => String(c[0]));
+      expect(lines.filter((l) => /unknown FASTAGENT_LOG_LEVEL "trace"/.test(l))).toHaveLength(1);
+      expect(lines.some((l) => l.includes("[t] d2"))).toBe(true);
     } finally {
       err.mockRestore();
     }

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -32,7 +32,7 @@ describe("createLogger", () => {
 });
 
 describe("log singleton + setLogLevel", () => {
-  // Assumes FASTAGENT_LOG_LEVEL is unset (an env override would win and skip setLogLevel by design).
+  // Assumes FASTAGENT_LOG_LEVEL is unset: a valid one wins at every emit and would gate these lines.
   it("setLogLevel moves the threshold; the singleton writes to stderr", () => {
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -70,6 +70,20 @@ describe("FASTAGENT_LOG_LEVEL override (read per emit)", () => {
       const lines = err.mock.calls.map((c) => String(c[0]));
       expect(lines).toContain("ERROR [t] e");
       expect(lines.some((l) => l.includes("[t] d"))).toBe(false); // debug gated by the override
+    } finally {
+      err.mockRestore();
+    }
+  });
+
+  it("an empty value is absent, not a typo — `KEY=` parks a key in a .env", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      vi.stubEnv("FASTAGENT_LOG_LEVEL", "");
+      setLogLevel("debug");
+      log.debug("[t] d4");
+      const lines = err.mock.calls.map((c) => String(c[0]));
+      expect(lines).toContain("DEBUG [t] d4"); // the posture applies
+      expect(lines.some((l) => /unknown FASTAGENT_LOG_LEVEL/.test(l))).toBe(false);
     } finally {
       err.mockRestore();
     }


### PR DESCRIPTION
Closes #451.

`src/log.ts` read `FASTAGENT_LOG_LEVEL` once at module scope. Every command module imports it transitively, so the read happened before any command reached `loadDotEnv` — the agent's `.secrets/.env` could never set the level, while the same line on the command line worked. `dev`'s watch worker was the accidental exception (the supervisor loads `.env` and the spawned worker's fresh import sees it), so `dev` and `dev --no-watch` logged at different levels from the same file.

The level is now resolved when a line is emitted: `setLogLevel` sets the posture, and a valid `FASTAGENT_LOG_LEVEL` wins over it at that moment. No command ordering contract is introduced, so `invoke`, `fire`, `chat` and `deploy` — which never set a posture — honour the file too. An invalid value still warns once per process and falls back to the posture.
