### PR TITLE
refactor(channels): scope preview and reply delivery with Effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ src/
 │   │   │                     # discover have none there. Neither side may reach for the other.
 │   │   ├── preview-kit.ts   # pure turn-view reducer, line renderers, and preview policies
 │   │   ├── delivery.ts      # scoped coalescing previews, ordered native writes, and snapshot terminal settlement
-│   │   ├── event-stream.ts  # typed iterator acquisition + abort-first AsyncIterable boundary
+│   │   ├── event-stream.ts  # typed, demand-driven Agent iterator acquisition and scoped cleanup
 │   │   ├── invoke-turn-kit.ts # demand-driven Effect stream: scoped attempts, cancellable busy wait, completed-event commit
 │   │   ├── turn-runner.ts   # accept → dequeue → execute → settle over the queue + store + buffer;
 │   │   │                     # business settlement removes intent, resource finalizers never do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,9 @@ src/
 │   │   │                     # imports, asserted in package-boundary.test.ts: every file here has
 │   │   │                     # consumers only under channels/<platform>/, and serve/http/control/
 │   │   │                     # discover have none there. Neither side may reach for the other.
-│   │   ├── preview-kit.ts   # turn-view reducer (event → view state + line renderers) + preview policies
+│   │   ├── preview-kit.ts   # pure turn-view reducer, line renderers, and preview policies
+│   │   ├── delivery.ts      # scoped coalescing previews, ordered native writes, and snapshot terminal settlement
+│   │   ├── event-stream.ts  # typed iterator acquisition + abort-first AsyncIterable boundary
 │   │   ├── invoke-turn-kit.ts # demand-driven Effect stream: scoped attempts, cancellable busy wait, completed-event commit
 │   │   ├── turn-runner.ts   # accept → dequeue → execute → settle over the queue + store + buffer;
 │   │   │                     # business settlement removes intent, resource finalizers never do

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -421,9 +421,9 @@ post-ACK write policies, and at-least-once replay are unchanged.
 
 The busy-retry stream pulls only on downstream demand. Each attempt owns its source iterator; a
 first-event `session_busy` rejection closes that iterator before waiting on the Effect clock. Other
-failures never reopen the retry window. The AsyncIterable adapter reuses abort-first cancellation,
-so returning during a quiet read aborts the actual Agent iterator and returning during backoff cancels
-the timer. Natural source exhaustion needs no additional `return()` call.
+failures never reopen the retry window. Interrupting consumption closes the actual Agent iterator
+during a quiet read and cancels the timer during backoff. Natural source exhaustion needs no
+additional `return()` call.
 
 The runner's internal `execute` hook returns an Effect, so input loading, source consumption, previews,
 terminal delivery, and Slack reaction cleanup remain children of the turn. Platform API clients retain

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -391,7 +391,7 @@ uses that same shutdown, logging cleanup errors while preserving the startup fai
 `ready` waiter stays outside the scope it may close; channel authors still return ordinary Promises
 and consume an `AbortSignal`. Agent turns and durable replay state remain outside this scope.
 Effect is internal to `/node` service assembly, `/pi` execution/control, and the stateful chat channels'
-shared execution kit. The contracts, `/core`, and `/session` remain dependency-free; public APIs expose
+execution and delivery. The contracts, `/core`, and `/session` remain dependency-free; public APIs expose
 no Effect runtime or types.
 
 `channels/sse.ts` owns the Fetch-only response lifecycle shared by HTTP invoke and session observation:
@@ -424,6 +424,21 @@ first-event `session_busy` rejection closes that iterator before waiting on the 
 failures never reopen the retry window. The AsyncIterable adapter reuses abort-first cancellation,
 so returning during a quiet read aborts the actual Agent iterator and returning during backoff cancels
 the timer. Natural source exhaustion needs no additional `return()` call.
+
+The runner's internal `execute` hook returns an Effect, so input loading, source consumption, previews,
+terminal delivery, and Slack reaction cleanup remain children of the turn. Platform API clients retain
+ordinary Promises and their existing retry/fallback policies. Already-issued operations are joined;
+interrupting input loading does not start a model after the input resolves.
+
+`delivery.ts` owns coalescing preview fibers and ordered native append/status queues. A preview starts
+its first write synchronously, cancels pending pacing at finish, and joins an issued write before the
+terminal update. Slack's mutation slot and append timer use the turn's clock. Its native stream is
+closed after accepted appends, even if error formatting fails; an attempted stop is never retried by
+scope cleanup. Status clearing follows stream cleanup. Preview callbacks capture the turn context
+when crossing a synchronous API boundary, preserving its clock without introducing a global runtime.
+Snapshot renderers share terminal ownership; formatting, continuation, and capability fallback stay
+platform-specific. Failed error notices are diagnosed without replacing the primary failure, and a
+failed final delivery does not trigger a second abnormal-turn delivery.
 
 ### GitHub
 

--- a/src/channels/feishu/feishu.ts
+++ b/src/channels/feishu/feishu.ts
@@ -31,7 +31,7 @@ import {
   feishuBufferText,
 } from "./context-buffer.ts";
 import { decryptEvent, verifySignature } from "./crypto.ts";
-import { invokeFeishuTurn } from "./invoke-turn.ts";
+import { feishuTurnStream } from "./invoke-turn.ts";
 import { type FeishuApi, type FeishuTarget, createFeishuApi } from "./feishu-api.ts";
 import type { FeishuEventHeader } from "./model.ts";
 import { normalizeFeishuMessage } from "./normalize.ts";
@@ -59,7 +59,7 @@ import {
   defaultErrorMessage,
   mountFeishuPreview,
   settleFeishuPreview,
-  streamFeishuReply,
+  feishuReply,
 } from "./preview.ts";
 import { connectFeishuWs } from "./ws-ingress.ts";
 import { registerFeishuApi } from "./shared-api.ts";
