### PR TITLE
chore: release 0.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastagent-sh/fastagent",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastagent-sh/fastagent",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Vibe first. Then FastAgent: turn a local agent directory into a live service in your app, on GitHub, Telegram, Slack, or behind any channel.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Release v0.21.1

Bump @fastagent-sh/fastagent from 0.21.0 to 0.21.1.

### Verification

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm pack --dry-run --json`

### After merge

Create and publish the GitHub Release `v0.21.1`. The protected publish workflow will verify and publish the package to npm via Trusted Publishing.