### PR TITLE
refactor(schedule): own timer loops and claimed turns with Effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,8 @@ src/
 │   ├── schedule.ts         # defineSchedule({ cron, tz?, prompt }) authoring surface + types (no session field — it's runtime-derived)
 │   ├── cron.ts             # the one place touching `croner` (zero-dep, IANA tz/DST): nextRun + cronError
 │   ├── discover.ts         # schedules/ filesystem discovery (loadSchedules/discoverScheduleFiles), isolates a bad file (G2)
-│   ├── scheduler.ts        # lifecycle + fire algorithm (overdue catch-up ONCE, claim-before-invoke) + stable per-schedule session + wake-up poll
+│   ├── scheduler.ts        # Effect clock loops + typed claim/run/audit; stop cancels waits, claimed turns finish;
+│   │                      # overdue catch-up ONCE, stable schedule sessions, wake busy ownership through durable settlement
 │   ├── wakeups.ts          # the agent's self-scheduled wake-ups, one-shot + recurring (2nd producer): engine-neutral store + guardrails (min delay/gap, cap, claim/defer)
 │   ├── audit.ts            # runs.jsonl append-only run audit (full reply) + `schedule history` reader — "did last night's run silently fail?"
 │   ├── wake-alarm.ts       # the wake-up's EXTERNAL-clock form: on a scale-to-zero host nothing is resident to

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -637,14 +637,15 @@ Static schedules are `schedules/<name>.ts` files exporting `{ cron, tz?, prompt 
 The resident scheduler owns one Effect loop per cron and one sequential wake loop. Their waits use
 the captured Effect clock; Croner still computes calendar instants, with capped waits rechecking wall
 time. Internal scheduler construction and the shared fire operation compose Effects directly; service
-and AgentCore callbacks retain ordinary TypeScript/Promise APIs. Claim IO failures are typed: the
+and AgentCore callbacks retain ordinary TypeScript/Promise APIs. Cron claim IO failures are typed: the
 resident loop logs and audits a skipped fire, while external slot delivery receives the original error.
 
 `stop()` interrupts pending waits synchronously without draining or canceling a claimed occurrence.
-That occurrence finishes execution and durable settlement before its loop exits; no next wake is
+That occurrence finishes execution and settlement handling before its loop exits; no next wake is
 claimed. Waiting loops do not count as business work. Wake execution keeps its busy ownership through
 one-shot deferral and audit, so the idle notification observes settled state. Boot-time cron-state
-read failures still fail startup synchronously.
+read failures still fail startup synchronously. Wake claim/deferral errors end the current poll and
+are logged before pending stop interruption resumes.
 
 With `selfSchedule: true`, the serving path mounts `wake`/`unwake`. Wake-ups are persisted, bounded by
 minimum delay/frequency and per-session count, and fired back into the originating session. A one-shot

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -634,6 +634,18 @@ Static schedules are `schedules/<name>.ts` files exporting `{ cron, tz?, prompt 
 - records each run in `<stateRoot>/schedule/runs.jsonl`;
 - leaves delivery to agent tools.
 
+The resident scheduler owns one Effect loop per cron and one sequential wake loop. Their waits use
+the captured Effect clock; Croner still computes calendar instants, with capped waits rechecking wall
+time. Internal scheduler construction and the shared fire operation compose Effects directly; service
+and AgentCore callbacks retain ordinary TypeScript/Promise APIs. Claim IO failures are typed: the
+resident loop logs and audits a skipped fire, while external slot delivery receives the original error.
+
+`stop()` interrupts pending waits synchronously without draining or canceling a claimed occurrence.
+That occurrence finishes execution and durable settlement before its loop exits; no next wake is
+claimed. Waiting loops do not count as business work. Wake execution keeps its busy ownership through
+one-shot deferral and audit, so the idle notification observes settled state. Boot-time cron-state
+read failures still fail startup synchronously.
+
 With `selfSchedule: true`, the serving path mounts `wake`/`unwake`. Wake-ups are persisted, bounded by
 minimum delay/frequency and per-session count, and fired back into the originating session. A one-shot
 wake that hits `session_busy` is deferred because the turn never started; other failures are not replayed

--- a/src/channels/agentcore-service.ts
+++ b/src/channels/agentcore-service.ts
@@ -14,6 +14,7 @@
  * it returns the same {@link AgentService}, so `start` picks an assembly once and everything after
  * that point is common.
  */
+import * as Effect from "effect/Effect";
 import type { Agent } from "../agent.ts";
 import { log } from "../log.ts";
 import type { Routes } from "../channel.ts";
@@ -152,7 +153,9 @@ export function mountAgentcore(options: {
         : (name, slot) => {
             const schedule = schedules.find((s) => s.name === name);
             if (!schedule) throw new UnknownScheduleError(name);
-            return fireScheduleOnce({ agent, stateRoot, schedule, slot });
+            return Effect.runPromise(
+              fireScheduleOnce({ agent, stateRoot, schedule, slot }).pipe(Effect.mapError((error) => error.cause)),
+            );
           },
   });
 }

--- a/src/channels/agentcore.ts
+++ b/src/channels/agentcore.ts
@@ -14,7 +14,7 @@
  *    envelope is the only way the forwarder can re-emit it verbatim (a Feishu URL-verification
  *    challenge needs the exact body + content-type back).
  *  - `{ kind: "schedule-fire", name, slot }` — one cron instant from the external clock. Dispatched
- *    to {@link fireScheduleOnce}-shaped `fire` with the slot as the idempotency key (EventBridge
+ *    to the bound `fire` callback with the slot as the idempotency key (EventBridge
  *    delivery is at-least-once; a duplicate slot must not double-fire).
  *  - `{ kind: "invoke", session, text }` — the programmatic data plane; streams the invoke back as
  *    SSE (AgentCore's streaming response form), reusing the HTTP channel's handler wholesale.
@@ -62,7 +62,7 @@ export interface AgentcoreAdapterOptions {
   stateRoot: string;
   /** Process-wide background-work signal (busy.ts `activeWork() > 0`) — injected for tests. */
   isBusy: () => boolean;
-  /** Slot-idempotent schedule fire ({@link fireScheduleOnce} bound to this workspace's schedules);
+  /** Slot-idempotent schedule fire, bound to this workspace's schedules;
    *  undefined when the workspace has none — a schedule-fire envelope then 404s (deploy drift: an
    *  external clock still firing for a schedule this definition no longer has). */
   fire?: (name: string, slot: Date) => Promise<ScheduleFireOutcome>;

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -258,20 +258,21 @@ export function createScheduler(options: SchedulerOptions): Effect.Effect<Schedu
         (done) => Effect.sync(done),
       );
       return true;
-    }).pipe(Effect.uninterruptible);
+    }).pipe(
+      // Log storage faults before a pending stop can replace the typed failure with interruption.
+      Effect.catchTag("ScheduleFailure", (error) =>
+        Effect.sync(() => {
+          log.error(`[schedule] wake-up poll failed (continuing next poll): ${String(error.cause)}`);
+          return false;
+        }),
+      ),
+      Effect.uninterruptible,
+    );
     const wakeLoop = Effect.gen(function* () {
       for (;;) {
-        yield* Effect.gen(function* () {
-          while (yield* wakeOnce) {
-            /* Claim only after the preceding occurrence settles. */
-          }
-        }).pipe(
-          Effect.catchTag("ScheduleFailure", (error) =>
-            Effect.sync(() => {
-              log.error(`[schedule] wake-up poll failed (continuing next poll): ${String(error.cause)}`);
-            }),
-          ),
-        );
+        while (yield* wakeOnce) {
+          /* Claim only after the preceding occurrence settles. */
+        }
         yield* Effect.sleep(WAKEUP_POLL_MS);
       }
     });

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -1,17 +1,12 @@
 /**
- * The scheduler: a time-trigger that fires the agent on each schedule's cron. SINGLE-PROCESS (like all
- * fastagent state today) — a deployment with schedules must keep one machine running, since cron has no
- * external wake-up (`deploy` enforces that). Started/stopped by the serve path (dev/start).
- *
- * Fire model:
- *  - **stable session per schedule** (`schedule:<name>`), so a schedule's turns share one continuing
- *    conversation persisted by the core session store; the scheduler is ZERO-touch on session storage.
- *  - **output is the agent's tools' job** — the scheduler only fires and logs the outcome.
- *  - **durability = catch up ONCE** (`state.ts`): on start, if the next instant after the last fire is
- *    already past (the process was down across it), fire once and advance — not once per missed slot.
- *    lastFired is claimed BEFORE the invoke (at-most-once per slot: a crash mid-turn won't re-fire it;
- *    "a digest late once" beats "twice"). Strict at-least-once (a per-turn WAL) is a later tier.
+ * Resident cron and wake polling. Each loop owns its waits; a claimed occurrence owns its execution
+ * and durable settlement. stop() interrupts waits without canceling or draining a claimed turn.
+ * Croner computes wall-clock instants; durable claims provide at-most-once occurrence handling.
  */