@@ -460,8 +460,8 @@ function createFeishuRuntimeFactory(
         // Recorded at ingress (see submit) — never re-derived from the session key, which may be a
         // routed OPAQUE id that only looks like a place key.
         const parentSession = rec.parentSession;
-        return streamFeishuReply(
-          invokeFeishuTurn(
+        return feishuReply(
+          feishuTurnStream(
             agent,
             rec.session,
             prompt,

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -346,7 +346,7 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
 
 /**
  * Run one turn: resolve its inputs, then stream agent.invoke with the shared busy-wait
- * (invoke-turn-kit — `onCompleted` is the durable-commit point; see streamTurnWithBusyRetry). A
+ * (invoke-turn-kit — `onCompleted` is the durable-commit point; see busyRetryStream). A
  * primary-input failure surfaces as a `failed` event (never a silent drop).
  */
 export function feishuTurnStream(

--- a/src/channels/feishu/invoke-turn.ts
+++ b/src/channels/feishu/invoke-turn.ts
@@ -13,6 +13,9 @@
  * or hide its still-readable siblings.
  */
 import type { Agent, AgentEvent, ImageRef, Scope } from "../../agent.ts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { type TaskFailure, taskEffect } from "../kit/tasks.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -21,7 +24,7 @@ import {
   attributedFileName,
   backgroundImagesManifest,
   missingAttachmentsNote,
-  streamTurnWithBusyRetry,
+  busyRetryStream,
 } from "../kit/invoke-turn-kit.ts";
 import { BUFFER_ATTACH_MAX } from "../kit/context-buffer.ts";
 import type { FeishuBufferedRef } from "./context-buffer.ts";
@@ -346,7 +349,7 @@ async function resolveTurnInputs(t: FeishuTurnTransport, attachments: FeishuTurn
  * (invoke-turn-kit — `onCompleted` is the durable-commit point; see streamTurnWithBusyRetry). A
  * primary-input failure surfaces as a `failed` event (never a silent drop).
  */
-export async function* invokeFeishuTurn(
+export function feishuTurnStream(
   agent: Agent,
   session: string,
   text: string,
@@ -354,21 +357,27 @@ export async function* invokeFeishuTurn(
   attachments: FeishuTurnAttachments,
   onCompleted?: () => void,
   busyRetry: BusyRetry = DEFAULT_BUSY_RETRY,
-): AsyncIterable<AgentEvent> {
-  let resolved: ResolvedInputs;
-  try {
-    resolved = await resolveTurnInputs(transport, attachments);
-  } catch (e) {
-    yield { type: "failed", details: `could not load attachment: ${String(e)}`, retryable: true };
-    return;
-  }
-  const prompt = { text: `${text}${resolved.promptSuffix}${REPLY_INSTRUCTION}`, images: resolved.images };
-  // A thread turn names its lineage: parent place + the message ids that can locate the branch point
-  // (the referent and its chain — nearest first). The engine reads them ONCE, when the thread's
-  // session does not exist yet; on every later turn they ride along inertly.
-  const scope: Scope =
-    transport.parentSession === undefined
-      ? { session }
-      : { session, parentSession: transport.parentSession, branchHints: resolved.referentIds };
-  yield* streamTurnWithBusyRetry(agent, scope, prompt, { label: transport.label, onCompleted, busyRetry });
+): Stream.Stream<AgentEvent, TaskFailure> {
+  return Stream.unwrap(
+    taskEffect(() => resolveTurnInputs(transport, attachments)).pipe(
+      Effect.map((resolved) => {
+        const prompt = { text: `${text}${resolved.promptSuffix}${REPLY_INSTRUCTION}`, images: resolved.images };
+        // Lineage is resolved per turn; the engine reads it only when creating a new session.
+        const scope: Scope =
+          transport.parentSession === undefined
+            ? { session }
+            : { session, parentSession: transport.parentSession, branchHints: resolved.referentIds };
+        return busyRetryStream(agent, scope, prompt, { label: transport.label, onCompleted, busyRetry });
+      }),
+      Effect.catchTag("TaskFailure", (error) =>
+        Effect.succeed(
+          Stream.succeed<AgentEvent>({
+            type: "failed",
+            details: `could not load attachment: ${String(error.cause)}`,
+            retryable: true,
+          }),
+        ),
+      ),
+    ),
+  );
 }

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -23,6 +23,12 @@
  */
 import { setTimeout as sleep } from "node:timers/promises";
 import type { AgentEvent } from "../../agent.ts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as Clock from "effect/Clock";
+import { eventStream } from "../kit/event-stream.ts";
+import { previewPump, renderReply } from "../kit/delivery.ts";
+import { type TaskFailure, runTask, taskEffect } from "../kit/tasks.ts";
 import { log } from "../../log.ts";
 import {
   ANSWER_ELEMENT_ID,
@@ -39,7 +45,6 @@ import {
   type ChannelFailure,
   applyTurnEvent,
   composeTurnBody,
-  createPreviewPump,
   createTurnView,
   defaultErrorMessage,
   revealedAnswer,
@@ -229,7 +234,7 @@ export async function settleFeishuPreview(
  * turn's already-mounted card/text message: the pump and terminal write mutate that same message rather
  * than recalling it and posting another reply.
  */
-export async function streamFeishuReply(
+export function streamFeishuReply(
   events: AsyncIterable<AgentEvent>,
   api: FeishuApi,
   target: FeishuTarget,
@@ -237,149 +242,120 @@ export async function streamFeishuReply(
   initialPreview?: MountedFeishuPreview,
   label = "[feishu]",
 ): Promise<void> {
-  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
-  // policy, the card-budget caps, and delivery below. The card is TWO elements (card.ts): the process
-  // block's head changes every frame (sliding thinking tail, `…`→`✓` flips), so it must never share
-  // an element with the answer — the client would re-type the whole card from the divergence point
-  // once a second. Each view feeds its own element; only the changed one is written.
-  const turn = createTurnView();
-  const processView = (): string => {
-    const v = composeTurnBody([
-      thinkingLine(turn, THINKING_PREVIEW),
-      toolLines(turn),
-      turn.retrying ? RETRY_NOTICE : "",
-    ]);
-    if (v !== "") return tailLines(v, PROCESS_MAX_POINTS);
-    // No process content: the placeholder covers only the silence BEFORE the answer reveals — once
-    // the answer is streaming, an empty block goes (stays) empty; "Thinking…" pinned above a live
-    // answer would misstate the phase. The empty frame is a real write: it clears a mounted
-    // placeholder. (The block cannot otherwise flicker: thinking and tools only grow — only the
-    // retry notice toggles, and its empty state resolves through this same rule.)
-    return revealedAnswer(turn, STREAM_THROTTLE_MS).trim() === "" ? THINKING_PLACEHOLDER : "";
-  };
-  const answerView = (): string => capBytes(revealedAnswer(turn, STREAM_THROTTLE_MS), CARD_MARKDOWN_MAX_BYTES);
+  return runTask(
+    Effect.scoped(
+      feishuReply(
+        eventStream(() => events, label).pipe(Stream.scoped),
+        api,
+        target,
+        formatError,
+        initialPreview,
+        label,
+      ),
+    ),
+  );
+}
 
-  // The live preview is ONE message: either the queue card/text handed in by the wiring, or a preview
-  // mounted lazily on this turn's first flush. `sequence` must increase strictly per card — the single-
-  // writer pump guarantees it by construction. A queue card has had no updates yet, so sequence starts
-  // at zero in both paths.
-  let preview: Preview = initialPreview ?? { kind: "none" };
-  let setupAttempted = initialPreview !== undefined;
-  let sequence = 0;
-  const nextSeq = (): number => ++sequence;
-  let streamDead = false; // the platform closed streaming (idle timeout) — freeze the live view
-  let finalized = false; // a terminal write (completed/failed) ran — the finally skips its orphan cleanup
-  let lastProcess = "";
-  let lastAnswer = "";
+export function feishuReply(
+  events: Stream.Stream<AgentEvent, TaskFailure>,
+  api: FeishuApi,
+  target: FeishuTarget,
+  formatError: (failed: FeishuFailure) => string | undefined,
+  initialPreview?: MountedFeishuPreview,
+  label = "[feishu]",
+) {
+  return Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const now = () => clock.currentTimeMillisUnsafe();
+    // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
+    // policy, the card-budget caps, and delivery below. The card is TWO elements (card.ts): the process
+    // block's head changes every frame (sliding thinking tail, `…`→`✓` flips), so it must never share
+    // an element with the answer — the client would re-type the whole card from the divergence point
+    // once a second. Each view feeds its own element; only the changed one is written.
+    const turn = createTurnView();
+    const processView = (): string => {
+      const v = composeTurnBody([
+        thinkingLine(turn, THINKING_PREVIEW),
+        toolLines(turn),
+        turn.retrying ? RETRY_NOTICE : "",
+      ]);
+      if (v !== "") return tailLines(v, PROCESS_MAX_POINTS);
+      // No process content: the placeholder covers only the silence BEFORE the answer reveals — once
+      // the answer is streaming, an empty block goes (stays) empty; "Thinking…" pinned above a live
+      // answer would misstate the phase. The empty frame is a real write: it clears a mounted
+      // placeholder. (The block cannot otherwise flicker: thinking and tools only grow — only the
+      // retry notice toggles, and its empty state resolves through this same rule.)
+      return revealedAnswer(turn, STREAM_THROTTLE_MS, now()).trim() === "" ? THINKING_PLACEHOLDER : "";
+    };
+    const answerView = (): string => capBytes(revealedAnswer(turn, STREAM_THROTTLE_MS, now()), CARD_MARKDOWN_MAX_BYTES);
 
-  const flushPreview = async (): Promise<void> => {
-    const process = processView();
-    if (!setupAttempted) {
-      setupAttempted = true;
-      // The mount seeds the process element with the current view; the answer element starts empty
-      // (card.ts), so the first answer snapshot is a clean prefix extension.
-      preview = await mountFeishuPreview(api, target, process, label);
-      lastProcess = process;
-      return;
-    }
-    if (preview.kind !== "card" || streamDead) return; // text tier / dead stream: frozen until the terminal write
-    try {
-      // `last*` advances BEFORE each write: a frame that fails for a non-streaming reason is logged
-      // once (the pump's onError) and not re-sent until its content actually changes. An EMPTY
-      // process frame is written like any other — it is the placeholder being cleared (processView).
-      if (process !== lastProcess) {
+    // The live preview is ONE message: either the queue card/text handed in by the wiring, or a preview
+    // mounted lazily on this turn's first flush. `sequence` must increase strictly per card — the single-
+    // writer pump guarantees it by construction. A queue card has had no updates yet, so sequence starts
+    // at zero in both paths.
+    let preview: Preview = initialPreview ?? { kind: "none" };
+    let setupAttempted = initialPreview !== undefined;
+    let sequence = 0;
+    const nextSeq = (): number => ++sequence;
+    let streamDead = false; // the platform closed streaming (idle timeout) — freeze the live view
+    let lastProcess = "";
+    let lastAnswer = "";
+
+    const flushPreview = async (): Promise<void> => {
+      const process = processView();
+      if (!setupAttempted) {
+        setupAttempted = true;
+        // The mount seeds the process element with the current view; the answer element starts empty
+        // (card.ts), so the first answer snapshot is a clean prefix extension.
+        preview = await mountFeishuPreview(api, target, process, label);
         lastProcess = process;
-        await api.updateCardElement(preview.cardId, PROCESS_ELEMENT_ID, process, nextSeq());
-      }
-      const answer = answerView();
-      // Never write an empty answer snapshot — the element is born empty and the answer only grows.
-      if (answer !== "" && answer !== lastAnswer) {
-        lastAnswer = answer;
-        await api.updateCardElement(preview.cardId, ANSWER_ELEMENT_ID, answer, nextSeq());
-      }
-    } catch (e) {
-      if (isCardStreamingClosed(e)) {
-        // The platform closed streaming (idle timeout). Freeze the live view; the settle write replaces
-        // the whole entity (streaming off) and still lands.
-        streamDead = true;
-        log.warn(`${label} card streaming closed mid-turn — preview frozen; the final answer still lands`);
         return;
       }
-      throw e;
-    }
-  };
-
-  // The shared single-writer pump (preview-kit) serializes snapshots to the one preview — which also
-  // guarantees the card's strictly-increasing `sequence` lands in order (no concurrent frames).
-  const { touch, finish } = createPreviewPump({
-    flush: flushPreview,
-    throttleMs: STREAM_THROTTLE_MS,
-    onError: (e) => log.warn(`${label} live preview failed (final reply still sends): ${String(e)}`),
-  });
-
-  touch(); // mount the "💭 Thinking…" preview immediately
-
-  /** Terminal write, whatever tier the preview reached. */
-  const settle = async (text: string): Promise<void> => {
-    await finalize(api, target, preview, text, nextSeq);
-  };
-
-  try {
-    for await (const e of events) {
-      if (e.type === "completed") {
-        await finish();
-        // Settle the preview into the final answer; the persisted card is the answer alone — the
-        // process (thinking/tools) was preview-only. Mark finalized BEFORE delivering: the terminal was
-        // reached, so a delivery failure here is a plain failure, not an "abnormal exit" (which would
-        // wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
-        finalized = true;
-        await settle(turn.answer.trim() !== "" ? turn.answer : "(no reply)");
-        return;
-      }
-      if (e.type === "failed") {
-        await finish();
-        // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
-        // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
-        // write as completed; an empty notice deletes the preview (suppress = no residue). Best-effort —
-        // we throw below regardless.
-        finalized = true;
-        {
-          const msg =
-            formatError({
-              details: e.details,
-              retryable: e.retryable,
-              ...(e.code !== undefined ? { code: e.code } : {}),
-            }) ?? "";
-          try {
-            await settle(msg);
-          } catch (deliveryError) {
-            // Preserve the Agent failure as the primary error below, but keep the broken final hop in
-            // the operator-visible chain — otherwise the log falsely implies the user saw the notice.
-            log.error(`${label} failed to deliver the agent-failure notice: ${String(deliveryError)}`);
-          }
-        }
-        throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
-      }
-      if (applyTurnEvent(turn, e)) touch();
-    }
-    throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
-  } finally {
-    await finish();
-    // Abnormal exit (stream ended without a terminal, the generator threw, or the consumer abandoned):
-    // no terminal write ran. Show the SAME neutral notice a `failed` event would — the preview may show
-    // real partial work, so don't delete it silently, and don't leave the user in silence. A suppressing
-    // onError still collapses to a delete (finalize on empty text).
-    if (!finalized) {
-      // retryable:false — an abnormal end (no terminal / a throw) is of UNKNOWN retryability, so use the
-      // neutral "something went wrong" default rather than promising "try again" that may not help.
-      const notice = formatError({ details: "the turn ended without completing", retryable: false }) ?? "";
+      if (preview.kind !== "card" || streamDead) return; // text tier / dead stream: frozen until the terminal write
       try {
-        await settle(notice);
-      } catch (deliveryError) {
-        // The stream's original throw remains primary; this explicit line records that the user-facing
-        // terminal notice failed too instead of silently breaking the responsibility chain.
-        log.error(`${label} failed to deliver the abnormal-turn notice: ${String(deliveryError)}`);
+        // `last*` advances BEFORE each write: a frame that fails for a non-streaming reason is logged
+        // once (the pump's onError) and not re-sent until its content actually changes. An EMPTY
+        // process frame is written like any other — it is the placeholder being cleared (processView).
+        if (process !== lastProcess) {
+          lastProcess = process;
+          await api.updateCardElement(preview.cardId, PROCESS_ELEMENT_ID, process, nextSeq());
+        }
+        const answer = answerView();
+        // Never write an empty answer snapshot — the element is born empty and the answer only grows.
+        if (answer !== "" && answer !== lastAnswer) {
+          lastAnswer = answer;
+          await api.updateCardElement(preview.cardId, ANSWER_ELEMENT_ID, answer, nextSeq());
+        }
+      } catch (e) {
+        if (isCardStreamingClosed(e)) {
+          // The platform closed streaming (idle timeout). Freeze the live view; the settle write replaces
+          // the whole entity (streaming off) and still lands.
+          streamDead = true;
+          log.warn(`${label} card streaming closed mid-turn — preview frozen; the final answer still lands`);
+          return;
+        }
+        throw e;
       }
-    }
-  }
+    };
+
+    // The scoped single writer keeps card sequences ordered through the terminal update.
+    const { touch, finish } = yield* previewPump({
+      flush: flushPreview,
+      throttleMs: STREAM_THROTTLE_MS,
+      onError: (e) => log.warn(`${label} live preview failed (final reply still sends): ${String(e)}`),
+    });
+
+    touch(); // mount the "💭 Thinking…" preview immediately
+
+    yield* renderReply(events, {
+      label,
+      finish,
+      formatError,
+      onEvent: (event) => {
+        if (applyTurnEvent(turn, event, now())) touch();
+      },
+      answer: () => (turn.answer.trim() !== "" ? turn.answer : "(no reply)"),
+      settle: (text) => taskEffect(() => finalize(api, target, preview, text, nextSeq)),
+    });
+  });
 }

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -24,11 +24,10 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import type { AgentEvent } from "../../agent.ts";
 import * as Effect from "effect/Effect";
-import * as Stream from "effect/Stream";
+import type * as Stream from "effect/Stream";
 import * as Clock from "effect/Clock";
-import { eventStream } from "../kit/event-stream.ts";
 import { previewPump, renderReply } from "../kit/delivery.ts";
-import { type TaskFailure, runTask, taskEffect } from "../kit/tasks.ts";
+import { type TaskFailure, taskEffect } from "../kit/tasks.ts";
 import { log } from "../../log.ts";
 import {
   ANSWER_ELEMENT_ID,
@@ -102,7 +101,7 @@ function tailLines(text: string, maxPoints: number): string {
 }
 
 /** A visible preview mounted into the chat. Exported only for the channel wiring: a queued turn mounts
- * one before execution, then hands the exact entity/message to {@link streamFeishuReply} for takeover. */
+ * one before execution, then hands the exact entity/message to {@link feishuReply} for takeover. */
 export type MountedFeishuPreview =
   | { kind: "card"; cardId: string; messageId: string }
   | { kind: "text"; messageId: string };
@@ -234,28 +233,6 @@ export async function settleFeishuPreview(
  * turn's already-mounted card/text message: the pump and terminal write mutate that same message rather
  * than recalling it and posting another reply.
  */
-export function streamFeishuReply(
-  events: AsyncIterable<AgentEvent>,
-  api: FeishuApi,
-  target: FeishuTarget,
-  formatError: (failed: FeishuFailure) => string | undefined,
-  initialPreview?: MountedFeishuPreview,
-  label = "[feishu]",
-): Promise<void> {
-  return runTask(
-    Effect.scoped(
-      feishuReply(
-        eventStream(() => events, label).pipe(Stream.scoped),
-        api,
-        target,
-        formatError,
-        initialPreview,
-        label,
-      ),
-    ),
-  );
-}
-
 export function feishuReply(
   events: Stream.Stream<AgentEvent, TaskFailure>,
   api: FeishuApi,

--- a/src/channels/kit/delivery.ts
+++ b/src/channels/kit/delivery.ts
@@ -1,0 +1,167 @@
+/** Scoped outbound writers. Frames coalesce; native append/status operations retain every queued write. */
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Queue from "effect/Queue";
+import type * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import type { AgentEvent } from "../../agent.ts";
+import { log } from "../../log.ts";
+import type { ChannelFailure } from "./preview-kit.ts";
+import { TaskFailure, taskEffect } from "./tasks.ts";
+
+/** Snapshot/edit renderers share terminal ownership; platform-specific settle policies stay injected. */
+export function renderReply(
+  events: Stream.Stream<AgentEvent, TaskFailure>,
+  opts: {
+    label: string;
+    onEvent: (event: AgentEvent) => void;
+    finish: Effect.Effect<void>;
+    answer: () => string;
+    settle: (text: string) => Effect.Effect<void, TaskFailure>;
+    formatError: (failure: ChannelFailure) => string | undefined;
+  },
+): Effect.Effect<void, TaskFailure, Scope.Scope> {
+  return Effect.gen(function* () {
+    let finalized = false;
+    const notify = (failure: ChannelFailure, phase: string) =>
+      Effect.try({ try: () => opts.formatError(failure) ?? "", catch: (cause) => new TaskFailure(cause) }).pipe(
+        Effect.flatMap(opts.settle),
+        Effect.catchTag("TaskFailure", (error) =>
+          Effect.sync(() => log.error(`${opts.label} failed to deliver the ${phase} notice: ${String(error.cause)}`)),
+        ),
+      );
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        yield* opts.finish;
+        if (!finalized)
+          yield* notify({ details: "the turn ended without completing", retryable: false }, "abnormal-turn");
+      }),
+    );
+    yield* Stream.runForEachWhile(events, (event) => {
+      if (event.type !== "completed" && event.type !== "failed") {
+        return Effect.try({
+          try: () => {
+            opts.onEvent(event);
+            return true;
+          },
+          catch: (cause) => new TaskFailure(cause),
+        });
+      }
+      return Effect.gen(function* () {
+        yield* opts.finish;
+        finalized = true;
+        if (event.type === "completed") {
+          yield* opts.settle(opts.answer());
+        } else {
+          yield* notify(
+            {
+              details: event.details,
+              retryable: event.retryable,
+              ...(event.code !== undefined ? { code: event.code } : {}),
+            },
+            "agent-failure",
+          );
+          return yield* Effect.fail(
+            new TaskFailure(new Error(`agent failed: ${event.details} (retryable=${event.retryable})`)),
+          );
+        }
+        return false;
+      }).pipe(Effect.uninterruptible);
+    });
+    if (!finalized) yield* Effect.fail(new TaskFailure(new Error("stream ended without a terminal event")));
+  });
+}
+
+export interface PreviewPump {
+  touch(): void;
+  /** Cancel pacing, join an issued write, and prevent any subsequent frame. */
+  finish: Effect.Effect<void>;
+}
+
+export function previewPump(opts: {
+  flush: () => Promise<void>;
+  throttleMs: number;
+  /** Slack's mutation slot precedes a write; stopping the pump can discard this pending frame. */
+  beforeFlush?: Effect.Effect<void>;
+  onError: (error: unknown) => void;
+}): Effect.Effect<PreviewPump, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const scope = yield* Effect.scope;
+    const run = Effect.runSyncWith(yield* Effect.context<never>());
+    let fiber: Fiber.Fiber<void> | undefined;
+    let stopped = false;
+    let dirty = false;
+    let reported = false;
+    const work = Effect.gen(function* () {
+      while (dirty && !stopped) {
+        dirty = false;
+        if (opts.beforeFlush) yield* opts.beforeFlush;
+        // An issued mutation may have reached the platform. Join it, including publishing its id
+        // and diagnosing its outcome, before the final writer takes over.
+        yield* taskEffect(opts.flush).pipe(
+          Effect.catchTag("TaskFailure", (error) =>
+            Effect.sync(() => {
+              if (!reported) {
+                reported = true;
+                opts.onError(error.cause);
+              }
+            }),
+          ),
+          Effect.uninterruptible,
+        );
+        if (dirty && !stopped) yield* Effect.sleep(opts.throttleMs);
+      }
+    });
+    const finish = Effect.gen(function* () {
+      stopped = true;
+      if (!fiber) return;
+      yield* Fiber.interrupt(fiber);
+      const exit = yield* Fiber.await(fiber);
+      if (Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)) yield* Effect.failCause(exit.cause);
+    });
+    yield* Effect.addFinalizer(() => finish);
+    return {
+      touch: () => {
+        if (stopped) return;
+        dirty = true;
+        const exit = fiber?.pollUnsafe();
+        if (fiber && (!exit || Exit.isFailure(exit))) return;
+        // The first placeholder starts before a fast source can reach its terminal event.
+        fiber = run(Effect.forkIn(work, scope, { startImmediately: true }));
+      },
+      finish,
+    };
+  });
+}
+
+export interface SerialWriter {
+  enqueue(work: () => Promise<void>): void;
+  /** End admission and join every accepted operation, including its caller-owned failure policy. */
+  finish: Effect.Effect<void, TaskFailure>;
+}
+
+export function serialWriter(): Effect.Effect<SerialWriter, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const queue = yield* Queue.unbounded<() => Promise<void>, Cause.Done>();
+    const work = Effect.gen(function* () {
+      for (;;) {
+        const next = yield* Queue.take(queue);
+        yield* taskEffect(next).pipe(Effect.uninterruptible);
+      }
+    }).pipe(Effect.catchTag("Done", () => Effect.void));
+    const fiber = yield* Effect.forkScoped(work);
+    const finish = Effect.sync(() => {
+      Queue.endUnsafe(queue);
+    }).pipe(Effect.andThen(Fiber.join(fiber)));
+    // This finalizer precedes forkScoped's interruption: accepted append/status writes must drain.
+    yield* Effect.addFinalizer(() => finish.pipe(Effect.orDie));
+    return {
+      enqueue: (next) => {
+        if (!Queue.offerUnsafe(queue, next)) throw new Error("delivery writer is closed");
+      },
+      finish,
+    };
+  });
+}

--- a/src/channels/kit/event-stream.ts
+++ b/src/channels/kit/event-stream.ts
@@ -1,13 +1,12 @@
-/** Promise/AsyncIterable adapters for internal channel streams. Public errors retain their original identity. */
+/** Own an Agent's AsyncIterable inside a typed, demand-driven channel stream. */
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
-import { cancellableStream } from "../../collect.ts";
 import { log } from "../../log.ts";
 import { TaskFailure } from "./tasks.ts";
 
-/** Acquire lazily; match for-await's natural exhaustion and abort-first return behavior. */
+/** Acquire lazily; interruption closes the source, while natural exhaustion needs no extra return. */
 export function eventStream<A>(
   open: () => AsyncIterable<A>,
   label: string,
@@ -40,25 +39,4 @@ export function eventStream<A>(
       });
     }),
   );
-}
-
-export function toEvents<A>(stream: Stream.Stream<A, TaskFailure>): AsyncIterable<A> {
-  return cancellableStream(async function* ({ onCancelReady }) {
-    const iterator = Stream.toAsyncIterable(stream.pipe(Stream.mapError((error) => error.cause)))[
-      Symbol.asyncIterator
-    ]() as Required<AsyncIterator<A>>;
-    let closing: Promise<IteratorResult<A>> | undefined;
-    onCancelReady(() => {
-      closing = iterator.return();
-    });
-    try {
-      for (;;) {
-        const result = await iterator.next();
-        if (result.done) return;
-        yield result.value;
-      }
-    } finally {
-      await (closing ?? iterator.return());
-    }
-  });
 }

--- a/src/channels/kit/event-stream.ts
+++ b/src/channels/kit/event-stream.ts
@@ -1,0 +1,64 @@
+/** Promise/AsyncIterable adapters for internal channel streams. Public errors retain their original identity. */
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import type * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import { cancellableStream } from "../../collect.ts";
+import { log } from "../../log.ts";
+import { TaskFailure } from "./tasks.ts";
+
+/** Acquire lazily; match for-await's natural exhaustion and abort-first return behavior. */
+export function eventStream<A>(
+  open: () => AsyncIterable<A>,
+  label: string,
+): Stream.Stream<A, TaskFailure, Scope.Scope> {
+  return Stream.fromPull(
+    Effect.gen(function* () {
+      let exhausted = false;
+      const iterator = yield* Effect.acquireRelease(
+        Effect.try({ try: () => open()[Symbol.asyncIterator](), catch: (cause) => new TaskFailure(cause) }),
+        (iterator) => {
+          const close = iterator.return?.bind(iterator);
+          if (!close || exhausted) return Effect.void;
+          return Effect.promise(close).pipe(
+            Effect.onError((cause) =>
+              Effect.sync(() => log.warn(`${label} source cleanup failed: ${String(Cause.squash(cause))}`)),
+            ),
+          );
+        },
+      );
+      return Effect.gen(function* () {
+        const result = yield* Effect.tryPromise({
+          try: () => iterator.next(),
+          catch: (cause) => new TaskFailure(cause),
+        });
+        if (result.done) {
+          exhausted = true;
+          return yield* Cause.done();
+        }
+        return [result.value] as const;
+      });
+    }),
+  );
+}
+
+export function toEvents<A>(stream: Stream.Stream<A, TaskFailure>): AsyncIterable<A> {
+  return cancellableStream(async function* ({ onCancelReady }) {
+    const iterator = Stream.toAsyncIterable(stream.pipe(Stream.mapError((error) => error.cause)))[
+      Symbol.asyncIterator
+    ]() as Required<AsyncIterator<A>>;
+    let closing: Promise<IteratorResult<A>> | undefined;
+    onCancelReady(() => {
+      closing = iterator.return();
+    });
+    try {
+      for (;;) {
+        const result = await iterator.next();
+        if (result.done) return;
+        yield result.value;
+      }
+    } finally {
+      await (closing ?? iterator.return());
+    }
+  });
+}

--- a/src/channels/kit/invoke-turn-kit.ts
+++ b/src/channels/kit/invoke-turn-kit.ts
@@ -2,7 +2,7 @@
  * Shared pieces of the channels' invoke-turn modules (telegram/feishu/slack `invoke-turn.ts`) — the
  * halves that are channel-independent, so a retry-policy or prompt-wording change lands ONCE:
  *
- *   - {@link streamTurnWithBusyRetry}: the busy-retry loop around `agent.invoke`, with the
+ *   - {@link busyRetryStream}: the busy-retry loop around `agent.invoke`, with the
  *     `onCompleted` durable-commit point;
  *   - the prompt-suffix wording: {@link attachedFilesManifest}, {@link backgroundImagesManifest},
  *     {@link missingAttachmentsNote}, {@link attributedFileName}.
@@ -18,7 +18,7 @@ import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 import { type Agent, type AgentEvent, type Prompt, SESSION_BUSY_CODE, type Scope } from "../../agent.ts";
-import { eventStream, toEvents } from "./event-stream.ts";
+import { eventStream } from "./event-stream.ts";
 import { TaskFailure } from "./tasks.ts";
 import { log } from "../../log.ts";
 
@@ -51,16 +51,6 @@ export const DEFAULT_BUSY_RETRY: BusyRetry = { delayMs: 5_000, maxWaitMs: 600_00
  * busy retries — a fail-fast reject is the only shape the engine emits it in, so nothing that started
  * is ever re-run.
  */
-export function streamTurnWithBusyRetry(
-  agent: Agent,
-  scope: Scope,
-  prompt: Prompt,
-  options: { label: string; onCompleted?: () => void; busyRetry?: BusyRetry },
-): AsyncIterable<AgentEvent> {
-  return toEvents(busyRetryStream(agent, scope, prompt, options));
-}
-
-/** Pull-based execution keeps commit and source cleanup under downstream backpressure. */
 export function busyRetryStream(
   agent: Agent,
   scope: Scope,

--- a/src/channels/kit/invoke-turn-kit.ts
+++ b/src/channels/kit/invoke-turn-kit.ts
@@ -14,12 +14,12 @@
  * Attachment RESOLUTION stays per channel — the platform resource models (Bot API file_ids,
  * message-scoped Feishu keys, Slack file objects) are real differences.
  */
-import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 import { type Agent, type AgentEvent, type Prompt, SESSION_BUSY_CODE, type Scope } from "../../agent.ts";
-import { cancellableStream } from "../../collect.ts";
+import { eventStream, toEvents } from "./event-stream.ts";
+import { TaskFailure } from "./tasks.ts";
 import { log } from "../../log.ts";
 
 /** How the busy-wait paces: retry the invoke every `delayMs` while the session's lease is held by an
@@ -57,26 +57,7 @@ export function streamTurnWithBusyRetry(
   prompt: Prompt,
   options: { label: string; onCompleted?: () => void; busyRetry?: BusyRetry },
 ): AsyncIterable<AgentEvent> {
-  return cancellableStream(async function* ({ onCancelReady }) {
-    // Effect implements return/throw; AsyncIterator makes them optional for arbitrary iterables.
-    const iterator = Stream.toAsyncIterable(busyRetryStream(agent, scope, prompt, options))[
-      Symbol.asyncIterator
-    ]() as Required<AsyncIterator<AgentEvent>>;
-    let closing: Promise<IteratorResult<AgentEvent>> | undefined;
-    // Stream.return interrupts a pending pull; the shared wrapper also silences an already-pulled event.
-    onCancelReady(() => {
-      closing = iterator.return();
-    });
-    try {
-      for (;;) {
-        const result = await iterator.next();
-        if (result.done) return;
-        yield result.value;
-      }
-    } finally {
-      await (closing ?? iterator.return());
-    }
-  });
+  return toEvents(busyRetryStream(agent, scope, prompt, options));
 }
 
 /** Pull-based execution keeps commit and source cleanup under downstream backpressure. */
@@ -89,42 +70,17 @@ export function busyRetryStream(
     onCompleted,
     busyRetry = DEFAULT_BUSY_RETRY,
   }: { label: string; onCompleted?: () => void; busyRetry?: BusyRetry },
-): Stream.Stream<AgentEvent, unknown> {
+): Stream.Stream<AgentEvent, TaskFailure> {
   return Stream.unwrap(
     Effect.map(Clock.currentTimeMillis, (started) => {
       const deadline = started + busyRetry.maxWaitMs;
-      const attempt = (): Stream.Stream<AgentEvent, unknown> =>
+      const attempt = (): Stream.Stream<AgentEvent, TaskFailure> =>
         Stream.suspend(() => {
           let retryBusy = false;
-          return Stream.fromPull(
-            Effect.gen(function* () {
-              let exhausted = false;
-              let first = true;
-              const iterator = yield* Effect.acquireRelease(
-                Effect.sync(() => agent.invoke(scope, prompt)[Symbol.asyncIterator]()),
-                (iterator) => {
-                  const close = iterator.return?.bind(iterator);
-                  // Match for-await: natural exhaustion already closed the source.
-                  if (!close || exhausted) return Effect.void;
-                  // Diagnose every exit, including cancellation. Keep Cause intact for the caller boundary.
-                  return Effect.promise(close).pipe(
-                    Effect.onError((cause) =>
-                      Effect.sync(() =>
-                        log.warn(
-                          `${label} source cleanup failed (session=${scope.session}): ${String(Cause.squash(cause))}`,
-                        ),
-                      ),
-                    ),
-                  );
-                },
-              );
-              return Effect.gen(function* () {
-                const result = yield* Effect.tryPromise({ try: () => iterator.next(), catch: (error) => error });
-                if (result.done) {
-                  exhausted = true;
-                  return yield* Cause.done();
-                }
-                const event = result.value;
+          let first = true;
+          return eventStream(() => agent.invoke(scope, prompt), `${label} (session=${scope.session})`).pipe(
+            Stream.takeWhileEffect((event) =>
+              Effect.gen(function* () {
                 if (
                   first &&
                   event.type === "failed" &&
@@ -132,14 +88,20 @@ export function busyRetryStream(
                   (yield* Clock.currentTimeMillis) + busyRetry.delayMs < deadline
                 ) {
                   retryBusy = true;
-                  return yield* Cause.done();
+                  return false;
                 }
                 first = false;
-                if (event.type === "completed") onCompleted?.();
-                return [event] as const;
-              });
-            }),
-          ).pipe(
+                return true;
+              }),
+            ),
+            Stream.tap((event) =>
+              Effect.try({
+                try: () => {
+                  if (event.type === "completed") onCompleted?.();
+                },
+                catch: (cause) => new TaskFailure(cause),
+              }),
+            ),
             Stream.scoped,
             // concat closes the attempt's scope (and its iterator) before the wait or next invoke.
             Stream.concat(

--- a/src/channels/kit/preview-kit.ts
+++ b/src/channels/kit/preview-kit.ts
@@ -2,11 +2,8 @@
  * Channel-neutral live-preview pieces shared by every messaging channel's preview renderer
  * (telegram/preview.ts, feishu/preview.ts, slack/preview.ts): the turn-view REDUCER (the one
  * event → view-state machine every renderer consumes), its line renderers, the terminal-failure
- * shape a channel hands to its `onError`, the customer-facing wording for it, and the serialized
- * single-writer pump. DELIVERY stays per-platform — message edits vs streaming cards vs chat.update,
- * pacing constants, reveal timing, and terminal-write policies are real platform differences — but
- * everything platform-independent lives here, so a new event type or a wording change lands in ONE
- * place instead of one hunk per channel.
+ * shape a channel hands to its `onError`, and the customer-facing wording for it.
+ * Scoped execution lives in delivery.ts; platform modules own formatting and delivery policies.
  */
 import type { AgentEvent, Json } from "../../agent.ts";
 import { truncateCodePointPrefix, truncateCodePointSuffix } from "./text.ts";
@@ -70,13 +67,13 @@ export function createTurnView(): TurnView {
  * summary, and any progress event closes an open retry notice (a stale "retrying" line must never
  * outlive actual progress). Terminal events only close the notice — they are the caller's business.
  */
-export function applyTurnEvent(view: TurnView, e: AgentEvent): boolean {
+export function applyTurnEvent(view: TurnView, e: AgentEvent, now = Date.now()): boolean {
   const closedRetry = view.retrying && e.type !== "retrying";
   if (closedRetry) view.retrying = false;
   switch (e.type) {
     case "text":
       view.answer += e.delta;
-      if (view.answerSince === undefined && view.answer.trim() !== "") view.answerSince = Date.now();
+      if (view.answerSince === undefined && view.answer.trim() !== "") view.answerSince = now;
       return true;
     case "thinking":
       view.thinking += e.delta;
@@ -125,9 +122,9 @@ export function thinkingLine(view: TurnView, maxTail: number): string {
  * clock, and there is deliberately NO timer at the boundary: a young answer surfaces on the next
  * content-driven pass, so a turn completing within the window delivers the final answer only.
  */
-export function revealedAnswer(view: TurnView, ageMs: number): string {
+export function revealedAnswer(view: TurnView, ageMs: number, now = Date.now()): string {
   if (view.answer.trim() === "" || view.answerSince === undefined) return "";
-  return Date.now() - view.answerSince >= ageMs ? view.answer : "";
+  return now - view.answerSince >= ageMs ? view.answer : "";
 }
 
 /** Compose body parts (thinking/tools/retry/answer) into one frame: skip empties, blank-line joins. */
@@ -136,80 +133,6 @@ export function composeTurnBody(parts: readonly string[]): string {
     .filter((s) => s.trim() !== "")
     .join("\n\n")
     .trim();
-}
-
-/**
- * The serialized live-preview writer shared by the edit/snapshot renderers (telegram, feishu).
- * Events mark the view dirty; the pump repaints to the LATEST view with at most ONE write in
- * flight, paced by `throttleMs`. One-in-flight is the whole point: concurrent writes can land out
- * of order — an older frame over a newer one is the "shows 3-4 steps, blanks, re-fills" flicker —
- * so a single writer keeps frames monotonic (and makes feishu's strictly-increasing card `sequence`
- * correct by construction). NOT used by slack-classic: its pacing lives inside the flush (the 3s
- * chat.update rate slot), not at the frame boundary.
- */
-export interface PreviewPump {
-  /** Mark the view dirty and ensure the single writer runs (an in-flight write picks the new state
-   *  up on its next loop). Synchronous — callers never await a network write. */
-  touch(): void;
-  /** Stop the pump, cut an in-flight throttle short, and await any in-flight write — so the
-   *  caller's terminal write is strictly the LAST one (no stale frame landing after the answer). */
-  finish(): Promise<void>;
-}
-
-export function createPreviewPump(opts: {
-  /** Write the LATEST view. Best-effort — the terminal write is authoritative. */
-  flush: () => Promise<void>;
-  /** Pace + coalesce a burst into one write; finish() interrupts a throttle in progress. */
-  throttleMs: number;
-  /** Called for the FIRST failing flush only (the pump keeps running): a never-rendering preview
-   *  must be diagnosable, not silent — and not a log flood. */
-  onError: (error: unknown) => void;
-}): PreviewPump {
-  let dirty = false;
-  let pumping = false;
-  let stopped = false;
-  let errored = false;
-  let pumpDone: Promise<void> | undefined;
-  let wakeThrottle: (() => void) | undefined; // set while mid-throttle; finish() cuts it short
-  const runPump = async (): Promise<void> => {
-    pumping = true;
-    try {
-      while (dirty && !stopped) {
-        dirty = false;
-        try {
-          await opts.flush();
-        } catch (error) {
-          if (!errored) {
-            errored = true;
-            opts.onError(error);
-          }
-        }
-        if (dirty && !stopped) {
-          await new Promise<void>((resolve) => {
-            const t = setTimeout(resolve, opts.throttleMs);
-            wakeThrottle = () => {
-              clearTimeout(t);
-              resolve();
-            };
-          });
-          wakeThrottle = undefined;
-        }
-      }
-    } finally {
-      pumping = false;
-    }
-  };
-  return {
-    touch() {
-      dirty = true;
-      if (!pumping) pumpDone = runPump();
-    },
-    async finish() {
-      stopped = true;
-      wakeThrottle?.();
-      await pumpDone?.catch(() => {});
-    },
-  };
 }
 
 /** Max length (code points) of a tool's arg preview. Slack's native stream cannot be retracted, so

--- a/src/channels/kit/tasks.ts
+++ b/src/channels/kit/tasks.ts
@@ -29,10 +29,6 @@ export function taskEffect<A>(run: () => Promise<A>): Effect.Effect<A, TaskFailu
   );
 }
 
-export function runTask<A>(work: Effect.Effect<A, TaskFailure>): Promise<A> {
-  return Effect.runPromise(work.pipe(Effect.mapError((error) => error.cause)));
-}
-
 export interface TaskTracker {
   /** Track already-started work. Rejections are logged without failing the drain. */
   track(task: Promise<unknown>): void;

--- a/src/channels/kit/tasks.ts
+++ b/src/channels/kit/tasks.ts
@@ -29,6 +29,10 @@ export function taskEffect<A>(run: () => Promise<A>): Effect.Effect<A, TaskFailu
   );
 }
 
+export function runTask<A>(work: Effect.Effect<A, TaskFailure>): Promise<A> {
+  return Effect.runPromise(work.pipe(Effect.mapError((error) => error.cause)));
+}
+
 export interface TaskTracker {
   /** Track already-started work. Rejections are logged without failing the drain. */
   track(task: Promise<unknown>): void;

--- a/src/channels/kit/turn-runner.ts
+++ b/src/channels/kit/turn-runner.ts
@@ -11,6 +11,7 @@
  */
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import type * as Scope from "effect/Scope";
 import { log } from "../../log.ts";
 import { type TaskFailure, taskEffect, taskFailure } from "./tasks.ts";
 import type { ContextBuffer } from "./context-buffer.ts";
@@ -49,9 +50,13 @@ export interface TurnRunnerOptions<R extends PendingBase<S>, S extends TurnRecor
   /** The turn started the ceiling's worth of times without finishing: tell the asker. */
   notifyDropped(rec: R): void;
   /** Run the turn. `onCompleted` is the durable-commit point (the turn's `completed` event): it drops
-   *  the intent and commits the folded discussion, in that order. A throw is logged as the turn's
-   *  failure; the intent is dropped either way. */
-  execute(rec: R, discussion: { text: string; consumed: E[] }, onCompleted: () => void): Promise<void>;
+   *  the intent and commits the folded discussion, in that order. Typed failures are logged and
+   *  settled; interruption and defects retain unfinished intent. */
+  execute(
+    rec: R,
+    discussion: { text: string; consumed: E[] },
+    onCompleted: () => void,
+  ): Effect.Effect<void, TaskFailure, Scope.Scope>;
 }
 
 export interface TurnRunner<R, S> {
@@ -86,9 +91,11 @@ export function runQueuedTurn<R extends PendingBase<S>, S extends TurnRecordBase
     log.info(`${label} turn start: turn=${rec.id} session=${rec.session} ${options.where(rec)}`);
     const bufferKey = options.bufferKey(rec);
     const discussion = buffer.peek(bufferKey);
-    yield* taskEffect(() =>
-      options.execute(rec, discussion, () =>
-        commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey, consumed: discussion.consumed }),
+    yield* Effect.scoped(
+      Effect.suspend(() =>
+        options.execute(rec, discussion, () =>
+          commitAnsweredTurn(store, buffer, { id: rec.id, bufferKey, consumed: discussion.consumed }),
+        ),
       ),
     ).pipe(
       Effect.matchEffect({

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -1,5 +1,9 @@
 /** Resolve Slack file IDs at dequeue, then stream one engine-neutral Agent turn. */
 import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { type TaskFailure, taskEffect } from "../kit/tasks.ts";
+import { toEvents } from "../kit/event-stream.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -8,7 +12,7 @@ import {
   attributedFileName,
   backgroundImagesManifest,
   missingAttachmentsNote,
-  streamTurnWithBusyRetry,
+  busyRetryStream,
 } from "../kit/invoke-turn-kit.ts";
 import type { SlackBufferedFileRef } from "./context-buffer.ts";
 import { type DownloadedSlackFile, type SlackApi, SlackApiError } from "./slack-api.ts";
@@ -93,7 +97,11 @@ async function resolveInputs(
   };
 }
 
-export async function* invokeSlackTurn(
+export function invokeSlackTurn(...args: Parameters<typeof slackTurnStream>): AsyncIterable<AgentEvent> {
+  return toEvents(slackTurnStream(...args));
+}
+
+export function slackTurnStream(
   agent: Agent,
   session: string,
   text: string,
@@ -101,18 +109,31 @@ export async function* invokeSlackTurn(
   attachments: SlackTurnAttachments,
   onCompleted?: () => void,
   busyRetry: BusyRetry = DEFAULT_BUSY_RETRY,
-): AsyncIterable<AgentEvent> {
-  let resolved: ResolvedInputs;
-  try {
-    resolved = await resolveInputs(transport, attachments);
-  } catch (error) {
-    // transient (network, exhausted 429 retries, Slack 5xx) is worth re-sending; an access or shape
-    // error reads the same every time, and "try again in a moment" is the wrong thing to tell the user
-    const retryable =
-      error instanceof SlackApiError && (error.status === 0 || error.status === 429 || error.status >= 500);
-    yield { type: "failed", details: `could not load Slack attachment: ${String(error)}`, retryable };
-    return;
-  }
-  const prompt = { text: `${text}${resolved.promptSuffix}${MARKDOWN_INSTRUCTION}`, images: resolved.images };
-  yield* streamTurnWithBusyRetry(agent, { session }, prompt, { label: transport.label, onCompleted, busyRetry });
+): Stream.Stream<AgentEvent, TaskFailure> {
+  return Stream.unwrap(
+    taskEffect(() => resolveInputs(transport, attachments)).pipe(
+      Effect.map((resolved) =>
+        busyRetryStream(
+          agent,
+          { session },
+          {
+            text: `${text}${resolved.promptSuffix}${MARKDOWN_INSTRUCTION}`,
+            images: resolved.images,
+          },
+          { label: transport.label, onCompleted, busyRetry },
+        ),
+      ),
+      Effect.catchTag("TaskFailure", ({ cause: error }) => {
+        const retryable =
+          error instanceof SlackApiError && (error.status === 0 || error.status === 429 || error.status >= 500);
+        return Effect.succeed(
+          Stream.succeed<AgentEvent>({
+            type: "failed",
+            details: `could not load Slack attachment: ${String(error)}`,
+            retryable,
+          }),
+        );
+      }),
+    ),
+  );
 }

--- a/src/channels/slack/invoke-turn.ts
+++ b/src/channels/slack/invoke-turn.ts
@@ -3,7 +3,6 @@ import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 import { type TaskFailure, taskEffect } from "../kit/tasks.ts";
-import { toEvents } from "../kit/event-stream.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -95,10 +94,6 @@ async function resolveInputs(
     images: allImages.length ? allImages : undefined,
     promptSuffix: `${missingNote}${imageManifest}${attachedFilesManifest(allFiles)}`,
   };
-}
-
-export function invokeSlackTurn(...args: Parameters<typeof slackTurnStream>): AsyncIterable<AgentEvent> {
-  return toEvents(slackTurnStream(...args));
 }
 
 export function slackTurnStream(

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -1,5 +1,12 @@
 /** Slack reply rendering: native Agent streams first, rate-safe edited-message compatibility second. */
 import type { AgentEvent, Json } from "../../agent.ts";
+import * as Effect from "effect/Effect";
+import * as Clock from "effect/Clock";
+import type * as Fiber from "effect/Fiber";
+import * as Stream from "effect/Stream";
+import { previewPump, renderReply, serialWriter } from "../kit/delivery.ts";
+import { eventStream } from "../kit/event-stream.ts";
+import { TaskFailure, runTask, taskEffect } from "../kit/tasks.ts";
 import { log } from "../../log.ts";
 import {
   RETRY_NOTICE,
@@ -30,8 +37,6 @@ const CLASSIC_UPDATE_INTERVAL_MS = 3_000;
 const NATIVE_APPEND_INTERVAL_MS = 750;
 const WORKING_STATUS = "is working on your request…";
 const GENERIC_FAILURE = "⚠️ The response stream stopped unexpectedly. Please try again.";
-
-const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /** LLM output uses standard Markdown, never Slack's notification control syntax. Keep explicit sends in
  * the slack-send tool, where the Agent has to choose a side-effecting delivery action deliberately.
@@ -132,131 +137,83 @@ export async function settleSlackPreview(
   await api.postMessage(target, text);
 }
 
-async function streamClassicSlackReply(
-  events: AsyncIterable<AgentEvent>,
+function streamClassicSlackReply(
+  events: Stream.Stream<AgentEvent, TaskFailure>,
   api: SlackApi,
   target: SlackTarget,
   formatError: (failure: SlackFailure) => string | undefined,
   initialPreviewTs: string | undefined,
   disclaimer: string | false | undefined,
   label: string,
-): Promise<void> {
-  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns mrkdwn
-  // sanitizing and delivery. Reasoning stays a static "Thinking…" here: raw chain-of-thought is not
-  // customer-facing on Slack, so the reducer accumulates it but this view never reads it.
-  const turn = createTurnView();
-  let previewTs = initialPreviewTs;
-  let previewAttempted = previewTs !== undefined;
-  let finalized = false;
-  let lastMutationAt = previewTs ? Date.now() : 0;
-  let lastSent = "";
-  let dirty = false;
-  let pumping = false;
-  let stopped = false;
-  let pumpDone: Promise<void> | undefined;
-  let previewErrorLogged = false;
+) {
+  return Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const now = () => clock.currentTimeMillisUnsafe();
+    // Event → view-state reduction is the shared machine (preview-kit); this renderer owns mrkdwn
+    // sanitizing and delivery. Reasoning stays a static "Thinking…" here: raw chain-of-thought is not
+    // customer-facing on Slack, so the reducer accumulates it but this view never reads it.
+    const turn = createTurnView();
+    let previewTs = initialPreviewTs;
+    let previewAttempted = previewTs !== undefined;
+    let lastMutationAt = previewTs ? now() : 0;
+    let lastSent = "";
 
-  const view = (): string =>
-    composeTurnBody([
-      THINKING_PLACEHOLDER,
-      toolLines(turn),
-      turn.retrying ? RETRY_NOTICE : "",
-      sanitizeSlackMarkdown(revealedAnswer(turn, CLASSIC_UPDATE_INTERVAL_MS)),
-    ]);
-  const waitForMutationSlot = async (): Promise<void> => {
-    const remaining = lastMutationAt + CLASSIC_UPDATE_INTERVAL_MS - Date.now();
-    if (remaining > 0) await wait(remaining);
-  };
-  const updateRateSafe = async (ts: string, markdown: string): Promise<void> => {
-    await waitForMutationSlot();
-    await api.updateMarkdown(target.channelId, ts, markdown);
-    lastMutationAt = Date.now();
-  };
-  const flushPreview = async (): Promise<void> => {
-    const markdown = chunkSlackText(view())[0] ?? THINKING_PLACEHOLDER;
-    if (markdown === lastSent) return;
-    if (previewTs) {
-      await updateRateSafe(previewTs, markdown);
-    } else {
-      if (previewAttempted) return;
-      previewAttempted = true;
-      previewTs = await api.postMarkdown(target, markdown);
-      lastMutationAt = Date.now();
-    }
-    lastSent = markdown;
-  };
-  const runPump = async (): Promise<void> => {
-    pumping = true;
-    try {
-      while (dirty && !stopped) {
-        dirty = false;
-        try {
-          await flushPreview();
-        } catch (error) {
-          if (!previewErrorLogged) {
-            previewErrorLogged = true;
-            log.warn(`${label} live preview failed (final reply still sends): ${String(error)}`);
-          }
-        }
+    const view = (): string =>
+      composeTurnBody([
+        THINKING_PLACEHOLDER,
+        toolLines(turn),
+        turn.retrying ? RETRY_NOTICE : "",
+        sanitizeSlackMarkdown(revealedAnswer(turn, CLASSIC_UPDATE_INTERVAL_MS, now())),
+      ]);
+    const waitForMutationSlot = Effect.suspend(() => {
+      const remaining = lastMutationAt + CLASSIC_UPDATE_INTERVAL_MS - now();
+      return remaining > 0 ? Effect.sleep(remaining) : Effect.void;
+    });
+    const update = async (ts: string, markdown: string): Promise<void> => {
+      await api.updateMarkdown(target.channelId, ts, markdown);
+      lastMutationAt = now();
+    };
+    const flushPreview = async (): Promise<void> => {
+      const markdown = chunkSlackText(view())[0] ?? THINKING_PLACEHOLDER;
+      if (markdown === lastSent) return;
+      if (previewTs) {
+        await update(previewTs, markdown);
+      } else {
+        if (previewAttempted) return;
+        previewAttempted = true;
+        previewTs = await api.postMarkdown(target, markdown);
+        lastMutationAt = now();
       }
-    } finally {
-      pumping = false;
-    }
-  };
-  const touch = (): void => {
-    dirty = true;
-    if (!pumping) pumpDone = runPump();
-  };
-  const finishPump = async (): Promise<void> => {
-    stopped = true;
-    await pumpDone?.catch(() => {});
-  };
-  const finalize = async (markdown: string): Promise<void> => {
-    await settleClassic(api, target, previewTs, sanitizeSlackMarkdown(markdown), updateRateSafe);
-  };
-
-  try {
-    for await (const event of events) {
-      if (event.type === "completed") {
-        await finishPump();
-        finalized = true;
-        await finalize(withDisclaimer(turn.answer, disclaimer));
-        return;
-      }
-      if (event.type === "failed") {
-        await finishPump();
-        finalized = true;
-        const notice =
-          formatError({
-            details: event.details,
-            retryable: event.retryable,
-            ...(event.code !== undefined ? { code: event.code } : {}),
-          }) ?? "";
-        await finalize(notice).catch((error) =>
-          log.error(`${label} failed to deliver the agent-failure notice: ${String(error)}`),
-        );
-        throw new Error(`agent failed: ${event.details} (retryable=${event.retryable})`);
-      }
-      const changed = applyTurnEvent(turn, event);
-      // A young (hidden) answer must not trigger the first frame: unlike telegram/feishu, classic
-      // rendering never posts an upfront placeholder, so a text-only fast turn delivers ONE final
-      // post instead of placeholder → 3s-rate-limited edit. Thinking/tool activity still paints.
-      if (changed && (event.type !== "text" || revealedAnswer(turn, CLASSIC_UPDATE_INTERVAL_MS) !== "")) touch();
-    }
-    throw new Error("stream ended without a terminal event");
-  } finally {
-    await finishPump();
-    if (!finalized) {
-      const notice = formatError({ details: "the turn ended without completing", retryable: false }) ?? "";
-      await finalize(notice).catch((error) =>
-        log.error(`${label} failed to deliver the abnormal-turn notice: ${String(error)}`),
-      );
-    }
-  }
+      lastSent = markdown;
+    };
+    const { touch, finish } = yield* previewPump({
+      flush: flushPreview,
+      throttleMs: 0,
+      beforeFlush: Effect.suspend(() => (previewTs ? waitForMutationSlot : Effect.void)),
+      onError: (error) => log.warn(`${label} live preview failed (final reply still sends): ${String(error)}`),
+    });
+    yield* renderReply(events, {
+      label,
+      finish,
+      formatError,
+      answer: () => withDisclaimer(turn.answer, disclaimer),
+      settle: (markdown) =>
+        Effect.gen(function* () {
+          if (previewTs && markdown.trim()) yield* waitForMutationSlot;
+          yield* taskEffect(() => settleClassic(api, target, previewTs, sanitizeSlackMarkdown(markdown), update));
+        }),
+      onEvent: (event) => {
+        const changed = applyTurnEvent(turn, event, now());
+        // A hidden answer must not open a placeholder followed by a rate-limited edit on a fast turn.
+        if (changed && (event.type !== "text" || revealedAnswer(turn, CLASSIC_UPDATE_INTERVAL_MS, now()) !== ""))
+          touch();
+      },
+    });
+  });
 }
 
-async function streamNativeSlackReply(
-  events: AsyncIterable<AgentEvent>,
+function streamNativeSlackReply(
+  events: Stream.Stream<AgentEvent, TaskFailure>,
   api: SlackApi,
   target: SlackTarget,
   formatError: (failure: SlackFailure) => string | undefined,
@@ -264,202 +221,281 @@ async function streamNativeSlackReply(
   threadTitle: string | undefined,
   disclaimer: string | false | undefined,
   label: string,
-): Promise<void> {
-  if (initialPreviewTs) {
-    await api
-      .deleteMessage(target.channelId, initialPreviewTs)
-      .catch((error) =>
-        log.warn(`${label} could not remove the compatibility queue notice before native streaming: ${String(error)}`),
+) {
+  return Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const now = () => clock.currentTimeMillisUnsafe();
+    const scope = yield* Effect.scope;
+    const run = Effect.runSyncWith(yield* Effect.context<never>());
+    let streamTs: string | undefined;
+    let retryStatusShown = false;
+    // Keep status updates ordered through the final clear, independently of content appends.
+    const statuses = yield* serialWriter();
+    const setStatus = (status: string): void => {
+      statuses.enqueue(() =>
+        api
+          .setThreadStatus(target, status)
+          .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
       );
-  }
-  if (target.channelId.startsWith("D")) {
-    await Promise.all([
-      api
-        .setThreadStatus(target, WORKING_STATUS)
-        .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
-      threadTitle
-        ? api
-            .setThreadTitle(target, threadTitle)
-            .catch((error) => log.warn(`${label} could not set Slack Agent thread title: ${String(error)}`))
-        : Promise.resolve(),
-    ]);
-  }
-
-  let streamTs: string | undefined;
-  let retryStatusShown = false;
-  // DM Agent-status writes are fire-and-forget for the render loop, but must reach Slack in order:
-  // an out-of-order pair would leave a stale "retrying" line after progress (or after the final
-  // clear). One promise chain serializes them; each link swallows its own delivery error.
-  let statusChain = Promise.resolve();
-  const setStatus = (status: string): void => {
-    statusChain = statusChain.then(() =>
-      api
-        .setThreadStatus(target, status)
-        .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
+    };
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        if (target.channelId.startsWith("D")) setStatus("");
+        yield* statuses.finish.pipe(Effect.orDie);
+      }),
     );
-  };
-  const toolTraces = new Map<string, NativeToolTrace>();
-  let pendingText = "";
-  let fullAnswer = "";
-  let textTimer: ReturnType<typeof setTimeout> | undefined;
-  let lastTextFlushAt = 0;
-  let operation = Promise.resolve();
-  let renderError: unknown;
-  let finalized = false;
-  let streamHasContent = false;
-  let streamEndsWithBlankLine = false;
+    let stopAttempted = false;
+    const stop = (ts: string, markdown?: string): Promise<void> => {
+      // A rejected stop may have landed; scope cleanup must not retry it.
+      stopAttempted = true;
+      return api.stopStream(target.channelId, ts, markdown);
+    };
+    yield* Effect.addFinalizer(() =>
+      Effect.suspend(() => {
+        const ts = streamTs;
+        return ts && !stopAttempted
+          ? taskEffect(() => stop(ts, `\n\n${GENERIC_FAILURE}`)).pipe(
+              Effect.catchTag("TaskFailure", (error) =>
+                Effect.sync(() =>
+                  log.error(`${label} failed to stop an abnormal Slack stream: ${String(error.cause)}`),
+                ),
+              ),
+            )
+          : Effect.void;
+      }),
+    );
+    const toolTraces = new Map<string, NativeToolTrace>();
+    let pendingText = "";
+    let fullAnswer = "";
+    let textTimer: Fiber.Fiber<void> | undefined;
+    let lastTextFlushAt = 0;
+    const operations = yield* serialWriter();
+    let renderError: unknown;
+    let finalized = false;
+    let streamHasContent = false;
+    let streamEndsWithBlankLine = false;
 
-  const enqueue = (work: () => Promise<void>): void => {
-    operation = operation.then(async () => {
-      if (renderError !== undefined) return;
-      try {
-        await work();
-      } catch (error) {
-        renderError = error;
+    const enqueue = (work: () => Promise<void>): void => {
+      operations.enqueue(async () => {
+        if (renderError !== undefined) return;
+        try {
+          await work();
+        } catch (error) {
+          renderError = error;
+        }
+      });
+    };
+    const sendContent = async (markdown: string): Promise<void> => {
+      if (streamTs) {
+        await api.appendStream(target.channelId, streamTs, markdown);
+      } else {
+        streamTs = await api.startStream(target, markdown);
+      }
+    };
+    const queueMarkdown = (markdown: string): void => {
+      if (!markdown) return;
+      streamHasContent = true;
+      streamEndsWithBlankLine = markdown.endsWith("\n\n");
+      enqueue(() => sendContent(markdown));
+    };
+    const flushText = (final = false): void => {
+      if (textTimer) {
+        textTimer.interruptUnsafe();
+        textTimer = undefined;
+      }
+      let value = pendingText;
+      pendingText = "";
+      if (!final) {
+        // Hold a possible Slack control token split across Agent deltas/flush windows until its closing
+        // `>` arrives. This prevents `<` + `!channel>` from bypassing the sanitizer.
+        const open = value.lastIndexOf("<");
+        if (open >= 0 && !value.slice(open).includes(">") && value.length - open <= 256) {
+          pendingText = value.slice(open);
+          value = value.slice(0, open);
+        }
+      }
+      if (!value) return;
+      lastTextFlushAt = now();
+      for (const chunk of chunkSlackText(sanitizeSlackMarkdown(value))) queueMarkdown(chunk);
+    };
+    const scheduleText = (): void => {
+      // A zero-delay clock can finish before its handle is published.
+      if (textTimer && !textTimer.pollUnsafe()) return;
+      const delay = Math.max(0, lastTextFlushAt + NATIVE_APPEND_INTERVAL_MS - now());
+      textTimer = run(
+        Effect.forkIn(
+          Effect.sleep(delay).pipe(
+            Effect.andThen(
+              Effect.sync(() => {
+                textTimer = undefined;
+                flushText();
+              }),
+            ),
+          ),
+          scope,
+        ),
+      );
+    };
+    // ponytail: a trace appended while the answer has an unclosed ``` fence lands inside it, and the
+    // trace's own backticks can close it early. Tracking fence parity across chunk boundaries (the job
+    // chunkSlackMarkdown does for the classic renderer) is the fix if a model is ever seen calling a
+    // tool mid-fence; the trace's blank-line framing keeps every other case well-formed.
+    const sendToolTrace = (line: string): void => {
+      flushText();
+      const separator = streamHasContent && !streamEndsWithBlankLine ? "\n\n" : "";
+      queueMarkdown(`${separator}${line}\n\n`);
+    };
+    const settleNative = (terminalMarkdown: string) =>
+      Effect.gen(function* () {
+        flushText(true);
+        yield* operations.finish;
+        yield* taskEffect(async () => {
+          const safeTerminal = sanitizeSlackMarkdown(terminalMarkdown);
+          if (renderError !== undefined) {
+            if (!streamTs && isSlackNativeUnavailable(renderError)) {
+              log.warn(`${label} native Slack stream was unavailable; delivering one compatibility Markdown reply`);
+              await api.sendMarkdown(target, safeTerminal);
+              return;
+            }
+            if (streamTs) {
+              await stop(streamTs, `\n\n${GENERIC_FAILURE}`).catch(() => {});
+            }
+            throw renderError;
+          }
+          if (!streamTs) streamTs = await api.startStream(target, safeTerminal);
+          await stop(streamTs);
+        });
+      });
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        if (textTimer) textTimer.interruptUnsafe();
+        if (!finalized) {
+          pendingText += `${fullAnswer.trim() ? "\n\n" : ""}${GENERIC_FAILURE}`;
+          yield* settleNative(fullAnswer.trim() || GENERIC_FAILURE).pipe(
+            Effect.catchTag("TaskFailure", (error) =>
+              Effect.sync(() => log.error(`${label} failed to stop an abnormal Slack stream: ${String(error.cause)}`)),
+            ),
+          );
+        }
+      }),
+    );
+    yield* taskEffect(async () => {
+      if (initialPreviewTs) {
+        await api
+          .deleteMessage(target.channelId, initialPreviewTs)
+          .catch((error) =>
+            log.warn(
+              `${label} could not remove the compatibility queue notice before native streaming: ${String(error)}`,
+            ),
+          );
+      }
+      if (target.channelId.startsWith("D")) {
+        await Promise.all([
+          api
+            .setThreadStatus(target, WORKING_STATUS)
+            .catch((error) => log.warn(`${label} could not set Slack Agent status: ${String(error)}`)),
+          threadTitle
+            ? api
+                .setThreadTitle(target, threadTitle)
+                .catch((error) => log.warn(`${label} could not set Slack Agent thread title: ${String(error)}`))
+            : Promise.resolve(),
+        ]);
       }
     });
-  };
-  const sendContent = async (markdown: string): Promise<void> => {
-    if (streamTs) {
-      await api.appendStream(target.channelId, streamTs, markdown);
-    } else {
-      streamTs = await api.startStream(target, markdown);
-    }
-  };
-  const queueMarkdown = (markdown: string): void => {
-    if (!markdown) return;
-    streamHasContent = true;
-    streamEndsWithBlankLine = markdown.endsWith("\n\n");
-    enqueue(() => sendContent(markdown));
-  };
-  const flushText = (final = false): void => {
-    if (textTimer) {
-      clearTimeout(textTimer);
-      textTimer = undefined;
-    }
-    let value = pendingText;
-    pendingText = "";
-    if (!final) {
-      // Hold a possible Slack control token split across Agent deltas/flush windows until its closing
-      // `>` arrives. This prevents `<` + `!channel>` from bypassing the sanitizer.
-      const open = value.lastIndexOf("<");
-      if (open >= 0 && !value.slice(open).includes(">") && value.length - open <= 256) {
-        pendingText = value.slice(open);
-        value = value.slice(0, open);
-      }
-    }
-    if (!value) return;
-    lastTextFlushAt = Date.now();
-    for (const chunk of chunkSlackText(sanitizeSlackMarkdown(value))) queueMarkdown(chunk);
-  };
-  const scheduleText = (): void => {
-    if (textTimer) return;
-    const delay = Math.max(0, lastTextFlushAt + NATIVE_APPEND_INTERVAL_MS - Date.now());
-    textTimer = setTimeout(() => {
-      textTimer = undefined;
-      flushText();
-    }, delay);
-  };
-  // ponytail: a trace appended while the answer has an unclosed ``` fence lands inside it, and the
-  // trace's own backticks can close it early. Tracking fence parity across chunk boundaries (the job
-  // chunkSlackMarkdown does for the classic renderer) is the fix if a model is ever seen calling a
-  // tool mid-fence; the trace's blank-line framing keeps every other case well-formed.
-  const sendToolTrace = (line: string): void => {
-    flushText();
-    const separator = streamHasContent && !streamEndsWithBlankLine ? "\n\n" : "";
-    queueMarkdown(`${separator}${line}\n\n`);
-  };
-  const settleNative = async (terminalMarkdown: string): Promise<void> => {
-    flushText(true);
-    await operation;
-    const safeTerminal = sanitizeSlackMarkdown(terminalMarkdown);
-    if (renderError !== undefined) {
-      if (!streamTs && isSlackNativeUnavailable(renderError)) {
-        log.warn(`${label} native Slack stream was unavailable; delivering one compatibility Markdown reply`);
-        await api.sendMarkdown(target, safeTerminal);
-        return;
-      }
-      if (streamTs) {
-        await api.stopStream(target.channelId, streamTs, `\n\n${GENERIC_FAILURE}`).catch(() => {});
-      }
-      throw renderError;
-    }
-    if (!streamTs) streamTs = await api.startStream(target, safeTerminal);
-    await api.stopStream(target.channelId, streamTs);
-  };
 
-  try {
-    for await (const event of events) {
-      if (event.type !== "retrying" && retryStatusShown) {
-        // Progress after a retry notice: restore the normal working status so the stale line doesn't
-        // contradict a visibly streaming answer.
-        retryStatusShown = false;
-        setStatus(WORKING_STATUS);
-      }
-      if (event.type === "text") {
-        pendingText += event.delta;
-        fullAnswer += event.delta;
-        scheduleText();
-      } else if (event.type === "thinking") {
-        // Slack's native loading status represents private reasoning without exposing it.
-      } else if (event.type === "retrying") {
-        // A summarization retry backoff pauses the stream (~14s worst case). Channels have no per-run
-        // status surface in native mode; DMs get the explicit Agent status line, restored on progress.
-        if (target.channelId.startsWith("D")) {
-          retryStatusShown = true;
-          setStatus("hit a temporary problem — retrying…");
+    yield* Stream.runForEachWhile(events, (event) =>
+      Effect.gen(function* () {
+        if (event.type !== "retrying" && retryStatusShown) {
+          // Progress after a retry notice: restore the normal working status so the stale line doesn't
+          // contradict a visibly streaming answer.
+          retryStatusShown = false;
+          setStatus(WORKING_STATUS);
         }
-      } else if (event.type === "tool_started") {
-        const trace = nativeToolTrace(event.name, event.args);
-        toolTraces.set(event.id, trace);
-        sendToolTrace(nativeToolLine(trace));
-      } else if (event.type === "tool_ended") {
-        const trace = toolTraces.get(event.id) ?? { label: "Tool" };
-        toolTraces.delete(event.id);
-        if (event.isError) sendToolTrace(nativeToolLine(trace, " failed"));
-      } else if (event.type === "completed") {
-        finalized = true;
-        const finalAnswer = withDisclaimer(fullAnswer, disclaimer);
-        const footer = finalAnswer.slice(fullAnswer.trim().length);
-        if (footer) pendingText += footer;
-        await settleNative(finalAnswer);
-        return;
-      } else if (event.type === "failed") {
-        finalized = true;
-        const notice =
-          formatError({
-            details: event.details,
-            retryable: event.retryable,
-            ...(event.code !== undefined ? { code: event.code } : {}),
-          }) ?? "";
-        if (notice) {
-          pendingText += `${fullAnswer.trim() ? "\n\n" : ""}${notice}`;
-          fullAnswer += `${fullAnswer.trim() ? "\n\n" : ""}${notice}`;
+        if (event.type === "text") {
+          pendingText += event.delta;
+          fullAnswer += event.delta;
+          scheduleText();
+        } else if (event.type === "thinking") {
+          // Slack's native loading status represents private reasoning without exposing it.
+        } else if (event.type === "retrying") {
+          // A summarization retry backoff pauses the stream (~14s worst case). Channels have no per-run
+          // status surface in native mode; DMs get the explicit Agent status line, restored on progress.
+          if (target.channelId.startsWith("D")) {
+            retryStatusShown = true;
+            setStatus("hit a temporary problem — retrying…");
+          }
+        } else if (event.type === "tool_started") {
+          const trace = nativeToolTrace(event.name, event.args);
+          toolTraces.set(event.id, trace);
+          sendToolTrace(nativeToolLine(trace));
+        } else if (event.type === "tool_ended") {
+          const trace = toolTraces.get(event.id) ?? { label: "Tool" };
+          toolTraces.delete(event.id);
+          if (event.isError) sendToolTrace(nativeToolLine(trace, " failed"));
+        } else if (event.type === "completed") {
+          finalized = true;
+          const finalAnswer = withDisclaimer(fullAnswer, disclaimer);
+          const footer = finalAnswer.slice(fullAnswer.trim().length);
+          if (footer) pendingText += footer;
+          yield* settleNative(finalAnswer);
+          return false;
+        } else if (event.type === "failed") {
+          finalized = true;
+          yield* Effect.gen(function* () {
+            const notice = yield* Effect.try({
+              try: () =>
+                formatError({
+                  details: event.details,
+                  retryable: event.retryable,
+                  ...(event.code !== undefined ? { code: event.code } : {}),
+                }) ?? "",
+              catch: (cause) => new TaskFailure(cause),
+            });
+            if (notice) {
+              pendingText += `${fullAnswer.trim() ? "\n\n" : ""}${notice}`;
+              fullAnswer += `${fullAnswer.trim() ? "\n\n" : ""}${notice}`;
+            }
+            yield* settleNative(fullAnswer.trim() || GENERIC_FAILURE);
+          }).pipe(
+            Effect.catchTag("TaskFailure", (error) =>
+              Effect.sync(() =>
+                log.error(`${label} failed to deliver the agent-failure stream: ${String(error.cause)}`),
+              ),
+            ),
+          );
+          return yield* Effect.fail(
+            new TaskFailure(new Error(`agent failed: ${event.details} (retryable=${event.retryable})`)),
+          );
         }
-        await settleNative(fullAnswer.trim() || GENERIC_FAILURE).catch((error) =>
-          log.error(`${label} failed to deliver the agent-failure stream: ${String(error)}`),
-        );
-        throw new Error(`agent failed: ${event.details} (retryable=${event.retryable})`);
-      }
-    }
-    throw new Error("stream ended without a terminal event");
-  } finally {
-    if (textTimer) clearTimeout(textTimer);
-    if (!finalized) {
-      pendingText += `${fullAnswer.trim() ? "\n\n" : ""}${GENERIC_FAILURE}`;
-      await settleNative(fullAnswer.trim() || GENERIC_FAILURE).catch((error) =>
-        log.error(`${label} failed to stop an abnormal Slack stream: ${String(error)}`),
-      );
-    }
-    if (target.channelId.startsWith("D")) {
-      setStatus("");
-      await statusChain;
-    }
-  }
+        return true;
+      }).pipe(Effect.uninterruptible),
+    );
+    if (!finalized) yield* Effect.fail(new TaskFailure(new Error("stream ended without a terminal event")));
+  });
 }
 
-export async function streamSlackReply(
+export function streamSlackReply(
   events: AsyncIterable<AgentEvent>,
+  api: SlackApi,
+  target: SlackTarget,
+  formatError: (failure: SlackFailure) => string | undefined,
+  options: Parameters<typeof slackReply>[4] = {},
+): Promise<void> {
+  return runTask(
+    Effect.scoped(
+      slackReply(
+        eventStream(() => events, options.label ?? "[slack]").pipe(Stream.scoped),
+        api,
+        target,
+        formatError,
+        options,
+      ),
+    ),
+  );
+}
+
+export function slackReply(
+  events: Stream.Stream<AgentEvent, TaskFailure>,
   api: SlackApi,
   target: SlackTarget,
   formatError: (failure: SlackFailure) => string | undefined,
@@ -470,13 +506,15 @@ export async function streamSlackReply(
     disclaimer?: string | false;
     label?: string;
   } = {},
-): Promise<void> {
-  const { rendering = "native", initialPreviewTs, threadTitle, disclaimer, label = "[slack]" } = options;
-  if (rendering === "native" && target.threadTs) {
-    return streamNativeSlackReply(events, api, target, formatError, initialPreviewTs, threadTitle, disclaimer, label);
-  }
-  if (rendering === "native") {
-    log.info(`${label} native streaming needs a thread target — using the classic renderer for this turn`);
-  }
-  return streamClassicSlackReply(events, api, target, formatError, initialPreviewTs, disclaimer, label);
+) {
+  return Effect.suspend(() => {
+    const { rendering = "native", initialPreviewTs, threadTitle, disclaimer, label = "[slack]" } = options;
+    if (rendering === "native" && target.threadTs) {
+      return streamNativeSlackReply(events, api, target, formatError, initialPreviewTs, threadTitle, disclaimer, label);
+    }
+    if (rendering === "native") {
+      log.info(`${label} native streaming needs a thread target — using the classic renderer for this turn`);
+    }
+    return streamClassicSlackReply(events, api, target, formatError, initialPreviewTs, disclaimer, label);
+  });
 }

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -5,8 +5,7 @@ import * as Clock from "effect/Clock";
 import type * as Fiber from "effect/Fiber";
 import * as Stream from "effect/Stream";
 import { previewPump, renderReply, serialWriter } from "../kit/delivery.ts";
-import { eventStream } from "../kit/event-stream.ts";
-import { TaskFailure, runTask, taskEffect } from "../kit/tasks.ts";
+import { TaskFailure, taskEffect } from "../kit/tasks.ts";
 import { log } from "../../log.ts";
 import {
   RETRY_NOTICE,
@@ -472,26 +471,6 @@ function streamNativeSlackReply(
     );
     if (!finalized) yield* Effect.fail(new TaskFailure(new Error("stream ended without a terminal event")));
   });
-}
-
-export function streamSlackReply(
-  events: AsyncIterable<AgentEvent>,
-  api: SlackApi,
-  target: SlackTarget,
-  formatError: (failure: SlackFailure) => string | undefined,
-  options: Parameters<typeof slackReply>[4] = {},
-): Promise<void> {
-  return runTask(
-    Effect.scoped(
-      slackReply(
-        eventStream(() => events, options.label ?? "[slack]").pipe(Stream.scoped),
-        api,
-        target,
-        formatError,
-        options,
-      ),
-    ),
-  );
 }
 
 export function slackReply(

--- a/src/channels/slack/slack.ts
+++ b/src/channels/slack/slack.ts
@@ -9,7 +9,9 @@ import { secretEquals } from "../secret.ts";
 import { createSeenRing } from "../kit/seen.ts";
 import { signatureIsFresh } from "../kit/signature.ts";
 import { createThreadParticipants } from "../kit/thread-participants.ts";
-import { createTaskTracker } from "../kit/tasks.ts";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { createTaskTracker, taskEffect } from "../kit/tasks.ts";
 import { ensureStateHome } from "../kit/state.ts";
 import { dispatchStop, isStopText } from "../kit/stop-command.ts";
 import { codePointPrefix } from "../kit/text.ts";
@@ -17,7 +19,7 @@ import { createTurnRunner } from "../kit/turn-runner.ts";
 import { createTurnStore } from "../kit/turn-store.ts";
 import { discussionBlock } from "../kit/context-buffer.ts";
 import { type SlackBufferEntry, collectSlackBufferedFiles, createSlackContextBuffer } from "./context-buffer.ts";
-import { invokeSlackTurn } from "./invoke-turn.ts";
+import { slackTurnStream } from "./invoke-turn.ts";
 import {
   type SlackEventEnvelope,
   type SlackFile,
@@ -44,7 +46,7 @@ import {
   type SlackRendering,
   defaultErrorMessage,
   settleSlackPreview,
-  streamSlackReply,
+  slackReply,
 } from "./preview.ts";
 import { resolveReactionEmojis, startSlackReaction } from "./reaction.ts";
 import { registerSlackApi } from "./shared-api.ts";
@@ -311,47 +313,52 @@ export function slackChannel(options: SlackChannelOptions): ChannelModule {
         }
       },
       notifyDropped,
-      execute: async (turn, discussion, onCompleted) => {
+      execute: (turn, discussion, onCompleted) => {
         const messageRef = messageRefOf(turn.id);
-        const reaction =
-          reactionEmojis && messageRef
-            ? await startSlackReaction({
+        return Effect.acquireUseRelease(
+          taskEffect(async () =>
+            reactionEmojis && messageRef
+              ? startSlackReaction({
+                  api,
+                  channelId: messageRef.channelId,
+                  ts: messageRef.ts,
+                  emojis: reactionEmojis,
+                  label,
+                })
+              : undefined,
+          ),
+          () =>
+            Effect.scoped(
+              slackReply(
+                slackTurnStream(
+                  agent,
+                  turn.session,
+                  `${discussionBlock(discussion.text)}${turn.baseText}`,
+                  { api, channelId: turn.channelId, filesDir: join(stateHome, "files"), label },
+                  {
+                    primaryFileIds: turn.fileIds,
+                    buffered: collectSlackBufferedFiles(discussion.consumed, new Set(turn.fileIds)),
+                  },
+                  onCompleted,
+                ),
                 api,
-                channelId: messageRef.channelId,
-                ts: messageRef.ts,
-                emojis: reactionEmojis,
-                label,
-              })
-            : undefined;
-        try {
-          await streamSlackReply(
-            invokeSlackTurn(
-              agent,
-              turn.session,
-              `${discussionBlock(discussion.text)}${turn.baseText}`,
-              { api, channelId: turn.channelId, filesDir: join(stateHome, "files"), label },
-              {
-                primaryFileIds: turn.fileIds,
-                buffered: collectSlackBufferedFiles(discussion.consumed, new Set(turn.fileIds)),
-              },
-              onCompleted,
+                targetOf(turn),
+                formatError,
+                {
+                  rendering,
+                  initialPreviewTs: turn.previewTs,
+                  threadTitle: turn.threadTitle,
+                  disclaimer: aiDisclaimer,
+                  label,
+                },
+              ),
             ),
-            api,
-            targetOf(turn),
-            formatError,
-            {
-              rendering,
-              initialPreviewTs: turn.previewTs,
-              threadTitle: turn.threadTitle,
-              disclaimer: aiDisclaimer,
-              label,
-            },
-          );
-        } catch (error) {
-          await reaction?.remove();
-          throw error;
-        }
-        await reaction?.complete();
+          (reaction, exit) =>
+            taskEffect(async () => {
+              if (Exit.isSuccess(exit)) await reaction?.complete();
+              else await reaction?.remove();
+            }).pipe(Effect.orDie),
+        );
       },
     });
     let seq = runner.recover().reduce((maximum, turn) => Math.max(maximum, turn.seq), 0);

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -1,15 +1,13 @@
 /**
  * Run one turn (the IO half of Telegram→Agent translation): assemble its inputs — resolve attachments
  * (download files to disk, load vision images) — and stream `agent.invoke` with the assembled prompt.
- * `invokeTurn` is the export; attachment resolution is an internal step. Split from parse.ts (which is
- * pure) because this half touches the Bot API + disk; split from telegram.ts so the factory keeps only
- * wiring and the per-turn lifecycle.
+ * Split from parse.ts because this half touches the Bot API + disk; split from telegram.ts so the
+ * factory keeps only wiring and the per-turn lifecycle.
  */
 import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 import { type TaskFailure, taskEffect } from "../kit/tasks.ts";
-import { toEvents } from "../kit/event-stream.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -108,13 +106,9 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
 
 /**
  * Run one turn: resolve its attachments, then stream agent.invoke with the shared busy-wait
- * (invoke-turn-kit — `onCompleted` is the durable-commit point; see streamTurnWithBusyRetry). A
+ * (invoke-turn-kit — `onCompleted` is the durable-commit point; see busyRetryStream). A
  * primary-attachment failure surfaces as a `failed` event (never a silent drop).
  */
-export function invokeTurn(...args: Parameters<typeof telegramTurnStream>): AsyncIterable<AgentEvent> {
-  return toEvents(telegramTurnStream(...args));
-}
-
 export function telegramTurnStream(
   agent: Agent,
   session: string,

--- a/src/channels/telegram/invoke-turn.ts
+++ b/src/channels/telegram/invoke-turn.ts
@@ -6,6 +6,10 @@
  * wiring and the per-turn lifecycle.
  */
 import type { Agent, AgentEvent, ImageRef } from "../../agent.ts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { type TaskFailure, taskEffect } from "../kit/tasks.ts";
+import { toEvents } from "../kit/event-stream.ts";
 import { log } from "../../log.ts";
 import {
   type BusyRetry,
@@ -13,7 +17,7 @@ import {
   attachedFilesManifest,
   attributedFileName,
   missingAttachmentsNote,
-  streamTurnWithBusyRetry,
+  busyRetryStream,
 } from "../kit/invoke-turn-kit.ts";
 import type { BufferedRef } from "./context-buffer.ts";
 import { type DownloadedFile, resolveFiles, resolveImages } from "./telegram-api.ts";
@@ -107,7 +111,11 @@ async function resolveTurnAttachments(t: TurnTransport, attachments: TurnAttachm
  * (invoke-turn-kit — `onCompleted` is the durable-commit point; see streamTurnWithBusyRetry). A
  * primary-attachment failure surfaces as a `failed` event (never a silent drop).
  */
-export async function* invokeTurn(
+export function invokeTurn(...args: Parameters<typeof telegramTurnStream>): AsyncIterable<AgentEvent> {
+  return toEvents(telegramTurnStream(...args));
+}
+
+export function telegramTurnStream(
   agent: Agent,
   session: string,
   text: string,
@@ -115,14 +123,29 @@ export async function* invokeTurn(
   attachments: TurnAttachments,
   onCompleted?: () => void,
   busyRetry: BusyRetry = DEFAULT_BUSY_RETRY,
-): AsyncIterable<AgentEvent> {
-  let resolved: ResolvedAttachments;
-  try {
-    resolved = await resolveTurnAttachments(transport, attachments);
-  } catch (e) {
-    yield { type: "failed", details: `could not load attachment: ${String(e)}`, retryable: true };
-    return;
-  }
-  const prompt = { text: `${text}${resolved.promptSuffix}${HTML_INSTRUCTION}`, images: resolved.images };
-  yield* streamTurnWithBusyRetry(agent, { session }, prompt, { label: "[telegram]", onCompleted, busyRetry });
+): Stream.Stream<AgentEvent, TaskFailure> {
+  return Stream.unwrap(
+    taskEffect(() => resolveTurnAttachments(transport, attachments)).pipe(
+      Effect.map((resolved) =>
+        busyRetryStream(
+          agent,
+          { session },
+          {
+            text: `${text}${resolved.promptSuffix}${HTML_INSTRUCTION}`,
+            images: resolved.images,
+          },
+          { label: "[telegram]", onCompleted, busyRetry },
+        ),
+      ),
+      Effect.catchTag("TaskFailure", (error) =>
+        Effect.succeed(
+          Stream.succeed<AgentEvent>({
+            type: "failed",
+            details: `could not load attachment: ${String(error.cause)}`,
+            retryable: true,
+          }),
+        ),
+      ),
+    ),
+  );
 }

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -7,11 +7,10 @@
  */
 import type { AgentEvent } from "../../agent.ts";
 import * as Effect from "effect/Effect";
-import * as Stream from "effect/Stream";
+import type * as Stream from "effect/Stream";
 import * as Clock from "effect/Clock";
-import { eventStream } from "../kit/event-stream.ts";
 import { previewPump, renderReply } from "../kit/delivery.ts";
-import { type TaskFailure, runTask, taskEffect } from "../kit/tasks.ts";
+import { type TaskFailure, taskEffect } from "../kit/tasks.ts";
 import {
   RETRY_NOTICE,
   THINKING_PLACEHOLDER,
@@ -41,7 +40,7 @@ const EDIT_THROTTLE_MS = 1500;
 const THINKING_PREVIEW = 280;
 
 /**
- * The terminal-write POLICY: resolve the single preview message into `text`. streamReply owns the
+ * The terminal-write POLICY: resolve the single preview message into `text`. telegramReply owns the
  * preview lifecycle, so this composition of transport primitives lives here, not in telegram-api. One
  * message → edit the preview in place; if the edit fails (preview gone, or a persistent 429/5xx) fall
  * back to deleting the placeholder and sending fresh, so no "Thinking…" is left pinned above the answer.
@@ -87,28 +86,6 @@ async function finalize(
  * model). Preview edits are best-effort (logged once if they fail); the final write is authoritative
  * and surfaces a real failure (bad token, etc.).
  */
-export function streamReply(
-  events: AsyncIterable<AgentEvent>,
-  api: string,
-  botToken: string,
-  target: Target,
-  formatError: (failed: TelegramFailure) => string | undefined,
-  previewId?: number,
-): Promise<void> {
-  return runTask(
-    Effect.scoped(
-      telegramReply(
-        eventStream(() => events, "[telegram]").pipe(Stream.scoped),
-        api,
-        botToken,
-        target,
-        formatError,
-        previewId,
-      ),
-    ),
-  );
-}
-
 export function telegramReply(
   events: Stream.Stream<AgentEvent, TaskFailure>,
   api: string,

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -6,13 +6,18 @@
  * message, works in groups and private (unlike sendMessageDraft, which is private/forum-topic only).
  */
 import type { AgentEvent } from "../../agent.ts";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as Clock from "effect/Clock";
+import { eventStream } from "../kit/event-stream.ts";
+import { previewPump, renderReply } from "../kit/delivery.ts";
+import { type TaskFailure, runTask, taskEffect } from "../kit/tasks.ts";
 import {
   RETRY_NOTICE,
   THINKING_PLACEHOLDER,
   type ChannelFailure,
   applyTurnEvent,
   composeTurnBody,
-  createPreviewPump,
   createTurnView,
   defaultErrorMessage,
   revealedAnswer,
@@ -82,7 +87,7 @@ async function finalize(
  * model). Preview edits are best-effort (logged once if they fail); the final write is authoritative
  * and surfaces a real failure (bad token, etc.).
  */
-export async function streamReply(
+export function streamReply(
   events: AsyncIterable<AgentEvent>,
   api: string,
   botToken: string,
@@ -90,104 +95,87 @@ export async function streamReply(
   formatError: (failed: TelegramFailure) => string | undefined,
   previewId?: number,
 ): Promise<void> {
-  // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
-  // policy, formatting, and delivery below.
-  const turn = createTurnView();
-  const view = (): string => {
-    const v = composeTurnBody([
-      thinkingLine(turn, THINKING_PREVIEW),
-      toolLines(turn),
-      turn.retrying ? RETRY_NOTICE : "",
-      revealedAnswer(turn, EDIT_THROTTLE_MS),
-    ]);
-    // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
-    return v === "" ? THINKING_PLACEHOLDER : v;
-  };
+  return runTask(
+    Effect.scoped(
+      telegramReply(
+        eventStream(() => events, "[telegram]").pipe(Stream.scoped),
+        api,
+        botToken,
+        target,
+        formatError,
+        previewId,
+      ),
+    ),
+  );
+}
 
-  // The live preview is ONE real message: sent once (capturing its id + threading under the asker),
-  // then edited in place. messageId/lastSent are shared with the final write on completion.
-  // `previewId`: an already-sent message to take over as the preview (the "⏳ queued" notice) — the
-  // pump edits it in place, so the queue notice morphs into the live view instead of leaving an orphan.
-  let messageId: number | undefined = previewId;
-  let previewSent = messageId !== undefined; // a placeholder send was attempted — guards against re-sending when no id came back
-  let finalized = false; // a terminal write (completed/failed) ran — the finally skips its orphan cleanup
-  let lastSent = "";
-  const flushPreview = async (): Promise<void> => {
-    const text = view();
-    if (text === lastSent) return; // skip an unchanged edit (Telegram rejects "message is not modified")
-    lastSent = text;
-    if (messageId !== undefined) {
-      await editMessageText(api, botToken, target, messageId, text); // plain — a partial answer may carry unbalanced HTML
-      return;
-    }
-    // No preview message yet. Send the placeholder ONCE; never re-send (that would spam a new message per
-    // frame). If Telegram returns ok WITHOUT a message_id (proxy / odd API base / unparseable body) we
-    // cannot edit — fail visibly and stop previewing (the final write still lands via finalize).
-    if (previewSent) return;
-    previewSent = true;
-    messageId = await sendMessage(api, botToken, target, text, { html: false });
-    if (messageId === undefined)
-      throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
-  };
+export function telegramReply(
+  events: Stream.Stream<AgentEvent, TaskFailure>,
+  api: string,
+  botToken: string,
+  target: Target,
+  formatError: (failed: TelegramFailure) => string | undefined,
+  previewId?: number,
+) {
+  return Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const now = () => clock.currentTimeMillisUnsafe();
+    // Event → view-state reduction is the shared machine (preview-kit); this renderer owns the reveal
+    // policy, formatting, and delivery below.
+    const turn = createTurnView();
+    const view = (): string => {
+      const v = composeTurnBody([
+        thinkingLine(turn, THINKING_PREVIEW),
+        toolLines(turn),
+        turn.retrying ? RETRY_NOTICE : "",
+        revealedAnswer(turn, EDIT_THROTTLE_MS, now()),
+      ]);
+      // Before any reasoning/tool/text arrives, show an explicit placeholder rather than an empty edit.
+      return v === "" ? THINKING_PLACEHOLDER : v;
+    };
 
-  // The shared single-writer pump (preview-kit) serializes edits to the one preview message. (No
-  // keepalive: a real message does not expire, unlike a Bot API `sendMessageDraft` (30s window).)
-  const { touch, finish } = createPreviewPump({
-    flush: flushPreview,
-    throttleMs: EDIT_THROTTLE_MS,
-    onError: (e) => log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`),
-  });
-
-  touch(); // send the "💭 Thinking…" placeholder immediately
-
-  try {
-    for await (const e of events) {
-      if (e.type === "completed") {
-        await finish();
-        // Edit the preview into the final answer (HTML, plain fallback); the persisted message is the
-        // answer alone — the process (thinking/tools) was preview-only. Mark finalized BEFORE delivering:
-        // the terminal was reached, so a delivery failure here is a plain failure, not an "abnormal exit"
-        // (which would wrongly fire the finally's neutral-notice fallback = double delivery + wrong text).
-        finalized = true;
-        await finalize(api, botToken, target, messageId, turn.answer.trim() !== "" ? turn.answer : "(no reply)");
+    // The live preview is ONE real message: sent once (capturing its id + threading under the asker),
+    // then edited in place. messageId/lastSent are shared with the final write on completion.
+    // `previewId`: an already-sent message to take over as the preview (the "⏳ queued" notice) — the
+    // pump edits it in place, so the queue notice morphs into the live view instead of leaving an orphan.
+    let messageId: number | undefined = previewId;
+    let previewSent = messageId !== undefined; // a placeholder send was attempted — guards against re-sending when no id came back
+    let lastSent = "";
+    const flushPreview = async (): Promise<void> => {
+      const text = view();
+      if (text === lastSent) return; // skip an unchanged edit (Telegram rejects "message is not modified")
+      lastSent = text;
+      if (messageId !== undefined) {
+        await editMessageText(api, botToken, target, messageId, text); // plain — a partial answer may carry unbalanced HTML
         return;
       }
-      if (e.type === "failed") {
-        await finish();
-        // Two audiences: the chat (customer-facing — formatError, neutral by default) and the operator
-        // log (dev-facing — the full details, via the throw below + the handler's catch). Same terminal
-        // write as completed: edit → fresh-send if the preview is gone; an empty notice deletes the
-        // placeholder (suppress = no residue). HTML like the answer — symmetric, and finalize already
-        // falls back to plain if a custom onError returns markup Telegram rejects. Best-effort — we throw
-        // below regardless.
-        finalized = true;
-        {
-          const msg =
-            formatError({
-              details: e.details,
-              retryable: e.retryable,
-              ...(e.code !== undefined ? { code: e.code } : {}),
-            }) ?? "";
-          await finalize(api, botToken, target, messageId, msg).catch(() => {});
-        }
-        throw new Error(`agent failed: ${e.details} (retryable=${e.retryable})`);
-      }
-      if (applyTurnEvent(turn, e)) touch();
-    }
-    throw new Error("stream ended without a terminal event"); // violates SPEC MUST 1
-  } finally {
-    await finish();
-    // Abnormal exit (stream ended without a terminal, the generator threw, or the consumer abandoned): no
-    // terminal write ran. Show the SAME neutral notice a `failed` event would — the preview may show real
-    // partial work, so don't delete it silently, and don't leave the user in silence. A suppressing
-    // onError still collapses to a delete (finalize on empty text).
-    if (!finalized) {
-      // retryable:false — an abnormal end (no terminal / a throw) is of UNKNOWN retryability, so use the
-      // neutral "something went wrong" default rather than promising "try again" that may not help.
-      const notice = formatError({ details: "the turn ended without completing", retryable: false }) ?? "";
-      // finalize handles messageId===undefined (no preview reached) with a fresh send — so the user is
-      // told even when the turn died before any message.
-      await finalize(api, botToken, target, messageId, notice).catch(() => {});
-    }
-  }
+      // No preview message yet. Send the placeholder ONCE; never re-send (that would spam a new message per
+      // frame). If Telegram returns ok WITHOUT a message_id (proxy / odd API base / unparseable body) we
+      // cannot edit — fail visibly and stop previewing (the final write still lands via finalize).
+      if (previewSent) return;
+      previewSent = true;
+      messageId = await sendMessage(api, botToken, target, text, { html: false });
+      if (messageId === undefined)
+        throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
+    };
+
+    const { touch, finish } = yield* previewPump({
+      flush: flushPreview,
+      throttleMs: EDIT_THROTTLE_MS,
+      onError: (e) => log.warn(`[telegram] live preview failed (final reply still sends): ${String(e)}`),
+    });
+
+    touch(); // send the "💭 Thinking…" placeholder immediately
+
+    yield* renderReply(events, {
+      label: "[telegram]",
+      finish,
+      formatError,
+      onEvent: (event) => {
+        if (applyTurnEvent(turn, event, now())) touch();
+      },
+      answer: () => (turn.answer.trim() !== "" ? turn.answer : "(no reply)"),
+      settle: (text) => taskEffect(() => finalize(api, botToken, target, messageId, text)),
+    });
+  });
 }

--- a/src/channels/telegram/telegram.ts
+++ b/src/channels/telegram/telegram.ts
@@ -28,7 +28,7 @@ import { log } from "../../log.ts";
 import { readBodyCapped } from "../body.ts";
 import { text } from "../respond.ts";
 import { secretEquals } from "../secret.ts";
-import { invokeTurn } from "./invoke-turn.ts";
+import { telegramTurnStream } from "./invoke-turn.ts";
 import { type BufferEntry, collectAttachments, createContextBuffer } from "./context-buffer.ts";
 import {
   type TelegramMessage,
@@ -46,7 +46,7 @@ import {
   telegramEnvelope,
   telegramStop,
 } from "./parse.ts";
-import { type TelegramFailure, defaultErrorMessage, streamReply } from "./preview.ts";
+import { type TelegramFailure, defaultErrorMessage, telegramReply } from "./preview.ts";
 import { ensureStateHome } from "../kit/state.ts";
 import { dispatchStop } from "../kit/stop-command.ts";
 import { type Target, callApi, editMessageText, sendMessage } from "./telegram-api.ts";
@@ -228,8 +228,8 @@ export function telegramChannel({
       },
       notifyDropped,
       execute: (rec, discussion, onCompleted) =>
-        streamReply(
-          invokeTurn(
+        telegramReply(
+          telegramTurnStream(
             agent,
             rec.session,
             `${discussionBlock(discussion.text)}${rec.baseText}`,

--- a/test/channel-effects.ts
+++ b/test/channel-effects.ts
@@ -1,0 +1,11 @@
+import * as Effect from "effect/Effect";
+import type * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import type { AgentEvent } from "../src/agent.ts";
+import { eventStream } from "../src/channels/kit/event-stream.ts";
+import type { TaskFailure } from "../src/channels/kit/tasks.ts";
+
+export const run = <A>(work: Effect.Effect<A, TaskFailure, Scope.Scope>): Promise<A> =>
+  Effect.runPromise(Effect.scoped(work).pipe(Effect.mapError((error) => error.cause)));
+
+export const stream = (events: AsyncIterable<AgentEvent>) => eventStream(() => events, "[test]").pipe(Stream.scoped);

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -18,12 +18,15 @@ import {
 import { createPiAgentFromSession, type PiAgentSessionFactory } from "../src/engines/pi/invoke-session.ts";
 import { piInMemorySessionRecordStore, piSessionRecordStore } from "../src/engines/pi/session-store.ts";
 import { collect, AgentFailure } from "../src/collect.ts";
-import { streamTurnWithBusyRetry } from "../src/channels/kit/invoke-turn-kit.ts";
+import { busyRetryStream } from "../src/channels/kit/invoke-turn-kit.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as Stream from "effect/Stream";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Exit from "effect/Exit";
+import * as Cause from "effect/Cause";
 import { runQueuedTurn } from "../src/channels/kit/turn-runner.ts";
 import type { TurnRecordBase } from "../src/channels/kit/turn-store.ts";
-import { toEvents } from "../src/channels/kit/event-stream.ts";
 import { telegramTurnStream } from "../src/channels/telegram/invoke-turn.ts";
 import { telegramReply } from "../src/channels/telegram/preview.ts";
 
@@ -193,10 +196,10 @@ describe("AgentSession L0: pi's auto-retry vs. append-only deltas", () => {
 it.each([
   ["return", "direct"],
   ["throw", "direct"],
-  ["return", "channel"],
-  ["throw", "channel"],
-  ["return", "delivery"],
-  ["throw", "delivery"],
+  ["abort", "channel"],
+  ["interrupt", "channel"],
+  ["abort", "delivery"],
+  ["interrupt", "delivery"],
 ] as const)(
   "quiet consumer %s through %s aborts the actual tool and joins cleanup before releasing",
   async (method, entry) => {
@@ -239,60 +242,76 @@ it.each([
       );
     }
     const removed = vi.fn();
-    const events =
-      entry === "delivery"
-        ? toEvents(
-            Stream.fromEffectDrain(
-              runQueuedTurn<TurnRecordBase, TurnRecordBase, never>(
-                {
-                  label: "[test]",
-                  store: { add: () => {}, remove: removed, recover: () => [], startAttempt: () => "run" },
-                  buffer: { push: () => {}, peek: () => ({ text: "", consumed: [] }), commit: () => {} },
-                  toStored: (rec) => ({ ...rec, attempts: 0 }),
-                  fromStored: (rec) => rec,
-                  bufferKey: () => "quiet",
-                  where: () => "test",
-                  onDeferred: () => {},
-                  notifyDropped: () => {},
-                  execute: () =>
-                    telegramReply(
-                      telegramTurnStream(
-                        agent,
-                        "quiet",
-                        "go",
-                        { api: "https://api.telegram.org", botToken: "token", chatId: 1, filesDir: "/tmp" },
-                        { primary: { imageFileIds: [], fileIds: [] }, buffered: { images: [], files: [], skipped: 0 } },
-                      ),
-                      "https://api.telegram.org",
-                      "token",
-                      { chatId: 1 },
-                      () => "neutral notice",
+    const stop = (() => {
+      if (entry === "direct") {
+        const iterator = agent.invoke({ session: "quiet" }, { text: "go" })[Symbol.asyncIterator]();
+        const first = iterator.next();
+        return async () => {
+          expect((await first).value).toMatchObject({ type: "tool_started" });
+          const pending = iterator.next();
+          const error = new Error("consumer stopped");
+          if (method === "return") await iterator.return?.();
+          else await expect(iterator.throw?.(error)).rejects.toBe(error);
+          expect(await pending).toEqual({ done: true, value: undefined });
+        };
+      }
+      const work =
+        entry === "delivery"
+          ? runQueuedTurn<TurnRecordBase, TurnRecordBase, never>(
+              {
+                label: "[test]",
+                store: { add: () => {}, remove: removed, recover: () => [], startAttempt: () => "run" },
+                buffer: { push: () => {}, peek: () => ({ text: "", consumed: [] }), commit: () => {} },
+                toStored: (rec) => ({ ...rec, attempts: 0 }),
+                fromStored: (rec) => rec,
+                bufferKey: () => "quiet",
+                where: () => "test",
+                onDeferred: () => {},
+                notifyDropped: () => {},
+                execute: () =>
+                  telegramReply(
+                    telegramTurnStream(
+                      agent,
+                      "quiet",
+                      "go",
+                      { api: "https://api.telegram.org", botToken: "token", chatId: 1, filesDir: "/tmp" },
+                      { primary: { imageFileIds: [], fileIds: [] }, buffered: { images: [], files: [], skipped: 0 } },
                     ),
-                },
-                { id: "turn", session: "quiet", attempts: 0 },
-              ),
-            ),
-          )
-        : entry === "channel"
-          ? streamTurnWithBusyRetry(agent, { session: "quiet" }, { text: "go" }, { label: "[test]" })
-          : agent.invoke({ session: "quiet" }, { text: "go" });
-    const iterator = events[Symbol.asyncIterator]();
-    const first = iterator.next();
-    if (entry !== "delivery") expect((await first).value).toMatchObject({ type: "tool_started" });
+                    "https://api.telegram.org",
+                    "token",
+                    { chatId: 1 },
+                    () => "neutral notice",
+                  ),
+              },
+              { id: "turn", session: "quiet", attempts: 0 },
+            )
+          : Stream.runDrain(busyRetryStream(agent, { session: "quiet" }, { text: "go" }, { label: "[test]" }));
+      if (method === "abort") {
+        const abort = new AbortController();
+        const done = Effect.runPromiseExit(work, { signal: abort.signal });
+        return async () => {
+          abort.abort();
+          const exit = await done;
+          expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+        };
+      }
+      const fiber = Effect.runFork(work);
+      return async () => {
+        await Effect.runPromise(Fiber.interrupt(fiber));
+        const exit = await Effect.runPromise(Fiber.await(fiber));
+        expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+      };
+    })();
     await entered.promise;
-    const pending = entry === "delivery" ? first : iterator.next();
-    const error = new Error("consumer stopped");
-    const closing = method === "return" ? iterator.return?.() : iterator.throw?.(error);
-    const checked = method === "return" ? closing : expect(closing).rejects.toBe(error);
+    const closing = stop();
     try {
       await aborted.promise;
       expect(disposed).toBe(false);
       expect(lease.tryAcquire("quiet")).toBeNull();
     } finally {
       finishCleanup.resolve();
-      await checked;
+      await closing;
     }
-    expect(await pending).toEqual({ done: true, value: undefined });
     expect(disposed).toBe(true);
     expect(removed).not.toHaveBeenCalled();
     const release = lease.tryAcquire("quiet");

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -19,7 +19,15 @@ import { createPiAgentFromSession, type PiAgentSessionFactory } from "../src/eng
 import { piInMemorySessionRecordStore, piSessionRecordStore } from "../src/engines/pi/session-store.ts";
 import { collect, AgentFailure } from "../src/collect.ts";
 import { streamTurnWithBusyRetry } from "../src/channels/kit/invoke-turn-kit.ts";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as Stream from "effect/Stream";
+import { runQueuedTurn } from "../src/channels/kit/turn-runner.ts";
+import type { TurnRecordBase } from "../src/channels/kit/turn-store.ts";
+import { toEvents } from "../src/channels/kit/event-stream.ts";
+import { telegramTurnStream } from "../src/channels/telegram/invoke-turn.ts";
+import { telegramReply } from "../src/channels/telegram/preview.ts";
+
+afterEach(() => vi.restoreAllMocks());
 import { makeFaux } from "./faux.ts";
 import { describeSpecConformance } from "./spec-conformance.ts";
 import { inProcessLease } from "../src/engines/pi/turn-kit.ts";
@@ -187,6 +195,8 @@ it.each([
   ["throw", "direct"],
   ["return", "channel"],
   ["throw", "channel"],
+  ["return", "delivery"],
+  ["throw", "delivery"],
 ] as const)(
   "quiet consumer %s through %s aborts the actual tool and joins cleanup before releasing",
   async (method, entry) => {
@@ -223,14 +233,54 @@ it.each([
         return session;
       },
     });
+    if (entry === "delivery") {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+        Response.json({ ok: true, result: { message_id: 1 } }),
+      );
+    }
+    const removed = vi.fn();
     const events =
-      entry === "channel"
-        ? streamTurnWithBusyRetry(agent, { session: "quiet" }, { text: "go" }, { label: "[test]" })
-        : agent.invoke({ session: "quiet" }, { text: "go" });
+      entry === "delivery"
+        ? toEvents(
+            Stream.fromEffectDrain(
+              runQueuedTurn<TurnRecordBase, TurnRecordBase, never>(
+                {
+                  label: "[test]",
+                  store: { add: () => {}, remove: removed, recover: () => [], startAttempt: () => "run" },
+                  buffer: { push: () => {}, peek: () => ({ text: "", consumed: [] }), commit: () => {} },
+                  toStored: (rec) => ({ ...rec, attempts: 0 }),
+                  fromStored: (rec) => rec,
+                  bufferKey: () => "quiet",
+                  where: () => "test",
+                  onDeferred: () => {},
+                  notifyDropped: () => {},
+                  execute: () =>
+                    telegramReply(
+                      telegramTurnStream(
+                        agent,
+                        "quiet",
+                        "go",
+                        { api: "https://api.telegram.org", botToken: "token", chatId: 1, filesDir: "/tmp" },
+                        { primary: { imageFileIds: [], fileIds: [] }, buffered: { images: [], files: [], skipped: 0 } },
+                      ),
+                      "https://api.telegram.org",
+                      "token",
+                      { chatId: 1 },
+                      () => "neutral notice",
+                    ),
+                },
+                { id: "turn", session: "quiet", attempts: 0 },
+              ),
+            ),
+          )
+        : entry === "channel"
+          ? streamTurnWithBusyRetry(agent, { session: "quiet" }, { text: "go" }, { label: "[test]" })
+          : agent.invoke({ session: "quiet" }, { text: "go" });
     const iterator = events[Symbol.asyncIterator]();
-    expect((await iterator.next()).value).toMatchObject({ type: "tool_started" });
+    const first = iterator.next();
+    if (entry !== "delivery") expect((await first).value).toMatchObject({ type: "tool_started" });
     await entered.promise;
-    const pending = iterator.next();
+    const pending = entry === "delivery" ? first : iterator.next();
     const error = new Error("consumer stopped");
     const closing = method === "return" ? iterator.return?.() : iterator.throw?.(error);
     const checked = method === "return" ? closing : expect(closing).rejects.toBe(error);
@@ -244,6 +294,7 @@ it.each([
     }
     expect(await pending).toEqual({ done: true, value: undefined });
     expect(disposed).toBe(true);
+    expect(removed).not.toHaveBeenCalled();
     const release = lease.tryAcquire("quiet");
     expect(release).toBeTypeOf("function");
     release?.();

--- a/test/delivery-platform.test.ts
+++ b/test/delivery-platform.test.ts
@@ -1,0 +1,175 @@
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+import { afterEach, expect, it, vi } from "vitest";
+import type { Agent, AgentEvent } from "../src/agent.ts";
+import type { FeishuApi } from "../src/channels/feishu/feishu-api.ts";
+import { feishuReply } from "../src/channels/feishu/preview.ts";
+import { busyRetryStream } from "../src/channels/kit/invoke-turn-kit.ts";
+import type { TaskFailure } from "../src/channels/kit/tasks.ts";
+import { slackReply } from "../src/channels/slack/preview.ts";
+import type { SlackApi } from "../src/channels/slack/slack-api.ts";
+import { telegramReply } from "../src/channels/telegram/preview.ts";
+
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve));
+const platforms = ["telegram", "feishu", "slack-classic", "slack-native"] as const;
+type Platform = (typeof platforms)[number];
+
+afterEach(() => vi.restoreAllMocks());
+
+function renderer(platform: Platform, open: () => Promise<void>, settle: () => Promise<void>) {
+  const neutral = () => "neutral notice";
+  if (platform === "telegram") {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      if (String(input).endsWith("/sendMessage")) await open();
+      else if (String(input).endsWith("/editMessageText")) await settle();
+      else throw new Error(`unexpected Telegram call: ${String(input)}`);
+      return Response.json({ ok: true, result: { message_id: 17 } });
+    });
+    return (events: Stream.Stream<AgentEvent, TaskFailure>) =>
+      telegramReply(events, "https://api.telegram.org", "token", { chatId: 1 }, neutral);
+  }
+  if (platform === "feishu") {
+    const api = {
+      createCard: async () => "card-1",
+      sendMessage: async () => {
+        await open();
+        return "message-1";
+      },
+      updateCard: async () => {
+        await settle();
+      },
+      updateCardElement: async () => {},
+    } as unknown as FeishuApi;
+    return (events: Stream.Stream<AgentEvent, TaskFailure>) => feishuReply(events, api, { chatId: "chat-1" }, neutral);
+  }
+  const api = {
+    postMarkdown: async () => {
+      await open();
+      return "1.0";
+    },
+    updateMarkdown: async () => {
+      await settle();
+    },
+    startStream: async () => {
+      await open();
+      return "1.0";
+    },
+    appendStream: async () => {},
+    sendMarkdown: async () => {
+      await settle();
+      return { ts: "1.0", channelId: "C1" };
+    },
+    stopStream: async () => {
+      await settle();
+    },
+  } as unknown as SlackApi;
+  return (events: Stream.Stream<AgentEvent, TaskFailure>) =>
+    slackReply(events, api, { channelId: "C1", threadTs: "1.0" }, neutral, {
+      rendering: platform === "slack-classic" ? "classic" : "native",
+      disclaimer: false,
+    });
+}
+
+it.each(platforms)(
+  "%s joins a late preview acquisition and terminal delivery before releasing ownership",
+  async (platform) => {
+    const opened = Promise.withResolvers<void>();
+    const releaseOpen = Promise.withResolvers<void>();
+    const settling = Promise.withResolvers<void>();
+    const releaseFinal = Promise.withResolvers<void>();
+    const open = vi.fn(async () => {
+      opened.resolve();
+      await releaseOpen.promise;
+    });
+    const settle = vi.fn(async () => {
+      settling.resolve();
+      await releaseFinal.promise;
+    });
+    const render = renderer(platform, open, settle);
+    let released = false;
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const events = Stream.fromIterable<AgentEvent>([
+          { type: "thinking", delta: "working" },
+          { type: "tool_started", id: "t1", name: "read", args: {} },
+        ]).pipe(Stream.concat(Stream.never));
+        const turn = yield* Effect.forkChild(
+          Effect.scoped(render(events)).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                released = true;
+              }),
+            ),
+          ),
+        );
+        yield* Effect.promise(() => opened.promise);
+        const closing = yield* Effect.forkChild(Fiber.interrupt(turn));
+        yield* Effect.promise(tick);
+        expect(released).toBe(false);
+        expect(settle).not.toHaveBeenCalled();
+        releaseOpen.resolve();
+        yield* TestClock.adjust(3_000);
+        yield* Effect.promise(() => settling.promise);
+        expect(released).toBe(false);
+        releaseFinal.resolve();
+        yield* Fiber.join(closing);
+        const exit = yield* Fiber.await(turn);
+        expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+        expect(released).toBe(true);
+        yield* TestClock.adjust(60_000);
+        expect(open).toHaveBeenCalledOnce();
+        expect(settle).toHaveBeenCalledOnce();
+      }).pipe(Effect.provide(TestClock.layer())),
+    );
+  },
+);
+
+it.each(platforms)(
+  "%s commits completion before delivery and keeps source cleanup behind the final write",
+  async (platform) => {
+    const settling = Promise.withResolvers<void>();
+    const releaseFinal = Promise.withResolvers<void>();
+    const committed = vi.fn();
+    let sourceClosed = false;
+    const agent: Agent = {
+      async *invoke() {
+        try {
+          yield { type: "text", delta: "answer" };
+          yield { type: "completed" };
+        } finally {
+          sourceClosed = true;
+        }
+      },
+    };
+    const render = renderer(
+      platform,
+      async () => {},
+      async () => {
+        settling.resolve();
+        expect(committed).toHaveBeenCalledOnce();
+        expect(sourceClosed).toBe(false);
+        await releaseFinal.promise;
+      },
+    );
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const turn = yield* Effect.forkChild(
+          Effect.scoped(
+            render(
+              busyRetryStream(agent, { session: "s" }, { text: "go" }, { label: "[test]", onCompleted: committed }),
+            ),
+          ),
+        );
+        yield* Effect.promise(() => settling.promise);
+        releaseFinal.resolve();
+        yield* Fiber.join(turn);
+        expect(sourceClosed).toBe(true);
+        expect(committed).toHaveBeenCalledOnce();
+      }),
+    );
+  },
+);

--- a/test/delivery.test.ts
+++ b/test/delivery.test.ts
@@ -1,0 +1,231 @@
+import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
+import * as Stream from "effect/Stream";
+import { expect, it, vi } from "vitest";
+import { previewPump, serialWriter, renderReply, type PreviewPump } from "../src/channels/kit/delivery.ts";
+import { runTask, taskFailure, TaskFailure, taskEffect } from "../src/channels/kit/tasks.ts";
+
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+it("requires a resource scope for an outbound pump", () => {
+  const pump = previewPump({ flush: async () => {}, throttleMs: 1, onError: () => {} });
+  // @ts-expect-error -- an outbound writer must have an owner
+  const unscoped: Effect.Effect<PreviewPump> = pump;
+  void unscoped;
+});
+
+it("starts the first placeholder synchronously at touch", async () => {
+  const flush = vi.fn(async () => {});
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const pump = yield* previewPump({ flush, throttleMs: 1, onError: () => {} });
+        pump.touch();
+        expect(flush).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+});
+
+it.each([false, true])("finish joins an issued frame and its outcome (reject=%s)", async (reject) => {
+  const entered = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const warning = vi.fn();
+  const flush = vi.fn(async () => {
+    entered.resolve();
+    await release.promise;
+  });
+  let finished = false;
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const pump = yield* previewPump({ flush, throttleMs: 60_000, onError: warning });
+        pump.touch();
+        yield* Effect.promise(() => entered.promise);
+        pump.touch();
+        const stop = yield* Effect.forkChild(
+          pump.finish.pipe(
+            Effect.tap(() =>
+              Effect.sync(() => {
+                finished = true;
+              }),
+            ),
+          ),
+        );
+        yield* Effect.promise(tick);
+        expect(finished).toBe(false);
+        if (reject) release.reject(new Error("late frame failure"));
+        else release.resolve();
+        yield* Fiber.join(stop);
+        expect(warning).toHaveBeenCalledTimes(reject ? 1 : 0);
+        pump.touch();
+        yield* Effect.promise(tick);
+        expect(flush).toHaveBeenCalledTimes(1);
+      }),
+    ),
+  );
+  expect(finished).toBe(true);
+});
+
+it("scope close cancels a mutation slot without issuing or leaking the pending frame", async () => {
+  const flush = vi.fn(async () => {});
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const clock = yield* Clock.Clock;
+      const sleep = vi.spyOn(clock, "sleep");
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const pump = yield* previewPump({
+            flush,
+            throttleMs: 0,
+            beforeFlush: Effect.sleep(60_000),
+            onError: () => {},
+          });
+          pump.touch();
+          yield* TestClock.adjust(59_999);
+          expect(sleep).toHaveBeenCalled();
+          expect(flush).not.toHaveBeenCalled();
+        }),
+      );
+      yield* TestClock.adjust(60_000);
+      expect(flush).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+it("a defective preview error callback remains visible at finish", async () => {
+  const error = new Error("diagnostic callback broke");
+  await expect(
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const pump = yield* previewPump({
+            flush: async () => {
+              throw new Error("frame failed");
+            },
+            throttleMs: 1,
+            onError: () => {
+              throw error;
+            },
+          });
+          pump.touch();
+          yield* Effect.promise(tick);
+          pump.touch(); // a later frame must not hide an earlier diagnostic defect
+          yield* pump.finish;
+        }),
+      ),
+    ),
+  ).rejects.toBe(error);
+});
+
+it("scope interruption drains accepted native writes in order before releasing", async () => {
+  const entered = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const abort = new AbortController();
+  const order: string[] = [];
+  const done = Effect.runPromiseExit(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const writer = yield* serialWriter();
+        writer.enqueue(async () => {
+          entered.resolve();
+          await release.promise;
+          order.push("append");
+        });
+        writer.enqueue(async () => {
+          order.push("clear");
+        });
+        yield* Effect.never;
+      }),
+    ),
+    { signal: abort.signal },
+  );
+  await entered.promise;
+  abort.abort();
+  await tick();
+  expect(order).toEqual([]);
+  release.resolve();
+  const exit = await done;
+  expect(order).toEqual(["append", "clear"]);
+  expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+});
+
+it("a failed writer surfaces its original cause, and closed admission fails visibly", async () => {
+  const error = new Error("append failed");
+  await expect(
+    runTask(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const writer = yield* serialWriter();
+          writer.enqueue(async () => {
+            throw error;
+          });
+          yield* writer.finish;
+        }),
+      ),
+    ),
+  ).rejects.toBe(error);
+  await runTask(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const writer = yield* serialWriter();
+        yield* writer.finish;
+        expect(() => writer.enqueue(async () => {})).toThrow("delivery writer is closed");
+      }),
+    ),
+  );
+});
+
+it.each(["source", "completed"] as const)(
+  "preserves a %s failure without duplicate terminal delivery",
+  async (phase) => {
+    const primary = new Error("primary failure");
+    const secondary = new Error("notice delivery failed");
+    const warning = vi.spyOn(console, "error").mockImplementation(() => {});
+    const settle = vi.fn(() =>
+      taskEffect(async () => {
+        throw phase === "source" ? secondary : primary;
+      }),
+    );
+    await expect(
+      runTask(
+        Effect.scoped(
+          renderReply(
+            phase === "source" ? Stream.fail(new TaskFailure(primary)) : Stream.succeed({ type: "completed" } as const),
+            {
+              label: "[test]",
+              finish: Effect.void,
+              onEvent: () => {},
+              answer: () => "answer",
+              formatError: () => "notice",
+              settle,
+            },
+          ),
+        ),
+      ),
+    ).rejects.toBe(primary);
+    expect(settle).toHaveBeenCalledOnce();
+    if (phase === "source") expect(warning).toHaveBeenCalledWith(expect.stringContaining(secondary.message));
+    warning.mockRestore();
+  },
+);
+
+it("source failure remains primary when writer cleanup also fails", async () => {
+  const primary = new Error("source failed");
+  const exit = await Effect.runPromiseExit(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const writer = yield* serialWriter();
+        writer.enqueue(async () => {
+          throw new Error("cleanup failed");
+        });
+        yield* Effect.fail(primary);
+      }),
+    ),
+  );
+  expect(Exit.isFailure(exit) && taskFailure(exit.cause)).toBe(primary);
+});

--- a/test/delivery.test.ts
+++ b/test/delivery.test.ts
@@ -7,7 +7,8 @@ import * as TestClock from "effect/testing/TestClock";
 import * as Stream from "effect/Stream";
 import { expect, it, vi } from "vitest";
 import { previewPump, serialWriter, renderReply, type PreviewPump } from "../src/channels/kit/delivery.ts";
-import { runTask, taskFailure, TaskFailure, taskEffect } from "../src/channels/kit/tasks.ts";
+import { taskFailure, TaskFailure, taskEffect } from "../src/channels/kit/tasks.ts";
+import { run } from "./channel-effects.ts";
 
 const tick = () => new Promise<void>((resolve) => setImmediate(resolve));
 
@@ -157,7 +158,7 @@ it("scope interruption drains accepted native writes in order before releasing",
 it("a failed writer surfaces its original cause, and closed admission fails visibly", async () => {
   const error = new Error("append failed");
   await expect(
-    runTask(
+    run(
       Effect.scoped(
         Effect.gen(function* () {
           const writer = yield* serialWriter();
@@ -169,7 +170,7 @@ it("a failed writer surfaces its original cause, and closed admission fails visi
       ),
     ),
   ).rejects.toBe(error);
-  await runTask(
+  await run(
     Effect.scoped(
       Effect.gen(function* () {
         const writer = yield* serialWriter();
@@ -192,7 +193,7 @@ it.each(["source", "completed"] as const)(
       }),
     );
     await expect(
-      runTask(
+      run(
         Effect.scoped(
           renderReply(
             phase === "source" ? Stream.fail(new TaskFailure(primary)) : Stream.succeed({ type: "completed" } as const),

--- a/test/feishu-preview.test.ts
+++ b/test/feishu-preview.test.ts
@@ -7,7 +7,8 @@ import {
   streamingCardJson,
 } from "../src/channels/feishu/card.ts";
 import type { FeishuApi } from "../src/channels/feishu/feishu-api.ts";
-import { streamFeishuReply } from "../src/channels/feishu/preview.ts";
+import { feishuReply } from "../src/channels/feishu/preview.ts";
+import { run, stream } from "./channel-effects.ts";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -110,12 +111,12 @@ describe("streaming card shape (pure)", () => {
   });
 });
 
-describe("streamFeishuReply two-element streaming (direct)", () => {
+describe("feishuReply two-element streaming (direct)", () => {
   it("process churn (sliding thinking tail, tool flips) never rewrites the answer element", async () => {
     vi.useFakeTimers();
     const { api, created, elementWrites, cardWrites } = fakeApi();
     const src = eventSource();
-    const turn = streamFeishuReply(src.iterable, api, { chatId: "oc_1" }, neutral);
+    const turn = run(feishuReply(stream(src.iterable), api, { chatId: "oc_1" }, neutral));
     await vi.advanceTimersByTimeAsync(0); // mount flush
     expect(created).toHaveLength(1);
 
@@ -185,7 +186,7 @@ describe("streamFeishuReply two-element streaming (direct)", () => {
     vi.useFakeTimers();
     const { api, created, elementWrites } = fakeApi();
     const src = eventSource();
-    const turn = streamFeishuReply(src.iterable, api, { chatId: "oc_1" }, neutral);
+    const turn = run(feishuReply(stream(src.iterable), api, { chatId: "oc_1" }, neutral));
     await vi.advanceTimersByTimeAsync(0); // mount flush — process seeded with the placeholder
     const mounted = JSON.parse(created[0] ?? "{}") as { body: { elements: { content: string }[] } };
     expect(mounted.body.elements[0]?.content).toBe("💭 Thinking…");
@@ -209,7 +210,7 @@ describe("streamFeishuReply two-element streaming (direct)", () => {
     vi.useFakeTimers();
     const { api, elementWrites } = fakeApi();
     const src = eventSource();
-    const turn = streamFeishuReply(src.iterable, api, { chatId: "oc_1" }, neutral);
+    const turn = run(feishuReply(stream(src.iterable), api, { chatId: "oc_1" }, neutral));
     await vi.advanceTimersByTimeAsync(0); // mount flush
     // 30 tool lines × ~60 points ≈ 1800 points — well past the 1000-point process budget.
     for (let i = 0; i < 30; i++) {
@@ -238,7 +239,7 @@ describe("streamFeishuReply two-element streaming (direct)", () => {
     vi.useFakeTimers();
     const { api, elementWrites } = fakeApi();
     const src = eventSource();
-    const turn = streamFeishuReply(src.iterable, api, { chatId: "oc_1" }, neutral);
+    const turn = run(feishuReply(stream(src.iterable), api, { chatId: "oc_1" }, neutral));
     await vi.advanceTimersByTimeAsync(0); // mount flush
     src.push({ type: "thinking", delta: "short" });
     await vi.advanceTimersByTimeAsync(1100);

--- a/test/invoke-turn-busy.test.ts
+++ b/test/invoke-turn-busy.test.ts
@@ -1,5 +1,7 @@
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import * as Exit from "effect/Exit";
+import * as Cause from "effect/Cause";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -7,8 +9,10 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Agent, type AgentEvent, SESSION_BUSY_CODE } from "../src/agent.ts";
-import { type BusyRetry, busyRetryStream, streamTurnWithBusyRetry } from "../src/channels/kit/invoke-turn-kit.ts";
-import { invokeTurn } from "../src/channels/telegram/invoke-turn.ts";
+import { type BusyRetry, busyRetryStream } from "../src/channels/kit/invoke-turn-kit.ts";
+import { telegramTurnStream } from "../src/channels/telegram/invoke-turn.ts";
+import type { TaskFailure } from "../src/channels/kit/tasks.ts";
+import { run as runEffect } from "./channel-effects.ts";
 import { log } from "../src/log.ts";
 
 /** A fake agent scripted per-invoke: call N yields script[N] (the last entry repeats). */
@@ -41,14 +45,10 @@ async function run(agent: Agent, retry: BusyRetry = FAST): Promise<AgentEvent[]>
     chatId: 1,
     filesDir: await mkdtemp(join(tmpdir(), "fa-")),
   };
-  return read(invokeTurn(agent, "s", "hi", transport, noAttachments, undefined, retry));
+  return read(telegramTurnStream(agent, "s", "hi", transport, noAttachments, undefined, retry));
 }
 
-async function read(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
-  const out: AgentEvent[] = [];
-  for await (const event of events) out.push(event);
-  return out;
-}
+const read = (events: Stream.Stream<AgentEvent, TaskFailure>) => runEffect(Stream.runCollect(events));
 
 afterEach(() => {
   vi.useRealTimers();
@@ -56,7 +56,7 @@ afterEach(() => {
 });
 
 const relay = (agent: Agent, onCompleted?: () => void, busyRetry = FAST) =>
-  streamTurnWithBusyRetry(agent, { session: "s" }, { text: "hi" }, { label: "[test]", onCompleted, busyRetry });
+  busyRetryStream(agent, { session: "s" }, { text: "hi" }, { label: "[test]", onCompleted, busyRetry });
 
 it("uses a virtual clock and closes the rejected attempt before its retry delay", async () => {
   const order: string[] = [];
@@ -97,24 +97,19 @@ it("uses a virtual clock and closes the rejected attempt before its retry delay"
 it("cancels an active backoff without another invoke or a leaked timer", async () => {
   vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
   const { agent, invokes } = scriptedAgent([[busyEvent]]);
-  const iterator = relay(agent, undefined, { delayMs: 60_000, maxWaitMs: 180_000 })[Symbol.asyncIterator]();
-  const pending = iterator.next();
+  const abort = new AbortController();
+  const done = Effect.runPromiseExit(
+    Stream.runDrain(relay(agent, undefined, { delayMs: 60_000, maxWaitMs: 180_000 })),
+    { signal: abort.signal },
+  );
   await new Promise<void>((resolve) => setImmediate(resolve));
   expect(vi.getTimerCount()).toBe(1);
-  let closed = false;
-  const closing = iterator.return?.().then(() => {
-    closed = true;
-  });
-  try {
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(closed).toBe(true);
-    expect(vi.getTimerCount()).toBe(0);
-    expect(invokes()).toBe(1);
-    expect(await pending).toMatchObject({ done: true });
-  } finally {
-    await vi.runAllTimersAsync();
-    await closing;
-  }
+  abort.abort();
+  const exit = await done;
+  expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+  expect(vi.getTimerCount()).toBe(0);
+  await vi.advanceTimersByTimeAsync(180_000);
+  expect(invokes()).toBe(1);
 });
 
 it("keeps source pulls and completion commits behind consumer demand", async () => {
@@ -125,15 +120,21 @@ it("keeps source pulls and completion commits behind consumer demand", async () 
     .mockResolvedValueOnce({ done: false, value: { type: "text", delta: "answer" } })
     .mockResolvedValueOnce({ done: false, value: { type: "completed" } });
   const agent: Agent = { invoke: () => ({ [Symbol.asyncIterator]: () => ({ next, return: close }) }) };
-  const iterator = relay(agent, onCompleted)[Symbol.asyncIterator]();
-  expect(next).not.toHaveBeenCalled();
-  expect((await iterator.next()).value).toEqual(ok[0]);
-  expect(next).toHaveBeenCalledTimes(1);
-  expect(onCompleted).not.toHaveBeenCalled();
-  expect((await iterator.next()).value).toEqual(ok[1]);
-  expect(onCompleted).toHaveBeenCalledTimes(1);
-  expect(close).not.toHaveBeenCalled();
-  await iterator.return?.();
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const pull = yield* Stream.toPull(relay(agent, onCompleted));
+        expect(next).not.toHaveBeenCalled();
+        expect(yield* pull).toEqual([ok[0]]);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(onCompleted).not.toHaveBeenCalled();
+        expect(yield* pull).toEqual([ok[1]]);
+        expect(onCompleted).toHaveBeenCalledTimes(1);
+        expect(close).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+
   expect(close).toHaveBeenCalledTimes(1);
 });
 
@@ -197,9 +198,22 @@ it("diagnoses source cleanup failure when a paused consumer cancels", async () =
     }),
   };
   const agent: Agent = { invoke: () => ({ [Symbol.asyncIterator]: () => source }) };
-  const iterator = relay(agent)[Symbol.asyncIterator]();
-  await iterator.next();
-  await iterator.return?.();
+  const pulled = Promise.withResolvers<void>();
+  const abort = new AbortController();
+  const done = Effect.runPromiseExit(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const pull = yield* Stream.toPull(relay(agent));
+        yield* pull;
+        pulled.resolve();
+        yield* Effect.never;
+      }),
+    ),
+    { signal: abort.signal },
+  );
+  await pulled.promise;
+  abort.abort();
+  await done;
   expect(source.return).toHaveBeenCalledTimes(1);
   expect(warn.mock.calls.flat().join(" ")).toContain("cancel cleanup broke");
 });
@@ -225,14 +239,14 @@ it("passes future events and extended scope through without reopening the retry 
     yield future;
     yield busyEvent;
   });
-  expect(await read(streamTurnWithBusyRetry({ invoke }, scope, { text: "hi" }, { label: "[test]" }))).toEqual([
+  expect(await read(busyRetryStream({ invoke }, scope, { text: "hi" }, { label: "[test]" }))).toEqual([
     future,
     busyEvent,
   ]);
   expect(invoke).toHaveBeenCalledExactlyOnceWith(scope, { text: "hi" });
 });
 
-describe("invokeTurn busy-wait (the reverse of the scheduler's wake defer)", () => {
+describe("telegramTurnStream busy-wait (the reverse of the scheduler's wake defer)", () => {
   it("a fail-fast busy reject retries (bounded) and the user gets the ANSWER, not an error", async () => {
     // Invoke 1: busy (an external wake turn holds the lease). Invoke 2: the lease freed — normal turn.
     const { agent, invokes } = scriptedAgent([[busyEvent], ok]);

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -67,6 +67,7 @@ describe("package boundary: embed entry stays free of CLI-only dependencies", ()
         "effect/Effect",
         "effect/Exit",
         "effect/Fiber",
+        "effect/Queue",
         "effect/Stream",
       ]);
       expect([...staticPackageGraph(entry)].filter((p) => p.startsWith("@earendil-works/"))).toEqual([]);

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
-import { streamReply } from "../src/channels/telegram/preview.ts";
+import { telegramReply } from "../src/channels/telegram/preview.ts";
+import { run, stream } from "./channel-effects.ts";
 
 const API = "http://tg.test";
 
@@ -10,7 +11,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** A push-based event source, so a test controls exactly WHEN each event reaches streamReply. */
+/** A push-based event source, so a test controls exactly WHEN each event reaches telegramReply. */
 const eventSource = () => {
   const queue: AgentEvent[] = [];
   let notify: (() => void) | undefined;
@@ -66,7 +67,7 @@ async function* events(...list: AgentEvent[]): AsyncIterable<AgentEvent> {
 
 const neutral = (): string => "⚠️ neutral";
 
-describe("streamReply single-writer pump (direct)", () => {
+describe("telegramReply single-writer pump (direct)", () => {
   it("one edit in flight; frames coalesce to the LATEST view — no stale or out-of-order frame", async () => {
     vi.useFakeTimers();
     let inFlight = 0;
@@ -91,7 +92,7 @@ describe("streamReply single-writer pump (direct)", () => {
       }),
     );
     const src = eventSource();
-    const turn = streamReply(src.iterable, API, "BOT", { chatId: 1 }, neutral);
+    const turn = run(telegramReply(stream(src.iterable), API, "BOT", { chatId: 1 }, neutral));
     const first = "ab";
     await vi.advanceTimersByTimeAsync(0); // placeholder sent
     src.push({ type: "text", delta: "a" });
@@ -115,15 +116,17 @@ describe("streamReply single-writer pump (direct)", () => {
   });
 });
 
-describe("streamReply answer preview (direct)", () => {
+describe("telegramReply answer preview (direct)", () => {
   it("does not stream an answer before one preview interval has elapsed", async () => {
     const { sends, edits } = recordingFetch();
-    await streamReply(
-      events({ type: "text", delta: "OK." }, { type: "completed" }),
-      API,
-      "BOT",
-      { chatId: 1 },
-      neutral,
+    await run(
+      telegramReply(
+        stream(events({ type: "text", delta: "OK." }, { type: "completed" })),
+        API,
+        "BOT",
+        { chatId: 1 },
+        neutral,
+      ),
     );
     expect(sends).toEqual(["💭 Thinking…"]);
     expect(edits).toEqual(["OK."]);
@@ -133,7 +136,7 @@ describe("streamReply answer preview (direct)", () => {
     vi.useFakeTimers();
     const { edits } = recordingFetch();
     const src = eventSource();
-    const turn = streamReply(src.iterable, API, "BOT", { chatId: 1 }, neutral);
+    const turn = run(telegramReply(stream(src.iterable), API, "BOT", { chatId: 1 }, neutral));
     await vi.advanceTimersByTimeAsync(0); // placeholder sent
     src.push({ type: "text", delta: "a" });
     await vi.advanceTimersByTimeAsync(1499);
@@ -168,7 +171,7 @@ describe("streamReply answer preview (direct)", () => {
       }),
     );
     const src = eventSource();
-    const turn = streamReply(src.iterable, API, "BOT", { chatId: 1 }, neutral);
+    const turn = run(telegramReply(stream(src.iterable), API, "BOT", { chatId: 1 }, neutral));
     await vi.advanceTimersByTimeAsync(0); // placeholder sent
     src.push({ type: "thinking", delta: "checking" });
     await vi.advanceTimersByTimeAsync(0); // first edit is now in flight
@@ -187,7 +190,7 @@ describe("streamReply answer preview (direct)", () => {
     vi.useFakeTimers();
     const { edits } = recordingFetch();
     const src = eventSource();
-    const turn = streamReply(src.iterable, API, "BOT", { chatId: 1 }, neutral);
+    const turn = run(telegramReply(stream(src.iterable), API, "BOT", { chatId: 1 }, neutral));
     await vi.advanceTimersByTimeAsync(0); // placeholder sent
     src.push({ type: "retrying", attempt: 1, maxAttempts: 3, delayMs: 2000, reason: "503 upstream" });
     await vi.advanceTimersByTimeAsync(0);
@@ -204,7 +207,7 @@ describe("streamReply answer preview (direct)", () => {
     vi.useFakeTimers();
     const { edits } = recordingFetch();
     const src = eventSource();
-    const turn = streamReply(src.iterable, API, "BOT", { chatId: 1 }, neutral);
+    const turn = run(telegramReply(stream(src.iterable), API, "BOT", { chatId: 1 }, neutral));
     await vi.advanceTimersByTimeAsync(0); // placeholder sent
     src.push({ type: "text", delta: "a" });
     await vi.advanceTimersByTimeAsync(0);
@@ -218,15 +221,17 @@ describe("streamReply answer preview (direct)", () => {
   });
 });
 
-describe("streamReply terminal writes (direct)", () => {
+describe("telegramReply terminal writes (direct)", () => {
   it("completed → the preview message is edited into the final answer", async () => {
     const { sends, edits } = recordingFetch();
-    await streamReply(
-      events({ type: "text", delta: "the answer" }, { type: "completed" }),
-      API,
-      "BOT",
-      { chatId: 1 },
-      neutral,
+    await run(
+      telegramReply(
+        stream(events({ type: "text", delta: "the answer" }, { type: "completed" })),
+        API,
+        "BOT",
+        { chatId: 1 },
+        neutral,
+      ),
     );
     expect(sends.length).toBe(1); // ONE preview message, never a second
     expect(edits.at(-1)).toBe("the answer"); // …edited into the answer in place
@@ -235,7 +240,15 @@ describe("streamReply terminal writes (direct)", () => {
   it("failed → the onError text is delivered and the failure is rethrown for the operator log", async () => {
     const { edits } = recordingFetch();
     await expect(
-      streamReply(events({ type: "failed", details: "boom", retryable: true }), API, "BOT", { chatId: 1 }, neutral),
+      run(
+        telegramReply(
+          stream(events({ type: "failed", details: "boom", retryable: true })),
+          API,
+          "BOT",
+          { chatId: 1 },
+          neutral,
+        ),
+      ),
     ).rejects.toThrow(/agent failed: boom/);
     expect(edits.at(-1)).toBe("⚠️ neutral"); // the user was told, in the same message
   });
@@ -243,20 +256,22 @@ describe("streamReply terminal writes (direct)", () => {
   it("a stream that ends without a terminal event delivers the neutral notice and throws (SPEC MUST 1)", async () => {
     const { sends, edits } = recordingFetch();
     await expect(
-      streamReply(events({ type: "text", delta: "partial…" }), API, "BOT", { chatId: 1 }, neutral),
+      run(telegramReply(stream(events({ type: "text", delta: "partial…" })), API, "BOT", { chatId: 1 }, neutral)),
     ).rejects.toThrow(/stream ended without a terminal event/);
     expect([...sends, ...edits]).toContain("⚠️ neutral"); // not silence, not a silent delete of partial work
   });
 
   it("takes over a pre-sent message id (the ⏳ notice) instead of sending its own placeholder", async () => {
     const { sends, edits } = recordingFetch();
-    await streamReply(
-      events({ type: "text", delta: "answer" }, { type: "completed" }),
-      API,
-      "BOT",
-      { chatId: 1 },
-      neutral,
-      77, // an existing message to morph
+    await run(
+      telegramReply(
+        stream(events({ type: "text", delta: "answer" }, { type: "completed" })),
+        API,
+        "BOT",
+        { chatId: 1 },
+        neutral,
+        77, // an existing message to morph
+      ),
     );
     expect(sends.length).toBe(0); // no second placeholder
     expect(edits.at(-1)).toBe("answer"); // the notice morphed into the answer

--- a/test/slack-invoke-turn.test.ts
+++ b/test/slack-invoke-turn.test.ts
@@ -4,7 +4,8 @@ import * as Stream from "effect/Stream";
 import * as Exit from "effect/Exit";
 import * as Cause from "effect/Cause";
 import type { Agent, AgentEvent, Prompt } from "../src/agent.ts";
-import { invokeSlackTurn, slackTurnStream } from "../src/channels/slack/invoke-turn.ts";
+import { slackTurnStream } from "../src/channels/slack/invoke-turn.ts";
+import { run } from "./channel-effects.ts";
 import { type SlackApi, SlackApiError } from "../src/channels/slack/slack-api.ts";
 
 function fakeApi(overrides: Partial<SlackApi> = {}): SlackApi {
@@ -34,12 +35,6 @@ function fakeApi(overrides: Partial<SlackApi> = {}): SlackApi {
     uploadFile: async () => ({ id: "F1", name: "x" }),
     ...overrides,
   };
-}
-
-async function collect(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
-  const out: AgentEvent[] = [];
-  for await (const event of events) out.push(event);
-  return out;
 }
 
 describe("Slack turn attachment resolution", () => {
@@ -99,14 +94,16 @@ describe("Slack turn attachment resolution", () => {
     });
     const completed = vi.fn();
 
-    const events = await collect(
-      invokeSlackTurn(
-        agent,
-        "s1",
-        "read these",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
-        { primaryFileIds: ["IMG", "DOC"], buffered: { files: [], skipped: 0 } },
-        completed,
+    const events = await run(
+      Stream.runCollect(
+        slackTurnStream(
+          agent,
+          "s1",
+          "read these",
+          { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+          { primaryFileIds: ["IMG", "DOC"], buffered: { files: [], skipped: 0 } },
+          completed,
+        ),
       ),
     );
 
@@ -121,13 +118,15 @@ describe("Slack turn attachment resolution", () => {
     const agent = { invoke } as unknown as Agent;
     const api = fakeApi({ fileInfo: async () => Promise.reject(new Error("access_denied")) });
 
-    const events = await collect(
-      invokeSlackTurn(
-        agent,
-        "s1",
-        "read it",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
-        { primaryFileIds: ["F1"], buffered: { files: [], skipped: 0 } },
+    const events = await run(
+      Stream.runCollect(
+        slackTurnStream(
+          agent,
+          "s1",
+          "read it",
+          { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+          { primaryFileIds: ["F1"], buffered: { files: [], skipped: 0 } },
+        ),
       ),
     );
 
@@ -145,13 +144,15 @@ describe("Slack turn attachment resolution", () => {
       fileInfo: async () => Promise.reject(new SlackApiError("files.info", status, "boom")),
     });
 
-    const events = await collect(
-      invokeSlackTurn(
-        { invoke: vi.fn() } as unknown as Agent,
-        "s1",
-        "read it",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
-        { primaryFileIds: ["F1"], buffered: { files: [], skipped: 0 } },
+    const events = await run(
+      Stream.runCollect(
+        slackTurnStream(
+          { invoke: vi.fn() } as unknown as Agent,
+          "s1",
+          "read it",
+          { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+          { primaryFileIds: ["F1"], buffered: { files: [], skipped: 0 } },
+        ),
       ),
     );
 
@@ -173,22 +174,24 @@ describe("Slack turn attachment resolution", () => {
       },
     });
 
-    await collect(
-      invokeSlackTurn(
-        agent,
-        "s1",
-        "answer",
-        { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
-        {
-          primaryFileIds: [],
-          buffered: {
-            files: [
-              { id: "OK", from: "user U1", messageId: "1.0" },
-              { id: "GONE", from: "user U2", messageId: "2.0" },
-            ],
-            skipped: 1,
+    await run(
+      Stream.runDrain(
+        slackTurnStream(
+          agent,
+          "s1",
+          "answer",
+          { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+          {
+            primaryFileIds: [],
+            buffered: {
+              files: [
+                { id: "OK", from: "user U1", messageId: "1.0" },
+                { id: "GONE", from: "user U2", messageId: "2.0" },
+              ],
+              skipped: 1,
+            },
           },
-        },
+        ),
       ),
     );
 

--- a/test/slack-invoke-turn.test.ts
+++ b/test/slack-invoke-turn.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as Exit from "effect/Exit";
+import * as Cause from "effect/Cause";
 import type { Agent, AgentEvent, Prompt } from "../src/agent.ts";
-import { invokeSlackTurn } from "../src/channels/slack/invoke-turn.ts";
+import { invokeSlackTurn, slackTurnStream } from "../src/channels/slack/invoke-turn.ts";
 import { type SlackApi, SlackApiError } from "../src/channels/slack/slack-api.ts";
 
 function fakeApi(overrides: Partial<SlackApi> = {}): SlackApi {
@@ -39,6 +43,49 @@ async function collect(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]>
 }
 
 describe("Slack turn attachment resolution", () => {
+  it.each([false, true])("cancellation joins input loading without starting the model (reject=%s)", async (reject) => {
+    const entered = Promise.withResolvers<void>();
+    const loaded = Promise.withResolvers<void>();
+    const abort = new AbortController();
+    const invoke = vi.fn();
+    const api = fakeApi({
+      fileInfo: async (id) => {
+        entered.resolve();
+        await loaded.promise;
+        return { id, mimetype: "text/plain", name: "file.txt" };
+      },
+    });
+    let released = false;
+    const done = Effect.runPromiseExit(
+      Stream.runDrain(
+        slackTurnStream(
+          { invoke },
+          "s",
+          "read it",
+          { api, channelId: "C1", filesDir: "/state", label: "[slack]" },
+          { primaryFileIds: ["F1"], buffered: { files: [], skipped: 0 } },
+        ),
+      ).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            released = true;
+          }),
+        ),
+      ),
+      { signal: abort.signal },
+    );
+    await entered.promise;
+    abort.abort();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(released).toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
+    if (reject) loaded.reject(new Error("late attachment failure"));
+    else loaded.resolve();
+    const exit = await done;
+    expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+    expect(released).toBe(true);
+    expect(invoke).not.toHaveBeenCalled();
+  });
   it("turns primary images into vision input and ordinary files into an absolute-path manifest", async () => {
     let prompt: Prompt | undefined;
     const agent: Agent = {

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
-import { sanitizeSlackMarkdown, slackReply, streamSlackReply } from "../src/channels/slack/preview.ts";
+import { sanitizeSlackMarkdown, slackReply } from "../src/channels/slack/preview.ts";
+import { run, stream } from "./channel-effects.ts";
 import * as Effect from "effect/Effect";
 import * as Clock from "effect/Clock";
 import * as Fiber from "effect/Fiber";
@@ -52,9 +53,11 @@ describe("Slack reply rendering", () => {
       yield { type: "failed", details: "model failed", retryable: false };
     })();
     await expect(
-      streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => {
-        throw new Error("formatter failed");
-      }),
+      run(
+        slackReply(stream(events), api, { channelId: "D1", threadTs: "1.0" }, () => {
+          throw new Error("formatter failed");
+        }),
+      ),
     ).rejects.toThrow("agent failed: model failed");
     expect(api.startStream).toHaveBeenCalledOnce();
     expect(api.stopStream).toHaveBeenCalledOnce();
@@ -68,7 +71,7 @@ describe("Slack reply rendering", () => {
     const error = new Error("stop response was lost");
     vi.mocked(api.stopStream).mockRejectedValue(error);
     await expect(
-      streamSlackReply(quickClassicTurn(), api, { channelId: "D1", threadTs: "1.0" }, () => "failed"),
+      run(slackReply(stream(quickClassicTurn()), api, { channelId: "D1", threadTs: "1.0" }, () => "failed")),
     ).rejects.toBe(error);
     expect(api.stopStream).toHaveBeenCalledOnce();
   });
@@ -79,10 +82,12 @@ describe("Slack reply rendering", () => {
     );
     const warn = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    await streamSlackReply(quickClassicTurn(), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
-      rendering: "native",
-      disclaimer: false,
-    });
+    await run(
+      slackReply(stream(quickClassicTurn()), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+        rendering: "native",
+        disclaimer: false,
+      }),
+    );
 
     expect(api.sendMarkdown).toHaveBeenCalledWith({ channelId: "D1", threadTs: "1.0" }, "**answer**");
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("native Slack stream was unavailable"));
@@ -95,10 +100,12 @@ describe("Slack reply rendering", () => {
     );
 
     await expect(
-      streamSlackReply(quickClassicTurn(), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
-        rendering: "native",
-        disclaimer: false,
-      }),
+      run(
+        slackReply(stream(quickClassicTurn()), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+          rendering: "native",
+          disclaimer: false,
+        }),
+      ),
     ).rejects.toThrow(/connection reset/);
     expect(api.sendMarkdown).not.toHaveBeenCalled();
   });
@@ -106,10 +113,12 @@ describe("Slack reply rendering", () => {
   it("enforces Slack's three-second chat.update interval across a completed pump", async () => {
     vi.useFakeTimers();
     const api = fakeApi();
-    const pending = streamSlackReply(quickClassicTurn(), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
-      rendering: "classic",
-      disclaimer: false,
-    });
+    const pending = run(
+      slackReply(stream(quickClassicTurn()), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+        rendering: "classic",
+        disclaimer: false,
+      }),
+    );
 
     await vi.advanceTimersByTimeAsync(2_999);
     expect(api.postMarkdown).toHaveBeenCalledWith({ channelId: "D1", threadTs: "1.0" }, "💭 Thinking…");
@@ -180,10 +189,12 @@ describe("native Slack tool traces", () => {
       yield { type: "completed" };
     })();
 
-    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
-      rendering: "native",
-      disclaimer: false,
-    });
+    await run(
+      slackReply(stream(events), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+        rendering: "native",
+        disclaimer: false,
+      }),
+    );
 
     const invocation = vi.mocked(api.startStream).mock.calls[0]?.[1] ?? "";
     expect(invocation).toContain("**Bash** — `npm test &lt;!channel>");
@@ -207,10 +218,12 @@ describe("native Slack tool traces", () => {
       yield { type: "completed" };
     })();
 
-    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
-      rendering: "native",
-      disclaimer: false,
-    });
+    await run(
+      slackReply(stream(events), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+        rendering: "native",
+        disclaimer: false,
+      }),
+    );
 
     const written = [
       vi.mocked(api.startStream).mock.calls[0]?.[1] ?? "",
@@ -228,10 +241,12 @@ describe("native Slack tool traces", () => {
       yield { type: "completed" };
     })();
 
-    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
-      rendering: "native",
-      disclaimer: false,
-    });
+    await run(
+      slackReply(stream(events), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+        rendering: "native",
+        disclaimer: false,
+      }),
+    );
 
     const written = [
       vi.mocked(api.startStream).mock.calls[0]?.[1] ?? "",
@@ -252,10 +267,12 @@ describe("native Slack tool traces", () => {
       yield { type: "completed" };
     })();
 
-    await streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
-      rendering: "native",
-      disclaimer: false,
-    });
+    await run(
+      slackReply(stream(events), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+        rendering: "native",
+        disclaimer: false,
+      }),
+    );
 
     expect(vi.mocked(api.startStream).mock.calls[0]?.[1]).toContain("**Deploy** — `sk-live-secret`");
   });
@@ -297,10 +314,12 @@ describe("native DM Agent status around a retry backoff", () => {
     const statuses = () => vi.mocked(api.setThreadStatus).mock.calls.map((c) => c[1]);
 
     const src = eventSource();
-    const turn = streamSlackReply(src.iterable, api, { channelId: "D1", threadTs: "1.0" }, () => undefined, {
-      rendering: "native",
-      disclaimer: false,
-    });
+    const turn = run(
+      slackReply(stream(src.iterable), api, { channelId: "D1", threadTs: "1.0" }, () => undefined, {
+        rendering: "native",
+        disclaimer: false,
+      }),
+    );
     await flush();
     gates.shift()?.(); // initial "is working…" status (awaited before the loop)
     await flush();

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "../src/agent.ts";
-import { sanitizeSlackMarkdown, streamSlackReply } from "../src/channels/slack/preview.ts";
+import { sanitizeSlackMarkdown, slackReply, streamSlackReply } from "../src/channels/slack/preview.ts";
+import * as Effect from "effect/Effect";
+import * as Clock from "effect/Clock";
+import * as Fiber from "effect/Fiber";
+import * as Queue from "effect/Queue";
+import type * as Cause from "effect/Cause";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { type SlackApi, SlackApiError } from "../src/channels/slack/slack-api.ts";
 
 function fakeApi(): SlackApi {
@@ -37,6 +44,34 @@ afterEach(() => {
 });
 
 describe("Slack reply rendering", () => {
+  it("closes an acquired native stream when the failure formatter throws", async () => {
+    const api = fakeApi();
+    const warning = vi.spyOn(console, "error").mockImplementation(() => {});
+    const events = (async function* (): AsyncIterable<AgentEvent> {
+      yield { type: "tool_started", id: "t", name: "read", args: {} };
+      yield { type: "failed", details: "model failed", retryable: false };
+    })();
+    await expect(
+      streamSlackReply(events, api, { channelId: "D1", threadTs: "1.0" }, () => {
+        throw new Error("formatter failed");
+      }),
+    ).rejects.toThrow("agent failed: model failed");
+    expect(api.startStream).toHaveBeenCalledOnce();
+    expect(api.stopStream).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("formatter failed"));
+    expect(vi.mocked(api.setThreadStatus).mock.calls.at(-1)?.[1]).toBe("");
+    warning.mockRestore();
+  });
+
+  it("does not retry an ambiguously failed native stop during scope cleanup", async () => {
+    const api = fakeApi();
+    const error = new Error("stop response was lost");
+    vi.mocked(api.stopStream).mockRejectedValue(error);
+    await expect(
+      streamSlackReply(quickClassicTurn(), api, { channelId: "D1", threadTs: "1.0" }, () => "failed"),
+    ).rejects.toBe(error);
+    expect(api.stopStream).toHaveBeenCalledOnce();
+  });
   it("falls back visibly to one compatibility reply when a native stream cannot start", async () => {
     const api = fakeApi();
     vi.mocked(api.startStream).mockRejectedValueOnce(
@@ -85,6 +120,44 @@ describe("Slack reply rendering", () => {
     expect(api.updateMarkdown).toHaveBeenCalledWith("D1", "1.0", "**answer**");
     expect(JSON.stringify(vi.mocked(api.postMarkdown).mock.calls)).not.toContain("private reasoning");
   });
+});
+
+it("uses the turn clock for append pacing and preserves split mention sanitization", async () => {
+  const api = fakeApi();
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* TestClock.setTime(10_000);
+      const clock = yield* Clock.Clock;
+      const sleep = vi.spyOn(clock, "sleep");
+      const queue = yield* Queue.unbounded<AgentEvent, Cause.Done>();
+      const turn = yield* Effect.forkChild(
+        Effect.scoped(
+          slackReply(Stream.fromQueue(queue), api, { channelId: "C1", threadTs: "1.0" }, () => "failure", {
+            disclaimer: false,
+          }),
+        ),
+      );
+      yield* Queue.offer(queue, { type: "text", delta: "ping <" });
+      yield* TestClock.adjust(0);
+      expect(sleep).toHaveBeenCalled();
+      yield* Effect.promise(() =>
+        vi.waitFor(() => expect(api.startStream).toHaveBeenCalledWith({ channelId: "C1", threadTs: "1.0" }, "ping ")),
+      );
+      yield* Queue.offer(queue, { type: "text", delta: "!channel> done" });
+      yield* TestClock.adjust(749);
+      expect(api.appendStream).not.toHaveBeenCalled();
+      yield* TestClock.adjust(1);
+      yield* Effect.promise(() =>
+        vi.waitFor(() => expect(api.appendStream).toHaveBeenCalledWith("C1", "1.0", "&lt;!channel> done")),
+      );
+      yield* Queue.offer(queue, { type: "completed" });
+      yield* Queue.end(queue);
+      yield* Fiber.join(turn);
+      yield* TestClock.adjust(60_000);
+      expect(api.appendStream).toHaveBeenCalledOnce();
+      expect(api.stopStream).toHaveBeenCalledOnce();
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
 });
 
 describe("native Slack tool traces", () => {
@@ -235,7 +308,7 @@ describe("native DM Agent status around a retry backoff", () => {
     src.push({ type: "text", delta: "a" });
     src.push({ type: "retrying", attempt: 1, maxAttempts: 4, delayMs: 2_000, reason: "503" });
     await flush();
-    expect(statuses().at(-1)).toContain("retrying");
+    await vi.waitFor(() => expect(statuses().at(-1)).toContain("retrying"));
 
     // Progress while the retry-status write is still in flight: the restore must QUEUE behind it,
     // not race it — otherwise the stale "retrying" line could land last.
@@ -244,13 +317,14 @@ describe("native DM Agent status around a retry backoff", () => {
     expect(statuses()).toHaveLength(2);
     gates.shift()?.(); // retry status delivered
     await flush();
-    expect(statuses()).toHaveLength(3);
+    await vi.waitFor(() => expect(statuses()).toHaveLength(3));
     expect(statuses().at(-1)).toBe("is working on your request…");
 
     src.push({ type: "completed" });
     src.end();
     gates.shift()?.(); // restore delivered
     await flush();
+    await vi.waitFor(() => expect(statuses().at(-1)).toBe(""));
     gates.shift()?.(); // final clear delivered
     await turn;
     expect(statuses().at(-1)).toBe(""); // the clear is last, after every queued write

--- a/test/turn-runner.test.ts
+++ b/test/turn-runner.test.ts
@@ -10,6 +10,7 @@ import { type ContextBuffer, createContextBuffer } from "../src/channels/kit/con
 import { createTurnRunner, runQueuedTurn, type TurnRunnerOptions } from "../src/channels/kit/turn-runner.ts";
 import { type TurnRecordBase, type TurnStore, createTurnStore } from "../src/channels/kit/turn-store.ts";
 import { createTurnQueue } from "../src/channels/kit/turn-queue.ts";
+import { taskEffect } from "../src/channels/kit/tasks.ts";
 import { activeWork } from "../src/channels/busy.ts";
 import * as atomic from "../src/atomic-write.ts";
 import { log } from "../src/log.ts";
@@ -70,10 +71,11 @@ function runnerOptions(
     where: (rec) => `session=${rec.session}`,
     onDeferred: (rec) => calls.push(`deferred ${rec.id}`),
     notifyDropped: (rec) => calls.push(`dropped ${rec.id}`),
-    execute: async (rec, discussion, onCompleted) => {
-      calls.push(`execute ${rec.id} notice=${rec.notice ?? "-"} text=${discussion.text}`);
-      onCompleted();
-    },
+    execute: (rec, discussion, onCompleted) =>
+      taskEffect(async () => {
+        calls.push(`execute ${rec.id} notice=${rec.notice ?? "-"} text=${discussion.text}`);
+        onCompleted();
+      }),
     ...overrides,
   };
 }
@@ -119,6 +121,7 @@ describe("turn runner: the lifecycle order every chat channel shares", () => {
         "-e",
         `
       import { createTurnRunner } from ${JSON.stringify(`${source}turn-runner.ts`)};
+      import { taskEffect } from ${JSON.stringify(`${source}tasks.ts`)};
       import { createTurnStore } from ${JSON.stringify(`${source}turn-store.ts`)};
       import { createContextBuffer } from ${JSON.stringify(`${source}context-buffer.ts`)};
       const root = ${JSON.stringify(dir)};
@@ -128,7 +131,7 @@ describe("turn runner: the lifecycle order every chat channel shares", () => {
       const runner = createTurnRunner({
         label: '[child]', store, buffer, toStored: r => ({ ...r, attempts: 0 }), fromStored: r => r,
         bufferKey: () => 'place:s', where: () => 'child', onDeferred: () => {}, notifyDropped: () => {},
-        execute: async (_rec, _discussion, onCompleted) => {
+        execute: (_rec, _discussion, onCompleted) => taskEffect(async () => {
           process.on('message', () => {
             onCompleted();
             buffer.push('place:s', 'later');
@@ -136,7 +139,7 @@ describe("turn runner: the lifecycle order every chat channel shares", () => {
           });
           process.send('running');
           await new Promise(() => {});
-        },
+        }),
       });
       runner.submit({ id: 'a', session: 's', text: '' }, true);
     `,
@@ -179,12 +182,13 @@ describe("turn runner: the lifecycle order every chat channel shares", () => {
     const { store, calls } = fakeStore();
     const r = runner(store, calls, {
       onQueuedBehind: () => ({ done: Promise.reject(new Error("notice rejected before dequeue")) }),
-      execute: async (rec) => {
-        if (rec.id === "a") {
-          entered.resolve();
-          await head.promise;
-        }
-      },
+      execute: (rec) =>
+        taskEffect(async () => {
+          if (rec.id === "a") {
+            entered.resolve();
+            await head.promise;
+          }
+        }),
     });
     r.submit({ id: "a", session: "s", text: "" }, true);
     r.submit({ id: "b", session: "s", text: "" }, true);
@@ -242,12 +246,13 @@ describe("turn runner: the lifecycle order every chat channel shares", () => {
       let running!: Fiber.Fiber<unknown, unknown>;
       const opts = runnerOptions(store, [], {
         buffer,
-        execute: async (_rec, discussion, onCompleted) => {
-          expect(discussion.consumed).toEqual(["earlier"]);
-          if (completed) onCompleted();
-          entered.resolve();
-          await finish.promise;
-        },
+        execute: (_rec, discussion, onCompleted) =>
+          taskEffect(async () => {
+            expect(discussion.consumed).toEqual(["earlier"]);
+            if (completed) onCompleted();
+            entered.resolve();
+            await finish.promise;
+          }),
       });
       const base = activeWork();
       const queue = createTurnQueue<Pending>({
@@ -386,10 +391,11 @@ describe("turn runner: the lifecycle order every chat channel shares", () => {
     const { store, calls, recovered } = fakeStore();
     recovered.push({ id: "r", session: "s", text: "again", attempts: 1 });
     const r = runner(store, calls, {
-      execute: async (rec) => {
-        calls.push(`execute ${rec.id}`);
-        throw new Error("transport down");
-      },
+      execute: (rec) =>
+        taskEffect(async () => {
+          calls.push(`execute ${rec.id}`);
+          throw new Error("transport down");
+        }),
     });
     expect(r.recover()).toHaveLength(1);
     await r.idle();


### PR DESCRIPTION
## Summary

- Run attachment loading, Agent consumption, preview updates, terminal delivery, and Slack reaction cleanup under the turn's Effect scope. Public Promise/AsyncIterable and channel-authoring contracts stay unchanged.
- Start previews synchronously, coalesce frames, cancel pending pacing, and join issued writes before final delivery. Keep native appends ordered and clear Slack status after stream cleanup.
- Close acquired native streams when error formatting fails without retrying an already-attempted stop. Diagnose failed notices while preserving the primary failure.
- Compose internal Effect streams directly. Tests exercise the production renderers and cancellation mechanisms without platform-specific Promise or outgoing AsyncIterable adapters.
- Preserve pre-ACK persistence, FIFO, completed-event commit ordering, source backpressure, durable recovery, and platform-specific retry/fallback/continuation policies. Shutdown remains non-draining.

## Validation

- Lint, typecheck, build, and **1,791 tests / 123 files** pass.
- Node **22.19.0** and **24.20.0**: **346 focused tests / 14 files** pass on each.
- Real runner + Pi SDK cancellation, late preview acquisition, final-write ordering, virtual clocks, SIGTERM/disk recovery, package boundaries, fault injection, and compiler-negative checks pass. The linked report distinguishes freshly rerun fault checks from earlier evidence.

## Measured cost

Fresh measurements of `cbe91fa5` against `4fb9dad6` pass all preregistered budgets:

| Increment | Measured maximum | Budget |
| --- | ---: | ---: |
| Channel cold import | +1.334 ms | +20 ms |
| Import retained heap | +0.028 MiB | +5 MiB |
| Warm measured operation | +0.093 ms | +2 ms |
| 1,000-event rendering | +1.946 ms | +50 ms |

Implementation grows **137 non-comment lines** (3,023 → 3,160 in the fixed accounting set). This is an ownership/type-safety tradeoff; budget compliance alone does not establish maintenance value. Ordinary TypeScript can implement the concrete guarantees too. Measurements use compiled artifacts and mocked network ports; production reliability and live-platform performance remain unmeasured.

[Current verification, methodology, and reproduction](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5580608766) · [Raw samples](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5580608247) · [Preregistered budgets](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5579188395)

Refs #480.
