### PR TITLE
refactor(slack): one runtime group behavior; --group-behavior is the app's scopes only

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -166,7 +166,6 @@ export default slackChannel({
   botTokenExpiresAt: process.env.SLACK_BOT_TOKEN_EXPIRES_AT
     ? Number(process.env.SLACK_BOT_TOKEN_EXPIRES_AT)
     : undefined,
-  groupBehavior: "context", // default; choose "mentions" only for explicit least privilege
   rendering: "native", // Slack Agent stream with inline tool traces; "classic" for compatibility
   // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
   // No session modes: an answer attaches to its question with a thread (Slack has no quote primitive),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -259,8 +259,8 @@ intentionally disable one, rename it to e.g. `channels/telegram.ts.disabled`; ch
 are the enable/disable source of truth.
 
 Slack scaffolds `channels/slack.ts` plus `tools/slack-send.ts`; `--group-behavior context|mentions`
-selects both runtime policy and manifest scopes/events, defaulting to context-aware `context`; choose
-`mentions` explicitly for least privilege. By default it opens Slack's App Configuration Token page,
+selects the created app's manifest scopes/events (the runtime has one behavior; it hears what the app
+is allowed to), defaulting to context-aware `context`; choose `mentions` explicitly for least privilege. By default it opens Slack's App Configuration Token page,
 creates a new internal app with `agent_view`, native Agent streaming, and suggested prompts through
 `apps.manifest.create`, installs it
 through OAuth, and writes rotating bot credentials + the Signing Secret to `.secrets/.env`. The configuration refresh token stays owner-readable

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -114,18 +114,19 @@ narrowed — it must be the same place and the place's own session — which onl
 record, never a participant one with humans missing.)
 
 That condition is built from STRUCTURAL facts only — is this a group? is this a thread? — and never
-from configuration. A group-behaviour setting or the presence of a custom route is the tempting gate,
-since nothing reads participation without them, but configuration changes while records outlive the
-change: gate on it, switch back, and `agentSpoke` is still on disk with the humans of the intervening
-window missing. Both channels therefore record in postures where no rule will read the result. The
-condition is the same in both: a group thread, whatever the posture. Unread records are harmless:
+from configuration. Feishu's group-behaviour setting or the presence of a custom route is the tempting
+gate, since nothing reads participation without them, but configuration changes while records outlive
+the change: gate on it, switch back, and `agentSpoke` is still on disk with the humans of the
+intervening window missing. Both channels therefore record in postures where no rule will read the
+result. The condition is the same in both: a group thread, whatever the posture. Unread records are harmless:
 they cost two ids, and the cap evicts bystander threads
 (ones the agent has only listened to) before threads it takes part in, so listening traffic can never
 push out a thread being served.
 
 The cost runs both ways, and the second direction is not free. A record is only as complete as the
-channel's hearing when it was written: an agent answering a mention in a restricted posture (Slack
-`mentions`, Feishu without `im:message.group_msg`) records itself plus the human who summoned it, while
+channel's hearing when it was written: an agent answering a mention in a restricted posture (a Slack
+app created without the history scopes, Feishu without `im:message.group_msg`) records itself plus the
+human who summoned it, while
 everyone else's bare messages in that thread are never delivered. Widen the posture later and the thread
 reads "participant + one human" though it holds several. That is accepted rather than defended against —
 the failure is one unwanted reply, it corrects itself the moment a second human speaks, and detecting it

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -14,12 +14,11 @@ The first-party Slack channel uses Slack's [HTTP Events API](https://docs.slack.
 fastagent add slack
 ```
 
-Choose one group behavior:
-
-| Mode | Group behavior | Additional access |
-|---|---|---|
-| `context` (default) | Explicit mentions, bare replies in threads the Agent takes part in, and recent unsummoned discussion | Channel/private-channel/MPIM history events and scopes |
-| `mentions` | Explicit `app_mention` only; no bare continuation or background context | Least privilege |
+`--group-behavior context|mentions` decides what the created app is allowed to hear. `context`
+(default) subscribes the channel/private-channel/MPIM message streams, which is what lets the Agent
+take part in a thread and read recent discussion ([Group context](#group-context)). `mentions` asks for
+`app_mention` and DMs only — least privilege, for a workspace that will not approve an app reading
+channel history. The runtime has one behavior either way; what differs is which events Slack delivers.
 
 The command creates:
 
@@ -87,10 +86,10 @@ files:write
 reactions:write
 ```
 