+import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import type * as Fiber from "effect/Fiber";
 import { type Agent, SESSION_BUSY_CODE } from "../agent.ts";
 import { beginWork } from "../channels/busy.ts";
 import { log } from "../log.ts";
@@ -19,21 +14,24 @@ import { appendRun } from "./audit.ts";
 import { nextRun } from "./cron.ts";
 import type { LoadedSchedule } from "./schedule.ts";
 import { loadFires, saveFires } from "./state.ts";
-import { deferWakeup, takeFirstDueWakeup } from "./wakeups.ts";
+import { deferWakeup, takeFirstDueWakeup, type Wakeup } from "./wakeups.ts";
 
-/** A schedule's turns share this stable session — a continuing conversation, like the telegram channel's
- *  per-chat session. Derived at RUNTIME from the name (never an authored field). */
+/** A schedule shares one continuing conversation without depending on engine session storage. */
 export function scheduleSession(name: string): string {
   return `schedule:${name}`;
 }
 
+export class ScheduleFailure extends Error {
+  readonly _tag = "ScheduleFailure";
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+  }
+}
+
 export interface Scheduler {
-  /** Arm every schedule (catching up an overdue one once). Idempotent-ish: call once per process. */
+  /** Arm schedules and catch up overdue work once. Call once per process. */
   start(): void;
-  /** Clear all armed timers. Does NOT drain an in-flight fire (SIGTERM exits mid-turn by design; the
-   *  interrupted turn is not re-fired — lastFired was already claimed). A catch-up fire in flight has NO
-   *  timer entry to clear either (the overdue branch fires directly, without arming), so `stop()` simply
-   *  lets it run out or be cut by process exit — same non-drain, and its claim is already persisted. */
+  /** Cancel pending waits. Claimed turns finish without blocking this call; no next occurrence starts. */
   stop(): void;
 }
 
@@ -41,293 +39,266 @@ export interface SchedulerOptions {
   agent: Agent;
   stateRoot: string;
   schedules: LoadedSchedule[];
-  /** Injectable clock for tests; defaults to the wall clock. */
+  /** Override wall-clock dates; elapsed time and waits use the Effect clock. */
   now?: () => Date;
-  /** External-clock mode (the AgentCore deployment): cron slots are DELIVERED by an external
-   *  scheduler through the serving surface ({@link fireScheduleOnce} with a `slot`), so `start()`
-   *  arms NO cron timers and does NO boot catch-up — delivery, including for instants that passed
-   *  while this process was down, is the external clock's job; the adapter's slot-idempotent claim
-   *  is the duplicate guard. The wake-up poll still runs (degraded: it only fires while the
-   *  process happens to be awake — the deploy path warns about this). */
+  /** External slot delivery owns cron timers and catch-up; local wake polling still runs. */
   externalClock?: boolean;
 }
 
-// A single setTimeout maxes out at ~24.8 days and drifts over long sleeps; cap each wait so a long
-// interval (or a suspended machine) re-checks against the wall clock rather than firing wildly early/late.
-const MAX_WAIT_MS = 6 * 60 * 60 * 1000; // 6h
-// How often to poll the agent's self-scheduled wake-ups (wakeups.ts). A wake fires within this of its
-// due time — fine for "wake me in N minutes"; cheap (reads a small JSON, writes only when one is due).
-const WAKEUP_POLL_MS = 30 * 1000;
+// Recheck the wall clock across long waits and machine suspension; never exceed setTimeout's limit.
+const MAX_WAIT_MS = 6 * 60 * 60 * 1000;
+const WAKEUP_POLL_MS = 30_000;
 
-/** Drive ONE turn (a cron fire or a wake-up) and log its outcome. Total — never throws (its callers are
- *  void-scheduled). Output is the agent's tools' job; this only fires and logs. Returns the turn's audit
- *  material — `failed` (details, if it failed), the accumulated `reply` text, `ms` — plus `busy`: whether
- *  it failed specifically because the session was BUSY (the turn never started) — the ONLY replay-safe
- *  reason to re-fire a wake-up; every other outcome is terminal (side effects may have run). Module-level
- *  (not a scheduler closure) so {@link fireScheduleOnce} — the external-clock fire path — shares it. */
-async function runTurn(
-  agent: Agent,
-  label: string,
-  session: string,
-  prompt: string,
-): Promise<{ busy: boolean; failed?: string; reply: string; ms: number }> {
-  const startedAt = Date.now();
-  log.info(`[schedule] ${label} firing (session=${session})`);
-  try {
-    let failed: string | undefined;
-    let busy = false;
-    let reply = "";
-    for await (const e of agent.invoke({ session }, { text: prompt })) {
-      if (e.type === "text") reply += e.delta;
-      if (e.type === "failed") {
-        failed = e.details;
-        busy = e.code === SESSION_BUSY_CODE; // structured (SPEC §8), not a details-text match
-      }
-    }
-    if (failed) log.error(`[schedule] ${label} failed (${Date.now() - startedAt}ms): ${failed}`);
-    else log.info(`[schedule] ${label} completed (${Date.now() - startedAt}ms)`);
-    return { busy: failed !== undefined && busy, failed, reply, ms: Date.now() - startedAt };
-  } catch (e) {
-    // invoke shouldn't throw (SPEC MUST 2 turns failures into events), but stay total regardless. A throw
-    // is not the busy case, so don't defer on it.
-    log.error(`[schedule] ${label} errored (${Date.now() - startedAt}ms): ${String(e)}`);
-    return { busy: false, failed: String(e), reply: "", ms: Date.now() - startedAt };
-  }
+/** The iterator is a Promise port inside an uninterruptible claimed occurrence, including its cleanup. */
+function runTurn(agent: Agent, label: string, session: string, prompt: string) {
+  return Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const startedAt = clock.currentTimeMillisUnsafe();
+    const elapsed = () => clock.currentTimeMillisUnsafe() - startedAt;
+    log.info(`[schedule] ${label} firing (session=${session})`);
+    return yield* Effect.tryPromise({
+      try: async () => {
+        let failed: string | undefined;
+        let busy = false;
+        let reply = "";
+        for await (const e of agent.invoke({ session }, { text: prompt })) {
+          if (e.type === "text") reply += e.delta;
+          if (e.type === "failed") {
+            failed = e.details;
+            busy = e.code === SESSION_BUSY_CODE;
+          }
+        }
+        return { busy: failed !== undefined && busy, failed, reply };
+      },
+      catch: (cause) => new ScheduleFailure(cause),
+    }).pipe(
+      Effect.match({
+        onSuccess: (result) => {
+          if (result.failed) log.error(`[schedule] ${label} failed (${elapsed()}ms): ${result.failed}`);
+          else log.info(`[schedule] ${label} completed (${elapsed()}ms)`);
+          return { ...result, ms: elapsed() };
+        },
+        onFailure: (error) => {
+          // An iterator throw violates SPEC MUST 2 and is never a replay-safe busy rejection.
+          log.error(`[schedule] ${label} errored (${elapsed()}ms): ${String(error.cause)}`);
+          return { busy: false, failed: String(error.cause), reply: "", ms: elapsed() };
+        },
+      }),
+    );
+  });
 }
 
