### PR TITLE
chore(pi): upgrade to 0.85.1

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -631,19 +631,18 @@ id holding a different history rejects `invalid_command`. Cloning is `fork` at t
 session's live `events()` streams; it is guarded by the same bearer token as every other call, which
 is the only key the framework owns.
 
-Overrides persist in the session record and every later turn's fresh session binding applies them — on any
-serving path, channels included. One exception: a recorded thinking level the session's CURRENT
-model cannot do is clamped by pi's own clamp instead of riding a run that would ignore it. The clamp
-happens where the pair is RESOLVED (`resolveSessionSettings`), not by rewriting the journal — the
-recorded level is the user's preference and returns when the session moves back to a capable model —
-so `state()` and the execution agree and the client gets the clamped level in the same
-`state_changed`; the resolve keeps clamping as a BACKSTOP for what the boundary cannot
-see (a deployment whose CONFIGURED model changed between restarts), and there it warns server-side
-while `state()` reports the recorded level. Note the clamp's direction: it takes the lowest supported
-level at or above the recorded one and only falls back downward if nothing above exists — a gap
-resolves upward, which costs more, not less. Writes require an EXISTING session (`no_such_session`
-otherwise): sessions are created by `invoke` or copied by `fork`, never minted by an update. Invalid
-payloads reject `invalid_command` before acceptance. `capabilities()` lists `allowedModels` (the
+Overrides persist in the session record and every later turn's fresh session binding applies them on any
+serving path, channels included. `resolveSessionSettings` clamps both recorded thinking levels and
+configured defaults to the current model's capabilities using pi's own clamp. Defaults apply when the
+active path has no valid thinking override, including after navigation removes one. The journal keeps
+the recorded preference, which returns when the session moves back to a capable model. `state()`,
+`state_changed`, and execution use the same resolved level, including after a deployment changes the
+configured model. The clamp takes the lowest supported level at or above the requested one and falls
+back downward only if nothing above exists; filling a gap can increase reasoning cost.
+
+Writes require an existing session (`no_such_session` otherwise): sessions are created by `invoke` or
+copied by `fork`, never minted by an update. Invalid payloads reject `invalid_command` before acceptance.
+`capabilities()` lists `allowedModels` (the
 deployment's registry — a static fact) but not thinking LEVELS: which exist depends on the model a
 session is running, so they ride `state().availableThinkingLevels`, and `update({ thinkingLevel })`
 validates against that same set rather than recording an override the run would ignore. Every write

--- a/docs/design/session-control.md
+++ b/docs/design/session-control.md
@@ -712,10 +712,10 @@ What each part of the plane settled on, where the reason is not obvious from the
 - **Boundary mutations under the lease.** `update({ model | thinkingLevel })` appends durable session
   overrides, validated against the registry and the MODEL's own thinking levels (`reasoning` +
   `thinkingLevelMap`, not the bare scale; `invalid_command` before acceptance). The per-invoke resolve
-  (`resolveSessionSettings`) applies them on every later turn; a registry change across deploys falls
-  back to the default with a deduped warn instead of bricking the session. `state()`, the update gate
-  and the per-invoke binding all read that ONE resolution — model and thinking level are one setting,
-  so deriving them separately is what let the surfaces disagree.
+  (`resolveSessionSettings`) applies them on every later turn and clamps both recorded and configured
+  thinking levels to the selected model's capabilities. A recorded model absent from the registry
+  resolves to the configured default. `state()`, the update gate, and the per-invoke binding all read
+  that same resolution, including when navigation removes a thinking override.
 - **`compact` is accept-fast.** §5.2 has no exceptions: a summarization is a full model call, so the
   dispatch answers on admission (lease held, session bound) and the outcome travels as
   `compaction_finished{summary|error|aborted}`, emitted after the lease frees. Pre-acceptance failures

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -27,7 +27,5 @@
     "src/deploy/agentcore/forwarder.js",
     "test/fixtures/**"
   ],
-  // pi-coding-agent's SDK imports pi-server without declaring it (earendil-works/pi#9132).
-  "ignoreDependencies": ["@earendil-works/pi-server"],
   "ignoreBinaries": ["fastagent", "cloudflared"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",
-        "@earendil-works/pi-agent-core": "^0.85.0",
-        "@earendil-works/pi-ai": "^0.85.0",
-        "@earendil-works/pi-coding-agent": "^0.85.0",
-        "@earendil-works/pi-server": "^0.85.0",
+        "@earendil-works/pi-agent-core": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
         "@hono/node-server": "^2.1.1",
         "@larksuiteoapi/node-sdk": "^1.71.1",
         "@octokit/webhooks-methods": "^6.0.0",
@@ -711,9 +710,9 @@
       }
     },
     "node_modules/@earendil-works/chord": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.0.tgz",
