### PR TITLE
refactor(runtime): own AgentCore state and alarm execution with Effect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,9 +112,10 @@ src/
 │   │                     # envelope union, the webhook reply, the snapshot URL pair, the wake-alarm request,
 │   │                     # the reserved paths. The forwarder (deploy/agentcore/forwarder.js) is JavaScript
 │   │                     # and cannot import it, so agentcore-forwarder.test.ts pins its literals to these
+│   ├── agentcore-effects.ts  # typed host IO + abort-and-join request deadlines; request/background error policies stay with callers
 │   ├── agentcore-state.ts    # cross-deploy durability: the platform wipes the state mount on every version
 │   │                     # update, so the root is restored from / pushed to an S3 snapshot via presigned URLs
-│   │                     # the forwarder mints per envelope
+│   │                     # the forwarder mints per envelope; cached restore + owned/coalesced upload fibers and fresh checkpoints
 │   ├── agentcore-limits.ts   # the HOST's body ceilings, computed once (a Function URL caps at 6 MB, and the
 │   │                     # body rides base64 inside a JSON envelope) — deploy states it at plan time
 │   ├── busy.ts               # process-wide in-flight work counter + the 0-in-flight EDGE. Webhook channels ACK
@@ -246,7 +247,7 @@ src/
 │   ├── audit.ts            # runs.jsonl append-only run audit (full reply) + `schedule history` reader — "did last night's run silently fail?"
 │   ├── wake-alarm.ts       # the wake-up's EXTERNAL-clock form: on a scale-to-zero host nothing is resident to
 │   │                     # poll, so each pending wake-up is mirrored into a one-shot EventBridge schedule
-│   │                     # through the forwarder, plus the boot reconcile that re-arms alarms a deploy lost
+│   │                     # through the forwarder, plus post-restore reconcile; Effect clock/backoff owns bounded retries and joined requests
 │   └── state.ts            # atomic schedule state under <stateRoot>/schedule/ (fires.json + wakeups.json)
 └── engines/pi/              # the pi reference implementation
     ├── service.ts           # createAgentService: the public one-call shortcut = this engine's opener +

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -752,6 +752,8 @@ if the service closes while restore is pending. `StateSync` keeps its ordinary P
 upload fiber owns busy accounting across URL refresh, filesystem packing, and PUT; background saves
 coalesce, while each checkpoint joins prior work and starts a fresh upload. An older refresh response
 cannot replace a newer envelope's URL pair. The upload's own idle edge never queues another snapshot.
+The alarm sink counts admission synchronously and yields before reconciling, so an empty alarm set
+cannot emit idle between a wake's claim notification and the scheduler's execution admission.
 
 AgentCore IO has a typed failure channel with separate boundary policies: restore/checkpoint reject,
 background save reports failure, and alarm reconciliation retains its bounded retry policy. PUT and

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -746,6 +746,22 @@ forwarder topology; schedule-only URLs refuse ordinary public traffic), which re
 transport-200 because the ordinary webhook relay folds a non-200 into an opaque 502, which would
 strip exactly these diagnostics.
 
+Restore and post-restore/channel activation outcomes are cached Effects, including failures. Static
+schedule definitions load at mount time; local wake polling starts only after restore and stays stopped
+if the service closes while restore is pending. `StateSync` keeps its ordinary Promise methods. Its
+upload fiber owns busy accounting across URL refresh, filesystem packing, and PUT; background saves
+coalesce, while each checkpoint joins prior work and starts a fresh upload. An older refresh response
+cannot replace a newer envelope's URL pair. The upload's own idle edge never queues another snapshot.
+
+AgentCore IO has a typed failure channel with separate boundary policies: restore/checkpoint reject,
+background save reports failure, and alarm reconciliation retains its bounded retry policy. PUT and
+alarm deadlines use the captured Effect clock, abort the actual request, and join its settlement before
+releasing ownership or retrying. Non-abortable filesystem/activation ports are joined. A transport
+ignoring abort may delay release; a timeout does not make unfinished IO safe to abandon. Service close
+still stops polling and detaches listeners without draining accepted turns, uploads, or the process-owned
+alarm sink. Snapshot structure and persisted alarm URLs are validated; malformed data is diagnosed,
+with only a missing URL file treated as not yet configured.
+
 **Credentials ride that snapshot, so the secrets dir is INSIDE the state root** (`/mnt/state/.secrets`,
 `deploy/agentcore/plan.ts` `SECRETS_DIR`) — the one place AgentCore departs from the sibling layout the
 volume-backed hosts use (`/data/.state` + `/data/.secrets`). There the persistence boundary is the mount

--- a/src/channels/agentcore-effects.ts
+++ b/src/channels/agentcore-effects.ts
@@ -1,0 +1,42 @@
+/** AgentCore's IO ownership; callers choose whether a failure rejects a request or is diagnosed. */
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+
+export class AgentcoreFailure extends Error {
+  readonly _tag = "AgentcoreFailure";
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+  }
+}
+
+export function agentcoreFailure(cause: Cause.Cause<unknown>): unknown {
+  const error = Cause.squash(cause);
+  return error instanceof AgentcoreFailure ? error.cause : error;
+}
+
+/** Filesystem/activation ports expose no abort hook; their owner must join issued work. */
+export function agentcoreOperation<A>(run: () => Promise<A>): Effect.Effect<A, AgentcoreFailure> {
+  return Effect.tryPromise({ try: run, catch: (cause) => new AgentcoreFailure(cause) }).pipe(Effect.uninterruptible);
+}
+
+/** A deadline aborts the real request and joins it before busy ownership or a retry can proceed. */
+export function agentcoreRequest<A>(
+  run: (signal: AbortSignal) => Promise<A>,
+  timeoutMs: number,
+): Effect.Effect<A, AgentcoreFailure> {
+  const wait = (pending: Promise<A>) =>
+    Effect.tryPromise({ try: () => pending, catch: (cause) => new AgentcoreFailure(cause) });
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const controller = new AbortController();
+      // Publish the controller before entering foreign code, including a synchronous fetch throw.
+      return { controller, pending: Promise.resolve().then(() => run(controller.signal)) };
+    }),
+    ({ pending }) =>
+      wait(pending).pipe(
+        Effect.timeout(timeoutMs),
+        Effect.mapError((error) => (error instanceof AgentcoreFailure ? error : new AgentcoreFailure(error))),
+      ),
+    ({ controller, pending }) => Effect.sync(() => controller.abort()).pipe(Effect.andThen(Effect.exit(wait(pending)))),
+  );
+}

--- a/src/channels/agentcore-service.ts
+++ b/src/channels/agentcore-service.ts
@@ -3,7 +3,7 @@
  * because the host is.
  *
  * Two facts drive every difference. There is no public URL (the adapter's `POST /invocations` is the
- * only ingress, and cron slots arrive through it from an external clock, so no resident timers), and
+ * only ingress, and cron slots arrive through it from an external clock, so no resident cron timers), and
  * **the state mount at boot is PRE-RESTORE** — empty after every version update. Discovering channels
  * eagerly would therefore cache that emptiness (thread participation, delivery dedup, pending turns)
  * and then clobber the restored files with it, so channels are constructed lazily on the first
@@ -26,7 +26,7 @@ import {
   assertNoControlPlaneCollision,
   mountSessionControl,
   routesFor,
-  startSchedules,
+  prepareSchedules,
 } from "../service.ts";
 import { type AgentcoreAdapterOptions, type RouteSurface, UnknownScheduleError, agentcoreRoutes } from "./agentcore.ts";
 import { createStateSync } from "./agentcore-state.ts";
