### PR TITLE
refactor(pi): scope invocation and control execution with Effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,12 +257,15 @@ src/
     │                         # must contend on the same lease and validate against the same registry
     ├── turn-kit.ts          # the turn mechanism's pi-CLASS-neutral half: lease (single-writer
     │                         # floor), terminals (settled message/thrown error → SPEC terminal +
-    │                         # retryable), EventQueue (push→pull), prompt image prep, the SPEC
+    │                         # retryable), prompt image prep, the SPEC
     │                         # projection, and the observation seam (RunControls + SessionObserver)
     ├── invoke-session.ts    # THE L0: pi's AgentSession, one per invoke, over the same durable
     │                         # record. Events translate ONCE into the rich SessionEvent vocabulary;
     │                         # the SPEC stream is its projection. Owns the run's identity, its
-    │                         # controls, and exactly one settlement
+    │                         # controls, and exactly one settlement. Its Effect scope stays alive through
+    │                         # consumer settlement; cancellation aborts and joins the actual SDK work
+    ├── session-effects.ts   # typed SDK failures and scoped lease/session acquisition shared by invocation
+    │                         # and control writes. Late acquisition keeps its lease; cleanup faults are logged
     ├── agent-session-factory.ts # the engine binding: the assembly (model/prompt/skills/tools) bound
     │                         # to one record per invoke. services shared, session per turn. Carries
     │                         # the adaptations pi's TUI origins require — see its header. bindPiSession

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -241,7 +241,7 @@ the scoped acquisition and typed SDK-failure adapters shared with control-plane 
    queues on it rather than finding no run;
 3. open/create the record and bind a session to it;
 4. subscribe, translating pi events ONCE into the rich `SessionEvent` vocabulary (the SPEC stream is
-   its projection);
+   its projection), then wake waiting controls so their synchronous queue events are observed;
 5. run the prompt;
 6. queue exactly one `completed` or `failed` terminal and wait for consumer settlement;
 7. unsubscribe, dispose, publish exactly one `run_settled`, and release the lease.

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -231,8 +231,10 @@ a second way to start work, and never resident process state as the source of co
 Pi's `AgentSession` exposes a subscription for streaming events and a `prompt()` that resolves without
 a value — a turn's outcome is the assistant message the stream ended on, never an index into session
 state (compaction and overflow recovery both rewrite that array mid-turn).
-`src/engines/pi/invoke-session.ts` combines the two into one async iterable, over the lease/terminal/
-queue parts in `turn-kit.ts`:
+`src/engines/pi/invoke-session.ts` combines the two into one async iterable. An Effect execution
+scope owns the shared lease, session and subscription; an Effect queue carries projected events.
+`turn-kit.ts` owns protocol projection and terminal classification. `session-effects.ts` supplies
+the scoped acquisition and typed SDK-failure adapters shared with control-plane writes:
 
 1. acquire the per-session lease;
 2. publish `run_started` with the run's controls — BEFORE binding, so a dispatch that races the build
@@ -241,12 +243,24 @@ queue parts in `turn-kit.ts`:
 4. subscribe, translating pi events ONCE into the rich `SessionEvent` vocabulary (the SPEC stream is
    its projection);
 5. run the prompt;
-6. emit exactly one `completed` or `failed` terminal, then exactly one `run_settled`;
-7. unsubscribe, dispose, and release the lease.
+6. queue exactly one `completed` or `failed` terminal and wait for consumer settlement;
+7. unsubscribe, dispose, publish exactly one `run_settled`, and release the lease.
 
-Setup, model, and tool-loop failures become `failed` events rather than thrown iteration errors.
-Consumer cancellation runs generator cleanup and aborts the session. Cleanup anomalies are logged but
-cannot turn an already-terminal stream into a throw.
+The scope remains alive while output is buffered or the consumer is paused at its terminal. Controls
+reject after SDK work finishes. Consumer cancellation interrupts the execution fiber, aborts and joins
+actual SDK work, and silences pending reads. Acquisition remains uninterruptible so a late-created
+session cannot publish durable state after its lease is released.
+
+`SessionBusy` and `SessionOperationError` remain typed failures inside execution. Protocol boundaries
+translate failures and defects into `failed` events or existing `SessionResult` codes. Cleanup faults
+are logged independently, continue remaining finalizers, and cannot overwrite a published outcome.
+An external SDK callback defect stops the turn and becomes one failed terminal.
+
+Control mutations take the same fail-fast lease through scoped acquisition. Manual compaction owns
+its own execution scope: admission returns before model work finishes, and `compaction_finished`
+is published after cleanup and lease release. Assembly services remain explicitly injected and
+shared; sessions and subscriptions remain per-operation. These scopes do not own channel turns,
+durable replay policy, or service shutdown.
 
 pi retries a failed assistant request itself. That is free resilience while the turn is silent and
 corruption once it is not — SPEC deltas are append-only, so a second attempt would concatenate its
@@ -376,7 +390,8 @@ concurrent and repeated `close()` calls wait for the same completion or failure.
 uses that same shutdown, logging cleanup errors while preserving the startup failure. The public
 `ready` waiter stays outside the scope it may close; channel authors still return ordinary Promises
 and consume an `AbortSignal`. Agent turns and durable replay state remain outside this scope.
-Effect is an internal dependency of `/node`; the contracts and `/core` remain dependency-free.
+Effect is internal to `/node` service assembly and `/pi` execution/control. The contracts, `/core`,
+and `/session` remain dependency-free; public APIs expose no Effect runtime or types.
 
 `channels/sse.ts` owns the Fetch-only response lifecycle shared by HTTP invoke and session observation:
 eager subscription, heartbeat, serialization and iterator cleanup. The callers own their event shapes.

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -126,7 +126,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
   ): AsyncGenerator<AgentEvent> {
     const queue = Effect.runSync(Queue.unbounded<AgentEvent, Cause.Done>());
     const consumed = Deferred.makeUnsafe<void>();
-    const bound = Deferred.makeUnsafe<AgentSession, SessionOperationError>();
+    const bound = Deferred.makeUnsafe<AgentSession, SessionBusy | SessionOperationError>();
     const abort = new AbortController();
     onCancelReady(() => abort.abort());
     const runId = crypto.randomUUID();
@@ -215,7 +215,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
               parentSession: scope.parentSession,
               ...(scope.branchHints !== undefined ? { branchHints: scope.branchHints } : {}),
             },
-      ).pipe(Effect.onExit((exit) => Deferred.done(bound, exit)));
+      );
       let finalAssistant: AssistantMessage | undefined;
       let streamedAnswer = false;
       let retriedAfterAnswer: string | undefined;
@@ -268,6 +268,8 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
         }),
         (unsubscribe) => sessionCleanup("unsubscribe", unsubscribe),
       );
+      // Completing the gate can run waiting controls synchronously; their queue events must be observed.
+      yield* Deferred.succeed(bound, session);
       const promptOptions = yield* sessionOperation("prepare prompt", () => toPiPromptOptions(prompt));
       if (eventFailure) return yield* Effect.fail(eventFailure);
       yield* sessionWork(
@@ -285,7 +287,7 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
               details: "the engine settled the run without ending an assistant message",
               retryable: false,
             } as const);
