### PR TITLE
fix(channels): drop rate-limited preview frames instead of parking the turn

### DIFF
--- a/src/channels/feishu/feishu-api.ts
+++ b/src/channels/feishu/feishu-api.ts
@@ -39,7 +39,7 @@ const RETRIES = 3;
  * absorbing a rate-limit backoff for it only parks the answer behind a view nobody needs. A droppable
  * write passes 0: the frame is lost, the answer is not.
  */
-interface FeishuCallOptions {
+export interface FeishuCallOptions {
   retries?: number;
 }
 /** Download sanity cap; a larger resource is rejected visibly (the engine resizes vision images

--- a/src/channels/feishu/feishu-api.ts
+++ b/src/channels/feishu/feishu-api.ts
@@ -29,6 +29,19 @@ const API_TIMEOUT_MS = 30_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 /** How many rate-limit rejects one call absorbs before giving up. */
 const RETRIES = 3;
+
+/**
+ * Per-call transport options.
+ *
+ * `retries` exists for ONE distinction the pipeline cannot make for itself: whether this write is
+ * worth waiting for. A card live-preview FRAME is a full content SNAPSHOT under a strictly increasing
+ * sequence — the next frame carries the same view and the settle write replaces the whole entity — so
+ * absorbing a rate-limit backoff for it only parks the answer behind a view nobody needs. A droppable
+ * write passes 0: the frame is lost, the answer is not.
+ */
+interface FeishuCallOptions {
+  retries?: number;
+}
 /** Download sanity cap; a larger resource is rejected visibly (the engine resizes vision images
  *  anyway, so this is a transport guard, not a model limit). */
 const MAX_DOWNLOAD_BYTES = 20 * 1024 * 1024;
@@ -209,7 +222,13 @@ export interface FeishuApi {
   /** Create a card entity (card JSON 2.0). Returns its card_id. */
   createCard(cardJson: string): Promise<string>;
   /** Stream-update a card element's text (full-content snapshot + strictly increasing sequence). */
-  updateCardElement(cardId: string, elementId: string, content: string, sequence: number): Promise<void>;
+  updateCardElement(
+    cardId: string,
+    elementId: string,
+    content: string,
+    sequence: number,
+    opts?: FeishuCallOptions,
+  ): Promise<void>;
   /** Replace a card entity's content (the settle write; also flips streaming_mode off via the JSON). */
   updateCard(cardId: string, cardJson: string, sequence: number): Promise<void>;
 }
@@ -285,7 +304,9 @@ export function createFeishuApi(opts: FeishuApiOptions): FeishuApi {
     method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
     path: string,
     body?: unknown,
+    opts: FeishuCallOptions = {},
   ): Promise<T> => {
+    const retries = opts.retries ?? RETRIES;
     let refreshedAuth = false;
     for (let attempt = 0; ; ) {
       const token = await tenantToken();
@@ -321,7 +342,7 @@ export function createFeishuApi(opts: FeishuApiOptions): FeishuApi {
         cached = undefined;
         continue;
       }
-      if ((res.status === 429 || code === RATE_LIMIT_CODE) && attempt < RETRIES) {
+      if ((res.status === 429 || code === RATE_LIMIT_CODE) && attempt < retries) {
         attempt++;
         await wait(attempt * 1000);
         continue;
@@ -511,12 +532,13 @@ export function createFeishuApi(opts: FeishuApiOptions): FeishuApi {
       if (!id) throw new FeishuApiError(kind, "createCard", 200, 0, "response carried no card_id");
       return id;
     },
-    async updateCardElement(cardId, elementId, content, sequence) {
+    async updateCardElement(cardId, elementId, content, sequence, opts) {
       await call(
         "updateCardElement",
         "PUT",
         `/open-apis/cardkit/v1/cards/${encodeURIComponent(cardId)}/elements/${encodeURIComponent(elementId)}/content`,
         { content, sequence },
+        opts,
       );
     },
     async updateCard(cardId, cardJson, sequence) {

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -293,15 +293,17 @@ export function feishuReply(
         // `last*` advances BEFORE each write: a frame that fails for a non-streaming reason is logged
         // once (the pump's onError) and not re-sent until its content actually changes. An EMPTY
         // process frame is written like any other — it is the placeholder being cleared (processView).
+        // Droppable frames: the next one carries the same snapshot under a higher sequence, so a
+        // rate-limit backoff here would only delay the answer behind a view that is already stale.
         if (process !== lastProcess) {
           lastProcess = process;
-          await api.updateCardElement(preview.cardId, PROCESS_ELEMENT_ID, process, nextSeq());
+          await api.updateCardElement(preview.cardId, PROCESS_ELEMENT_ID, process, nextSeq(), { retries: 0 });
         }
         const answer = answerView();
         // Never write an empty answer snapshot — the element is born empty and the answer only grows.
         if (answer !== "" && answer !== lastAnswer) {
           lastAnswer = answer;
-          await api.updateCardElement(preview.cardId, ANSWER_ELEMENT_ID, answer, nextSeq());
+          await api.updateCardElement(preview.cardId, ANSWER_ELEMENT_ID, answer, nextSeq(), { retries: 0 });
         }
       } catch (e) {
         if (isCardStreamingClosed(e)) {

--- a/src/channels/feishu/preview.ts
+++ b/src/channels/feishu/preview.ts
@@ -37,7 +37,16 @@ import {
   finalCardJson,
   streamingCardJson,
 } from "./card.ts";
-import { type FeishuApi, type FeishuTarget, chunkFeishuText, isCardStreamingClosed } from "./feishu-api.ts";
+import {
+  type FeishuApi,
+  type FeishuCallOptions,
+  type FeishuTarget,
+  chunkFeishuText,
+  isCardStreamingClosed,
+} from "./feishu-api.ts";
+
+/** Every live card frame is droppable — see {@link FeishuCallOptions}. */
+const DROPPABLE_FRAME: FeishuCallOptions = { retries: 0 };
 import {
   RETRY_NOTICE,
   THINKING_PLACEHOLDER,
@@ -295,15 +304,20 @@ export function feishuReply(
         // process frame is written like any other — it is the placeholder being cleared (processView).
         // Droppable frames: the next one carries the same snapshot under a higher sequence, so a
         // rate-limit backoff here would only delay the answer behind a view that is already stale.
-        if (process !== lastProcess) {
-          lastProcess = process;
-          await api.updateCardElement(preview.cardId, PROCESS_ELEMENT_ID, process, nextSeq(), { retries: 0 });
-        }
+        //
+        // ANSWER FIRST. A failing write ends the whole flush, and the two elements are not worth the
+        // same: the answer is the reply being typed out, the process block is decoration. Writing the
+        // process element first meant one rate-limited tool line could keep the answer element unwritten
+        // for the entire streaming phase, leaving the user staring at a card that never fills in.
         const answer = answerView();
         // Never write an empty answer snapshot — the element is born empty and the answer only grows.
         if (answer !== "" && answer !== lastAnswer) {
           lastAnswer = answer;
-          await api.updateCardElement(preview.cardId, ANSWER_ELEMENT_ID, answer, nextSeq(), { retries: 0 });
+          await api.updateCardElement(preview.cardId, ANSWER_ELEMENT_ID, answer, nextSeq(), DROPPABLE_FRAME);
+        }
+        if (process !== lastProcess) {
+          lastProcess = process;
+          await api.updateCardElement(preview.cardId, PROCESS_ELEMENT_ID, process, nextSeq(), DROPPABLE_FRAME);
         }
       } catch (e) {
         if (isCardStreamingClosed(e)) {

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -22,6 +22,7 @@ import {
 } from "../kit/preview-kit.ts";
 import {
   type SlackApi,
+  type SlackCallOptions,
   type SlackTarget,
   chunkSlackMarkdown,
   chunkSlackText,
@@ -168,15 +169,17 @@ function streamClassicSlackReply(
       const remaining = lastMutationAt + CLASSIC_UPDATE_INTERVAL_MS - now();
       return remaining > 0 ? Effect.sleep(remaining) : Effect.void;
     });
-    const update = async (ts: string, markdown: string): Promise<void> => {
-      await api.updateMarkdown(target.channelId, ts, markdown);
+    const update = async (ts: string, markdown: string, opts?: SlackCallOptions): Promise<void> => {
+      await api.updateMarkdown(target.channelId, ts, markdown, opts);
       lastMutationAt = now();
     };
     const flushPreview = async (): Promise<void> => {
       const markdown = chunkSlackText(view())[0] ?? THINKING_PLACEHOLDER;
       if (markdown === lastSent) return;
       if (previewTs) {
-        await update(previewTs, markdown);
+        // Droppable: the next frame carries the same snapshot, so a rate-limit wait here would only
+        // delay the answer behind a view that is already stale.
+        await update(previewTs, markdown, { retries: 0 });
       } else {
         if (previewAttempted) return;
         previewAttempted = true;

--- a/src/channels/slack/preview.ts
+++ b/src/channels/slack/preview.ts
@@ -170,8 +170,15 @@ function streamClassicSlackReply(
       return remaining > 0 ? Effect.sleep(remaining) : Effect.void;
     });
     const update = async (ts: string, markdown: string, opts?: SlackCallOptions): Promise<void> => {
-      await api.updateMarkdown(target.channelId, ts, markdown, opts);
-      lastMutationAt = now();
+      try {
+        await api.updateMarkdown(target.channelId, ts, markdown, opts);
+      } finally {
+        // An ATTEMPT spends the slot, not a success. A droppable frame fails instantly on a 429, so a
+        // success-only timestamp would leave `waitForMutationSlot` open and (with throttleMs 0) re-send
+        // the same rejected view once per token — request amplification aimed at a channel that is
+        // already rate-limiting us. The failure itself still propagates to the pump's onError.
+        lastMutationAt = now();
+      }
     };
     const flushPreview = async (): Promise<void> => {
       const markdown = chunkSlackText(view())[0] ?? THINKING_PLACEHOLDER;

--- a/src/channels/slack/slack-api.ts
+++ b/src/channels/slack/slack-api.ts
@@ -12,6 +12,20 @@ const FILE_TRANSFER_TIMEOUT_MS = 120_000;
 const MAX_DOWNLOAD_BYTES = 20 * 1024 * 1024;
 const RETRIES = 3;
 const MAX_RETRY_AFTER_S = 30;
+
+/**
+ * Per-call transport options.
+ *
+ * `retries` exists for ONE distinction the pipeline cannot make for itself: whether this write is
+ * worth waiting for. A classic live-preview FRAME is a full SNAPSHOT — redrawn by the next frame and
+ * superseded by the final write — so absorbing Slack's `retry-after` for it would park the turn, and
+ * everything queued behind it, for up to 3 × MAX_RETRY_AFTER_S seconds to deliver a view nobody needs.
+ * A droppable write passes 0: the frame is lost, the answer is not. NOT for `chat.appendStream`, whose
+ * ordered appends each carry content of their own — dropping one loses it.
+ */
+export interface SlackCallOptions {
+  retries?: number;
+}
 /** Slack's standard-Markdown fields cap each call at 12,000 characters. Keep headroom for
  * code-fence balancing and future server-side transformations. */
 const SLACK_MAX_MARKDOWN = 10_000;
@@ -95,7 +109,7 @@ export interface SlackApi {
   postMessage(target: SlackTarget, text: string): Promise<string>;
   postMarkdown(target: SlackTarget, markdown: string): Promise<string>;
   updateMessage(channelId: string, ts: string, text: string): Promise<void>;
-  updateMarkdown(channelId: string, ts: string, markdown: string): Promise<void>;
+  updateMarkdown(channelId: string, ts: string, markdown: string, opts?: SlackCallOptions): Promise<void>;
   deleteMessage(channelId: string, ts: string): Promise<void>;
   /** Post standard Markdown, split under Slack's limit. `target.channelId` may be a user id: Slack
    *  then opens (or reuses) the app's DM with that user, and the result names it. */
@@ -228,7 +242,9 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
     method: string,
     body: Record<string, unknown>,
     httpMethod: "GET" | "POST" = "POST",
+    opts: SlackCallOptions = {},
   ): Promise<T> => {
+    const retries = opts.retries ?? RETRIES;
     const url = new URL(`${apiBase}/${method}`);
     if (httpMethod === "GET") {
       for (const [name, value] of Object.entries(body)) {
@@ -260,7 +276,7 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
       }
       if (response.ok && data.ok === true) return data;
       const rateLimited = response.status === 429 || data.error === "ratelimited";
-      if (rateLimited && attempt < RETRIES) {
+      if (rateLimited && attempt < retries) {
         const retryAfter = Number(response.headers.get("retry-after") ?? attempt + 1);
         if (Number.isFinite(retryAfter) && retryAfter <= MAX_RETRY_AFTER_S) {
           await wait(Math.max(1, retryAfter) * 1000);
@@ -338,9 +354,9 @@ export function createSlackApi({ botToken, baseUrl = "https://slack.com/api" }: 
         throw error;
       }
     },
-    async updateMarkdown(channelId, ts, markdown) {
+    async updateMarkdown(channelId, ts, markdown, opts) {
       try {
-        await call("chat.update", { channel: channelId, ts, markdown_text: markdown });
+        await call("chat.update", { channel: channelId, ts, markdown_text: markdown }, "POST", opts);
       } catch (error) {
         if (error instanceof SlackApiError && error.slackError === "message_not_modified") return;
         throw error;

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -123,7 +123,9 @@ export function telegramReply(
       if (text === lastSent) return; // skip an unchanged edit (Telegram rejects "message is not modified")
       lastSent = text;
       if (messageId !== undefined) {
-        await editMessageText(api, botToken, target, messageId, text); // plain — a partial answer may carry unbalanced HTML
+        // plain — a partial answer may carry unbalanced HTML; droppable — the next frame redraws it and
+        // the final write supersedes it, so a flood wait here would park the answer behind a dead view.
+        await editMessageText(api, botToken, target, messageId, text, { retries: 0 });
         return;
       }
       // No preview message yet. Send the placeholder ONCE; never re-send (that would spam a new message per
@@ -131,7 +133,7 @@ export function telegramReply(
       // cannot edit — fail visibly and stop previewing (the final write still lands via finalize).
       if (previewSent) return;
       previewSent = true;
-      messageId = await sendMessage(api, botToken, target, text, { html: false });
+      messageId = await sendMessage(api, botToken, target, text, { html: false, retries: 0 });
       if (messageId === undefined)
         throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
     };

--- a/src/channels/telegram/preview.ts
+++ b/src/channels/telegram/preview.ts
@@ -131,9 +131,13 @@ export function telegramReply(
       // No preview message yet. Send the placeholder ONCE; never re-send (that would spam a new message per
       // frame). If Telegram returns ok WITHOUT a message_id (proxy / odd API base / unparseable body) we
       // cannot edit — fail visibly and stop previewing (the final write still lands via finalize).
+      //
+      // NOT droppable, unlike the frames above: this send happens once and every later frame depends on
+      // its id, so dropping it costs the whole turn's live preview rather than one redrawable view. The
+      // asymmetry is Telegram's own — it rate-limits edits to a single message far tighter than sends.
       if (previewSent) return;
       previewSent = true;
-      messageId = await sendMessage(api, botToken, target, text, { html: false, retries: 0 });
+      messageId = await sendMessage(api, botToken, target, text, { html: false });
       if (messageId === undefined)
         throw new Error("telegram sendMessage returned ok without a message_id — live preview disabled for this turn");
     };

--- a/src/channels/telegram/telegram-api.ts
+++ b/src/channels/telegram/telegram-api.ts
@@ -7,7 +7,8 @@
  *     connection cannot hang a turn, its session queue, or webhook registration.
  *  2. Only a 429 is retried (bounded attempts, honouring `retry_after` up to FLOOD_WAIT_MAX_S per
  *     wait); a longer flood ban or exhausted retries fail visibly. No other failure class is retried:
- *     the request may have been processed, and a retried sendMessage would double-deliver.
+ *     the request may have been processed, and a retried sendMessage would double-deliver. A caller
+ *     whose write is DROPPABLE passes `retries: 0` — see {@link CallOptions}.
  *  3. Success requires the body's own `ok:true` — an intermediary's HTTP 200 is not a sent message.
  *  4. Every failure is a {@link TelegramApiError} naming the method: self-description is a property of
  *     the error type, not per-call-site string assembly.
@@ -37,6 +38,20 @@ const FLOOD_WAIT_MAX_S = 30;
 
 /** How many 429s one call absorbs before giving up. */
 const RETRIES = 3;
+
+/**
+ * Per-call transport options.
+ *
+ * `retries` exists for ONE distinction the pipeline cannot make for itself: whether this write is
+ * worth waiting for. Telegram rate-limits edits to a single message far tighter than sends, and its
+ * `retry_after` is routinely tens of seconds — so a live-preview FRAME, whose content the next frame
+ * redraws and the final write supersedes, would park the turn (and everything queued behind it) for up
+ * to 3 × (FLOOD_WAIT_MAX_S + 1) seconds waiting to deliver a view nobody needs. A droppable write
+ * passes 0: the frame is lost, the answer is not.
+ */
+export interface CallOptions {
+  retries?: number;
+}
 
 /** Download sanity cap (Telegram's own getFile limit); a larger file/image is rejected visibly. The
  *  engine resizes images to the model's needs, so this is a transport guard, not the model size limit. */
@@ -107,7 +122,9 @@ export async function callApi<M extends keyof Api>(
   botToken: string,
   method: M,
   params: Record<string, unknown>,
+  opts: CallOptions = {},
 ): Promise<Api[M]> {
+  const retries = opts.retries ?? RETRIES;
   for (let attempt = 0; ; attempt++) {
     let res: Response;
     let raw: string;
@@ -129,7 +146,7 @@ export async function callApi<M extends keyof Api>(
       data = {}; // only the parse is forgiven — the ok-gate below turns it into a named failure
     }
     if (res.ok && data.ok === true) return data.result as Api[M];
-    if (res.status === 429 && attempt < RETRIES) {
+    if (res.status === 429 && attempt < retries) {
       const floodWait = data.parameters?.retry_after ?? attempt + 1; // no retry_after → short linear backoff
       if (floodWait <= FLOOD_WAIT_MAX_S) {
         await wait((floodWait + 1) * 1000);
@@ -253,7 +270,7 @@ export async function sendMessage(
   botToken: string,
   t: Target,
   body: string,
-  opts: { html?: boolean } = {},
+  opts: { html?: boolean } & CallOptions = {},
 ): Promise<number | undefined> {
   let mode = opts.html ?? true;
   let chunks = chunkText(body, { html: mode });
@@ -271,7 +288,7 @@ export async function sendMessage(
     }
     let result: Api["sendMessage"];
     try {
-      result = await callApi(api, botToken, "sendMessage", mode ? { ...base, parse_mode: "HTML" } : base);
+      result = await callApi(api, botToken, "sendMessage", mode ? { ...base, parse_mode: "HTML" } : base, opts);
     } catch (e) {
       if (!(mode && e instanceof TelegramApiError && PARSE_ERROR.test(e.description))) throw e;
       if (first) {
@@ -282,7 +299,7 @@ export async function sendMessage(
         continue;
       }
       // A later chunk failed after the first parsed cleanly (rare) — best-effort plain resend of this chunk.
-      result = await callApi(api, botToken, "sendMessage", base);
+      result = await callApi(api, botToken, "sendMessage", base, opts);
     }
     if (first) firstId = result.message_id;
     first = false;
@@ -302,7 +319,7 @@ export async function editMessageText(
   t: Target,
   messageId: number,
   body: string,
-  opts: { html?: boolean } = {},
+  opts: { html?: boolean } & CallOptions = {},
 ): Promise<void> {
   const base: Record<string, unknown> = {
     chat_id: t.chatId,
@@ -312,12 +329,12 @@ export async function editMessageText(
   const notModified = (e: unknown): boolean =>
     e instanceof TelegramApiError && /message is not modified/i.test(e.description);
   try {
-    await callApi(api, botToken, "editMessageText", opts.html ? { ...base, parse_mode: "HTML" } : base);
+    await callApi(api, botToken, "editMessageText", opts.html ? { ...base, parse_mode: "HTML" } : base, opts);
   } catch (e) {
     if (notModified(e)) return;
     if (!(opts.html && e instanceof TelegramApiError && PARSE_ERROR.test(e.description))) throw e;
     try {
-      await callApi(api, botToken, "editMessageText", base); // plain fallback for rejected markup
+      await callApi(api, botToken, "editMessageText", base, opts); // plain fallback for rejected markup
     } catch (e2) {
       if (!notModified(e2)) throw e2;
     }

--- a/test/feishu-api.test.ts
+++ b/test/feishu-api.test.ts
@@ -132,6 +132,20 @@ describe("pipeline invariants", () => {
     expect(calls).toBe(4); // 1 + 3 bounded retries
   });
 
+  it("a droppable card frame fails on the first rate-limit reject instead of waiting", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    stubFetch(() => {
+      calls++;
+      return new Response(JSON.stringify({ code: 99991400, msg: "frequency limit" }), { status: 429 });
+    });
+    const api = createFeishuApi({ baseUrl: BASE, appId: "a", appSecret: "s" });
+    const failed = api.updateCardElement("c1", "e1", "frame", 2, { retries: 0 }).catch((e: Error) => e);
+    // No timer advance: the next frame carries the same snapshot under a higher sequence.
+    expect(String(await failed)).toContain("frequency limit");
+    expect(calls).toBe(1); // one attempt, no backoff
+  });
+
   it("getMessage pins user_id_type=open_id (callers match open_ids, not the platform default)", async () => {
     const fx = stubFetch(() => okData({ items: [{ message_id: "om_1" }] }));
     const api = createFeishuApi({ baseUrl: BASE, appId: "a", appSecret: "s" });

--- a/test/feishu-preview.test.ts
+++ b/test/feishu-preview.test.ts
@@ -50,6 +50,7 @@ const eventSource = () => {
 };
 
 interface ElementWrite {
+  retries?: number;
   cardId: string;
   elementId: string;
   content: string;
@@ -66,8 +67,14 @@ function fakeApi() {
       created.push(cardJson);
       return `c${created.length}`;
     },
-    async updateCardElement(cardId: string, elementId: string, content: string, sequence: number) {
-      elementWrites.push({ cardId, elementId, content, sequence });
+    async updateCardElement(
+      cardId: string,
+      elementId: string,
+      content: string,
+      sequence: number,
+      opts?: { retries?: number },
+    ) {
+      elementWrites.push({ cardId, elementId, content, sequence, retries: opts?.retries });
     },
     async updateCard(cardId: string, cardJson: string, sequence: number) {
       cardWrites.push({ cardId, cardJson, sequence });
@@ -166,6 +173,10 @@ describe("feishuReply two-element streaming (direct)", () => {
       expect(next.length).toBeGreaterThan(prev.length);
     }
     expect(answerWrites.at(-1)?.content).toBe("hello world");
+
+    // Every live frame is droppable: a rate-limit wait for a snapshot the next frame redraws would
+    // park the answer behind it.
+    expect(elementWrites.map((w) => w.retries)).toEqual(elementWrites.map(() => 0));
 
     // The card's sequence is strictly increasing across BOTH elements (single-writer pump).
     const sequences = elementWrites.map((w) => w.sequence);

--- a/test/feishu-preview.test.ts
+++ b/test/feishu-preview.test.ts
@@ -119,6 +119,31 @@ describe("streaming card shape (pure)", () => {
 });
 
 describe("feishuReply two-element streaming (direct)", () => {
+  it("a rate-limited process frame does not withhold the answer element in the same flush", async () => {
+    vi.useFakeTimers();
+    const { api, elementWrites } = fakeApi();
+    // The process block is rate-limited from the first frame on; the answer must still be written.
+    vi.spyOn(api, "updateCardElement").mockImplementation(async (cardId, elementId, content, sequence, opts) => {
+      if (elementId === PROCESS_ELEMENT_ID) throw new Error("frequency limit");
+      elementWrites.push({ cardId, elementId, content, sequence, retries: opts?.retries });
+    });
+    const src = eventSource();
+    const turn = run(feishuReply(stream(src.iterable), api, { chatId: "oc_1" }, neutral));
+    await vi.advanceTimersByTimeAsync(0); // mount flush
+    // The process block keeps changing (a live tool trace), so it is retried on every frame.
+    for (let i = 0; i < 6; i++) {
+      src.push({ type: "tool_started", id: `t${i}`, name: "bash", args: { cmd: `step ${i}` } });
+      src.push({ type: "text", delta: `chunk${i} ` });
+      await vi.advanceTimersByTimeAsync(1100);
+    }
+    // One answer write per chunk: a rejected process write ends the flush it is in, so writing the
+    // decoration first costs the answer change that shared that flush.
+    expect(elementWrites.filter((w) => w.elementId === ANSWER_ELEMENT_ID)).toHaveLength(6);
+    src.push({ type: "completed" });
+    src.end();
+    await turn;
+  });
+
   it("process churn (sliding thinking tail, tool flips) never rewrites the answer element", async () => {
     vi.useFakeTimers();
     const { api, created, elementWrites, cardWrites } = fakeApi();

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -281,6 +281,37 @@ describe("telegramReply terminal writes (direct)", () => {
 });
 
 describe("telegramReply preview frames are droppable (direct)", () => {
+  it("absorbs a rate limit on the placeholder send — losing it would cost the whole turn's preview", async () => {
+    vi.useFakeTimers();
+    let sends = 0;
+    const edits: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const body = init?.body ? (JSON.parse(String(init.body)) as { text?: string }) : {};
+        if (String(url).endsWith("/sendMessage")) {
+          sends++;
+          if (sends === 1) {
+            return new Response(JSON.stringify({ ok: false, parameters: { retry_after: 1 } }), { status: 429 });
+          }
+          return okSend();
+        }
+        if (String(url).endsWith("/editMessageText")) edits.push(body.text ?? "");
+        return new Response(JSON.stringify({ ok: true, result: {} }), { status: 200 });
+      }),
+    );
+    const src = eventSource();
+    const turn = run(telegramReply(stream(src.iterable), API, "BOT", { chatId: 1 }, neutral));
+    await vi.advanceTimersByTimeAsync(2_100); // the placeholder retries past Telegram's 1s flood wait
+    expect(sends).toBe(2);
+    src.push({ type: "text", delta: "hello" });
+    src.push({ type: "completed" });
+    src.end();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await turn;
+    expect(edits.at(-1)).toBe("hello"); // the preview survived, so the answer edits it in place
+  });
+
   it("a rate-limited preview frame does not park the turn on its flood wait", async () => {
     vi.useFakeTimers();
     const edits: string[] = [];

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -67,6 +67,8 @@ async function* events(...list: AgentEvent[]): AsyncIterable<AgentEvent> {
 
 const neutral = (): string => "⚠️ neutral";
 
+const okSend = () => new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+
 describe("telegramReply single-writer pump (direct)", () => {
   it("one edit in flight; frames coalesce to the LATEST view — no stale or out-of-order frame", async () => {
     vi.useFakeTimers();
@@ -275,5 +277,52 @@ describe("telegramReply terminal writes (direct)", () => {
     );
     expect(sends.length).toBe(0); // no second placeholder
     expect(edits.at(-1)).toBe("answer"); // the notice morphed into the answer
+  });
+});
+
+describe("telegramReply preview frames are droppable (direct)", () => {
+  it("a rate-limited preview frame does not park the turn on its flood wait", async () => {
+    vi.useFakeTimers();
+    const edits: string[] = [];
+    let frames = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const body = init?.body ? (JSON.parse(String(init.body)) as { text?: string }) : {};
+        if (String(url).endsWith("/editMessageText")) {
+          frames++;
+          // Telegram rate-limits edits far tighter than sends; a preview frame is the common victim.
+          if (frames === 1) {
+            return new Response(JSON.stringify({ ok: false, parameters: { retry_after: 25 } }), { status: 429 });
+          }
+          edits.push(body.text ?? "");
+        }
+        if (String(url).endsWith("/sendMessage")) return okSend();
+        return new Response(JSON.stringify({ ok: true, result: {} }), { status: 200 });
+      }),
+    );
+    const src = eventSource();
+    const turn = run(telegramReply(stream(src.iterable), API, "BOT", { chatId: 1 }, neutral));
+    await vi.advanceTimersByTimeAsync(0); // placeholder sent
+    src.push({ type: "text", delta: "hel" });
+    await vi.advanceTimersByTimeAsync(1600); // the partial answer ages into view…
+    src.push({ type: "text", delta: "lo" }); // …and this frame carries it, rate-limited below
+    await vi.advanceTimersByTimeAsync(0);
+    expect(frames).toBe(1);
+    src.push({ type: "completed" });
+    src.end();
+    // The answer must land without waiting out Telegram's 25s flood wait for a frame nobody needs:
+    // the next frame redraws the same view, and the final write is authoritative.
+    const started = Date.now();
+    let elapsed = -1;
+    void turn.then(() => {
+      elapsed = Date.now() - started;
+    });
+    // Well past any flood wait: the question is not WHETHER the answer lands, but whether it waited.
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(elapsed).toBeGreaterThanOrEqual(0);
+    expect(elapsed).toBeLessThan(5_000);
+    expect(edits.at(-1)).toBe("hello");
+    await turn;
   });
 });

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -129,6 +129,20 @@ describe("Slack Web API transport", () => {
     expect(calls).toBe(2);
   });
 
+  it("a droppable write fails on the first 429 instead of absorbing Retry-After", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    vi.stubGlobal("fetch", async () => {
+      calls++;
+      return Response.json({ ok: false, error: "ratelimited" }, { status: 429, headers: { "retry-after": "30" } });
+    });
+    const api = createSlackApi({ botToken: "x", baseUrl: "https://slack.test/api" });
+    const failed = api.updateMarkdown("C1", "1.0", "frame", { retries: 0 }).catch((e: Error) => e);
+    // No timer advance: a preview frame must not park the turn behind a view the next frame redraws.
+    expect(String(await failed)).toContain("ratelimited");
+    expect(calls).toBe(1);
+  });
+
   it("downloads authenticated Slack-hosted bytes, creates vision refs, and writes ordinary files", async () => {
     const calls: { url: string; authorization?: string }[] = [];
     vi.stubGlobal("fetch", async (input: string | URL, init?: RequestInit) => {

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -110,6 +110,35 @@ describe("Slack reply rendering", () => {
     expect(api.sendMarkdown).not.toHaveBeenCalled();
   });
 
+  it("marks a live preview frame droppable so a rate limit cannot park the answer", async () => {
+    vi.useFakeTimers();
+    const api = fakeApi();
+    const pending = run(
+      slackReply(
+        stream(
+          (async function* (): AsyncIterable<AgentEvent> {
+            yield { type: "tool_started", id: "t", name: "read", args: {} };
+            // Past the mutation interval, so the pump writes a real frame before the answer settles.
+            await vi.advanceTimersByTimeAsync(3_500);
+            yield { type: "tool_ended", id: "t", isError: false, content: "ok" };
+            await vi.advanceTimersByTimeAsync(3_500);
+            yield { type: "text", delta: "**answer**" };
+            yield { type: "completed" };
+          })(),
+        ),
+        api,
+        { channelId: "D1", threadTs: "1.0" },
+        () => "failed",
+        { rendering: "classic", disclaimer: false },
+      ),
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    await pending;
+    const frames = vi.mocked(api.updateMarkdown).mock.calls.slice(0, -1);
+    expect(frames.length).toBeGreaterThan(0);
+    expect(frames.map((call) => call[3])).toEqual(frames.map(() => ({ retries: 0 })));
+  });
+
   it("enforces Slack's three-second chat.update interval across a completed pump", async () => {
     vi.useFakeTimers();
     const api = fakeApi();
@@ -126,7 +155,8 @@ describe("Slack reply rendering", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await pending;
-    expect(api.updateMarkdown).toHaveBeenCalledWith("D1", "1.0", "**answer**");
+    // The settle write carries no droppable option: the answer is worth a rate-limit retry.
+    expect(api.updateMarkdown).toHaveBeenCalledWith("D1", "1.0", "**answer**", undefined);
     expect(JSON.stringify(vi.mocked(api.postMarkdown).mock.calls)).not.toContain("private reasoning");
   });
 });

--- a/test/slack-preview.test.ts
+++ b/test/slack-preview.test.ts
@@ -40,6 +40,38 @@ async function* quickClassicTurn(): AsyncIterable<AgentEvent> {
   yield { type: "completed" };
 }
 
+/** A push-based event source, so the TEST BODY advances timers — a generator that advances them
+ *  while the test body is already inside `advanceTimersByTimeAsync` deadlocks. */
+function pushSource() {
+  const queue: AgentEvent[] = [];
+  let notify: (() => void) | undefined;
+  let ended = false;
+  return {
+    iterable: (async function* (): AsyncIterable<AgentEvent> {
+      for (;;) {
+        if (queue.length > 0) {
+          yield queue.shift() as AgentEvent;
+          continue;
+        }
+        if (ended) return;
+        await new Promise<void>((resolve) => {
+          notify = resolve;
+        });
+      }
+    })(),
+    push(event: AgentEvent): void {
+      queue.push(event);
+      notify?.();
+      notify = undefined;
+    },
+    end(): void {
+      ended = true;
+      notify?.();
+      notify = undefined;
+    },
+  };
+}
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -108,6 +140,36 @@ describe("Slack reply rendering", () => {
       ),
     ).rejects.toThrow(/connection reset/);
     expect(api.sendMarkdown).not.toHaveBeenCalled();
+  });
+
+  it("a rejected frame still spends its rate-limit slot (no per-token retry storm)", async () => {
+    vi.useFakeTimers();
+    const api = fakeApi();
+    // Slack is rate-limiting every edit; a droppable frame fails instantly instead of waiting it out.
+    vi.mocked(api.updateMarkdown).mockRejectedValue(new SlackApiError("chat.update", 429, "ratelimited"));
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const src = pushSource();
+    const pending = run(
+      slackReply(stream(src.iterable), api, { channelId: "D1", threadTs: "1.0" }, () => "failed", {
+        rendering: "classic",
+        disclaimer: false,
+      }),
+    );
+    src.push({ type: "text", delta: "start " });
+    await vi.advanceTimersByTimeAsync(3_500); // the answer ages into view; the first slot opens
+    for (let i = 0; i < 100; i++) {
+      src.push({ type: "text", delta: `t${i} ` });
+      await vi.advanceTimersByTimeAsync(100); // the model's token pace, well inside one 3s slot
+    }
+    // The rejected frames must not reopen the mutation slot: one attempt per slot, not one per token.
+    // ~10s of tokens against a 3s slot: a handful of attempts. Without the slot being spent by the
+    // ATTEMPT, every rejected frame reopens it and the same view is re-sent once per token (72 here).
+    expect(vi.mocked(api.updateMarkdown).mock.calls.length).toBeLessThanOrEqual(5);
+    src.push({ type: "completed" });
+    src.end();
+    await vi.advanceTimersByTimeAsync(10_000);
+    await pending.catch(() => {}); // the settle write fails too; its diagnostics are asserted elsewhere
+    warning.mockRestore();
   });
 
   it("marks a live preview frame droppable so a rate limit cannot park the answer", async () => {


### PR DESCRIPTION
## The defect

A live-preview frame is a snapshot: the next frame redraws it and the final write supersedes it. Every transport nevertheless absorbed the platform's rate-limit backoff for one, inside the single-writer pump that the answer waits on.

Measured on the real code paths, one 429 on a preview edit delays the answer by:

| Channel | Worst case |
|---|---|
| Telegram | 3 × (`FLOOD_WAIT_MAX_S` + 1) = 93 s |
| Slack (classic) | 3 × `MAX_RETRY_AFTER_S` = 90 s |
| Feishu (card) | 1 + 2 + 3 = 6 s |

Telegram rate-limits edits to one message far tighter than sends, so the preview frame is the common victim.

## The change

Each pipeline takes a per-call retry budget, and the preview edit paths pass `retries: 0`. The frame is lost, the answer is not.

Dropping a frame must not also drop the pacing that frame was subject to: Slack's classic renderer gives its whole 3-second interval to `waitForMutationSlot` (the pump's `throttleMs` is 0), so the mutation slot is now spent by the **attempt**. Recording it only on success left the slot open, and a rejected view was re-sent once per token — 72 attempts where the slot allows 3.

Two writes deliberately keep the default retries:

- Telegram's placeholder `sendMessage` happens once and every later frame depends on its id, so dropping it costs the whole turn's live preview rather than one redrawable view.
- Slack's ordered `chat.appendStream`: each append carries content of its own, so dropping one loses it.

Feishu writes the answer element before the process block: a rejected write ends the flush, and the process block is decoration while the answer is the reply being typed out.

Terminal/settle writes, timeouts, error classification and pump semantics are unchanged.

## Verification

- Lint, typecheck, build, diff checks and **1,839 tests / 125 files** pass (7 new).
- Telegram: an end-to-end preview regression through a real `fetch` mock — the turn settles in <5 s where a single `retry_after: 25` frame previously took 26 s — plus one proving the placeholder send still absorbs a rate limit.
- Slack: a rejected-frame storm probe (≤5 attempts, 72 before the slot fix) and a call-site assertion that live frames are issued droppable.
- Feishu: a transport regression, a call-site assertion, and one proving a rejected process frame no longer withholds the answer element in the same flush.
- Every new test was confirmed to fail with its own fix reverted.
- `test/live/` was not run: real platform rate-limit behavior is unverified.
