### PR TITLE
refactor(service): manage resident lifecycle with Effect

### DIFF
--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -369,6 +369,15 @@ the service's handler through `channels/serve.ts` and exits on unexpected channe
 SIGINT/SIGTERM handler closes the service and listener, force-closes active HTTP streams, and bounds
 shutdown time; it does not drain Agent turns.
 
+The resident service lifecycle uses an Effect scope for scheduler cleanup, connection readiness and
+closure observers, and the caller's abort listener. Shutdown broadcasts the transport abort before
+closing the scope, then waits for all connections under one deadline. Its result is cached so
+concurrent and repeated `close()` calls wait for the same completion or failure. Startup rollback
+uses that same shutdown, logging cleanup errors while preserving the startup failure. The public
+`ready` waiter stays outside the scope it may close; channel authors still return ordinary Promises
+and consume an `AbortSignal`. Agent turns and durable replay state remain outside this scope.
+Effect is an internal dependency of `/node`; the contracts and `/core` remain dependency-free.
+
 `channels/sse.ts` owns the Fetch-only response lifecycle shared by HTTP invoke and session observation:
 eager subscription, heartbeat, serialization and iterator cleanup. The callers own their event shapes.
 Synchronous subscription errors reach the HTTP error boundary before a response is created; errors

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -251,6 +251,10 @@ package at all. `@fastagent-sh/fastagent/node` adds what needs a Node runtime (`
 `@fastagent-sh/fastagent/pi` is the engine-specific assembly. The root entry re-exports every one of
 them, which is what every example above uses.
 
+The resident service manages its lifecycle internally with Effect. Embedders and channel authors
+continue to use the Promise, AsyncIterable, and Fetch APIs above; they do not need to create or
+configure an Effect runtime.
+
 ## Where next
 
 - [SPEC](SPEC.md) — the Agent Handler contract the whole thing rests on.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "chokidar": "^5.0.0",
         "commander": "^15.0.0",
         "croner": "^10.0.1",
+        "effect": "4.0.0-rc.112",
         "giget": "^3.3.0",
         "ignore": "^7.0.5",
         "proper-lockfile": "^4.1.2",
@@ -3634,6 +3635,84 @@
         "ws": "^8.19.0"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
@@ -5863,7 +5942,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5907,6 +5986,16 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-rc.112",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-rc.112.tgz",
+      "integrity": "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-check": "^4.9.0",
+        "msgpackr": "^2.0.5"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -6097,6 +6186,28 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -7281,6 +7392,37 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.1.0.tgz",
+      "integrity": "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -7367,6 +7509,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/object-inspect": {
@@ -7755,6 +7912,22 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.16.0",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "chokidar": "^5.0.0",
     "commander": "^15.0.0",
     "croner": "^10.0.1",
+    "effect": "4.0.0-rc.112",
     "giget": "^3.3.0",
     "ignore": "^7.0.5",
     "proper-lockfile": "^4.1.2",

--- a/src/service.ts
+++ b/src/service.ts
@@ -14,6 +14,11 @@
  * substantive one: its channels load lazily after a state-snapshot restore, so it cannot use an
  * assembly that discovers them eagerly (cli/commands/start.ts says so at the branch).
  */
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Scope from "effect/Scope";
 import type { Agent } from "./agent.ts";
 import { CONTROL_TOKEN_ENV, createControlPlane } from "./channels/control.ts";
 import { createInvokeHandler } from "./channels/http.ts";
@@ -34,41 +39,43 @@ import type { LoadedSchedule } from "./schedule/schedule.ts";
  *  the process leaves at 0 before the failure is known. */
 const CLOSE_DEADLINE_MS = 5_000;
 
-/** Settle when every connection has closed, or when the deadline passes. Reports the ones that did
- *  NOT settle — named individually, so a single stuck channel is not reported as all of them. */
-async function closeWithin(
+/** One deadline for all connections; a failed close must not hide a sibling that is still running. */
+function closeWithin(
   runs: readonly LongConnection[],
   names: readonly string[],
   deadlineMs: number,
-): Promise<{ stuck: string[]; failures: unknown[] }> {
-  const pending = new Set(runs.map((_, i) => i));
-  const failures: unknown[] = [];
-  const tracked = runs.map((run, i) =>
-    run.closed.then(
-      () => {
-        pending.delete(i);
-      },
-      (error: unknown) => {
-        pending.delete(i);
-        failures.push(error);
-      },
-    ),
-  );
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    await Promise.race([
-      Promise.all(tracked),
-      // NOT unref'd: this timer is the thing being awaited, and an unref'd one lets the loop go
-      // idle with nothing left to advance it. Cleared below so a prompt close does not hold the
-      // process for the rest of the deadline.
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, deadlineMs);
-      }),
-    ]);
-  } finally {
-    clearTimeout(timer);
-  }
-  return { stuck: [...pending].map((i) => names[i] ?? "channel"), failures };
+): Effect.Effect<void, unknown> {
+  return Effect.gen(function* () {
+    const pending = new Set(runs.map((_, i) => i));
+    const failures: unknown[] = [];
+    yield* Effect.forEach(
+      runs,
+      (run, i) =>
+        Effect.tryPromise({ try: () => run.closed, catch: (error) => error }).pipe(
+          Effect.match({
+            onSuccess: () => {
+              pending.delete(i);
+            },
+            onFailure: (error) => {
+              pending.delete(i);
+              failures.push(error);
+            },
+          }),
+        ),
+      { concurrency: "unbounded", discard: true },
+    ).pipe(Effect.timeoutOrElse({ duration: deadlineMs, orElse: () => Effect.void }));
+    if (pending.size > 0) {
+      const stuck = [...pending].map((i) => names[i] ?? "channel");
+      return yield* Effect.fail(
+        new Error(`long connection(s) did not stop within ${deadlineMs}ms: ${stuck.join(", ")}`),
+      );
+    }
+    if (failures.length > 0) {
+      return yield* Effect.fail(
+        failures.length === 1 ? failures[0] : new AggregateError(failures, "long connections failed to close"),
+      );
+    }
+  });
 }
 
 export interface ServingSurface {
@@ -320,158 +327,151 @@ export async function mountAgentService(
   // guarantee, and a throw after the scheduler ticks and channels dial would leave both running
   // with no service for the caller to close. Free to order correctly; expensive to discover later.
   const handler = router(withControl.routes, withControl.mounts);
-  const scheduled = await startSchedules(agentDir, agent, stateRoot, opened.selfSchedule);
-
-  const abort = new AbortController();
-  // A connection that drops while others are still dialling must not be undone by their later
-  // readiness: the service is missing a declared channel from that moment on, whatever else arrives.
-  let dropped = false;
-  const onClosed =
-    options.onChannelClosed ??
-    ((name, error) =>
-      log.error(`[fastagent] long connection ${name} ${error === undefined ? "closed" : `failed: ${String(error)}`}`));
-  const runs: LongConnection[] = [];
-
-  // A FUNCTION declaration, not a const: `close()` detaches this listener, and a rollback can call
-  // `close()` before this point is reached — a `const` would be in its temporal dead zone there, so
-  // the cleanup would throw a ReferenceError and silently skip everything after it.
-  //
-  // Detached because a caller that closes services itself while holding one long-lived signal would
-  // otherwise accumulate listeners, each pinning a whole service through its closure. The signal
-  // path has no caller awaiting the promise, so a failure to stop is reported rather than left as an
-  // unhandled rejection — in an embedded library, potentially the host's exit.
-  function onAbort(): void {
-    void close().catch((error: unknown) => log.error(`[fastagent] service close failed: ${String(error)}`));
-  }
-
-  let closing: Promise<void> | undefined;
-  const close = (): Promise<void> => {
-    // Awaits the connections rather than only signalling them: `close()` promises they are stopped,
-    // and a caller tearing down a test or a request-scoped service needs that to be true on return.
-    closing ??= (async () => {
-      abort.abort();
-      scheduled.stop();
-      options.signal?.removeEventListener("abort", onAbort);
-      // A failure to stop is the caller's to know about — swallowing it would let `close()` report
-      // success over a channel still holding on. Bounded, because a channel that ignores its abort
-      // signal must not hang the teardown either.
-      const { stuck, failures } = await closeWithin(
-        runs,
-        routed.longConnections.map((c) => c.name),
-        closeTimeoutMs,
-      );
-      if (stuck.length > 0) {
-        throw new Error(`long connection(s) did not stop within ${closeTimeoutMs}ms: ${stuck.join(", ")}`);
-      }
-      if (failures.length > 0) {
-        throw failures.length === 1 ? failures[0] : new AggregateError(failures, "long connections failed to close");
-      }
-    })();
-    return closing;
-  };
-
-  // Rollback IS close(), plus keeping the original error: a failure to clean up is the aftermath,
-  // and replacing the reason the caller needs with it hides the actual cause.
-  const rollback = async (error: unknown): Promise<never> => {
-    await close().catch((closeError: unknown) =>
-      log.error(`[fastagent] cleanup after a failed start also failed: ${String(closeError)}`),
-    );
-    throw error;
-  };
-  // Rolled back on failure: a connection that throws while the ones before it are open, and the
-  // scheduler already ticking, would otherwise leave both running behind a rejected open().
-  for (const connection of routed.longConnections) {
-    let run: LongConnection;
-    try {
-      run = connection.connect(abort.signal);
-    } catch (error) {
-      return rollback(error);
-    }
-    if (typeof run?.ready?.then !== "function" || typeof run?.closed?.then !== "function") {
-      return rollback(new Error(`${connection.name} connect(signal) must return { ready: Promise, closed: Promise }`));
-    }
-    void run.closed.then(
-      () => {
-        if (abort.signal.aborted) return;
-        // A channel that dies leaves the service serving something it no longer has.
-        dropped = true;
-        routed.setReady(false);
-        onClosed(connection.name);
-      },
-      (error: unknown) => {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const lifetime = yield* Scope.make();
+      const abort = new AbortController();
+      const runs: LongConnection[] = [];
+      const names = routed.longConnections.map((c) => c.name);
+      // A connection lost during startup must not be hidden by a sibling becoming ready later.
+      let dropped = false;
+      const onClosed =
+        options.onChannelClosed ??
+        ((name, error) =>
+          log.error(
+            `[fastagent] long connection ${name} ${error === undefined ? "closed" : `failed: ${String(error)}`}`,
+          ));
+      const notifyClosed = (name: string, error?: unknown): void => {
         if (abort.signal.aborted) return;
         dropped = true;
         routed.setReady(false);
-        onClosed(connection.name, error);
-      },
-    );
-    runs.push(run);
-  }
+        onClosed(name, error);
+      };
 
-  if (options.signal?.aborted) await close();
-  else options.signal?.addEventListener("abort", onAbort, { once: true });
-
-  // Health answers 503 until EVERY long connection is up, so a load balancer does not route into a
-  // service whose socket-mode channels are still dialling. An abort before that settles `ready` as
-  // cancellation, not readiness — a service being torn down must not report itself healthy.
-  const ready = (async () => {
-    try {
-      await Promise.all(
-        runs.map(async (run, i) => {
-          const name = routed.longConnections[i]?.name ?? "channel";
-          // Raced against `closed`, because the contract puts a terminal failure THERE: a channel
-          // that dies dialling may leave `ready` pending forever, and waiting on it alone hangs
-          // startup with no diagnosis.
-          await Promise.race([
-            run.ready,
-            run.closed.then(
-              () => Promise.reject(new Error(`${name} closed before it was ready`)),
-              (error: unknown) => Promise.reject(new Error(`${name} failed before it was ready: ${String(error)}`)),
-            ),
-          ]);
-          if (!abort.signal.aborted) log.info(`[fastagent] long connection ready: ${name}`);
+      // Scope.close alone does not join concurrent closes or retain their failure. Cache the whole
+      // shutdown so every caller waits for the same result, including startup rollback.
+      const shutdown = yield* Effect.cached(
+        Effect.gen(function* () {
+          abort.abort();
+          yield* Scope.close(lifetime, Exit.void);
         }),
       );
-    } catch (error) {
-      // A connection that cannot come up is a startup failure, not a degraded service: tear the rest
-      // down before rejecting, so nothing is left running behind a caller that saw an error. A
-      // cleanup that ALSO fails is logged, never rethrown — it would replace the reason the caller
-      // actually needs with the aftermath of it.
-      await close().catch((closeError: unknown) =>
-        log.error(`[fastagent] cleanup after a failed start also failed: ${String(closeError)}`),
+      const close = (): Promise<void> => Effect.runPromise(shutdown);
+      const rollback = shutdown.pipe(
+        Effect.catchCause((cause) =>
+          Effect.sync(() =>
+            log.error(`[fastagent] cleanup after a failed start also failed: ${String(Cause.squash(cause))}`),
+          ),
+        ),
       );
-      throw error;
-    }
-    // A `ready` that settles because the service was CLOSED is cancellation, not readiness — the
-    // contract lets a connection resolve it on abort. Returning normally would tell a caller its
-    // channels are up while the service is shut and health says 503.
-    if (abort.signal.aborted) throw new Error("service closed before it became ready");
-    // A drop DURING startup fails it. `dropped` is only reachable here from the startup window —
-    // after this line `ready` has settled — and resolving while health is permanently 503 would
-    // hand the caller two contradictory answers about the same surface.
-    if (dropped) {
-      await close();
-      throw new Error("a long connection closed before startup completed");
-    }
-    routed.setReady(true);
-  })();
-  // Observed here so a rejection is never unhandled; every caller still sees it through `ready`.
-  ready.catch(() => {});
+      const onAbort = (): void => {
+        void close().catch((error: unknown) => log.error(`[fastagent] service close failed: ${String(error)}`));
+      };
 
-  return {
-    handler,
-    agent,
-    routes: withControl.routes,
-    agentDir,
-    workspace,
-    channels: {
-      routes: routed.routeChannels,
-      longConnections: routed.longConnections.map((c) => c.name),
-      builtinInvoke: routed.builtinInvoke,
-    },
-    schedules: scheduled.schedules,
-    ready,
-    ...(withControl.control ? { control: withControl.control } : {}),
-    close,
-  };
+      return yield* Effect.gen(function* () {
+        // Registered first, so subscriptions and schedule timers stop before waiting for transports.
+        // Finalizers have no typed error channel; a close failure must reject the public Promise.
+        yield* Effect.addFinalizer(() => closeWithin(runs, names, closeTimeoutMs).pipe(Effect.orDie));
+        const scheduled = yield* Effect.acquireRelease(
+          Effect.tryPromise({
+            try: () => startSchedules(agentDir, agent, stateRoot, opened.selfSchedule),
+            catch: (error) => error,
+          }),
+          (scheduled) => Effect.sync(scheduled.stop),
+        );
+        const readiness = yield* Effect.forEach(routed.longConnections, (connection) =>
+          Effect.gen(function* () {
+            const run = yield* Effect.try({
+              try: () => connection.connect(abort.signal),
+              catch: (error) => error,
+            });
+            if (typeof run?.ready?.then !== "function" || typeof run?.closed?.then !== "function") {
+              return yield* Effect.fail(
+                new Error(`${connection.name} connect(signal) must return { ready: Promise, closed: Promise }`),
+              );
+            }
+            runs.push(run);
+            const closed = Effect.tryPromise({ try: () => run.closed, catch: (error) => error });
+            yield* closed.pipe(
+              Effect.match({
+                onSuccess: () => notifyClosed(connection.name),
+                onFailure: (error) => notifyClosed(connection.name, error),
+              }),
+              Effect.catchCause((cause) =>
+                Effect.sync(() =>
+                  log.error(`[fastagent] channel closure callback failed: ${String(Cause.squash(cause))}`),
+                ),
+              ),
+              Effect.forkScoped({ startImmediately: true }),
+            );
+            // Observe ready immediately, including when a later connect() throws and mount rolls back.
+            return yield* Effect.raceFirst(
+              Effect.tryPromise({ try: () => run.ready, catch: (error) => error }),
+              closed.pipe(
+                Effect.matchEffect({
+                  onSuccess: () => Effect.fail(new Error(`${connection.name} closed before it was ready`)),
+                  onFailure: (error) =>
+                    Effect.fail(new Error(`${connection.name} failed before it was ready: ${String(error)}`)),
+                }),
+              ),
+            ).pipe(
+              Effect.tap(() =>
+                Effect.sync(() => {
+                  if (!abort.signal.aborted) log.info(`[fastagent] long connection ready: ${connection.name}`);
+                }),
+              ),
+              Effect.forkScoped({ startImmediately: true }),
+            );
+          }),
+        );
+
+        if (options.signal?.aborted) yield* shutdown;
+        else
+          yield* Effect.acquireRelease(
+            Effect.sync(() => options.signal?.addEventListener("abort", onAbort, { once: true })),
+            () => Effect.sync(() => options.signal?.removeEventListener("abort", onAbort)),
+          );
+
+        // The public readiness waiter lives outside the scope it may roll back. Its source fibers
+        // belong to the service, so closing also releases waits on an uncooperative channel.
+        const ready = Effect.runPromise(
+          Effect.gen(function* () {
+            yield* Effect.forEach(readiness, Fiber.join, { concurrency: "unbounded", discard: true });
+            if (abort.signal.aborted) return yield* Effect.fail(new Error("service closed before it became ready"));
+            if (dropped) return yield* Effect.fail(new Error("a long connection closed before startup completed"));
+            routed.setReady(true);
+          }).pipe(
+            Effect.catchCause((cause) =>
+              abort.signal.aborted
+                ? Effect.fail(new Error("service closed before it became ready"))
+                : Effect.failCause(cause),
+            ),
+            Effect.onError(() => rollback),
+          ),
+        );
+        // The rejection is still delivered to callers that await ready.
+        ready.catch(() => {});
+
+        return {
+          handler,
+          agent,
+          routes: withControl.routes,
+          agentDir,
+          workspace,
+          channels: {
+            routes: routed.routeChannels,
+            longConnections: names,
+            builtinInvoke: routed.builtinInvoke,
+          },
+          schedules: scheduled.schedules,
+          ready,
+          ...(withControl.control ? { control: withControl.control } : {}),
+          close,
+        };
+      }).pipe(
+        Scope.provide(lifetime),
+        Effect.onError(() => rollback),
+      );
+    }),
+  );
 }

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -276,7 +276,16 @@ describe("the contracts depend on nothing", () => {
     // them: /core has both, /node drops the second (a filesystem, a clock, an environment), /pi
     // drops both. Each layer's package list is that statement, checkable.
     expect([...staticPackageGraph("core.ts")]).toEqual([]);
-    expect([...staticPackageGraph("node.ts")].sort()).toEqual(["@hono/node-server", "croner"]);
+    // Service lifecycle management uses Effect; channel and agent contracts remain dependency-free.
+    expect([...staticPackageGraph("node.ts")].sort()).toEqual([
+      "@hono/node-server",
+      "croner",
+      "effect/Cause",
+      "effect/Effect",
+      "effect/Exit",
+      "effect/Fiber",
+      "effect/Scope",
+    ]);
     // ...and neither neutral layer names an engine (the engine-neutrality suite above covers this
     // for core; node now carries the assembly, so it needs the same bar).
     expect([...staticPackageGraph("node.ts")].filter((p) => p.startsWith("@earendil-works/"))).toEqual([]);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -7,7 +7,9 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { getEventListeners } from "node:events";
+import { log } from "../src/log.ts";
 import { describe, expect, it, vi } from "vitest";
 import { createAgentService } from "../src/engines/pi/service.ts";
 import { createPiAgentFromDir } from "../src/engines/pi/open.ts";
@@ -233,6 +235,57 @@ describe("createAgentService", () => {
     await expect(service.close()).resolves.toBeUndefined(); // idempotent
   });
 
+  it.each([false, true])("concurrent close calls share completion and failure (reject=%s)", async (reject) => {
+    const dir = await agentDir({
+      "channels/sock.mjs": `export let stopped = false;
+      export default { name: "sock", connect: (ctx, signal) => ({
+        ready: Promise.resolve(),
+        closed: new Promise((resolve, reject) => signal.addEventListener("abort", () => {
+          setTimeout(() => { stopped = true; ${reject ? 'reject(new Error("shutdown failed"))' : "resolve()"}; }, 30);
+        }, { once: true })),
+      }) };`,
+    });
+    const channel = await import(pathToFileURL(join(dir, "channels/sock.mjs")).href);
+    const service = await createAgentService(dir);
+    await service.ready;
+    const first = service.close().finally(() => {
+      expect(channel.stopped).toBe(true);
+    });
+    const second = service.close().finally(() => {
+      expect(channel.stopped).toBe(true);
+    });
+    const results = await Promise.allSettled([first, second]);
+    if (reject) {
+      const [a, b] = results as PromiseRejectedResult[];
+      expect(a?.status).toBe("rejected");
+      expect(b?.reason).toBe(a?.reason);
+      await expect(service.close()).rejects.toBe(a?.reason);
+    } else {
+      expect(results).toEqual([
+        { status: "fulfilled", value: undefined },
+        { status: "fulfilled", value: undefined },
+      ]);
+    }
+  });
+
+  it("close() stops the self-scheduling poll timer", async () => {
+    const timers = vi.spyOn(globalThis, "setTimeout");
+    const cleared = vi.spyOn(globalThis, "clearTimeout");
+    const service = await createAgentService(
+      await agentDir({}, `{ model: "openai-codex/gpt-5.5", selfSchedule: true }`),
+    );
+    try {
+      const polls = timers.mock.calls.flatMap((args, i) => (args[1] === 30_000 ? [timers.mock.results[i]?.value] : []));
+      expect(polls).toHaveLength(1);
+      await service.close();
+      expect(cleared).toHaveBeenCalledWith(polls[0]);
+    } finally {
+      await service.close();
+      timers.mockRestore();
+      cleared.mockRestore();
+    }
+  });
+
   it("close() detaches from the caller's signal", async () => {
     // A host that opens and closes surfaces while holding one long-lived signal would otherwise
     // accumulate listeners, each pinning a whole closed surface through its closure.
@@ -261,6 +314,12 @@ describe("createAgentService", () => {
     // its connections and scheduler running behind a caller who believes it is shut.
     const service = await createAgentService(dir, { signal: AbortSignal.abort() });
     expect((globalThis as Record<string, unknown>).__faAbortedClosed).toBe(true);
+    await service.close();
+  });
+
+  it("an already-aborted signal rejects readiness without long connections", async () => {
+    const service = await createAgentService(await agentDir(), { signal: AbortSignal.abort() });
+    await expect(service.ready).rejects.toThrow("service closed before it became ready");
     await service.close();
   });
 
@@ -329,6 +388,58 @@ describe("createAgentService", () => {
     expect((globalThis as unknown as { __faRolledBack?: boolean }).__faRolledBack).toBe(true);
   });
 
+  it("observes a ready rejection when a later connect throws", async () => {
+    const dir = await agentDir({
+      "channels/a-first.mjs": `export default { name: "a-first", connect: (ctx, signal) => ({
+        ready: Promise.reject(new Error("first dial failed")),
+        closed: new Promise(resolve => signal.addEventListener("abort", () => setTimeout(resolve, 10), { once: true })),
+      }) };`,
+      "channels/b-throws.mjs": `export default { name: "b-throws", connect: () => { throw new Error("cannot dial"); } };`,
+    });
+    await expect(createAgentService(dir)).rejects.toThrow("cannot dial");
+  });
+
+  it.each(["ready", "closed"])("rejects an invalid %s promise and rolls back earlier connections", async (field) => {
+    const dir = await agentDir({
+      "channels/a-first.mjs": `export default { name: "a-first", connect: (ctx, signal) => ({
+        ready: Promise.resolve(),
+        closed: new Promise((_, reject) => signal.addEventListener("abort", () => reject(new Error("rollback reached first")), { once: true })),
+      }) };`,
+      "channels/b-invalid.mjs": `export default { name: "b-invalid", connect: () => ({
+        ready: Promise.resolve(), closed: Promise.resolve(), ${field}: null,
+      }) };`,
+    });
+    const logged = vi.spyOn(log, "error").mockImplementation(() => {});
+    try {
+      await expect(createAgentService(dir)).rejects.toThrow("b-invalid connect(signal) must return");
+      expect(logged).toHaveBeenCalledWith(expect.stringContaining("rollback reached first"));
+    } finally {
+      logged.mockRestore();
+    }
+  });
+
+  it("logs a throwing closure callback and still rolls back startup", async () => {
+    const dir = await agentDir({
+      "channels/sock.mjs": `export default { name: "sock", connect: () => ({
+        ready: new Promise(() => {}), closed: Promise.resolve(),
+      }) };`,
+    });
+    const logged = vi.spyOn(log, "error").mockImplementation(() => {});
+    try {
+      const service = await createAgentService(dir, {
+        onChannelClosed: () => {
+          throw new Error("callback broke");
+        },
+      });
+      await expect(service.ready).rejects.toThrow("sock closed before it was ready");
+      expect((await service.handler(new Request("http://h/health"))).status).toBe(503);
+      expect(logged).toHaveBeenCalledWith(expect.stringContaining("callback broke"));
+      await service.close();
+    } finally {
+      logged.mockRestore();
+    }
+  });
+
   it("a failed start reports the start failure, not the cleanup's", async () => {
     // Both fail here: the connection cannot come up AND cannot stop. The caller needs the first —
     // the second is the aftermath, and replacing one with the other hides the actual cause.
@@ -352,6 +463,41 @@ describe("createAgentService", () => {
     const service = await createAgentService(dir, { onChannelClosed: () => {}, closeTimeoutMs: 200 });
     await service.ready;
     await expect(service.close()).rejects.toThrow(/did not stop within 200ms: deaf/);
+  });
+
+  it("closing an unresponsive dialing channel also settles ready", async () => {
+    const dir = await agentDir({
+      "channels/deaf.mjs": `export default { name: "deaf", connect: () => ({
+        ready: new Promise(() => {}), closed: new Promise(() => {}),
+      }) };`,
+    });
+    const service = await createAgentService(dir, { closeTimeoutMs: 20 });
+    await expect(service.close()).rejects.toThrow("did not stop within 20ms: deaf");
+    await expect(service.ready).rejects.toThrow("service closed before it became ready");
+  });
+
+  it("aggregates close failures after all connections settle", async () => {
+    const dir = await agentDir(
+      Object.fromEntries(
+        ["a", "b"].map((name) => [
+          `channels/${name}.mjs`,
+          `export default { name: "${name}", connect: (ctx, signal) => ({
+        ready: Promise.resolve(),
+        closed: new Promise((_, reject) => signal.addEventListener("abort", () => {
+          setTimeout(() => reject(new Error("${name} failed to stop")), ${name === "a" ? 5 : 20});
+        }, { once: true })),
+      }) };`,
+        ]),
+      ),
+    );
+    const service = await createAgentService(dir);
+    await service.ready;
+    const error = await service.close().catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors.map((e: Error) => e.message)).toEqual([
+      "a failed to stop",
+      "b failed to stop",
+    ]);
   });
 
   it("names only the connection that is stuck, not the ones that stopped", async () => {


### PR DESCRIPTION
## Summary

- Own connection readiness/closure fibers, scheduler cleanup, and the caller's abort listener in a service-local Effect scope. Keep the Promise, AsyncIterable, Fetch, and channel authoring contracts unchanged.
- Broadcast transport cancellation before scoped cleanup and wait for all connections under one deadline. Cache shutdown so concurrent closes and startup rollback share its completion or failure.
- Observe readiness immediately during acquisition, settle readiness on shutdown even for an unresponsive channel, and report closure-callback defects. Preserve startup errors when cleanup also fails.
- Pin `effect@4.0.0-rc.112`; keep `/core` and the public contracts dependency-free. Agent execution, scheduler stop policy, durable replay state, and the AgentCore assembly remain outside this change.

Refs #480.

## Verification

- `npm run lint && npm run typecheck && npm test && npm run build`: passed; 120 test files, 1,711 tests.
- Service, package-boundary, and real Express/Fastify embedding checks: 93 tests passed on Node 22.19.0 and 24.20.0, in addition to the full suite on Node 26.8.1.
- Added coverage for concurrent close results, malformed connection handles, readiness rejection during rollback, callback defects, shutdown aggregation, unresponsive readiness, pre-aborted startup without connections, and scheduler timer cleanup.

## Measured costs

Compiled public entries, fresh Node 26.8.1 processes on macOS arm64, warm filesystem cache, one discarded warmup plus 15 measured processes per case. Local channel fixtures have immediate readiness and abort-driven closure; no network or model calls. Heap figures are retained increases after explicit GC. Baseline: `3654c244`.

| `/node` fixture | Import + ready, baseline / PR | Mount only, baseline / PR | Retained heap, baseline / PR |
| --- | ---: | ---: | ---: |
| No connections | 36.95 / 57.25 ms | 1.09 / 3.17 ms | 3.44 / 6.85 MiB |
| Two connections | 44.01 / 66.18 ms | 9.36 / 12.29 ms | 3.47 / 6.94 MiB |

Median close cost for two connections is 0.28 / 0.80 ms. `/core` retains the same 0.34 MiB heap increase. These results fit the pilot budgets recorded in #480 before implementation: +50 ms import/mount, +10 MiB heap, and +5 ms each for mount and close. They do not establish production throughput or live transport performance.

## Trade-offs

Effect owns lifecycle timers, races, tasks, and shutdown-result sharing. `src/service.ts` grows from 296 to 330 non-comment lines (+11.5%), including boundary adapters, and the dependency is a pinned release candidate. The service-lifecycle adoption accepts these implementation and measured runtime costs for explicit resource ownership.

Public interfaces remain ordinary TypeScript, Promise, AsyncIterable, and Fetch. Callers can independently adopt Effect through those standard interfaces. Adoption is limited to the service lifecycle; expansion requires separate evidence of simplification and maintainer approval.