-    });
+    }).pipe(Effect.onError((cause) => Deferred.failCause(bound, cause)));
 
     const work = Effect.runFork(
       Effect.scoped(

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -1,25 +1,15 @@
 /**
- * THE L0: pi's `AgentSession`, one per invoke, over the same durable record —
- * [conformance-levels.md](../../../docs/design/conformance-levels.md) §2's `per-invoke` posture.
- * Build a session, run one turn, dispose; continuity lives in the record, never in this process.
- *
- * Why this class: pi 0.84 replaced `AgentHarness` with an unimplemented lane-based skeleton, and pi
- * does not consume that class itself — its TUI, RPC and SDK all run on `AgentSession`. Being the
- * sole consumer of a surface nobody dogfoods is a position, not an architecture.
- *
- * Events are translated ONCE, into the rich `SessionEvent` vocabulary the observation plane speaks;
- * the SPEC stream is a projection of that (`docs/design/session-control.md` §6 — one translation
- * plus one projection, never two parallel ones).
- *
- * Two disciplines this file exists to hold:
- * - the turn's outcome comes from the EVENT STREAM, never from an index into session state, which
- *   compaction and overflow recovery both rewrite mid-turn;
- * - `run_started` is published BEFORE the session is bound, so a dispatch racing the build queues on
- *   the run's controls instead of finding no run.
+ * Pi's per-invoke binding over a durable session record. The execution scope owns the lease,
+ * session and subscription until the consumer settles, even when the producer finishes first.
+ * Events translate once into SessionEvent; AgentEvent is its projection.
  */
 import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
-import type { SessionInheritance } from "./session-inheritance.ts";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type * as Cause from "effect/Cause";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Queue from "effect/Queue";
 import {
   ABORTED_CODE,
   SESSION_BUSY_CODE,
@@ -30,11 +20,21 @@ import {
   type Scope,
 } from "../../agent.ts";
 import type { RunSettledEvent, SessionEvent } from "../../session.ts";
-import { toRetryScheduledEvent } from "./retry-event.ts";
 import { type CancelHooks, cancellableStream } from "../../collect.ts";
 import { log } from "../../log.ts";
+import { toRetryScheduledEvent } from "./retry-event.ts";
+import type { SessionInheritance } from "./session-inheritance.ts";
 import {
-  EventQueue,
+  SessionBusy,
+  SessionOperationError,
+  acquireSession,
+  acquireSessionLease,
+  sessionCleanup,
+  sessionFailure,
+  sessionOperation,
+  sessionWork,
+} from "./session-effects.ts";
+import {
   type Lease,
   type RunControls,
   type SessionObserver,
@@ -45,46 +45,35 @@ import {
   toTerminal,
 } from "./turn-kit.ts";
 
-/** Open-or-create the session behind `sessionId` and bind an `AgentSession` to it, per invoke.
- *  `inherit` reaches the CREATE path only — an existing session ignores it. */
+/** Open or create a record and bind a session. Inheritance applies only when creating the record. */
 export type PiAgentSessionFactory = (sessionId: string, inherit?: SessionInheritance) => Promise<AgentSession>;
 
 export interface CreatePiAgentFromSessionOptions {
   sessionFactory: PiAgentSessionFactory;
-  /** Single-writer lease. Defaults to the in-process per-session fail-fast lease. */
+  /** Shared with control-plane writes; admission is synchronous and fail-fast. */
   lease?: Lease;
-  /** Observation-plane tap: every rich event of every run, plus the run's live {@link RunControls}
-   *  on `run_started`. Optional; the SPEC stream is identical with or without it. */
+  /** Trusted observation tap; controls arrive with run_started, before session binding. */
   observer?: SessionObserver;
 }
 
-/**
- * pi session events into the rich `SessionEvent` vocabulary — the SINGLE translation point. Events
- * with no vocabulary yet (agent_start, turn_start, entry_appended, …) are dropped.
- *
- * `auto_retry_start` reports as a `retry_scheduled` with `operation: "assistant"`: pi retries a
- * failed ANSWER request itself, which the summarization-only cases of that vocabulary predate.
- */
 function toSessionEvent(event: AgentSessionEvent, runId: string): SessionEvent | null {
   const at = Date.now();
   switch (event.type) {
     case "message_start":
-      // Assistant streaming only — a user/toolResult message is not a live message boundary.
       if (event.message.role !== "assistant") return null;
       return { type: "message_started", timestamp: at, runId, data: {} };
     case "message_update": {
-      // An empty delta is not output: it moves no consumer's state, and treating it as output would
-      // spend the silent window that auto-retry is allowed to use (see runOnSession).
       const ev = event.assistantMessageEvent;
-      if (ev.type === "text_delta") {
+      if (ev.type === "text_delta" || ev.type === "thinking_delta") {
+        // Empty deltas must not spend the silent window in which a provider retry is safe.
         return ev.delta === ""
           ? null
-          : { type: "message_delta", timestamp: at, runId, data: { channel: "text", delta: ev.delta } };
-      }
-      if (ev.type === "thinking_delta") {
-        return ev.delta === ""
-          ? null
-          : { type: "message_delta", timestamp: at, runId, data: { channel: "thinking", delta: ev.delta } };
+          : {
+              type: "message_delta",
+              timestamp: at,
+              runId,
+              data: { channel: ev.type === "text_delta" ? "text" : "thinking", delta: ev.delta },
+            };
       }
       return null;
     }
@@ -127,26 +116,6 @@ function toSessionEvent(event: AgentSessionEvent, runId: string): SessionEvent |
   }
 }
 
-/**
- * The turn's outcome. `prompt()` resolves void and never throws for an engine-side failure (measured:
- * a provider error and an abort both resolve normally), so the terminal comes from the assistant
- * message the run ended on.
- *
- * That message is taken from the EVENT STREAM, not from `session.state.messages`. Session state is
- * mutable mid-turn: compaction replaces the array, and overflow recovery splices the last assistant
- * message out of it outright (`state.messages = messages.slice(0, -1)`). Any index into it is a
- * turn boundary that the engine is free to invalidate, while a `message_end` payload is a fact that
- * already happened. Auto-compaction runs its own model call outside the agent's event stream, so it
- * cannot masquerade as the turn's answer here.
- */
-const ENGINE_PRODUCED_NOTHING: AgentEvent = {
-  // Unreachable on a settled run: pi ends every outcome, error and abort included, with an assistant
-  // message. Reaching it means the engine broke its own contract — name the engine, not the turn.
-  type: "failed",
-  details: "the engine settled the run without ending an assistant message",
-  retryable: false,
-};
-
 export function createPiAgentFromSession(options: CreatePiAgentFromSessionOptions): Agent {
   const { sessionFactory, lease = inProcessLease(), observer } = options;
 
@@ -155,237 +124,228 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
     prompt: Prompt,
     { onCancelReady, wasCancelled }: CancelHooks,
   ): AsyncGenerator<AgentEvent> {
-    const release = lease.tryAcquire(scope.session);
-    if (!release) {
-      // Rejected BEFORE acceptance: no run exists, so the observer sees nothing (replay-safe).
-      yield {
-        type: "failed",
-        details: "session busy: a turn is already in flight for this session",
-        retryable: true,
-        code: SESSION_BUSY_CODE,
-      };
-      return;
-    }
-    // The run exists from here: exactly one run_started, exactly one run_settled. The settlement is
-    // emitted in the outer finally, immediately before the lease releases, so the observation
-    // plane's "running" window equals the lease window — state() must never read idle while a new
-    // invoke would still be rejected session_busy. A run with no recorded outcome was cancelled by
-    // the caller (SPEC: cancellation has no terminal event), which settles as aborted.
+    const queue = Effect.runSync(Queue.unbounded<AgentEvent, Cause.Done>());
+    const consumed = Deferred.makeUnsafe<void>();
+    const bound = Deferred.makeUnsafe<AgentSession, SessionOperationError>();
+    const abort = new AbortController();
+    onCancelReady(() => abort.abort());
     const runId = crypto.randomUUID();
+    let settled = false;
     let outcome: RunSettledEvent["data"] | undefined;
+    let abortsInFlight = 0;
+    let abortSucceeded = false;
     const observe = (event: SessionEvent | null, run?: RunControls): void => {
       if (!event || !observer) return;
       try {
         observer(scope.session, event, run);
       } catch (error) {
-        // The observation plane must never break the data plane; a broken hub is its own problem.
         log.warn(`[fastagent] session observer threw (event ${event.type}): ${String(error)}`);
       }
     };
-
-    // run_started is published BEFORE the session is built, so no early event can outrun the
-    // registration — which means the controls have to await the build rather than reject during it:
-    // a dispatch that races it simply queues on the freshly bound session. A build failure rejects
-    // the gate, so a pending dispatch learns why instead of hanging.
-    let sessionReady!: (session: AgentSession) => void;
-    let sessionFailed!: (error: unknown) => void;
-    const bound = new Promise<AgentSession>((resolve, reject) => {
-      sessionReady = resolve;
-      sessionFailed = reject;
-    });
-    bound.catch(() => {}); // observed through the controls only when a dispatch actually happens
-
-    // Stale-controls guard: after settlement pi's steer()/followUp()/abort() would still resolve
-    // (they queue onto a session about to be disposed), which is a silent acceptance of a command
-    // that can never take effect. The check and the engine call share one synchronous block — pi
-    // enqueues at method entry, so a check behind its own await would only shrink the race.
-    let settled = false;
-    const settledError = () => new Error("run already settled; the command cannot take effect");
-    // Aborted classification has two sources, either sufficient: pi's own stopReason "aborted", and
-    // control-plane INTENT — providers do not uniformly attribute an aborted stream, so an abort
-    // that was still in flight when the terminal arrived counts too.
-    let abortsInFlight = 0;
-    let abortSucceeded = false;
+    const ready = Deferred.await(bound);
     const controls: RunControls = {
-      async steer(p: Prompt) {
-        const opts = await toPiPromptOptions(p);
-        const session = await bound;
-        if (settled) throw settledError();
-        await session.steer(p.text, opts?.images);
-      },
-      async followUp(p: Prompt) {
-        const opts = await toPiPromptOptions(p);
-        const session = await bound;
-        if (settled) throw settledError();
-        await session.followUp(p.text, opts?.images);
-      },
-      async abort() {
-        const session = await bound;
-        if (settled) throw settledError();
-        abortsInFlight++;
-        try {
-          await session.abort();
-          abortSucceeded = true;
-        } finally {
-          abortsInFlight--;
-        }
-      },
-    };
-    observe({ type: "run_started", timestamp: Date.now(), runId, data: {} }, controls);
-
-    try {
-      let session: AgentSession;
-      try {
-        // The scope's lineage reaches the store's CREATE path only — an existing session opens
-        // exactly as before, whatever the scope names.
-        session = await sessionFactory(
-          scope.session,
-          scope.parentSession === undefined
-            ? undefined
-            : {
-                parentSession: scope.parentSession,
-                ...(scope.branchHints !== undefined ? { branchHints: scope.branchHints } : {}),
-              },
-        );
-        sessionReady(session);
-      } catch (error) {
-        // Setup failures (session open, auth, a broken definition) are EVENTS, never throws
-        // (MUST 2) — and they settle the run as failed: an unrecorded outcome means the caller
-        // cancelled, which this is not.
-        sessionFailed(error); // a pending dispatch learns the run cannot take commands
-        const terminal = errorToTerminal(error);
-        outcome = { status: "failed", error: { message: terminal.details, retryable: terminal.retryable } };
-        settled = true;
-        yield terminal;
-        return;
-      }
-      try {
-        const abort = () => session.abort().catch(() => {});
-        onCancelReady(() => void abort());
-        const queue = new EventQueue<AgentEvent>();
-        let finalAssistant: AssistantMessage | undefined;
-        /** Whether any of THIS attempt's answer has been streamed — the only output a retry duplicates. */
-        let streamedAnswer = false;
-        /** Set when a retry is refused because the answer already streamed — carries the ending error. */
-        let retriedAfterAnswer: string | undefined;
-        const unsub = session.subscribe((event) => {
-          if (retriedAfterAnswer !== undefined) return; // decided; the retry's output is not ours
-          if (event.type === "message_end" && event.message.role === "assistant") {
-            finalAssistant = event.message as AssistantMessage;
-            // Error messages and details can contain provider payloads; log only diagnostic metadata.
-            for (const diagnostic of finalAssistant.diagnostics ?? []) {
-              log.warn(
-                `[fastagent] provider diagnostic ${diagnostic.type} (${finalAssistant.provider}/${finalAssistant.model}, session ${scope.session}, run ${runId})`,
+      steer: (p) =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const opts = yield* sessionOperation("prepare steering", () => toPiPromptOptions(p));
+            const session = yield* ready;
+            if (settled)
+              return yield* Effect.fail(
+                new SessionOperationError("steer", new Error("run already settled; the command cannot take effect")),
               );
-            }
-          }
-          if (event.type === "compaction_end" && event.reason !== "manual") {
-            const status = event.aborted ? "aborted" : event.errorMessage ? "failed" : "completed";
-            const emit = event.errorMessage && !event.aborted ? log.warn : log.debug;
-            emit(
-              `[fastagent] automatic compaction ${event.reason} (session ${scope.session}, run ${runId}): ${status}`,
+            yield* sessionOperation("steer", () => session.steer(p.text, opts?.images));
+          }),
+        ),
+      followUp: (p) =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const opts = yield* sessionOperation("prepare follow-up", () => toPiPromptOptions(p));
+            const session = yield* ready;
+            if (settled)
+              return yield* Effect.fail(
+                new SessionOperationError(
+                  "follow-up",
+                  new Error("run already settled; the command cannot take effect"),
+                ),
+              );
+            yield* sessionOperation("follow-up", () => session.followUp(p.text, opts?.images));
+          }),
+        ),
+      abort: () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const session = yield* ready;
+            if (settled)
+              return yield* Effect.fail(
+                new SessionOperationError("abort", new Error("run already settled; the command cannot take effect")),
+              );
+            abortsInFlight++;
+            yield* sessionOperation("abort", () => session.abort()).pipe(
+              Effect.tap(() =>
+                Effect.sync(() => {
+                  abortSucceeded = true;
+                }),
+              ),
+              Effect.ensuring(
+                Effect.sync(() => {
+                  abortsInFlight--;
+                }),
+              ),
             );
-          }
-          // pi retries a failed assistant request by DISCARDING that attempt's assistant message and
-          // asking again. Everything the turn achieved before it survives — executed tools keep
-          // their persisted results, and the retry resumes from them — so the only thing a retry can
-          // duplicate is answer text already streamed, which SPEC deltas cannot retract. Refuse it
-          // exactly there: refusing on tool events instead would push the retry out to the CALLER,
-          // who can only re-run the whole prompt and execute the tool a second time.
-          if (event.type === "auto_retry_start" && streamedAnswer) {
-            retriedAfterAnswer = event.errorMessage;
-            // Not synchronously: pi emits this event BEFORE creating the controller that makes its
-            // backoff abortable, so an abort from inside the listener would find nothing to cancel
-            // and the turn would still pay the delay and burn a provider call on a discarded answer.
-            queueMicrotask(() => void abort());
-            return;
-          }
-          const rich = toSessionEvent(event, runId);
-          if (!rich) return;
-          observe(rich);
-          const projected = projectAgentEvent(rich);
-          if (!projected) return;
-          if (projected.type === "text" || projected.type === "thinking") streamedAnswer = true;
-          queue.push(projected);
-        });
-        try {
-          // Resolving prompt options lazy-loads the image pipeline and re-encodes every attachment,
-          // so it both takes time and can throw before any engine work exists to fail. Hence the two
-          // guards, in this order and no earlier: its failure is a turn failure (MUST 2), and the
-          // latch has to be read after the LAST await before the call — the door armed above only
-          // stops a RUNNING session, so a consumer who walked away during the build or the resize
-          // would knock on an idle one and have the turn start anyway.
-          let promptOptions: Awaited<ReturnType<typeof toPiPromptOptions>>;
-          try {
-            promptOptions = await toPiPromptOptions(prompt);
-          } catch (error) {
-            const terminal = errorToTerminal(error);
-            outcome = { status: "failed", error: { message: terminal.details, retryable: terminal.retryable } };
-            settled = true;
-            yield terminal;
-            return;
-          }
-          if (wasCancelled()) {
-            settled = true;
-            await abort();
-            return; // cancelled: the outer finally settles it as aborted
-          }
-          const run = session.prompt(prompt.text, promptOptions);
-          yield* queue.drainUntil(run);
-          let terminal: AgentEvent;
-          try {
-            await run;
-            terminal =
-              retriedAfterAnswer !== undefined
-                ? { type: "failed", details: retriedAfterAnswer, retryable: true }
-                : finalAssistant
-                  ? toTerminal(finalAssistant)
-                  : ENGINE_PRODUCED_NOTHING;
-          } catch (error) {
-            terminal = errorToTerminal(error);
-          }
-          if ((abortSucceeded || abortsInFlight > 0) && terminal.type === "failed") {
-            terminal = { type: "failed", details: terminal.details, retryable: false, code: ABORTED_CODE };
-          }
-          if (terminal.type === "failed") {
+          }),
+        ),
+    };
+
+    const execute = Effect.gen(function* () {
+      yield* acquireSessionLease(lease, scope.session);
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          settled = true;
+          observe({ type: "run_settled", timestamp: Date.now(), runId, data: outcome ?? { status: "aborted" } });
+        }),
+      );
+      // Admission precedes binding so a racing control command waits on this run's readiness gate.
+      observe({ type: "run_started", timestamp: Date.now(), runId, data: {} }, controls);
+      const session = yield* acquireSession(
+        sessionFactory,
+        scope.session,
+        scope.parentSession === undefined
+          ? undefined
+          : {
+              parentSession: scope.parentSession,
+              ...(scope.branchHints !== undefined ? { branchHints: scope.branchHints } : {}),
+            },
+      ).pipe(Effect.onExit((exit) => Deferred.done(bound, exit)));
+      let finalAssistant: AssistantMessage | undefined;
+      let streamedAnswer = false;
+      let retriedAfterAnswer: string | undefined;
+      let eventFailure: SessionOperationError | undefined;
+      const stop = () => {
+        void Effect.runPromise(sessionCleanup("abort", () => session.abort()));
+      };
+      yield* Effect.acquireRelease(
+        Effect.try({
+          try: () =>
+            session.subscribe((event) => {
+              if (retriedAfterAnswer !== undefined || eventFailure) return;
+              try {
+                // Compaction rewrites session history; the event's assistant message is the turn's fact.
+                if (event.type === "message_end" && event.message.role === "assistant") {
+                  finalAssistant = event.message as AssistantMessage;
+                  for (const diagnostic of finalAssistant.diagnostics ?? []) {
+                    log.warn(
+                      `[fastagent] provider diagnostic ${diagnostic.type} (${finalAssistant.provider}/${finalAssistant.model}, session ${scope.session}, run ${runId})`,
+                    );
+                  }
+                }
+                if (event.type === "compaction_end" && event.reason !== "manual") {
+                  const status = event.aborted ? "aborted" : event.errorMessage ? "failed" : "completed";
+                  const emit = event.errorMessage && !event.aborted ? log.warn : log.debug;
+                  emit(
+                    `[fastagent] automatic compaction ${event.reason} (session ${scope.session}, run ${runId}): ${status}`,
+                  );
+                }
+                if (event.type === "auto_retry_start" && streamedAnswer) {
+                  retriedAfterAnswer = event.errorMessage;
+                  // Pi installs the retry controller after emitting this event. Tool output alone is
+                  // replay-safe: Pi resumes from persisted tool results, rather than running tools twice.
+                  queueMicrotask(stop);
+                  return;
+                }
+                const rich = toSessionEvent(event, runId);
+                observe(rich);
+                if (!rich) return;
+                const projected = projectAgentEvent(rich);
+                if (!projected) return;
+                if (projected.type === "text" || projected.type === "thinking") streamedAnswer = true;
+                Queue.offerUnsafe(queue, projected);
+              } catch (error) {
+                eventFailure = new SessionOperationError("event translation", error);
+                queueMicrotask(stop);
+              }
+            }),
+          catch: (error) => new SessionOperationError("subscribe", error),
+        }),
+        (unsubscribe) => sessionCleanup("unsubscribe", unsubscribe),
+      );
+      const promptOptions = yield* sessionOperation("prepare prompt", () => toPiPromptOptions(prompt));
+      if (eventFailure) return yield* Effect.fail(eventFailure);
+      yield* sessionWork(
+        "prompt",
+        () => session.prompt(prompt.text, promptOptions),
+        () => session.abort(),
+      );
+      if (eventFailure) return yield* Effect.fail(eventFailure);
+      return retriedAfterAnswer !== undefined
+        ? ({ type: "failed", details: retriedAfterAnswer, retryable: true } as const)
+        : finalAssistant
+          ? toTerminal(finalAssistant)
+          : ({
+              type: "failed",
+              details: "the engine settled the run without ending an assistant message",
+              retryable: false,
+            } as const);
+    });
+
+    const work = Effect.runFork(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const terminal = yield* execute.pipe(
+            Effect.catchCause((cause) => {
+              const error = sessionFailure(cause);
+              return Effect.succeed(
+                error instanceof SessionBusy
+                  ? ({
+                      type: "failed",
+                      details: "session busy: a turn is already in flight for this session",
+                      retryable: true,
+                      code: SESSION_BUSY_CODE,
+                    } as const)
+                  : errorToTerminal(error),
+              );
+            }),
+          );
+          settled = true;
+          Queue.offerUnsafe(
+            queue,
+            terminal.type === "failed" && (abortSucceeded || abortsInFlight > 0)
+              ? { ...terminal, retryable: false, code: ABORTED_CODE }
+              : terminal,
+          );
+          Queue.endUnsafe(queue);
+          // Producer completion is earlier than consumer completion. Keep all resources until the
+          // consumer has drained or cancelled, including when its terminal is still buffered.
+          yield* Deferred.await(consumed);
+        }),
+      ).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            Queue.endUnsafe(queue);
+          }),
+        ),
+      ),
+      { signal: abort.signal },
+    );
+
+    const read = Queue.takeAll(queue).pipe(Effect.catchTag("Done", () => Effect.succeed([] as AgentEvent[])));
+    try {
+      for (;;) {
+        const events = await Effect.runPromise(read);
+        if (events.length === 0) return;
+        for (const event of events) {
+          if (wasCancelled()) return;
+          if (event.type === "failed") {
             outcome =
-              terminal.code === ABORTED_CODE
-                ? // Carry the detail: an independent error that raced an accepted abort must stay
-                  // diagnosable in the settlement, which is what audit consumers read.
-                  { status: "aborted", error: { message: terminal.details, retryable: false } }
-                : {
-                    status: "failed",
-                    error: { code: terminal.code, message: terminal.details, retryable: terminal.retryable },
-                  };
-          } else {
-            outcome = { status: "completed" };
-          }
-          // Commands become ineffective the moment the run resolved — not at the outer finally,
-          // which sits behind a consumer-paced `yield`.
-          settled = true;
-          yield terminal;
-        } finally {
-          settled = true;
-          unsub();
-        }
-      } finally {
-        // NO session_shutdown here, deliberately. A per-invoke session makes one look right, but the
-        // extension INSTANCE it would tear down is not per-invoke: extensions belong to the agent's
-        // assembly and every turn shares one. Emitting a shutdown per turn had a finished
-        // turn clearing a timer a concurrent turn had just opened (measured, and pinned in
-        // definition-extensions.test.ts). The lifecycle has to match the instance, not the session
-        // wrapper: one agent, one instance, no per-turn teardown. Extensions that need per-turn
-        // cleanup do it in the tool or handler that opened the resource.
-        try {
-          session.dispose();
-        } catch (error) {
-          log.warn(`[fastagent] session dispose failed during cleanup: ${String(error)}`);
+              event.code === ABORTED_CODE
+                ? { status: "aborted", error: { message: event.details, retryable: false } }
+                : { status: "failed", error: { code: event.code, message: event.details, retryable: event.retryable } };
+          } else if (event.type === "completed") outcome = { status: "completed" };
+          yield event;
         }
       }
     } finally {
-      settled = true;
-      observe({ type: "run_settled", timestamp: Date.now(), runId, data: outcome ?? { status: "aborted" } });
-      release(); // after the settlement, so the next invoke for this session cannot outrun it
+      Deferred.doneUnsafe(consumed, Effect.void);
+      await Effect.runPromise(Fiber.await(work));
     }
   }
 

