### PR TITLE
chore: drop stale migration docs and unread Feishu wire fields

### DIFF
--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -418,50 +418,10 @@ Two consequences worth stating rather than papering over:
   quote-reply to the agent in a group's main timeline is buffered rather than answered, and the user
   either mentions it or opens a thread.
 
-## 12. Migration
+## 12. Why there is no session-mode option
 
-The participant model replaces the earlier `threaded` / `continuous` mode pair. Those two options
-coupled three independent axes — session identity, reply placement, and the summon rule — so a user
-who wanted room-level sessions was forced to also give up mention-free thread continuations. The
-model above sets each axis on its own principle, which leaves nothing for the modes to select.
-
-For Feishu/Lark, `buffers.json` buckets keyed `<chat>:root:<id>` become unreachable — the re-keying
-means no place key can produce that shape again, so nothing can fold or clear them. Nothing deletes
-them either, and nothing deletes the obsolete `owned-threads.json`: both cleanups were migration code,
-which this repo does not carry. They are the operator's to remove, with the process stopped.
-
-The buffered content is lost to the agent either way: the retired shape covered EVERY thread bucket and
-every main-chat quoted-reply bucket, so buffered discussion in threads does not survive the upgrade (a
-chat's own `<chat>` bucket does), and a turn in flight across the upgrade loses its buffered context too
-— `turns.json` persisted its `bufferKey` under the old shape. What differs from a drop is only where it
-rests: those buckets sit in `buffers.json` holding chat content until someone removes them.
-
-Breaking changes for existing Feishu/Lark deployments:
-
-- direct messages become one continuous conversation instead of one session per top-level message;
-- group summons answer in place instead of opening a thread;
-- threads answer bare messages only while no second human has been heard in them;
-- **the concurrency unit changes with the session.** Turns serialize per session (§6), so a whole room
-  — and a whole DM chat — is now one queue. Previously each top-level summon was its own session and
-  ran concurrently; now a second person's `@Agent` in a busy room waits behind an unrelated
-  multi-minute turn. Opening a thread is the way to run something alongside it;
-- **sessions are re-keyed** from `<kind>:<root_id ?? message_id>` to the place
-  (`<kind>:<chat_id>`, or `<kind>:<chat_id>:<thread_id>` in a thread — §5; the kind brand stays). Existing session history is NOT migrated: every conversation starts fresh
-  after the upgrade, which reads to users as the agent forgetting, and the old records stay in the
-  session store unreferenced (there is no TTL or GC — see docs/feishu.md). Deleting them is optional
-  and safe; nothing will ever read them again.
-
-For Slack, placement and sessions are unchanged **under the default configuration**; what changes is
-the summon rule: a thread the agent has answered in admits bare replies until a second human is heard
-there, which restores the mention requirement. `owned-threads.json` is left behind by the upgrade (see
-above); nothing reads it.
-
-Breaking changes for existing Slack deployments:
-
-- `directMessageSession` and `groupMessageSession` are removed — placement and session identity follow
-  from Slack's own primitives (§5), which leaves nothing for the options to select. Delete them by
-  hand: a workspace's `channels/slack.ts` is loaded as ESM, not type-checked, so a leftover option is
-  ignored in silence while placement and the memory boundary change underneath it. Feishu/Lark options
-  are the same;
-- a deployment that set either to `continuous` therefore changes both where answers land and how
-  sessions are keyed. Existing history is not migrated, for the same reason as Feishu's re-keying above.
+A `threaded` / `continuous` mode pair would couple three independent axes — session identity, reply
+placement, and the summon rule — so a user who wanted room-level sessions would also have to give up
+mention-free thread continuations. The model above sets each axis on its own principle, which leaves
+nothing for such a mode to select. An author who needs endpoint-shaped behaviour supplies an explicit
+`route` (§1) rather than picking a mode.

--- a/docs/design/participant-model.md
+++ b/docs/design/participant-model.md
@@ -357,6 +357,7 @@ back (§7). A thread neither learns about later room activity nor reports its ow
 | Answering every bare message in a joined thread | barges into multi-human discussion |
 | Per-entry concurrency inside a session | divergence without convergence; stale reads |
 | Automatic summaries posted to the room | attention has a noise cost, so it needs consent |
+| A `threaded` / `continuous` session-mode pair | couples session identity, placement and the summon rule into one switch; an endpoint-shaped bot uses an explicit `route` (§1) |
 
 ## 10. Mapping to platforms
 
@@ -417,11 +418,3 @@ Two consequences worth stating rather than papering over:
   every message the agent has sent. Neither is worth it while the thread rule covers the same flow: a
   quote-reply to the agent in a group's main timeline is buffered rather than answered, and the user
   either mentions it or opens a thread.
-
-## 12. Why there is no session-mode option
-
-A `threaded` / `continuous` mode pair would couple three independent axes — session identity, reply
-placement, and the summon rule — so a user who wanted room-level sessions would also have to give up
-mention-free thread continuations. The model above sets each axis on its own principle, which leaves
-nothing for such a mode to select. An author who needs endpoint-shaped behaviour supplies an explicit
-`route` (§1) rather than picking a mode.

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -340,13 +340,6 @@ The channel persists its state under `<state root>/channels/<kind>/` (`channels/
 - `buffers.json` — unsummoned human group/thread discussion, persisted before the transport ACK and consumed only after an Agent turn completes,
 - `files/c-<chat>/` — downloaded inbound files, one directory per chat.
 
-An upgrade from the earlier session-mode model leaves two dead things behind, and nothing removes them:
-the obsolete `owned-threads.json`, and `buffers.json` buckets keyed `<chat>:root:<id>`. The re-keying
-means no place key can produce that shape again, so those buckets can never be folded or cleared —
-**buffered discussion in threads does not survive the upgrade** (a chat's own bucket does), and it stays
-on disk holding that chat content until you delete it. Remove the file and those keys by hand, with the
-process stopped.
-
 The seen ring is bounded, best-effort delivery dedup rather than exactly-once execution. It is written
 after the turn/buffer state so a failed pre-ACK state write can still be redelivered safely; a crash
 between those writes, a failed ring write, or a duplicate older than the cap can therefore still re-run
@@ -373,32 +366,6 @@ directory or an independent `cwd`.
 `fastagent add feishu|lark` rewrites the tool, keeps `channels/<kind>.ts` and the credentials already in
 `.env`, and re-checks the app's group visibility. That is how an agent scaffolded by an earlier release
 picks up the current tool.
-
-## Upgrading from the session-mode releases
-
-Three behaviour changes, none of them opt-in:
-
-- **Direct messages become one continuous conversation** instead of one session per top-level message,
-  and a group summon is answered **in place** instead of opening a thread.
-- **Sessions are re-keyed** to the place (`<kind>:<chat_id>`, or `<kind>:<chat_id>:<thread_id>` in a
-  thread). Existing history is NOT migrated — every conversation starts fresh, which reads to users as
-  the Agent forgetting. The old session records stay in the store unreferenced; deleting them is
-  optional and safe.
-- **The concurrency unit changes with it.** Turns serialize per session, so a whole room is now one
-  queue: a second person's `@Agent` in a busy room waits behind an unrelated multi-minute turn (they
-  see the "⏳ Queued" card). Open a thread to run something alongside it.
-
-- **Unrelated to the model, but in the same release:** the scaffolded send tool's description gained a
-  "do not use this to answer the current turn" boundary (without it the Agent posts its reply twice).
-  An agent scaffolded earlier still carries the old text — re-run `fastagent add feishu|lark` to rewrite
-  the tool (see the send-tool section above).
-
-State does not clean itself up: `owned-threads.json` and the `buffers.json` buckets under the retired
-key shape are both left in place, unread and unreachable — which means **buffered discussion in threads
-does not survive the upgrade** (a chat's own bucket does), while its content stays on disk. Delete both
-by hand with the process stopped (see State & restarts above).
-
-Derivation in [design/participant-model.md](design/participant-model.md) §3 and §12.
 
 ## Limits
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -352,25 +352,6 @@ lines in `.secrets/.env`, then run `fastagent add slack` again; the runtime secr
 `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` alone. Remove the app in the Slack console when the new one
 answers.
 
-## Upgrading from the session-mode releases
-
-`directMessageSession` and `groupMessageSession` are **removed** — placement and session identity
-follow from Slack's own primitives (an answer goes in a thread on the ask, and that thread is the
-session), which leaves nothing for the options to select. Delete them from `channels/slack.ts`
-yourself: nothing rejects them at startup, and the file is loaded as ESM rather than type-checked, so a
-leftover option is ignored in silence while placement and the memory boundary change underneath it.
-
-If either was set to `continuous`, both where answers land and how sessions are keyed change with the
-removal, and **existing conversation history is not migrated** — every thread starts fresh. The obsolete
-`owned-threads.json` is left behind, unread by anything; delete it if you want the state directory clean.
-
-Slack's scaffolded `slack-send` already carried the "do not use this to answer the current turn"
-boundary its Feishu and Telegram siblings gained this release, so nothing to paste here.
-
-Behaviour that changes even on the default configuration: a bare reply in a thread is answered while
-the Agent takes part and it has not heard a second human there (previously: any thread it had created).
-Derivation in [design/participant-model.md](design/participant-model.md) §3 and §12.
-
 ## Current boundaries
 
 - HTTP Events API only; Socket Mode is not included.

--- a/src/channels/feishu/model.ts
+++ b/src/channels/feishu/model.ts
@@ -23,7 +23,6 @@ export interface FeishuMention {
   key: string;
   id?: { open_id?: string; user_id?: string; union_id?: string };
   name?: string;
-  mentioned_type?: string;
   tenant_key?: string;
   [k: string]: unknown;
 }
@@ -41,8 +40,6 @@ export interface FeishuMessage {
   message_type: string;
   content: string;
   mentions?: FeishuMention[];
-  user_agent?: string;
-  lark_agent_context?: { active_chat_id?: string; [k: string]: unknown };
   [k: string]: unknown;
 }
 


### PR DESCRIPTION
Repo-wide audit for redundant or outdated design, structure, code, tests and comments. The mechanical layer came back empty — `knip` (files, exports, types, duplicate exports, dependencies), `biome`, the doc-link checker, a comment-to-source-path cross-check, and an export-reference count all report nothing dead. Two findings remained, both removed here.

## Stale migration documentation (99 lines)

Three "Upgrading from the session-mode releases" sections document the participant-model change that shipped in v0.16.0. The package is at v0.21.1, and this repo does not carry migration guidance.

Removed from `docs/feishu.md`, `docs/slack.md`, and the leftover-state paragraph under `docs/feishu.md`'s State & restarts. Every behavioural fact in them is already documented as current behaviour: `docs/feishu.md` L235 (summon rule), L252 (session keys), L286-292 (per-session queue), L387 (no session TTL/GC); `docs/slack.md` L148, L181-182 (summon rule). Nothing is lost.

`docs/design/participant-model.md` §12 is gone. The one durable idea in it — that a `threaded`/`continuous` pair would couple session identity, placement and the summon rule into a single switch — becomes a row in §9 `Rejected designs`, which is already the single place this document answers "why was that design refused". `docs/design/core.md` L569 depends on that reasoning and links the file without an anchor, so nothing breaks.

`docs/slack.md`'s "Upgrading from a rotating-token app (releases up to 0.20)" stays: it covers the immediately preceding release and users still hit it.

## Unread Feishu wire fields

`FeishuMention.mentioned_type`, `FeishuMessage.user_agent` and `FeishuMessage.lark_agent_context` were added in #242 and have never been read — one occurrence each across `src/`, `test/` and `docs/`. The module header already states the rule they break: "Do not pre-model unused transport metadata for a future ingress." Both interfaces carry `[k: string]: unknown`, so an author's `route(event)` callback can still reach the fields; the type narrows from `string | undefined` to `unknown`, so a downstream reader asserts. Restoring any of them should come with a read site.

## Deliberately not changed

- **Eight one-line `sleep`/`wait` helpers** (`tunnel.ts`, `slack-api.ts`, `feishu-api.ts`, `telegram-api.ts`, `registration.ts`, `register-app.ts`, `docker/run.ts`, `bootstrap-token.ts`). `node:timers/promises` would bypass the fake timers `test/registration-retry.test.ts` and the preview suites rely on, and a shared module would couple `deploy/` to `channels/` for a stdlib-shaped one-liner.
- **`src/channels/slack/model.ts`'s unread fields** (`filetype`, `api_app_id`, `event_time` and others). Unlike the Feishu models these have no index signature, and `SlackEventEnvelope` is public — it is the argument of the author-supplied `route(envelope)` callback. Removing them would break author code with no fallback.

## Verification

`npm run lint`, `npm run typecheck`, `npm test` (125 files, 1839 tests) all pass. No dangling `§12`, `owned-threads` or session-mode-upgrade reference remains in the repo.