-      "integrity": "sha512-m/eFMaUg2gFUqEqzffgt/d3xPNKEvD++NZrYDBqpCEc2/dqMoS13Pdx/tofe8t5/DHgnzHxlRQFD5bLPUdPmvw==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
+      "integrity": "sha512-VDlkEC3dhCzQ5fcyH1OhG19dq+6jCn+rqc/iXFivwDYGR5anwo2RCiXij9PpHhqNR5GuhhE+Er69Zi1Sn4eY6w==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "0.28.1"
@@ -723,14 +722,14 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.0.tgz",
-      "integrity": "sha512-uOvSDEG5B/P1mpxnuXCkvlvEKcFpyQ9qgCB2r+LY3YTko996iCCq6OEUWk/Af4xCPXx92Pj73ilNoYa40M7EQg==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
+      "integrity": "sha512-hIXIP3eAWueAYiAl8aMvWCvvZ8Q5gT3Dip5bE5uJyIGh4+YlWRjtMLI4BaeoXoSs93zndjue61u1B/vhefLnuA==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/chord": "^0.85.0",
-        "@earendil-works/pi-ai": "^0.85.0",
-        "@earendil-works/pi-telemetry": "^0.85.0",
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -750,14 +749,14 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.0.tgz",
-      "integrity": "sha512-CbeeZH3NHav7Rs182tYq0eoCAWfDd1MvOAXKzonIF4uN3uO99EB8iT1HfyGofJmPkAf8MeIwOBQtqqd0zgrPWA==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.85.0",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
@@ -774,18 +773,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.85.0.tgz",
-      "integrity": "sha512-INxVkLAVfAMju5MojJpmyu/0bMP+r+ffZuS7UqVv32E2JwHBRbcHfELDfmFNvapEbgYfKN2r9OYO1p3TqDBR+g==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.85.1.tgz",
+      "integrity": "sha512-FGRN+OHbWaefBPGaTggAdLjrIHW+s2PzLyglz/5dfLzb9of7uuXMXYC0fJIeZTw+shS32o2cuQ9jF7YSDuL/oQ==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/chord": "^0.85.0",
-        "@earendil-works/pi-agent-core": "^0.85.0",
-        "@earendil-works/pi-ai": "^0.85.0",
-        "@earendil-works/pi-client": "^0.85.0",
-        "@earendil-works/pi-protocol": "^0.85.0",
-        "@earendil-works/pi-tui": "^0.85.0",
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-agent-core": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-tui": "^0.85.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1249,8 +1246,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/chord": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.0.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
       "license": "MIT",
       "dependencies": {
         "esbuild": "0.28.1"
@@ -1260,13 +1257,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.0.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/chord": "^0.85.0",
-        "@earendil-works/pi-ai": "^0.85.0",
-        "@earendil-works/pi-telemetry": "^0.85.0",
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1277,13 +1274,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.0.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.85.0",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
@@ -1299,41 +1296,17 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.85.0.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/chord": "^0.85.0",
-        "@earendil-works/pi-protocol": "^0.85.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.85.0.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/chord": "^0.85.0",
-        "typebox": "1.3.7"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.0.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.85.0.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.85.1.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -3027,37 +3000,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/@earendil-works/pi-protocol": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.85.0.tgz",
-      "integrity": "sha512-knPb0QeV6/1K6t9X6K4Wri9ZOlhqnGx1HYRy2N7x5ZEU7zcYDlR0oSfgbrsmMFmJJal5DZ9Q2HjekayjssKCVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/chord": "^0.85.0",
-        "typebox": "1.3.7"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-server": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-server/-/pi-server-0.85.0.tgz",
-      "integrity": "sha512-S8a6a26TM40C7WInj7bNu+HLbVMGosg4gRo2jB5yw0mH1TZ6HHKMxT2YDJpDpnSyGmCwEPj5GBG2sG1jbthWrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/chord": "^0.85.0",
-        "@earendil-works/pi-agent-core": "^0.85.0",
-        "@earendil-works/pi-protocol": "^0.85.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.0.tgz",
-      "integrity": "sha512-gs8Zq1lySn8liq7U7CCSgWHJcA8c6+ZWk+CBPp7w0K+SN5LcLcsbs3+bh7zipm4CqNkVhcpwGAEGJp7qZqsVnA==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -106,10 +106,9 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.6.0",
-    "@earendil-works/pi-agent-core": "^0.85.0",
-    "@earendil-works/pi-ai": "^0.85.0",
-    "@earendil-works/pi-coding-agent": "^0.85.0",
-    "@earendil-works/pi-server": "^0.85.0",
+    "@earendil-works/pi-agent-core": "^0.85.1",
+    "@earendil-works/pi-ai": "^0.85.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
     "@hono/node-server": "^2.1.1",
     "@larksuiteoapi/node-sdk": "^1.71.1",
     "@octokit/webhooks-methods": "^6.0.0",

--- a/src/engines/pi/session-settings.ts
+++ b/src/engines/pi/session-settings.ts
@@ -66,7 +66,7 @@ export interface SessionSettings {
   thinkingLevel: ThinkingLevel;
   /** What `update({ thinkingLevel })` accepts for this session. */
   availableThinkingLevels: string[];
-  /** Recorded but not honored — only the execution path reports it (as a warn). */
+  /** Recorded overrides that could not be applied. */
   dropped?: { model?: string; thinkingLevel?: { recorded: string; running: string; known: boolean } };
 }
 
@@ -88,7 +88,7 @@ export function resolveSessionSettings(
   }
 
   const availableThinkingLevels = getSupportedThinkingLevels(model) as string[];
-  let thinkingLevel = defaults.thinkingLevel;
+  let thinkingLevel = clampThinkingLevel(model, defaults.thinkingLevel) as ThinkingLevel;
   if (recorded.thinkingLevel !== undefined) {
     const level = recorded.thinkingLevel;
     if (!THINKING_LEVELS.has(level as ThinkingLevel)) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -166,6 +166,7 @@ describe("config: listModels (fastagent models discovery)", () => {
     }
     expect(specs).toEqual([...specs].sort()); // sorted
     expect(specs).toContain("openai-codex/gpt-5.5"); // the spec used across the repo
+    expect(specs).toEqual(expect.arrayContaining(["openai/gpt-6-astra", "openai-codex/gpt-6-astra"]));
   });
 });
 

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -19,6 +19,8 @@ import {
 } from "../src/engines/pi/session-control.ts";
 import { type PiSessionRecordStore, piInMemorySessionRecordStore } from "../src/engines/pi/session-store.ts";
 import { activePath, resolveSessionSettings } from "../src/engines/pi/session-settings.ts";