-Context mode additionally needs `channels:history`, `groups:history`, and `mpim:history`. Native mode
+A `context` app additionally needs `channels:history`, `groups:history`, and `mpim:history`. Native mode
 requires `assistant:write` and the **Agents** feature with the Agent messaging experience (`agent_view`);
 a manually configured classic-only app may omit those two Agent capabilities. Subscribe `app_home_opened`,
-`app_context_changed`, `app_mention`, and `message.im`; context mode additionally subscribes
+`app_context_changed`, `app_mention`, and `message.im`; a `context` app additionally subscribes
 `message.channels`, `message.groups`, and `message.mpim`. Set `https://<host>/slack` under Event
 Subscriptions while FastAgent is running,
 then put the Bot Token and Signing Secret in `.env`. Without local onboarding state, tunnel/deploy commands
@@ -112,7 +111,6 @@ export default slackChannel({
   botTokenExpiresAt: process.env.SLACK_BOT_TOKEN_EXPIRES_AT
     ? Number(process.env.SLACK_BOT_TOKEN_EXPIRES_AT)
     : undefined,
-  groupBehavior: "context", // default; choose "mentions" only for explicit least privilege
   rendering: "native", // native Agent stream with inline tool traces; "classic" is the compatibility renderer
   // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
   // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: generic)
@@ -139,8 +137,8 @@ The default route answers:
 
 - every human `message.im` DM;
 - human `app_mention` events in channels;
-- in context mode, unmentioned human replies in a thread the Agent takes part in while exactly one
-  human does (see [Group context](#group-context)).
+- unmentioned human replies in a thread the Agent takes part in while exactly one human does (see
+  [Group context](#group-context)) — an event the app receives only with the group message subscriptions.
 
 Bot messages, edits, deletes, hidden events, and service subtypes are ignored. `file_share` and
 `thread_broadcast` are new human content and remain eligible. Overlapping `app_mention` and `message.*`
@@ -171,7 +169,7 @@ custom route is then the complete authority.
 
 ## Group context
 
-In context mode the Agent behaves as a participant of the channel
+Given the group message subscriptions (the default app), the Agent behaves as a participant of the channel
 ([design note](design/participant-model.md)): it answers a bare message in a thread while it takes part
 and **has not heard a second human** there. Mentioning it inside a thread is the bootstrap — it answers,
 which makes it a participant, and later bare replies reach it without the name. When a second person
@@ -197,8 +195,9 @@ The next answered turn in that place receives a bounded sender-prefixed block. C
 3. commit exactly that snapshot only when the Agent emits `completed`;
 4. retain it on failure/crash, and retain messages that arrive while the turn is running.
 
-This mode deliberately lets the app read messages in channels where it is installed. Use `mentions` when
-that permission or retention boundary is inappropriate. State is local to the deployment and gitignored
+This deliberately lets the app read messages in channels where it is installed. Create the app with
+`--group-behavior mentions` when that permission or retention boundary is inappropriate: without the
+history subscriptions none of the above ever fires. State is local to the deployment and gitignored
 from git, but operators still own retention/privacy policy.
 
 ## Inbound files
@@ -319,12 +318,11 @@ Slack state lives under:
 
 `thread-participants.json` records what the Agent HEARD in each group thread — the humans it saw speak
 (capped at two, since the rule only asks whether a second one exists) and whether it has answered
-there. It is written for **every group thread the channel can see, in every posture** — including
-`groupBehavior: "mentions"` and behind a custom route, where the summon rule never reads it. That is
-deliberate: the posture is configuration and a record outlives a change to it, so gating the write
-would leave a thread marked as answered-in while the humans who spoke during the intervening window
-went unrecorded, and the Agent would then speak into a crowd. Deleting the file is safe; each thread
-then costs one mention to re-enter.
+there. It is written for **every group thread the channel can see**, including behind a custom route,
+where the summon rule never reads it: a route is configuration and the record outlives a change to it,
+so gating the write would leave a thread marked as answered-in while the humans who spoke in the
+intervening window went unrecorded, and the Agent would then speak into a crowd. Deleting the file is
+safe; each thread then costs one mention to re-enter.
 
 The onboarded App Manifest enables Slack token rotation. Before expiry, the runtime exchanges the bot
 refresh token, atomically persists the replacement pair in `bot-auth.json`, and uses that durable pair on

--- a/src/channels/slack/scaffold/channel.ts
+++ b/src/channels/slack/scaffold/channel.ts
@@ -19,7 +19,6 @@ export default slackChannel({
   botTokenExpiresAt: process.env.SLACK_BOT_TOKEN_EXPIRES_AT
     ? Number(process.env.SLACK_BOT_TOKEN_EXPIRES_AT)
     : undefined,
-  groupBehavior: "context", // default; use "mentions" only for an explicit least-privilege setup
   // Slack Agent stream; its inline tool traces show each call's first argument and stay in the
   // delivered message. "classic" settles into the answer alone (and gives up native streaming).
   rendering: "native",

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -112,11 +112,6 @@ export interface SlackChannelOptions {
   clientId?: string;
   clientSecret?: string;
   botTokenExpiresAt?: number;
-  /** `context` (default) subscribes to group message streams, which is what lets the channel HEAR a
-   * thread: bare replies are then admitted by the participation rule (design/participant-model.md §3),
-   * and other discussion is buffered. `mentions` answers only app_mention plus DMs for an explicit
-   * least-privilege setup. */
-  groupBehavior?: "context" | "mentions";
   /** `native` (default) uses Slack Agent streams for threaded replies. Its inline tool traces carry a
    * bounded summary of each call's first argument and cannot be retracted, so they stay in the
    * delivered message beside the answer. `classic` retains the compatibility renderer based on one
@@ -172,7 +167,6 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
     clientId,
     clientSecret,
     botTokenExpiresAt,
-    groupBehavior = "context",
     rendering = "native",
     aiDisclaimer,
     welcome = DEFAULT_WELCOME,
@@ -182,9 +176,6 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
     apiBaseUrl = "https://slack.com/api",
   } = options;
 
-  if (!(["context", "mentions"] as const).includes(groupBehavior)) {
-    throw new Error('slackChannel groupBehavior must be "context" or "mentions"');
-  }
   if (!(["native", "classic"] as const).includes(rendering)) {
     throw new Error('slackChannel rendering must be "native" or "classic"');
   }
@@ -409,7 +400,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
       // Listening is not speaking: every message the channel can see refines who takes part in its
       // thread, whether or not it is answered. Humans only — a bot's own posts are recorded where they
       // are known — this channel answering.
-      // Structural facts only, never `groupBehavior` or `route` — see thread-participants.ts. Slack
+      // Structural facts only, never `route` — see thread-participants.ts. Slack
       // adds no delta of its own here; its summon rule is the only consumer.
       if (group && event.thread_ts !== undefined) {
         threadParticipants.merge(threadKey(teamId, event.channel, event.thread_ts), { humans: [event.user] });
@@ -432,7 +423,6 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
       // store cannot know about someone it has never heard.
       if (
         !routed &&
-        groupBehavior === "context" &&
         route === undefined &&
         group &&
         event.thread_ts !== undefined &&
@@ -446,7 +436,7 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
       }
       if (!routed) {
         if (route === undefined && group && botUserId === undefined && mightBeTheBot) return;
-        if (groupBehavior === "context" && route === undefined && group) {
+        if (route === undefined && group) {
           const body = slackBufferText(slackMessageText(event));
           if (body) {
             const fileIds = slackFileIds(event);

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -64,7 +64,7 @@ export async function runAddChannel(
     console.error(`[fastagent] ${relative(target, file)} already exists — keeping it`);
   } else {
     await assertChannelReady(target).catch(failStartup);
-    await scaffoldChannel(target, channelKind, { ingress, groupBehavior: groupBehavior.behavior }).catch(failStartup);
+    await scaffoldChannel(target, channelKind, { ingress }).catch(failStartup);
     console.error(`[fastagent] created ${relative(target, file)}`);
   }
   // Companion tools are the package's, not authored glue: written on every add, so an upgraded

--- a/src/deploy/channel-ingress.ts
+++ b/src/deploy/channel-ingress.ts
@@ -89,7 +89,7 @@ const INGRESS: Record<ChannelKind, ChannelIngress> = {
     manual: (baseUrl) => `slack: set Event Subscriptions → Request URL → ${baseUrl}/slack`,
     runbook: (baseUrl) => [
       `# Set Slack Event Subscriptions → Request URL (default route POST /slack; the running service`,
-      `# answers Slack's challenge), and match scopes/subscriptions to channels/slack.ts groupBehavior:`,
+      `# answers Slack's challenge), and match scopes/subscriptions to the app \`add slack --group-behavior\` created:`,
       `#   Request URL = ${baseUrl}/slack`,
     ],
   },

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -394,7 +394,7 @@ export async function channelExists(dir: string, kind: ChannelKind): Promise<boo
 export async function scaffoldChannel(
   dir: string,
   kind: ChannelKind,
-  options: { ingress?: FeishuSubscriptionMode; groupBehavior?: GroupBehavior } = {},
+  options: { ingress?: FeishuSubscriptionMode } = {},
 ): Promise<string> {
   const channelsDir = join(dir, "channels");
   // Don't write through a channels/ symlink that escapes the agent dir; one inside it is fine.
@@ -432,11 +432,6 @@ export async function scaffoldChannel(
           !line.includes(`encryptKey: process.env.${prefix}_ENCRYPT_KEY`),
       )
       .join("\n");
-    content = configured;
-  }
-  if (kind === "slack" && options.groupBehavior === "mentions") {
-    const configured = content.replace('groupBehavior: "context"', 'groupBehavior: "mentions"');
-    if (configured === content) throw new Error("slack channel template has no groupBehavior anchor");
     content = configured;
   }
   await writeFile(file, content, { flag: "wx" });

--- a/test/add-channel-env.test.ts
+++ b/test/add-channel-env.test.ts
@@ -55,13 +55,8 @@ describe("channel setup guidance", () => {
     await writeFile(join(dir, "tools", "slack-send.ts"), "// 0.20.0: process.env.SLACK_BOT_TOKEN");
     await scaffoldCompanionTools(dir, "slack");
     const source = await readFile(join(dir, "channels", "slack.ts"), "utf8");
-    expect(source).toContain('groupBehavior: "context"');
     expect(source).toContain('rendering: "native"');
     expect(await readFile(join(dir, "tools", "slack-send.ts"), "utf8")).toContain("slackTransport(ctx.cwd)");
-
-    const mentionsDir = await mkdtemp(join(tmpdir(), "fa-slack-mentions-scaffold-"));
-    await scaffoldChannel(mentionsDir, "slack", { groupBehavior: "mentions" });
-    expect(await readFile(join(mentionsDir, "channels", "slack.ts"), "utf8")).toContain('groupBehavior: "mentions"');
   });
 
   it("WebSocket setup needs only App ID/Secret and writes the WebSocket factory into the scaffold", async () => {

--- a/test/slack-proactive-send.test.ts
+++ b/test/slack-proactive-send.test.ts
@@ -88,7 +88,6 @@ function mountChannel(stateRoot: string, expiresAt: number) {
     clientId: "SYNTHETIC-CLIENT",
     clientSecret: "SYNTHETIC-SECRET",
     botTokenExpiresAt: expiresAt,
-    groupBehavior: "mentions",
     welcome: false,
     reactionAck: false,
   })({ stateRoot, agent })["POST /slack"]!;

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -441,21 +441,18 @@ describe("Slack sessions, context, and thread participation", () => {
     expect(calls).toHaveLength(2);
   });
 
-  it("records participation even where no rule reads it, so a posture change cannot leave a gap", async () => {
+  it("records a second human who summons it by mention, so it does not barge into a crowd later", async () => {
     vi.stubGlobal("fetch", okFetch());
     const { agent, calls } = replyingAgent();
-    const { handler, stateRoot } = mount(agent, { groupBehavior: "mentions" });
+    const { handler, stateRoot } = mount(agent);
     await new Promise((resolve) => setImmediate(resolve));
 
     await handler(signedRequest(message("30.1", { type: "app_mention", text: "<@UBOT> hi", thread_ts: "30.0" })));
     await settle();
     expect(calls).toHaveLength(1);
-    // A second human summons it in the same thread — an `app_mention`, which IS delivered under
-    // `mentions` (a bare channel message is not, which is why the posture's under-count is documented
-    // as accepted in §3 rather than defended against here). Nothing reads participation in this
-    // posture, but the posture is configuration and this record outlives a change to it: skipping the
-    // write would leave `agentSpoke` on disk with U2 missing, and after a switch back to `context` the
-    // agent would barge into a thread it believes is two-party.
+    // A second human summons it by `app_mention` — the one group event a mention-only app (no history
+    // scopes) still receives. Their presence must be recorded off that event too, or the thread would
+    // read as two-party with U2 missing.
     await handler(
       signedRequest(message("30.2", { user: "U2", type: "app_mention", text: "<@UBOT> and also", thread_ts: "30.0" })),
     );
@@ -470,7 +467,7 @@ describe("Slack sessions, context, and thread participation", () => {
   it("a bare reply reaches the agent in a thread it answered in, while one human is in it", async () => {
     vi.stubGlobal("fetch", okFetch());
     const { agent, calls } = replyingAgent();
-    const { handler } = mount(agent, { groupBehavior: "context" });
+    const { handler } = mount(agent);
     await new Promise((resolve) => setImmediate(resolve));
 
     // Mentioning it inside a thread is the bootstrap: it answers, which makes it a participant.
@@ -489,7 +486,7 @@ describe("Slack sessions, context, and thread participation", () => {
   it("a bare message that mentions only other people is discussion, not an ask", async () => {
     vi.stubGlobal("fetch", okFetch());
     const { agent, calls } = replyingAgent();
-    const { handler, stateRoot } = mount(agent, { groupBehavior: "context" });
+    const { handler, stateRoot } = mount(agent);
     await new Promise((resolve) => setImmediate(resolve));
     await handler(signedRequest(message("14.1", { type: "app_mention", text: "<@UBOT> hi", thread_ts: "14.0" })));
     await settle();
@@ -524,7 +521,7 @@ describe("Slack sessions, context, and thread participation", () => {
       ),
     );
     const { agent, calls } = replyingAgent();
-    const { handler, stateRoot } = mount(agent, { groupBehavior: "context" });
+    const { handler, stateRoot } = mount(agent);
 
     await handler(signedRequest(message("50.1", { text: "<!here> standup in five" })));
     await settle();
@@ -536,7 +533,7 @@ describe("Slack sessions, context, and thread participation", () => {
   it("the labelled mention form counts too, on both sides of the guard", async () => {
     vi.stubGlobal("fetch", okFetch());
     const { agent, calls } = replyingAgent();
-    const { handler, stateRoot } = mount(agent, { groupBehavior: "context" });
+    const { handler, stateRoot } = mount(agent);
     await new Promise((resolve) => setImmediate(resolve));
 
     // `<@UBOT|agent>` is a summon, not background text.
@@ -567,7 +564,7 @@ describe("Slack sessions, context, and thread participation", () => {
   it("a top-level ask counts as heard in the thread the answer creates, so a stranger's reply does not summon", async () => {
     vi.stubGlobal("fetch", okFetch());
     const { agent, calls } = replyingAgent();
-    const { handler, stateRoot } = mount(agent, { groupBehavior: "context" });
+    const { handler, stateRoot } = mount(agent);
     await new Promise((resolve) => setImmediate(resolve));
 
     // U1 asks at CHANNEL top level: the ask carries no thread_ts, so the observation on the way in
@@ -587,7 +584,7 @@ describe("Slack sessions, context, and thread participation", () => {
   it("a second human in the thread restores the mention requirement, and the agent keeps listening", async () => {
     vi.stubGlobal("fetch", okFetch());
     const { agent, calls } = replyingAgent();
-    const { handler, stateRoot } = mount(agent, { groupBehavior: "context" });
+    const { handler, stateRoot } = mount(agent);
     await new Promise((resolve) => setImmediate(resolve));
 
     await handler(signedRequest(message("10.1", { type: "app_mention", text: "<@UBOT> inspect", thread_ts: "10.0" })));
@@ -620,7 +617,7 @@ describe("Slack sessions, context, and thread participation", () => {
     const fetchMock = okFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { agent, calls } = replyingAgent();
-    const { handler } = mount(agent, { groupBehavior: "context" });
+    const { handler } = mount(agent);
     await new Promise((resolve) => setImmediate(resolve));
 
     // Slack has no quote primitive, so answering in place means opening a thread on the ask — and the
@@ -636,23 +633,6 @@ describe("Slack sessions, context, and thread participation", () => {
     await settle();
     expect(calls).toHaveLength(2);
     expect(calls[1]?.scope.session).toBe("slack:T1:C1:20.0");
-  });
-
-  it("keeps mention-only mode available explicitly without buffering group traffic", async () => {
-    vi.stubGlobal("fetch", okFetch());
-    const { agent, calls } = replyingAgent();
-    const { handler, stateRoot } = mount(agent, { groupBehavior: "mentions" });
-    await new Promise((resolve) => setImmediate(resolve));
-
-    await handler(signedRequest(message("1.0", { text: "background" })));
-    await handler(signedRequest(message("2.0", { type: "app_mention", text: "<@UBOT> answer" })));
-    await settle();
-    await handler(signedRequest(message("3.0", { text: "bare reply", thread_ts: "2.0" })));
-    await settle();
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.prompt.text).not.toContain("background");
-    expect(() => readFileSync(join(stateRoot, "channels", "slack", "buffers.json"), "utf8")).toThrow();
   });
 
   it("persists a turn before ACK and uses only Slack file IDs in the intent", async () => {


### PR DESCRIPTION
## Summary

`slackChannel` had a `groupBehavior: "context" | "mentions"` option mirroring the `add slack --group-behavior` choice. The two are not the same decision. The CLI flag decides what the created app is **allowed to hear** (`channels:history`/`groups:history`/`mpim:history` and the `message.channels|groups|mpim` subscriptions) — a real choice, because a workspace admin sees it at install time. The runtime option only gated the thread-participation rule and the context buffer, both of which fire on exactly the events those scopes deliver: without them nothing arrives, and the gates were never reached.

So the runtime keeps one behavior and the option is gone:

- `slackChannel`: `groupBehavior` removed, with its validation and its two conditions in `acceptEvent`.
- Scaffold and docs drop the line; `--group-behavior` is documented as the app's scopes/events.
- Tests: the mention-only runtime posture test is deleted (there is no runtime posture); the participation-record test keeps its assertion — a second human summoning by `app_mention` is recorded — with its reason restated.

Onboarding state, the manifest and `register-webhook` still carry `groupBehavior`: that is the app's scope set, which is what a reinstall must preserve.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Added or updated the smallest relevant tests

## Checklist

- [x] The PR carries a label — from the branch prefix, or added by hand
- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added (`*_PLAN.md`, `HANDOFF.md`, session notes, etc.)
- [x] Docs were updated when behavior or public APIs changed
