### PR TITLE
refactor(channels): scope shared turn execution with Effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,18 +146,16 @@ src/
 │   │   │                     # consumers only under channels/<platform>/, and serve/http/control/
 │   │   │                     # discover have none there. Neither side may reach for the other.
 │   │   ├── preview-kit.ts   # turn-view reducer (event → view state + line renderers) + preview policies
-│   │   ├── invoke-turn-kit.ts # busy-retry stream loop around agent.invoke (onCompleted commit point)
-│   │   ├── turn-runner.ts   # THE durable-turn lifecycle (accept → dequeue → execute → end) over the
-│   │   │                     # queue + store + buffer; a channel supplies only what names a platform
-│   │   │                     # object (notice, prompt, attachments, the dropped-turn line). Three
-│   │   │                     # channels wrote it out and drifted in ways that were not decisions
-│   │   ├── turn-queue.ts    # in-memory per-session serial turns (FIFO; the runner's)
+│   │   ├── invoke-turn-kit.ts # demand-driven Effect stream: scoped attempts, cancellable busy wait, completed-event commit
+│   │   ├── turn-runner.ts   # accept → dequeue → execute → settle over the queue + store + buffer;
+│   │   │                     # business settlement removes intent, resource finalizers never do
+│   │   ├── turn-queue.ts    # per-session FIFO root fibers; queued work counts busy and survives ingress ACK
 │   │   ├── turn-store.ts    # generic durable turn intent (L1) — record shape/validator/order injected
 │   │   ├── context-buffer.ts# generic durable un-summoned-discussion buffer (peek→completed→commit)
 │   │   ├── thread-participants.ts # who the agent has HEARD in a thread (the summon rule)
 │   │   ├── state.ts, seen.ts# atomic channel state + bounded durable delivery dedup
 │   │   ├── signature.ts     # replay window for a signed webhook ingress (the LENGTH is the platform's)
-│   │   ├── tasks.ts         # fire-and-forget side-task tracking — channels drain it in turnsIdle
+│   │   ├── tasks.ts         # typed Promise ownership (join on interruption) + side-task tracking; drain is observation only
 │   │   ├── text.ts          # Unicode-safe code-point slicing (cards, preview kit)
 │   │   ├── attachment-path.ts # where an attachment lands: the conversation id is ENCODED into a
 │   │   │                     # directory (like piSessionId — an id belongs to the caller, so it is

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -390,14 +390,40 @@ concurrent and repeated `close()` calls wait for the same completion or failure.
 uses that same shutdown, logging cleanup errors while preserving the startup failure. The public
 `ready` waiter stays outside the scope it may close; channel authors still return ordinary Promises
 and consume an `AbortSignal`. Agent turns and durable replay state remain outside this scope.
-Effect is internal to `/node` service assembly and `/pi` execution/control. The contracts, `/core`,
-and `/session` remain dependency-free; public APIs expose no Effect runtime or types.
+Effect is internal to `/node` service assembly, `/pi` execution/control, and the stateful chat channels'
+shared execution kit. The contracts, `/core`, and `/session` remain dependency-free; public APIs expose
+no Effect runtime or types.
 
 `channels/sse.ts` owns the Fetch-only response lifecycle shared by HTTP invoke and session observation:
 eager subscription, heartbeat, serialization and iterator cleanup. The callers own their event shapes.
 Synchronous subscription errors reach the HTTP error boundary before a response is created; errors
 during body streaming close the source and heartbeat and propagate through the response body.
 The remote invoke client stops at the first terminal event; malformed control envelopes fail visibly.
+
+### Shared chat execution
+
+Telegram, Slack, and Feishu/Lark use the same execution lifecycle. Acceptance persists intent before
+ACK and counts queued work as busy immediately. Each turn runs in an independent Effect root fiber;
+per-session successors wait for the preceding scope to close, while other sessions run concurrently.
+Request completion does not close these fibers, and service shutdown still does not drain them.
+
+`tasks.ts` translates Promise rejection into `TaskFailure` and joins already-started work on
+interruption. Platform hooks expose no abort operation, so releasing ownership while their Promises
+still run would permit overlapping work and premature idle snapshots. Side-task drains observe only
+the tasks tracked when called. Queue notices are observed from acceptance and joined at dequeue,
+including when a notice's cancellation hook fails.
+
+`runQueuedTurn` separates business settlement from resource cleanup. The `completed` callback removes
+intent before committing the exact context snapshot consumed; later discussion remains buffered.
+Caught execution/delivery failures retain the existing intent-removal policy. Effect interruption and
+process termination preserve unfinished intent for recovery. Store formats, poison-attempt limits,
+post-ACK write policies, and at-least-once replay are unchanged.
+
+The busy-retry stream pulls only on downstream demand. Each attempt owns its source iterator; a
+first-event `session_busy` rejection closes that iterator before waiting on the Effect clock. Other
+failures never reopen the retry window. The AsyncIterable adapter reuses abort-first cancellation,
+so returning during a quiet read aborts the actual Agent iterator and returning during backoff cancels
+the timer. Natural source exhaustion needs no additional `return()` call.
 
 ### GitHub
 

--- a/src/channels/kit/invoke-turn-kit.ts
+++ b/src/channels/kit/invoke-turn-kit.ts
@@ -14,7 +14,12 @@
  * Attachment RESOLUTION stays per channel — the platform resource models (Bot API file_ids,
  * message-scoped Feishu keys, Slack file objects) are real differences.
  */
+import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 import { type Agent, type AgentEvent, type Prompt, SESSION_BUSY_CODE, type Scope } from "../../agent.ts";
+import { cancellableStream } from "../../collect.ts";
 import { log } from "../../log.ts";
 
 /** How the busy-wait paces: retry the invoke every `delayMs` while the session's lease is held by an
@@ -34,11 +39,10 @@ export const DEFAULT_BUSY_RETRY: BusyRetry = { delayMs: 5_000, maxWaitMs: 600_00
 
 /**
  * Stream one Agent turn with the shared busy-wait. `onCompleted` (if given) fires on the turn's
- * `completed` event — the durable-commit point: only then does the turn provably live in the session,
- * so a failure or crash at ANY earlier point leaves the caller's pre-ACK state (turn intent, context
- * buffer) intact for replay/the next summon. The caller uses it to remove the turn intent AND commit
- * the context buffer, in that order, so a crash between the two clears cannot replay a
- * context-stripped turn.
+ * `completed` event — the durable-commit point: the turn now lives in the session. The callback
+ * removes its intent before committing the consumed context snapshot. Other endings retain context;
+ * the runner separately decides whether an intent is removed (caught execution failure) or retained
+ * (interruption). Source pulls remain demand-driven, including while final platform delivery runs.
  *
  * BUSY-WAIT: a `failed{code: session_busy}` FIRST event means an external turn holds this session's
  * lease and OUR turn never started — replay-safe. Retry (bounded) instead of yielding it: the user
@@ -47,33 +51,117 @@ export const DEFAULT_BUSY_RETRY: BusyRetry = { delayMs: 5_000, maxWaitMs: 600_00
  * busy retries — a fail-fast reject is the only shape the engine emits it in, so nothing that started
  * is ever re-run.
  */