-/** One schedule fire's outcome, for the external caller (the AgentCore adapter returns it to the
- *  triggering clock's logs). The resident scheduler ignores it beyond completion. */
 export interface ScheduleFireOutcome {
   fired: boolean;
-  /** Set when a slot-keyed fire was skipped because that slot (or a later one) was already claimed. */
+  /** A slot-keyed delivery whose slot (or a later one) was already claimed. */
   skippedReason?: string;
   failed?: string;
   ms: number;
 }
 
 /**
- * Fire ONE schedule's turn: claim (persist lastFired BEFORE invoking, so a crash mid-turn does not
- * re-fire on restart), run, audit. Shared by the resident scheduler's timers and the external-clock
- * serving surface (the AgentCore adapter).
- *
- * `slot` is the external clock's idempotency key — the cron instant this fire is FOR. External
- * delivery (EventBridge-style) is at-least-once, so a duplicate slot must not double-fire: when
- * lastFired ≥ slot the fire is SKIPPED (at-most-once per slot, same trade as the resident claim —
- * "a digest late once" beats "twice"). The resident scheduler omits `slot`: its timers fire each
- * slot exactly once, so the unconditional claim is already correct.
- *
- * A state fault while claiming (loadFires/saveFires — both before the invoke, so nothing ran)
- * THROWS: the resident path catches it at its single skip+audit boundary ({@link createScheduler}'s
- * fireThenReArm — skipping rather than firing unclaimed also avoids an infinite catch-up loop on
- * restart), and the external path lets it surface as a failed request (visible in the clock's logs).
+ * Shared resident/external claim → run → audit. An external delivery claims its cron instant, not
+ * arrival time, so delayed delivery cannot suppress a later distinct slot. Claim IO failures remain
+ * typed failures: the resident loop skips and audits; the external request surfaces them to its clock.
  */
-export async function fireScheduleOnce(opts: {
+export function fireScheduleOnce(opts: {
   agent: Agent;
   stateRoot: string;
   schedule: LoadedSchedule;
   slot?: Date;
   now?: () => Date;
-}): Promise<ScheduleFireOutcome> {
-  const { agent, stateRoot, schedule: s, slot, now = () => new Date() } = opts;
-  const fires = loadFires(stateRoot);
-  const last = fires[s.name];
-  if (slot && last && new Date(last).getTime() >= slot.getTime()) {
-    const reason = `slot ${slot.toISOString()} already fired (lastFired=${last})`;
-    log.info(`[schedule] ${s.name}: skipping — ${reason}`);
-    return { fired: false, skippedReason: reason, ms: 0 };
-  }
-  // An external delivery claims the cron instant it represents, not its (possibly much later)
-  // delivery time. Otherwise a delayed fire can make the next distinct slot look like a duplicate.
-  fires[s.name] = (slot ?? now()).toISOString();
-  saveFires(stateRoot, fires);
-  const firedAt = now().toISOString();
-  const r = await runTurn(agent, s.name, scheduleSession(s.name), s.prompt);
-  appendRun(stateRoot, {
-    name: s.name,
-    session: scheduleSession(s.name),
-    firedAt,
-    ms: r.ms,
-    outcome: r.failed ? "failed" : "completed",
-    reply: r.failed ? undefined : r.reply,
-    error: r.failed,
-  });
-  return { fired: true, failed: r.failed, ms: r.ms };
+}): Effect.Effect<ScheduleFireOutcome, ScheduleFailure> {
+  return Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const { agent, stateRoot, schedule: s, slot, now = () => new Date(clock.currentTimeMillisUnsafe()) } = opts;
+    const skippedReason = yield* Effect.try({
+      try: () => {
+        const fires = loadFires(stateRoot);
+        const last = fires[s.name];
+        if (slot && last && new Date(last).getTime() >= slot.getTime()) {
+          const reason = `slot ${slot.toISOString()} already fired (lastFired=${last})`;
+          log.info(`[schedule] ${s.name}: skipping — ${reason}`);
+          return reason;
+        }
+        fires[s.name] = (slot ?? now()).toISOString();
+        saveFires(stateRoot, fires);
+        return undefined;
+      },
+      catch: (cause) => new ScheduleFailure(cause),
+    });
+    if (skippedReason !== undefined) return { fired: false, skippedReason, ms: 0 };
+    const firedAt = now().toISOString();
+    const r = yield* runTurn(agent, s.name, scheduleSession(s.name), s.prompt);
+    appendRun(stateRoot, {
+      name: s.name,
+      session: scheduleSession(s.name),
+      firedAt,
+      ms: r.ms,
+      outcome: r.failed ? "failed" : "completed",
+      reply: r.failed ? undefined : r.reply,
+      error: r.failed,
+    });
+    return { fired: true, failed: r.failed, ms: r.ms };
+  }).pipe(Effect.uninterruptible);
 }
 
