### PR TITLE
fix(add): re-running add refreshes the companion send tool for every channel

### DIFF
--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -369,8 +369,10 @@ reads the matching `FEISHU_*` / `LARK_*` environment credentials and uses that c
 Standalone sending requires no `fastagent.config.*`; an embedded agent can use a bare definition
 directory or an independent `cwd`.
 
-Scaffolded files are workspace-owned copies. To adopt the current send tool in an existing workspace,
-generate it with `fastagent add feishu|lark` in a scratch directory and copy the tool file.
+`tools/feishu-send.ts` / `tools/lark-send.ts` are the package's, not authored glue: re-running
+`fastagent add feishu|lark` rewrites the tool, keeps `channels/<kind>.ts` and the credentials already in
+`.env`, and re-checks the app's group visibility. That is how an agent scaffolded by an earlier release
+picks up the current tool.
 
 ## Upgrading from the session-mode releases
 
@@ -388,8 +390,8 @@ Three behaviour changes, none of them opt-in:
 
 - **Unrelated to the model, but in the same release:** the scaffolded send tool's description gained a
   "do not use this to answer the current turn" boundary (without it the Agent posts its reply twice).
-  Scaffolded files are copies, so an existing workspace keeps the old text — see the send-tool section
-  above for updating the tool.
+  An agent scaffolded earlier still carries the old text — re-run `fastagent add feishu|lark` to rewrite
+  the tool (see the send-tool section above).
 
 State does not clean itself up: `owned-threads.json` and the `buffers.json` buckets under the retired
 key shape are both left in place, unread and unreachable — which means **buffered discussion in threads

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -156,13 +156,13 @@ fastagent start
 
 `start` uses the same assembly as `dev`, but does not watch files. There is no build step: copy the agent to a host with Node >= 22.19, install dependencies, and run `fastagent start`.
 
-For deployments, point the whole machine-state root (auth, sessions, **and** channel state — Telegram's durable turn replay lives there too) at durable storage:
+For deployments, point both machinery roots at durable storage: the state root (sessions **and** channel state — Telegram's durable turn replay lives there too) and the secrets dir (the agent's `.env` and the `auth.json` an OAuth refresh rotates on the box):
 
 ```bash
-FASTAGENT_STATE_DIR=/data/fastagent fastagent start
+FASTAGENT_STATE_DIR=/data/.state FASTAGENT_SECRETS_DIR=/data/.secrets fastagent start
 ```
 
-(`FASTAGENT_SESSIONS_DIR` / `--sessions-dir` override just the sessions path; they do not move channel state.)
+(`FASTAGENT_SESSIONS_DIR` / `--sessions-dir` override just the sessions path; they do not move channel state, and neither knob moves `auth.json`.)
 
 ## 7. Add channels
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -223,7 +223,7 @@ The state home lives under `.state/`, which the agent `.gitignore` excludes, so 
 
 `fastagent add telegram` also scaffolds `tools/telegram-send.ts`. Because tool names come from filenames, the agent can call the `telegram-send` tool with a `chatId` from the `[telegram: chat …]` envelope to send a text message or a local file back through the bot. It is also the delivery path for turns no channel is carrying — a cron schedule or a self-scheduled wake-up, whose plain reply is not delivered anywhere; those turns have no `[telegram: chat …]` line, so the schedule's prompt (or the wake's) must name the target chat id.
 