-export async function* streamTurnWithBusyRetry(
+export function streamTurnWithBusyRetry(
   agent: Agent,
-  /** The full scope, not a session string — channels that set extension fields (lineage) pass them
-   *  through here; channels that don't pass `{ session }` and nothing changes. */
   scope: Scope,
   prompt: Prompt,
   options: { label: string; onCompleted?: () => void; busyRetry?: BusyRetry },
 ): AsyncIterable<AgentEvent> {
-  const { label, onCompleted, busyRetry = DEFAULT_BUSY_RETRY } = options;
-  const session = scope.session;
-  const deadline = Date.now() + busyRetry.maxWaitMs;
-  for (;;) {
-    let retryBusy = false;
-    let first = true;
-    for await (const e of agent.invoke(scope, prompt)) {
-      if (first && e.type === "failed" && e.code === SESSION_BUSY_CODE && Date.now() + busyRetry.delayMs < deadline) {
-        retryBusy = true; // fail-fast reject — the stream ends after this event; wait and re-invoke
-        break;
+  return cancellableStream(async function* ({ onCancelReady }) {
+    // Effect implements return/throw; AsyncIterator makes them optional for arbitrary iterables.
+    const iterator = Stream.toAsyncIterable(busyRetryStream(agent, scope, prompt, options))[
+      Symbol.asyncIterator
+    ]() as Required<AsyncIterator<AgentEvent>>;
+    let closing: Promise<IteratorResult<AgentEvent>> | undefined;
+    // Stream.return interrupts a pending pull; the shared wrapper also silences an already-pulled event.
+    onCancelReady(() => {
+      closing = iterator.return();
+    });
+    try {
+      for (;;) {
+        const result = await iterator.next();
+        if (result.done) return;
+        yield result.value;
       }
-      first = false;
-      if (e.type === "completed") onCompleted?.(); // the turn is durably in the session — commit point
-      yield e;
+    } finally {
+      await (closing ?? iterator.return());
     }
-    if (!retryBusy) return;
-    log.info(`${label} session ${session} is busy (an external turn holds it) — retrying in ${busyRetry.delayMs}ms`);
-    await new Promise((r) => setTimeout(r, busyRetry.delayMs));
-  }
+  });
+}
+
+/** Pull-based execution keeps commit and source cleanup under downstream backpressure. */
+export function busyRetryStream(
+  agent: Agent,
+  scope: Scope,
+  prompt: Prompt,
+  {
+    label,
+    onCompleted,
+    busyRetry = DEFAULT_BUSY_RETRY,
+  }: { label: string; onCompleted?: () => void; busyRetry?: BusyRetry },
+): Stream.Stream<AgentEvent, unknown> {
+  return Stream.unwrap(
+    Effect.map(Clock.currentTimeMillis, (started) => {
+      const deadline = started + busyRetry.maxWaitMs;
+      const attempt = (): Stream.Stream<AgentEvent, unknown> =>
+        Stream.suspend(() => {
+          let retryBusy = false;
+          return Stream.fromPull(
+            Effect.gen(function* () {
+              let exhausted = false;
+              let first = true;
+              const iterator = yield* Effect.acquireRelease(
+                Effect.sync(() => agent.invoke(scope, prompt)[Symbol.asyncIterator]()),
+                (iterator) => {
+                  const close = iterator.return?.bind(iterator);
+                  // Match for-await: natural exhaustion already closed the source.
+                  if (!close || exhausted) return Effect.void;
+                  // Diagnose every exit, including cancellation. Keep Cause intact for the caller boundary.
+                  return Effect.promise(close).pipe(
+                    Effect.onError((cause) =>
+                      Effect.sync(() =>
+                        log.warn(
+                          `${label} source cleanup failed (session=${scope.session}): ${String(Cause.squash(cause))}`,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              );
+              return Effect.gen(function* () {
+                const result = yield* Effect.tryPromise({ try: () => iterator.next(), catch: (error) => error });
+                if (result.done) {
+                  exhausted = true;
+                  return yield* Cause.done();
+                }
+                const event = result.value;
+                if (
+                  first &&
+                  event.type === "failed" &&
+                  event.code === SESSION_BUSY_CODE &&
+                  (yield* Clock.currentTimeMillis) + busyRetry.delayMs < deadline
+                ) {
+                  retryBusy = true;
+                  return yield* Cause.done();
+                }
+                first = false;
+                if (event.type === "completed") onCompleted?.();
+                return [event] as const;
+              });
+            }),
+          ).pipe(
+            Stream.scoped,
+            // concat closes the attempt's scope (and its iterator) before the wait or next invoke.
+            Stream.concat(
+              Stream.suspend(() =>
+                retryBusy
+                  ? Stream.unwrap(
+                      Effect.gen(function* () {
+                        log.info(
+                          `${label} session ${scope.session} is busy (an external turn holds it) — retrying in ${busyRetry.delayMs}ms`,
+                        );
+                        yield* Effect.sleep(busyRetry.delayMs);
+                        return attempt();
+                      }),
+                    )
+                  : Stream.empty,
+              ),
+            ),
+          );
+        });
+      return attempt();
+    }),
+  );
 }
 
 /** What the attached-files manifest renders per file: display name, byte size, absolute local path. */

--- a/src/channels/kit/tasks.ts
+++ b/src/channels/kit/tasks.ts
@@ -1,39 +1,58 @@
-/**
- * SHARED fire-and-forget side-task tracking. Channels launch work off the request path (stop
- * feedback, DM welcomes) that must not block the transport ACK but MUST be drained on shutdown
- * (`turnsIdle`) — otherwise a reply in flight when the process exits is silently dropped. Error
- * handling stays with the caller: track() only guarantees the drain sees the task SETTLE, and settle
- * includes reject. A caller that handles its error on a separate branch (`p.catch(log); track(p)`)
- * still hands us a promise that rejects, and a drain that propagated it would fail the channel's whole
- * `turnsIdle` over one side task. A rejection that reaches us is logged — we
- * cannot tell a missing `.catch` from one on a separate branch, so the line is a visibility floor
- * rather than a diagnosis, and without it a dropped side task leaves no trace anywhere.
- */
+/** Promise ownership and ACK-independent side-task tracking. Drains are observation hooks, not service shutdown. */
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import { beginWork } from "../busy.ts";
 import { log } from "../../log.ts";
 
+export class TaskFailure extends Error {
+  readonly _tag = "TaskFailure";
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+  }
+}
+
+export function taskFailure(cause: Cause.Cause<unknown>): unknown {
+  const error = Cause.squash(cause);
+  return error instanceof TaskFailure ? error.cause : error;
+}
+
+/** These ports expose no abort hook. Interruption must join their actual work before releasing ownership. */
+export function taskEffect<A>(run: () => Promise<A>): Effect.Effect<A, TaskFailure> {
+  const wait = (pending: Promise<A>) =>
+    Effect.tryPromise({ try: () => pending, catch: (cause) => new TaskFailure(cause) });
+  return Effect.acquireUseRelease(
+    Effect.try({ try: run, catch: (cause) => new TaskFailure(cause) }),
+    wait,
+    (pending, exit) => (Exit.hasInterrupts(exit) ? Effect.exit(wait(pending)) : Effect.void),
+  );
+}
+
 export interface TaskTracker {
-  /** Track one task. The caller keeps its own `.catch` — rejections must already be handled. */
+  /** Track already-started work. Rejections are logged without failing the drain. */
   track(task: Promise<unknown>): void;
   /** Resolves when every currently-tracked task has settled. */
   drain(): Promise<void>;
 }
 
 export function createTaskTracker(label: string): TaskTracker {
-  const tasks = new Set<Promise<unknown>>();
+  const tasks = new Set<Fiber.Fiber<void>>();
   return {
     track(task) {
-      tasks.add(task);
-      // Tracked side tasks count as process-wide in-flight work (busy.ts) — same signal the turn
-      // queue reports, read by serving surfaces that must not idle while background work runs.
       const workDone = beginWork();
-      void task
-        .finally(() => {
-          workDone();
-          tasks.delete(task);
-        })
-        .catch((error) => log.warn(`${label} side task rejected: ${String(error)}`));
+      const fiber = Effect.runFork(
+        taskEffect(() => task).pipe(
+          Effect.asVoid,
+          Effect.catchCause((cause) =>
+            Effect.sync(() => log.warn(`${label} side task rejected: ${String(taskFailure(cause))}`)),
+          ),
+          Effect.ensuring(Effect.sync(workDone)),
+        ),
+      );
+      tasks.add(fiber);
+      fiber.addObserver(() => tasks.delete(fiber));
     },
-    drain: () => Promise.allSettled(tasks).then(() => undefined),
+    drain: () => Effect.runPromise(Effect.asVoid(Fiber.awaitAll([...tasks]))),
   };
 }

--- a/src/channels/kit/turn-queue.ts
+++ b/src/channels/kit/turn-queue.ts
@@ -1,74 +1,64 @@
-/**
- * Per-session serial turn execution: one turn at a time per session (FIFO chains), different
- * sessions concurrent. IN-MEMORY — the runtime queue holds no durability of its own. The engine lease
- * is the corruption floor beneath this; this adds the group-UX queue (a second summon waits its turn
- * instead of colliding on the lease and being dropped as "busy").
- *
- * Channel-neutral (records are opaque beyond a `session` key), shared by the stateful chat channels
- * (Telegram, Feishu/Lark, Slack). Durability is layered ON TOP by the caller: turn-store.ts
- * persists an accepted turn's intent pre-ACK and replays a crash-surviving one on the next start (L1,
- * process-crash recovery, at-least-once). Exactly-once / deterministic step-replay (L2) is the K-axis
- * backend — an external queue with distributed locking (SPEC §11) — not this in-memory queue.
- */
+/** Per-session FIFO execution. Root fibers outlive ingress ACKs; persistence and replay belong to the runner. */
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import type * as Scope from "effect/Scope";
 import { log } from "../../log.ts";
 import { beginWork } from "../busy.ts";
+import { taskFailure } from "./tasks.ts";
 
 export interface TurnQueue<T> {
-  /** Schedule onto the session's serial chain (runs after that session's previous turn). */
   accept(rec: T): void;
-  /** Resolve once no turn is in flight (every per-session chain has drained). A test/observability seam
-   *  — the production runtime does NOT drain on shutdown (SIGTERM exits mid-turn by design; see the module
-   *  header), so this is not a graceful-drain hook; it just lets a caller await the fire-and-forget turns. */
+  /** Observation only: production shutdown does not drain channel turns. */
   idle(): Promise<void>;
 }
 
 export function createTurnQueue<T extends { session: string }>(opts: {
-  /** Log prefix naming the consumer (e.g. "[telegram]") — the queue itself is channel-neutral. */
   label: string;
-  /** Executes ONE turn. The queue wraps it: dequeue in FIFO order per session. The runner owns its
-   *  own error surface; a rejection that escapes anyway is caught and logged here (never a silent
-   *  unhandled rejection), but the runner's own catch is where diagnosis belongs. */
-  run: (rec: T) => Promise<void>;
-  /** Fired synchronously when a record is scheduled BEHIND an active turn — the caller's hook for
-   *  queue feedback to the user (e.g. an "⏳ queued" notice). */
+  /** The queue diagnoses escaped failures and closes this turn's resources before its successor runs. */
+  run: (rec: T) => Effect.Effect<void, unknown, Scope.Scope>;
+  /** Synchronous queue feedback for a turn behind an active or queued predecessor. */
   onQueuedBehind?: (rec: T) => void;
 }): TurnQueue<T> {
   const { label, run, onQueuedBehind } = opts;
-
-  // Per-session serial chains: a second turn for the same session waits its turn (FIFO) instead of
-  // colliding on the engine lease and being dropped as "busy". Different sessions run concurrently.
-  const chains = new Map<string, Promise<void>>();
-
+  const chains = new Map<string, Fiber.Fiber<void>>();
   return {
     accept(rec) {
       if (chains.has(rec.session)) onQueuedBehind?.(rec);
-      // Process-wide busy signal (busy.ts): an accepted turn counts as in-flight work from acceptance
-      // until its run settles — serving surfaces that must not idle mid-turn (the AgentCore adapter's
-      // /ping) read it. Counted here, not in run(), so a QUEUED turn (accepted, waiting on the chain)
-      // already reads as busy.
+      const prev = chains.get(rec.session);
+      // Admission counts immediately, including while waiting behind another turn.
       const workDone = beginWork();
-      const prev = chains.get(rec.session) ?? Promise.resolve();
-      const task = async (): Promise<void> => {
-        try {
-          await run(rec);
-        } catch (e) {
-          log.error(
-            `${label} turn runner rejected (session=${rec.session}; own your error surface in run()): ${String(e)}`,
-          );
-        }
-      };
-      const next = prev.then(task, task); // run after this session's previous turn, in arrival order
-      chains.set(rec.session, next);
-      void next.finally(() => {
-        workDone();
-        if (chains.get(rec.session) === next) chains.delete(rec.session); // drop the entry when drained
-      });
+      const fiber = Effect.runFork(
+        Effect.scoped(
+          Effect.gen(function* () {
+            // Publish the tail before execution can finish or submit another turn.
+            yield* Effect.yieldNow;
+            if (prev) yield* Fiber.await(prev);
+            yield* run(rec);
+          }),
+        ).pipe(
+          Effect.catchCause((cause) =>
+            Effect.sync(() =>
+              log.error(
+                `${label} turn runner rejected (session=${rec.session}; own your error surface in run()): ${String(taskFailure(cause))}`,
+              ),
+            ),
+          ),
+          Effect.ensuring(
+            Effect.sync(() => {
+              workDone();
+              if (chains.get(rec.session) === fiber) chains.delete(rec.session);
+            }),
+          ),
+        ),
+      );
+      chains.set(rec.session, fiber);
     },
-    async idle() {
-      // Await outstanding chains until none remain — a chain may schedule a follow-up turn, and each
-      // deletes its own map entry on settle, so an emptied map means every turn ran to completion. The
-      // tasks catch their own rejections, but allSettled keeps idle() itself total regardless.
-      while (chains.size > 0) await Promise.allSettled([...chains.values()]);
-    },
+    idle: () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          // A finishing turn or idle listener may enqueue more work.
+          while (chains.size > 0) yield* Fiber.awaitAll([...chains.values()]);
+        }),
+      ),
   };
 }

--- a/src/channels/kit/turn-runner.ts
+++ b/src/channels/kit/turn-runner.ts
@@ -9,7 +9,10 @@
  * mounted and taken over, what the prompt looks like, how attachments resolve, what a dropped turn
  * says and where. Those arrive as hooks; the ORDER they run in is this module's.
  */
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import { log } from "../../log.ts";
+import { type TaskFailure, taskEffect, taskFailure } from "./tasks.ts";
 import type { ContextBuffer } from "./context-buffer.ts";
 import { createTurnQueue } from "./turn-queue.ts";
 import { type TurnRecordBase, type TurnStore, commitAnsweredTurn } from "./turn-store.ts";
@@ -62,62 +65,89 @@ export interface TurnRunner<R, S> {
   idle(): Promise<void>;
 }
 
+/** Execute a dequeued turn. Business settlement removes intent; resource cleanup never does. */
+export function runQueuedTurn<R extends PendingBase<S>, S extends TurnRecordBase, E>(
+  options: TurnRunnerOptions<R, S, E>,
+  rec: R,
+): Effect.Effect<void, TaskFailure> {
+  return Effect.gen(function* () {
+    const { label, store, buffer, beforeRun } = options;
+    if (beforeRun && !(yield* taskEffect(() => beforeRun(rec)))) return;
+    const decision = store.startAttempt(rec.id);
+    if (decision === "exceeded") {
+      options.notifyDropped(rec);
+      return;
+    }
+    if (decision === "defer") {
+      options.onDeferred(rec);
+      return;
+    }
+    const startedAt = Date.now();
+    log.info(`${label} turn start: turn=${rec.id} session=${rec.session} ${options.where(rec)}`);
+    const bufferKey = options.bufferKey(rec);
+    const discussion = buffer.peek(bufferKey);
+    yield* taskEffect(() =>
+      options.execute(rec, discussion, () =>
+        commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey, consumed: discussion.consumed }),
+      ),
+    ).pipe(
+      Effect.matchEffect({
+        onSuccess: () =>
+          Effect.sync(() =>
+            log.info(`${label} turn done: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms)`),
+          ),
+        onFailure: (error) =>
+          Effect.sync(() =>
+            log.error(
+              `${label} turn failed: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms): ${String(error.cause)}`,
+            ),
+          ),
+      }),
+    );
+    // Caught execution/delivery failures are not replay-safe. Interruption never reaches this removal.
+    store.remove(rec.id);
+  });
+}
+
 export function createTurnRunner<
   R extends PendingBase<S> & { id: string; session: string },
   S extends TurnRecordBase,
   E,
 >(options: TurnRunnerOptions<R, S, E>): TurnRunner<R, S> {
-  const { label, store, buffer, seen, onQueuedBehind } = options;
-  const notices = new Map<string, { done: Promise<void>; cancel?: () => void }>();
+  const { label, store, seen, onQueuedBehind } = options;
+  const notices = new Map<string, { done: Fiber.Fiber<void>; cancel?: () => void }>();
   const queue = createTurnQueue<R>({
     label,
-    onQueuedBehind: onQueuedBehind && ((rec) => notices.set(rec.id, onQueuedBehind(rec))),
-    run: async (rec) => {
-      // Runs at DEQUEUE time (serialized). The queue wait is over: cancel a notice that has not
-      // fired, then settle so the turn's preview handle is final — in the common path this await is
-      // instant. BEFORE the ceiling check so a dropped or deferred turn can take the notice over too.
-      const notice = notices.get(rec.id);
-      notice?.cancel?.();
-      // The notice is the PLATFORM's feedback, not the turn: a failed post must not throw out of the
-      // run, which would leak the persisted intent (removed only below) into a replay that burns an
-      // attempt against the ceiling. Logged, then the turn proceeds without its handle.
-      await notice?.done.catch((error) =>
-        log.warn(`${label} queue notice failed: turn=${rec.id} session=${rec.session}: ${String(error)}`),
-      );
-      notices.delete(rec.id);
-      if (options.beforeRun && !(await options.beforeRun(rec))) return;
-      const decision = store.startAttempt(rec.id);
-      if (decision === "exceeded") {
-        options.notifyDropped(rec);
-        return;
-      }
-      if (decision === "defer") {
-        options.onDeferred(rec);
-        return;
-      }
-      const startedAt = Date.now();
-      log.info(`${label} turn start: turn=${rec.id} session=${rec.session} ${options.where(rec)}`);
-      // Snapshot the discussion at dequeue; commit only this snapshot on `completed`, so a message
-      // arriving while the turn runs stays buffered for the next answered turn.
-      const bufferKey = options.bufferKey(rec);
-      const discussion = buffer.peek(bufferKey);
-      try {
-        await options.execute(rec, discussion, () =>
-          commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey, consumed: discussion.consumed }),
+    onQueuedBehind:
+      onQueuedBehind &&
+      ((rec) => {
+        const notice = onQueuedBehind(rec);
+        // Observe rejection at acceptance, even if dequeue is minutes away.
+        const done = Effect.runFork(
+          taskEffect(() => notice.done).pipe(
+            Effect.catchCause((cause) =>
+              Effect.sync(() =>
+                log.warn(
+                  `${label} queue notice failed: turn=${rec.id} session=${rec.session}: ${String(taskFailure(cause))}`,
+                ),
+              ),
+            ),
+          ),
         );
-        log.info(`${label} turn done: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms)`);
-      } catch (error) {
-        log.error(
-          `${label} turn failed: turn=${rec.id} session=${rec.session} (${Date.now() - startedAt}ms): ${String(error)}`,
-        );
-      } finally {
-        // Fallback removal for the caught-error paths (a `failed` event or a transport throw): those
-        // never reach the completed hook. Idempotent. Only an INTERRUPTED run (this finally never
-        // runs — a crash or SIGTERM deploy) leaves the record for replay; a transport throw is
-        // dropped, not retried (safe retry needs an L2 delivery key).
-        store.remove(rec.id);
-      }
-    },
+        notices.set(rec.id, { done, cancel: notice.cancel });
+      }),
+    run: (rec) =>
+      Effect.gen(function* () {
+        const notice = notices.get(rec.id);
+        notices.delete(rec.id);
+        if (notice) {
+          // A broken cancel hook must still join any post already in flight.
+          yield* Effect.addFinalizer(() => Fiber.await(notice.done));
+          notice.cancel?.();
+          yield* Fiber.await(notice.done);
+        }
+        yield* runQueuedTurn(options, rec);
+      }),
   });
   const submit = (rec: R, persist: boolean): void => {
     if (persist) {

--- a/src/channels/kit/turn-store.ts
+++ b/src/channels/kit/turn-store.ts
@@ -1,18 +1,19 @@
 /**
  * Durable turn intent: the L1 half of durable execution (the L2 exactly-once / deterministic
  * step-replay layer is the K-axis backend — docs/design/core.md §11). Persists an accepted turn BEFORE
- * the webhook 200 (pre-ACK, like the telegram context-buffer) and removes it when the turn ENDS — the
- * runner's `finally`: a completed turn OR any caught error both remove it. Precisely, a completed turn's
+ * the webhook 200 (pre-ACK, like the telegram context-buffer) and removes it at business settlement:
+ * a completed turn OR a caught execution error both remove it. Precisely, a completed turn's
  * removal fires at the `completed` event (the session is committed), which is BEFORE the reply reaches
  * the chat platform: so L1 recovers the ACKed-but-un-COMPLETED window, not un-DELIVERED. A crash in
  * that narrow tail (completed, session-committed, but the message not yet sent) leaves the answer in the
  * session history undelivered and is deliberately NOT replayed — replaying a session-committed turn
  * would double-append it; the asker re-asks (and sees the prior answer in history). L1's scope is the
- * INTERRUPTED-run window (the `finally` never runs); a caught error is NOT retried here — a `failed`
+ * interrupted-run window (business settlement is not reached); a caught error is NOT retried here — a `failed`
  * event already told the user, and a transport throw is dropped exactly like the pre-L1 in-memory queue
  * did (replaying it could double-send). Only an interrupted run leaves the record on disk — and
  * "interrupted" is not just a rare crash: `runStart` has no graceful drain (cli.ts), so a SIGTERM exits
  * mid-turn too, i.e. EVERY rolling deploy that catches an in-flight turn. Recovery re-enqueues it next start.
+ * Effect interruption also preserves unfinished intent; resource finalizers never remove it.
  *
  * This recovers the ACKed-but-unfinished window the in-memory turn-queue drops (turn-queue.ts). Weigh
  * the trade before trusting it: the alternative (dropping the turn) fails VISIBLY and self-corrects

--- a/test/busy.test.ts
+++ b/test/busy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { activeWork, beginWork } from "../src/channels/busy.ts";
-import { createTaskTracker } from "../src/channels/kit/tasks.ts";
+import { createTaskTracker, taskEffect } from "../src/channels/kit/tasks.ts";
 import { createTurnQueue } from "../src/channels/kit/turn-queue.ts";
 
 /** Wait until `cond` holds (settlement callbacks run on the microtask queue). */
@@ -25,7 +25,7 @@ describe("channels/busy: the process-wide in-flight signal", () => {
     const gate = new Promise<void>((r) => {
       release = r;
     });
-    const queue = createTurnQueue<{ session: string }>({ label: "[test]", run: () => gate });
+    const queue = createTurnQueue<{ session: string }>({ label: "[test]", run: () => taskEffect(() => gate) });
     queue.accept({ session: "s" });
     expect(activeWork()).toBe(base + 1); // queued/running both count — the process must not idle
     release();
@@ -40,7 +40,7 @@ describe("channels/busy: the process-wide in-flight signal", () => {
     const gate = new Promise<void>((r) => {
       release = r;
     });
-    const queue = createTurnQueue<{ session: string }>({ label: "[test]", run: () => gate });
+    const queue = createTurnQueue<{ session: string }>({ label: "[test]", run: () => taskEffect(() => gate) });
     queue.accept({ session: "s" });
     queue.accept({ session: "s" });
     expect(activeWork()).toBe(base + 2);

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -18,6 +18,7 @@ import {
 import { createPiAgentFromSession, type PiAgentSessionFactory } from "../src/engines/pi/invoke-session.ts";
 import { piInMemorySessionRecordStore, piSessionRecordStore } from "../src/engines/pi/session-store.ts";
 import { collect, AgentFailure } from "../src/collect.ts";
+import { streamTurnWithBusyRetry } from "../src/channels/kit/invoke-turn-kit.ts";
 import { describe, expect, it } from "vitest";
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
@@ -181,9 +182,14 @@ describe("AgentSession L0: pi's auto-retry vs. append-only deltas", () => {
   });
 });
 
-it.each(["return", "throw"] as const)(
-  "quiet consumer %s aborts the actual tool and joins its cleanup before releasing",
-  async (method) => {
+it.each([
+  ["return", "direct"],
+  ["throw", "direct"],
+  ["return", "channel"],
+  ["throw", "channel"],
+] as const)(
+  "quiet consumer %s through %s aborts the actual tool and joins cleanup before releasing",
+  async (method, entry) => {
     const entered = Promise.withResolvers<void>();
     const aborted = Promise.withResolvers<void>();
     const finishCleanup = Promise.withResolvers<void>();
@@ -217,7 +223,11 @@ it.each(["return", "throw"] as const)(
         return session;
       },
     });
-    const iterator = agent.invoke({ session: "quiet" }, { text: "go" })[Symbol.asyncIterator]();
+    const events =
+      entry === "channel"
+        ? streamTurnWithBusyRetry(agent, { session: "quiet" }, { text: "go" }, { label: "[test]" })
+        : agent.invoke({ session: "quiet" }, { text: "go" });
+    const iterator = events[Symbol.asyncIterator]();
     expect((await iterator.next()).value).toMatchObject({ type: "tool_started" });
     await entered.promise;
     const pending = iterator.next();

--- a/test/invoke-turn-busy.test.ts
+++ b/test/invoke-turn-busy.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Agent, type AgentEvent, SESSION_BUSY_CODE } from "../src/agent.ts";
-import type { BusyRetry } from "../src/channels/kit/invoke-turn-kit.ts";
+import { type BusyRetry, busyRetryStream, streamTurnWithBusyRetry } from "../src/channels/kit/invoke-turn-kit.ts";
 import { invokeTurn } from "../src/channels/telegram/invoke-turn.ts";
+import { log } from "../src/log.ts";
 
 /** A fake agent scripted per-invoke: call N yields script[N] (the last entry repeats). */
 function scriptedAgent(script: AgentEvent[][]) {
@@ -36,10 +41,196 @@ async function run(agent: Agent, retry: BusyRetry = FAST): Promise<AgentEvent[]>
     chatId: 1,
     filesDir: await mkdtemp(join(tmpdir(), "fa-")),
   };
+  return read(invokeTurn(agent, "s", "hi", transport, noAttachments, undefined, retry));
+}
+
+async function read(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   const out: AgentEvent[] = [];
-  for await (const e of invokeTurn(agent, "s", "hi", transport, noAttachments, undefined, retry)) out.push(e);
+  for await (const event of events) out.push(event);
   return out;
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const relay = (agent: Agent, onCompleted?: () => void, busyRetry = FAST) =>
+  streamTurnWithBusyRetry(agent, { session: "s" }, { text: "hi" }, { label: "[test]", onCompleted, busyRetry });
+
+it("uses a virtual clock and closes the rejected attempt before its retry delay", async () => {
+  const order: string[] = [];
+  let calls = 0;
+  const agent: Agent = {
+    async *invoke() {
+      const id = ++calls;
+      order.push(`invoke ${id}`);
+      try {
+        yield* id === 1 ? [busyEvent] : ok;
+      } finally {
+        order.push(`close ${id}`);
+      }
+    },
+  };
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const work = yield* Stream.runCollect(
+        busyRetryStream(
+          agent,
+          { session: "s" },
+          { text: "hi" },
+          {
+            label: "[test]",
+            busyRetry: { delayMs: 60_000, maxWaitMs: 180_000 },
+          },
+        ),
+      ).pipe(Effect.forkChild);
+      yield* TestClock.adjust(59_999);
+      expect(order).toEqual(["invoke 1", "close 1"]);
+      yield* TestClock.adjust(1);
+      expect(yield* Fiber.join(work)).toEqual(ok);
+      expect(order).toEqual(["invoke 1", "close 1", "invoke 2", "close 2"]);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+it("cancels an active backoff without another invoke or a leaked timer", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+  const { agent, invokes } = scriptedAgent([[busyEvent]]);
+  const iterator = relay(agent, undefined, { delayMs: 60_000, maxWaitMs: 180_000 })[Symbol.asyncIterator]();
+  const pending = iterator.next();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(vi.getTimerCount()).toBe(1);
+  let closed = false;
+  const closing = iterator.return?.().then(() => {
+    closed = true;
+  });
+  try {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(closed).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(invokes()).toBe(1);
+    expect(await pending).toMatchObject({ done: true });
+  } finally {
+    await vi.runAllTimersAsync();
+    await closing;
+  }
+});
+
+it("keeps source pulls and completion commits behind consumer demand", async () => {
+  const onCompleted = vi.fn();
+  const close = vi.fn(async () => ({ done: true as const, value: undefined }));
+  const next = vi
+    .fn()
+    .mockResolvedValueOnce({ done: false, value: { type: "text", delta: "answer" } })
+    .mockResolvedValueOnce({ done: false, value: { type: "completed" } });
+  const agent: Agent = { invoke: () => ({ [Symbol.asyncIterator]: () => ({ next, return: close }) }) };
+  const iterator = relay(agent, onCompleted)[Symbol.asyncIterator]();
+  expect(next).not.toHaveBeenCalled();
+  expect((await iterator.next()).value).toEqual(ok[0]);
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(onCompleted).not.toHaveBeenCalled();
+  expect((await iterator.next()).value).toEqual(ok[1]);
+  expect(onCompleted).toHaveBeenCalledTimes(1);
+  expect(close).not.toHaveBeenCalled();
+  await iterator.return?.();
+  expect(close).toHaveBeenCalledTimes(1);
+});
+
+it("preserves natural exhaustion without calling return on an already-closed source", async () => {
+  const close = vi.fn(async () => {
+    throw new Error("source was already closed");
+  });
+  const next = vi
+    .fn()
+    .mockResolvedValueOnce({ done: false, value: { type: "completed" } })
+    .mockResolvedValueOnce({ done: true, value: undefined });
+  const agent: Agent = { invoke: () => ({ [Symbol.asyncIterator]: () => ({ next, return: close }) }) };
+  expect(await read(relay(agent))).toEqual([{ type: "completed" }]);
+  expect(close).not.toHaveBeenCalled();
+});
+
+it("commit failures keep their identity, close the source, and never trigger retry", async () => {
+  const error = new Error("commit failed");
+  const { agent, invokes } = scriptedAgent([ok]);
+  await expect(
+    read(
+      relay(agent, () => {
+        throw error;
+      }),
+    ),
+  ).rejects.toBe(error);
+  expect(invokes()).toBe(1);
+});
+
+it("logs cleanup failure without replacing a commit error or exposing its payload", async () => {
+  const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+  const primary = new Error("commit broke");
+  const cleanup = new Error("source close broke", { cause: { payload: "private-provider-data" } });
+  const agent: Agent = {
+    async *invoke() {
+      try {
+        yield { type: "completed" };
+      } finally {
+        // biome-ignore lint/correctness/noUnsafeFinally: inject an iterator cleanup failure.
+        throw cleanup;
+      }
+    },
+  };
+  await expect(
+    read(
+      relay(agent, () => {
+        throw primary;
+      }),
+    ),
+  ).rejects.toBe(primary);
+  expect(warn.mock.calls.flat().join(" ")).toContain("source close broke");
+  expect(warn.mock.calls.flat().join(" ")).not.toContain("private-provider-data");
+});
+
+it("diagnoses source cleanup failure when a paused consumer cancels", async () => {
+  const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+  const source = {
+    next: vi.fn(async () => ({ done: false as const, value: { type: "text" as const, delta: "partial" } })),
+    return: vi.fn(async () => {
+      throw new Error("cancel cleanup broke");
+    }),
+  };
+  const agent: Agent = { invoke: () => ({ [Symbol.asyncIterator]: () => source }) };
+  const iterator = relay(agent)[Symbol.asyncIterator]();
+  await iterator.next();
+  await iterator.return?.();
+  expect(source.return).toHaveBeenCalledTimes(1);
+  expect(warn.mock.calls.flat().join(" ")).toContain("cancel cleanup broke");
+});
+
+it("a failed close of a busy attempt surfaces instead of retrying ambiguous work", async () => {
+  const error = new Error("close failed");
+  const invoke = vi.fn(async function* () {
+    try {
+      yield busyEvent;
+    } finally {
+      // biome-ignore lint/correctness/noUnsafeFinally: inject an iterator cleanup failure.
+      throw error;
+    }
+  });
+  await expect(read(relay({ invoke }))).rejects.toBe(error);
+  expect(invoke).toHaveBeenCalledTimes(1);
+});
+
+it("passes future events and extended scope through without reopening the retry window", async () => {
+  const future = { type: "future", data: "x" } as unknown as AgentEvent;
+  const scope = { session: "s", parentSession: "parent", branchHints: ["entry"] };
+  const invoke = vi.fn(async function* () {
+    yield future;
+    yield busyEvent;
+  });
+  expect(await read(streamTurnWithBusyRetry({ invoke }, scope, { text: "hi" }, { label: "[test]" }))).toEqual([
+    future,
+    busyEvent,
+  ]);
+  expect(invoke).toHaveBeenCalledExactlyOnceWith(scope, { text: "hi" });
+});
 
 describe("invokeTurn busy-wait (the reverse of the scheduler's wake defer)", () => {
   it("a fail-fast busy reject retries (bounded) and the user gets the ANSWER, not an error", async () => {

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -58,6 +58,21 @@ describe("package boundary: embed entry stays free of CLI-only dependencies", ()
     expect(pkgs).not.toContain("@octokit/webhooks-methods");
   });
 
+  it.each(["telegram.ts", "slack.ts", "feishu.ts", "lark.ts"])(
+    "%s pays the explicit channel execution dependency budget",
+    (entry) => {
+      expect([...staticPackageGraph(entry)].filter((p) => p.startsWith("effect/")).sort()).toEqual([
+        "effect/Cause",
+        "effect/Clock",
+        "effect/Effect",
+        "effect/Exit",
+        "effect/Fiber",
+        "effect/Stream",
+      ]);
+      expect([...staticPackageGraph(entry)].filter((p) => p.startsWith("@earendil-works/"))).toEqual([]);
+    },
+  );
+
   it("the CLI entry is a thin shell: NO static package loads at all (everything is lazy)", () => {
     // `fastagent <cmd>` pays only for the executed command's module graph — the entry itself must not
     // pull anything eagerly (startup responsiveness, clig).

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -1,5 +1,66 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { createTaskTracker } from "../src/channels/kit/tasks.ts";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { type TaskFailure, createTaskTracker, taskEffect, taskFailure } from "../src/channels/kit/tasks.ts";
+
+it("keeps Promise failures typed until the task boundary handles them", () => {
+  const work = taskEffect(async () => 1);
+  expectTypeOf(work).toEqualTypeOf<Effect.Effect<number, TaskFailure>>();
+  // @ts-expect-error -- a task rejection still needs a failure policy
+  const infallible: Effect.Effect<number> = work;
+  void infallible;
+  expectTypeOf(work.pipe(Effect.catchTag("TaskFailure", () => Effect.succeed(0)))).toEqualTypeOf<
+    Effect.Effect<number>
+  >();
+});
+
+it.each(["resolve", "reject"])("joins an interrupted task before cleanup (%s)", async (settle) => {
+  const pending = Promise.withResolvers<void>();
+  const entered = Promise.withResolvers<void>();
+  const abort = new AbortController();
+  let cleaned = false;
+  const done = Effect.runPromiseExit(
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            cleaned = true;
+          }),
+        );
+        yield* taskEffect(() => {
+          entered.resolve();
+          return pending.promise;
+        });
+      }),
+    ),
+    { signal: abort.signal },
+  );
+  try {
+    await entered.promise;
+    abort.abort();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(cleaned).toBe(false);
+  } finally {
+    if (settle === "resolve") pending.resolve();
+    else pending.reject(new Error("late task failure"));
+    await done;
+  }
+  expect(cleaned).toBe(true);
+  const exit = await done;
+  expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+});
+
+it.each(["throw", "reject"])("preserves the original task failure (%s)", async (mode) => {
+  const error = new Error("task broke");
+  const exit = await Effect.runPromiseExit(
+    taskEffect(() => {
+      if (mode === "throw") throw error;
+      return Promise.reject(error);
+    }),
+  );
+  expect(Exit.isFailure(exit) && taskFailure(exit.cause)).toBe(error);
+});
 
 describe("createTaskTracker", () => {
   afterEach(() => vi.restoreAllMocks());

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -314,7 +314,7 @@ describe("durable turn intent (crash recovery)", () => {
   it("replays a crash-surviving turn on the next start, then removes it", async () => {
     vi.stubGlobal("fetch", okFetch());
     const state = freshStateDir();
-    // Simulate a crash: a record persisted pre-ACK but never removed (the runner's finally never ran).
+    // Simulate a crash before business settlement: the pre-ACK intent remains for recovery.
     writeFileSync(
       join(state, "turns.json"),
       JSON.stringify({

--- a/test/turn-queue.test.ts
+++ b/test/turn-queue.test.ts
@@ -1,6 +1,9 @@
+import * as Effect from "effect/Effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { activeWork, onIdle } from "../src/channels/busy.ts";
 import { type TurnQueue, createTurnQueue } from "../src/channels/kit/turn-queue.ts";
 import { log } from "../src/log.ts";
+import { taskEffect } from "../src/channels/kit/tasks.ts";
 
 /** The consumer-side record for these tests: a `session` key plus caller-domain fields. */
 interface Rec {
@@ -18,9 +21,88 @@ const until = async (cond: () => boolean): Promise<void> => {
 };
 
 const makeQueue = (run: (r: Rec) => Promise<void>, onQueuedBehind?: (r: Rec) => void): TurnQueue<Rec> =>
-  createTurnQueue<Rec>({ label: "[test]", run, onQueuedBehind });
+  createTurnQueue<Rec>({ label: "[test]", run: (rec) => taskEffect(() => run(rec)), onQueuedBehind });
 
 describe("turn-queue", () => {
+  it("owns cleanup before the successor runs, counts queued work, and isolates sessions", async () => {
+    const base = activeWork();
+    const releasing = Promise.withResolvers<void>();
+    const released = Promise.withResolvers<void>();
+    const other = Promise.withResolvers<void>();
+    const order: string[] = [];
+    const queue = createTurnQueue<Rec>({
+      label: "[test]",
+      run: (r) =>
+        Effect.gen(function* () {
+          order.push(r.id);
+          if (r.id === "1")
+            yield* Effect.addFinalizer(() =>
+              Effect.promise(async () => {
+                releasing.resolve();
+                await released.promise;
+                order.push("cleanup");
+              }),
+            );
+          if (r.id === "3") other.resolve();
+        }),
+    });
+    queue.accept(rec("1"));
+    queue.accept(rec("2"));
+    queue.accept(rec("3", "other"));
+    expect(order).toEqual([]);
+    expect(activeWork()).toBe(base + 3);
+    const idle = queue.idle();
+    try {
+      await Promise.all([releasing.promise, other.promise]);
+      expect(order).toEqual(["1", "3"]);
+      expect(activeWork()).toBe(base + 2);
+    } finally {
+      released.resolve();
+      await idle;
+    }
+    expect(order).toEqual(["1", "3", "cleanup", "2"]);
+    expect(activeWork()).toBe(base);
+  });
+
+  it("an idle listener can enqueue another turn without losing its tail or busy count", async () => {
+    const base = activeWork();
+    const ran: string[] = [];
+    const queue = makeQueue(async (r) => {
+      ran.push(r.id);
+    });
+    const off = onIdle(() => {
+      if (ran.length === 1) queue.accept(rec("2"));
+    });
+    try {
+      queue.accept(rec("1"));
+      await queue.idle();
+      expect(ran).toEqual(["1", "2"]);
+      expect(activeWork()).toBe(base);
+    } finally {
+      off();
+    }
+  });
+
+  it("a scope cleanup defect is diagnosed and the FIFO still advances", async () => {
+    const errors = vi.spyOn(log, "error").mockImplementation(() => {});
+    const base = activeWork();
+    const ran: string[] = [];
+    const queue = createTurnQueue<Rec>({
+      label: "[test]",
+      run: (r) =>
+        Effect.gen(function* () {
+          ran.push(r.id);
+          if (r.id === "1") yield* Effect.addFinalizer(() => Effect.die(new Error("cleanup broke")));
+        }),
+    });
+    queue.accept(rec("1"));
+    queue.accept(rec("2"));
+    await queue.idle();
+    expect(ran).toEqual(["1", "2"]);
+    expect(activeWork()).toBe(base);
+    expect(errors.mock.calls.flat().join(" ")).toContain("cleanup broke");
+  });
+
   it("accept runs the turn", async () => {
     const ran: string[] = [];
     const queue = makeQueue(async (r) => {

--- a/test/turn-runner.test.ts
+++ b/test/turn-runner.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
-import type { ContextBuffer } from "../src/channels/kit/context-buffer.ts";
-import { createTurnRunner } from "../src/channels/kit/turn-runner.ts";
-import type { TurnRecordBase, TurnStore } from "../src/channels/kit/turn-store.ts";
+import { mkdtempSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type ContextBuffer, createContextBuffer } from "../src/channels/kit/context-buffer.ts";
+import { createTurnRunner, runQueuedTurn, type TurnRunnerOptions } from "../src/channels/kit/turn-runner.ts";
+import { type TurnRecordBase, type TurnStore, createTurnStore } from "../src/channels/kit/turn-store.ts";
+import { createTurnQueue } from "../src/channels/kit/turn-queue.ts";
+import { activeWork } from "../src/channels/busy.ts";
+import * as atomic from "../src/atomic-write.ts";
 import { log } from "../src/log.ts";
 
 interface Stored extends TurnRecordBase {
@@ -44,12 +54,12 @@ function fakeBuffer(calls: string[]): ContextBuffer<string> {
   };
 }
 
-function runner(
+function runnerOptions(
   store: TurnStore<Stored>,
   calls: string[],
-  overrides: Partial<Parameters<typeof createTurnRunner<Pending, Stored, string>>[0]> = {},
-) {
-  return createTurnRunner<Pending, Stored, string>({
+  overrides: Partial<TurnRunnerOptions<Pending, Stored, string>> = {},
+): TurnRunnerOptions<Pending, Stored, string> {
+  return {
     label: "[t]",
     store,
     buffer: fakeBuffer(calls),
@@ -65,10 +75,240 @@ function runner(
       onCompleted();
     },
     ...overrides,
-  });
+  };
+}
+const runner = (
+  store: TurnStore<Stored>,
+  calls: string[],
+  overrides: Partial<TurnRunnerOptions<Pending, Stored, string>> = {},
+) => createTurnRunner(runnerOptions(store, calls, overrides));
+
+const dirs: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+function durable() {
+  const dir = mkdtempSync(join(tmpdir(), "turn-runner-"));
+  dirs.push(dir);
+  const storePath = join(dir, "turns.json");
+  const openStore = () =>
+    createTurnStore<Stored>(storePath, {
+      label: "[t]",
+      isRecord: (r): r is Stored => typeof r === "object" && r !== null && "attempts" in r,
+      order: (a, b) => a.id.localeCompare(b.id),
+    });
+  const openBuffer = () =>
+    createContextBuffer<string>({
+      path: join(dir, "buffer.json"),
+      label: "[t]",
+      isEntry: (entry): entry is string => typeof entry === "string",
+      line: (entry) => entry,
+    });
+  return { dir, storePath, openStore, openBuffer, store: openStore(), buffer: openBuffer() };
 }
 
 describe("turn runner: the lifecycle order every chat channel shares", () => {
+  it.each(["running", "committed"])("SIGTERM preserves the durable %s state", async (phase) => {
+    const { dir, openStore, openBuffer } = durable();
+    const source = new URL("../src/channels/kit/", import.meta.url).href;
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+      import { createTurnRunner } from ${JSON.stringify(`${source}turn-runner.ts`)};
+      import { createTurnStore } from ${JSON.stringify(`${source}turn-store.ts`)};
+      import { createContextBuffer } from ${JSON.stringify(`${source}context-buffer.ts`)};
+      const root = ${JSON.stringify(dir)};
+      const store = createTurnStore(root + '/turns.json', { label: '[child]', isRecord: () => true, order: () => 0 });
+      const buffer = createContextBuffer({ path: root + '/buffer.json', label: '[child]', isEntry: () => true, line: x => x });
+      buffer.push('place:s', 'earlier');
+      const runner = createTurnRunner({
+        label: '[child]', store, buffer, toStored: r => ({ ...r, attempts: 0 }), fromStored: r => r,
+        bufferKey: () => 'place:s', where: () => 'child', onDeferred: () => {}, notifyDropped: () => {},
+        execute: async (_rec, _discussion, onCompleted) => {
+          process.on('message', () => {
+            onCompleted();
+            buffer.push('place:s', 'later');
+            process.send('committed');
+          });
+          process.send('running');
+          await new Promise(() => {});
+        },
+      });
+      runner.submit({ id: 'a', session: 's', text: '' }, true);
+    `,
+      ],
+      { stdio: ["ignore", "ignore", "pipe", "ipc"] },
+    );
+    let stderr = "";
+    child.stderr?.on("data", (data) => {
+      stderr += data;
+    });
+    const exited = once(child, "exit");
+    const message = () =>
+      Promise.race([
+        once(child, "message").then(([value]) => value),
+        exited.then(() => {
+          throw new Error(`child exited before the expected message: ${stderr}`);
+        }),
+      ]);
+    try {
+      expect(await message()).toBe("running");
+      if (phase === "committed") {
+        const committed = message();
+        child.send("complete");
+        expect(await committed).toBe("committed");
+      }
+    } finally {
+      child.kill("SIGTERM");
+      await exited;
+    }
+    expect(openStore().recover()).toEqual(
+      phase === "running" ? [{ id: "a", session: "s", text: "", attempts: 1 }] : [],
+    );
+    expect(openBuffer().peek("place:s").consumed).toEqual(phase === "running" ? ["earlier"] : ["later"]);
+  });
+
+  it("observes a rejected queue notice while its predecessor is still running", async () => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const head = Promise.withResolvers<void>();
+    const entered = Promise.withResolvers<void>();
+    const { store, calls } = fakeStore();
+    const r = runner(store, calls, {
+      onQueuedBehind: () => ({ done: Promise.reject(new Error("notice rejected before dequeue")) }),
+      execute: async (rec) => {
+        if (rec.id === "a") {
+          entered.resolve();
+          await head.promise;
+        }
+      },
+    });
+    r.submit({ id: "a", session: "s", text: "" }, true);
+    r.submit({ id: "b", session: "s", text: "" }, true);
+    try {
+      await entered.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(warn.mock.calls.flat().join(" ")).toContain("notice rejected before dequeue");
+      expect(calls).not.toContain("attempt b");
+    } finally {
+      head.resolve();
+      await r.idle();
+    }
+    expect(calls).toContain("attempt b");
+  });
+
+  it("joins the notice even when its cancel hook throws, leaving the turn for recovery", async () => {
+    const errors = vi.spyOn(log, "error").mockImplementation(() => {});
+    const posted = Promise.withResolvers<void>();
+    const cancelled = Promise.withResolvers<void>();
+    const base = activeWork();
+    const { store, calls } = fakeStore();
+    const r = runner(store, calls, {
+      onQueuedBehind: () => ({
+        done: posted.promise,
+        cancel: () => {
+          cancelled.resolve();
+          throw new Error("cancel broke");
+        },
+      }),
+    });
+    r.submit({ id: "a", session: "s", text: "" }, true);
+    r.submit({ id: "b", session: "s", text: "" }, true);
+    try {
+      await cancelled.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(activeWork()).toBe(base + 1);
+      expect(calls).not.toContain("attempt b");
+    } finally {
+      posted.resolve();
+      await r.idle();
+    }
+    expect(calls).not.toContain("remove b");
+    expect(errors.mock.calls.flat().join(" ")).toContain("cancel broke");
+    expect(activeWork()).toBe(base);
+  });
+
+  it.each([false, true])(
+    "interruption joins work and preserves the actual commit decision (completed=%s)",
+    async (completed) => {
+      const { store, buffer, openStore, openBuffer } = durable();
+      buffer.push("place:s", "earlier");
+      store.add({ id: "a", session: "s", text: "", attempts: 0 });
+      const entered = Promise.withResolvers<void>();
+      const finish = Promise.withResolvers<void>();
+      let running!: Fiber.Fiber<unknown, unknown>;
+      const opts = runnerOptions(store, [], {
+        buffer,
+        execute: async (_rec, discussion, onCompleted) => {
+          expect(discussion.consumed).toEqual(["earlier"]);
+          if (completed) onCompleted();
+          entered.resolve();
+          await finish.promise;
+        },
+      });
+      const base = activeWork();
+      const queue = createTurnQueue<Pending>({
+        label: "[t]",
+        run: (rec) =>
+          Effect.gen(function* () {
+            running = yield* Effect.withFiber(Effect.succeed);
+            yield* runQueuedTurn(opts, rec);
+          }),
+      });
+      queue.accept({ id: "a", session: "s", text: "" });
+      await entered.promise;
+      buffer.push("place:s", "later");
+      const interrupted = Effect.runPromise(Fiber.interrupt(running));
+      try {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(activeWork()).toBe(base + 1);
+      } finally {
+        finish.resolve();
+        await interrupted;
+        await queue.idle();
+      }
+      expect(activeWork()).toBe(base);
+      expect(openStore().recover()).toEqual(completed ? [] : [{ id: "a", session: "s", text: "", attempts: 1 }]);
+      expect(openBuffer().peek("place:s").consumed).toEqual(completed ? ["later"] : ["earlier", "later"]);
+      if (!completed) {
+        const replay = runner(openStore(), [], { buffer: openBuffer() });
+        expect(replay.recover()).toHaveLength(1);
+        await replay.idle();
+        expect(openStore().recover()).toEqual([]);
+        expect(openBuffer().peek("place:s").consumed).toEqual([]);
+      }
+    },
+  );
+
+  it("pre-ACK persistence and attempt failures preserve dedup, busy accounting and restart recovery", async () => {
+    const { store, buffer, storePath, openStore } = durable();
+    const calls: string[] = [];
+    const base = activeWork();
+    const r = runner(store, calls, { buffer });
+    const write = vi.spyOn(atomic, "writeFileAtomic").mockImplementation(() => {
+      throw new Error("disk failed");
+    });
+    const rec = { id: "a", session: "s", text: "" };
+    expect(() => r.submit(rec, true)).toThrow("disk failed");
+    expect(calls).toEqual([]);
+    expect(activeWork()).toBe(base);
+    write.mockRestore();
+    r.submit(rec, true);
+    expect(openStore().recover()).toMatchObject([{ id: "a", attempts: 0 }]);
+    const original = atomic.writeFileAtomic;
+    vi.spyOn(atomic, "writeFileAtomic").mockImplementation((path, ...args) => {
+      if (path === storePath) throw new Error("attempt write failed");
+      return original(path, ...args);
+    });
+    await r.idle();
+    expect(calls).toEqual(["seen a", "deferred a"]);
+    expect(openStore().recover()).toMatchObject([{ id: "a", attempts: 0 }]);
+    expect(activeWork()).toBe(base);
+  });
+
   it("accepts, settles the queue notice, counts the attempt, folds, executes, commits, and drops the intent", async () => {
     const { store, calls } = fakeStore();
     const r = runner(store, calls, {


### PR DESCRIPTION
## Summary

- Run shared Telegram, Slack, and Feishu/Lark turns in per-session FIFO Effect scopes. Admission persists and counts busy synchronously; root fibers outlive webhook ACKs and wait through predecessor cleanup.
- Keep Promise failures typed until their policy boundary. Join non-abortable work before releasing ownership. Business settlement removes durable intent; resource finalizers do not.
- Observe queue-notice failures at acceptance and join notices at dequeue, including cancel-hook failure. Track side tasks with their existing drain semantics.
- Use demand-driven, scoped retry attempts and the Effect clock. Preserve first-event-only busy retry, completion/context ordering, natural iterator exhaustion, primary errors, and actual Agent cancellation through the AsyncIterable boundary.

Public APIs, platform protocols, storage formats, schedules, AgentCore assembly, and non-draining service shutdown remain unchanged. `/core`, `/session`, and the neutral contracts stay dependency-free.

## Verification

- Lint, typecheck, build, and **1,763 tests / 121 files** pass on Node 26.8.1.
- **358 focused tests / 13 files** pass on each of Node 22.19.0 and 24.20.0.
- Real Pi tool cancellation and delayed cleanup, ACK-independent Telegram execution, real SIGTERM recovery, persistence failures, queue isolation, backpressure, and cleanup diagnostics are covered.
- Nine fault-injection groups fail when their protections are removed or misplaced. Compiler checks reject dropped `TaskFailure` and `Scope` requirements.

## Costs

All [preregistered budgets](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5578189398) pass against `15be0022`:

| Measurement | Added cost | Budget |
|---|---:|---:|
| Worst channel cold import | 34.953 ms | 50 ms |
| Worst channel retained import heap | 4.837 MiB | 10 MiB |
| Warm runner admission / first event / full turn | 0.005 / 0.054 / 0.073 ms | 2 ms each |
| Full no-network Telegram turn | 0.109 ms | 2 ms |
| Drain 1,000 buffered turns | 47.963 ms | 100 ms |

Telegram webhook ACK measured 0.426 → 0.231 ms; `/core` remained effectively unchanged. Shared implementation grows **210 → 374 non-comment lines**. These are local mechanism/cost checks, not production reliability or throughput claims. Non-abortable platform Promise hooks are joined on interruption; platform I/O remains owned by those hooks.

[Full evidence, measurements, limitations, and reproduction](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5578906098).

Related to #480.