@@ -57,7 +57,7 @@ export async function mountAgentcoreService(
   // collision rule runs again then (below) against what they actually brought.
   const withControl = mountSessionControl({}, sessionControl, { agent });
 
-  const scheduled = await startSchedules(agentDir, agent, stateRoot, opened.selfSchedule, {
+  const scheduled = await prepareSchedules(agentDir, agent, stateRoot, opened.selfSchedule, {
     externalClock: true,
   });
 
@@ -82,7 +82,11 @@ export async function mountAgentcoreService(
     agent,
     stateRoot,
     schedules: scheduled.schedules,
-    onStateReady: options.onStateReady,
+    onStateReady: () => {
+      options.onStateReady?.();
+      // An envelope may finish restoring after service closure; it must not re-arm the clock.
+      if (!closed.signal.aborted) scheduled.start();
+    },
     channels: lazyChannels,
   });
   const handler = router(adapterRoutes, withControl.mounts);
@@ -102,9 +106,6 @@ export async function mountAgentcoreService(
     ready: Promise.resolve(), // nothing to open: no port of our own, no resident connections
     ...(withControl.control ? { control: withControl.control } : {}),
     async close() {
-      // UNTESTED, deliberately noted: no test observes these timers being cleared. Installing fake
-      // timers early enough to count them deadlocks the assembly's own IO. What IS tested is that
-      // close() runs and is idempotent; the stop itself rides on scheduler.stop()'s own tests.
       scheduled.stop();
       closed.abort();
     },
@@ -141,7 +142,7 @@ export function mountAgentcore(options: {
     // the state root is restored from (and pushed to) an S3 snapshot through presigned URLs the
     // forwarder mints per envelope. Always wired on this path — the platform gives no other way to
     // keep an agent's memory across a deploy.
-    stateSync: createStateSync({ stateRoot }),
+    stateSync: Effect.runSync(createStateSync({ stateRoot })),
     // What separates a forwarder envelope from any IAM principal's InvokeAgentRuntime call. Absent =
     // no forwarder in this topology, so only the public `invoke` kind is servable.
     ingressSecret: process.env.FASTAGENT_INGRESS_SECRET,

--- a/src/channels/agentcore-state.ts
+++ b/src/channels/agentcore-state.ts
@@ -15,8 +15,8 @@
  * a live deployment) and stays AWS-SDK-free: a snapshot is one `fetch` GET and one `fetch` PUT.
  *
  * Format: gzip(JSON `{ v, files: { relPath: base64 } }`). Deliberately NOT tar — the state root is a
- * handful of small JSON/JSONL files, and a single self-describing object makes restore ATOMIC: a
- * half-applied state root is far worse than a slightly stale one.
+ * handful of small JSON/JSONL files. Activation stays blocked until the whole object is restored;
+ * a partial restore must never be served or uploaded.
  */
 import { Buffer } from "node:buffer";
 import type { Dirent } from "node:fs";
@@ -26,6 +26,9 @@ import { gunzipSync, gzipSync } from "node:zlib";
 import { log } from "../log.ts";
 import type { StateUrls } from "./agentcore-protocol.ts";
 import { beginWork } from "./busy.ts";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import { type AgentcoreFailure, agentcoreFailure, agentcoreOperation, agentcoreRequest } from "./agentcore-effects.ts";
 
 /** Snapshot envelope version — an unknown version fails the restore loudly (never a silent skip). */
 export const SNAPSHOT_VERSION = 1;
@@ -36,7 +39,7 @@ export const MAX_SNAPSHOT_BYTES = 64 << 20;
 /** Warn past this — the operator should know the snapshot is getting expensive to round-trip. */
 const WARN_SNAPSHOT_BYTES = 16 << 20;
 
-/** Upload deadline. Generous (a large snapshot on a cold network) but finite. */
+/** Request abort deadline; ownership is retained until the request settles. */
 const PUT_TIMEOUT_MS = 60_000;
 
 /**
@@ -112,7 +115,12 @@ export async function unpackIntoStateRoot(stateRoot: string, packed: Buffer): Pr
   } catch (e) {
     throw new Error(`state snapshot is unreadable (${String(e)})`);
   }
-  if (snapshot?.v !== SNAPSHOT_VERSION || typeof snapshot.files !== "object" || snapshot.files === null) {
+  if (
+    snapshot?.v !== SNAPSHOT_VERSION ||
+    typeof snapshot.files !== "object" ||
+    snapshot.files === null ||
+    Array.isArray(snapshot.files)
+  ) {
     throw new Error(`state snapshot has an unsupported shape (v=${String(snapshot?.v)})`);
   }
   let written = 0;
@@ -123,6 +131,7 @@ export async function unpackIntoStateRoot(stateRoot: string, packed: Buffer): Pr
       throw new Error(`state snapshot contains an unsafe path (${rel})`);
     }
     if (EXCLUDED.has(rel)) continue; // never write a per-boot artifact from an older boot
+    if (typeof b64 !== "string") throw new Error(`state snapshot contains invalid file content (${rel})`);
     const target = join(stateRoot, rel);
     await mkdir(dirname(target), { recursive: true });
     await writeFile(target, Buffer.from(b64, "base64"));
@@ -173,154 +182,174 @@ export interface StateSync {
   checkpoint(): Promise<{ written: boolean; reason?: string }>;
 }
 
-export function createStateSync(options: StateSyncOptions): StateSync {
-  const { stateRoot } = options;
-  const doFetch = options.fetchImpl ?? fetch;
-  let urls: StateUrls | undefined;
-  let restore: Promise<void> | undefined;
-  let restored = false;
-  let saving: Promise<void> | undefined;
-  let queued = false;
-  // Whether the upload loop is still able to pick up another round. Counting the upload as in-flight
-  // work (below) means ITS completion is itself a 0-in-flight edge, which re-enters save() — without
-  // this the snapshot would queue a redundant follow-up after every single upload.
-  let looping = false;
+export function createStateSync(options: StateSyncOptions): Effect.Effect<StateSync> {
+  return Effect.gen(function* () {
+    const context = yield* Effect.context<never>();
+    const run = Effect.runPromiseWith(context);
+    const fork = Effect.runForkWith(context);
+    const { stateRoot } = options;
+    const doFetch = options.fetchImpl ?? fetch;
+    let urls: StateUrls | undefined;
+    let restore: Effect.Effect<void, AgentcoreFailure> | undefined;
+    let restored = false;
+    let saving: Fiber.Fiber<unknown, unknown> | undefined;
+    let queued = false;
+    // Whether the upload loop is still able to pick up another round. Counting the upload as in-flight
+    // work (below) means ITS completion is itself a 0-in-flight edge, which re-enters save() — without
+    // this the snapshot would queue a redundant follow-up after every single upload.
+    let looping = false;
 
-  const runRestore = async (urls: StateUrls): Promise<void> => {
-    const res = await doFetch(urls.getUrl, { method: "GET" });
-    // ONLY a proven 404 is "first deploy". A missing key answers 404 only because the generated
-    // template grants the signer s3:ListBucket on the snapshot prefix — without it S3 folds "absent"
-    // into 403 (anti-enumeration). A 403 therefore means an expired or malformed signature, a
-    // revoked permission, or a template from before that grant — i.e. the snapshot may well exist.
-    // Reading 403 as "absent" would serve an empty agent and then overwrite the real snapshot with
-    // that emptiness.
-    if (res.status === 404) {
-      log.info("[agentcore] no state snapshot yet — starting from an empty state root (first deploy)");
+    const runRestore = async (urls: StateUrls): Promise<void> => {
+      const res = await doFetch(urls.getUrl, { method: "GET" });
+      // ONLY a proven 404 is "first deploy". A missing key answers 404 only because the generated
+      // template grants the signer s3:ListBucket on the snapshot prefix — without it S3 folds "absent"
+      // into 403 (anti-enumeration). A 403 therefore means an expired or malformed signature, a
+      // revoked permission, or a template from before that grant — i.e. the snapshot may well exist.
+      // Reading 403 as "absent" would serve an empty agent and then overwrite the real snapshot with
+      // that emptiness.
+      if (res.status === 404) {
+        log.info("[agentcore] no state snapshot yet — starting from an empty state root (first deploy)");
+        restored = true;
+        return;
+      }
+      if (!res.ok) {
+        const hint =
+          res.status === 403
+            ? " (an expired presigned URL, a revoked permission, or a template generated before the " +
+              "ForwarderRole granted s3:ListBucket — S3 answers 403 even for a MISSING first-deploy " +
+              "snapshot without it; regenerate with `fastagent deploy agentcore --force` and redeploy)"
+            : "";
+        throw new Error(`state snapshot GET failed: ${res.status}${hint}`);
+      }
+      const written = await unpackIntoStateRoot(stateRoot, Buffer.from(await res.arrayBuffer()));
+      log.info(`[agentcore] restored ${written} state file(s) from the snapshot`);
       restored = true;
-      return;
-    }
-    if (!res.ok) {
-      const hint =
-        res.status === 403
-          ? " (an expired presigned URL, a revoked permission, or a template generated before the " +
-            "ForwarderRole granted s3:ListBucket — S3 answers 403 even for a MISSING first-deploy " +
-            "snapshot without it; regenerate with `fastagent deploy agentcore --force` and redeploy)"
-          : "";
-      throw new Error(`state snapshot GET failed: ${res.status}${hint}`);
-    }
-    const written = await unpackIntoStateRoot(stateRoot, Buffer.from(await res.arrayBuffer()));
-    log.info(`[agentcore] restored ${written} state file(s) from the snapshot`);
-    restored = true;
-  };
+    };
 
-  const refreshUrls = async (): Promise<void> => {
-    if (!urls?.refresh) return;
-    const res = await doFetch(urls.refresh.url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ auth: urls.refresh.auth }),
-      signal: AbortSignal.timeout(PUT_TIMEOUT_MS),
+    const refreshUrls = Effect.suspend(() => {
+      const current = urls;
+      const refresh = current?.refresh;
+      if (!refresh) return Effect.void;
+      return agentcoreRequest(async (signal) => {
+        const res = await doFetch(refresh.url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ auth: refresh.auth }),
+          signal,
+        });
+        if (!res.ok) throw new Error(`state snapshot URL refresh failed: ${res.status}`);
+        const fresh = (await res.json()) as { getUrl?: unknown; putUrl?: unknown };
+        if (typeof fresh.getUrl !== "string" || typeof fresh.putUrl !== "string") {
+          throw new Error("state snapshot URL refresh returned an invalid response");
+        }
+        // An envelope received during the refresh owns the newer URL pair.
+        if (urls === current) urls = { ...current, getUrl: fresh.getUrl, putUrl: fresh.putUrl };
+      }, PUT_TIMEOUT_MS);
     });
-    if (!res.ok) throw new Error(`state snapshot URL refresh failed: ${res.status}`);
-    const fresh = (await res.json()) as { getUrl?: unknown; putUrl?: unknown };
-    if (typeof fresh.getUrl !== "string" || typeof fresh.putUrl !== "string") {
-      throw new Error("state snapshot URL refresh returned an invalid response");
-    }
-    urls = { ...urls, getUrl: fresh.getUrl, putUrl: fresh.putUrl };
-  };
 
-  const runSave = async (): Promise<void> => {
-    // Counted as in-flight work for its whole duration: `save()` fires on the 0-in-flight edge, the
-    // exact moment /ping starts answering Healthy — without this the platform may reclaim the microVM
-    // mid-upload and the turn that just finished is lost with only a log line. Bounded too: a hung
-    // PUT would otherwise pin `saving` forever and block every later snapshot.
-    const workDone = beginWork();
-    looping = true;
-    try {
+    const upload = Effect.gen(function* () {
       do {
         queued = false;
         if (!restored || !urls) return;
         // A webhook turn may settle hours after its envelope. Re-mint immediately before every PUT
         // instead of assuming the Lambda credentials that signed the envelope outlive the turn.
-        await refreshUrls();
-        const body = await packStateRoot(stateRoot);
-        const res = await doFetch(urls.putUrl, {
-          method: "PUT",
-          body: new Uint8Array(body),
-          signal: AbortSignal.timeout(PUT_TIMEOUT_MS),
-        });
-        if (!res.ok) {
-          const hint =
-            res.status === 403 ? " (presigned URL or its temporary signing credentials may have expired)" : "";
-          throw new Error(`state snapshot PUT failed: ${res.status}${hint}`);
-        }
+        yield* refreshUrls;
+        const body = yield* agentcoreOperation(() => packStateRoot(stateRoot));
+        const putUrl = urls.putUrl;
+        yield* agentcoreRequest(async (signal) => {
+          const res = await doFetch(putUrl, {
+            method: "PUT",
+            body: new Uint8Array(body),
+            signal,
+          });
+          if (!res.ok) {
+            const hint =
+              res.status === 403 ? " (presigned URL or its temporary signing credentials may have expired)" : "";
+            throw new Error(`state snapshot PUT failed: ${res.status}${hint}`);
+          }
+        }, PUT_TIMEOUT_MS);
       } while (queued);
-    } finally {
-      looping = false;
-      workDone();
-    }
-  };
+    });
 
-  return {
-    use(next) {
-      urls = next;
-    },
-    configured() {
-      return urls !== undefined;
-    },
-    ready() {
-      // No URLs = not an ingress envelope (a direct invoke has its own isolated storage): nothing to
-      // restore, and deliberately NOT cached, so the first envelope that does carry them still runs
-      // the restore.
-      if (!urls) return Promise.resolve();
-      // One attempt per process otherwise: a rejected restore stays rejected so every subsequent
-      // envelope fails the same visible way instead of quietly serving an empty agent.
-      restore ??= runRestore(urls);
-      return restore;
-    },
-    save() {
-      if (!restored) return; // never overwrite a good snapshot with a state root we failed to fill
-      if (saving) {
-        if (looping) queued = true; // otherwise this is the upload's own completion edge, not new work
-        return;
-      }
-      saving = runSave()
-        .catch((e) => {
-          log.error(`[agentcore] could not save the state snapshot: ${String(e)} — retrying when work next settles`);
-        })
-        .finally(() => {
-          saving = undefined;
-        });
-    },
-    async flush() {
-      while (saving) await saving;
-    },
-    async checkpoint() {
-      if (!urls) {
-        return { written: false, reason: "this session has never served a forwarder envelope" };
-      }
-      if (!restored) {
-        return { written: false, reason: "the state root is not authoritative here (nothing restored)" };
-      }
-      // Never overlap an in-flight upload, then run a FRESH one: joining the running round could
-      // return before the bytes written moments ago (the interrupted turn's intent) are included.
-      while (saving) await saving;
-      const run = runSave();
-      // Stored form never rejects (an unawaited rejection would be an unhandled crash); the caller
-      // awaits `run` itself and gets the error.
-      saving = run.then(
-        () => {},
-        () => {},
+    const startSave = (work: Effect.Effect<void, AgentcoreFailure>) =>
+      fork(
+        Effect.withFiber((fiber) => {
+          saving = fiber;
+          looping = true;
+          return Effect.acquireUseRelease(
+            Effect.sync(beginWork),
+            () => work,
+            (done) =>
+              Effect.sync(() => {
+                looping = false;
+                done();
+              }),
+          ).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                saving = undefined;
+              }),
+            ),
+          );
+        }),
       );
-      const settle = saving.finally(() => {
-        saving = undefined;
-      });
-      try {
-        await run;
-      } finally {
-        await settle;
-      }
-      return { written: true };
-    },
-  };
+    const flush = Effect.gen(function* () {
+      while (saving) yield* Fiber.await(saving);
+    });
+
+    return {
+      use(next) {
+        urls = next;
+      },
+      configured() {
+        return urls !== undefined;
+      },
+      ready() {
+        // No URLs = not an ingress envelope (a direct invoke has its own isolated storage): nothing to
+        // restore, and deliberately NOT cached, so the first envelope that does carry them still runs
+        // the restore.
+        if (!urls) return Promise.resolve();
+        // One attempt per process otherwise: a rejected restore stays rejected so every subsequent
+        // envelope fails the same visible way instead of quietly serving an empty agent.
+        const current = urls;
+        restore ??= Effect.runSync(Effect.cached(agentcoreOperation(() => runRestore(current))));
+        return run(restore.pipe(Effect.mapError((error) => error.cause)));
+      },
+      save() {
+        if (!restored) return; // never overwrite a good snapshot with a state root we failed to fill
+        if (saving) {
+          if (looping) queued = true; // otherwise this is the upload's own completion edge, not new work
+          return;
+        }
+        startSave(
+          upload.pipe(
+            Effect.catchCause((cause) =>
+              Effect.sync(() => {
+                log.error(
+                  `[agentcore] could not save the state snapshot: ${String(agentcoreFailure(cause))} — retrying when work next settles`,
+                );
+              }),
+            ),
+          ),
+        );
+      },
+      flush: () => run(flush),
+      checkpoint: () =>
+        run(
+          Effect.gen(function* () {
+            if (!urls) {
+              return { written: false, reason: "this session has never served a forwarder envelope" };
+            }
+            if (!restored) {
+              return { written: false, reason: "the state root is not authoritative here (nothing restored)" };
+            }
+            // Never overlap an in-flight upload, then run a FRESH one: joining the running round could
+            // return before the bytes written moments ago (the interrupted turn's intent) are included.
+            yield* flush;
+            yield* Fiber.join(startSave(upload));
+            return { written: true };
+          }).pipe(Effect.mapError((error) => error.cause)),
+        ),
+    } satisfies StateSync;
+  });
 }

--- a/src/channels/agentcore.ts
+++ b/src/channels/agentcore.ts
@@ -26,6 +26,8 @@
  * the platform reclaim the microVM (that idle-to-zero IS the point of this deployment).
  */
 import { Buffer } from "node:buffer";
+import * as Effect from "effect/Effect";
+import { AgentcoreFailure, agentcoreOperation } from "./agentcore-effects.ts";
 import type { Agent } from "../agent.ts";
 import type { StateSync } from "./agentcore-state.ts";
 import { type AgentcoreEnvelope, ENVELOPE_KINDS, type WebhookReply } from "./agentcore-protocol.ts";
@@ -118,54 +120,67 @@ function createActivation(deps: {
    *  restore (once — the sync memoizes it), persist the forwarder's URL, run the post-restore hook
    *  once. REJECTS when a snapshot exists but cannot be restored; the caller fails the request
    *  rather than serve an empty agent (and then snapshot that emptiness over the good copy). */
-  restore(envelope: AgentcoreEnvelope): Promise<void>;
+  restore(envelope: AgentcoreEnvelope): Effect.Effect<void, AgentcoreFailure>;
   /** The channel surface, constructed on first use after a restore; the outcome is cached either way. */
-  channels(): Promise<ChannelHandler>;
+  channels: Effect.Effect<ChannelHandler, AgentcoreFailure>;
 } {
   const { stateSync, stateRoot, onStateReady } = deps;
   let warnedUnsnapshotted = false;
-  let stateReadyFired = false;
-  let dispatchP: Promise<ChannelHandler> | undefined;
+  const stateReady = Effect.runSync(
+    Effect.cached(
+      agentcoreOperation(async () => {
+        onStateReady?.();
+      }),
+    ),
+  );
+  const channels = Effect.runSync(
+    Effect.cached(
+      agentcoreOperation(async () => {
+        const surface = await deps.channels();
+        return router(surface.routes, surface.mounts);
+      }),
+    ),
+  );
   return {
-    async restore(envelope) {
-      if (stateSync) {
-        if (envelope.state && typeof envelope.state.getUrl === "string" && typeof envelope.state.putUrl === "string") {
-          stateSync.use(envelope.state);
-        } else if (envelope.kind !== "invoke" && !stateSync.configured() && !warnedUnsnapshotted) {
-          // webhook/schedule-fire/wake-poke/probe reach us ONLY through the forwarder, which mints the
-          // pair. Missing = a broken/stale topology whose state dies at the next deploy: say so, loudly,
-          // once per process (a direct `invoke` legitimately has none — its session storage is its own).
-          warnedUnsnapshotted = true;
-          log.warn(unsnapshottedWarning);
+    restore: (envelope) =>
+      Effect.gen(function* () {
+        if (stateSync) {
+          yield* agentcoreOperation(async () => {
+            if (
+              envelope.state &&
+              typeof envelope.state.getUrl === "string" &&
+              typeof envelope.state.putUrl === "string"
+            ) {
+              stateSync.use(envelope.state);
+            } else if (envelope.kind !== "invoke" && !stateSync.configured() && !warnedUnsnapshotted) {
+              // webhook/schedule-fire/wake-poke/probe reach us ONLY through the forwarder, which mints the
+              // pair. Missing = a broken/stale topology whose state dies at the next deploy: say so, loudly,
+              // once per process (a direct `invoke` legitimately has none — its session storage is its own).
+              warnedUnsnapshotted = true;
+              log.warn(unsnapshottedWarning);
+            }
+            await stateSync.ready();
+          });
         }
-        await stateSync.ready();
-      }
-      // The forwarder rides its public URL along on every envelope — persist it (write-if-changed) so
-      // the wake-alarm sink can call back. AFTER the restore: a stale snapshot copy must not win over
-      // the URL this deployment is actually reachable at. A bad persist must not fail the turn.
-      if (typeof envelope.wake?.url === "string") {
-        try {
-          rememberWakeAlarmUrl(stateRoot, envelope.wake.url);
-        } catch (e) {
-          log.error(`[agentcore] could not persist the wake-alarm URL: ${String(e)}`);
+        // The forwarder rides its public URL along on every envelope — persist it (write-if-changed) so
+        // the wake-alarm sink can call back. AFTER the restore: a stale snapshot copy must not win over
+        // the URL this deployment is actually reachable at. A bad persist must not fail the turn.
+        if (typeof envelope.wake?.url === "string") {
+          const url = envelope.wake.url;
+          yield* Effect.try({
+            try: () => rememberWakeAlarmUrl(stateRoot, url),
+            catch: (cause) => new AgentcoreFailure(cause),
+          }).pipe(
+            Effect.catchTag("AgentcoreFailure", (error) =>
+              Effect.sync(() => {
+                log.error(`[agentcore] could not persist the wake-alarm URL: ${String(error.cause)}`);
+              }),
+            ),
+          );
         }
-      }
-      if (onStateReady && !stateReadyFired) {
-        stateReadyFired = true;
-        onStateReady();
-      }
-    },
-    channels() {
-      if (!dispatchP) {
-        // The factory runs INSIDE the chain: a synchronous throw must land in the cached rejection,
-        // not escape before `dispatchP` is assigned (which would silently re-run the activation).
-        dispatchP = Promise.resolve()
-          .then(deps.channels)
-          .then((surface) => router(surface.routes, surface.mounts));
-        dispatchP.catch(() => {}); // observed here so the CACHED rejection is never "unhandled"
-      }
-      return dispatchP;
-    },
+        yield* stateReady;
+      }),
+    channels,
   };
 }
 
@@ -176,8 +191,10 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
   // Snapshot on the 0-in-flight edge: webhook channels ACK fast and finish the turn in the
   // background, so "the request returned" is NOT when the state root settles.
   if (stateSync) {
-    const off = onIdle(() => stateSync.save());
-    options.signal?.addEventListener("abort", off, { once: true });
+    if (!options.signal?.aborted) {
+      const off = onIdle(() => stateSync.save());
+      options.signal?.addEventListener("abort", off, { once: true });
+    }
   }
 
   const handleInvocation = async (req: Request): Promise<Response> => {
@@ -210,7 +227,7 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
     // Cross-deploy state: the platform wipes /mnt/state on every version update, so the durable copy
     // must be pulled back BEFORE anything reads it.
     try {
-      await activation.restore(envelope);
+      await Effect.runPromise(activation.restore(envelope).pipe(Effect.mapError((error) => error.cause)));
     } catch (e) {
       log.error(`[agentcore] state restore failed: ${String(e)}`);
       // The probe is the deploy driver's verification channel: its diagnostics must survive the
@@ -232,7 +249,7 @@ export function agentcoreRoutes(options: AgentcoreAdapterOptions): Routes {
     let dispatch: ChannelHandler | undefined;
     if (trusted && envelope.kind !== "checkpoint" && envelope.kind !== "invoke") {
       try {
-        dispatch = await activation.channels();
+        dispatch = await Effect.runPromise(activation.channels.pipe(Effect.mapError((error) => error.cause)));
       } catch (e) {
         constructionError = String(e);
         log.error(`[agentcore] channel construction failed: ${constructionError}`);

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -3,6 +3,7 @@
  * directory is the agent), just no file-watching. No build step: start reads the definition directly.
  */
 import { dirname } from "node:path";
+import * as Effect from "effect/Effect";
 import { writeFileAtomic } from "../../atomic-write.ts";
 import { authSeedBytes, collectAuthSeed } from "../../deploy/secrets.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
@@ -133,7 +134,7 @@ async function maybeSeedAuth(authPath: string): Promise<void> {
 }
 
 /**
- * Install the wake-ALARM sink before the scheduler starts — the boot wake pump may advance a
+ * Install the wake-ALARM sink before the scheduler starts — the first wake poll may advance a
  * recurring entry, and that save must already re-arm its alarm. Returns the post-restore reconcile:
  * running it at boot would read the pre-restore state mount, see no pending wake-ups, and conclude
  * there is nothing to re-arm.
@@ -147,7 +148,7 @@ function armWakeAlarms(stateRoot: string): (() => void) | undefined {
     );
     return undefined;
   }
-  const sink = createWakeAlarmSink({ secret });
+  const sink = Effect.runSync(createWakeAlarmSink({ secret }));
   setWakeupsSink(sink);
   log.info(`[fastagent] wake alarms: EventBridge-backed via the forwarder`);
   // Boot reconcile: pending wake-ups may exist while their alarms were lost (a deploy replaced the

--- a/src/schedule/wake-alarm.ts
+++ b/src/schedule/wake-alarm.ts
@@ -23,6 +23,14 @@
  * wasted wake-up of the box, traded for never needing list/delete choreography.
  */
 import { readFileSync } from "node:fs";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import {
+  AgentcoreFailure,
+  agentcoreFailure,
+  agentcoreOperation,
+  agentcoreRequest,
+} from "../channels/agentcore-effects.ts";
 import { RESERVED_PATHS, type WakeAlarm, type WakeAlarmRequest } from "../channels/agentcore-protocol.ts";
 import { beginWork } from "../channels/busy.ts";
 import { log } from "../log.ts";
@@ -46,9 +54,11 @@ export function rememberWakeAlarmUrl(stateRoot: string, url: string): void {
 export function readWakeAlarmUrl(stateRoot: string): string | undefined {
   try {
     const v = JSON.parse(readFileSync(scheduleFile(stateRoot, URL_FILE), "utf8")) as { url?: unknown };
-    return typeof v.url === "string" ? v.url : undefined;
-  } catch {
-    return undefined; // absent/corrupt — the next envelope rewrites it
+    if (typeof v?.url !== "string" || v.url === "") throw new Error("expected a nonempty url string");
+    return v.url;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw new Error(`wake-alarm URL ${scheduleFile(stateRoot, URL_FILE)} is unreadable: ${String(cause)}`, { cause });
   }
 }
 
@@ -94,92 +104,118 @@ export function createWakeAlarmSink(options: {
   now?: () => Date;
   /** Injectable retry pause (tests); defaults to exponential-ish backoff off RETRY_BASE_MS. */
   delay?: (ms: number) => Promise<void>;
-}): (stateRoot: string) => void {
-  const { secret, fetchImpl = fetch, now = () => new Date() } = options;
-  const delay = options.delay ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  let running = false;
-  let dirty = false;
+}): Effect.Effect<(stateRoot: string) => void> {
+  return Effect.gen(function* () {
+    const clock = yield* Clock.Clock;
+    const fork = Effect.runForkWith(yield* Effect.context<never>());
+    const { secret, fetchImpl = fetch, now = () => new Date(clock.currentTimeMillisUnsafe()), delay: pause } = options;
+    const delay = (ms: number) => (pause ? agentcoreOperation(() => pause(ms)) : Effect.sleep(ms));
+    let running = false;
+    let dirty = false;
 
-  /** One POST of the CURRENT desired set. Returns false to retry, true when there is nothing left
-   *  to do (converged, or nothing this loop can act on). */
-  async function attemptOnce(stateRoot: string, attempt: number): Promise<boolean> {
-    const alarms = toAlarms(listWakeups(stateRoot), now());
-    // Nothing future to mirror: converged. Deletion is lazy by design — alarms already mirrored for
-    // cancelled wake-ups fire, find nothing, self-delete — so an empty set is never POSTed.
-    if (alarms.length === 0) return true;
-    const url = readWakeAlarmUrl(stateRoot);
-    if (!url) {
-      // Before the first envelope, or an unreadable state mount (readWakeAlarmUrl folds both into
-      // undefined). The wake itself is stored; the next store mutation or boot re-mirrors it.
-      log.warn("[schedule] wake alarm skipped — forwarder URL unavailable (not seen yet, or unreadable)");
-      return true;
-    }
-    const body: WakeAlarmRequest = { secret, alarms };
-    try {
-      const res = await fetchImpl(`${url.replace(/\/$/, "")}${RESERVED_PATHS.wakeAlarm}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(SYNC_TIMEOUT_MS),
-      });
-      if (res.ok) return true;
-      log.warn(`[schedule] wake alarm sync attempt ${attempt}/${MAX_SYNC_ATTEMPTS} failed: HTTP ${res.status}`);
-    } catch (e) {
-      log.warn(`[schedule] wake alarm sync attempt ${attempt}/${MAX_SYNC_ATTEMPTS} failed: ${String(e)}`);
-    }
-    return false;
-  }
-
-  async function reconcile(stateRoot: string): Promise<void> {
-    // Counted as in-flight work: the retry loop is exactly the window where the box must not be
-    // reclaimed — idle away mid-retry and a pending wake has no alarm until the next boot.
-    const workDone = beginWork();
-    // Consecutive failures ACROSS passes, not within one. A mid-retry mutation restarts the attempt
-    // sequence (the backoff and the log's `n/N` are about the new desired set), but it must not renew
-    // the budget: a store mutating faster than the backoff would keep the loop alive forever, and the
-    // one loud line saying the forwarder is down — the per-attempt warns are filterable — would never
-    // be reached. This counter is the thing that survives to reach it.
-    let failures = 0;
-    try {
-      while (dirty && failures < MAX_SYNC_ATTEMPTS) {
-        dirty = false;
-        for (let attempt = 1; attempt <= MAX_SYNC_ATTEMPTS; attempt++) {
-          if (await attemptOnce(stateRoot, attempt)) {
-            failures = 0;
-            break;
-          }
-          failures++;
-          if (attempt === MAX_SYNC_ATTEMPTS || failures >= MAX_SYNC_ATTEMPTS) break;
-          await delay(RETRY_BASE_MS * attempt);
-          // A mutation landed mid-retry: the desired state moved, so this budget is spent on a set
-          // that no longer exists. Restart the attempt count against the new one.
-          if (dirty) break;
+    /** One POST of the CURRENT desired set. Returns false to retry, true when there is nothing left
+     *  to do (converged, or nothing this loop can act on). */
+    const attemptOnce = (stateRoot: string, attempt: number) =>
+      Effect.gen(function* () {
+        const alarms = yield* Effect.try({
+          try: () => toAlarms(listWakeups(stateRoot), now()),
+          catch: (cause) => new AgentcoreFailure(cause),
+        });
+        // Nothing future to mirror: converged. Deletion is lazy by design — alarms already mirrored for
+        // cancelled wake-ups fire, find nothing, self-delete — so an empty set is never POSTed.
+        if (alarms.length === 0) return true;
+        const url = yield* Effect.try({
+          try: () => readWakeAlarmUrl(stateRoot),
+          catch: (cause) => new AgentcoreFailure(cause),
+        });
+        if (!url) {
+          log.warn("[schedule] wake alarm skipped — forwarder URL not seen yet");
+          return true;
         }
-      }
-      if (failures >= MAX_SYNC_ATTEMPTS) {
-        log.error(
-          `[schedule] wake alarm sync FAILED after ${MAX_SYNC_ATTEMPTS} attempts — pending wake-ups have no ` +
-            `external alarm until the next store change or boot re-mirrors them`,
+        const body: WakeAlarmRequest = { secret, alarms };
+        return yield* agentcoreRequest(async (signal) => {
+          const res = await fetchImpl(`${url.replace(/\/$/, "")}${RESERVED_PATHS.wakeAlarm}`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(body),
+            signal,
+          });
+          return res;
+        }, SYNC_TIMEOUT_MS).pipe(
+          Effect.match({
+            onSuccess: (res) => {
+              if (res.ok) return true;
+              log.warn(`[schedule] wake alarm sync attempt ${attempt}/${MAX_SYNC_ATTEMPTS} failed: HTTP ${res.status}`);
+              return false;
+            },
+            onFailure: (error) => {
+              log.warn(
+                `[schedule] wake alarm sync attempt ${attempt}/${MAX_SYNC_ATTEMPTS} failed: ${String(error.cause)}`,
+              );
+              return false;
+            },
+          }),
         );
-      }
-    } catch (e) {
-      // The END of the error path: nothing awaits this loop, so an escape is an unhandled rejection
-      // that kills the container. `listWakeups` throws by design on an unreadable store (state.ts),
-      // exactly the fault a wake alarm cannot fix — report it and leave the store write untouched,
-      // which is this sink's whole contract. The next mutation or boot re-runs the mirror.
-      log.error(`[schedule] wake alarm reconcile failed (alarms are stale until the next store change): ${String(e)}`);
-    } finally {
-      running = false;
-      workDone();
-    }
-  }
+      });
 
-  // Single-flight: a save arriving while the loop runs only marks it dirty, so a burst coalesces
-  // into one more pass instead of one concurrent loop each.
-  return (stateRoot) => {
-    dirty = true;
-    if (running) return;
-    running = true;
-    void reconcile(stateRoot);
-  };
+    const reconcile = (stateRoot: string) =>
+      Effect.gen(function* () {
+        // Consecutive failures ACROSS passes, not within one. A mid-retry mutation restarts the attempt
+        // sequence (the backoff and the log's `n/N` are about the new desired set), but it must not renew
+        // the budget: a store mutating faster than the backoff would keep the loop alive forever, and the
+        // one loud line saying the forwarder is down — the per-attempt warns are filterable — would never
+        // be reached. This counter is the thing that survives to reach it.
+        let failures = 0;
+        while (dirty && failures < MAX_SYNC_ATTEMPTS) {
+          dirty = false;
+          for (let attempt = 1; attempt <= MAX_SYNC_ATTEMPTS; attempt++) {
+            if (yield* attemptOnce(stateRoot, attempt)) {
+              failures = 0;
+              break;
+            }
+            failures++;
+            if (attempt === MAX_SYNC_ATTEMPTS || failures >= MAX_SYNC_ATTEMPTS) break;
+            yield* delay(RETRY_BASE_MS * attempt);
+            // A mutation landed mid-retry: the desired state moved, so this budget is spent on a set
+            // that no longer exists. Restart the attempt count against the new one.
+            if (dirty) break;
+          }
+        }
+        if (failures >= MAX_SYNC_ATTEMPTS) {
+          log.error(
+            `[schedule] wake alarm sync FAILED after ${MAX_SYNC_ATTEMPTS} attempts — pending wake-ups have no ` +
+              `external alarm until the next store change or boot re-mirrors them`,
+          );
+        }
+      });
+
+    // Single-flight: a save arriving while the loop runs only marks it dirty, so a burst coalesces
+    // into one more pass instead of one concurrent loop each.
+    return (stateRoot) => {
+      dirty = true;
+      if (running) return;
+      running = true;
+      fork(
+        Effect.acquireUseRelease(
+          Effect.sync(beginWork),
+          () =>
+            reconcile(stateRoot).pipe(
+              Effect.catchCause((cause) =>
+                Effect.sync(() => {
+                  // Store/clock faults cannot be repaired by another POST. A new mutation may retry the mirror.
+                  log.error(
+                    `[schedule] wake alarm reconcile failed (alarms are stale until the next store change): ${String(agentcoreFailure(cause))}`,
+                  );
+                }),
+              ),
+            ),
+          (done) =>
+            Effect.sync(() => {
+              running = false;
+              done();
+            }),
+        ),
+      );
+    };
+  });
 }

--- a/src/schedule/wake-alarm.ts
+++ b/src/schedule/wake-alarm.ts
@@ -199,7 +199,9 @@ export function createWakeAlarmSink(options: {
         Effect.acquireUseRelease(
           Effect.sync(beginWork),
           () =>
-            reconcile(stateRoot).pipe(
+            // Claim notification precedes scheduler admission; retain busy ownership through that handoff.
+            Effect.yieldNow.pipe(
+              Effect.andThen(reconcile(stateRoot)),
               Effect.catchCause((cause) =>
                 Effect.sync(() => {
                   // Store/clock faults cannot be repaired by another POST. A new mutation may retry the mirror.

--- a/src/service.ts
+++ b/src/service.ts
@@ -209,31 +209,42 @@ export function mountSessionControl(
  * ONE load instead of re-discovering. `externalClock` (AgentCore) arms no resident cron timers.
  */
 export async function startSchedules(
+  ...args: Parameters<typeof prepareSchedules>
+): Promise<{ schedules: LoadedSchedule[]; stop: () => void }> {
+  const scheduled = await prepareSchedules(...args);
+  scheduled.start();
+  return { schedules: scheduled.schedules, stop: scheduled.stop };
+}
+
+/** Load definitions without reading execution state; AgentCore starts polling only after restore. */
+export async function prepareSchedules(
   agentDir: string,
   agent: Agent,
   stateRoot: string,
   selfSchedule: boolean,
   options: { externalClock?: boolean } = {},
-): Promise<{ schedules: LoadedSchedule[]; stop: () => void }> {
+): Promise<{ schedules: LoadedSchedule[]; start: () => void; stop: () => void }> {
   // Thrown, not exited on: this runs inside an embedder's app as well as the CLI, and a library
   // that calls process.exit takes a decision (degrade? retry? stop?) that belongs to its host. The
   // CLI catches at its own boundary.
   const { schedules, failures } = await loadSchedules(agentDir);
   reportModuleLoadFailures(failures);
-  if (schedules.length === 0 && !selfSchedule) return { schedules, stop: () => {} };
+  if (schedules.length === 0 && !selfSchedule) return { schedules, start: () => {}, stop: () => {} };
   const scheduler = Effect.runSync(
     createScheduler({ agent, stateRoot, schedules, externalClock: options.externalClock }),
   );
-  scheduler.start();
-  if (schedules.length > 0) {
-    log.info(
-      `[fastagent] schedules: ${schedules.map((s) => s.name).join(", ")}${options.externalClock ? " (external clock — no resident cron timers)" : ""}`,
-    );
-  }
-  // Returned rather than bound to process signals here: this runs inside an embedder's app as well
-  // as the CLI, and a library that installs SIGINT handlers is deciding something that is not its
-  // to decide. `runStart`/`runDev` wire it to their own shutdown.
-  return { schedules, stop: () => scheduler.stop() };
+  return {
+    schedules,
+    start() {
+      scheduler.start();
+      if (schedules.length > 0) {
+        log.info(
+          `[fastagent] schedules: ${schedules.map((s) => s.name).join(", ")}${options.externalClock ? " (external clock — no resident cron timers)" : ""}`,
+        );
+      }
+    },
+    stop: () => scheduler.stop(),
+  };
 }
 
 export interface AgentService {

--- a/test/agentcore-adapter.test.ts
+++ b/test/agentcore-adapter.test.ts
@@ -228,6 +228,21 @@ describe("agentcore adapter: lazy channel construction", () => {
   });
 });
 
+it("does not subscribe to idle edges with an already-aborted owner", async () => {
+  const { beginWork } = await import("../src/channels/busy.ts");
+  const sync = fakeStateSync();
+  agentcoreRoutes({
+    channels: () => ({ routes: {} }),
+    agent: scriptedAgent(),
+    stateRoot,
+    isBusy: () => false,
+    stateSync: sync,
+    signal: AbortSignal.abort(),
+  });
+  beginWork()();
+  expect(sync.saves()).toBe(0);
+});
+
 describe("agentcore adapter: /ping", () => {
   it("reports Healthy when idle and HealthyBusy while background work is in flight", async () => {
     let busy = false;
@@ -618,6 +633,42 @@ describe("agentcore adapter: the authentication boundary", () => {
 });
 
 describe("agentcore adapter: post-restore hooks", () => {
+  it("caches a failed post-restore hook instead of serving on the next envelope", async () => {
+    const error = new Error("activation failed");
+    const onStateReady = vi.fn(() => {
+      throw error;
+    });
+    const channels = vi.fn(() => ({ routes: {} }));
+    const routes = adapter({ onStateReady, channels });
+    for (let i = 0; i < 2; i++) {
+      const res = await postEnvelope(routes, { kind: "probe" });
+      expect(await res.json()).toEqual({ ok: false, error: `state restore failed: ${String(error)}` });
+    }
+    expect(onStateReady).toHaveBeenCalledOnce();
+    expect(channels).not.toHaveBeenCalled();
+  });
+
+  it("joins concurrent activation callers and caches their shared failure", async () => {
+    const entered = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    const channels = vi.fn(async () => {
+      entered.resolve();
+      await finish.promise;
+      throw new Error("partial construction failed");
+    });
+    const routes = adapter({ channels });
+    const first = postEnvelope(routes, { kind: "probe" });
+    await entered.promise;
+    const second = postEnvelope(routes, { kind: "probe" });
+    finish.resolve();
+    for (const response of await Promise.all([first, second])) {
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "channel construction failed: Error: partial construction failed",
+      });
+    }
+    expect(channels).toHaveBeenCalledOnce();
+  });
   it("runs onStateReady ONCE, after the restore — a boot-time reconcile would see the wiped mount", async () => {
     const order: string[] = [];
     const sync = fakeStateSync({

--- a/test/agentcore-effects.test.ts
+++ b/test/agentcore-effects.test.ts
@@ -1,0 +1,86 @@
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
+import { createServer } from "node:http";
+import { expect, expectTypeOf, it } from "vitest";
+import { type AgentcoreFailure, agentcoreOperation, agentcoreRequest } from "../src/channels/agentcore-effects.ts";
+
+it("keeps IO errors typed and joins an issued non-abortable port on interruption", async () => {
+  const entered = Promise.withResolvers<void>();
+  const finish = Promise.withResolvers<void>();
+  let completed = false;
+  const work = agentcoreOperation(async () => {
+    entered.resolve();
+    await finish.promise;
+    completed = true;
+  });
+  expectTypeOf(work).toEqualTypeOf<Effect.Effect<void, AgentcoreFailure>>();
+  // @ts-expect-error -- a storage/activation failure needs a boundary policy
+  const infallible: Effect.Effect<void> = work;
+  void infallible;
+  const abort = new AbortController();
+  let settled = false;
+  const done = Effect.runPromiseExit(work, { signal: abort.signal }).then((exit) => {
+    settled = true;
+    return exit;
+  });
+  await entered.promise;
+  abort.abort();
+  await new Promise(setImmediate);
+  expect(settled).toBe(false);
+  finish.resolve();
+  const exit = await done;
+  expect(completed).toBe(true);
+  expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+});
+
+it.each([false, true])("preserves a request failure and closes its signal (synchronous=%s)", async (synchronous) => {
+  const error = new Error("request failed");
+  let signal: AbortSignal | undefined;
+  const work = agentcoreRequest((s) => {
+    signal = s;
+    if (synchronous) throw error;
+    return Promise.reject(error);
+  }, 10_000);
+  await expect(Effect.runPromise(work.pipe(Effect.mapError((e) => e.cause)))).rejects.toBe(error);
+  expect(signal?.aborted).toBe(true);
+});
+
+it("a virtual deadline aborts and joins a real fetch response body", async () => {
+  const entered = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<void>();
+  const server = createServer((_req, res) => {
+    res.writeHead(200);
+    res.write("partial");
+    res.once("close", () => closed.resolve());
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("expected an IP listener");
+  try {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          agentcoreRequest(async (signal) => {
+            const response = await fetch(`http://127.0.0.1:${address.port}`, { signal });
+            entered.resolve();
+            return response.text();
+          }, 1_000),
+        );
+        yield* Effect.promise(() => entered.promise);
+        yield* TestClock.adjust(1_000);
+        const exit = yield* Fiber.await(fiber);
+        expect(Exit.isFailure(exit) && Cause.squash(exit.cause)).toMatchObject({
+          _tag: "AgentcoreFailure",
+          cause: { _tag: "TimeoutError" },
+        });
+        yield* Effect.promise(() => closed.promise);
+      }).pipe(Effect.provide(TestClock.layer())),
+    );
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});

--- a/test/agentcore-service.test.ts
+++ b/test/agentcore-service.test.ts
@@ -9,7 +9,14 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { gzipSync } from "node:zlib";
+import * as Clock from "effect/Clock";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import { activeWork } from "../src/channels/busy.ts";
+import { scheduleFile, writeScheduleFile } from "../src/schedule/state.ts";
+import type { Agent } from "../src/agent.ts";
 import { createPiAgentFromDir } from "../src/engines/pi/open.ts";
 import { mountAgentcoreService } from "../src/channels/agentcore-service.ts";
 
@@ -26,7 +33,96 @@ async function agentDir(files: Record<string, string> = {}, config = `{ model: "
 
 const open = async (dir: string) => createPiAgentFromDir(dir, { serving: true });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
 describe("mountAgentcoreService", () => {
+  it.each([false, true])(
+    "starts wake polling only after restore and owns its wait (close during restore=%s)",
+    async (closeEarly) => {
+      const opened = await open(await agentDir({}, `{ model: "openai-codex/gpt-5.5", selfSchedule: true }`));
+      const wake = (id: string) => ({ id, session: id, prompt: "go", fireAt: "2020-01-01T00:00:00Z" });
+      writeScheduleFile(scheduleFile(opened.stateRoot, "wakeups"), [wake("seed")]);
+      const snapshot = gzipSync(
+        Buffer.from(
+          JSON.stringify({
+            v: 1,
+            files: {
+              "schedule/wakeups.json": Buffer.from(JSON.stringify([wake("restored")])).toString("base64"),
+            },
+          }),
+        ),
+      );
+      const entered = Promise.withResolvers<void>();
+      const finish = Promise.withResolvers<void>();
+      vi.stubEnv("FASTAGENT_INGRESS_SECRET", "s");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url, init) => {
+          if (init?.method === "GET") {
+            entered.resolve();
+            await finish.promise;
+            return new Response(snapshot);
+          }
+          return new Response(null);
+        }),
+      );
+      const calls: string[] = [];
+      const agent: Agent = {
+        async *invoke(scope) {
+          calls.push(scope.session);
+          yield { type: "completed" };
+        },
+      };
+      const base = activeWork();
+      const service = await mountAgentcoreService(opened, { wrapAgent: () => agent });
+      const clock = Effect.runSync(Clock.Clock);
+      const sleep = clock.sleep.bind(clock);
+      let armed = 0,
+        cleared = 0;
+      vi.spyOn(clock, "sleep").mockImplementation((ms) => {
+        if (Duration.toMillis(ms) !== 30_000) return sleep(ms);
+        armed++;
+        return Effect.never.pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              cleared++;
+            }),
+          ),
+        );
+      });
+      try {
+        await new Promise(setImmediate);
+        expect(calls).toEqual([]);
+        const pending = service.handler(
+          new Request("http://x/invocations", {
+            method: "POST",
+            body: JSON.stringify({
+              auth: "s",
+              kind: "probe",
+              state: { getUrl: "https://s3/get", putUrl: "https://s3/put" },
+            }),
+          }),
+        );
+        await entered.promise;
+        expect(calls).toEqual([]);
+        if (closeEarly) await service.close();
+        finish.resolve();
+        expect(await (await pending).json()).toEqual({ ok: true });
+        await vi.waitFor(() => expect(activeWork()).toBe(base));
+        expect(calls).toEqual(closeEarly ? [] : ["restored"]);
+        expect(armed).toBe(closeEarly ? 0 : 1);
+        await service.close();
+        await vi.waitFor(() => expect(cleared).toBe(armed));
+      } finally {
+        finish.resolve();
+        await service.close();
+      }
+    },
+  );
   it("serves the adapter surface, not the channel routes", async () => {
     // The channel exists, but on this host it is reachable only THROUGH an envelope — the platform
     // invokes POST /invocations and nothing else.
@@ -88,7 +184,7 @@ describe("mountAgentcoreService", () => {
     }
   });
 
-  it("owns the schedules, and close() is safe to call twice", async () => {
+  it("reports loaded schedules, and close() is safe to call twice", async () => {
     const dir = await agentDir(
       { "schedules/digest.ts": `export default { cron: "0 9 * * *", prompt: "hi" };` },
       `{ model: "openai-codex/gpt-5.5" }`,
@@ -99,8 +195,5 @@ describe("mountAgentcoreService", () => {
     await service.close();
     // Both the shutdown hook and an explicit close can run.
     await expect(service.close()).resolves.toBeUndefined();
-    // NOT asserted: that the scheduler's timers are gone. Fake timers would have to be installed
-    // before the assembly, which deadlocks its filesystem IO, so the stop is unobservable from here
-    // — see the note on close() in agentcore-service.ts.
   });
 });

--- a/test/agentcore-state.test.ts
+++ b/test/agentcore-state.test.ts
@@ -13,6 +13,9 @@ import * as Effect from "effect/Effect";
 import * as TestClock from "effect/testing/TestClock";
 import { activeWork, onIdle } from "../src/channels/busy.ts";
 import { log } from "../src/log.ts";
+import { createScheduler } from "../src/schedule/scheduler.ts";
+import { createWakeAlarmSink } from "../src/schedule/wake-alarm.ts";
+import { setWakeupsSink } from "../src/schedule/wakeups.ts";
 import {
   MAX_SNAPSHOT_BYTES,
   SNAPSHOT_VERSION,
@@ -157,6 +160,85 @@ describe("agentcore state snapshot", () => {
   });
 
   describe("sync lifecycle", () => {
+    it.each([false, true])(
+      "snapshots the settled wake after a synchronous alarm pass (future wake=%s)",
+      async (future) => {
+        const now = new Date("2026-07-28T10:00:00Z");
+        const pending = [{ id: "due", session: "s", prompt: "go", fireAt: now.toISOString() }];
+        if (future) pending.push({ id: "future", session: "s", prompt: "later", fireAt: "2026-07-28T11:00:00Z" });
+        const before = '{"role":"user","content":"go"}\n';
+        const after = `${before}{"role":"assistant","content":"done"}\n`;
+        const local = await stateRoot({ "sessions/s.jsonl": before, "schedule/wakeups.json": JSON.stringify(pending) });
+        const entered = Promise.withResolvers<void>();
+        const finishTurn = Promise.withResolvers<void>();
+        const putStarted = Promise.withResolvers<void>();
+        const finishPut = Promise.withResolvers<void>();
+        const { impl, calls } = fakeFetch(async (_url, init) => {
+          if (init?.method === "PUT") {
+            putStarted.resolve();
+            await finishPut.promise;
+            return new Response(null);
+          }
+          return new Response(null, { status: 404 });
+        });
+        const sync = createStateSync({ stateRoot: local, fetchImpl: impl });
+        sync.use(urls);
+        await sync.ready();
+        const alarmFetch = vi.fn<typeof fetch>();
+        setWakeupsSink(Effect.runSync(createWakeAlarmSink({ secret: "s", fetchImpl: alarmFetch, now: () => now })));
+        const idle = vi.fn(() => sync.save());
+        const off = onIdle(idle);
+        const scheduler = Effect.runSync(
+          createScheduler({
+            stateRoot: local,
+            schedules: [],
+            now: () => now,
+            agent: {
+              async *invoke() {
+                entered.resolve();
+                await finishTurn.promise;
+                await writeFile(join(local, "sessions/s.jsonl"), after);
+                yield { type: "text", delta: "done" };
+                yield { type: "completed" };
+              },
+            },
+          }),
+        );
+        try {
+          scheduler.start();
+          await entered.promise;
+          // If admission emitted idle, freeze that already-packed upload until the turn has settled.
+          if (idle.mock.calls.length > 0) await putStarted.promise;
+          scheduler.stop();
+          finishTurn.resolve();
+          const auditPath = join(local, "schedule/runs.jsonl");
+          await vi.waitFor(async () =>
+            expect(JSON.parse(await readFile(auditPath, "utf8"))).toMatchObject({
+              outcome: "completed",
+              reply: "done",
+            }),
+          );
+          await putStarted.promise;
+          finishPut.resolve();
+          await sync.flush();
+          const puts = calls.filter((c) => c.method === "PUT");
+          expect(puts).toHaveLength(1);
+          expect(JSON.parse(gunzipSync(puts[0]!.body!).toString()).files).toMatchObject({
+            "sessions/s.jsonl": Buffer.from(after).toString("base64"),
+            "schedule/runs.jsonl": (await readFile(auditPath)).toString("base64"),
+          });
+          expect(alarmFetch).not.toHaveBeenCalled();
+        } finally {
+          off();
+          setWakeupsSink(undefined);
+          scheduler.stop();
+          finishTurn.resolve();
+          finishPut.resolve();
+          await sync.flush();
+        }
+      },
+    );
+
     it("does not overwrite newer envelope URLs with a late refresh response", async () => {
       const local = await stateRoot();
       const entered = Promise.withResolvers<void>();

--- a/test/agentcore-state.test.ts
+++ b/test/agentcore-state.test.ts
@@ -9,14 +9,19 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { activeWork } from "../src/channels/busy.ts";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+import { activeWork, onIdle } from "../src/channels/busy.ts";
+import { log } from "../src/log.ts";
 import {
   MAX_SNAPSHOT_BYTES,
   SNAPSHOT_VERSION,
-  createStateSync,
+  createStateSync as stateSync,
   packStateRoot,
   unpackIntoStateRoot,
 } from "../src/channels/agentcore-state.ts";
+
+const createStateSync = (options: Parameters<typeof stateSync>[0]) => Effect.runSync(stateSync(options));
 
 const dirs: string[] = [];
 async function stateRoot(files: Record<string, string> = {}): Promise<string> {
@@ -128,6 +133,20 @@ describe("agentcore state snapshot", () => {
     await expect(unpackIntoStateRoot(target, Buffer.from("not gzip"))).rejects.toThrow(/unreadable/);
   });
 
+  it.each([[], { "a.json": [1, 2] }])(
+    "rejects malformed snapshot files before treating the root as authoritative: %j",
+    async (files) => {
+      const packed = gzipSync(Buffer.from(JSON.stringify({ v: SNAPSHOT_VERSION, files })));
+      const { impl, calls } = fakeFetch(() => new Response(packed));
+      const sync = createStateSync({ stateRoot: await stateRoot(), fetchImpl: impl });
+      sync.use(urls);
+      await expect(sync.ready()).rejects.toThrow(/unsupported shape|invalid file content/);
+      sync.save();
+      await sync.flush();
+      expect(calls.filter((c) => c.method === "PUT")).toEqual([]);
+    },
+  );
+
   it("caps the packed size — a runaway state root fails visibly instead of OOMing the microVM", async () => {
     const dir = await stateRoot();
     await writeFile(join(dir, "big.bin"), Buffer.alloc(4096));
@@ -138,6 +157,118 @@ describe("agentcore state snapshot", () => {
   });
 
   describe("sync lifecycle", () => {
+    it("does not overwrite newer envelope URLs with a late refresh response", async () => {
+      const local = await stateRoot();
+      const entered = Promise.withResolvers<void>();
+      const finish = Promise.withResolvers<void>();
+      const { impl, calls } = fakeFetch(async (_url, init) => {
+        if (init?.method === "POST") {
+          entered.resolve();
+          await finish.promise;
+          return Response.json({ getUrl: "https://s3/old-get", putUrl: "https://s3/old-put" });
+        }
+        return new Response(null, { status: init?.method === "GET" ? 404 : 200 });
+      });
+      const sync = createStateSync({ stateRoot: local, fetchImpl: impl });
+      sync.use({ ...urls, refresh: { url: "https://forwarder/refresh", auth: "secret" } });
+      await sync.ready();
+      sync.save();
+      await entered.promise;
+      sync.use({ getUrl: "https://s3/new-get", putUrl: "https://s3/new-put" });
+      finish.resolve();
+      await sync.flush();
+      expect(calls.filter((c) => c.method === "PUT").map((c) => c.url)).toEqual(["https://s3/new-put"]);
+    });
+
+    it("serializes fresh checkpoints behind a save without resaving its own idle edge", async () => {
+      const local = await stateRoot({ "intent.json": "old" });
+      const entered = Promise.withResolvers<void>();
+      const finish = Promise.withResolvers<void>();
+      let active = 0,
+        peak = 0;
+      const { impl, calls } = fakeFetch(async (_url, init) => {
+        if (init?.method === "PUT") {
+          active++;
+          peak = Math.max(peak, active);
+          if (calls.filter((c) => c.method === "PUT").length === 1) {
+            entered.resolve();
+            await finish.promise;
+          }
+          active--;
+        }
+        return new Response(null, { status: init?.method === "GET" ? 404 : 200 });
+      });
+      const sync = createStateSync({ stateRoot: local, fetchImpl: impl });
+      sync.use(urls);
+      await sync.ready();
+      const off = onIdle(() => sync.save());
+      try {
+        sync.save();
+        await entered.promise;
+        await writeFile(join(local, "intent.json"), "new");
+        const checkpoints = [sync.checkpoint(), sync.checkpoint()];
+        finish.resolve();
+        expect(await Promise.all(checkpoints)).toEqual([{ written: true }, { written: true }]);
+        await sync.flush();
+        const puts = calls.filter((c) => c.method === "PUT");
+        expect(puts).toHaveLength(3);
+        expect(peak).toBe(1);
+        for (const put of puts.slice(1)) {
+          expect(JSON.parse(gunzipSync(put.body!).toString()).files["intent.json"]).toBe(
+            Buffer.from("new").toString("base64"),
+          );
+        }
+      } finally {
+        off();
+        finish.resolve();
+        await sync.flush();
+      }
+    });
+
+    it("uses the captured deadline and joins a late PUT failure before releasing busy ownership", async () => {
+      const local = await stateRoot();
+      const base = activeWork();
+      const entered = Promise.withResolvers<void>();
+      const finish = Promise.withResolvers<void>();
+      const aborted = vi.fn();
+      const errors = vi.spyOn(log, "error").mockImplementation(() => {});
+      let fail = true;
+      const { impl, calls } = fakeFetch(async (_url, init) => {
+        if (init?.method === "PUT" && fail) {
+          init.signal?.addEventListener("abort", aborted, { once: true });
+          entered.resolve();
+          await finish.promise;
+          throw new Error("late PUT failure");
+        }
+        return new Response(null, { status: init?.method === "GET" ? 404 : 200 });
+      });
+      try {
+        await Effect.runPromise(
+          Effect.gen(function* () {
+            const sync = yield* stateSync({ stateRoot: local, fetchImpl: impl });
+            sync.use(urls);
+            yield* Effect.promise(() => sync.ready());
+            sync.save();
+            yield* Effect.promise(() => entered.promise);
+            yield* TestClock.adjust(60_000);
+            expect(aborted).toHaveBeenCalledOnce();
+            expect(activeWork()).toBe(base + 1);
+            finish.resolve();
+            yield* Effect.promise(() => sync.flush());
+            expect(activeWork()).toBe(base);
+            expect(errors).toHaveBeenCalledOnce();
+            expect(errors).toHaveBeenCalledWith(expect.stringContaining("TimeoutError"));
+            fail = false;
+            sync.save();
+            yield* Effect.promise(() => sync.flush());
+            expect(calls.filter((c) => c.method === "PUT")).toHaveLength(2);
+          }).pipe(Effect.provide(TestClock.layer())),
+        );
+      } finally {
+        finish.resolve();
+        errors.mockRestore();
+      }
+    });
     it("restores on the first ready() and pushes the packed root on save()", async () => {
       const remote = await packStateRoot(await stateRoot({ "sessions/a.jsonl": "history" }));
       const local = await stateRoot();
@@ -339,7 +470,9 @@ describe("agentcore state snapshot", () => {
     it("an upload failure is logged, not thrown — the local mount still holds the data until next settle", async () => {
       const local = await stateRoot({ "a.json": "1" });
       const { impl } = fakeFetch((_u, init) =>
-        init?.method === "PUT" ? new Response(null, { status: 403 }) : new Response(null, { status: 404 }),
+        init?.method === "PUT"
+          ? new Response("private snapshot response", { status: 403 })
+          : new Response(null, { status: 404 }),
       );
       const sync = createStateSync({ stateRoot: local, fetchImpl: impl });
       sync.use(urls);
@@ -348,6 +481,8 @@ describe("agentcore state snapshot", () => {
       const spy = vi.spyOn(console, "error").mockImplementation(() => {});
       sync.save();
       await expect(sync.flush()).resolves.toBeUndefined();
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("state snapshot PUT failed: 403"));
+      expect(spy.mock.calls.flat().join(" ")).not.toContain("private snapshot response");
       spy.mockRestore();
     });
   });

--- a/test/wake-alarm.test.ts
+++ b/test/wake-alarm.test.ts
@@ -1,4 +1,7 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+import { activeWork } from "../src/channels/busy.ts";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,12 +11,14 @@ import { scheduleFile, writeScheduleFile } from "../src/schedule/state.ts";
 import { RESERVED_PATHS, type WakeAlarmRequest } from "../src/channels/agentcore-protocol.ts";
 import {
   MAX_SYNC_ATTEMPTS,
-  createWakeAlarmSink,
+  createWakeAlarmSink as alarmSink,
   readWakeAlarmUrl,
   rememberWakeAlarmUrl,
   toAlarms,
 } from "../src/schedule/wake-alarm.ts";
 import { type Wakeup, addWakeup, removeWakeup, setWakeupsSink, takeFirstDueWakeup } from "../src/schedule/wakeups.ts";
+
+const createWakeAlarmSink = (options: Parameters<typeof alarmSink>[0]) => Effect.runSync(alarmSink(options));
 
 const freshRoot = (): Promise<string> => mkdtemp(join(tmpdir(), "fa-wake-alarm-"));
 
@@ -66,6 +71,25 @@ function fakeFetch(status = 200) {
 }
 
 describe("schedule/wake-alarm: the URL store", () => {
+  it.each(["{broken", "{}", "null", '{"url":""}'])("rejects a corrupt or malformed URL record: %s", async (content) => {
+    const root = await freshRoot();
+    rememberWakeAlarmUrl(root, "https://fn.on.aws");
+    writeFileSync(scheduleFile(root, "wake-alarm-url"), content);
+    expect(() => readWakeAlarmUrl(root)).toThrow(/wake-alarm URL.*unreadable/);
+  });
+
+  it("reports URL read IO failure at the sink boundary without issuing a POST", async () => {
+    const root = await freshRoot();
+    seed(root, [{ id: "a", session: "s", prompt: "p", fireAt: "2099-01-01T00:00:00Z" }]);
+    mkdirSync(scheduleFile(root, "wake-alarm-url"));
+    const errors = vi.spyOn(log, "error").mockImplementation(() => {});
+    const { impl, calls } = fakeFetch();
+    createWakeAlarmSink({ secret: "s", fetchImpl: impl })(root);
+    await vi.waitFor(() =>
+      expect(errors).toHaveBeenCalledWith(expect.stringMatching(/reconcile failed.*wake-alarm URL.*EISDIR/)),
+    );
+    expect(calls).toEqual([]);
+  });
   it("remembers the forwarder URL (write-if-changed) and reads it back", async () => {
     const root = await freshRoot();
     expect(readWakeAlarmUrl(root)).toBeUndefined();
@@ -77,6 +101,29 @@ describe("schedule/wake-alarm: the URL store", () => {
 });
 
 describe("schedule/wake-alarm: the sink", () => {
+  it("uses its captured clock for retry pacing and expires alarms during backoff", async () => {
+    const root = await freshRoot();
+    const now = new Date("2026-07-28T09:00:00Z");
+    rememberWakeAlarmUrl(root, "https://fn.on.aws");
+    seed(root, [{ id: "a", session: "s", prompt: "p", fireAt: new Date(now.getTime() + 8_000).toISOString() }]);
+    const { impl, calls } = fakeFetch(500);
+    const base = activeWork();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(now.getTime());
+        const sink = yield* alarmSink({ secret: "s", fetchImpl: impl });
+        sink(root);
+        yield* TestClock.adjust(0);
+        expect(calls).toHaveLength(1);
+        expect(activeWork()).toBe(base + 1);
+        yield* TestClock.adjust(2_000);
+        expect(calls).toHaveLength(2);
+        yield* TestClock.adjust(4_000);
+        expect(calls).toHaveLength(2);
+        expect(activeWork()).toBe(base);
+      }).pipe(Effect.provide(TestClock.layer())),
+    );
+  });
   it("POSTs the pending set (declarative reconcile) to the reserved path with the secret", async () => {
     const root = await freshRoot();
     rememberWakeAlarmUrl(root, "https://fn.on.aws/");


### PR DESCRIPTION
## Summary

- Own AgentCore restoration, activation, snapshot uploads/checkpoints and external alarm reconciliation with typed internal Effects; keep public Promise/Fetch/AgentService APIs.
- Start local wake polling after restore, cache activation failures, and keep it stopped when restoration finishes after service close.
- Coalesce background uploads, serialize fresh checkpoints, and prevent stale refresh responses from replacing newer envelope URLs. Hold alarm admission through the wake-claim handoff so synchronous reconciliation cannot snapshot before execution settles.
- Abort and join issued requests at captured-clock deadlines. Preserve alarm retry budgets, request/background failure policies, snapshot formats and non-draining shutdown.
- Diagnose malformed snapshots and corrupt/unreadable alarm URL records without treating them as absent state.

Uploads and the alarm sink retain their own business-work lifetime. Service close stops polling and detaches listeners; it does not abandon accepted IO or drain turns. A transport that ignores abort may delay release.

## Verification

- Lint, typecheck, build, diff checks and **1,832 tests / 125 files** pass. CI Node 22.19.0/24/26, CodeQL, packed-package and Bun smoke pass on `020929a5`.
- **289 tests / 13 files** pass on each of Node **22.19.0** and **24.20.0**.
- Real local fetch-body abort/join, restore/close races, serialized fresh checkpoints, URL precedence, cached failure, virtual-clock retry/deadline and malformed-state regressions pass.
- Real-disk regressions verify that empty-set and URL-unavailable alarm passes retain completed session/audit bytes in the uploaded snapshot, including stop during the claimed turn.
- Five restored fault mutations, an actual-helper compiler-negative check and passing preregistered performance measurements are historical evidence from `14097985`; they were not rerun for the admission repair. Production implementation grows **146 non-comment lines (13.5%)**. The historical isolated private adapter import additionally costs **22.93 ms / 3.37 MiB**; CLI cold startup remains unmeasured; real AWS validation is partial and blocked by model credit (see below).

Refs #480. [Full measurements, raw samples and reproduction](https://github.com/fastagent-sh/fastagent/issues/480#issuecomment-5584010525).

## AWS validation

The current candidate was deployed without merging. First-boot state/activation checks passed; the real model call returned `You have no credits remaining`. Wake execution, settled S3 data and redeploy restoration remain unverified. All temporary AWS resources were independently confirmed removed. [Full partial-validation report](https://github.com/fastagent-sh/fastagent/pull/500#issuecomment-5585821909).