-export function createScheduler({
-  agent,
-  stateRoot,
-  schedules,
-  now = () => new Date(),
-  externalClock = false,
-}: SchedulerOptions): Scheduler {
-  const timers = new Map<string, ReturnType<typeof setTimeout>>();
-  let wakeupTimer: ReturnType<typeof setTimeout> | undefined;
-  let stopped = false;
+/** Wakes re-enter a chat session; identify the agent's own instruction and its cancellation handle. */
+function wakeEnvelope(w: Wakeup): string {
+  const tag = w.cron
+    ? `[wake-up ${w.id} fired — YOUR recurring self-scheduled turn (cron "${w.cron}"${w.tz ? ` ${w.tz}` : ""}), not a user message; unwake({ id: "${w.id}" }) stops it]`
+    : `[wake-up ${w.id} fired — YOUR self-scheduled turn, not a user message]`;
+  return `${tag} ${w.prompt}`;
+}
 
-  /** The resident fire path — the shared claim+run+audit, without a slot (see {@link fireScheduleOnce}). */
-  async function fire(s: LoadedSchedule): Promise<void> {
-    await fireScheduleOnce({ agent, stateRoot, schedule: s, now });
-  }
+export function createScheduler(options: SchedulerOptions): Effect.Effect<Scheduler> {
+  return Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const fork = Effect.runForkWith(yield* Effect.context<never>());
+    const {
+      agent,
+      stateRoot,
+      schedules,
+      now = () => new Date(clock.currentTimeMillisUnsafe()),
+      externalClock = false,
+    } = options;
+    const loops = new Set<Fiber.Fiber<unknown, unknown>>();
+    let stopped = false;
 
-  /**
-   * The woken turn's prompt arrives ENVELOPED: without it the model sees its own instruction as a bare
-   * user message — in a chat session it may answer a "user" who said nothing — and it has no way to know
-   * the wake-up's id (buried in a long-past tool result), which `unwake` needs. Static cron fires stay raw
-   * on purpose: their prompt is the AUTHOR's instruction in a dedicated `schedule:<name>` session, where
-   * every turn is a fire and an envelope would only dilute it.
-   */
-  function wakeEnvelope(w: { id: string; prompt: string; cron?: string; tz?: string }): string {
-    const tag = w.cron
-      ? `[wake-up ${w.id} fired — YOUR recurring self-scheduled turn (cron "${w.cron}"${w.tz ? ` ${w.tz}` : ""}), not a user message; unwake({ id: "${w.id}" }) stops it]`
-      : `[wake-up ${w.id} fired — YOUR self-scheduled turn, not a user message]`;
-    return `${tag} ${w.prompt}`;
-  }
-
-  /**
-   * Fire every due self-scheduled wake-up, ONE at a time (claim → fire → claim next) so a crash loses at
-   * most one occurrence. Each fires back into the session it was set in. Busy handling splits by kind: a
-   * ONE-SHOT that failed because the session was BUSY (`code: session_busy` — the turn never started; the
-   * very case "wake me in 10 min" hits while the user is still chatting) is deferred to the next poll,
-   * bounded, because a dropped one-shot has no "next time"; a RECURRING busy occurrence is skipped
-   * immediately (its claim already advanced the entry — the next occurrence comes by definition). Any
-   * other failure is terminal for that occurrence (the turn ran — re-running risks duplicate side effects).
-   */
-  async function pollWakeups(): Promise<void> {
-    for (;;) {
-      if (stopped) break; // stop() must halt an in-flight drain, like it clears the cron timers
-      const w = takeFirstDueWakeup(stateRoot, now());
-      if (!w) break;
-      const label = `wake ${w.id.slice(0, 8)}`;
-      const firedAt = now().toISOString();
-      // A wake turn runs in the BACKGROUND (no open request tracks it) — count it as in-flight work
-      // (busy.ts) so a serving surface that must not idle mid-turn (the AgentCore /ping) sees it.
-      const workDone = beginWork();
-      const r = await runTurn(agent, label, w.session, wakeEnvelope(w)).finally(workDone);
-      // Busy handling differs by kind (busy = the turn never started — replay-safe; every other outcome is
-      // terminal for this occurrence, since a turn that DID start may have run side effects). ONE-SHOT: defer (bounded) — it has no "next time", dropping it
-      // would lose it forever. RECURRING: the claim already ADVANCED the entry to the next instant (see
-      // takeFirstDueWakeup), so a busy occurrence is simply SKIPPED and audited — the next one comes by
-      // definition, and never touching the stored entry here is what keeps unwake/cancel race-free.
-      let kept = false;
-      if (r.busy && !w.cron) {
-        kept = deferWakeup(stateRoot, w, new Date(now().getTime() + WAKEUP_POLL_MS));
-        if (kept) log.info(`[schedule] ${label}: session busy — retrying next poll`);
-        else log.error(`[schedule] ${label}: dropped after too many busy retries`);
-      } else if (r.busy && w.cron) {
-        log.error(`[schedule] ${label}: occurrence skipped (session busy); next fires per cron`);
-      }
-      // Audit honesty: `deferred` ONLY when the same occurrence was actually re-scheduled. A busy one-shot
-      // dropped at the ceiling, and a busy recurring occurrence (skipped — its recurrence survives), are
-      // both FINAL for that occurrence → `failed`.
-      appendRun(stateRoot, {
-        name: "wake",
-        session: w.session,
-        firedAt,
-        ms: r.ms,
-        outcome: r.busy ? (kept ? "deferred" : "failed") : r.failed ? "failed" : "completed",
-        reply: r.failed || r.busy ? undefined : r.reply,
-        error: r.busy
-          ? kept
-            ? undefined
-            : w.cron
-              ? "occurrence skipped (session busy); the recurrence continues"
-              : "dropped after too many busy retries"
-          : r.failed,
-      });
-    }
-  }
-
-  /** Drain due wake-ups, then chain the next poll AFTER — never overlapping two drains. TOTAL: a state-IO
-   *  fault (an unreadable store) is caught + logged and the chain continues, never a crash / a silent stop
-   *  (this is `void`-scheduled, so an escaping throw would be an unhandled rejection). */
-  async function pumpWakeups(): Promise<void> {
-    if (stopped) return;
-    try {
-      await pollWakeups();
-    } catch (e) {
-      log.error(`[schedule] wake-up poll failed (continuing next poll): ${String(e)}`);
-    }
-    if (stopped) return;
-    wakeupTimer = setTimeout(() => void pumpWakeups(), WAKEUP_POLL_MS);
-  }
-
-  /** Arm a timer for `at`, capped so a long wait re-checks the wall clock instead of trusting one sleep. */
-  function arm(s: LoadedSchedule, at: Date): void {
-    if (stopped) return;
-    const delay = Math.min(Math.max(0, at.getTime() - now().getTime()), MAX_WAIT_MS);
-    timers.set(
-      s.name,
-      setTimeout(() => {
-        if (stopped) return;
-        if (now().getTime() >= at.getTime()) void fireThenReArm(s);
-        else arm(s, at); // woke early (the cap) — keep waiting for the real instant
-      }, delay),
-    );
-  }
-
-  /** Fire, then arm the NEXT run computed from now — so a slow fire never double-fires the same slot and
-   *  missed slots collapse to the single catch-up already done. TOTAL, like pumpWakeups: this is
-   *  void-scheduled from a timer, so an escaping throw (a state-IO fault while claiming — an unreadable
-   *  fires.json, an unpersistable claim) would be an unhandled rejection = the WHOLE service crashing over
-   *  one skipped fire. Log it and keep the schedule armed instead; boot-time state faults still fail `start()`
-   *  loudly (an operator fixes those before serving). */
-  async function fireThenReArm(s: LoadedSchedule): Promise<void> {
-    try {
-      await fire(s);
-    } catch (e) {
-      // Audited too (appendRun is total, and runs.jsonl ≠ the broken state file) — a skipped fire must
-      // show up in `schedule history`, not only in stderr.
-      log.error(`[schedule] ${s.name}: fire failed (skipping this run, schedule stays armed): ${String(e)}`);
-      appendRun(stateRoot, {
-        name: s.name,
-        session: scheduleSession(s.name),
-        firedAt: now().toISOString(),
-        ms: 0,
-        outcome: "failed",
-        error: `run skipped — fire failed: ${String(e)}`,
-      });
-    }
-    const due = nextRun(s.cron, s.tz, now());
-    if (due) arm(s, due);
-  }
-
-  return {
-    start() {
-      stopped = false;
-      // External-clock mode: no cron timers, no boot catch-up — slot delivery (including instants
-      // that passed while this process was down) belongs to the external clock; only the wake-up
-      // pump below runs. See SchedulerOptions.externalClock.
-      const fires = externalClock ? {} : loadFires(stateRoot);
-      const current = now();
-      for (const s of externalClock ? [] : schedules) {
-        // Anchor on the last fire (catch-up basis), or `now` on a first-ever run so a brand-new schedule
-        // never back-fires before the process first booted.
-        const lastFired = fires[s.name];
-        const anchor = lastFired ? new Date(lastFired) : current;
-        const due = nextRun(s.cron, s.tz, anchor);
-        if (!due) {
-          log.warn(`[schedule] ${s.name}: cron "${s.cron}" will never fire again — not armed`);
-          continue;
+    const launch = (label: string, work: Effect.Effect<void>): void => {
+      fork(
+        Effect.withFiber((fiber) => {
+          // Publish ownership before a synchronous invoke callback can re-enter stop().
+          loops.add(fiber);
+          return work.pipe(
+            Effect.catchCause((cause) =>
+              Effect.sync(() => {
+                if (!Cause.hasInterruptsOnly(cause))
+                  log.error(`[schedule] ${label}: stopped unexpectedly: ${String(Cause.squash(cause))}`);
+              }),
+            ),
+            Effect.ensuring(
+              Effect.sync(() => {
+                loops.delete(fiber);
+              }),
+            ),
+          );
+        }),
+      );
+    };
+    const cronLoop = (s: LoadedSchedule, first: Date) =>
+      Effect.gen(function* () {
+        let due: Date | undefined = first;
+        while (due) {
+          while (now().getTime() < due.getTime()) {
+            yield* Effect.sleep(Math.min(due.getTime() - now().getTime(), MAX_WAIT_MS));
+          }
+          yield* fireScheduleOnce({ agent, stateRoot, schedule: s, now }).pipe(
+            Effect.catchTag("ScheduleFailure", (error) =>
+              Effect.sync(() => {
+                log.error(
+                  `[schedule] ${s.name}: fire failed (skipping this run, schedule stays armed): ${String(error.cause)}`,
+                );
+                appendRun(stateRoot, {
+                  name: s.name,
+                  session: scheduleSession(s.name),
+                  firedAt: now().toISOString(),
+                  ms: 0,
+                  outcome: "failed",
+                  error: `run skipped — fire failed: ${String(error.cause)}`,
+                });
+              }),
+            ),
+            Effect.uninterruptible,
+          );
+          due = nextRun(s.cron, s.tz, now());
         }
-        if (due.getTime() <= current.getTime()) {
-          log.info(`[schedule] ${s.name}: catching up a missed run`);
-          void fireThenReArm(s); // overdue → fire once, then arm the next
-        } else {
-          arm(s, due);
-        }
+      });
+
+    const wakeOnce = Effect.gen(function* () {
+      const w = yield* Effect.try({
+        try: () => takeFirstDueWakeup(stateRoot, now()),
+        catch: (cause) => new ScheduleFailure(cause),
+      });
+      if (!w) return false;
+      yield* Effect.acquireUseRelease(
+        Effect.sync(beginWork),
+        () =>
+          Effect.gen(function* () {
+            const label = `wake ${w.id.slice(0, 8)}`;
+            const firedAt = now().toISOString();
+            const r = yield* runTurn(agent, label, w.session, wakeEnvelope(w));
+            let kept = false;
+            if (r.busy && !w.cron) {
+              kept = yield* Effect.try({
+                try: () => deferWakeup(stateRoot, w, new Date(now().getTime() + WAKEUP_POLL_MS)),
+                catch: (cause) => new ScheduleFailure(cause),
+              });
+              if (kept) log.info(`[schedule] ${label}: session busy — retrying next poll`);
+              else log.error(`[schedule] ${label}: dropped after too many busy retries`);
+            } else if (r.busy && w.cron) {
+              log.error(`[schedule] ${label}: occurrence skipped (session busy); next fires per cron`);
+            }
+            // The recurrence was advanced by the claim; only a retained one-shot is audited deferred.
+            appendRun(stateRoot, {
+              name: "wake",
+              session: w.session,
+              firedAt,
+              ms: r.ms,
+              outcome: r.busy ? (kept ? "deferred" : "failed") : r.failed ? "failed" : "completed",
+              reply: r.failed || r.busy ? undefined : r.reply,
+              error: r.busy
+                ? kept
+                  ? undefined
+                  : w.cron
+                    ? "occurrence skipped (session busy); the recurrence continues"
+                    : "dropped after too many busy retries"
+                : r.failed,
+            });
+          }),
+        (done) => Effect.sync(done),
+      );
+      return true;
+    }).pipe(Effect.uninterruptible);
+    const wakeLoop = Effect.gen(function* () {
+      for (;;) {
+        yield* Effect.gen(function* () {
+          while (yield* wakeOnce) {
+            /* Claim only after the preceding occurrence settles. */
+          }
+        }).pipe(
+          Effect.catchTag("ScheduleFailure", (error) =>
+            Effect.sync(() => {
+              log.error(`[schedule] wake-up poll failed (continuing next poll): ${String(error.cause)}`);
+            }),
+          ),
+        );
+        yield* Effect.sleep(WAKEUP_POLL_MS);
       }
-      // Self-scheduled wake-ups: drain now (catch any overdue while the process was down), then chain the
-      // next poll AFTER this drain finishes — a CHAIN, not setInterval, so a wake turn longer than the poll
-      // interval never overlaps two drains (which would break the one-at-a-time claim→fire→claim promise).
-      void pumpWakeups();
-    },
-    stop() {
-      stopped = true;
-      for (const t of timers.values()) clearTimeout(t);
-      timers.clear();
-      if (wakeupTimer) clearTimeout(wakeupTimer);
-      wakeupTimer = undefined;
-    },
-  };
+    });
+
+    return {
+      start() {
+        stopped = false;
+        // A boot-time read fault stays synchronous, before any timers or turns are started.
+        const fires = externalClock ? {} : loadFires(stateRoot);
+        const current = now();
+        for (const s of externalClock ? [] : schedules) {
+          if (stopped) break;
+          const last = fires[s.name];
+          const due = nextRun(s.cron, s.tz, last ? new Date(last) : current);
+          if (!due) {
+            log.warn(`[schedule] ${s.name}: cron "${s.cron}" will never fire again — not armed`);
+            continue;
+          }
+          if (due.getTime() <= current.getTime()) log.info(`[schedule] ${s.name}: catching up a missed run`);
+          launch(s.name, cronLoop(s, due));
+        }
+        if (!stopped) launch("wake-up poll", wakeLoop);
+      },
+      stop() {
+        stopped = true;
+        for (const loop of loops) loop.interruptUnsafe();
+      },
+    };
+  });
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -221,7 +221,9 @@ export async function startSchedules(
   const { schedules, failures } = await loadSchedules(agentDir);
   reportModuleLoadFailures(failures);
   if (schedules.length === 0 && !selfSchedule) return { schedules, stop: () => {} };
-  const scheduler = createScheduler({ agent, stateRoot, schedules, externalClock: options.externalClock });
+  const scheduler = Effect.runSync(
+    createScheduler({ agent, stateRoot, schedules, externalClock: options.externalClock }),
+  );
   scheduler.start();
   if (schedules.length > 0) {
     log.info(

--- a/test/conformance-session.test.ts
+++ b/test/conformance-session.test.ts
@@ -29,6 +29,10 @@ import { runQueuedTurn } from "../src/channels/kit/turn-runner.ts";
 import type { TurnRecordBase } from "../src/channels/kit/turn-store.ts";
 import { telegramTurnStream } from "../src/channels/telegram/invoke-turn.ts";
 import { telegramReply } from "../src/channels/telegram/preview.ts";
+import { createScheduler } from "../src/schedule/scheduler.ts";
+import { saveFires, scheduleFile, writeScheduleFile } from "../src/schedule/state.ts";
+import { listWakeups } from "../src/schedule/wakeups.ts";
+import { readRuns } from "../src/schedule/audit.ts";
 
 afterEach(() => vi.restoreAllMocks());
 import { makeFaux } from "./faux.ts";
@@ -317,5 +321,72 @@ it.each([
     const release = lease.tryAcquire("quiet");
     expect(release).toBeTypeOf("function");
     release?.();
+  },
+);
+
+it.each(["cron", "wake"] as const)(
+  "scheduler stop lets a claimed %s finish its actual SDK tool and audit",
+  async (kind) => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "fa-scheduled-sdk-"));
+    const entered = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    const abort = vi.fn();
+    const lease = inProcessLease();
+    const sessionId = kind === "cron" ? "schedule:job" : "conversation";
+    const factory = await sessionFactory(
+      [fauxAssistantMessage(fauxToolCall("wait", {}, { id: "scheduled-tool" })), fauxAssistantMessage("done")],
+      {
+        customTools: [
+          {
+            name: "wait",
+            label: "wait",
+            description: "Wait for completion",
+            parameters: Type.Object({}),
+            execute: async (_id, _args, signal) => {
+              signal!.addEventListener("abort", abort, { once: true });
+              entered.resolve();
+              await finish.promise;
+              return { content: [{ type: "text", text: "finished" }], details: {} };
+            },
+          } as ToolDefinition,
+        ],
+      },
+    );
+    const bound = vi.fn(factory);
+    const agent = createPiAgentFromSession({ lease, sessionFactory: bound });
+    if (kind === "cron") saveFires(stateRoot, { job: "2026-07-07T08:00:00Z" });
+    else
+      writeScheduleFile(scheduleFile(stateRoot, "wakeups"), [
+        { id: "first", session: sessionId, prompt: "go", fireAt: "2026-07-07T09:00:00Z" },
+        { id: "next", session: "other", prompt: "later", fireAt: "2026-07-07T09:00:00Z" },
+      ]);
+    const s = Effect.runSync(
+      createScheduler({
+        agent,
+        stateRoot,
+        schedules: kind === "cron" ? [{ name: "job", cron: "0 * * * *", prompt: "go" }] : [],
+        now: () => new Date("2026-07-07T10:30:00Z"),
+      }),
+    );
+    try {
+      s.start();
+      await entered.promise;
+      expect(s.stop()).toBeUndefined();
+      expect(abort).not.toHaveBeenCalled();
+      expect(lease.tryAcquire(sessionId)).toBeNull();
+      expect(readRuns(stateRoot)).toEqual([]);
+      finish.resolve();
+      await vi.waitFor(() => expect(readRuns(stateRoot)).toHaveLength(1));
+      expect(readRuns(stateRoot)[0]).toMatchObject({ outcome: "completed", reply: "done" });
+      expect(abort).not.toHaveBeenCalled();
+      expect(bound).toHaveBeenCalledOnce();
+      if (kind === "wake") expect(listWakeups(stateRoot).map((w) => w.id)).toEqual(["next"]);
+      const release = lease.tryAcquire(sessionId);
+      expect(release).toBeTypeOf("function");
+      release?.();
+    } finally {
+      s.stop();
+      finish.resolve();
+    }
   },
 );

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -297,6 +297,7 @@ describe("the contracts depend on nothing", () => {
       "@hono/node-server",
       "croner",
       "effect/Cause",
+      "effect/Clock",
       "effect/Effect",
       "effect/Exit",
       "effect/Fiber",

--- a/test/scheduler-effects.test.ts
+++ b/test/scheduler-effects.test.ts
@@ -1,0 +1,353 @@
+import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as TestClock from "effect/testing/TestClock";
+import { mkdtemp, mkdir } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, expectTypeOf, it, vi } from "vitest";
+import type { Agent, AgentEvent } from "../src/agent.ts";
+import { activeWork } from "../src/channels/busy.ts";
+import { readRuns } from "../src/schedule/audit.ts";
+import {
+  createScheduler,
+  fireScheduleOnce,
+  type ScheduleFailure,
+  type ScheduleFireOutcome,
+  type Scheduler,
+} from "../src/schedule/scheduler.ts";
+import { loadFires, saveFires, scheduleFile, writeScheduleFile } from "../src/schedule/state.ts";
+import { listWakeups } from "../src/schedule/wakeups.ts";
+import { log } from "../src/log.ts";
+
+const NOW = new Date("2026-07-07T10:30:00Z");
+const hourly = (name = "job") => ({ name, cron: "0 * * * *", tz: "UTC", prompt: "go" });
+const freshRoot = () => mkdtemp(join(tmpdir(), "fa-scheduler-effects-"));
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve));
+afterEach(() => vi.restoreAllMocks());
+
+it.each(["cron", "one-shot", "recurring"] as const)(
+  "SIGTERM preserves the claimed %s state without claiming the next wake",
+  async (kind) => {
+    const stateRoot = await freshRoot();
+    const schedules = kind === "cron" ? [hourly()] : [];
+    if (kind === "cron") saveFires(stateRoot, { job: "2026-07-07T08:00:00Z" });
+    else
+      writeScheduleFile(scheduleFile(stateRoot, "wakeups"), [
+        {
+          id: "first",
+          session: "first",
+          prompt: "go",
+          fireAt: "2026-07-07T09:00:00Z",
+          ...(kind === "recurring" ? { cron: "0 * * * *", tz: "UTC" } : {}),
+        },
+        { id: "next", session: "next", prompt: "later", fireAt: "2026-07-07T09:00:00Z" },
+      ]);
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+    import * as Effect from "effect/Effect";
+    import { createScheduler } from ${JSON.stringify(new URL("../src/schedule/scheduler.ts", import.meta.url).href)};
+    process.on("message", () => {});
+    const agent = { async *invoke() { process.send("running"); await new Promise(() => {}); } };
+    Effect.runSync(createScheduler({ agent, stateRoot: ${JSON.stringify(stateRoot)}, schedules: ${JSON.stringify(schedules)}, now: () => new Date(${JSON.stringify(NOW.toISOString())}) })).start();
+  `,
+      ],
+      { stdio: ["ignore", "ignore", "pipe", "ipc"] },
+    );
+    let stderr = "";
+    child.stderr?.on("data", (data) => {
+      stderr += data;
+    });
+    const exited = once(child, "exit");
+    try {
+      expect(
+        await Promise.race([
+          once(child, "message").then(([value]) => value),
+          exited.then(() => {
+            throw new Error(`child exited before running: ${stderr}`);
+          }),
+        ]),
+      ).toBe("running");
+    } finally {
+      child.kill("SIGTERM");
+      await exited;
+    }
+    expect(readRuns(stateRoot)).toEqual([]);
+    if (kind === "cron") expect(loadFires(stateRoot).job).toBe(NOW.toISOString());
+    else {
+      expect(listWakeups(stateRoot).map((w) => w.id)).toEqual(kind === "recurring" ? ["first", "next"] : ["next"]);
+      if (kind === "recurring") expect(listWakeups(stateRoot)[0]?.fireAt).toBe("2026-07-07T11:00:00.000Z");
+    }
+    const calls: string[] = [];
+    const s = Effect.runSync(
+      createScheduler({
+        agent: {
+          async *invoke(scope) {
+            calls.push(scope.session);
+            yield { type: "completed" };
+          },
+        },
+        stateRoot,
+        schedules,
+        now: () => NOW,
+      }),
+    );
+    try {
+      s.start();
+      await tick();
+      expect(calls).toEqual(kind === "cron" ? [] : ["next"]);
+    } finally {
+      s.stop();
+    }
+  },
+);
+
+it("uses the provided clock across start and stop, without counting idle timers as work", async () => {
+  const stateRoot = await freshRoot();
+  const calls: string[] = [];
+  const agent: Agent = {
+    async *invoke(scope) {
+      calls.push(scope.session);
+      yield { type: "completed" };
+    },
+  };
+  const base = activeWork();
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* TestClock.setTime(NOW.getTime());
+      const s = yield* createScheduler({ agent, stateRoot, schedules: [hourly()] });
+      try {
+        s.start();
+        yield* TestClock.adjust(29 * 60_000);
+        expect(calls).toEqual([]);
+        expect(activeWork()).toBe(base);
+        yield* TestClock.adjust(60_000);
+        expect(calls).toEqual(["schedule:job"]);
+        expect(readRuns(stateRoot)[0]).toMatchObject({
+          firedAt: "2026-07-07T11:00:00.000Z",
+          outcome: "completed",
+          ms: 0,
+        });
+        s.stop();
+        yield* TestClock.adjust(2 * 60 * 60_000);
+        expect(calls).toHaveLength(1);
+        expect(activeWork()).toBe(base);
+      } finally {
+        s.stop();
+      }
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+it("keeps schedules concurrent, serializes each schedule, and skips slots missed by a slow turn", async () => {
+  const stateRoot = await freshRoot();
+  const finish = Promise.withResolvers<void>();
+  const calls: string[] = [];
+  const agent: Agent = {
+    async *invoke(scope) {
+      calls.push(scope.session);
+      await finish.promise;
+      yield { type: "completed" };
+    },
+  };
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* TestClock.setTime(NOW.getTime());
+      const s = yield* createScheduler({ agent, stateRoot, schedules: [hourly("a"), hourly("b")] });
+      try {
+        s.start();
+        yield* TestClock.adjust(2 * 60 * 60_000);
+        expect(calls).toEqual(["schedule:a", "schedule:b"]);
+        finish.resolve();
+        yield* Effect.promise(tick);
+        yield* TestClock.adjust(29 * 60_000);
+        expect(calls).toHaveLength(2);
+        yield* TestClock.adjust(60_000);
+        expect(calls).toEqual(["schedule:a", "schedule:b", "schedule:a", "schedule:b"]);
+      } finally {
+        s.stop();
+        finish.resolve();
+      }
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+it("rechecks capped waits against wall-clock jumps and never fires early", async () => {
+  const stateRoot = await freshRoot();
+  let wall = new Date("2026-07-07T10:30:00Z");
+  const invoke = vi.fn(async function* (): AsyncIterable<AgentEvent> {
+    yield { type: "completed" };
+  });
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const s = yield* createScheduler({
+        agent: { invoke },
+        stateRoot,
+        schedules: [{ ...hourly(), cron: "0 9 * * *" }],
+        now: () => wall,
+      });
+      try {
+        s.start();
+        wall = new Date("2026-07-06T10:30:00Z");
+        yield* TestClock.adjust(6 * 60 * 60_000);
+        expect(invoke).not.toHaveBeenCalled();
+        wall = new Date("2026-07-09T10:30:00Z");
+        yield* TestClock.adjust(6 * 60 * 60_000);
+        expect(invoke).toHaveBeenCalledOnce();
+        expect(loadFires(stateRoot).job).toBe(wall.toISOString());
+      } finally {
+        s.stop();
+      }
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+it("publishes the running loop before an invoke callback re-enters stop", async () => {
+  const stateRoot = await freshRoot();
+  saveFires(stateRoot, { a: "2026-07-07T08:00:00Z", b: "2026-07-07T08:00:00Z" });
+  let s: Scheduler;
+  const invoke = vi.fn(() => {
+    s.stop();
+    return (async function* (): AsyncIterable<AgentEvent> {
+      yield { type: "completed" };
+    })();
+  });
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* TestClock.setTime(NOW.getTime());
+      s = yield* createScheduler({ agent: { invoke }, stateRoot, schedules: [hourly("a"), hourly("b")] });
+      try {
+        s.start();
+        yield* Effect.promise(tick);
+        yield* TestClock.adjust(2 * 60 * 60_000);
+        expect(invoke).toHaveBeenCalledOnce();
+        expect(readRuns(stateRoot, "a")).toHaveLength(1);
+        expect(loadFires(stateRoot).b).toBe("2026-07-07T08:00:00Z");
+      } finally {
+        s.stop();
+      }
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+it("reports a defective wake clock instead of silently losing its polling loop", async () => {
+  const stateRoot = await freshRoot();
+  const error = new Error("clock failed");
+  const logged = vi.spyOn(log, "error").mockImplementation(() => {});
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const clock = yield* Clock.Clock;
+      vi.spyOn(clock, "sleep").mockReturnValue(Effect.die(error));
+      const s = yield* createScheduler({ agent: { invoke: vi.fn() }, stateRoot, schedules: [] });
+      s.start();
+      expect(logged).toHaveBeenCalledWith(
+        expect.stringContaining("wake-up poll: stopped unexpectedly: Error: clock failed"),
+      );
+      s.stop();
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+});
+
+it.each([false, true])("an iterator throw stays terminal even after a busy event (busy=%s)", async (busy) => {
+  const stateRoot = await freshRoot();
+  const error = new Error("iterator failed", { cause: { payload: "private-provider-data" } });
+  const logged = vi.spyOn(log, "error").mockImplementation(() => {});
+  const invoke = vi.fn(async function* (): AsyncIterable<AgentEvent> {
+    if (busy) yield { type: "failed", code: "session_busy", retryable: true, details: "busy" };
+    throw error;
+  });
+  writeScheduleFile(scheduleFile(stateRoot, "wakeups"), [
+    { id: "w", session: "s", prompt: "go", fireAt: "2026-07-07T09:00:00Z" },
+  ]);
+  const s = Effect.runSync(createScheduler({ agent: { invoke }, stateRoot, schedules: [], now: () => NOW }));
+  try {
+    s.start();
+    await vi.waitFor(() => expect(readRuns(stateRoot)).toHaveLength(1));
+    expect(readRuns(stateRoot)[0]).toMatchObject({ outcome: "failed", error: "Error: iterator failed" });
+    expect(listWakeups(stateRoot)).toEqual([]);
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(logged.mock.calls.flat().join(" ")).not.toContain("private-provider-data");
+  } finally {
+    s.stop();
+  }
+});
+
+it("keeps claim IO failures typed and never invokes before a successful durable claim", async () => {
+  const stateRoot = await freshRoot();
+  await mkdir(join(stateRoot, "schedule", "fires.json.tmp"), { recursive: true });
+  const invoke = vi.fn();
+  const work = fireScheduleOnce({ agent: { invoke }, stateRoot, schedule: hourly() });
+  expectTypeOf(work).toEqualTypeOf<Effect.Effect<ScheduleFireOutcome, ScheduleFailure>>();
+  // @ts-expect-error -- a failed durable claim still needs a failure policy
+  const infallible: Effect.Effect<ScheduleFireOutcome> = work;
+  void infallible;
+  const exit = await Effect.runPromiseExit(work);
+  expect(Exit.isFailure(exit)).toBe(true);
+  if (Exit.isFailure(exit))
+    expect(Cause.squash(exit.cause)).toMatchObject({ _tag: "ScheduleFailure", cause: expect.any(Error) });
+  expect(invoke).not.toHaveBeenCalled();
+  expect(readRuns(stateRoot)).toEqual([]);
+});
+
+it("a boot-time cron-state fault fails start synchronously before any loop runs", async () => {
+  const stateRoot = await freshRoot();
+  await mkdir(scheduleFile(stateRoot, "fires"), { recursive: true });
+  const invoke = vi.fn();
+  const s = Effect.runSync(createScheduler({ agent: { invoke }, stateRoot, schedules: [hourly()] }));
+  expect(() => s.start()).toThrow("unreadable");
+  s.stop();
+  await tick();
+  expect(invoke).not.toHaveBeenCalled();
+});
+
+it("an interrupted external fire joins its claimed turn and audit", async () => {
+  const stateRoot = await freshRoot();
+  const entered = Promise.withResolvers<void>();
+  const finish = Promise.withResolvers<void>();
+  const abort = new AbortController();
+  const agent: Agent = {
+    async *invoke() {
+      entered.resolve();
+      await finish.promise;
+      yield { type: "completed" };
+    },
+  };
+  const done = Effect.runPromiseExit(fireScheduleOnce({ agent, stateRoot, schedule: hourly(), slot: NOW }), {
+    signal: abort.signal,
+  });
+  await entered.promise;
+  abort.abort();
+  expect(readRuns(stateRoot)).toEqual([]);
+  finish.resolve();
+  const exit = await done;
+  expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+  expect(readRuns(stateRoot)[0]).toMatchObject({ outcome: "completed" });
+});
+
+it("claims an external slot synchronously before a concurrent duplicate can invoke", async () => {
+  const stateRoot = await freshRoot();
+  const finish = Promise.withResolvers<void>();
+  const invoke = vi.fn(async function* (): AsyncIterable<AgentEvent> {
+    await finish.promise;
+    yield { type: "completed" };
+  });
+  const options = { agent: { invoke }, stateRoot, schedule: hourly(), slot: NOW };
+  const first = Effect.runPromise(fireScheduleOnce(options));
+  try {
+    expect(loadFires(stateRoot).job).toBe(NOW.toISOString());
+    const second = await Effect.runPromise(fireScheduleOnce(options));
+    expect(second).toMatchObject({ fired: false, skippedReason: expect.stringContaining("already fired") });
+    expect(invoke).toHaveBeenCalledOnce();
+  } finally {
+    finish.resolve();
+    await first;
+  }
+  expect(readRuns(stateRoot)).toHaveLength(1);
+});

--- a/test/scheduler-effects.test.ts
+++ b/test/scheduler-effects.test.ts
@@ -3,7 +3,7 @@ import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as TestClock from "effect/testing/TestClock";
-import { mkdtemp, mkdir } from "node:fs/promises";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { tmpdir } from "node:os";
@@ -280,6 +280,64 @@ it.each([false, true])("an iterator throw stays terminal even after a busy event
   } finally {
     s.stop();
   }
+});
+
+it.each([false, true])("reports a wake deferral write failure before restoring stop (stopped=%s)", async (stopped) => {
+  const stateRoot = await freshRoot();
+  const entered = Promise.withResolvers<void>();
+  const finish = Promise.withResolvers<void>();
+  const errors = vi.spyOn(log, "error").mockImplementation(() => {});
+  const calls: string[] = [];
+  const agent: Agent = {
+    async *invoke(scope) {
+      calls.push(scope.session);
+      if (scope.session === "busy") {
+        entered.resolve();
+        await finish.promise;
+        yield { type: "failed", code: "session_busy", retryable: true, details: "busy" };
+      } else yield { type: "completed" };
+    },
+  };
+  const path = scheduleFile(stateRoot, "wakeups");
+  writeScheduleFile(path, [
+    { id: "first", session: "busy", prompt: "go", fireAt: NOW.toISOString() },
+    { id: "next", session: "next", prompt: "later", fireAt: NOW.toISOString() },
+  ]);
+  const base = activeWork();
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* TestClock.setTime(NOW.getTime());
+      const s = yield* createScheduler({ agent, stateRoot, schedules: [] });
+      try {
+        s.start();
+        yield* Effect.promise(() => entered.promise);
+        yield* Effect.promise(() => mkdir(`${path}.tmp`));
+        if (stopped) s.stop();
+        expect(activeWork()).toBe(base + 1);
+        finish.resolve();
+        yield* Effect.promise(() =>
+          vi.waitFor(() =>
+            expect(errors).toHaveBeenCalledWith(
+              expect.stringMatching(/wake-up poll failed.*EISDIR.*wakeups\.json\.tmp/),
+            ),
+          ),
+        );
+        expect(activeWork()).toBe(base);
+        expect(calls).toEqual(["busy"]);
+        expect(listWakeups(stateRoot).map((w) => w.id)).toEqual(["next"]);
+        expect(readRuns(stateRoot)).toEqual([]);
+        yield* Effect.promise(() => rm(`${path}.tmp`, { recursive: true }));
+        yield* TestClock.adjust(30_000);
+        expect(calls).toEqual(stopped ? ["busy"] : ["busy", "next"]);
+        expect(listWakeups(stateRoot).map((w) => w.id)).toEqual(stopped ? ["next"] : []);
+        expect(readRuns(stateRoot)).toHaveLength(stopped ? 0 : 1);
+        expect(errors.mock.calls.filter(([message]) => message.includes("wake-up poll failed"))).toHaveLength(1);
+      } finally {
+        s.stop();
+        finish.resolve();
+      }
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
 });
 
 it("keeps claim IO failures typed and never invokes before a successful durable claim", async () => {

--- a/test/scheduler-effects.test.ts
+++ b/test/scheduler-effects.test.ts
@@ -53,11 +53,14 @@ it.each(["cron", "one-shot", "recurring"] as const)(
         "-e",
         `
     import * as Effect from "effect/Effect";
-    import { createScheduler } from ${JSON.stringify(new URL("../src/schedule/scheduler.ts", import.meta.url).href)};
+    const { createScheduler } = await import(process.argv[1]);
+    const { stateRoot, schedules, now } = JSON.parse(process.argv[2]);
     process.on("message", () => {});
     const agent = { async *invoke() { process.send("running"); await new Promise(() => {}); } };
-    Effect.runSync(createScheduler({ agent, stateRoot: ${JSON.stringify(stateRoot)}, schedules: ${JSON.stringify(schedules)}, now: () => new Date(${JSON.stringify(NOW.toISOString())}) })).start();
+    Effect.runSync(createScheduler({ agent, stateRoot, schedules, now: () => new Date(now) })).start();
   `,
+        new URL("../src/schedule/scheduler.ts", import.meta.url).href,
+        JSON.stringify({ stateRoot, schedules, now: NOW.toISOString() }),
       ],
       { stdio: ["ignore", "ignore", "pipe", "ipc"] },
     );

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -5,9 +5,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Agent, AgentEvent } from "../src/agent.ts";
 import type { LoadedSchedule } from "../src/schedule/schedule.ts";
-import { createScheduler, fireScheduleOnce, scheduleSession } from "../src/schedule/scheduler.ts";
+import * as Effect from "effect/Effect";
+import { createScheduler as scheduler, fireScheduleOnce as fire, scheduleSession } from "../src/schedule/scheduler.ts";
+
+const createScheduler = (options: Parameters<typeof scheduler>[0]) => Effect.runSync(scheduler(options));
+const fireScheduleOnce = (options: Parameters<typeof fire>[0]) => Effect.runPromise(fire(options));
 import { MAX_WAKE_ATTEMPTS, addWakeup, listWakeups } from "../src/schedule/wakeups.ts";
 import { readRuns } from "../src/schedule/audit.ts";
+import { onIdle } from "../src/channels/busy.ts";
 
 /** A fake agent that records each invoke's session + text and yields the scripted terminal. */
 function recordingAgent(events: AgentEvent[] = [{ type: "completed" }]) {
@@ -37,7 +42,33 @@ function seedFires(root: string, fires: Record<string, string>): void {
 const readFires = async (root: string): Promise<Record<string, string>> =>
   JSON.parse(await readFile(join(root, "schedule", "fires.json"), "utf8"));
 
-afterEach(() => vi.useRealTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+it("reports idle only after a busy wake is deferred and audited", async () => {
+  const root = await freshRoot();
+  addWakeup(
+    root,
+    { session: "busy", prompt: "resume", fireAt: new Date("2026-07-07T11:00:00Z") },
+    new Date("2026-07-07T10:00:00Z"),
+  );
+  const { agent } = recordingAgent([{ type: "failed", retryable: true, code: "session_busy", details: "busy" }]);
+  const snapshots: unknown[] = [];
+  const off = onIdle(() =>
+    snapshots.push({ attempts: listWakeups(root)[0]?.attempts, outcome: readRuns(root, "wake")[0]?.outcome }),
+  );
+  const s = createScheduler({ agent, stateRoot: root, schedules: [], now: () => new Date("2026-07-07T12:00:00Z") });
+  try {
+    s.start();
+    await vi.waitFor(() => expect(readRuns(root, "wake")).toHaveLength(1));
+    expect(snapshots).toEqual([{ attempts: 1, outcome: "deferred" }]);
+  } finally {
+    s.stop();
+    off();
+  }
+});
 
 describe("schedule/scheduler: fire algorithm", () => {
   it("a brand-new schedule does NOT back-fire on first start (no fires.json)", async () => {


### PR DESCRIPTION
## Summary

- Own resident cron waits and sequential wake polling with Effect loops and the captured clock. Keep Croner, synchronous durable claims, external-slot deduplication, overdue catch-up, and recurrence policies.
- Keep claimed execution and durable settlement uninterruptible. `stop()` cancels pending waits without draining or canceling a claimed turn; no next wake is claimed afterward.
- Retain wake busy ownership through deferral and audit so idle notifications observe settled state.
- Surface typed claim failures at the resident skip/audit or external Promise boundary. Log wake claim/deferral failures before restoring pending stop interruption and end the current poll. Diagnose unexpected loop failures and preserve synchronous startup state errors.
- Preserve public APIs, store formats, and AgentCore restore/activation/snapshot behavior. External alarm mirroring remains separate.

## Validation

- Lint, typecheck, build, and **1,810 tests / 124 files** pass. CI, CodeQL, packed-package smoke, and Bun smoke pass.
- Node **22.19.0** and **24.20.0**: **229 focused tests / 13 files** pass on each.
- Real Pi SDK/tool stop behavior, SIGTERM and restart for three claim types, virtual clocks, callback-reentrant stop, failure injection, typed-error checks, and package boundaries pass.

## Measured cost

Historical measurements at `258beba6` pass the preregistered budgets against `90970b6f`. Current-head performance has not been remeasured:

| Increment | Measured maximum | Budget |
| --- | ---: | ---: |
| `/node` and root cold import | No measured increase | +20 ms |
| Import retained heap | +0.009 MiB | +5 MiB |
| Warm measured operation | +0.060 ms | +2 ms |
| Drain 1,000 disk-backed wakes | +1.086 ms | +100 ms |

Implementation grows **62 non-comment lines**: `scheduler.ts` **210 → 267 (+57)** and two assembly boundaries **+5**. This pays for explicit ownership, clock composition, and typed error handling. Ordinary TypeScript can fix the idle-ordering defect too; passing runtime budgets alone does not establish maintenance value.

Measurements use compiled artifacts, real disk state, and a scripted Agent. Production reliability, live provider/cloud behavior, long-duration behavior, compiler peak memory, and editor responsiveness remain unmeasured.

[Verification, measurements, and reproduction](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5581786467) · [Preregistered scope and budgets](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5581321265)

Refs #480.