+import { piAgentSessionFactory } from "../src/engines/pi/agent-session-factory.ts";
+import { createPiModelRuntime } from "../src/engines/pi/models.ts";
 import { fauxAgent, fauxControlledAgent } from "./agent.ts";
 import { createPiAgentFromDir } from "../src/engines/pi/open.ts";
 import {
@@ -1090,6 +1092,60 @@ describe("session control: boundary mutations", () => {
     const record = { getBranch: () => cut } as unknown as Parameters<typeof activePath>[0];
     expect(() => activePath(record)).toThrow(/missing from the journal/);
   });
+
+  it.each([
+    ["openai", "off"],
+    ["openai", "minimal"],
+    ["openai-codex", "off"],
+  ] as const)(
+    "%s Astra state matches execution after navigation restores the %s default",
+    async (provider, thinkingLevel) => {
+      const { mkdtemp, rm } = await import("node:fs/promises");
+      const { tmpdir } = await import("node:os");
+      const { join } = await import("node:path");
+      const cwd = await mkdtemp(join(tmpdir(), "fa-astra-thinking-"));
+      try {
+        const modelRuntime = await createPiModelRuntime({ authPath: join(cwd, "auth.json") });
+        const model = modelRuntime.getModel(provider, "gpt-6-astra")!;
+        expect(model).toBeDefined();
+        const sessions = piInMemorySessionRecordStore({ cwd });
+        const sessionFactory = piAgentSessionFactory({
+          sessions,
+          engine: async () => ({ modelRuntime, model }),
+          thinkingLevel,
+          tools: [],
+          cwd,
+          readDefinition: () => ({ systemPrompt: "test", skills: [] }),
+        });
+        const { control } = createPiSessionControl({
+          sessions,
+          boundary: {
+            lease: inProcessLease(),
+            models: modelRuntime,
+            sessionFactory,
+            defaults: { model, thinkingLevel },
+          },
+        });
+        const initial = await sessionFactory("astra");
+        initial.dispose();
+        const handle = control.sessions.get("astra");
+        const { entries } = await handle.entries();
+        const modelEntry = entries.find((entry) => entry.kind === "model_change")!;
+        expect(modelEntry).toBeDefined();
+        expect(await handle.update({ leafEntryId: modelEntry.id })).toEqual({ ok: true });
+        const reported = await handle.state();
+        const rebound = await sessionFactory("astra");
+        try {
+          expect(reported.thinkingLevel).toBe(rebound.thinkingLevel);
+          expect(reported.availableThinkingLevels).toContain(reported.thinkingLevel);
+        } finally {
+          rebound.dispose();
+        }
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("the resolve still clamps as a BACKSTOP — the case the boundary cannot see", () => {
     const { faux, models } = makeFaux({ models: [{ id: "thinker", reasoning: true }, { id: "plain" }] });


### PR DESCRIPTION
## Summary

- Upgrade the pi dependency group to 0.85.1 and remove the pi-server dependency and Knip exception. The supported SDK imports without the experimental client/server dependency tree.
- Clamp configured thinking defaults to the selected model capabilities so session state and execution agree after navigation removes a recorded override. Keep recorded preferences intact and document the shared resolution behavior.
- Verify OpenAI and Codex Astra discovery and cover unsupported defaults through real session binding.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (120 files, 1,701 tests)
- [x] `npm run build`
- [x] Fresh tarball installation: all public imports, Astra discovery, CLI version, and absence of experimental dependencies
- [x] Bun 1.3.14: all public imports, Astra discovery, and CLI version
- [x] Added the smallest relevant regression tests and updated companion documentation

Real provider requests and interactive terminal mouse behavior were not exercised.