### PR TITLE
fix(agentcore): read the checkpoint reply off the line before the CLI's metadata block

### DIFF
--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -165,10 +165,12 @@ export interface CheckpointReply {
   reason?: string;
 }
 
-/** Parse the runtime's checkpoint acknowledgement without treating malformed output as success. */
+/** Parse the runtime's checkpoint acknowledgement without treating malformed output as success.
+ *  With `/dev/stdout` as the outfile the CLI writes the body there and then its own metadata JSON to
+ *  the same stream, so stdout holds two values; the container's reply is the one line before it. */
 export function parseCheckpointReply(stdout: string): CheckpointReply | undefined {
   try {
-    const parsed = JSON.parse(stdout.trim()) as unknown;
+    const parsed = JSON.parse(stdout.trim().split("\n")[0] ?? "") as unknown;
     if (
       parsed === null ||
       typeof parsed !== "object" ||

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -544,6 +544,15 @@ describe("deploy/agentcore/run: helpers", () => {
     for (const invalid of ["not json", "{}", '{"written":"true"}', "null"]) {
       expect(parseCheckpointReply(invalid)).toBeUndefined();
     }
+    // What `aws bedrock-agentcore invoke-agent-runtime … /dev/stdout` really prints: the body, then
+    // the CLI's own metadata block on the same stream (#470).
+    const metadata =
+      '{\n    "runtimeSessionId": "fastagent-ingress-x",\n    "contentType": "application/json",\n    "statusCode": 200\n}\n';
+    expect(parseCheckpointReply(`{"written":true}\n${metadata}`)).toEqual({ written: true, reason: undefined });
+    expect(parseCheckpointReply(`{"written":false,"reason":"idle"}\n${metadata}`)).toEqual({
+      written: false,
+      reason: "idle",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #470. `aws bedrock-agentcore invoke-agent-runtime … /dev/stdout` writes the response body to the outfile and then its own metadata JSON to stdout — the same stream — so `parseCheckpointReply` saw two JSON values, `JSON.parse` threw, and every `deploy agentcore --run` warned that the snapshot could not be verified even when it had been written.

The container's reply is one line (`json()` in `channels/agentcore.ts` emits `JSON.stringify(body)\n`), so the parser reads the line before the metadata block. The test feeds the real two-value stdout from the issue; it fails on the previous parser.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] Added or updated the smallest relevant tests

## Checklist

- [x] The PR carries a label — from the branch prefix, or added by hand
- [x] Public-facing text is in English
- [x] Errors fail visibly; no silent fallbacks or swallowed exceptions
- [x] No secrets, local paths, or machine-specific state were committed
- [x] No process-only notes were added (`*_PLAN.md`, `HANDOFF.md`, session notes, etc.)
- [x] Docs were updated when behavior or public APIs changed