--- a/src/engines/pi/session-control.ts
+++ b/src/engines/pi/session-control.ts
@@ -13,6 +13,19 @@
  * `unsupported_capability` — a client gating on `capabilities()` never sends them.
  */
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import type * as Scope from "effect/Scope";
+import {
+  type SessionBusy,
+  SessionOperationError,
+  acquireSession,
+  acquireSessionLease,
+  sessionCleanup,
+  sessionFailure,
+  sessionOperation,
+  sessionWork,
+} from "./session-effects.ts";
 import {
   type SessionEntry as PiSessionEntry,
   findCutPoint,
@@ -451,7 +464,7 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
 
   /** No boundary wiring — the write path does not exist in this deployment. A capability-gating
    *  client never lands here; one that does gets the same answer every gate publishes. */
-  const unsupported = (what: string): SessionResult => ({
+  const unsupported = (what: string): Extract<SessionResult, { ok: false }> => ({
     ok: false,
     error: {
       code: UNSUPPORTED_CAPABILITY_CODE,
@@ -460,17 +473,17 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
     },
   });
 
-  const noSuchSession = (session: string): SessionResult => ({
+  const noSuchSession = (session: string): Extract<SessionResult, { ok: false }> => ({
     ok: false,
     error: { code: NO_SUCH_SESSION_CODE, message: `session "${session}" does not exist`, retryable: false },
   });
 
-  const invalid = (message: string): SessionResult => ({
+  const invalid = (message: string): Extract<SessionResult, { ok: false }> => ({
     ok: false,
     error: { code: INVALID_COMMAND_CODE, message, retryable: false },
   });
 
-  const busy = (): SessionResult => ({
+  const busy = (): Extract<SessionResult, { ok: false }> => ({
     ok: false,
     error: {
       code: SESSION_BUSY_CODE,
@@ -479,63 +492,80 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
     },
   });
 
-  const failed = (error: unknown): SessionResult => ({
+  const failed = (error: unknown): Extract<SessionResult, { ok: false }> => ({
     ok: false,
     error: { code: BOUNDARY_COMMAND_FAILED_CODE, message: String(error), retryable: true },
   });
 
+  const runBoundary = (
+    command: Effect.Effect<SessionResult, SessionOperationError | SessionBusy, Scope.Scope>,
+  ): Promise<SessionResult> =>
+    Effect.runPromise(
+      Effect.scoped(command).pipe(
+        Effect.catchTag("SessionBusy", () => Effect.succeed(busy())),
+        Effect.catchCause((cause) => Effect.succeed(failed(sessionFailure(cause)))),
+      ),
+    );
+
   /** steer / follow_up / abort — the run actions. They reach the LIVE run through the controls
    *  registered with `run_started`; nothing durable is written. */
-  const runAction = async (session: string, action: SessionAction): Promise<SessionResult> => {
-    const run = active.get(session);
-    if (!run) {
-      // Run/compaction symmetry: an in-flight compaction is a model call too, and `abort` is its
-      // only door — interrupting it converges through the detached task's catch into
-      // `compaction_finished{aborted}` with the lease released; answering no_active_run against a
-      // state() that says "compacting" would be a lie.
-      const comp = action.type === "abort" ? compacting.get(session) : undefined;
-      if (comp) {
-        comp.abort();
-        return { ok: true }; // no runId — the outcome travels as compaction_finished{aborted}
-      }
-      // Rejected BEFORE acceptance: no run exists, nothing happened. retryable: false — the same
-      // call fails again; call it after state() shows an active run.
-      return {
-        ok: false,
-        error: {
-          code: NO_ACTIVE_RUN_CODE,
-          message: `no active run for this session — ${action.type} modulates a run an invoke is driving`,
-          retryable: false,
-        },
-      };
-    }
-    if (!run.controls) {
-      // A run EXISTS (state() rightly reports running) but was registered observation-only (the
-      // observer seam allows run_started without controls). That is a CAPABILITY problem, not a run
-      // problem — permanent for this wiring, so neither no_active_run (would poll forever) nor
-      // run_command_failed (transient) fits.
-      return {
-        ok: false,
-        error: {
-          code: UNSUPPORTED_CAPABILITY_CODE,
-          message: `the active run registered without modulation controls (observation-only) — ${action.type} cannot reach it`,
-          retryable: false,
-        },
-      };
-    }
-    try {
-      if (action.type === "steer") await run.controls.steer(action.prompt);
-      else if (action.type === "follow_up") await run.controls.followUp(action.prompt);
-      else await run.controls.abort();
-    } catch (error) {
-      // The run raced us to settlement, failed setup, or the engine refused: still pre-acceptance
-      // (nothing was queued), distinct from "no run existed". retryable: false for the same reason —
-      // the run is gone; consult state() before calling again.
-      return { ok: false, error: { code: RUN_COMMAND_FAILED_CODE, message: String(error), retryable: false } };
-    }
-    // Accepted: joined (or stopped) THIS run. The outcome arrives as run_settled.
-    return { ok: true, runId: run.runId };
-  };
+  const runAction = (session: string, action: SessionAction): Promise<SessionResult> =>
+    Effect.runPromise(
+      Effect.gen(function* (): Effect.fn.Return<SessionResult, SessionOperationError> {
+        const run = active.get(session);
+        if (!run) {
+          // Run/compaction symmetry: an in-flight compaction is a model call too, and `abort` is its
+          // only door — interrupting it converges through the detached task's catch into
+          // `compaction_finished{aborted}` with the lease released; answering no_active_run against a
+          // state() that says "compacting" would be a lie.
+          const comp = action.type === "abort" ? compacting.get(session) : undefined;
+          if (comp) {
+            comp.abort();
+            return { ok: true }; // no runId — the outcome travels as compaction_finished{aborted}
+          }
+          // Rejected BEFORE acceptance: no run exists, nothing happened. retryable: false — the same
+          // call fails again; call it after state() shows an active run.
+          return {
+            ok: false,
+            error: {
+              code: NO_ACTIVE_RUN_CODE,
+              message: `no active run for this session — ${action.type} modulates a run an invoke is driving`,
+              retryable: false,
+            },
+          };
+        }
+        if (!run.controls) {
+          // A run EXISTS (state() rightly reports running) but was registered observation-only (the
+          // observer seam allows run_started without controls). That is a CAPABILITY problem, not a run
+          // problem — permanent for this wiring, so neither no_active_run (would poll forever) nor
+          // run_command_failed (transient) fits.
+          return {
+            ok: false,
+            error: {
+              code: UNSUPPORTED_CAPABILITY_CODE,
+              message: `the active run registered without modulation controls (observation-only) — ${action.type} cannot reach it`,
+              retryable: false,
+            },
+          };
+        }
+        const controls = run.controls;
+        yield* sessionOperation(action.type, () =>
+          action.type === "steer"
+            ? controls.steer(action.prompt)
+            : action.type === "follow_up"
+              ? controls.followUp(action.prompt)
+              : controls.abort(),
+        );
+        return { ok: true, runId: run.runId };
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.succeed({
+            ok: false as const,
+            error: { code: RUN_COMMAND_FAILED_CODE, message: String(sessionFailure(cause)), retryable: false },
+          }),
+        ),
+      ),
+    );
 
   /**
    * {@link Session.update} — validate the whole patch, take the lease once, hand the writes to the
@@ -545,249 +575,232 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
    * behind. What a value MEANS is decided here (a model spec against the registry, a level against
    * the model it lands on); how a record takes it is the store's.
    */
-  const updateOf = async (session: string, patch: SessionUpdate): Promise<SessionResult> => {
-    // Keys, not values: a field this runtime does not know must not be silently skipped — that is a
-    // client typo, or a newer client talking to an older serve, and both need to hear about it.
-    const named = Object.keys(patch) as SessionUpdateField[];
-    const unknown = named.filter((f) => !UPDATE_FIELDS.includes(f));
-    if (unknown.length > 0) {
-      return unsupported(`update field(s) ${unknown.join(", ")} — capabilities().updatable lists what this serve sets`);
-    }
-    const fields = named.filter((f) => patch[f] !== undefined);
-    if (fields.length === 0) return { ok: true }; // an empty patch asks for nothing, and gets it
-    const b = boundary;
-    if (!b) return unsupported(`update(${fields.join(", ")})`);
-
-    // PAYLOAD validation first — before the session is even opened, and long before the lease: an
-    // invalid value must not briefly block a run.
-    let model: AnyModel | undefined;
-    if (patch.model !== undefined) {
-      const slash = patch.model.indexOf("/");
-      model = slash > 0 ? b.models.getModel(patch.model.slice(0, slash), patch.model.slice(slash + 1)) : undefined;
-      if (!model) {
-        return invalid(`unknown model "${patch.model}" — capabilities().allowedModels lists the accepted specs`);
-      }
-    }
-    if (patch.thinkingLevel !== undefined && !(THINKING_LEVELS as ReadonlySet<string>).has(patch.thinkingLevel)) {
-      return invalid(
-        `unknown thinking level "${patch.thinkingLevel}" — state().availableThinkingLevels lists what this session accepts`,
-      );
-    }
-    // A name is the client's own label; the only thing that cannot be one is nothing.
-    if (patch.name !== undefined && patch.name.trim() === "") return invalid("a session name cannot be empty");
-
-    // Sessions are created by invoke or copied by fork, never minted by an update: an unknown id is
-    // rejected, not turned into a ghost record. (Read-only handle — the WRITE one is opened under
-    // the lease below, and this one is discarded.)
-    const existing = await sessions.openIfExists(session);
-    if (!existing) return noSuchSession(session);
-
-    if (patch.leafEntryId !== undefined) {
-      // A target that cannot BE a leaf is a permanent payload error, not a session error — the same
-      // disposition as an unknown model spec. Same predicate `entries()` publishes by, so
-      // "everything published is a position" holds by construction rather than by two literals
-      // agreeing.
-      const entry = existing.getEntry(patch.leafEntryId) as PiSessionEntry | undefined;
-      if (!entry || !isNavigable(entry)) {
-        return invalid(
-          entry
-            ? `entry "${patch.leafEntryId}" is not a position — entries() publishes every id you can move to, and this is not one of them`
-            : `entry "${patch.leafEntryId}" does not exist in session "${session}" — entries() lists the positions`,
-        );
-      }
-    }
-    if (patch.thinkingLevel !== undefined) {
-      // The same set `state()` showed the client. Reject here rather than record a level the run
-      // would not use. The read is guarded because this must never REJECT — the contract promises a
-      // SessionResult, so an unreadable chain has to arrive as a code.
-      let resolved: ReturnType<typeof resolveSessionSettings>;
-      try {
-        // Against the path this patch LANDS on: a leaf move is written first, and the branch it
-        // moves to can carry a model override of its own — validating on the path being left would
-        // reject a level the destination supports, and accept one it does not.
-        resolved = resolveSessionSettings(activePath(existing, patch.leafEntryId), b.models, b.defaults);
-      } catch (error) {
-        return failed(error);
-      }
-      // An explicit model in the same patch wins over the one that path resolves to: it is applied
-      // after the move, so it is what the session ends up running.
-      const target = model ?? resolved.model;
-      const levels = model ? (getSupportedThinkingLevels(model) as string[]) : resolved.availableThinkingLevels;
-      if (!levels.includes(patch.thinkingLevel)) {
-        return invalid(
-          `thinking level "${patch.thinkingLevel}" is not supported by ${target.provider}/${target.id} (allowed: ${levels.join(", ")})`,
-        );
-      }
-    }
-
-    // The control plane's writes take the same lease as every run — a write must never race one
-    // (design §9).
-    const release = b.lease.tryAcquire(session);
-    if (!release) return busy();
-    let applied: Awaited<ReturnType<PiSessionRecordStore["applyProperties"]>>;
-    try {
-      // HOW a record takes a property — order, the leaf pointer, the name pi rewrites — is the
-      // store's to know. This asks for the writes and is told what landed.
-      applied = await sessions.applyProperties(session, {
-        ...(patch.name !== undefined ? { name: patch.name } : {}),
-        ...(model ? { model: { provider: model.provider, id: model.id } } : {}),
-        ...(patch.thinkingLevel !== undefined ? { thinkingLevel: patch.thinkingLevel } : {}),
-        ...(patch.leafEntryId !== undefined ? { leafEntryId: patch.leafEntryId } : {}),
-      });
-    } catch (error) {
-      // Opening the record failed — nothing was written; the same patch may succeed on retry. The
-      // lease is freed by the `finally` on the way out, once.
-      return failed(error);
-    } finally {
-      release();
-    }
-    if (!applied) return noSuchSession(session); // vanished in the window: same condition, same code
-
-    if (applied.landed.length > 0) {
-      // ONE event for the patch, built from what the RECORD holds. The settings pair rides along
-      // whenever anything but the name changed: model and thinking level are one setting, and a
-      // moved leaf can drop an override that used to apply.
-      let settings: ReturnType<typeof resolveSessionSettings> | undefined;
-      if (applied.path) {
-        try {
-          settings = resolveSessionSettings(applied.path, b.models, b.defaults);
-        } catch (error) {
-          // Already durable, so an unresolvable pair must NOT read as "nothing took effect": report
-          // the position without it and let the next invoke — which walks the same path — be where
-          // the fault surfaces.
-          log.warn(`[fastagent] session ${session}: updated, settings unresolvable: ${String(error)}`);
+  const updateOf = (session: string, patch: SessionUpdate): Promise<SessionResult> =>
+    runBoundary(
+      Effect.gen(function* () {
+        // Keys, not values: a field this runtime does not know must not be silently skipped — that is a
+        // client typo, or a newer client talking to an older serve, and both need to hear about it.
+        const named = Object.keys(patch) as SessionUpdateField[];
+        const unknown = named.filter((f) => !UPDATE_FIELDS.includes(f));
+        if (unknown.length > 0) {
+          return unsupported(
+            `update field(s) ${unknown.join(", ")} — capabilities().updatable lists what this serve sets`,
+          );
         }
-      }
-      emitOwn(session, {
-        type: "state_changed",
-        timestamp: Date.now(),
-        data: {
-          ...(applied.landed.includes("leafEntryId") ? { leafEntryId: applied.leafEntryId as string } : {}),
-          ...(settings && applied.landed.some((f) => f !== "name")
-            ? { model: `${settings.model.provider}/${settings.model.id}`, thinkingLevel: settings.thinkingLevel }
-            : {}),
-          ...(applied.landed.includes("name") && applied.name ? { name: applied.name } : {}),
-        },
-      });
-    }
-    if (applied.failure !== undefined) {
-      // `boundary_command_failed` means nothing durable landed. When something did, the client needs
-      // a different sentence — and the fields, so it knows what its retry would repeat.
-      return applied.landed.length === 0
-        ? failed(applied.failure)
-        : {
+        const fields = named.filter((f) => patch[f] !== undefined);
+        if (fields.length === 0) return { ok: true }; // an empty patch asks for nothing, and gets it
+        const b = boundary;
+        if (!b) return unsupported(`update(${fields.join(", ")})`);
+
+        // PAYLOAD validation first — before the session is even opened, and long before the lease: an
+        // invalid value must not briefly block a run.
+        let model: AnyModel | undefined;
+        if (patch.model !== undefined) {
+          const slash = patch.model.indexOf("/");
+          model = slash > 0 ? b.models.getModel(patch.model.slice(0, slash), patch.model.slice(slash + 1)) : undefined;
+          if (!model) {
+            return invalid(`unknown model "${patch.model}" — capabilities().allowedModels lists the accepted specs`);
+          }
+        }
+        if (patch.thinkingLevel !== undefined && !(THINKING_LEVELS as ReadonlySet<string>).has(patch.thinkingLevel)) {
+          return invalid(
+            `unknown thinking level "${patch.thinkingLevel}" — state().availableThinkingLevels lists what this session accepts`,
+          );
+        }
+        // A name is the client's own label; the only thing that cannot be one is nothing.
+        if (patch.name !== undefined && patch.name.trim() === "") return invalid("a session name cannot be empty");
+
+        // Sessions are created by invoke or copied by fork, never minted by an update: an unknown id is
+        // rejected, not turned into a ghost record. (Read-only handle — the WRITE one is opened under
+        // the lease below, and this one is discarded.)
+        const existing = yield* sessionOperation("read session", () => sessions.openIfExists(session));
+        if (!existing) return noSuchSession(session);
+
+        if (patch.leafEntryId !== undefined) {
+          // A target that cannot BE a leaf is a permanent payload error, not a session error — the same
+          // disposition as an unknown model spec. Same predicate `entries()` publishes by, so
+          // "everything published is a position" holds by construction rather than by two literals
+          // agreeing.
+          const entry = existing.getEntry(patch.leafEntryId) as PiSessionEntry | undefined;
+          if (!entry || !isNavigable(entry)) {
+            return invalid(
+              entry
+                ? `entry "${patch.leafEntryId}" is not a position — entries() publishes every id you can move to, and this is not one of them`
+                : `entry "${patch.leafEntryId}" does not exist in session "${session}" — entries() lists the positions`,
+            );
+          }
+        }
+        if (patch.thinkingLevel !== undefined) {
+          // The same set `state()` showed the client. Reject here rather than record a level the run
+          // would not use. The read is guarded because this must never REJECT — the contract promises a
+          // SessionResult, so an unreadable chain has to arrive as a code.
+          let resolved: ReturnType<typeof resolveSessionSettings>;
+          try {
+            // Against the path this patch LANDS on: a leaf move is written first, and the branch it
+            // moves to can carry a model override of its own — validating on the path being left would
+            // reject a level the destination supports, and accept one it does not.
+            resolved = resolveSessionSettings(activePath(existing, patch.leafEntryId), b.models, b.defaults);
+          } catch (error) {
+            return failed(error);
+          }
+          // An explicit model in the same patch wins over the one that path resolves to: it is applied
+          // after the move, so it is what the session ends up running.
+          const target = model ?? resolved.model;
+          const levels = model ? (getSupportedThinkingLevels(model) as string[]) : resolved.availableThinkingLevels;
+          if (!levels.includes(patch.thinkingLevel)) {
+            return invalid(
+              `thinking level "${patch.thinkingLevel}" is not supported by ${target.provider}/${target.id} (allowed: ${levels.join(", ")})`,
+            );
+          }
+        }
+
+        // Release before publishing state_changed: an observer may immediately issue another command.
+        const applied = yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* acquireSessionLease(b.lease, session);
+            return yield* sessionOperation("update", () =>
+              sessions.applyProperties(session, {
+                ...(patch.name !== undefined ? { name: patch.name } : {}),
+                ...(model ? { model: { provider: model.provider, id: model.id } } : {}),
+                ...(patch.thinkingLevel !== undefined ? { thinkingLevel: patch.thinkingLevel } : {}),
+                ...(patch.leafEntryId !== undefined ? { leafEntryId: patch.leafEntryId } : {}),
+              }),
+            );
+          }),
+        );
+        if (!applied) return noSuchSession(session); // vanished in the window: same condition, same code
+
+        if (applied.landed.length > 0) {
+          // ONE event for the patch, built from what the RECORD holds. The settings pair rides along
+          // whenever anything but the name changed: model and thinking level are one setting, and a
+          // moved leaf can drop an override that used to apply.
+          let settings: ReturnType<typeof resolveSessionSettings> | undefined;
+          if (applied.path) {
+            try {
+              settings = resolveSessionSettings(applied.path, b.models, b.defaults);
+            } catch (error) {
+              // Already durable, so an unresolvable pair must NOT read as "nothing took effect": report
+              // the position without it and let the next invoke — which walks the same path — be where
+              // the fault surfaces.
+              log.warn(`[fastagent] session ${session}: updated, settings unresolvable: ${String(error)}`);
+            }
+          }
+          emitOwn(session, {
+            type: "state_changed",
+            timestamp: Date.now(),
+            data: {
+              ...(applied.landed.includes("leafEntryId") ? { leafEntryId: applied.leafEntryId as string } : {}),
+              ...(settings && applied.landed.some((f) => f !== "name")
+                ? { model: `${settings.model.provider}/${settings.model.id}`, thinkingLevel: settings.thinkingLevel }
+                : {}),
+              ...(applied.landed.includes("name") && applied.name ? { name: applied.name } : {}),
+            },
+          });
+        }
+        if (applied.failure !== undefined) {
+          // `boundary_command_failed` means nothing durable landed. When something did, the client needs
+          // a different sentence — and the fields, so it knows what its retry would repeat.
+          return applied.landed.length === 0
+            ? failed(applied.failure)
+            : {
+                ok: false,
+                error: {
+                  code: PARTIAL_UPDATE_CODE,
+                  message: `applied ${applied.landed.join(", ")}, then failed: ${String(applied.failure)} — read state() before retrying`,
+                  retryable: false,
+                },
+              };
+        }
+        return { ok: true };
+      }),
+    );
+
+  /** Admission waits for binding and local preparation, not the model call. Its execution scope
+   *  survives the control response; completion is published only after releasing the shared lease. */
+  const compactOf = (session: string, instructions?: string): Promise<SessionResult> => {
+    const admitted = Deferred.makeUnsafe<SessionResult>();
+    let accepted = false;
+    let aborted = false;
+    const work = Effect.scoped(
+      Effect.gen(function* (): Effect.fn.Return<
+        { summary: string } | Extract<SessionResult, { ok: false }>,
+        SessionBusy | SessionOperationError,
+        Scope.Scope
+      > {
+        const b = boundary;
+        if (!b) return unsupported("compact()");
+        const existing = yield* sessionOperation("read session", () => sessions.openIfExists(session));
+        if (!existing) return noSuchSession(session);
+        yield* acquireSessionLease(b.lease, session);
+        const bound = yield* acquireSession(b.sessionFactory, session);
+        // Use Pi's own thresholds: a different cut point can admit work Pi later refuses.
+        if (
+          !hasCompactableHistory(
+            bound.sessionManager.getBranch(),
+            bound.settingsManager.getCompactionSettings().keepRecentTokens,
+          )
+        ) {
+          return {
             ok: false,
             error: {
-              code: PARTIAL_UPDATE_CODE,
-              message: `applied ${applied.landed.join(", ")}, then failed: ${String(applied.failure)} — read state() before retrying`,
+              code: NOTHING_TO_COMPACT_CODE,
+              message: "nothing to compact — the session has no compactable history yet; retry after more turns",
               retryable: false,
             },
-          };
-    }
-    return { ok: true };
-  };
-
-  /**
-   * ACCEPT-FAST compaction: a full model call (tens of seconds is normal), so holding the call open
-   * until it finishes would make acceptance = outcome — the one exception to §5.2, and what broke
-   * remote clients whose request timeouts are sized for control calls. This answers once the work is
-   * ADMITTED (lease held, session bound); the outcome travels as
-   * `compaction_finished{summary|error|aborted}`.
-   *
-   * Admission is everything cheap and local: binding the session (the ONE canonical resolution of
-   * overrides + auth) plus the compaction PREPARATION, a pure branch read. The boundary between
-   * "reject" and "the outcome travels as an event" sits where the work becomes asynchronous and
-   * expensive: the model call. "Nothing to compact" is therefore a pre-acceptance answer, never a
-   * finished{error} dressed as a failure — pi reports it as a throw from compact(), too late.
-   */
-  const compactOf = async (session: string, instructions?: string): Promise<SessionResult> => {
-    const b = boundary;
-    if (!b) return unsupported("compact()");
-    const existing = await sessions.openIfExists(session);
-    if (!existing) return noSuchSession(session);
-    const release = b.lease.tryAcquire(session);
-    if (!release) return busy();
-
-    let bound: Awaited<ReturnType<typeof b.sessionFactory>>;
-    try {
-      bound = await b.sessionFactory(session);
-    } catch (error) {
-      release();
-      return failed(error);
-    }
-    const teardown = () => {
-      try {
-        bound.dispose();
-      } catch (error) {
-        log.warn(`[fastagent] compaction session teardown failed: ${String(error)}`);
-      }
-    };
-    try {
-      // The SAME settings pi will use inside compact(): asking with different thresholds would
-      // either reject a compaction pi would have run, or admit one it refuses — and its refusal
-      // arrives too late to be a pre-acceptance answer.
-      const path = bound.sessionManager.getBranch();
-      if (!hasCompactableHistory(path, bound.settingsManager.getCompactionSettings().keepRecentTokens)) {
-        teardown();
-        release();
-        // A no-op, not a failure — its OWN code (the NO_ACTIVE_RUN pattern): a client must
-        // machine-distinguish "give up" from "call again once the session grows", and branching on
-        // message prose is forbidden by contract.
-        return {
-          ok: false,
-          error: {
-            code: NOTHING_TO_COMPACT_CODE,
-            message: "nothing to compact — the session has no compactable history yet; retry after more turns",
-            retryable: false,
+          } as const;
+        }
+        accepted = true;
+        compacting.set(session, {
+          abort: () => {
+            aborted = true;
+            bound.abortCompaction();
           },
-        };
-      }
-    } catch (error) {
-      teardown();
-      release();
-      return failed(error);
-    }
-    // Pi creates the abort controller after an await and emits compaction_start immediately after.
-    // Retain early cancellation until that event; there is no time limit on session startup.
-    let aborted = false;
-    compacting.set(session, {
-      abort: () => {
-        aborted = true;
-        bound.abortCompaction();
-      },
-    });
-    emitOwn(session, { type: "compaction_started", timestamp: Date.now(), data: {} });
-    void (async () => {
-      let outcome: { summary: string } | { error: string } | { aborted: true };
-      // Retries are otherwise invisible between compaction_started and _finished — surface each
-      // backoff so a long gap is diagnosable (not confusable with a hang): as a session event for
-      // attached observers, as a warn for server logs.
-      const unsub = bound.subscribe((event) => {
-        if (event.type === "compaction_start" && event.reason === "manual" && aborted) bound.abortCompaction();
-        if (event.type !== "summarization_retry_scheduled") return;
-        log.warn(
-          `[fastagent] compaction retry ${event.attempt}/${event.maxAttempts} in ${event.delayMs}ms (session ${session}): ${event.errorMessage}`,
+        });
+        emitOwn(session, { type: "compaction_started", timestamp: Date.now(), data: {} });
+        yield* Deferred.succeed(admitted, { ok: true });
+        yield* Effect.acquireRelease(
+          Effect.try({
+            try: () =>
+              bound.subscribe((event) => {
+                // Pi creates the controller after an await; retain an early stop until this event.
+                if (event.type === "compaction_start" && event.reason === "manual" && aborted) bound.abortCompaction();
+                if (event.type !== "summarization_retry_scheduled") return;
+                log.warn(
+                  `[fastagent] compaction retry ${event.attempt}/${event.maxAttempts} in ${event.delayMs}ms (session ${session}): ${event.errorMessage}`,
+                );
+                emitOwn(session, toRetryScheduledEvent(event));
+              }),
+            catch: (error) => new SessionOperationError("subscribe", error),
+          }),
+          (unsubscribe) => sessionCleanup("unsubscribe", unsubscribe),
         );
-        emitOwn(session, toRetryScheduledEvent(event));
-      });
-      try {
-        const done = await bound.compact(instructions);
-        outcome = { summary: done.summary };
-      } catch (error) {
-        // A deliberate stop is not a failure — run/compaction symmetry with run_settled{aborted}:
-        // the intent is the classification, same discipline as run abort attribution (a racing real
-        // failure still reads as aborted).
-        outcome = aborted ? { aborted: true } : { error: String(error) };
-      }
-      unsub();
-      teardown();
-      // Release BEFORE emitting finished: a watcher seeing finished may act next — "finished ⇒ the
-      // lease is free and status is no longer compacting" must hold.
-      compacting.delete(session);
-      release();
-      emitOwn(session, { type: "compaction_finished", timestamp: Date.now(), data: outcome });
-    })();
-    return { ok: true };
+        const done = yield* sessionWork(
+          "compact",
+          () => bound.compact(instructions),
+          () => bound.abortCompaction(),
+        );
+        return { summary: done.summary };
+      }),
+    ).pipe(
+      Effect.catchTag("SessionBusy", () => Effect.succeed(busy())),
+      Effect.catchCause((cause) => Effect.succeed(failed(sessionFailure(cause)))),
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          if (accepted) {
+            compacting.delete(session);
+            emitOwn(session, {
+              type: "compaction_finished",
+              timestamp: Date.now(),
+              data: "summary" in result ? result : aborted ? { aborted: true } : { error: result.error.message },
+            });
+          }
+          Deferred.doneUnsafe(admitted, Effect.succeed("summary" in result ? { ok: true } : result));
+        }),
+      ),
+    );
+    // The admitted operation, rather than the request waiting on this Deferred, owns the scope.
+    Effect.runFork(work);
+    return Effect.runPromise(Deferred.await(admitted));
   };
 
   /**
@@ -797,95 +810,80 @@ export function createPiSessionControl(options: CreatePiSessionControlOptions): 
    * safe rather than merely quiet: the same `into` naming a session that came from somewhere else is
    * a rejection, not an overwrite.
    */
-  const forkOf = async (options: { from: string; at: string; into: string }): Promise<SessionResult> => {
-    const { from, at, into } = options;
-    /** WHICH fork this is: source + branch point. Two forks of one session at different entries are
-     *  different requests, so a retry of one must not be answered by the other. */
-    const provenance = `${from}@${at}`;
-    const b = boundary;
-    if (!b) return unsupported("fork()");
-    // An id no client could then open: the empty string, `.` and `..` are not URL path segments
-    // (isAddressableSession), so minting one would put a row in list() that nothing can address —
-    // listed, unopenable by the client that just listed it.
-    if (!isAddressableSession(into)) {
-      return invalid(`${JSON.stringify(into)} cannot be a session id — the control plane could not address it`);
-    }
-    const source = await sessions.openIfExists(from);
-    if (!source) return noSuchSession(from);
-    // The entry predicate is the one `entries()` publishes by, so "everything published is forkable"
-    // holds by construction — the same argument the leaf move makes.
-    const entry = source.getEntry(at) as PiSessionEntry | undefined;
-    if (!entry || !isNavigable(entry)) {
-      return invalid(`entry "${at}" is not a forkable position in session "${from}" — entries() lists the ids`);
-    }
-    const existingTarget = await sessions.openIfExists(into);
-    if (existingTarget) {
-      // Already forked from HERE: the request already happened, so answering ok is the truth rather
-      // than a convenience. Anything else under that id is a different history, and saying yes would
-      // be the id lying about what it holds.
-      return forkProvenance(existingTarget) === provenance
-        ? { ok: true }
-        : invalid(`session "${into}" already exists with a different history — fork mints nothing over it`);
-    }
+  const forkOf = (options: { from: string; at: string; into: string }): Promise<SessionResult> =>
+    runBoundary(
+      Effect.gen(function* () {
+        const { from, at, into } = options;
+        /** WHICH fork this is: source + branch point. Two forks of one session at different entries are
+         *  different requests, so a retry of one must not be answered by the other. */
+        const provenance = `${from}@${at}`;
+        const b = boundary;
+        if (!b) return unsupported("fork()");
+        // An id no client could then open: the empty string, `.` and `..` are not URL path segments
+        // (isAddressableSession), so minting one would put a row in list() that nothing can address —
+        // listed, unopenable by the client that just listed it.
+        if (!isAddressableSession(into)) {
+          return invalid(`${JSON.stringify(into)} cannot be a session id — the control plane could not address it`);
+        }
+        const source = yield* sessionOperation("read fork source", () => sessions.openIfExists(from));
+        if (!source) return noSuchSession(from);
+        // The entry predicate is the one `entries()` publishes by, so "everything published is forkable"
+        // holds by construction — the same argument the leaf move makes.
+        const entry = source.getEntry(at) as PiSessionEntry | undefined;
+        if (!entry || !isNavigable(entry)) {
+          return invalid(`entry "${at}" is not a forkable position in session "${from}" — entries() lists the ids`);
+        }
+        const existingTarget = yield* sessionOperation("read fork target", () => sessions.openIfExists(into));
+        if (existingTarget) {
+          // Already forked from HERE: the request already happened, so answering ok is the truth rather
+          // than a convenience. Anything else under that id is a different history, and saying yes would
+          // be the id lying about what it holds.
+          return forkProvenance(existingTarget) === provenance
+            ? { ok: true }
+            : invalid(`session "${into}" already exists with a different history — fork mints nothing over it`);
+        }
 
-    // BOTH ends. The source lease keeps the copy from reading a history a run is mid-write on; the
-    // destination lease closes the window the existence check above leaves open — an invoke creating
-    // `into`, or a second fork from a DIFFERENT source (whose source lease is another key entirely),
-    // otherwise lands between that check and this write. tryAcquire never blocks, so taking two
-    // cannot deadlock.
-    const release = b.lease.tryAcquire(from);
-    if (!release) return busy();
-    const releaseInto = b.lease.tryAcquire(into);
-    if (!releaseInto) {
-      release();
-      return busy();
-    }
-    try {
-      // Holding the lease is not the same as having looked: re-asked under it, as the update path
-      // re-opens its record, so an id taken inside the window is a payload error rather than a
-      // store failure the client would read as retryable.
-      const raced = await sessions.openIfExists(into);
-      if (raced) {
-        return forkProvenance(raced) === provenance
-          ? { ok: true }
-          : invalid(`session "${into}" already exists with a different history — fork mints nothing over it`);
-      }
-      await sessions.fork(from, at, into, provenance);
-    } catch (error) {
-      // Nothing durable landed: the copy is staged and published by rename.
-      return failed(error);
-    } finally {
-      releaseInto();
-      release();
-    }
-    return { ok: true };
-  };
+        // BOTH ends. The source lease keeps the copy from reading a history a run is mid-write on; the
+        // destination lease closes the window the existence check above leaves open — an invoke creating
+        // `into`, or a second fork from a DIFFERENT source (whose source lease is another key entirely),
+        // otherwise lands between that check and this write. tryAcquire never blocks, so taking two
+        // cannot deadlock.
+        yield* acquireSessionLease(b.lease, from);
+        yield* acquireSessionLease(b.lease, into);
+        // Recheck under both leases: another creator may have taken the target since validation.
+        const raced = yield* sessionOperation("read fork target", () => sessions.openIfExists(into));
+        if (raced) {
+          return forkProvenance(raced) === provenance
+            ? { ok: true }
+            : invalid(`session "${into}" already exists with a different history — fork mints nothing over it`);
+        }
+        yield* sessionOperation("fork", () => sessions.fork(from, at, into, provenance));
+        return { ok: true };
+      }),
+    );
 
-  const deleteOf = async (session: string): Promise<SessionResult> => {
-    const b = boundary;
-    if (!b) return unsupported("delete()");
-    const existing = await sessions.openIfExists(session);
-    if (!existing) return noSuchSession(session);
-    // The same lease as a run: a delete racing one would pull the record out from under it.
-    const release = b.lease.tryAcquire(session);
-    if (!release) return busy();
-    try {
-      // It was there before the lease and is gone now — the same real condition the check above
-      // answers, so the same code.
-      if (!(await sessions.delete(session))) return noSuchSession(session);
-    } catch (error) {
-      // A delete that throws left the record in place.
-      return failed(error);
-    } finally {
-      release();
-    }
-    // The session is gone, so its live streams have nothing left to report: end them rather than
-    // hold connections open on a record that no longer exists. A client's reconnect then reads an
-    // empty `state()`, which is the truth.
-    for (const sub of [...(subscribers.get(session) ?? [])]) sub.close();
-    subscribers.delete(session);
-    return { ok: true };
-  };
+  const deleteOf = (session: string): Promise<SessionResult> =>
+    runBoundary(
+      Effect.gen(function* () {
+        const b = boundary;
+        if (!b) return unsupported("delete()");
+        const existing = yield* sessionOperation("read session", () => sessions.openIfExists(session));
+        if (!existing) return noSuchSession(session);
+        const removed = yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* acquireSessionLease(b.lease, session);
+            return yield* sessionOperation("delete", () => sessions.delete(session));
+          }),
+        );
+        if (!removed) return noSuchSession(session);
+        // The session is gone, so its live streams have nothing left to report: end them rather than
+        // hold connections open on a record that no longer exists. A client's reconnect then reads an
+        // empty `state()`, which is the truth.
+        for (const sub of [...(subscribers.get(session) ?? [])]) sub.close();
+        subscribers.delete(session);
+        return { ok: true };
+      }),
+    );
 
   const control: SessionControl = {
     capabilities: reads.capabilities,

--- a/src/engines/pi/session-effects.ts
+++ b/src/engines/pi/session-effects.ts
@@ -1,0 +1,83 @@
+/** Shared execution boundaries for invocation and control-plane writes. Public ports stay Promise-based. */
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { log } from "../../log.ts";
+import type { PiAgentSessionFactory } from "./invoke-session.ts";
+import type { SessionInheritance } from "./session-inheritance.ts";
+import type { Lease } from "./turn-kit.ts";
+
+export class SessionBusy extends Error {
+  readonly _tag = "SessionBusy";
+  constructor() {
+    super("session busy: a turn or another write is already in flight");
+  }
+}
+
+export class SessionOperationError extends Error {
+  readonly _tag = "SessionOperationError";
+  readonly operation: string;
+  constructor(operation: string, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.operation = operation;
+  }
+}
+
+/** Keep foreign error metadata intact for protocol retry classification. */
+export function sessionFailure(cause: Cause.Cause<unknown>): unknown {
+  const error = Cause.squash(cause);
+  return error instanceof SessionOperationError ? error.cause : error;
+}
+
+export function sessionOperation<A>(operation: string, run: () => Promise<A>): Effect.Effect<A, SessionOperationError> {
+  return Effect.tryPromise({ try: run, catch: (cause) => new SessionOperationError(operation, cause) });
+}
+
+/** Cleanup anomalies are diagnostic; they cannot change an already-published operation outcome. */
+export function sessionCleanup(operation: string, run: () => void | Promise<void>): Effect.Effect<void> {
+  return sessionOperation(operation, async () => run()).pipe(
+    Effect.catchCause((cause) =>
+      Effect.sync(() =>
+        log.warn(`[fastagent] session ${operation} failed during cleanup: ${String(sessionFailure(cause))}`),
+      ),
+    ),
+  );
+}
+
+export function acquireSessionLease(lease: Lease, session: string) {
+  return Effect.acquireRelease(
+    Effect.suspend(() => {
+      const release = lease.tryAcquire(session);
+      return release ? Effect.succeed(release) : Effect.fail(new SessionBusy());
+    }),
+    (release) => sessionCleanup("lease release", release),
+  );
+}
+
+export function acquireSession(factory: PiAgentSessionFactory, session: string, inherit?: SessionInheritance) {
+  // Acquisition stays uninterruptible: a late factory may still publish durable state under the lease.
+  // Disposal must not emit session_shutdown: extension instances belong to the shared assembly.
+  return Effect.acquireRelease(
+    sessionOperation("open", () => factory(session, inherit)),
+    (bound) => sessionCleanup("dispose", () => bound.dispose()),
+  );
+}
+
+/** Interrupting a Promise wait must also abort and join the SDK operation before resources are released. */
+export function sessionWork<A>(
+  operation: string,
+  run: () => Promise<A>,
+  abort: () => void | Promise<void>,
+): Effect.Effect<A, SessionOperationError> {
+  return Effect.acquireUseRelease(
+    Effect.try({ try: run, catch: (cause) => new SessionOperationError(operation, cause) }),
+    (pending) => sessionOperation(operation, () => pending),
+    (pending, exit) =>
+      Exit.hasInterrupts(exit)
+        ? sessionCleanup(`${operation} abort`, abort).pipe(
+            // Cancellation silences the SDK result, but its work must settle before release.
+            Effect.andThen(Effect.exit(sessionOperation(operation, () => pending))),
+          )
+        : Effect.void,
+  );
+}

--- a/src/engines/pi/turn-kit.ts
+++ b/src/engines/pi/turn-kit.ts
@@ -6,7 +6,6 @@
  *
  *   Lease       — single-writer concurrency floor (injectable port + in-process default)
  *   Terminals   — a settled pi message or a thrown error → the SPEC terminal, `retryable` included
- *   EventQueue  — push→pull plumbing for engines that emit events beside their result
  *   Prompt prep — SPEC images → pi's ImageContent
  *   Projection  — the rich SessionEvent stream → the narrow SPEC one
  *   Observation — the seam a control-plane hub attaches to (RunControls + SessionObserver)
@@ -199,49 +198,5 @@ export function projectAgentEvent(se: SessionEvent): AgentEvent | null {
     }
     default:
       return null;
-  }
-}
-
-// ── EventQueue: push→pull plumbing for a two-port engine ────────────────────
-//
-// Single-consumer async queue; single-threaded JS means no await interleaves between push and
-// drain, so no locking. Engines that are natively async-iterable would not need it.
-
-export class EventQueue<T> {
-  private buffer: T[] = [];
-  private wake?: () => void;
-
-  push(item: T): void {
-    this.buffer.push(item);
-    const wake = this.wake;
-    this.wake = undefined;
-    wake?.();
-  }
-
-  /**
-   * Yield pushed events in order until `done` settles AND the buffer is drained. The terminal is
-   * produced separately (toTerminal); rejections of `done` are swallowed here (the caller awaits
-   * `run` itself) to avoid unhandled rejections.
-   */
-  async *drainUntil(done: Promise<unknown>): AsyncGenerator<T> {
-    let settled = false;
-    const onSettle = () => {
-      settled = true;
-      const wake = this.wake;
-      this.wake = undefined;
-      wake?.();
-    };
-    const finished = done.then(onSettle, onSettle);
-
-    while (true) {
-      while (this.buffer.length > 0) {
-        yield this.buffer.shift() as T;
-      }
-      if (settled) break;
-      await new Promise<void>((resolve) => {
-        this.wake = resolve;
-      });
-    }
-    await finished;
   }
 }

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -21,6 +21,7 @@ import { collect, AgentFailure } from "../src/collect.ts";
 import { describe, expect, it } from "vitest";
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
+import { inProcessLease } from "../src/engines/pi/turn-kit.ts";
 
 /**
  * A per-invoke `AgentSession` factory over one faux model. `dir` makes the record durable (the
@@ -179,3 +180,62 @@ describe("AgentSession L0: pi's auto-retry vs. append-only deltas", () => {
     expect(toolRuns).toBe(1);
   });
 });
+
+it.each(["return", "throw"] as const)(
+  "quiet consumer %s aborts the actual tool and joins its cleanup before releasing",
+  async (method) => {
+    const entered = Promise.withResolvers<void>();
+    const aborted = Promise.withResolvers<void>();
+    const finishCleanup = Promise.withResolvers<void>();
+    const lease = inProcessLease();
+    const factory = await sessionFactory([fauxAssistantMessage(fauxToolCall("wait", {}, { id: "blocked" }))], {
+      customTools: [
+        {
+          name: "wait",
+          label: "wait",
+          description: "Wait for cancellation",
+          parameters: Type.Object({}),
+          execute: async (_id, _args, signal) => {
+            signal!.addEventListener("abort", () => aborted.resolve(), { once: true });
+            entered.resolve();
+            await finishCleanup.promise;
+            return { content: [{ type: "text", text: "cleaned" }], details: {} };
+          },
+        } as ToolDefinition,
+      ],
+    });
+    let disposed = false;
+    const agent = createPiAgentFromSession({
+      lease,
+      sessionFactory: async (id) => {
+        const session = await factory(id);
+        const dispose = session.dispose.bind(session);
+        session.dispose = () => {
+          disposed = true;
+          dispose();
+        };
+        return session;
+      },
+    });
+    const iterator = agent.invoke({ session: "quiet" }, { text: "go" })[Symbol.asyncIterator]();
+    expect((await iterator.next()).value).toMatchObject({ type: "tool_started" });
+    await entered.promise;
+    const pending = iterator.next();
+    const error = new Error("consumer stopped");
+    const closing = method === "return" ? iterator.return?.() : iterator.throw?.(error);
+    const checked = method === "return" ? closing : expect(closing).rejects.toBe(error);
+    try {
+      await aborted.promise;
+      expect(disposed).toBe(false);
+      expect(lease.tryAcquire("quiet")).toBeNull();
+    } finally {
+      finishCleanup.resolve();
+      await checked;
+    }
+    expect(await pending).toEqual({ done: true, value: undefined });
+    expect(disposed).toBe(true);
+    const release = lease.tryAcquire("quiet");
+    expect(release).toBeTypeOf("function");
+    release?.();
+  },
+);

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -1,8 +1,4 @@
-/**
- * The AgentSession L0's own turn-boundary discipline. The conformance suite drives a real engine;
- * this drives a stub, because the case that matters — a run that settles without producing anything —
- * is exactly what a healthy engine never does.
- */
+/** Per-invoke terminal, cancellation and resource-ownership checks, including faulty SDK boundaries. */
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import {
   type AgentSession,
@@ -15,7 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
 import { createPiAgentFromSession } from "../src/engines/pi/invoke-session.ts";
 import { piInMemorySessionRecordStore } from "../src/engines/pi/session-store.ts";
-import type { RunControls } from "../src/engines/pi/turn-kit.ts";
+import { inProcessLease, type RunControls } from "../src/engines/pi/turn-kit.ts";
 import type { SessionEvent } from "../src/session.ts";
 import { makeFaux } from "./faux.ts";
 import { log } from "../src/log.ts";
@@ -93,8 +89,7 @@ describe("AgentSession L0: cancelling before the model call", () => {
     const { session, prompted } = promptRecordingSession();
     const agent = createPiAgentFromSession({ sessionFactory: async () => session });
     const iterator = agent.invoke({ session: "early-cancel" }, { text: "go" })[Symbol.asyncIterator]();
-    // The consumer leaves before the first event exists — the window where the cancellation door is
-    // armed but the session is still idle, so knocking on it does nothing.
+    // Cancellation arrives before any event exists, while the session is still being prepared.
     const first = iterator.next();
     await iterator.return?.(undefined);
     const settled = await first;
@@ -105,8 +100,7 @@ describe("AgentSession L0: cancelling before the model call", () => {
   it("never starts the turn when the consumer walks away while the prompt's images are resized", async () => {
     const { session, prompted } = promptRecordingSession();
     const agent = createPiAgentFromSession({ sessionFactory: async () => session });
-    // Park the generator INSIDE prompt-option resolution: the session exists and is idle, so the
-    // armed door has nothing to abort — only a latch read after this await can stop the turn.
+    // The session is idle while images are prepared. Cancellation must prevent the model call.
     let leaveTheWindow!: () => void;
     let entered!: () => void;
     const inTheWindow = new Promise<void>((resolve) => (entered = resolve));
@@ -322,5 +316,188 @@ describe("AgentSession L0: the observation plane", () => {
 
     await expect(controls?.steer({ text: "too late" })).rejects.toThrow(/already settled/);
     await expect(controls?.abort()).rejects.toThrow(/already settled/);
+  });
+});
+
+describe("invocation execution scope", () => {
+  it("joins late acquisition before disposing and releasing, without starting the model", async () => {
+    const opened = Promise.withResolvers<AgentSession>();
+    const entered = Promise.withResolvers<void>();
+    const lease = inProcessLease();
+    const { session, prompted } = promptRecordingSession();
+    const disposed = vi.spyOn(session, "dispose");
+    session.steer = vi.fn(async () => {});
+    let command: Promise<boolean> | undefined;
+    const agent = createPiAgentFromSession({
+      lease,
+      observer: (_s, _event, run) => {
+        if (run)
+          command = run.steer({ text: "queued" }).then(
+            () => true,
+            () => false,
+          );
+      },
+      sessionFactory: () => {
+        entered.resolve();
+        return opened.promise;
+      },
+    });
+    const iterator = agent.invoke({ session: "late" }, { text: "hi" })[Symbol.asyncIterator]();
+    const read = iterator.next();
+    await entered.promise;
+    let returned = false;
+    const closed = iterator.return?.().then(() => {
+      returned = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(returned).toBe(false);
+    expect(lease.tryAcquire("late")).toBeNull();
+    opened.resolve(session);
+    await closed;
+    expect(await read).toEqual({ done: true, value: undefined });
+    expect(prompted()).toBe(false);
+    expect(await command).toBe(false);
+    expect(session.steer).not.toHaveBeenCalled();
+    expect(disposed).toHaveBeenCalledTimes(1);
+    const release = lease.tryAcquire("late");
+    expect(release).toBeTypeOf("function");
+    release?.();
+  });
+
+  it.each([false, true, "pending"])("holds the lease through buffered consumption (cancel=%s)", async (cancel) => {
+    const lease = inProcessLease();
+    const session = silentSessionAfterHistory();
+    const disposed = vi.spyOn(session, "dispose");
+    let emit!: (event: AgentSessionEvent) => void;
+    session.subscribe = (listener) => {
+      emit = listener;
+      return () => {};
+    };
+    const produced = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    session.prompt = async () => {
+      for (const delta of ["one", "two"])
+        emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta } } as AgentSessionEvent);
+      await finish.promise;
+      emit({ type: "message_end", message: fauxAssistantMessage("one two") });
+      produced.resolve();
+    };
+    const seen: SessionEvent[] = [];
+    let controls: RunControls | undefined;
+    const agent = createPiAgentFromSession({
+      lease,
+      sessionFactory: async () => session,
+      observer: (_s, event, run) => {
+        if (run) controls = run;
+        seen.push(event);
+      },
+    });
+    const iterator = agent.invoke({ session: "buffered" }, { text: "hi" })[Symbol.asyncIterator]();
+    expect((await iterator.next()).value).toEqual({ type: "text", delta: "one" });
+    if (cancel === "pending") expect((await iterator.next()).value).toEqual({ type: "text", delta: "two" });
+    finish.resolve();
+    await produced.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await expect(controls?.steer({ text: "too late" })).rejects.toThrow(/already settled/);
+    expect(lease.tryAcquire("buffered")).toBeNull();
+    expect(disposed).not.toHaveBeenCalled();
+    if (cancel === "pending") {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const terminal = iterator.next();
+      await iterator.return?.();
+      expect(await terminal).toEqual({ done: true, value: undefined });
+    } else if (cancel) {
+      await iterator.return?.();
+    } else {
+      expect((await iterator.next()).value).toEqual({ type: "text", delta: "two" });
+      expect((await iterator.next()).value).toEqual({ type: "completed" });
+      expect(lease.tryAcquire("buffered")).toBeNull();
+      expect(disposed).not.toHaveBeenCalled();
+    }
+    expect((await iterator.next()).done).toBe(true);
+    expect(disposed).toHaveBeenCalledTimes(1);
+    expect(seen.filter((e) => e.type === "run_settled")).toMatchObject([
+      { data: { status: cancel ? "aborted" : "completed" } },
+    ]);
+    const release = lease.tryAcquire("buffered");
+    expect(release).toBeTypeOf("function");
+    release?.();
+  });
+
+  it.each(["subscribe", "prompt"])(
+    "translates a callback defect during %s into a failure without continuing SDK work",
+    async (phase) => {
+      const session = silentSessionAfterHistory();
+      const started = Promise.withResolvers<void>();
+      const stopped = Promise.withResolvers<void>();
+      const event: AgentSessionEvent = {
+        type: "message_update",
+        message: fauxAssistantMessage(""),
+        get assistantMessageEvent(): never {
+          throw new Error("bad callback");
+        },
+      };
+      let emit!: (event: AgentSessionEvent) => void;
+      session.subscribe = (listener) => {
+        emit = listener;
+        if (phase === "subscribe") emit(event);
+        return () => {};
+      };
+      session.prompt = vi.fn(async () => {
+        started.resolve();
+        await stopped.promise;
+      });
+      session.abort = async () => {
+        stopped.resolve();
+      };
+      const agent = createPiAgentFromSession({ sessionFactory: async () => session });
+      const result = drain(agent.invoke({ session: "defect" }, { text: "hi" }));
+      if (phase === "prompt") {
+        await started.promise;
+        expect(() => emit(event)).not.toThrow();
+      }
+      expect(await result).toMatchObject([{ type: "failed", details: "bad callback", retryable: false }]);
+      expect(session.prompt).toHaveBeenCalledTimes(phase === "prompt" ? 1 : 0);
+    },
+  );
+
+  it("continues all cleanup after defects without changing the primary protocol failure", async () => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      const calls: string[] = [];
+      const session = silentSessionAfterHistory();
+      session.subscribe = () => () => {
+        calls.push("unsubscribe");
+        throw new Error("unsubscribe defect");
+      };
+      session.dispose = () => {
+        calls.push("dispose");
+        throw new Error("dispose defect");
+      };
+      session.prompt = async () => {
+        throw Object.assign(new Error("provider unavailable"), { status: 503 });
+      };
+      const agent = createPiAgentFromSession({
+        sessionFactory: async () => session,
+        lease: {
+          tryAcquire: () => () => {
+            calls.push("release");
+            throw new Error("release defect");
+          },
+        },
+        observer: (_s, event) => {
+          if (event.type === "run_settled") calls.push("settled");
+        },
+      });
+      expect(await drain(agent.invoke({ session: "cleanup" }, { text: "hi" }))).toMatchObject([
+        { type: "failed", details: "provider unavailable", retryable: true },
+      ]);
+      expect(calls).toEqual(["unsubscribe", "dispose", "settled", "release"]);
+      expect(warn.mock.calls.flat().join(" ")).toContain("unsubscribe defect");
+      expect(warn.mock.calls.flat().join(" ")).toContain("dispose defect");
+      expect(warn.mock.calls.flat().join(" ")).toContain("release defect");
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -1704,6 +1704,114 @@ describe("session control: boundary mutations", () => {
     expect((await control.sessions.get("sB4").state()).status).toBe("idle");
   });
 
+  it.each(["subscribe", "unsubscribe", "dispose", "abort"])(
+    "compaction survives a %s defect and releases before publishing its outcome",
+    async (defect) => {
+      const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+      try {
+        const { faux, models } = makeFaux();
+        const sessions = piInMemorySessionRecordStore({ cwd: process.cwd() });
+        const record = await sessions.openOrCreate("cleanup");
+        record.appendMessage({ role: "user", content: "earlier", timestamp: 1 });
+        record.appendMessage(fauxAssistantMessage(LONG_ANSWER));
+        record.appendMessage({ role: "user", content: "recent", timestamp: 2 });
+        const lease = inProcessLease();
+        const finish = Promise.withResolvers<void>();
+        let disposed = false;
+        const session = {
+          sessionManager: record,
+          settingsManager: { getCompactionSettings: () => ({ keepRecentTokens: 0 }) },
+          subscribe: () => {
+            if (defect === "subscribe") throw new Error("subscribe defect");
+            return () => {
+              if (defect === "unsubscribe") throw new Error("unsubscribe defect");
+            };
+          },
+          compact: async () => {
+            if (defect === "abort") await finish.promise;
+            return { summary: "summary" };
+          },
+          abortCompaction: () => {
+            finish.resolve();
+            throw new Error("abort defect");
+          },
+          dispose: () => {
+            disposed = true;
+            if (defect === "dispose") throw new Error("dispose defect");
+          },
+        } as unknown as AgentSession;
+        const { control } = createPiSessionControl({
+          sessions,
+          boundary: {
+            lease,
+            models,
+            defaults: { model: faux.getModel(), thinkingLevel: "medium" },
+            sessionFactory: async () => session,
+          },
+        });
+        const handle = control.sessions.get("cleanup");
+        const finished = (async () => {
+          for await (const event of handle.events()) if (event.type === "compaction_finished") return event;
+        })();
+        expect(await handle.compact()).toEqual({ ok: true });
+        if (defect === "abort")
+          expect(await handle.abort()).toMatchObject({
+            ok: false,
+            error: {
+              code: RUN_COMMAND_FAILED_CODE,
+              message: "Error: abort defect",
+              retryable: false,
+            },
+          });
+        expect((await finished)?.data).toEqual(
+          defect === "subscribe" ? { error: "Error: subscribe defect" } : { summary: "summary" },
+        );
+        expect(disposed).toBe(true);
+        const release = lease.tryAcquire("cleanup");
+        expect(release).toBeTypeOf("function");
+        release?.();
+        expect((await handle.state()).status).toBe("idle");
+        if (defect === "unsubscribe" || defect === "dispose")
+          expect(warn.mock.calls.flat().join(" ")).toContain(`${defect} defect`);
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
+
+  it("every mutation translates an initial store rejection into a command result", async () => {
+    const { faux, models } = makeFaux();
+    const sessions = piInMemorySessionRecordStore({ cwd: process.cwd() });
+    vi.spyOn(sessions, "openIfExists").mockRejectedValue(new Error("store unavailable"));
+    const { control } = createPiSessionControl({
+      sessions,
+      boundary: {
+        lease: inProcessLease(),
+        models,
+        defaults: { model: faux.getModel(), thinkingLevel: "medium" },
+        sessionFactory: async () => {
+          throw new Error("must not bind");
+        },
+      },
+    });
+    const handle = control.sessions.get("unreadable");
+    const results = await Promise.all([
+      handle.update({ name: "new" }),
+      handle.delete(),
+      handle.compact(),
+      control.sessions.fork({ from: "unreadable", at: "entry", into: "target" }),
+    ]);
+    for (const result of results)
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          code: BOUNDARY_COMMAND_FAILED_CODE,
+          message: "Error: store unavailable",
+          retryable: true,
+        },
+      });
+  });
+
   it("publishes manual compaction retries without a run identity", async () => {
     const { faux, models } = makeFaux();
     const sessions = piInMemorySessionRecordStore({ cwd: process.cwd() });

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -508,6 +508,69 @@ async function waitForToolStarted(control: SessionControl, session: string) {
 }
 
 describe("session control: run modulation", () => {
+  it.each(["steer", "followUp"] as const)(
+    "observes %s queued during session binding before the model starts",
+    async (method) => {
+      const { control, observer, sessions, lease, models, faux } = await fauxControlledAgent([
+        fauxAssistantMessage("first answer"),
+        fauxAssistantMessage("queued answer"),
+      ]);
+      const factory = piAgentSessionFactory({
+        sessions,
+        engine: async () => ({ modelRuntime: models, model: faux.getModel() }),
+        readDefinition: () => ({ systemPrompt: "test", skills: [] }),
+        cwd: process.cwd(),
+      });
+      const session = await factory("binding");
+      const binding = Promise.withResolvers<void>();
+      const entered = Promise.withResolvers<void>();
+      const startPrompt = Promise.withResolvers<void>();
+      const prompt = session.prompt.bind(session);
+      session.prompt = async (...args) => {
+        await startPrompt.promise;
+        return prompt(...args);
+      };
+      const seen: SessionEvent[] = [];
+      const agent = createPiAgentFromSession({
+        lease,
+        observer: (id, event, run) => {
+          observer(id, event, run);
+          seen.push(event);
+        },
+        sessionFactory: async () => {
+          entered.resolve();
+          await binding.promise;
+          return session;
+        },
+      });
+      const invoked = drive(agent, "binding");
+      try {
+        await entered.promise;
+        const handle = control.sessions.get("binding");
+        const before = await handle.state();
+        const command = handle[method]({ text: "queued during binding" });
+        // Flush prompt preparation so the command is waiting on binding before the factory returns.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        binding.resolve();
+        expect(await command).toEqual({ ok: true, runId: before.activeRunId });
+        expect(method === "steer" ? session.getSteeringMessages() : session.getFollowUpMessages()).toEqual([
+          "queued during binding",
+        ]);
+        const pending = { steering: method === "steer" ? 1 : 0, followUp: method === "followUp" ? 1 : 0 };
+        expect((await handle.state()).pending).toEqual(pending);
+        expect(seen.filter((event) => event.type === "queue_changed")).toMatchObject([
+          { runId: before.activeRunId, data: pending },
+        ]);
+      } finally {
+        binding.resolve();
+        startPrompt.resolve();
+        await invoked;
+      }
+      expect((await control.sessions.get("binding").state()).pending).toEqual({ steering: 0, followUp: 0 });
+      expect(seen.at(-1)).toMatchObject({ type: "run_settled", data: { status: "completed" } });
+    },
+  );
+
   it("steer joins the active run: accepted with its runId, delivered before the next model call, settle window spans it", async () => {
     const { agent, control, gate } = await makeGated([
       fauxAssistantMessage(fauxToolCall("gate", {}, { id: "g1" })),
@@ -612,33 +675,58 @@ describe("session control: run modulation", () => {
     await expect((captured as NonNullable<typeof captured>).abort()).rejects.toThrow(/already settled/);
   });
 
-  it("a dispatch racing a failing harness build gets run_command_failed with the setup error", async () => {
-    const sessions = piInMemorySessionRecordStore({ cwd: process.cwd() });
-    const { control, observer } = createPiSessionControl({ sessions });
-    let releaseFactory: () => void = () => {};
-    const factoryGate = new Promise<void>((r) => {
-      releaseFactory = r;
-    });
-    const agent = createPiAgentFromSession({
-      observer,
-      sessionFactory: async () => {
-        await factoryGate;
-        throw new Error("boom: setup exploded");
-      },
-    });
-    const invoked = drive(agent, "sSetup");
-    await waitForRunning(control, "sSetup"); // run_started observed; the session is still being built
-    const pending = control.sessions.get("sSetup").steer({ text: "late" });
-    releaseFactory(); // → factory throws → gate rejects → the pending dispatch learns it
-    const result = await pending;
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.code).toBe(RUN_COMMAND_FAILED_CODE);
-      expect(result.error.message).toContain("boom");
-    }
-    const events = await invoked;
-    expect(events.at(-1)).toMatchObject({ type: "failed" }); // the data plane failed visibly too
-  });
+  it.each(["factory", "subscribe"])(
+    "commands waiting on a failing %s get run_command_failed with the setup error",
+    async (phase) => {
+      const sessions = piInMemorySessionRecordStore({ cwd: process.cwd() });
+      const { control, observer } = createPiSessionControl({ sessions });
+      let releaseFactory: () => void = () => {};
+      const factoryGate = new Promise<void>((r) => {
+        releaseFactory = r;
+      });
+      const error = new Error(`boom: ${phase} exploded`);
+      const session = {
+        subscribe: () => {
+          throw error;
+        },
+        steer: vi.fn(async () => {}),
+        followUp: vi.fn(async () => {}),
+        abort: vi.fn(async () => {}),
+        prompt: vi.fn(async () => {}),
+        dispose: vi.fn(),
+      };
+      const agent = createPiAgentFromSession({
+        observer,
+        sessionFactory: async () => {
+          await factoryGate;
+          if (phase === "factory") throw error;
+          return session as unknown as AgentSession;
+        },
+      });
+      const invoked = drive(agent, "sSetup");
+      await waitForRunning(control, "sSetup"); // run_started observed; the session is still being built
+      const handle = control.sessions.get("sSetup");
+      const pending = Promise.all([handle.steer({ text: "late" }), handle.followUp({ text: "late" }), handle.abort()]);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      releaseFactory();
+      for (const result of await pending)
+        expect(result).toEqual({
+          ok: false,
+          error: {
+            code: RUN_COMMAND_FAILED_CODE,
+            message: expect.stringContaining(error.message),
+            retryable: false,
+          },
+        });
+      const events = await invoked;
+      expect(events).toEqual([{ type: "failed", details: error.message, retryable: false }]);
+      expect(session.steer).not.toHaveBeenCalled();
+      expect(session.followUp).not.toHaveBeenCalled();
+      expect(session.abort).not.toHaveBeenCalled();
+      expect(session.prompt).not.toHaveBeenCalled();
+      expect(session.dispose).toHaveBeenCalledTimes(phase === "subscribe" ? 1 : 0);
+    },
+  );
 
   it("a subscriber far behind is closed instead of buffering without bound", async () => {
     const { control, observer } = createPiSessionControl({

--- a/test/session-effects.test.ts
+++ b/test/session-effects.test.ts
@@ -1,0 +1,103 @@
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import type * as Scope from "effect/Scope";
+import { expect, expectTypeOf, it, vi } from "vitest";
+import {
+  acquireSession,
+  acquireSessionLease,
+  SessionOperationError,
+  sessionWork,
+} from "../src/engines/pi/session-effects.ts";
+import { inProcessLease } from "../src/engines/pi/turn-kit.ts";
+import { log } from "../src/log.ts";
+
+it("retains the resource scope and both expected failure channels until explicitly handled", () => {
+  const opened = acquireSession(async () => ({}) as AgentSession, "types");
+  const leased = acquireSessionLease(inProcessLease(), "types");
+  expectTypeOf(opened).toEqualTypeOf<Effect.Effect<AgentSession, SessionOperationError, Scope.Scope>>();
+  // @ts-expect-error -- acquisition still requires an owned resource scope
+  const unscoped: Effect.Effect<AgentSession, SessionOperationError> = opened;
+  // @ts-expect-error -- SDK failures remain expected failures until translated
+  const infallible: Effect.Effect<AgentSession, never, Scope.Scope> = opened;
+  // @ts-expect-error -- the shared lease may reject admission
+  const uncontended: Effect.Effect<() => void, never, Scope.Scope> = leased;
+  void [unscoped, infallible, uncontended];
+  const handled = Effect.scoped(opened).pipe(Effect.catchTag("SessionOperationError", () => Effect.succeed(null)));
+  expectTypeOf(handled).toEqualTypeOf<Effect.Effect<AgentSession | null>>();
+});
+
+it.each(["resolve", "reject"])("joins outstanding SDK work (%s) even when its abort hook fails", async (settle) => {
+  const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+  const pending = Promise.withResolvers<void>();
+  const entered = Promise.withResolvers<void>();
+  const abortCalled = Promise.withResolvers<void>();
+  const abort = new AbortController();
+  const lease = inProcessLease();
+  let disposed = false;
+  const done = Effect.runPromiseExit(
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* acquireSessionLease(lease, "abort-error");
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            disposed = true;
+          }),
+        );
+        yield* sessionWork(
+          "prompt",
+          () => {
+            entered.resolve();
+            return pending.promise;
+          },
+          () => {
+            abortCalled.resolve();
+            throw new Error("abort hook failed");
+          },
+        );
+      }),
+    ),
+    { signal: abort.signal },
+  );
+  try {
+    await entered.promise;
+    abort.abort();
+    await abortCalled.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(disposed).toBe(false);
+    expect(lease.tryAcquire("abort-error")).toBeNull();
+    expect(warn.mock.calls.flat().join(" ")).toContain("abort hook failed");
+  } finally {
+    if (settle === "resolve") pending.resolve();
+    else pending.reject(new Error("SDK failed after cancellation"));
+    await done;
+    warn.mockRestore();
+  }
+  const exit = await done;
+  expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+  expect(disposed).toBe(true);
+  const release = lease.tryAcquire("abort-error");
+  expect(release).toBeTypeOf("function");
+  release?.();
+});
+
+it("preserves a synchronous SDK failure without running release for an uncreated Promise", async () => {
+  const abort = new AbortController();
+  let stopped = false;
+  const exit = await Effect.runPromiseExit(
+    sessionWork(
+      "prompt",
+      () => {
+        abort.abort();
+        throw new Error("synchronous SDK failure");
+      },
+      () => {
+        stopped = true;
+      },
+    ),
+    { signal: abort.signal },
+  );
+  expect(stopped).toBe(false);
+  expect(Exit.isFailure(exit) && Cause.squash(exit.cause)).toBeInstanceOf(SessionOperationError);
+});

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../src/telegram.ts";
 import type { Agent, AgentEvent, Prompt, Scope } from "../src/index.ts";
 import { NO_ACTIVE_RUN_CODE, type SessionControl } from "../src/session.ts";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { fauxControlledAgent } from "./agent.ts";
 
 /** A faux Agent that records each invocation's prompt and replies with `reply`. */
 function replyingAgent(reply = "") {
@@ -144,6 +146,47 @@ describe("durable group buffer (single-process restarts)", () => {
   // Summon on "@go …" — an explicit route keeps these tests independent of bot-identity resolution.
   const route = (u: TelegramUpdate) =>
     (u.message as { text?: string } | undefined)?.text?.startsWith("@go") ? {} : null;
+
+  it("runs the real engine after ACK and commits only the folded discussion on completion", async () => {
+    const entered = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    let sawDiscussion = false;
+    const { agent, control } = await fauxControlledAgent([
+      async (context) => {
+        sawDiscussion = JSON.stringify(context.messages).includes("earlier discussion");
+        entered.resolve();
+        await finish.promise;
+        return fauxAssistantMessage("answer");
+      },
+    ]);
+    vi.stubGlobal("fetch", okFetch());
+    const state = freshStateDir();
+    const channel = telegramChannel(agent, { secretToken: SECRET, botToken: "1:A", route, stateDir: state, control });
+    await channel(tgRequest(group(1, "earlier discussion")));
+    const request = new AbortController();
+    expect((await channel(new Request(tgRequest(group(2, "@go answer")), { signal: request.signal }))).status).toBe(
+      200,
+    );
+    request.abort();
+    try {
+      await entered.promise;
+      expect(sawDiscussion).toBe(true);
+      expect(Object.keys(JSON.parse(readFileSync(join(state, "turns.json"), "utf8")))).toHaveLength(1);
+      expect(await control.sessions.get("-100").update({ name: "while running" })).toMatchObject({
+        ok: false,
+        error: { code: "session_busy" },
+      });
+      await channel(tgRequest(group(3, "later arrival")));
+    } finally {
+      finish.resolve();
+    }
+    await Promise.all([...channelIdles].map((idle) => idle()));
+    expect(JSON.parse(readFileSync(join(state, "turns.json"), "utf8"))).toEqual({});
+    const buffered = readFileSync(join(state, "buffers.json"), "utf8");
+    expect(buffered).toContain("later arrival");
+    expect(buffered).not.toContain("earlier discussion");
+    expect(await control.sessions.get("-100").update({ name: "after completion" })).toEqual({ ok: true });
+  });
 
   it("the group buffer is persisted BEFORE the ACK and survives a restart", async () => {
     vi.stubGlobal("fetch", okFetch());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "ES2024.Promise"],
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

- Keep invocation leases, sessions and subscriptions scoped through consumer settlement. Publish readiness after subscribing so waiting controls emit observable queue events. Cancel by aborting and joining actual SDK work, including late session acquisition and quiet iterator reads.
- Share typed SDK failures and scoped acquisition with control-plane writes. Keep compaction accept-fast and release resources before publishing its outcome.
- Translate callback and command failures at their protocol boundaries. Log cleanup faults without losing subsequent cleanup or replacing the operation outcome.
- Preserve public APIs, dependency-free contracts, shared assembly identity, channel shutdown and durable replay policies.

## Validation

- `npm run lint && npm run typecheck && npm test && npm run build`: passed, 1,733 tests across 121 files on Node 26.8.1.
- 178 focused tests passed on each of Node 22.19.0 and 24.20.0.
- Seven fault-injection groups and three compiler-negative checks verified.
- Real Pi tool cancellation and HTTP/control coverage; real Telegram/Pi integration verifies ACK-independent execution and completed-event context commits.
- Runtime, heap, build and implementation-size measurements are recorded in [#480](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5574040792).

Refs #480.