-**Do not use it to answer the current turn** — the channel already delivers the reply, so calling the tool as well posts it twice. The scaffolded description says so; a workspace scaffolded before that was added keeps its own copy, so paste the boundary into the tool's `description` (or re-run `fastagent add` in a scratch dir and copy the file) if the Agent is double-posting.
+**Do not use it to answer the current turn** — the channel already delivers the reply, so calling the tool as well posts it twice. The scaffolded description says so. `tools/telegram-send.ts` is the package's, not authored glue: re-running `fastagent add telegram` rewrites it and keeps `channels/telegram.ts`, which is how an agent scaffolded by an earlier release picks up the current tool if it is double-posting.
 
 ## Limits
 

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -50,17 +50,14 @@ export async function runAddChannel(
   const inAgent = (p: string): string => (agentFromCwd === undefined ? p : join(agentFromCwd, p));
   const envPath = dotEnvPath(target);
   const envLabel = isUnderDir(envPath, target) ? inAgent(relative(target, envPath)) : envPath;
-  // Preconditions before the write, so a refusal is side-effect-free. slack/feishu/lark are exceptions:
-  // their add is scaffold + ONBOARD THE APP, so an existing scaffold skips the write and continues (a
-  // failed/cancelled app or OAuth flow must be re-runnable without hand-deleting authored glue).
+  // An existing channel file is authored glue: kept, never rewritten. The add continues past it — the
+  // companion tools below are refreshed, and slack/feishu/lark resume a failed/cancelled app or OAuth
+  // flow — so re-running `add <kind>` never requires hand-deleting the glue.
   const file = join(target, "channels", `${channelKind}.ts`);
   const existsAlready = await channelExists(target, channelKind).catch(failStartup);
   const ingress = await resolveIngress(channelKind, file, existsAlready, opts.ingress);
   const groupBehavior = await resolveGroupBehavior(channelKind, opts.groupBehavior);
   if (existsAlready) {
-    if (channelKind !== "slack" && channelKind !== "feishu" && channelKind !== "lark") {
-      failStartup(new Error(`${relative(target, file)} already exists — edit it, or remove it to re-scaffold`));
-    }
     console.error(`[fastagent] ${relative(target, file)} already exists — keeping it`);
   } else {
     await assertChannelReady(target).catch(failStartup);
@@ -68,7 +65,7 @@ export async function runAddChannel(
     console.error(`[fastagent] created ${relative(target, file)}`);
   }
   // Companion tools are the package's, not authored glue: written on every add, so an upgraded
-  // package reaches an existing agent by re-running `add <kind>` (`--no-onboard` skips the prompts).
+  // package reaches an existing agent by re-running `add <kind>` (slack: `--no-onboard` skips the prompts).
   for (const tool of await scaffoldCompanionTools(target, channelKind).catch(failStartup)) {
     console.error(`[fastagent] wrote ${relative(target, tool)}`);
   }

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -457,6 +457,15 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     await cliInit(["add", "github"], dir);
     expect(await exists(join(dir, "channels", "github.ts"))).toBe(true);
     expect(await exists(join(dir, "channels", "telegram.ts"))).toBe(true);
+
+    // Re-running add on an existing channel keeps the authored glue and rewrites the package-owned
+    // companion tool — the upgrade path for an agent scaffolded by an earlier release.
+    await writeFile(join(dir, "channels", "telegram.ts"), `${src}// edited\n`);
+    await writeFile(join(dir, "tools", "telegram-send.ts"), "// 0.20.0\n");
+    const out3 = await cliInit(["add", "telegram"], dir);
+    expect(out3).toContain("channels/telegram.ts already exists — keeping it");
+    expect(await readFile(join(dir, "channels", "telegram.ts"), "utf8")).toBe(`${src}// edited\n`);
+    expect(await readFile(join(dir, "tools", "telegram-send.ts"), "utf8")).toBe(sendTool);
   });
 
   it("writes generated telegram secret to .secrets/.env, leaving only the BotFather token as a manual step", async () => {


### PR DESCRIPTION
## What

- `fastagent add telegram` / `add github` no longer refuse when `channels/<kind>.ts` already exists. Like slack/feishu/lark, the authored channel file is kept and the package-owned companion tool (`tools/telegram-send.ts`) is rewritten — the upgrade path for an agent scaffolded by an earlier release.
- `docs/quickstart.md`: the deploy snippet placed `auth.json` under the state root; it lives in the secrets dir, so the snippet now sets `FASTAGENT_SECRETS_DIR` alongside `FASTAGENT_STATE_DIR` (matching configuration.md / troubleshooting.md).
- `docs/feishu.md`, `docs/telegram.md`: the send-tool refresh instructions point at re-running `fastagent add <kind>` in place instead of scaffolding into a scratch directory and copying the file.

## Why

The comment in `add.ts` already stated that companion tools are written on every add so re-running `add <kind>` upgrades them; the telegram/github refusal predated companion tools and made that false for telegram.

## Verification

- `npm run lint && npm run typecheck && npm test` (1701 passing).
- New assertion in `test/init.test.ts` fails without the `add.ts` change (re-run exits with "already exists — edit it").
