### PR TITLE
secrets: declare them where the code is, receive the values there

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,12 @@ src/
 ├── loader.ts               # neutral ESM discovery/loading + failure reporting for tools/ channels/ schedules/ config
 ├── paths.ts                # PLACEMENT (which directory is the agent, which is the workspace) + the shared
 │                           # path predicates and the machinery paths that follow (.secrets/.state)
+├── declared-secrets.ts     # WHICH env vars this agent needs, in ONE shape, wherever it was declared
+│                           # (defineTool/defineChannel/defineSchedule + deploy.secrets): the ONE read of
+│                           # an authored `secrets:`, the values handed back to the code that declared
+│                           # them, and what "has no value" means
+├── secrets-gate.ts         # THE refusal: which declarations gate THIS run (all vs one owner), load
+│                           # failures reported before it throws, and the shape of that throw
 ├── atomic-write.ts         # writeFileAtomic: the ONE "whole file or none of it" write
 ├── version.ts              # package version (deploy pins it into the image)
 ├── scaffold/               # `init` / `add <channel>` / `add skill` + templates/ (real files)
@@ -81,6 +87,8 @@ src/
 │   ├── control.ts          # session-control transport: bearer-token /control/* routes + SSE events + /control/invoke
 │   ├── sse.ts              # Fetch-only response lifecycle shared by invoke and observation
 │   ├── discover.ts         # channels/ filesystem discovery (ChannelModule → Routes), engine-neutral
+│   ├── define-channel.ts   # the channel file's authoring surface: declare secrets, receive their values
+│   │                       # (the only way a CUSTOM channel's credentials can reach a deploy)
 │   ├── body.ts, respond.ts # channel-authoring kit (body cap, responses)
 │   ├── secret.ts           # the ONE constant-time comparison every shared-secret gate reads through
 │   ├── wait-health.ts      # readiness probe for a server THIS process reaches directly (not a public URL)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -270,6 +270,34 @@ export default defineTool({
 
 `tools/<name>.ts` files are discovered by the assembly, and the filename becomes the tool name.
 
+### Declaring the secrets a tool needs
+
+A tool that needs an env var says so where it is defined:
+
+```ts
+export default defineTool({
+  description: "Post to X.",
+  input: z.object({ text: z.string() }),
+  secrets: ["X_API_KEY", "X_API_SECRET"],
+  async execute({ text }, ctx) {
+    return await post(text, ctx.secrets.X_API_KEY); // typed from the list above
+  },
+});
+```
+
+**This is how agent code gets a credential — not `process.env`.** The declaration buys two things a
+bare read cannot have:
+
+- **`deploy` carries the value** to the host and lists it in the runbook against this file. There is no
+  second list to keep in sync — `config.deploy.secrets` is only for names no code declares.
+- **`dev`/`start` refuse to boot** while a declared name is unset, naming the file. Without the
+  declaration the same mistake surfaces as a failed tool call on the deployed box, days later.
+
+`ctx.secrets` reads the process environment on every call, so a value rotated IN THE ENVIRONMENT
+takes effect without a restart — a value rotated in `.secrets/.env` does not, since that file is read
+once at startup. Its keys are typed from the list: a typo is a compile error. `defineChannel` and `defineSchedule` take the same
+field, and `fastagent info` prints every declared name plus the ones with no local value.
+
 The second `execute` argument is a `ToolContext`:
 
 ```ts
@@ -278,6 +306,8 @@ interface ToolContext {
   signal?: AbortSignal;
   sessionManager?: ReadonlySessionManager;
   tools?: ToolActivation;
+  /** The values of this tool's own `secrets`, keyed by the names it declared. */
+  secrets: Record<string, string>;
 }
 
 interface ReadonlySessionManager {
@@ -393,6 +423,7 @@ export default defineSchedule({
   cron: "0 9 * * *",
   tz: "America/New_York",
   prompt: "Generate today's digest and send it to the team Telegram.",
+  secrets: ["SLACK_DIGEST_CHANNEL"], // same contract as a tool's — carried by deploy, asserted at start
 });
 ```
 

--- a/docs/channel-development.md
+++ b/docs/channel-development.md
@@ -229,12 +229,21 @@ The user's agent installs the adapter and wires it in `channels/acme.ts`:
 
 ```ts
 import { acmeChannel } from "fastagent-channel-acme";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default acmeChannel({
-  secret: process.env.ACME_WEBHOOK_SECRET ?? "",
-  on: (event) => ({ session: event.id, text: event.text }),
+export default defineChannel({
+  secrets: ["ACME_WEBHOOK_SECRET"],
+  channel: (secrets) =>
+    acmeChannel({
+      secret: secrets.ACME_WEBHOOK_SECRET,
+      on: (event) => ({ session: event.id, text: event.text }),
+    }),
 });
 ```
+
+Take the adapter's credentials as OPTIONS, never from `process.env` inside the package: the agent file
+declares them with `defineChannel`, which is what lets `deploy` carry them and the serve refuse to
+start without them.
 
 Keep agent-specific policy in the user's `channels/*.ts`; keep transport mechanics in the adapter package.
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -125,13 +125,18 @@ Example GitHub glue:
 
 ```ts
 import { githubChannel } from "@fastagent-sh/fastagent/github";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default githubChannel({
-  secret: process.env.GITHUB_WEBHOOK_SECRET ?? "",
-  on: (event) =>
-    event.event === "pull_request" && event.action === "opened" && "pull_request" in event.payload
-      ? [{ session: event.deliveryId, text: `Review PR #${event.payload.pull_request.number}` }]
-      : [],
+export default defineChannel({
+  secrets: ["GITHUB_WEBHOOK_SECRET"],
+  channel: (secrets) =>
+    githubChannel({
+      secret: secrets.GITHUB_WEBHOOK_SECRET,
+      on: (event) =>
+        event.event === "pull_request" && event.action === "opened" && "pull_request" in event.payload
+          ? [{ session: event.deliveryId, text: `Review PR #${event.payload.pull_request.number}` }]
+          : [],
+    }),
 });
 ```
 
@@ -139,10 +144,15 @@ Example Telegram glue:
 
 ```ts
 import { telegramChannel } from "@fastagent-sh/fastagent/telegram";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default telegramChannel({
-  secretToken: process.env.TELEGRAM_SECRET_TOKEN ?? "",
-  botToken: process.env.TELEGRAM_BOT_TOKEN ?? "",
+export default defineChannel({
+  secrets: ["TELEGRAM_SECRET_TOKEN", "TELEGRAM_BOT_TOKEN"],
+  channel: (secrets) =>
+    telegramChannel({
+      secretToken: secrets.TELEGRAM_SECRET_TOKEN,
+      botToken: secrets.TELEGRAM_BOT_TOKEN,
+    }),
 });
 ```
 
@@ -150,14 +160,19 @@ Example Slack glue:
 
 ```ts
 import { slackChannel } from "@fastagent-sh/fastagent/slack";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default slackChannel({
-  botToken: process.env.SLACK_BOT_TOKEN ?? "",
-  signingSecret: process.env.SLACK_SIGNING_SECRET ?? "",
-  rendering: "native", // Slack Agent stream with inline tool traces; "classic" for compatibility
-  // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
-  // No session modes: an answer attaches to its question with a thread (Slack has no quote primitive),
-  // and that thread is the session — see docs/design/participant-model.md.
+export default defineChannel({
+  secrets: ["SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET"],
+  channel: (secrets) =>
+    slackChannel({
+      botToken: secrets.SLACK_BOT_TOKEN,
+      signingSecret: secrets.SLACK_SIGNING_SECRET,
+      rendering: "native", // Slack Agent stream with inline tool traces; "classic" for compatibility
+      // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
+      // No session modes: an answer attaches to its question with a thread (Slack has no quote primitive),
+      // and that thread is the session — see docs/design/participant-model.md.
+    }),
 });
 ```
 
@@ -166,20 +181,25 @@ adapter over this engine and reads `LARK_*`):
 
 ```ts
 import { feishuChannel } from "@fastagent-sh/fastagent/feishu";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default feishuChannel({
-  appId: process.env.FEISHU_APP_ID ?? "",
-  appSecret: process.env.FEISHU_APP_SECRET ?? "",
-  verificationToken: process.env.FEISHU_VERIFICATION_TOKEN ?? "",
-  encryptKey: process.env.FEISHU_ENCRYPT_KEY || undefined,
-  // No session modes: a chat is one session and a thread is another, and the summon/placement rules
-  // follow from that (docs/design/participant-model.md).
+export default defineChannel({
+  secrets: ["FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_VERIFICATION_TOKEN"],
+  channel: (secrets) =>
+    feishuChannel({
+      appId: secrets.FEISHU_APP_ID,
+      appSecret: secrets.FEISHU_APP_SECRET,
+      verificationToken: secrets.FEISHU_VERIFICATION_TOKEN,
+      encryptKey: process.env.FEISHU_ENCRYPT_KEY || undefined,
+      // No session modes: a chat is one session and a thread is another, and the summon/placement rules
+      // follow from that (docs/design/participant-model.md).
+    }),
 });
 ```
 
 A route-adapter call returns a `ChannelModule`; a WebSocket adapter such as
 `feishuWebSocketChannel` returns a `LongConnectionChannelModule`. In either form the glue holds only
-policy (secrets from env, `on`/`route`), while `agent` and the state root flow from the framework to the adapter without transiting your code.
+policy (the declared `secrets` and `on`/`route`), while `agent` and the state root flow from the framework to the adapter without transiting your code.
 The adapter owns its default route (`POST /webhook`, `POST /telegram`, `POST /slack`, `POST /feishu`, `POST /lark`);
 wrap it in your own `ChannelModule` to remap.
 
@@ -229,12 +249,20 @@ The user's agent installs the adapter and wires it with a channel file:
 
 ```ts
 import { acmeChannel } from "fastagent-channel-acme";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default acmeChannel({
-  secret: process.env.ACME_SECRET ?? "",
-  on: (event) => ({ session: event.user, text: event.text }),
+export default defineChannel({
+  secrets: ["ACME_SECRET"],
+  channel: (secrets) =>
+    acmeChannel({
+      secret: secrets.ACME_SECRET,
+      on: (event) => ({ session: event.user, text: event.text }),
+    }),
 });
 ```
+
+A custom channel's credentials exist nowhere else in the definition, so `secrets` is the only way
+`deploy` learns to carry them and the only thing that makes an unset value a startup failure.
 
 Read [Channel development](channel-development.md) for adapter design, packaging, and testing guidance.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,6 +80,7 @@ Prints the assembled surface without starting a server:
 - channel files,
 - schedules (name + next fire instant; a broken schedule file is reported here, not first at `dev`),
 - whether self-scheduling (`selfSchedule`) is on,
+- declared secrets (`defineTool({ secrets })`, `defineChannel({ secrets })`, `defineSchedule({ secrets })`, `config.deploy.secrets`), flagging any that have no value here and which of those block `dev`/`start`,
 - session directory.
 
 `info` is read-only: it does not create sessions or modify `.state/`/`.secrets/`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,7 +77,7 @@ Prints the assembled surface without starting a server:
 - persona presence and context files (`AGENTS.md`),
 - skills and their diagnostics,
 - the complete coding-tool set (`read`/`grep`/`find`/`ls`/`bash`/`edit`/`write`), plus authored tools and collisions,
-- channel files,
+- channel files that IMPORT cleanly (`info` loads them to read their declarations); one that fails to import is absent from this list and reported instead — as a warning, and as `channelFailures` in `--json`,
 - schedules (name + next fire instant; a broken schedule file is reported here, not first at `dev`),
 - whether self-scheduling (`selfSchedule`) is on,
 - declared secrets (`defineTool({ secrets })`, `defineChannel({ secrets })`, `defineSchedule({ secrets })`, `config.deploy.secrets`), flagging any that have no value here and which of those block `dev`/`start`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ Supported keys:
 | `http.host` | Bind address for `dev` / `start`. Unset (or `0.0.0.0`) binds all interfaces — what containers need. `--bind` overrides it; prefer the flag for a local-only bind, since this value travels into a deployed image (see [Bind address](#bind-address)). |
 | `selfSchedule` | Mount the built-in `wake` tool so the agent can schedule its own follow-up turns (self-scheduling). Off by default — an autonomy capability, opt in when you want it; only active on the serving path (`dev`/`start` or `createAgentService`). Resident hosts poll locally; [AgentCore ingress](deploy.md#aws-bedrock-agentcore) uses external wake alarms. |
 | `sessionControl` | Serve the session control plane at `/control/*` (a session's state/entries/live events, its actions — steer/abort/compact — its properties, and the deployment's session list) for remote consumers — a Web panel, a desktop app, `fastagent attach`. Off by default (it is a remote-control surface). When on, `dev`/`start` mint a per-boot bearer token into `<stateRoot>/control.json`; the serve binds all interfaces by default, so the routes are LAN-reachable with the token as the only protection — bind loopback (`--bind 127.0.0.1` — not `http.host`, which travels into a deployed image), firewall the port, or wrap it. On a deployed box (`fastagent deploy`) the routes ride the public host URL, so the token comes from outside instead: set `FASTAGENT_CONTROL_TOKEN` as a deploy secret (`deploy` lists it and warns) and the serve uses that value rather than minting one nothing outside can read. |
-| `deploy.secrets` | Extra secret env-var names the deployed agent needs (e.g. `["GH_TOKEN"]`). `deploy` lists them in the runbook and, under `--run`, carries each value from your local env to the host secret store; a missing value gates the run. |
+| `deploy.secrets` | Secret env-var names **no code declares** — a value read outside `tools/`/`schedules/`, or a key used only in a `models.json` header. A tool or schedule that needs a var declares it itself (`defineTool({ secrets: […] })`, see [API reference](api-reference.md#declaring-the-secrets-a-tool-needs)) and `deploy` carries it without it being listed here. Every declared name, from either source, is listed in the runbook against its declaring file and carried from your local env under `--run`; a missing value gates the run. |
 | `deploy.apt` | Extra apt packages baked into the generated image (`["git", "ripgrep"]` — Debian default repos). For a package needing a custom apt repo (e.g. `gh`) or a different base image, provide your own `Dockerfile` — `deploy` keeps an existing one (and warns that `deploy.apt` isn't applied to a hand-written Dockerfile). A `Dockerfile` fastagent generated that later drifts from the current config (a changed `deploy.apt`, a new lockfile) is kept but flagged stale; `--force` regenerates it. |
 
 Unknown keys fail at startup. This catches typos such as `modle` instead of silently degrading to defaults.
@@ -332,12 +332,21 @@ Reusable packages do not need a separate plugin contract: export ordinary `Fasta
 import { integrationTools } from "@acme/fastagent-tools";
 
 export default defineConfig({
-  tools: integrationTools({ apiKey: process.env.ACME_API_KEY! }),
+  tools: integrationTools(),
+  deploy: { secrets: ["ACME_API_KEY"] }, // only if the package reads it itself
 });
 ```
 
 Package tools receive the same `ToolContext` as definition-local `defineTool` tools, including the
-optional read-only `sessionManager` during serving/chat turns.
+optional read-only `sessionManager` during serving/chat turns and the `secrets` the package's own
+`defineTool` calls declared. A package that instead reads an env var itself declares nothing, so its
+name belongs in `deploy.secrets` — that is what the list is for.
+
+**A mounted package's declarations are treated like your own.** `deploy` will list them in the
+runbook and, under `--run`, read those names from your local environment and set them on the host.
+Every host's `--run` prints the names it carries before setting them, and a name with no local value
+stops the run — but the list is no longer only what you typed, so read a new tool package's `secrets`
+the way you read the rest of its code before mounting it.
 
 ## Extensions
 

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -151,13 +151,18 @@ A minimal channel module looks like this (`channels/feishu.ts`; the lark kind mi
 
 ```ts
 import { feishuChannel } from "@fastagent-sh/fastagent/feishu";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default feishuChannel({
-  appId: process.env.FEISHU_APP_ID ?? "",
-  appSecret: process.env.FEISHU_APP_SECRET ?? "",
-  verificationToken: process.env.FEISHU_VERIFICATION_TOKEN ?? "",
-  encryptKey: process.env.FEISHU_ENCRYPT_KEY || undefined,
-  onError: (failed) => `⚠️ ${failed.details}`, // dev transparency; drop for a public bot
+export default defineChannel({
+  secrets: ["FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_VERIFICATION_TOKEN"],
+  channel: (secrets) =>
+    feishuChannel({
+      appId: secrets.FEISHU_APP_ID,
+      appSecret: secrets.FEISHU_APP_SECRET,
+      verificationToken: secrets.FEISHU_VERIFICATION_TOKEN,
+      encryptKey: process.env.FEISHU_ENCRYPT_KEY || undefined,
+      onError: (failed) => `⚠️ ${failed.details}`, // dev transparency; drop for a public bot
+    }),
 });
 ```
 
@@ -165,10 +170,15 @@ The WebSocket form uses its transport-specific factory and has no webhook-only o
 
 ```ts
 import { feishuWebSocketChannel } from "@fastagent-sh/fastagent/feishu";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default feishuWebSocketChannel({
-  appId: process.env.FEISHU_APP_ID ?? "",
-  appSecret: process.env.FEISHU_APP_SECRET ?? "",
+export default defineChannel({
+  secrets: ["FEISHU_APP_ID", "FEISHU_APP_SECRET"],
+  channel: (secrets) =>
+    feishuWebSocketChannel({
+      appId: secrets.FEISHU_APP_ID,
+      appSecret: secrets.FEISHU_APP_SECRET,
+    }),
 });
 ```
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -22,21 +22,26 @@ This creates `channels/github.ts` and appends the required env var to `.env.exam
 
 ```ts
 import { githubChannel } from "@fastagent-sh/fastagent/github";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default githubChannel({
-  secret: process.env.GITHUB_WEBHOOK_SECRET ?? "",
-  on: (event) => {
-    if (event.event === "pull_request" && event.action === "opened" && "pull_request" in event.payload) {
-      const { repository, pull_request } = event.payload;
-      return [
-        {
-          session: event.deliveryId,
-          text: `Review PR #${pull_request.number} in ${repository.full_name}`,
-        },
-      ];
-    }
-    return [];
-  },
+export default defineChannel({
+  secrets: ["GITHUB_WEBHOOK_SECRET"],
+  channel: (secrets) =>
+    githubChannel({
+      secret: secrets.GITHUB_WEBHOOK_SECRET,
+      on: (event) => {
+        if (event.event === "pull_request" && event.action === "opened" && "pull_request" in event.payload) {
+          const { repository, pull_request } = event.payload;
+          return [
+            {
+              session: event.deliveryId,
+              text: `Review PR #${pull_request.number} in ${repository.full_name}`,
+            },
+          ];
+        }
+        return [];
+      },
+    }),
 });
 ```
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -115,16 +115,21 @@ without touching the installed app or its runtime credentials.
 
 ```ts
 import { slackChannel } from "@fastagent-sh/fastagent/slack";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default slackChannel({
-  botToken: process.env.SLACK_BOT_TOKEN ?? "",
-  signingSecret: process.env.SLACK_SIGNING_SECRET ?? "",
-  rendering: "native", // native Agent stream with inline tool traces; "classic" is the compatibility renderer
-  // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
-  // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: generic)
-  // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)
-  // No session modes: an answer attaches to its question with a thread, and that thread is the session.
-  onError: (failed) => `⚠️ ${failed.details}`, // development transparency
+export default defineChannel({
+  secrets: ["SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET"],
+  channel: (secrets) =>
+    slackChannel({
+      botToken: secrets.SLACK_BOT_TOKEN,
+      signingSecret: secrets.SLACK_SIGNING_SECRET,
+      rendering: "native", // native Agent stream with inline tool traces; "classic" is the compatibility renderer
+      // aiDisclaimer: "AI-generated; verify important information.", // optional policy footer
+      // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: generic)
+      // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)
+      // No session modes: an answer attaches to its question with a thread, and that thread is the session.
+      onError: (failed) => `⚠️ ${failed.details}`, // development transparency
+    }),
 });
 ```
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -61,12 +61,17 @@ A minimal channel module looks like this:
 
 ```ts
 import { telegramChannel } from "@fastagent-sh/fastagent/telegram";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
-export default telegramChannel({
-  secretToken: process.env.TELEGRAM_SECRET_TOKEN ?? "",
-  botToken: process.env.TELEGRAM_BOT_TOKEN ?? "",
-  // Optional. The scaffold uses this for development transparency.
-  onError: (failed) => `⚠️ ${failed.details}`,
+export default defineChannel({
+  secrets: ["TELEGRAM_SECRET_TOKEN", "TELEGRAM_BOT_TOKEN"],
+  channel: (secrets) =>
+    telegramChannel({
+      secretToken: secrets.TELEGRAM_SECRET_TOKEN,
+      botToken: secrets.TELEGRAM_BOT_TOKEN,
+      // Optional. The scaffold uses this for development transparency.
+      onError: (failed) => `⚠️ ${failed.details}`,
+    }),
 });
 ```
 
@@ -97,24 +102,29 @@ The buffer needs Telegram **group privacy mode off** (@BotFather → `/setprivac
 
 ```ts
 import { defaultTelegramRoute, telegramChannel, telegramEnvelope } from "@fastagent-sh/fastagent/telegram";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
 const botUsername = "my_bot";
 
-telegramChannel({
-  secretToken: process.env.TELEGRAM_SECRET_TOKEN ?? "",
-  botToken: process.env.TELEGRAM_BOT_TOKEN ?? "",
-  botUsername,
-  route(update) {
-    const base = defaultTelegramRoute(update, { botUsername });
-    if (!base) return null;
-    const message = update.message;
-    if (!message) return null;
-    return {
-      ...base,
-      session: `telegram:${message.chat.id}`,
-      text: `${telegramEnvelope(message)}\n\nAnswer briefly.`,
-    };
-  },
+export default defineChannel({
+  secrets: ["TELEGRAM_BOT_TOKEN", "TELEGRAM_SECRET_TOKEN"],
+  channel: (secrets) =>
+    telegramChannel({
+      secretToken: secrets.TELEGRAM_SECRET_TOKEN,
+      botToken: secrets.TELEGRAM_BOT_TOKEN,
+      botUsername,
+      route(update) {
+        const base = defaultTelegramRoute(update, { botUsername });
+        if (!base) return null;
+        const message = update.message;
+        if (!message) return null;
+        return {
+          ...base,
+          session: `telegram:${message.chat.id}`,
+          text: `${telegramEnvelope(message)}\n\nAnswer briefly.`,
+        };
+      },
+    }),
 });
 ```
 

--- a/src/channels/define-channel.ts
+++ b/src/channels/define-channel.ts
@@ -1,0 +1,50 @@
+/**
+ * `defineChannel` — a channel file's authoring surface, and the third member of the `defineX` family
+ * (with `defineTool` / `defineSchedule`). Its whole job is the secrets: a channel is the one code
+ * input that is ALL credentials (a bot token, a signing secret), and before this it read them from
+ * `process.env` at module scope, which meant a CUSTOM channel could not tell `deploy` what to carry —
+ * the deploy could only guess from a table of first-party names.
+ *
+ * The declaration attaches to the module WITHOUT adding a third module form to the Channel contract
+ * (channel.ts §7 fixes two: a function is a route channel, an object with `connect` is a long
+ * connection). The builder runs at import and returns one of those two; the declared names ride along
+ * as a property that the discovery reads and everything else ignores.
+ *
+ * Values are read at import, so a rotated credential needs a restart — the same lifetime an adapter
+ * configured with a literal already has, and the reason there is no per-request accessor here.
+ *
+ * KNOWN GAP: every declared name is REQUIRED (the gate refuses an empty value), so an
+ * OPTIONAL credential has no expression here — declare it and an agent that does not use it cannot
+ * start; leave it out and `deploy` does not carry it. First-party channels have the third answer in
+ * the scaffold table (`ChannelEnv.required`), which is why feishu/lark still read their optional
+ * `*_ENCRYPT_KEY` from the environment. Closing it means a second entry shape here
+ * (`{ name, required: false }`) carried through `DeclaredSecret`, `missingSecrets` and the deploy
+ * runbook's required flag — a contract change, not a local one.
+ */
+import type { ChannelModule, LongConnectionChannelModule } from "../channel.ts";
+import { secretValues } from "../declared-secrets.ts";
+
+/** A channel module carrying what it declared it needs. Read by discovery; ignored by the server. */
+type DeclaringChannelModule<M> = M & { secrets?: readonly string[] };
+
+export interface DefineChannelOptions<S extends readonly string[], M> {
+  /**
+   * Env vars this channel needs (`["TELEGRAM_BOT_TOKEN"]`), typed into `channel`. `deploy` carries
+   * them to the host and `dev`/`start` refuse to serve while one is unset, naming this file.
+   */
+  secrets?: S;
+  /** Build the channel from those values — usually one call to an adapter (`telegramChannel({...})`). */
+  channel: (secrets: Record<S[number], string>) => M;
+}
+
+// `S` defaults to the EMPTY tuple for the same reason as `defineTool`: a channel that declares
+// nothing must not type-check `secrets.ANYTHING`.
+export function defineChannel<
+  const S extends readonly string[] = readonly [],
+  M extends ChannelModule | LongConnectionChannelModule = ChannelModule,
+>(options: DefineChannelOptions<S, M>): DeclaringChannelModule<M> {
+  const built = options.channel(secretValues(options.secrets));
+  // Object.assign on a FUNCTION module keeps it a function (the route-channel form); on the
+  // long-connection object it adds one field. Either way the shape the server sees is unchanged.
+  return Object.assign(built, options.secrets ? { secrets: options.secrets } : {}) as DeclaringChannelModule<M>;
+}

--- a/src/channels/discover.ts
+++ b/src/channels/discover.ts
@@ -111,22 +111,22 @@ export async function loadChannels(
   const longConnections: LoadedLongConnectionChannel[] = [];
   const routeChannels: string[] = [];
   const collisions: ChannelCollision[] = [];
-  // Collected here, GATED at the end of the function: this is a serving path, so an unset declared
-  // value must stop it (a channel built from an empty credential is the failure the declaration
-  // exists to prevent — a webhook that accepts forged updates, a bot that cannot reply), while
-  // `inspectChannels` — the reporting reader — only collects.
+  // Collected from the channels that actually MOUNTED, GATED at the end of the function: this is a
+  // serving path, so an unset declared value must stop it (a channel built from an empty credential
+  // is the failure the declaration exists to prevent — a webhook that accepts forged updates, a bot
+  // that cannot reply), while `inspectChannels` — the reporting reader — only collects. A channel
+  // that failed to mount does not gate: its own failure is the report the author needs.
   const declaredSecrets = new Map<string, DeclaredSecret[]>();
-  const declaring = modules.filter(({ name, label, file, mod }) => {
-    const declaration = readSecretDeclaration(mod.default, label);
+  const declaring = modules.flatMap((entry) => {
+    const declaration = readSecretDeclaration(entry.mod.default, entry.label);
     if (declaration.error !== undefined) {
-      failures.push({ label, file, message: declaration.error });
-      return false;
+      failures.push({ label: entry.label, file: entry.file, message: declaration.error });
+      return [];
     }
-    declaredSecrets.set(name, declaration.secrets);
-    return true;
+    return [{ ...entry, secrets: declaration.secrets }];
   });
 
-  for (const { name, label, file, mod } of declaring) {
+  for (const { name, label, file, mod, secrets } of declaring) {
     try {
       if (longConnectionModule(mod.default)) {
         validateLongConnectionModule(mod.default, label);
@@ -135,6 +135,7 @@ export async function loadChannels(
           name: channel.name,
           connect: (signal) => channel.connect(ctx, signal),
         });
+        declaredSecrets.set(name, secrets);
         continue;
       }
       if (typeof mod.default !== "function") {
@@ -159,6 +160,7 @@ export async function loadChannels(
         routes[route] = handler;
       }
       routeChannels.push(name);
+      declaredSecrets.set(name, secrets);
     } catch (error) {
       failures.push({ label, file, message: (error as Error).message });
     }

--- a/src/channels/discover.ts
+++ b/src/channels/discover.ts
@@ -2,7 +2,9 @@
 import { isAbsolute, join } from "node:path";
 import type { ChannelContext, ChannelModule, LongConnection, LongConnectionChannelModule, Routes } from "../channel.ts";
 import { assertRouteKey, routeKeysConflict } from "./serve.ts";
-import { type ModuleLoadFailure, loadModuleDir, moduleInventory } from "../loader.ts";
+import { type ModuleLoadFailure, loadModuleDir } from "../loader.ts";
+import { type DeclaredSecret, readSecretDeclaration } from "../declared-secrets.ts";
+import { gateSecrets } from "../secrets-gate.ts";
 import { assertInsideAgentDir } from "../paths.ts";
 
 /** A dropped route: two channels claim the same key. */
@@ -44,38 +46,33 @@ export function declaredChannels(names: readonly string[], ingress: ChannelIngre
 /** Import channel files without mounting route factories or opening connections. */
 export async function inspectChannels(dir: string): Promise<{
   channels: DeclaredChannel[];
+  /** What each channel declared through {@link defineChannel}, BY CHANNEL NAME — the only way a
+   *  CUSTOM channel's credentials can reach a deploy, since nothing else here can name them. */
+  secrets: Map<string, DeclaredSecret[]>;
   failures: ModuleLoadFailure[];
 }> {
   await assertInsideAgentDir(dir, "channels");
   const { modules, failures } = await loadModuleDir(join(dir, "channels"));
   const channels: DeclaredChannel[] = [];
+  const secrets = new Map<string, DeclaredSecret[]>();
   for (const { name, label, file, mod } of modules) {
     try {
+      const declaration = readSecretDeclaration(mod.default, label);
+      if (declaration.error !== undefined) throw new Error(declaration.error);
       if (typeof mod.default === "function") {
         channels.push({ name, ingress: "webhook" });
-        continue;
-      }
-      if (longConnectionModule(mod.default)) {
+      } else if (longConnectionModule(mod.default)) {
         validateLongConnectionModule(mod.default, label);
         channels.push({ name, ingress: "long-connection" });
-        continue;
+      } else {
+        throw new Error(`${label} must default-export (ctx) => Routes or { name, connect(ctx, signal) }`);
       }
-      throw new Error(`${label} must default-export (ctx) => Routes or { name, connect(ctx, signal) }`);
+      secrets.set(name, declaration.secrets);
     } catch (error) {
       failures.push({ label, file, message: (error as Error).message });
     }
   }
-  return { channels, failures };
-}
-
-/**
- * Channel file basenames under `<dir>/channels/` — the authoring view (`fastagent info`), which lists WITHOUT
- * importing.
- */
-export async function discoverChannelFiles(dir: string): Promise<string[]> {
-  await assertInsideAgentDir(dir, "channels");
-  const entries = await moduleInventory(join(dir, "channels"));
-  return entries.map((entry) => entry.name);
+  return { channels, secrets, failures };
 }
 
 function validateRoutes(value: unknown, label: string): [string, (req: Request) => Response | Promise<Response>][] {
@@ -114,8 +111,22 @@ export async function loadChannels(
   const longConnections: LoadedLongConnectionChannel[] = [];
   const routeChannels: string[] = [];
   const collisions: ChannelCollision[] = [];
+  // Collected here, GATED at the end of the function: this is a serving path, so an unset declared
+  // value must stop it (a channel built from an empty credential is the failure the declaration
+  // exists to prevent — a webhook that accepts forged updates, a bot that cannot reply), while
+  // `inspectChannels` — the reporting reader — only collects.
+  const declaredSecrets = new Map<string, DeclaredSecret[]>();
+  const declaring = modules.filter(({ name, label, file, mod }) => {
+    const declaration = readSecretDeclaration(mod.default, label);
+    if (declaration.error !== undefined) {
+      failures.push({ label, file, message: declaration.error });
+      return false;
+    }
+    declaredSecrets.set(name, declaration.secrets);
+    return true;
+  });
 
-  for (const { name, label, file, mod } of modules) {
+  for (const { name, label, file, mod } of declaring) {
     try {
       if (longConnectionModule(mod.default)) {
         validateLongConnectionModule(mod.default, label);
@@ -152,5 +163,9 @@ export async function loadChannels(
       failures.push({ label, file, message: (error as Error).message });
     }
   }
+  // Gated LAST, after the loop has said what it found (the gate reports those failures before it
+  // refuses — src/secrets-gate.ts, decision 2). Binding a module ahead of the gate costs nothing: a
+  // route factory builds handlers; nothing listens or dials until the caller mounts what this returns.
+  gateSecrets({ declared: declaredSecrets, failures });
   return { routes, longConnections, routeChannels, collisions, failures };
 }

--- a/src/channels/feishu/scaffold/channel.ts
+++ b/src/channels/feishu/scaffold/channel.ts
@@ -1,4 +1,5 @@
 import { feishuChannel } from "@fastagent-sh/fastagent/feishu";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
 // feishuChannel is fastagent's canonical Feishu adapter (verify + run + reply), configured with YOUR
 // policy. fastagent discovers this file, mounts POST /feishu, and pipes the agent + state home to it.
@@ -20,23 +21,30 @@ import { feishuChannel } from "@fastagent-sh/fastagent/feishu";
 //   5. create a version and publish the app (a Feishu admin approves it), then add the bot to a chat
 // `fastagent add feishu` already did steps 1-3 for you (scan-to-create); this walkthrough is for a
 // hand-made app or for auditing what the scan configured.
-export default feishuChannel({
-  appId: process.env.FEISHU_APP_ID ?? "", // missing → fails at startup (no replies could be sent)
-  appSecret: process.env.FEISHU_APP_SECRET ?? "",
-  verificationToken: process.env.FEISHU_VERIFICATION_TOKEN ?? "", // authenticates inbound events
-  encryptKey: process.env.FEISHU_ENCRYPT_KEY || undefined, // optional; when set, plaintext events are refused
-  // No session modes: a chat is one session and a thread is another, and where the answer goes follows
-  // from that (docs/design/participant-model.md).
-  // Dev/personal bot: surface raw errors to the chat so you (and your AI agent) can act on them. The
-  // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
-  // full details always go to the server log regardless.
-  onError: (failed) => `⚠️ ${failed.details}`,
-  // The channel owns transport + format (markdown card) + attachments (image→vision, file→disk) +
-  // the live streaming preview. `route` (POLICY) is OPTIONAL — omitted, it uses defaultFeishuRoute:
-  // p2p chats always answer; groups answer on @this-bot, plus bare messages in a thread where the
-  // Agent takes part and exactly ONE human does. Other human group/thread discussion buffers until
-  // that place's next answered turn; @other-only messages buffer rather than triggering the Agent.
-  // Override to customise explicit routing, reusing the export:
-  //   route: (e) => defaultFeishuRoute(e, { botOpenId: "ou_xxx" }) && { session: `user:${e.sender?.sender_id?.open_id}` },
-  //   route: (e) => defaultFeishuRoute(e, { botOpenId: "ou_xxx" }) && { text: `${feishuEnvelope(e)}\n[extra]` },
+export default defineChannel({
+  // The env vars this channel needs. fastagent carries them to a deployed box and refuses to serve
+  // while one is unset — a bare process.env read gets neither guarantee. FEISHU_ENCRYPT_KEY is
+  // optional, so it is NOT declared here: an undeclared read stays undeclared on purpose.
+  secrets: ["FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_VERIFICATION_TOKEN"],
+  channel: (secrets) =>
+    feishuChannel({
+      appId: secrets.FEISHU_APP_ID,
+      appSecret: secrets.FEISHU_APP_SECRET,
+      verificationToken: secrets.FEISHU_VERIFICATION_TOKEN, // authenticates inbound events
+      encryptKey: process.env.FEISHU_ENCRYPT_KEY || undefined, // optional; when set, plaintext events are refused
+      // No session modes: a chat is one session and a thread is another, and where the answer goes follows
+      // from that (docs/design/participant-model.md).
+      // Dev/personal bot: surface raw errors to the chat so you (and your AI agent) can act on them. The
+      // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
+      // full details always go to the server log regardless.
+      onError: (failed) => `⚠️ ${failed.details}`,
+      // The channel owns transport + format (markdown card) + attachments (image→vision, file→disk) +
+      // the live streaming preview. `route` (POLICY) is OPTIONAL — omitted, it uses defaultFeishuRoute:
+      // p2p chats always answer; groups answer on @this-bot, plus bare messages in a thread where the
+      // Agent takes part and exactly ONE human does. Other human group/thread discussion buffers until
+      // that place's next answered turn; @other-only messages buffer rather than triggering the Agent.
+      // Override to customise explicit routing, reusing the export:
+      //   route: (e) => defaultFeishuRoute(e, { botOpenId: "ou_xxx" }) && { session: `user:${e.sender?.sender_id?.open_id}` },
+      //   route: (e) => defaultFeishuRoute(e, { botOpenId: "ou_xxx" }) && { text: `${feishuEnvelope(e)}\n[extra]` },
+    }),
 });

--- a/src/channels/feishu/scaffold/channel.websocket.ts
+++ b/src/channels/feishu/scaffold/channel.websocket.ts
@@ -1,0 +1,31 @@
+import { feishuWebSocketChannel } from "@fastagent-sh/fastagent/feishu";
+import { defineChannel } from "@fastagent-sh/fastagent";
+
+// Feishu WebSocket long connection: the process connects OUT to the platform, so no public URL,
+// Verification Token, Encrypt Key, or --tunnel is needed. In Events & Callbacks choose long
+// connection, subscribe im.message.receive_v1, then publish the app version. Keep one process
+// running in production: scale-to-zero/App Sleeping would disconnect ingress.
+export default defineChannel({
+  // The env vars this channel needs. fastagent carries them to a deployed box and refuses to serve
+  // while one is unset — a bare process.env read gets neither guarantee.
+  secrets: ["FEISHU_APP_ID", "FEISHU_APP_SECRET"],
+  channel: (secrets) =>
+    feishuWebSocketChannel({
+      appId: secrets.FEISHU_APP_ID,
+      appSecret: secrets.FEISHU_APP_SECRET,
+      // No session modes: a chat is one session and a thread is another, and where the answer goes follows
+      // from that (docs/design/participant-model.md).
+      // Dev/personal bot: surface raw errors to the chat so you (and your AI agent) can act on them. The
+      // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
+      // full details always go to the server log regardless.
+      onError: (failed) => `⚠️ ${failed.details}`,
+      // The channel owns transport + format (markdown card) + attachments (image→vision, file→disk) +
+      // the live streaming preview. `route` (POLICY) is OPTIONAL — omitted, it uses defaultFeishuRoute:
+      // p2p chats always answer; groups answer on @this-bot, plus bare messages in a thread where the
+      // Agent takes part and exactly ONE human does. Other human group/thread discussion buffers until
+      // that place's next answered turn; @other-only messages buffer rather than triggering the Agent.
+      // Override to customise explicit routing, reusing the export:
+      //   route: (e) => defaultFeishuRoute(e, { botOpenId: "ou_xxx" }) && { session: `user:${e.sender?.sender_id?.open_id}` },
+      //   route: (e) => defaultFeishuRoute(e, { botOpenId: "ou_xxx" }) && { text: `${feishuEnvelope(e)}\n[extra]` },
+    }),
+});

--- a/src/channels/github/scaffold/channel.ts
+++ b/src/channels/github/scaffold/channel.ts
@@ -1,25 +1,32 @@
 import { githubChannel } from "@fastagent-sh/fastagent/github";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
 // A channel = a third-party ADAPTER (githubChannel: verify + parse + ACK) configured with YOUR on() policy.
 // fastagent discovers this file under channels/, mounts POST /webhook, and pipes the agent to the
 // adapter — this file holds only policy. Set GITHUB_WEBHOOK_SECRET in .env (a missing secret fails at
 // startup — an empty key would accept forged deliveries) and point a GitHub webhook (JSON) at POST /webhook.
-export default githubChannel({
-  secret: process.env.GITHUB_WEBHOOK_SECRET ?? "",
-  // Map a verified event to the intents the agent acts on (empty array = ignore). Each review is
-  // INDEPENDENT and idempotent (it reconciles against the PR's existing comments), so use a
-  // distinct per-delivery session (event.deliveryId): overlapping deliveries then run on their
-  // own session without a shared-lease drop.
-  on: (event) => {
-    if (event.event === "pull_request" && event.action === "opened" && "pull_request" in event.payload) {
-      const { repository, pull_request } = event.payload;
-      return [
-        {
-          session: event.deliveryId,
-          text: `Review pull request #${pull_request.number} in ${repository.full_name}.`,
-        },
-      ];
-    }
-    return [];
-  },
+export default defineChannel({
+  // The env vars this channel needs. fastagent carries them to a deployed box and refuses to serve
+  // while one is unset — a bare process.env read gets neither guarantee.
+  secrets: ["GITHUB_WEBHOOK_SECRET"],
+  channel: (secrets) =>
+    githubChannel({
+      secret: secrets.GITHUB_WEBHOOK_SECRET,
+      // Map a verified event to the intents the agent acts on (empty array = ignore). Each review is
+      // INDEPENDENT and idempotent (it reconciles against the PR's existing comments), so use a
+      // distinct per-delivery session (event.deliveryId): overlapping deliveries then run on their
+      // own session without a shared-lease drop.
+      on: (event) => {
+        if (event.event === "pull_request" && event.action === "opened" && "pull_request" in event.payload) {
+          const { repository, pull_request } = event.payload;
+          return [
+            {
+              session: event.deliveryId,
+              text: `Review pull request #${pull_request.number} in ${repository.full_name}.`,
+            },
+          ];
+        }
+        return [];
+      },
+    }),
 });

--- a/src/channels/lark/scaffold/channel.ts
+++ b/src/channels/lark/scaffold/channel.ts
@@ -1,4 +1,5 @@
 import { larkChannel } from "@fastagent-sh/fastagent/lark";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
 // larkChannel is the branded compatibility adapter over fastagent's canonical Feishu engine, configured
 // with YOUR policy. fastagent discovers this file, mounts POST /lark, and pipes the agent + state home
@@ -18,23 +19,30 @@ import { larkChannel } from "@fastagent-sh/fastagent/lark";
 //      the URL automatically. If this app returns a config-API 404, do both BY HAND in the console
 //      with the server running (the platform verifies https://your.host/lark with a challenge).
 //   5. create a version and publish the app (a tenant admin approves it), then add the bot to a chat
-export default larkChannel({
-  appId: process.env.LARK_APP_ID ?? "", // missing → fails at startup (no replies could be sent)
-  appSecret: process.env.LARK_APP_SECRET ?? "",
-  verificationToken: process.env.LARK_VERIFICATION_TOKEN ?? "", // authenticates inbound events
-  encryptKey: process.env.LARK_ENCRYPT_KEY || undefined, // optional; when set, plaintext events are refused
-  // No session modes: a chat is one session and a thread is another, and where the answer goes follows
-  // from that (docs/design/participant-model.md).
-  // Dev/personal bot: surface raw errors to the chat so you (and your AI agent) can act on them. The
-  // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
-  // full details always go to the server log regardless.
-  onError: (failed) => `⚠️ ${failed.details}`,
-  // The channel owns transport + format (markdown card) + attachments (image→vision, file→disk) +
-  // the live streaming preview. `route` (POLICY) is OPTIONAL — omitted, it uses defaultLarkRoute:
-  // p2p chats always answer; groups answer on @this-bot, plus bare messages in a thread where the
-  // Agent takes part and exactly ONE human does. Other human group/thread discussion buffers until
-  // that place's next answered turn; @other-only messages buffer rather than triggering the Agent.
-  // Override to customise explicit routing, reusing the export:
-  //   route: (e) => defaultLarkRoute(e, { botOpenId: "ou_xxx" }) && { session: `user:${e.sender?.sender_id?.open_id}` },
-  //   route: (e) => defaultLarkRoute(e, { botOpenId: "ou_xxx" }) && { text: `${larkEnvelope(e)}\n[extra]` },
+export default defineChannel({
+  // The env vars this channel needs. fastagent carries them to a deployed box and refuses to serve
+  // while one is unset — a bare process.env read gets neither guarantee. LARK_ENCRYPT_KEY is
+  // optional, so it is NOT declared here: an undeclared read stays undeclared on purpose.
+  secrets: ["LARK_APP_ID", "LARK_APP_SECRET", "LARK_VERIFICATION_TOKEN"],
+  channel: (secrets) =>
+    larkChannel({
+      appId: secrets.LARK_APP_ID,
+      appSecret: secrets.LARK_APP_SECRET,
+      verificationToken: secrets.LARK_VERIFICATION_TOKEN, // authenticates inbound events
+      encryptKey: process.env.LARK_ENCRYPT_KEY || undefined, // optional; when set, plaintext events are refused
+      // No session modes: a chat is one session and a thread is another, and where the answer goes follows
+      // from that (docs/design/participant-model.md).
+      // Dev/personal bot: surface raw errors to the chat so you (and your AI agent) can act on them. The
+      // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
+      // full details always go to the server log regardless.
+      onError: (failed) => `⚠️ ${failed.details}`,
+      // The channel owns transport + format (markdown card) + attachments (image→vision, file→disk) +
+      // the live streaming preview. `route` (POLICY) is OPTIONAL — omitted, it uses defaultLarkRoute:
+      // p2p chats always answer; groups answer on @this-bot, plus bare messages in a thread where the
+      // Agent takes part and exactly ONE human does. Other human group/thread discussion buffers until
+      // that place's next answered turn; @other-only messages buffer rather than triggering the Agent.
+      // Override to customise explicit routing, reusing the export:
+      //   route: (e) => defaultLarkRoute(e, { botOpenId: "ou_xxx" }) && { session: `user:${e.sender?.sender_id?.open_id}` },
+      //   route: (e) => defaultLarkRoute(e, { botOpenId: "ou_xxx" }) && { text: `${larkEnvelope(e)}\n[extra]` },
+    }),
 });

--- a/src/channels/lark/scaffold/channel.websocket.ts
+++ b/src/channels/lark/scaffold/channel.websocket.ts
@@ -1,0 +1,31 @@
+import { larkWebSocketChannel } from "@fastagent-sh/fastagent/lark";
+import { defineChannel } from "@fastagent-sh/fastagent";
+
+// Lark WebSocket long connection: the process connects OUT to the platform, so no public URL,
+// Verification Token, Encrypt Key, or --tunnel is needed. In Events & Callbacks choose long
+// connection, subscribe im.message.receive_v1, then publish the app version. Keep one process
+// running in production: scale-to-zero/App Sleeping would disconnect ingress.
+export default defineChannel({
+  // The env vars this channel needs. fastagent carries them to a deployed box and refuses to serve
+  // while one is unset — a bare process.env read gets neither guarantee.
+  secrets: ["LARK_APP_ID", "LARK_APP_SECRET"],
+  channel: (secrets) =>
+    larkWebSocketChannel({
+      appId: secrets.LARK_APP_ID,
+      appSecret: secrets.LARK_APP_SECRET,
+      // No session modes: a chat is one session and a thread is another, and where the answer goes follows
+      // from that (docs/design/participant-model.md).
+      // Dev/personal bot: surface raw errors to the chat so you (and your AI agent) can act on them. The
+      // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
+      // full details always go to the server log regardless.
+      onError: (failed) => `⚠️ ${failed.details}`,
+      // The channel owns transport + format (markdown card) + attachments (image→vision, file→disk) +
+      // the live streaming preview. `route` (POLICY) is OPTIONAL — omitted, it uses defaultLarkRoute:
+      // p2p chats always answer; groups answer on @this-bot, plus bare messages in a thread where the
+      // Agent takes part and exactly ONE human does. Other human group/thread discussion buffers until
+      // that place's next answered turn; @other-only messages buffer rather than triggering the Agent.
+      // Override to customise explicit routing, reusing the export:
+      //   route: (e) => defaultLarkRoute(e, { botOpenId: "ou_xxx" }) && { session: `user:${e.sender?.sender_id?.open_id}` },
+      //   route: (e) => defaultLarkRoute(e, { botOpenId: "ou_xxx" }) && { text: `${larkEnvelope(e)}\n[extra]` },
+    }),
+});

--- a/src/channels/slack/scaffold/channel.ts
+++ b/src/channels/slack/scaffold/channel.ts
@@ -1,4 +1,5 @@
 import { slackChannel } from "@fastagent-sh/fastagent/slack";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
 // Slack HTTP Events API channel. Setup:
 //   1. Create a Slack app at https://api.slack.com/apps and add a bot user.
@@ -10,17 +11,23 @@ import { slackChannel } from "@fastagent-sh/fastagent/slack";
 //      Set Request URL to https://<host>/slack.
 //   4. Install the app (reinstall after changing scopes) and leave token rotation OFF: it cannot be
 //      turned off again, and this channel takes one long-lived Bot User OAuth Token.
-export default slackChannel({
-  botToken: process.env.SLACK_BOT_TOKEN ?? "", // OAuth & Permissions → Bot User OAuth Token (xoxb-…)
-  signingSecret: process.env.SLACK_SIGNING_SECRET ?? "", // Basic Information → App Credentials
-  // Slack Agent stream; its inline tool traces show each call's first argument and stay in the
-  // delivered message. "classic" settles into the answer alone (and gives up native streaming).
-  rendering: "native",
-  // Optional per-reply footer, if your policy requires one: aiDisclaimer: "AI-generated; verify important information.",
-  // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: a generic greeting)
-  // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)
-  // No session modes: an answer attaches to its question with a thread (Slack has no quote primitive),
-  // and that thread is the session — see docs/design/participant-model.md.
-  // Dev/personal bot: surface raw errors. Remove this for a customer-facing bot; details remain in logs.
-  onError: (failed) => `⚠️ ${failed.details}`,
+export default defineChannel({
+  // The env vars this channel needs. fastagent carries them to a deployed box and refuses to serve
+  // while one is unset — a bare process.env read gets neither guarantee.
+  secrets: ["SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET"],
+  channel: (secrets) =>
+    slackChannel({
+      botToken: secrets.SLACK_BOT_TOKEN, // OAuth & Permissions → Bot User OAuth Token (xoxb-…)
+      signingSecret: secrets.SLACK_SIGNING_SECRET, // Basic Information → App Credentials
+      // Slack Agent stream; its inline tool traces show each call's first argument and stay in the
+      // delivered message. "classic" settles into the answer alone (and gives up native streaming).
+      rendering: "native",
+      // Optional per-reply footer, if your policy requires one: aiDisclaimer: "AI-generated; verify important information.",
+      // welcome: "Custom first-run DM greeting", // sent once on first DM open; false disables (default: a generic greeting)
+      // reactionAck: false, // disable the 👀→✅ ack on the user's message (default on; needs reactions:write)
+      // No session modes: an answer attaches to its question with a thread (Slack has no quote primitive),
+      // and that thread is the session — see docs/design/participant-model.md.
+      // Dev/personal bot: surface raw errors. Remove this for a customer-facing bot; details remain in logs.
+      onError: (failed) => `⚠️ ${failed.details}`,
+    }),
 });

--- a/src/channels/telegram/scaffold/channel.ts
+++ b/src/channels/telegram/scaffold/channel.ts
@@ -1,4 +1,5 @@
 import { telegramChannel } from "@fastagent-sh/fastagent/telegram";
+import { defineChannel } from "@fastagent-sh/fastagent";
 
 // A channel = a third-party ADAPTER (telegramChannel: verify + run + reply) configured with YOUR policy.
 // fastagent discovers this file under channels/, mounts POST /telegram, and pipes the agent + state
@@ -8,22 +9,28 @@ import { telegramChannel } from "@fastagent-sh/fastagent/telegram";
 //   3. register the webhook once, pointing Telegram at POST /telegram with that secret:
 //        curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
 //          -d url=https://your.host/telegram -d secret_token=$TELEGRAM_SECRET_TOKEN
-export default telegramChannel({
-  secretToken: process.env.TELEGRAM_SECRET_TOKEN ?? "", // missing → fails at startup (would accept forged updates)
-  botToken: process.env.TELEGRAM_BOT_TOKEN ?? "", // used to send the agent's reply back to the chat
-  // Dev/personal bot: surface raw errors to the chat so you (and your AI agent) can act on them. The
-  // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
-  // full details always go to the server log regardless.
-  onError: (failed) => `⚠️ ${failed.details}`,
-  // Your bot's @username. Optional — resolved via getMe when omitted — but set it if you pass a `route`
-  // below: the channel needs its own copy to recognise a `/stop` addressed to it.
-  // botUsername: "your_bot",
-  // The channel owns transport + format (HTML) + attachments (photo→vision, file→disk) + streaming.
-  // `route` (POLICY) is OPTIONAL — omitted, it uses defaultTelegramRoute: private chats always answer,
-  // groups only on a reply to THIS bot, an @mention of it, or a `/stop` addressed to it. Override to
-  // customise, reusing the export — but pass your bot's identity BOTH here and as `botUsername` above
-  // (the omitted default gets it from the channel; a bare `defaultTelegramRoute(u)` answers only
-  // private chats):
-  //   route: (u) => defaultTelegramRoute(u, { botUsername: "my_bot" }) && { session: `user:${u.message?.from?.id}` },
-  //   route: (u) => defaultTelegramRoute(u, { botUsername: "my_bot" }) && { text: `${telegramEnvelope(u.message!)}\n[extra]` },
+export default defineChannel({
+  // The env vars this channel needs. fastagent carries them to a deployed box and refuses to serve
+  // while one is unset — a bare process.env read gets neither guarantee.
+  secrets: ["TELEGRAM_BOT_TOKEN", "TELEGRAM_SECRET_TOKEN"],
+  channel: (secrets) =>
+    telegramChannel({
+      secretToken: secrets.TELEGRAM_SECRET_TOKEN, // verifies inbound updates really come from Telegram
+      botToken: secrets.TELEGRAM_BOT_TOKEN, // used to send the agent's reply back to the chat
+      // Dev/personal bot: surface raw errors to the chat so you (and your AI agent) can act on them. The
+      // chat is customer-facing by default — for a public bot, drop this or return a neutral string;
+      // full details always go to the server log regardless.
+      onError: (failed) => `⚠️ ${failed.details}`,
+      // Your bot's @username. Optional — resolved via getMe when omitted — but set it if you pass a `route`
+      // below: the channel needs its own copy to recognise a `/stop` addressed to it.
+      // botUsername: "your_bot",
+      // The channel owns transport + format (HTML) + attachments (photo→vision, file→disk) + streaming.
+      // `route` (POLICY) is OPTIONAL — omitted, it uses defaultTelegramRoute: private chats always answer,
+      // groups only on a reply to THIS bot, an @mention of it, or a `/stop` addressed to it. Override to
+      // customise, reusing the export — but pass your bot's identity BOTH here and as `botUsername` above
+      // (the omitted default gets it from the channel; a bare `defaultTelegramRoute(u)` answers only
+      // private chats):
+      //   route: (u) => defaultTelegramRoute(u, { botUsername: "my_bot" }) && { session: `user:${u.message?.from?.id}` },
+      //   route: (u) => defaultTelegramRoute(u, { botUsername: "my_bot" }) && { text: `${telegramEnvelope(u.message!)}\n[extra]` },
+    }),
 });

--- a/src/channels/telegram/scaffold/telegram-send.ts
+++ b/src/channels/telegram/scaffold/telegram-send.ts
@@ -73,9 +73,11 @@ export default defineTool({
     asPhoto: z.boolean().optional().describe("send the file as a photo (inline) instead of a document"),
     messageThreadId: z.number().optional().describe("thread to reply into (from the context line), if any"),
   }),
-  async execute({ chatId, text, path, caption, asPhoto, messageThreadId }) {
-    const token = process.env.TELEGRAM_BOT_TOKEN;
-    if (!token) throw new Error("TELEGRAM_BOT_TOKEN is not set");
+  // The bot token, declared: fastagent carries it to a deployed box and refuses to start while it is
+  // unset, so `execute` gets a value rather than checking for one.
+  secrets: ["TELEGRAM_BOT_TOKEN"],
+  async execute({ chatId, text, path, caption, asPhoto, messageThreadId }, ctx) {
+    const token = ctx.secrets.TELEGRAM_BOT_TOKEN;
     if ((text === undefined) === (path === undefined)) {
       throw new Error("pass exactly one of `text` (a message) or `path` (a file)");
     }

--- a/src/cli/commands/deploy/agentcore.ts
+++ b/src/cli/commands/deploy/agentcore.ts
@@ -22,6 +22,7 @@ import { type ResolvedPlacement, exists } from "../../../paths.ts";
 import { loadSchedules } from "../../../schedule/discover.ts";
 import { failStartup } from "../../fail.ts";
 import { type HostDeploy, carryCredentials, gateOnModelCredential, registrarsFor } from "./shared.ts";
+import type { DeclaredSecret } from "../../../declared-secrets.ts";
 
 /** A copy/paste-safe POSIX shell argument for the command hints deploy prints. */
 function shellArg(value: string): string {
@@ -134,7 +135,7 @@ async function runDeployAgentcore(
     modelKeyInDefinition: boolean;
     authPath: string;
     channels: readonly DeclaredChannel[];
-    extraSecrets: string[];
+    extraSecrets: readonly DeclaredSecret[];
     topology: AgentcoreTopology;
   },
 ): Promise<void> {

--- a/src/cli/commands/deploy/docker.ts
+++ b/src/cli/commands/deploy/docker.ts
@@ -15,6 +15,7 @@ import { announceWebhooks } from "../../../tunnel.ts";
 import { failStartup } from "../../fail.ts";
 import { type HostDeploy, carryCredentials } from "./shared.ts";
 import type { DeclaredChannel } from "../../../channels/discover.ts";
+import type { DeclaredSecret } from "../../../declared-secrets.ts";
 
 export const dockerHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith("fastagent.compose.yml") && isGeneratedCompose(content),
@@ -89,7 +90,7 @@ async function runDeployDocker(
     modelKeyInDefinition: boolean;
     authPath: string;
     channels: readonly DeclaredChannel[];
-    extraSecrets: string[];
+    extraSecrets: readonly DeclaredSecret[];
   },
 ): Promise<void> {
   const { agentDir, workspace, composeFile, port, requireTunnel, channels } = params;

--- a/src/cli/commands/deploy/fly.ts
+++ b/src/cli/commands/deploy/fly.ts
@@ -15,6 +15,7 @@ import { spawnRunner } from "../../../deploy/runner.ts";
 import { type ResolvedPlacement, readTextIfExists } from "../../../paths.ts";
 import { failStartup } from "../../fail.ts";
 import { type HostDeploy, carryCredentials, gateOnModelCredential, registrarsFor } from "./shared.ts";
+import type { DeclaredSecret } from "../../../declared-secrets.ts";
 
 export const flyHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith("fly.toml") && isGeneratedFlyToml(content),
@@ -106,7 +107,7 @@ async function runDeployFly(
     authPath: string;
     channels: readonly DeclaredChannel[];
     flyTomlPath: string;
-    extraSecrets: string[];
+    extraSecrets: readonly DeclaredSecret[];
   },
 ): Promise<void> {
   const { agentDir, workspace, agentPrefix, appName, channels, flyTomlPath } = params;

--- a/src/cli/commands/deploy/railway.ts
+++ b/src/cli/commands/deploy/railway.ts
@@ -15,6 +15,7 @@ import { spawnRunner } from "../../../deploy/runner.ts";
 import type { ResolvedPlacement } from "../../../paths.ts";
 import { failStartup } from "../../fail.ts";
 import { type HostDeploy, carryCredentials, gateOnModelCredential, registrarsFor } from "./shared.ts";
+import type { DeclaredSecret } from "../../../declared-secrets.ts";
 
 export const railwayHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith("railway.json") && isGeneratedRailwayJson(content),
@@ -67,7 +68,7 @@ async function runDeployRailway(
     modelKeyInDefinition: boolean;
     authPath: string;
     channels: readonly DeclaredChannel[];
-    extraSecrets: string[];
+    extraSecrets: readonly DeclaredSecret[];
     intoLinked: boolean;
     /** RAILWAY_DOCKERFILE_PATH — the scriptable route to the agent's non-root Dockerfile. */
     dockerfilePath: string;

--- a/src/cli/commands/deploy/shared.ts
+++ b/src/cli/commands/deploy/shared.ts
@@ -17,6 +17,7 @@ import { assembleSecrets } from "../../../deploy/secrets.ts";
 import type { FastagentConfig } from "../../../engines/pi/config.ts";
 import { exists, resolveStateRoot } from "../../../paths.ts";
 import { failStartup } from "../../fail.ts";
+import type { DeclaredSecret } from "../../../declared-secrets.ts";
 
 export interface DeployOptions {
   run?: boolean;
@@ -82,7 +83,7 @@ export async function carryCredentials(params: {
   modelKeyInDefinition: boolean;
   authPath: string;
   channels: readonly DeclaredChannel[];
-  extraSecrets: string[];
+  extraSecrets: readonly DeclaredSecret[];
 }): Promise<{ secrets: Record<string, string>; missingSecrets: string[]; needsModelCredential: boolean }> {
   const { modelAuth, modelKeyInDefinition, authPath, channels, extraSecrets } = params;
   return assembleSecrets({

--- a/src/cli/commands/fire.ts
+++ b/src/cli/commands/fire.ts
@@ -9,7 +9,7 @@ import { createPiAgentFromDir } from "../../engines/pi/open.ts";
 import { runInvokeStream } from "../invoke-stream.ts";
 import { loadSchedules } from "../../schedule/discover.ts";
 import { scheduleSession } from "../../schedule/scheduler.ts";
-import { failStartup } from "../fail.ts";
+import { failStartup, gateSecretsOrExit } from "../fail.ts";
 import { enterAgentCommand, reportAuth } from "../shared.ts";
 
 export interface FireOptions {
@@ -23,7 +23,9 @@ export async function runFire(name: string, dirArg: string, opts: FireOptions): 
   const placement = await enterAgentCommand(dirArg, opts);
   // Schedules are agent surface — discover them where dev/start/`schedule list` do (the agent dir), so `fire` sees
   // the same set the scheduler serves.
-  const { schedules, failures } = await loadSchedules(placement.agentDir).catch(failStartup);
+  const { schedules, secrets, failures } = await loadSchedules(placement.agentDir).catch(failStartup);
+  // Reported BEFORE the name is looked up: a schedule file that failed to import is missing from
+  // `schedules`, so "unknown schedule" is the case where the author most needs to hear about it.
   reportModuleLoadFailures(failures);
   const schedule = schedules.find((s) => s.name === name);
   if (!schedule) {
@@ -36,6 +38,14 @@ export async function runFire(name: string, dirArg: string, opts: FireOptions): 
       ),
     );
   }
+  // `fire` RUNS this schedule, so it takes the serving path's guarantee: a prompt built from an
+  // unset declared value is the degraded turn this feature exists to prevent (`Post the digest to `
+  // — sent and executed), and the loader resolved it into a string before anything could notice.
+  // THIS schedule only (`owner`): firing one job by hand must not fail because a sibling needs a
+  // credential this machine has no reason to hold. The failures go to the gate too, even though they
+  // were printed above — its guarantee must not depend on this call site remembering (a repeated
+  // line on the refusal path is the cheaper failure).
+  gateSecretsOrExit({ declared: secrets, failures, owner: name });
   const { agent, modelSpec, authPath } = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
     authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)

--- a/src/cli/commands/fire.ts
+++ b/src/cli/commands/fire.ts
@@ -41,10 +41,12 @@ export async function runFire(name: string, dirArg: string, opts: FireOptions): 
   // `fire` RUNS this schedule, so it takes the serving path's guarantee: a prompt built from an
   // unset declared value is the degraded turn this feature exists to prevent (`Post the digest to `
   // — sent and executed), and the loader resolved it into a string before anything could notice.
-  // THIS schedule only (`owner`): firing one job by hand must not fail because a sibling needs a
-  // credential this machine has no reason to hold. The failures go to the gate too, even though they
-  // were printed above — its guarantee must not depend on this call site remembering (a repeated
-  // line on the refusal path is the cheaper failure).
+  // THIS schedule only (`owner`): firing one job must not fail because a SIBLING SCHEDULE needs a
+  // credential this machine has no reason to hold. The agent assembled below is a different question
+  // and gates every mounted tool — a fired turn can call any of them — so `fire` is not free of a
+  // tool's declaration, only of another schedule's. The failures go to the gate too, even though they
+  // were printed above: its guarantee must not depend on this call site remembering (a repeated line
+  // on the refusal path is the cheaper failure).
   gateSecretsOrExit({ declared: secrets, failures, owner: name });
   const { agent, modelSpec, authPath } = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -1,7 +1,7 @@
 /** `fastagent info [dir] [--json]`: print what the directory ASSEMBLES into, WITHOUT booting a server. */
 import { resolve } from "node:path";
 import { loadDotEnv } from "../../env.ts";
-import { discoverChannelFiles } from "../../channels/discover.ts";
+import { inspectChannels } from "../../channels/discover.ts";
 import {
   defaultSessionsDir,
   loadConfig,
@@ -15,6 +15,7 @@ import { resolveStateRoot, workspaceHint } from "../../paths.ts";
 import { CODING_TOOL_NAMES, resolveAgentTools } from "../../engines/pi/create.ts";
 import { loadAgentDefinition } from "../../engines/pi/definition.ts";
 import { reportFindingsIfChanged, reportToolCollisions } from "../../engines/pi/report.ts";
+import { type DeclaredSecret, allSecrets, describeSecrets, missingSecrets } from "../../declared-secrets.ts";
 import { log } from "../../log.ts";
 import { reportModuleLoadFailures } from "../../loader.ts";
 import { nextRun } from "../../schedule/cron.ts";
@@ -45,6 +46,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
       deferred: r.deferredToolNames,
       collisions: r.toolCollisions,
       failures: r.toolFailures,
+      secrets: allSecrets(r.toolSecrets),
       error: undefined as string | undefined,
     }))
     .catch((e: unknown) => ({
@@ -52,11 +54,33 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
       deferred: [] as string[],
       collisions: [],
       failures: [],
+      secrets: [] as DeclaredSecret[],
       error: (e as Error).message,
     }));
-  const channels = await discoverChannelFiles(agentDir).catch(failStartup);
+  // IMPORTED, like tools and schedules: a channel's declared secrets are part of what this command
+  // exists to report (and a channel that cannot load is what `dev` would fail on next).
+  const inspected = await inspectChannels(agentDir).catch(failStartup);
+  const channels = inspected.channels.map((c) => c.name);
   // Loaded (imported + validated), not just discovered.
   const sched = await loadSchedules(agentDir).catch(failStartup);
+  // What the definition DECLARED it needs, and which of those have no value here. `info` reports
+  // (never asserts): it is the read-only view of the same list `dev`/`start` refuse to boot without
+  // and `deploy` carries to the host.
+  // Split by CONSEQUENCE: a code-input declaration gates the boot (the same list the serving gate
+  // reads), while a config-only name is carried by deploy and never read by `dev` (it exists for
+  // values consumed outside the code inputs, e.g. a models.json header key). One ⚠ for both would
+  // misreport one of them — so the boot list is built ONCE and the full list extends it.
+  const codeInputSecrets: DeclaredSecret[] = [
+    ...tools.secrets,
+    ...allSecrets(sched.secrets),
+    ...allSecrets(inspected.secrets),
+  ];
+  const declaredSecrets: DeclaredSecret[] = [
+    ...codeInputSecrets,
+    ...(config.deploy?.secrets ?? []).map((name) => ({ name, source: "fastagent.config deploy.secrets" })),
+  ];
+  const unsetSecrets = missingSecrets(declaredSecrets);
+  const unsetAtBoot = missingSecrets(codeInputSecrets);
   const schedules = sched.schedules.map((s) => ({
     name: s.name,
     cron: s.cron,
@@ -100,6 +124,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
           channels,
           schedules,
           scheduleFailures: sched.failures,
+          channelFailures: inspected.failures,
           selfSchedule: config.selfSchedule ?? false,
           stateRoot,
           sessionsDir,
@@ -108,6 +133,9 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
           skillCollisions: definition.collisions,
           toolCollisions: tools.collisions,
           toolFailures: tools.failures,
+          declaredSecrets,
+          unsetSecrets,
+          unsetAtBoot,
         },
         null,
         2,
@@ -137,12 +165,23 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   line("channels", channels.join(", ") || "(none)");
   line("schedules", schedules.map((s) => `${s.name} (next ${s.next ?? "never"})`).join(", ") || "(none)");
   line("selfSchedule", config.selfSchedule ? "on (mounts the wake tool when serving)" : "off");
+  line("secrets", declaredSecrets.length > 0 ? describeSecrets(declaredSecrets) : "(none declared)");
+  // Each unset name appears in exactly ONE ⚠, by consequence: the boot-blocking ones say so, and
+  // the rest (config-only names, which `deploy` carries but `dev` never reads) say only that. Listing
+  // a name twice reads as two different problems.
+  const bootNames = new Set(unsetAtBoot.map((s) => s.name));
+  const unsetElsewhere = unsetSecrets.filter((s) => !bootNames.has(s.name));
+  if (unsetAtBoot.length > 0)
+    cont(`⚠ dev/start refuse to boot until set: ${unsetAtBoot.map((s) => s.name).join(", ")}`);
+  if (unsetElsewhere.length > 0)
+    cont(`⚠ no value here (carried by deploy only): ${unsetElsewhere.map((s) => s.name).join(", ")}`);
   line("state", stateRoot);
   line("sessions", sessionsDir);
   line("auth", authPath);
   reportToolCollisions(tools.collisions);
   reportModuleLoadFailures(tools.failures);
   reportModuleLoadFailures(sched.failures);
+  reportModuleLoadFailures(inspected.failures);
   if (tools.error) log.warn(`[fastagent] ${tools.error}`);
   reportFindingsIfChanged(definition.dir, definition);
 }

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -6,7 +6,7 @@ import { loadConfig } from "../../engines/pi/config.ts";
 import { resolveAgentTools } from "../../engines/pi/create.ts";
 import { reportModuleLoadFailures } from "../../loader.ts";
 import { turnContext } from "../../engines/pi/tool-context.ts";
-import { failStartup, failUsage, placementOrExit } from "../fail.ts";
+import { failStartup, failUsage, gateSecretsOrExit, placementOrExit } from "../fail.ts";
 
 export async function runTool(name: string, argsJson: string, dirArg: string): Promise<void> {
   // Argument shape first: malformed JSON is a USAGE error (exit 2), independent of whether the directory is an agent
@@ -17,19 +17,31 @@ export async function runTool(name: string, argsJson: string, dirArg: string): P
   const { config } = await loadConfig(agentDir).catch(failStartup);
   // The same tool set dev/start mount (all coding tools + config.tools + discovered, deduped), so the runner
   // exercises exactly what gets served.
-  const { tools, toolCollisions, toolFailures } = await resolveAgentTools(config, agentDir, workspace).catch(
-    failStartup,
-  );
+  const { tools, toolCollisions, toolFailures, toolSecrets } = await resolveAgentTools(
+    config,
+    agentDir,
+    workspace,
+  ).catch(failStartup);
   for (const c of toolCollisions) {
     console.error(
       `[fastagent] warn: tool "${c.name}" (${c.source}) is shadowed by a default/config tool — not mounted`,
     );
   }
+  // Reported BEFORE the name is looked up: a file that failed to import is missing from `tools`, so
+  // "unknown tool" is exactly the case where the author most needs to hear that something blew up
+  // rather than that they mistyped it.
   reportModuleLoadFailures(toolFailures);
   const tool = tools.find((t) => t.name === name);
   if (!tool) {
     failStartup(new Error(`unknown tool "${name}". available: ${tools.map((t) => t.name).join(", ") || "(none)"}`));
   }
+  // This command RUNS one tool body, so it takes the same guarantee dev/start take — for THAT tool
+  // only (`owner`): running one tool by hand must not require the credentials of the tools it is not
+  // running, and `fire` scopes the same way for one schedule.
+  // The failures go to the gate as well, even though they were just printed: the gate's guarantee is
+  // that a refusal never hides them, and it cannot know a caller already reported. A repeated line on
+  // the refusal path is the cheaper failure than one that depends on this call site remembering.
+  gateSecretsOrExit({ declared: toolSecrets, failures: toolFailures, owner: name });
   // Authored tools read cwd from turnContext; coding tools are already rooted at the workspace.
   const result = await turnContext.run({ cwd: workspace }, () => tool.execute(`cli-${name}`, args)).catch(failStartup);
   const out =

--- a/src/cli/fail.ts
+++ b/src/cli/fail.ts
@@ -1,4 +1,5 @@
 import { type ResolvedPlacement, resolvePlacement } from "../paths.ts";
+import { gateSecrets } from "../secrets-gate.ts";
 
 /** stderr renders color: a color TTY, with Node's `hasColors()` carrying the NO_COLOR/TERM=dumb veto. */
 function stderrHasColors(): boolean {
@@ -18,6 +19,21 @@ export function failStartup(error: unknown): never {
   if (error instanceof Error && error.constructor === Error) console.error(`${errorPrefix()} ${error.message}`);
   else console.error(errorPrefix(), error);
   process.exit(1);
+}
+
+/**
+ * {@link gateSecrets} at the process boundary, for a command that runs ONE owner's code (`fastagent
+ * tool`, `fastagent fire`). The gate throws SYNCHRONOUSLY, so there is no promise to hang the usual
+ * `.catch(failStartup)` on, and a raw throw reaches `cli.ts`'s top-level await as a Node stack that
+ * buries the one line naming the file. The catch translates that expected failure into the CLI's
+ * single-line refusal and exits 1; nothing is recovered.
+ */
+export function gateSecretsOrExit(input: Parameters<typeof gateSecrets>[0]): void {
+  try {
+    gateSecrets(input);
+  } catch (error) {
+    failStartup(error);
+  }
 }
 
 /** THE placement entry point for commands: resolve `dir`, or exit 1 with the one-line refusal. */

--- a/src/core.ts
+++ b/src/core.ts
@@ -23,4 +23,9 @@ export type {
   Routes,
 } from "./channel.ts";
 // Mounting only.
-export { defineSchedule, type LoadedSchedule, type Schedule } from "./schedule/schedule.ts";
+export { defineSchedule, type DefineScheduleOptions, type LoadedSchedule, type Schedule } from "./schedule/schedule.ts";
+// What a `channels/*.ts` file is written against when it needs credentials: declaring them is what
+// lets `deploy` carry them and the serve refuse to start without them.
+export { defineChannel, type DefineChannelOptions } from "./channels/define-channel.ts";
+// The one shape "which env vars does this agent need" travels in, from every authoring surface.
+export type { DeclaredSecret } from "./declared-secrets.ts";

--- a/src/declared-secrets.ts
+++ b/src/declared-secrets.ts
@@ -36,11 +36,27 @@ export interface DeclaredSecret {
   source: string;
 }
 
-/** Is an authored `secrets:` field usable? A `.js` tool or a wrong type never met TypeScript, and a
- *  malformed declaration must fail as a load error rather than be silently dropped — the whole value
- *  of the field is that its absence is meaningful. */
-function validSecretNames(value: unknown): boolean {
-  return value === undefined || (Array.isArray(value) && value.every((n) => typeof n === "string" && n !== ""));
+/**
+ * What an env-var NAME may look like. Checked at the declaration, not left to the host: these names
+ * are written verbatim into a Compose file, a Fly/Railway runbook and a CloudFormation parameter, so
+ * a typo (`"X_API_KEY "`, `"my key"`) or a quote/newline produces a broken or wrong artifact whose
+ * error surfaces in someone's cloud CLI, pointing at nothing. Case is not dictated — `http_proxy` is
+ * a real variable — only the shape a shell and every artifact format agree on.
+ */
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Why an authored `secrets:` is unusable, or undefined when it is fine. A `.js` tool or a wrong type
+ *  never met TypeScript, and a malformed declaration must fail as a load error rather than be
+ *  silently dropped — the whole value of the field is that its absence is meaningful. */
+function secretNamesProblem(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return "secrets must be an array of env-var names";
+  for (const name of value) {
+    if (typeof name !== "string" || !ENV_NAME.test(name)) {
+      return `secrets must be an array of env-var names — ${JSON.stringify(name)} is not one`;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -58,7 +74,8 @@ export function readSecretDeclaration(
   label: string,
 ): { secrets: DeclaredSecret[]; error?: undefined } | { secrets?: undefined; error: string } {
   const declared = (moduleDefault as { secrets?: unknown } | undefined)?.secrets;
-  if (!validSecretNames(declared)) return { error: `${label}: secrets must be an array of env-var names` };
+  const problem = secretNamesProblem(declared);
+  if (problem !== undefined) return { error: `${label}: ${problem}` };
   return { secrets: ((declared as readonly string[] | undefined) ?? []).map((name) => ({ name, source: label })) };
 }
 

--- a/src/declared-secrets.ts
+++ b/src/declared-secrets.ts
@@ -81,7 +81,7 @@ export function readSecretDeclaration(
 
 /** Every owner's declarations as one list — what a path that runs ALL of them (a serve, a deploy)
  *  asserts or carries. A path that runs ONE reads that owner's entry instead. */
-export function allSecrets(byOwner: ReadonlyMap<string, DeclaredSecret[]>): DeclaredSecret[] {
+export function allSecrets(byOwner: ReadonlyMap<string, readonly DeclaredSecret[]>): DeclaredSecret[] {
   return [...byOwner.values()].flat();
 }
 

--- a/src/declared-secrets.ts
+++ b/src/declared-secrets.ts
@@ -1,0 +1,109 @@
+/**
+ * WHICH ENV VARS THIS AGENT NEEDS — the one shape the answer travels in, wherever it was declared.
+ *
+ * Before this existed the concept had three homes and one hole: a first-party channel declared its
+ * vars in the scaffold table (typed, with hints), `fastagent.config` `deploy.secrets` listed names as
+ * bare strings, the model key was inferred by a third mechanism — and a TOOL, the thing authors write
+ * most, declared nothing at all. A tool's need lived only inside `process.env.X` in its own body, so
+ * `deploy` could not carry it and nothing could check it: the name had to be copied by hand into
+ * `deploy.secrets`, and forgetting meant the deployed box read `undefined` on the first real call,
+ * days later, with the error only in the host's logs.
+ *
+ * So the declaration moved next to the code that needs it (`defineTool({ secrets: [...] })`,
+ * `defineSchedule({ secrets: [...] })`), and this module is where every source converges. Two things
+ * follow from having ONE list, and they are the whole point:
+ *
+ *  - `deploy` CARRIES a declared name automatically — no second list to keep in sync.
+ *  - a serving path ASSERTS the values before it runs, so a missing one is a startup failure naming
+ *    the file, not a 401 three days later (the same contract a channel already has: an empty
+ *    `botToken` fails `telegramChannel` at mount).
+ *
+ * Agent code does not read `process.env`: each authoring surface (`defineTool`, `defineChannel`,
+ * `defineSchedule`) hands back exactly the values it declared, so the declaration cannot drift from
+ * the read, and a typo is a type error rather than an `undefined` at 3am. What this can NOT force is
+ * the environment itself — a provider SDK reads its own variable, and the coding tools need `PATH`
+ * and `HOME` — so the values still travel through the process env; what changes is that no authored
+ * file has a reason to reach into it.
+ */
+
+/** One env var some part of the definition declared, and where that declaration is. */
+export interface DeclaredSecret {
+  /** The env-var name. */
+  name: string;
+  /** Where it was declared: "tools/x-post.ts", "schedules/daily-digest.ts", "config.tools",
+   *  "fastagent.config deploy.secrets" — printed in runbooks and failures, so it must name a place
+   *  the author can open. */
+  source: string;
+}
+
+/** Is an authored `secrets:` field usable? A `.js` tool or a wrong type never met TypeScript, and a
+ *  malformed declaration must fail as a load error rather than be silently dropped — the whole value
+ *  of the field is that its absence is meaningful. */
+function validSecretNames(value: unknown): boolean {
+  return value === undefined || (Array.isArray(value) && value.every((n) => typeof n === "string" && n !== ""));
+}
+
+/**
+ * THE READ: what a code-input module declared, attributed to its file — the one implementation for
+ * `tools/`, `schedules/` and `channels/`.
+ *
+ * It is one function because it was four, and the fourth was written without the shape check the
+ * other three had: a `secrets: "FOO"` in a channel file crashed the whole directory with a
+ * `TypeError` naming nothing, while the same mistake in a tool was that file's load failure. What a
+ * caller DOES with a bad declaration still differs (push a failure and skip, or throw inside its own
+ * per-file try), so the verdict travels back as data rather than as an exception.
+ */
+export function readSecretDeclaration(
+  moduleDefault: unknown,
+  label: string,
+): { secrets: DeclaredSecret[]; error?: undefined } | { secrets?: undefined; error: string } {
+  const declared = (moduleDefault as { secrets?: unknown } | undefined)?.secrets;
+  if (!validSecretNames(declared)) return { error: `${label}: secrets must be an array of env-var names` };
+  return { secrets: ((declared as readonly string[] | undefined) ?? []).map((name) => ({ name, source: label })) };
+}
+
+/** Every owner's declarations as one list — what a path that runs ALL of them (a serve, a deploy)
+ *  asserts or carries. A path that runs ONE reads that owner's entry instead. */
+export function allSecrets(byOwner: ReadonlyMap<string, DeclaredSecret[]>): DeclaredSecret[] {
+  return [...byOwner.values()].flat();
+}
+
+/** Declared names as a stable list, first declaration winning — the form a carrier iterates. */
+export function dedupeSecrets(declared: readonly DeclaredSecret[]): DeclaredSecret[] {
+  const seen = new Set<string>();
+  return declared.filter((s) => !seen.has(s.name) && seen.add(s.name));
+}
+
+/**
+ * The values for a declared list, as the authoring surfaces hand them to author code. A name with no
+ * value reads as `""` rather than throwing: the deploy pre-flight IMPORTS these modules on a machine
+ * that legitimately holds no secrets, and a throwing accessor would make the channel whose secrets we
+ * came to collect unloadable. Presence is guaranteed by the gate (src/secrets-gate.ts) on the paths
+ * that run the code, which is the one place that can tell "not set" from "not needed here".
+ */
+export function secretValues<const S extends readonly string[]>(
+  names: S | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<S[number], string> {
+  const values = {} as Record<S[number], string>;
+  for (const name of names ?? []) values[name as S[number]] = env[name] ?? "";
+  return values;
+}
+
+/** Declared names with no value in `env` — empty string counts as missing (an unset `.env` line). */
+export function missingSecrets(
+  declared: readonly DeclaredSecret[],
+  env: NodeJS.ProcessEnv = process.env,
+): DeclaredSecret[] {
+  return dedupeSecrets(declared).filter((s) => !env[s.name]);
+}
+
+/** "X_API_KEY, X_API_SECRET (tools/x-post.ts); SLACK_TOKEN (schedules/digest.ts)" — grouped by the
+ *  file to open, since that is the unit the author fixes. */
+export function describeSecrets(declared: readonly DeclaredSecret[]): string {
+  const bySource = new Map<string, string[]>();
+  for (const { name, source } of dedupeSecrets(declared)) {
+    bySource.set(source, [...(bySource.get(source) ?? []), name]);
+  }
+  return [...bySource].map(([source, names]) => `${names.join(", ")} (${source})`).join("; ");
+}

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -281,7 +281,9 @@ function template(
     const p = cfnParamName(s.name);
     params.push(`  ${p}:`, `    Type: String`);
     if (!s.required) params.push(`    Default: ""`);
-    params.push(`    NoEcho: true`, `    Description: ${s.hint}`);
+    // Quoted: the hint carries an authored `source` (a file name, a config.tools key), and a plain
+    // scalar holding `: ` is invalid YAML — the template would fail to parse in `aws cloudformation deploy`.
+    params.push(`    NoEcho: true`, `    Description: ${yamlSingleQuote(s.hint)}`);
     envLines.push(`        ${s.name}: !Ref ${p}`);
   }
   if (needsForwarder) {

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -8,6 +8,7 @@ import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookKinds, webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
+import type { DeclaredSecret } from "../../declared-secrets.ts";
 
 /** The one schedule fact the plan needs (from loadSchedules) — name + cron + tz. */
 export interface ScheduleFact {
@@ -26,8 +27,8 @@ export interface AgentcorePlanInput extends ContainerInput {
    * forwarder is needed at all (ANY webhook channel requires it, customs included).
    */
   channels: readonly DeclaredChannel[];
-  /** Extra secret env-var names (fastagent.config deploy.secrets). */
-  extraSecrets?: string[];
+  /** Everything the definition declared it needs (deploy.secrets + tool/schedule declarations). */
+  extraSecrets?: readonly DeclaredSecret[];
   /** Static schedules — each becomes an EventBridge Scheduler rule targeting the forwarder. */
   schedules: ScheduleFact[];
   /** Mirror the wake tool's pending work into EventBridge alarms. */

--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -208,6 +208,10 @@ export async function deployAgentcoreRun(
       return gate(`secret ${k} is ${v.length} chars — AgentCore environment values cap at 2048; shorten it`);
     }
   }
+  // Name what travels from THIS machine's environment onto the runtime: the list is no longer only
+  // what the author typed in deploy.secrets (a mounted tool/channel/schedule declares its own).
+  const secretNames = Object.keys(plan.secrets);
+  if (secretNames.length > 0) log(`carrying ${secretNames.length} secret(s): ${secretNames.join(", ")}`);
 
   // 3c. Say what this deploy is ABOUT TO TOUCH while it can still be stopped for free: until here the account and
   // region only surfaced several hundred log lines in, inside the ECR image URI.

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -3,6 +3,7 @@ import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookPaths } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
+import type { DeclaredSecret } from "../../declared-secrets.ts";
 
 export interface DockerPlanInput extends ContainerInput {
   /** Stable Compose project name, sanitized by {@link toDockerProjectName}. */
@@ -15,8 +16,8 @@ export interface DockerPlanInput extends ContainerInput {
   channels: readonly DeclaredChannel[];
   /** Generate an optional Cloudflare Quick Tunnel service in Compose. */
   tunnel: boolean;
-  /** Extra environment-variable names declared in config.deploy.secrets. */
-  extraSecrets?: string[];
+  /** Everything the definition declared it needs (deploy.secrets + tool/schedule declarations). */
+  extraSecrets?: readonly DeclaredSecret[];
 }
 
 export interface DockerPlan {

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -128,6 +128,11 @@ export async function deployDockerRun(
     );
   }
 
+  // Name what travels from THIS machine's environment into the container: the list is no longer
+  // only what the author typed in deploy.secrets (a mounted tool/channel/schedule declares its own).
+  const secretNames = Object.keys(plan.secrets);
+  if (secretNames.length > 0) log(`passing ${secretNames.length} secret(s) to Compose: ${secretNames.join(", ")}`);
+
   if ((await docker(["info"], { capture: true })).code !== 0) {
     return gate("Docker daemon is unavailable — start Docker Engine/Desktop, then re-run");
   }

--- a/src/deploy/fly/plan.ts
+++ b/src/deploy/fly/plan.ts
@@ -3,6 +3,7 @@ import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
+import type { DeclaredSecret } from "../../declared-secrets.ts";
 
 export interface FlyPlanInput extends ContainerInput {
   // Container facts (hasPackageJson, runtime, hasLockfile, bunVersion, version, apt) come from ContainerInput.
@@ -17,8 +18,9 @@ export interface FlyPlanInput extends ContainerInput {
    * must stay up for an outbound connection.
    */
   channels: readonly DeclaredChannel[];
-  /** Extra secret env-var names (fastagent.config deploy.secrets) — added to the runbook's secret list. */
-  extraSecrets?: string[];
+  /** Everything the definition declared it needs (deploy.secrets + tool/schedule/channel declarations),
+   *  attributed to the file that declared it. */
+  extraSecrets?: readonly DeclaredSecret[];
   /** `auto_stop_machines` — `"suspend"` (default, fast resume) or `"stop"` (cold start). */
   autostop: "suspend" | "stop";
   /** Allow scaling to zero when idle (default true → `min_machines_running=0`). */

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -407,11 +407,17 @@ export async function preflightDeploy(input: {
   // for what no code declares. Read through the SAME resolver dev/start mount with, so "which tool declarations
   // count" has one answer (config.tools declare too; a shadowed file's declaration is dropped in both places).
   const resolvedTools = await resolveAgentTools(config, agentDir, workspace);
+  // A code input we could not READ is a code input whose declarations we cannot carry — and the box
+  // WILL read it (its deps are installed there), so its gate fires after the deploy reported success:
+  // a crash loop, which is the failure mode this whole mechanism exists to move to build time. Under
+  // `--run` that is a gate, like a channel that fails to inspect; generate-only warns, since the
+  // operator may be producing artifacts from a machine that never installed the agent's deps.
   for (const failure of [...resolvedTools.toolFailures, ...loadedSchedules.failures]) {
-    messages.push({
-      level: "warn",
-      text: `${failure.label} failed to load (${failure.message}) — any secrets it declares cannot be carried to the host`,
-    });
+    const issue =
+      `${failure.label} failed to load (${failure.message}) — any secrets it declares cannot be carried ` +
+      `to the host, so the deployed box would refuse to start`;
+    if (run) return { ok: false, gate: issue };
+    messages.push({ level: "warn", text: issue });
   }
   const extraSecrets: DeclaredSecret[] = [
     ...(config.deploy?.secrets ?? []).map((name) => ({ name, source: "fastagent.config deploy.secrets" })),

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -11,7 +11,9 @@ import { isReleaseAgentName } from "./workspace.ts";
 import { type FastagentConfig, resolveAuthPath } from "../engines/pi/config.ts";
 import { type ResolvedPlacement, resolveSecretsDir, resolveStateRoot, exists, readTextIfExists } from "../paths.ts";
 import { type DeclaredChannel, inspectChannels } from "../channels/discover.ts";
-import { discoverScheduleFiles } from "../schedule/discover.ts";
+import { loadSchedules } from "../schedule/discover.ts";
+import { resolveAgentTools } from "../engines/pi/create.ts";
+import { type DeclaredSecret, allSecrets } from "../declared-secrets.ts";
 import { createPiModelRuntime, modelCredentialCarry, probeAuthSource } from "../engines/pi/models.ts";
 import { CHANNEL_KINDS } from "../scaffold/add-channel.ts";
 import { detectRuntime, readPackageJson } from "../runtime.ts";
@@ -41,12 +43,14 @@ interface DeployFacts {
    * gating on it would strand a correctly configured agent.
    */
   modelKeyInDefinition: boolean;
+  /** The declared secrets — config `deploy.secrets`, the control token, and every tool/schedule
+   *  declaration — carried to the host and listed in the runbook by their declaring file. */
+  extraSecrets: DeclaredSecret[];
   /** The project-level auth file `--run` reads to carry the credential (probed with the same path). */
   authPath: string;
   /** Container facts shared by the plan and the generated Dockerfile — ONE source, so they can't drift. */
   container: ContainerInput;
   port: number;
-  extraSecrets: string[];
 }
 
 /** Done (facts for the host branch), or a hard gate the CLI stops on (a model that won't reach the box). */
@@ -143,8 +147,8 @@ export async function preflightDeploy(input: {
     });
   }
 
-  // Known channel kinds only — a custom channel's secrets/webhook are unknown to us; note and let the author wire
-  // them.
+  // Known channel kinds only — a custom channel's webhook (and, unless it declared them, its secrets) are unknown to
+  // us; note and let the author wire them.
   const inspected = await inspectChannels(agentDir);
   if (inspected.failures.length > 0) {
     throw new Error(
@@ -152,20 +156,35 @@ export async function preflightDeploy(input: {
     );
   }
   const channels = inspected.channels;
+  // A custom channel that used `defineChannel({ secrets })` HAS told us its credentials, and they are
+  // carried below with every other declaration — telling its author to configure them by hand would
+  // send them to copy a list into deploy.secrets, which is the duplicate list this replaced.
+  const declaresSecrets = new Set(
+    [...inspected.secrets].flatMap(([owner, declared]) => (declared.length > 0 ? [owner] : [])),
+  );
   for (const { name, ingress } of channels) {
     if ((CHANNEL_KINDS as string[]).includes(name)) continue;
+    const declares = declaresSecrets.has(name);
+    const secretsPart = declares
+      ? `its declared secrets travel with the deploy`
+      : `configure its secrets yourself (declare them with defineChannel to have deploy carry them)`;
     messages.push({
       level: "note",
       text:
         ingress === "long-connection"
-          ? `long-connection channel "${name}" is custom — configure its secrets yourself; generated deploy plans keep the process running and skip webhook registration`
-          : `route channel "${name}" is custom — configure its secrets and webhook yourself`,
+          ? `long-connection channel "${name}" is custom — ${secretsPart}; generated deploy plans keep the process running and skip webhook registration`
+          : `route channel "${name}" is custom — ${secretsPart}; configure its webhook yourself`,
     });
   }
   const longConnectionChannels = channels.filter((c) => c.ingress === "long-connection").map((c) => c.name);
 
   // Time triggers (static schedules or self-scheduling) need a machine kept running.
-  const hasTimeTriggers = (await discoverScheduleFiles(agentDir)).length > 0 || !!config.selfSchedule;
+  // Loaded, not just listed: the same load answers "are there time triggers" AND "what did they declare they need".
+  // A file that FAILED to load still counts as a trigger — the author will fix it, and a plan that scaled to zero
+  // because a cron was broken on deploy day would sleep through it afterwards.
+  const loadedSchedules = await loadSchedules(agentDir);
+  const hasTimeTriggers =
+    loadedSchedules.schedules.length + loadedSchedules.failures.length > 0 || !!config.selfSchedule;
   if (longConnectionChannels.length > 0 && !externalClock) {
     messages.push({
       level: "note",
@@ -384,10 +403,28 @@ export async function preflightDeploy(input: {
     if (run) return { ok: false, gate: issue };
     messages.push({ level: "warn", text: issue });
   }
-  // What the agent declared it needs on the box (fastagent.config deploy.secrets).
-  const extraSecrets = [...(config.deploy?.secrets ?? [])];
+  // EVERYTHING the definition declared it needs, from wherever it was declared. `deploy.secrets` is now only the list
+  // for what no code declares. Read through the SAME resolver dev/start mount with, so "which tool declarations
+  // count" has one answer (config.tools declare too; a shadowed file's declaration is dropped in both places).
+  const resolvedTools = await resolveAgentTools(config, agentDir, workspace);
+  for (const failure of [...resolvedTools.toolFailures, ...loadedSchedules.failures]) {
+    messages.push({
+      level: "warn",
+      text: `${failure.label} failed to load (${failure.message}) — any secrets it declares cannot be carried to the host`,
+    });
+  }
+  const extraSecrets: DeclaredSecret[] = [
+    ...(config.deploy?.secrets ?? []).map((name) => ({ name, source: "fastagent.config deploy.secrets" })),
+    ...allSecrets(resolvedTools.toolSecrets),
+    ...allSecrets(loadedSchedules.secrets),
+    // A CUSTOM channel's credentials exist nowhere else: the first-party table can only name the channels fastagent
+    // ships, and guessing a custom one's variables is impossible.
+    ...allSecrets(inspected.secrets),
+  ];
   // The plane's bearer token is the DEPLOYMENT's secret, not the container's.
-  if (config.sessionControl === true) extraSecrets.push(CONTROL_TOKEN_ENV);
+  if (config.sessionControl === true) {
+    extraSecrets.push({ name: CONTROL_TOKEN_ENV, source: "fastagent.config sessionControl" });
+  }
   // deploy.apt only shapes the GENERATED Dockerfile.
   const dockerfileHome = join(agentDir, "Dockerfile");
   if (config.deploy?.apt?.length && !force && (await exists(dockerfileHome))) {

--- a/src/deploy/railway/plan.ts
+++ b/src/deploy/railway/plan.ts
@@ -3,6 +3,7 @@ import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookRunbook } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
+import type { DeclaredSecret } from "../../declared-secrets.ts";
 
 export interface RailwayPlanInput extends ContainerInput {
   // No `port`: Railway injects PORT and the container CMD/railway.json never name one (unlike Fly's internal_port) —
@@ -17,8 +18,9 @@ export interface RailwayPlanInput extends ContainerInput {
    */
   channels: readonly DeclaredChannel[];
   // Container facts (hasPackageJson, runtime, hasLockfile, bunVersion, version, apt) come from ContainerInput.
-  /** Extra secret env-var names (fastagent.config deploy.secrets) — added to the runbook's secret list. */
-  extraSecrets?: string[];
+  /** Everything the definition declared it needs (deploy.secrets + tool/schedule/channel declarations),
+   *  attributed to the file that declared it. */
+  extraSecrets?: readonly DeclaredSecret[];
   /**
    * Time triggers present (schedules/ or selfSchedule) — the runbook forbids App Sleeping: cron/wake has no external
    * wake-up, so a sleeping service sleeps through them.

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -150,8 +150,13 @@ export async function deployRailwayRun(
     `FASTAGENT_SECRETS_DIR=${plan.mountPath}/.secrets`,
     `RAILWAY_DOCKERFILE_PATH=${plan.dockerfilePath}`,
   ];
+  // The secret NAMES, not a count: what `--run` uploads is read from THIS machine's environment and
+  // is no longer only what the author typed in deploy.secrets (a mounted tool/channel/schedule
+  // declares its own), so the operator has to be able to see the list on every host.
+  const secretNames = Object.keys(plan.secrets);
   log(
-    `setting ${machineryVars.map((v) => v.split("=")[0]).join("/")} + ${Object.keys(plan.secrets).length} secret(s)…`,
+    `setting ${machineryVars.map((v) => v.split("=")[0]).join("/")} + ${secretNames.length} secret(s)` +
+      `${secretNames.length > 0 ? `: ${secretNames.join(", ")}` : ""}…`,
   );
   if ((await railway(["variables", "set", ...machineryVars, ...svc])).code !== 0) {
     return gate("`railway variables set` failed — see the railway output above");

--- a/src/deploy/secrets.ts
+++ b/src/deploy/secrets.ts
@@ -1,5 +1,6 @@
 /** The secret set a deployed agent needs, computed from the definition — host-neutral. */
 import { CONTROL_TOKEN_ENV } from "../channels/control.ts";
+import { type DeclaredSecret, dedupeSecrets } from "../declared-secrets.ts";
 import type { DeclaredChannel } from "../channels/discover.ts";
 import { CHANNEL_KINDS, type ChannelKind, channelSetup } from "../scaffold/add-channel.ts";
 
@@ -21,12 +22,13 @@ export function isEnvKey(source: string | undefined): source is string {
 
 /**
  * Secret NAMES + hints for a runbook: the model key (when local auth is an env key), discovered channel secrets, and
- * config extras.
+ * everything the definition declared (src/declared-secrets.ts) — each hinted by the file that declared it, since the
+ * reader is the person who must find the value.
  */
 export function deploymentSecrets(
   modelAuth: string | undefined,
   channels: readonly DeclaredChannel[],
-  extraSecrets: string[] = [],
+  extraSecrets: readonly DeclaredSecret[] = [],
 ): { name: string; hint: string; required: boolean }[] {
   const secrets: { name: string; hint: string; required: boolean }[] = [];
   if (isEnvKey(modelAuth)) secrets.push({ name: modelAuth, hint: "your model provider key", required: true });
@@ -35,15 +37,19 @@ export function deploymentSecrets(
       secrets.push({ name: e.name, hint: e.hint, required: e.required });
     }
   }
-  // Dedup: a name already covered by the model key / a channel secret must not appear twice in the runbook.
-  for (const name of extraSecrets) {
+  // Dedup: a name already covered by the model key / a channel secret must not appear twice in the
+  // runbook, and two tools declaring the same name are one secret.
+  for (const { name, source } of dedupeSecrets(extraSecrets)) {
     if (!secrets.some((s) => s.name === name)) {
       const control = name === CONTROL_TOKEN_ENV;
       secrets.push({
         name,
+        // The SOURCE, not a fixed sentence: a declared name now comes from wherever it was declared
+        // (a tool, a schedule, the config list), and the runbook's reader is the person who has to
+        // find the value — pointing at the wrong file is worse than pointing at none.
         hint: control
           ? "the /control/* bearer token — mint one (uuidgen) and give the same value to callers"
-          : "declared in fastagent.config deploy.secrets",
+          : `required by ${source}`,
         // OPTIONAL, unlike every other extra: unset, the box mints a per-boot token and still serves, and every host
         // with a shell can read it back out of control.json.
         required: !control,
@@ -66,8 +72,9 @@ export function assembleSecrets(input: {
   modelKeyInDefinition?: boolean;
   authFile: Buffer | undefined;
   channels: readonly DeclaredChannel[];
-  /** Extra secret env-var names from `fastagent.config` deploy.secrets — carried like channel secrets. */
-  extraSecrets?: string[];
+  /** Everything the definition declared it needs — `deploy.secrets` plus every tool/schedule
+   *  declaration — carried like channel secrets. */
+  extraSecrets?: readonly DeclaredSecret[];
   env: NodeJS.ProcessEnv;
 }): {
   secrets: Record<string, string>;
@@ -101,7 +108,7 @@ export function assembleSecrets(input: {
       }
     }
   }
-  for (const name of input.extraSecrets ?? []) {
+  for (const { name } of dedupeSecrets(input.extraSecrets ?? [])) {
     if (name in secrets || missingSecrets.includes(name)) continue; // already covered by model/channel — no dup
     const v = input.env[name];
     if (v) secrets[name] = v;

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -10,6 +10,7 @@ import type { FastagentTool } from "./tool.ts";
 import type { Models } from "@earendil-works/pi-ai";
 import type { AnyModel } from "./models.ts";
 import { THINKING_LEVELS } from "./session-settings.ts";
+import { readSecretDeclaration } from "../../declared-secrets.ts";
 import { isBindAddress } from "../../bind.ts";
 import { moduleLoadHint } from "../../loader.ts";
 import { AGENT_CONFIG_NAMES, resolveOverridePath, resolveSecretsDir } from "../../paths.ts";
@@ -145,6 +146,12 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
       if (typeof candidate.name !== "string" || typeof candidate.execute !== "function") {
         throw new Error(`${path}: "tools[${i}]" must have string "name" and function "execute"`);
       }
+      // The declaration's SHAPE, checked with the same read the code-input loaders use. Here rather
+      // than at tool resolution because this is the author's own config file: a wrong shape in it is
+      // a config error like any other (it stops the command with one line naming the entry), while a
+      // wrong shape in `tools/x.ts` is that one file's load failure and the agent serves without it.
+      const declaration = readSecretDeclaration(candidate, `${path}: "tools[${i}]"`);
+      if (declaration.error !== undefined) throw new Error(declaration.error);
     }
   }
   if (c.http !== undefined && (typeof c.http !== "object" || c.http === null)) {

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -18,7 +18,15 @@ import { isAgentcoreRuntime, isDeployedWorkspace, resolveSecretsDir } from "../.
 import { type LoadedDefinition, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
 import { reportFindingsIfChanged } from "./report.ts";
 import type { ModuleLoadFailure } from "../../loader.ts";
-import { type ToolCollision, isDeferredTool, loadTools, mergeDiscoveredTools, type MountedTool } from "./tool.ts";
+import {
+  type FastagentTool,
+  type ToolCollision,
+  isDeferredTool,
+  loadTools,
+  mergeDiscoveredTools,
+  type MountedTool,
+} from "./tool.ts";
+import { type DeclaredSecret, readSecretDeclaration } from "../../declared-secrets.ts";
 import { withSearchTool } from "./search-tools.ts";
 import { type PiAgentSessionFactory, createPiAgentFromSession } from "./invoke-session.ts";
 import { type PiAgentSessionFactoryOptions, piAgentSessionFactory } from "./agent-session-factory.ts";
@@ -88,6 +96,13 @@ export async function resolveAgentTools(
   deferredToolNames: string[];
   toolCollisions: ToolCollision[];
   toolFailures: ModuleLoadFailure[];
+  /** Env vars the MOUNTED tools declared they need, BY TOOL NAME — a discovered tool shadowed by a
+   *  coding tool or `config.tools` never executes, so its declaration is dropped here rather than
+   *  gating a start. Per tool because a caller that runs exactly ONE of them (`fastagent tool`) must
+   *  not be stopped by a sibling's credential; the serving paths flatten it (they mount all of
+   *  them). DATA: `info` reports it and the deploy pre-flight carries it, while the serving opener
+   *  asserts it (open.ts) — this function must stay reportable. */
+  toolSecrets: Map<string, DeclaredSecret[]>;
 }> {
   // Discovered `tools/` come from `agentDir` (the agent's own surface); the coding tools are rooted at `cwd`, the
   // WORKSPACE.
@@ -95,6 +110,10 @@ export async function resolveAgentTools(
   const configured = piAllCodingTools(cwd);
   const configuredNames = new Set(configured.map((tool) => tool.name));
   const configuredCollisions: ToolCollision[] = [];
+  // The config.tools that actually MOUNT — collected here rather than re-derived from `config.tools`
+  // afterwards, so a tool dropped for sharing a coding tool's name cannot contribute a declaration
+  // (its body never runs, and gating a start on its secret would refuse to serve for nothing).
+  const mountedConfigTools: FastagentTool[] = [];
   for (const tool of config.tools ?? []) {
     if (configuredNames.has(tool.name)) {
       configuredCollisions.push({ name: tool.name, source: "config.tools" });
@@ -102,6 +121,7 @@ export async function resolveAgentTools(
     }
     configuredNames.add(tool.name);
     configured.push(tool);
+    mountedConfigTools.push(tool);
   }
   const merged = mergeDiscoveredTools(configured, discovered.tools);
   // The built-in `search_tools` loader mounts here.
@@ -112,6 +132,9 @@ export async function resolveAgentTools(
     !merged.tools.some((t) => t.name === "search_tools") && tools.some((t) => t.name === "search_tools");
   const toolCollisions = [...discovered.collisions, ...configuredCollisions, ...merged.collisions];
   // `toolNames` is the AUTHOR's active-by-default surface (config.tools + tools/).
+  // The discovered tools that were DROPPED (a coding tool or config.tools already owns the name):
+  // asking the mounted set instead would read the winner's name as proof the loser is mounted.
+  const shadowed = new Set(merged.collisions.map((c) => c.name));
   const defaultNames = new Set<string>(CODING_TOOL_NAMES);
   const toolNames = tools
     .filter(
@@ -124,6 +147,21 @@ export async function resolveAgentTools(
     deferredToolNames: tools.filter(isDeferredTool).map((t) => t.name),
     toolCollisions,
     toolFailures: discovered.failures,
+    // Mounted only, and config.tools are FastagentTools too, so a programmatic tool declares the
+    // same way a file does.
+    toolSecrets: new Map([
+      ...[...discovered.secrets].filter(([name]) => !shadowed.has(name)),
+      // A programmatic tool declares the same way a file does. The source names the ENTRY, not just
+      // the list: `source` has to point at something the author can find, and "config.tools" alone
+      // locates nothing when the list has several tools. The shape was already refused by config
+      // validation (config.ts), so a throw here means a FastagentConfig assembled in code bypassed
+      // it — still the caller's own object, so it fails loudly rather than being isolated.
+      ...mountedConfigTools.map((tool) => {
+        const declaration = readSecretDeclaration(tool, `config.tools "${tool.name}"`);
+        if (declaration.error !== undefined) throw new Error(declaration.error);
+        return [tool.name, declaration.secrets] as [string, DeclaredSecret[]];
+      }),
+    ]),
   };
 }
 

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -23,6 +23,8 @@ import { type LoadedDefinition, loadAgentSkills } from "./definition.ts";
 import { reportFindingsIfChanged } from "./report.ts";
 import { type PiSessionRecordStore, piSessionRecordStore } from "./session-store.ts";
 import type { ToolCollision, MountedTool } from "./tool.ts";
+import type { DeclaredSecret } from "../../declared-secrets.ts";
+import { gateSecrets } from "../../secrets-gate.ts";
 
 export interface CreatePiAgentFromDirOptions {
   /** Model spec override (e.g. the CLI --model flag). */
@@ -64,6 +66,8 @@ export interface AgentAssembly {
   deferredToolNames: string[];
   toolCollisions: ToolCollision[];
   toolFailures: ModuleLoadFailure[];
+  /** Env vars the mounted tools declared, by tool name — already asserted present by this function. */
+  toolSecrets: Map<string, DeclaredSecret[]>;
 }
 
 export async function resolveAgentAssembly(
@@ -79,11 +83,21 @@ export async function resolveAgentAssembly(
       `missing model: set --model, "model" in fastagent.config.ts, or FASTAGENT_MODEL (e.g. "openai-codex/gpt-5.5")`,
     );
   }
-  const { tools, toolNames, deferredToolNames, toolCollisions, toolFailures } = await resolveAgentTools(
+  const { tools, toolNames, deferredToolNames, toolCollisions, toolFailures, toolSecrets } = await resolveAgentTools(
     config,
     agentDir,
     workspace,
   );
+  // THE serving-path gate for tool declarations. Here rather than inside resolveAgentTools, which
+  // `info` and `fastagent tool` call to REPORT on a definition and must survive an unset value; every
+  // path through this function is about to run ALL of the tools, so no `owner`. `toolFailures` goes
+  // to the gate because the refusal throws out of here while the caller prints them only after it
+  // gets an assembly back (secrets-gate.ts, decision 2).
+  //
+  // DEFERRED tools gate too, deliberately: `search_tools` can activate one mid-turn, so "registered"
+  // means "may run in this process" — letting it start would put the empty-credential failure back
+  // inside a turn. An author who does not want that opts out per tool by not declaring.
+  gateSecrets({ declared: toolSecrets, failures: toolFailures });
   // The state root: sessions/channel state/schedule state derive from it (FASTAGENT_STATE_DIR moves it in one knob —
   // a container points it at its volume).
   const stateRoot = resolveStateRoot(agentDir);
@@ -102,6 +116,7 @@ export async function resolveAgentAssembly(
     deferredToolNames,
     toolCollisions,
     toolFailures,
+    toolSecrets,
   };
 }
 

--- a/src/engines/pi/tool.ts
+++ b/src/engines/pi/tool.ts
@@ -5,6 +5,7 @@ import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { z } from "zod";
 import { type ModuleLoadFailure, loadModuleDir } from "../../loader.ts";
+import { type DeclaredSecret, readSecretDeclaration, secretValues } from "../../declared-secrets.ts";
 import { type ReadonlySessionManager, type ToolActivation, turnContext } from "./tool-context.ts";
 
 export interface ToolContext {
@@ -18,9 +19,15 @@ export interface ToolContext {
    * the built-in `search_tools` is one consumer).
    */
   tools?: ToolActivation;
+  /** THE values of {@link DefineToolOptions.secrets}, keyed by the names this tool declared — read
+   *  from the process environment per call, so a value rotated THERE takes effect without a restart
+   *  (one rotated in `.secrets/.env` does not: that file is loaded once at startup). This is how a
+   *  tool gets a credential: reaching into `process.env` instead leaves the name undeclared, which
+   *  means nothing carries it to a deployed box and nothing checks it before the call fails. */
+  secrets: Record<string, string>;
 }
 
-export interface DefineToolOptions<I extends z.ZodType> {
+export interface DefineToolOptions<I extends z.ZodType, S extends readonly string[] = readonly []> {
   name?: string;
   description: string;
   input: I;
@@ -31,7 +38,18 @@ export interface DefineToolOptions<I extends z.ZodType> {
   deferred?: boolean;
   /** pi's per-tool execution mode: "sequential" makes pi run any batch containing this tool serially. */
   executionMode?: "sequential" | "parallel";
-  execute: (input: z.infer<I>, ctx: ToolContext) => unknown | Promise<unknown>;
+  /**
+   * Env vars this tool needs (`secrets: ["X_API_KEY"]`). Their values arrive as `ctx.secrets.X_API_KEY`,
+   * typed from this list. Declaring buys the two guarantees a bare `process.env` read cannot have:
+   * `deploy` carries the value to the host without it being listed anywhere else, and `dev`/`start`
+   * REFUSE TO START while it is unset, naming this file — instead of the tool failing on its first
+   * real call (see src/declared-secrets.ts).
+   */
+  secrets?: S;
+  execute: (
+    input: z.infer<I>,
+    ctx: Omit<ToolContext, "secrets"> & { secrets: Record<S[number], string> },
+  ) => unknown | Promise<unknown>;
 }
 
 /** AgentTool with Pi's optional per-call context; absent for sessionless CLI execution. */
@@ -42,6 +60,8 @@ export type MountedTool = Omit<AgentTool, "execute"> & {
 /** An AgentTool with fastagent's deferral marker. */
 export type FastagentTool = AgentTool & {
   deferred?: boolean;
+  /** {@link DefineToolOptions.secrets} — read back by `readSecretDeclaration`; pi ignores it. */
+  secrets?: readonly string[];
 };
 
 /**
@@ -71,7 +91,13 @@ function wrapResult(value: unknown): AgentToolResult<unknown> {
   return { content: [{ type: "text", text }], details: value };
 }
 
-export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): FastagentTool {
+// `S` defaults to the EMPTY tuple, not `readonly string[]`: a tool that declares nothing then gets
+// `ctx.secrets` with no keys, so `ctx.secrets.X_API_KEY` fails to compile instead of type-checking as
+// a `string` that is `undefined` at run time. "A typo is a compile error" has to hold for the tool
+// that forgot to declare, which is the one making the mistake.
+export function defineTool<I extends z.ZodType, const S extends readonly string[] = readonly []>(
+  options: DefineToolOptions<I, S>,
+): FastagentTool {
   const { $schema: _drop, ...parameters } = z.toJSONSchema(options.input) as Record<string, unknown>;
   const tool = {
     name: options.name ?? "",
@@ -80,6 +106,7 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
     parameters,
     ...(options.deferred ? { deferred: true } : {}),
     ...(options.executionMode ? { executionMode: options.executionMode } : {}),
+    ...(options.secrets?.length ? { secrets: options.secrets } : {}),
     async execute(_toolCallId: string, rawParams: unknown, signal?: AbortSignal): Promise<AgentToolResult<unknown>> {
       const parsed = options.input.safeParse(rawParams);
       if (!parsed.success) {
@@ -107,6 +134,7 @@ export function defineTool<I extends z.ZodType>(options: DefineToolOptions<I>): 
           signal,
           sessionManager: store?.sessionManager,
           tools,
+          secrets: secretValues(options.secrets),
         }),
       );
       if (added.length > 0) {
@@ -127,18 +155,30 @@ export interface ToolCollision {
 }
 
 /** Discover code tools in `<dir>/tools/`: each `*.ts|.js|.mjs` default-exports a tool, named from its filename. */
-export async function loadTools(
-  dir: string,
-): Promise<{ tools: AgentTool[]; collisions: ToolCollision[]; failures: ModuleLoadFailure[] }> {
+export async function loadTools(dir: string): Promise<{
+  tools: AgentTool[];
+  /** What each loaded tool declared it needs, BY TOOL NAME and attributed to the file. Per tool
+   *  because whether a declaration counts depends on whether that tool ends up MOUNTED — a name
+   *  shadowed by a coding tool never runs ({@link resolveAgentTools} makes that call). */
+  secrets: Map<string, DeclaredSecret[]>;
+  collisions: ToolCollision[];
+  failures: ModuleLoadFailure[];
+}> {
   // The same containment guard channels/schedules/skills get.
   await assertInsideAgentDir(dir, "tools");
   const { modules, failures } = await loadModuleDir(join(dir, "tools"));
   const byName = new Map<string, AgentTool>();
   const collisions: ToolCollision[] = [];
+  const secrets = new Map<string, DeclaredSecret[]>();
   for (const { name, label, file, mod } of modules) {
     const tool = mod.default as Partial<AgentTool> | undefined;
     if (!tool || typeof tool.execute !== "function") {
       failures.push({ label, file, message: `${label} must default-export defineTool({...})` });
+      continue;
+    }
+    const declaration = readSecretDeclaration(tool, label);
+    if (declaration.error !== undefined) {
+      failures.push({ label, file, message: declaration.error });
       continue;
     }
     if (byName.has(name)) {
@@ -146,8 +186,9 @@ export async function loadTools(
       continue;
     }
     byName.set(name, { ...(tool as AgentTool), name });
+    secrets.set(name, declaration.secrets);
   }
-  return { tools: [...byName.values()], collisions, failures };
+  return { tools: [...byName.values()], secrets, collisions, failures };
 }
 
 /** Merge resolved tools (pi coding tools + `config.tools`) with discovered `tools/`, deduped by name. */

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -21,7 +21,7 @@ function moduleName(fileName: string): string {
 }
 
 /** One module file a directory declares. */
-export interface InventoryEntry {
+interface InventoryEntry {
   /** Basename without extension — the authoritative name for tools/channels/schedules. */
   name: string;
   /** "tools/foo.ts"-style label for errors and collisions. */
@@ -31,9 +31,9 @@ export interface InventoryEntry {
 
 /**
  * WHAT A CODE-INPUT DIRECTORY DECLARES — the single answer to "which files here are modules", without importing any of
- * them.
+ * them. Internal: the loading functions below are its only consumers.
  */
-export async function moduleInventory(subDir: string): Promise<InventoryEntry[]> {
+async function moduleInventory(subDir: string): Promise<InventoryEntry[]> {
   let dirents: Dirent[];
   try {
     dirents = await readdir(subDir, { withFileTypes: true });

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -353,37 +353,24 @@ export async function scaffoldChannel(
     throw new Error(`${file} already exists — edit it, or remove it to re-scaffold`);
   }
   await mkdir(channelsDir, { recursive: true });
-  let content = channelTemplate(kind, "channel.ts");
-  if ((kind === "feishu" || kind === "lark") && options.ingress === "websocket") {
-    const factory = `${kind}Channel`;
-    const wsFactory = `${kind}WebSocketChannel`;
-    let configured = content
-      .replace(`import { ${factory} }`, `import { ${wsFactory} }`)
-      .replace(`export default ${factory}({`, `export default ${wsFactory}({`);
-    if (configured === content) throw new Error(`${kind} channel template has no factory anchors`);
-    const prefix = kind === "feishu" ? "FEISHU" : "LARK";
-    const exportAt = configured.indexOf("export default");
-    const importEnd = configured.indexOf("\n\n");
-    if (exportAt < 0 || importEnd < 0) throw new Error(`${kind} channel template header anchors are missing`);
-    const brand = kind === "feishu" ? "Feishu" : "Lark";
-    configured =
-      `${configured.slice(0, importEnd)}\n\n` +
-      `// ${brand} WebSocket long connection: the process connects OUT to the platform, so no public URL,\n` +
-      `// Verification Token, Encrypt Key, or --tunnel is needed. In Events & Callbacks choose long\n` +
-      `// connection, subscribe im.message.receive_v1, then publish the app version. Keep one process\n` +
-      `// running in production: scale-to-zero/App Sleeping would disconnect ingress.\n` +
-      configured.slice(exportAt);
-    configured = configured
-      .split("\n")
-      .filter(
-        (line) =>
-          !line.includes(`verificationToken: process.env.${prefix}_VERIFICATION_TOKEN`) &&
-          !line.includes(`encryptKey: process.env.${prefix}_ENCRYPT_KEY`),
-      )
-      .join("\n");
-    content = configured;
+  // The long-connection variant is its own template FILE, not a transform of the webhook one: the
+  // surgery that used to produce it (rename the factory, splice a header, delete the credential
+  // lines) had to be re-taught by hand every time the template changed shape, and a missed anchor
+  // scaffolded a channel configured for the wrong ingress with nothing failing.
+  // Which templates exist is the BUNDLE's fact, asked here rather than assumed from the kind: only
+  // feishu/lark ship a long-connection variant today, and a caller asking for one that is missing
+  // must get that sentence, not the ENOENT of a path it never named.
+  const template = options.ingress === "websocket" ? "channel.websocket.ts" : "channel.ts";
+  // CHANNEL templates only: the bundle also holds companion tools (`telegram-send.ts`), and listing
+  // one as an available scaffold sends whoever reads this line looking for an ingress that is a tool.
+  const available = channelBundleFiles(kind).filter((f) => f.startsWith("channel."));
+  if (!available.includes(template)) {
+    throw new Error(
+      `${kind} has no ${options.ingress ?? "webhook"} scaffold (${template} is not in its bundle) — ` +
+        `available: ${available.join(", ")}`,
+    );
   }
-  await writeFile(file, content, { flag: "wx" });
+  await writeFile(file, channelTemplate(kind, template), { flag: "wx" });
   return file;
 }
 
@@ -391,7 +378,7 @@ export async function scaffoldChannel(
 export async function scaffoldCompanionTools(dir: string, kind: ChannelKind): Promise<string[]> {
   const written: string[] = [];
   for (const name of channelBundleFiles(kind)) {
-    if (name === "channel.ts") continue;
+    if (name.startsWith("channel.")) continue; // channel.ts / channel.websocket.ts are the channel, not tools
     const file = join(dir, "tools", name);
     await mkdir(dirname(file), { recursive: true });
     await writeFile(file, channelTemplate(kind, name));

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -15,7 +15,8 @@ const channelScaffoldDir = (kind: string): URL => new URL(`../channels/${kind}/s
 export const channelTemplate = (kind: string, name: string): string =>
   readFileSync(new URL(name, channelScaffoldDir(kind)), "utf8");
 
-/** The .ts files in a channel's bundle: `channel.ts` is the channel adapter; the rest are companion tools. */
+/** The .ts files in a channel's bundle: `channel.*` are the channel templates (one per ingress —
+ *  `channel.ts`, `channel.websocket.ts`); the rest are companion tools. */
 export const channelBundleFiles = (kind: string): string[] =>
   readdirSync(channelScaffoldDir(kind)).filter((f) => f.endsWith(".ts"));
 

--- a/src/schedule/discover.ts
+++ b/src/schedule/discover.ts
@@ -3,34 +3,38 @@
  * mirroring `tools/` and `channels/`.
  */
 import { join } from "node:path";
-import { type ModuleLoadFailure, loadModuleDir, moduleInventory } from "../loader.ts";
+import { type ModuleLoadFailure, loadModuleDir } from "../loader.ts";
+import { type DeclaredSecret, readSecretDeclaration } from "../declared-secrets.ts";
 import { assertInsideAgentDir } from "../paths.ts";
 import { cronError } from "./cron.ts";
 import type { LoadedSchedule, Schedule } from "./schedule.ts";
-
-/** Schedule file basenames under `<dir>/schedules/`. */
-export async function discoverScheduleFiles(dir: string): Promise<string[]> {
-  await assertInsideAgentDir(dir, "schedules");
-  const entries = await moduleInventory(join(dir, "schedules"));
-  return entries.map((entry) => entry.name);
-}
 
 /**
  * Discover schedules in `<dir>/schedules/`: each file default-exports a `defineSchedule({...})`, named from its
  * filename.
  */
-export async function loadSchedules(
-  dir: string,
-): Promise<{ schedules: LoadedSchedule[]; failures: ModuleLoadFailure[] }> {
+export async function loadSchedules(dir: string): Promise<{
+  schedules: LoadedSchedule[];
+  /** What each loaded schedule declared it needs, BY SCHEDULE NAME and attributed to its file. Per
+   *  schedule because a caller that fires exactly ONE of them (`fastagent fire`) must not be stopped
+   *  by a sibling's credential, and because two schedules declaring the same variable would
+   *  otherwise blame whichever file was read first. The scheduler flattens it (it runs all of them).
+   *  Data, not a check — only a serving path asserts it (src/declared-secrets.ts). */
+  secrets: Map<string, DeclaredSecret[]>;
+  failures: ModuleLoadFailure[];
+}> {
   await assertInsideAgentDir(dir, "schedules");
   const { modules, failures } = await loadModuleDir(join(dir, "schedules"));
   const byName = new Map<string, LoadedSchedule>();
+  const secrets = new Map<string, DeclaredSecret[]>();
   for (const { name, label, file, mod } of modules) {
     try {
       const s = mod.default as Partial<Schedule> | undefined;
       if (!s || typeof s.cron !== "string" || typeof s.prompt !== "string") {
         throw new Error(`${label} must default-export defineSchedule({ cron, prompt })`);
       }
+      const declaration = readSecretDeclaration(s, label);
+      if (declaration.error !== undefined) throw new Error(declaration.error);
       const err = cronError(s.cron, s.tz);
       if (err) throw new Error(`${label}: invalid cron/tz — ${err}`);
       // "wake" is reserved: the run audit records self-scheduled wake-ups under that name, so a schedule named wake
@@ -39,9 +43,10 @@ export async function loadSchedules(
         throw new Error(`${label}: "wake" is a reserved schedule name (the self-scheduling audit uses it)`);
       if (byName.has(name)) throw new Error(`${label}: duplicate schedule name "${name}" — kept the first`);
       byName.set(name, { name, cron: s.cron, tz: s.tz, prompt: s.prompt });
+      secrets.set(name, declaration.secrets);
     } catch (error) {
       failures.push({ label, file, message: (error as Error).message });
     }
   }
-  return { schedules: [...byName.values()], failures };
+  return { schedules: [...byName.values()], secrets, failures };
 }

--- a/src/schedule/schedule.ts
+++ b/src/schedule/schedule.ts
@@ -1,4 +1,6 @@
-/** Schedule authoring: `defineSchedule` (the authoring surface). */
+/** Schedule authoring: `defineSchedule`. A `prompt` may be a function of the file's declared
+ *  `secrets` — the only reason such a file ever read the environment (src/declared-secrets.ts). */
+import { secretValues } from "../declared-secrets.ts";
 
 /**
  * A time-triggered invocation: at each `cron` instant (in `tz`, default UTC) the scheduler invokes the agent with
@@ -11,11 +13,31 @@ export interface Schedule {
   tz?: string;
   /** The turn's text = the job's instruction. */
   prompt: string;
+  /** Env vars this schedule declared — carried by `deploy`, asserted before the scheduler starts. */
+  secrets?: readonly string[];
 }
 
-/** Identity function for typing + IDE completion (like `defineTool`/`defineConfig`). */
-export function defineSchedule(schedule: Schedule): Schedule {
-  return schedule;
+/** What an author writes. `prompt` may be built FROM the declared secrets, which is the only reason a
+ *  schedule file ever read the environment (a channel id, a target inbox). */
+export interface DefineScheduleOptions<S extends readonly string[]> {
+  cron: string;
+  tz?: string;
+  prompt: string | ((secrets: Record<S[number], string>) => string);
+  /**
+   * Env vars this schedule needs (`["SLACK_DIGEST_CHANNEL"]`), typed into the `prompt` builder.
+   * `deploy` carries them and the scheduler refuses to start while one is unset, naming this file
+   * (see src/declared-secrets.ts) — the guarantees a bare `process.env` read cannot have.
+   */
+  secrets?: S;
+}
+
+/** Type + completion for a schedule file, and the ONE place a prompt builder is resolved (at load:
+ *  what the scheduler stores is always a string, so every consumer sees one shape). */
+export function defineSchedule<const S extends readonly string[] = readonly []>(
+  schedule: DefineScheduleOptions<S>,
+): Schedule {
+  const { prompt, ...rest } = schedule;
+  return { ...rest, prompt: typeof prompt === "function" ? prompt(secretValues(schedule.secrets)) : prompt };
 }
 
 /** A loaded schedule: its authored fields plus the name derived from its filename (authoritative). */

--- a/src/secrets-gate.ts
+++ b/src/secrets-gate.ts
@@ -1,0 +1,46 @@
+/**
+ * THE GATE: refuse to run while a declaration for what is ABOUT TO RUN has no value.
+ *
+ * `declared-secrets.ts` answers "which env vars did this code declare, and which have no value" —
+ * a predicate. This module owns the three decisions that turn that predicate into a refusal, and it
+ * exists because those three were hand-written at five call sites (the agent opener, the scheduler
+ * start, channel loading, `fastagent tool`, `fastagent fire`) and review found one or another of
+ * them wrong seven times:
+ *
+ *  1. WHICH declarations gate this run. A serve mounts every tool, schedule and channel, so all of
+ *     them gate it; `fastagent tool <name>` / `fire <name>` run exactly one owner, and requiring the
+ *     credentials of the ones they are not running blocks a machine that is configured correctly for
+ *     the job at hand. That is why declarations travel keyed BY OWNER.
+ *  2. ORDER against load failures. The refusal throws, and a caller that prints `failures` after it
+ *     gets a value back would lose them: a broken `tools/x.ts` beside an unset declaration would
+ *     stay invisible until the author fixed the environment and ran again. So the gate reports them
+ *     itself, on the refusal path, before throwing. A caller that also reports on its own success
+ *     path is correct; one that reports before gating merely repeats a line, which is cosmetic —
+ *     the signal cannot be lost either way.
+ *  3. The failure SHAPE. This throws a plain `Error` (a user-fixable startup problem). CLI commands
+ *     whose call is synchronous route it through the process boundary with `gateSecretsOrExit`
+ *     (cli/fail.ts) so the author sees the one line naming the file, never a Node stack.
+ */
+import { type DeclaredSecret, describeSecrets, missingSecrets } from "./declared-secrets.ts";
+import { type ModuleLoadFailure, reportModuleLoadFailures } from "./loader.ts";
+
+export function gateSecrets(input: {
+  /** Owner (tool / schedule / channel name) → what it declared, as the loaders return it. */
+  declared: ReadonlyMap<string, readonly DeclaredSecret[]>;
+  /** What could not be loaded from the same directory — reported before any refusal (decision 2). */
+  failures: readonly ModuleLoadFailure[];
+  /** The ONE owner about to run; omitted means every one of them is about to run. */
+  owner?: string;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  const scope =
+    input.owner === undefined ? [...input.declared.values()].flat() : (input.declared.get(input.owner) ?? []);
+  const missing = missingSecrets(scope, input.env);
+  if (missing.length === 0) return;
+  reportModuleLoadFailures(input.failures);
+  throw new Error(
+    `missing required secrets: ${describeSecrets(missing)} — set them in .secrets/.env (or the ` +
+      `environment). Deployed, they travel as deploy secrets; a tool that should run WITHOUT the ` +
+      `value must not declare it.`,
+  );
+}

--- a/src/secrets-gate.ts
+++ b/src/secrets-gate.ts
@@ -21,7 +21,7 @@
  *     whose call is synchronous route it through the process boundary with `gateSecretsOrExit`
  *     (cli/fail.ts) so the author sees the one line naming the file, never a Node stack.
  */
-import { type DeclaredSecret, describeSecrets, missingSecrets } from "./declared-secrets.ts";
+import { type DeclaredSecret, allSecrets, describeSecrets, missingSecrets } from "./declared-secrets.ts";
 import { type ModuleLoadFailure, reportModuleLoadFailures } from "./loader.ts";
 
 export function gateSecrets(input: {
@@ -33,8 +33,7 @@ export function gateSecrets(input: {
   owner?: string;
   env?: NodeJS.ProcessEnv;
 }): void {
-  const scope =
-    input.owner === undefined ? [...input.declared.values()].flat() : (input.declared.get(input.owner) ?? []);
+  const scope = input.owner === undefined ? allSecrets(input.declared) : (input.declared.get(input.owner) ?? []);
   const missing = missingSecrets(scope, input.env);
   if (missing.length === 0) return;
   reportModuleLoadFailures(input.failures);

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,6 +16,7 @@ import type { SessionControl } from "./session.ts";
 import type { ChannelHandler, LongConnection, Routes } from "./channel.ts";
 import { log } from "./log.ts";
 import { reportModuleLoadFailures } from "./loader.ts";
+import { gateSecrets } from "./secrets-gate.ts";
 import type { LoadedSchedule } from "./schedule/schedule.ts";
 
 /** Default wait for a channel's `closed` before reporting it stuck. */
@@ -174,7 +175,11 @@ export async function startSchedules(
 ): Promise<{ schedules: LoadedSchedule[]; stop: () => void }> {
   // Thrown, not exited on: this runs inside an embedder's app as well as the CLI, and a library that calls
   // process.exit takes a decision (degrade? retry? stop?) that belongs to its host.
-  const { schedules, failures } = await loadSchedules(agentDir);
+  const { schedules, secrets, failures } = await loadSchedules(agentDir);
+  // The schedules' half of the serving-path gate (the opener does the tools', loadChannels the
+  // channels'): a schedule reads its env at IMPORT time, so an unset declared value has already
+  // produced a broken prompt — refusing here is the last point where that is a startup failure.
+  gateSecrets({ declared: secrets, failures });
   reportModuleLoadFailures(failures);
   if (schedules.length === 0 && !selfSchedule) return { schedules, stop: () => {} };
   const scheduler = Effect.runSync(

--- a/test/add-channel-env.test.ts
+++ b/test/add-channel-env.test.ts
@@ -52,6 +52,20 @@ describe("channel setup guidance", () => {
     expect(await readFile(join(dir, "tools", "slack-send.ts"), "utf8")).toContain("slackTransport(ctx.cwd)");
   });
 
+  it("a kind with no long-connection template says so, instead of an ENOENT for a path nobody named", async () => {
+    // The CLI's resolveIngress only asks for websocket on feishu/lark, but that is the caller's
+    // guarantee, not this function's: `scaffoldChannel` is exported and a new kind may arrive first.
+    const dir = await mkdtemp(join(tmpdir(), "fa-ws-missing-"));
+    await expect(scaffoldChannel(dir, "telegram", { ingress: "websocket" })).rejects.toThrow(
+      /telegram has no websocket scaffold/,
+    );
+    // The "available" list names CHANNEL templates only — a companion tool in the same bundle is not
+    // an ingress anyone can ask for, and offering it sends the reader after the wrong file.
+    await expect(scaffoldChannel(dir, "telegram", { ingress: "websocket" })).rejects.toThrow(
+      /available: channel\.ts$/m,
+    );
+  });
+
   it("WebSocket setup needs only App ID/Secret and writes the WebSocket factory into the scaffold", async () => {
     const setup = channelSetup("feishu", "websocket");
     expect(setup.env.map((entry) => entry.name)).toEqual(["FEISHU_APP_ID", "FEISHU_APP_SECRET"]);

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Agent } from "../src/index.ts";
-import { loadChannels, discoverChannelFiles, inspectChannels } from "../src/channels/discover.ts";
+import { loadChannels, inspectChannels } from "../src/channels/discover.ts";
 import { log } from "../src/log.ts";
 
 // loadChannels only forwards the ctx to the factory; these factories ignore it.
@@ -254,10 +254,14 @@ describe("loadChannels (filesystem discovery)", () => {
   });
 });
 
-describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
-  it("lists channel basenames (sorted, no import); empty when there is no channels/", async () => {
+/** The names `info` prints: what inspectChannels imported and accepted, in inventory order. */
+const channelNames = async (dir: string): Promise<string[]> =>
+  (await inspectChannels(dir)).channels.map((channel) => channel.name);
+
+describe("inspectChannels (the `fastagent info` / deploy pre-flight reading view)", () => {
+  it("lists channel basenames (sorted, by import); empty when there is no channels/", async () => {
     const dir = await freshDir();
-    expect(await discoverChannelFiles(dir)).toEqual([]);
+    expect(await channelNames(dir)).toEqual([]);
     await mkdir(join(dir, "channels"));
     await writeFile(join(dir, "channels", "telegram.ts"), "export default () => ({});\n");
     await writeFile(join(dir, "channels", "github.ts"), "export default () => ({});\n");
@@ -268,7 +272,7 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     const said: string[] = [];
     const warn = vi.spyOn(log, "warn").mockImplementation((message: string) => void said.push(message));
     try {
-      expect(await discoverChannelFiles(dir)).toEqual(["github", "telegram"]);
+      expect(await channelNames(dir)).toEqual(["github", "telegram"]);
     } finally {
       warn.mockRestore();
     }
@@ -283,7 +287,7 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     await mkdir(join(dir, "channels"));
     await writeFile(join(dir, "channels", "a.ts"), "export default () => ({});\n");
     await writeFile(join(dir, "channels", "a-b.ts"), "export default () => ({});\n");
-    expect(await discoverChannelFiles(dir)).toEqual(["a", "a-b"]);
+    expect(await channelNames(dir)).toEqual(["a", "a-b"]);
   });
 
   it("a SYMLINKED channel file is skipped, and says why", async () => {
@@ -307,7 +311,7 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
       // The LISTING path says it too: `fastagent info` only lists names, so a silent skip there
       // reads as "I never created it" rather than "this one cannot be loaded".
       said.length = 0;
-      expect(await discoverChannelFiles(dir)).toEqual([]);
+      expect(await channelNames(dir)).toEqual([]);
       expect(said.filter((m) => m.includes("symlink"))).toHaveLength(1);
     } finally {
       warn.mockRestore();
@@ -320,7 +324,7 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     // they wrote. service.test.ts pins the same verdict for `schedules`.
     const dir = await freshDir();
     await writeFile(join(dir, "channels"), "not a directory\n");
-    await expect(discoverChannelFiles(dir)).rejects.toThrow(/ENOTDIR|not a directory/i);
+    await expect(inspectChannels(dir)).rejects.toThrow(/ENOTDIR|not a directory/i);
   });
 
   it("enforces containment on its OWN path: rejects a channels/ symlink escaping the workspace", async () => {
@@ -329,6 +333,6 @@ describe("discoverChannelFiles (the `fastagent info` authoring view)", () => {
     const ext = await freshDir();
     await mkdir(join(ext, "ch"));
     await symlink(join(ext, "ch"), join(dir, "channels"));
-    await expect(discoverChannelFiles(dir)).rejects.toThrow(/outside the agent dir/);
+    await expect(inspectChannels(dir)).rejects.toThrow(/outside the agent dir/);
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -245,6 +245,89 @@ describe("cli papercuts", () => {
     expect(stderr).toMatch(/looked in .*fastagent\/schedules/);
   });
 
+  it("an unknown name still reports the file that failed to load — that IS why the name is missing", async () => {
+    // A broken file is absent from the available list, so "unknown tool/schedule" is exactly the case
+    // where the author needs to hear about the import error rather than doubt their spelling.
+    const dir = await agentWorkspace("fa-unknown-broken-", {
+      "tools/broken.mjs": `throw new Error("boom at import");\n`,
+      "schedules/broken.mjs": `throw new Error("sched boom");\n`,
+    });
+    const tool = await run(["tool", "nope", "{}", dir]);
+    expect(tool.code).toBe(1);
+    expect(tool.stderr).toMatch(/tools\/broken\.mjs failed to load/);
+    expect(tool.stderr).toMatch(/unknown tool "nope"/);
+
+    const fired = await run(["fire", "nope", dir]);
+    expect(fired.code).toBe(1);
+    expect(fired.stderr).toMatch(/schedules\/broken\.mjs failed to load/);
+    expect(fired.stderr).toMatch(/unknown schedule "nope"/);
+  });
+
+  it("fire refuses a schedule whose declared secret has no value, instead of running a degraded prompt", async () => {
+    // `defineSchedule` resolves a prompt builder at load, so an unset value would have produced
+    // "Post the digest to " and `fire` would have sent it — the exact failure the declaration exists
+    // to prevent. `fire` runs the schedule, so it takes the serving path's assertion.
+    const scheduleHref = new URL("../src/schedule/schedule.ts", import.meta.url).href;
+    const dir = await agentWorkspace("fa-fire-secret-", {
+      "schedules/digest.ts":
+        `import { defineSchedule } from ${JSON.stringify(scheduleHref)};\n` +
+        `export default defineSchedule({ cron: "0 9 * * *", secrets: ["FA_TEST_FIRE_CHANNEL"],\n` +
+        `  prompt: (s) => \`Post the digest to \${s.FA_TEST_FIRE_CHANNEL}\` });\n`,
+    });
+    const env = { ...process.env };
+    delete env.FA_TEST_FIRE_CHANNEL;
+    const { code, stderr } = await run(["fire", "digest", dir], undefined, env);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/FA_TEST_FIRE_CHANNEL \(schedules\/digest\.ts\)/);
+    // Through the CLI's failure boundary: the one line that names the file, never a Node stack that
+    // buries it (the assertion throws synchronously, so it has no opener promise to ride).
+    expect(stderr).toMatch(/^Error: missing required secrets/m);
+    expect(stderr).not.toMatch(/at gateSecrets|Node\.js v/);
+  });
+
+  it("tool asserts only the named tool's secrets, not every mounted tool's", async () => {
+    // Same scoping as `fire`: running one tool by hand on a machine that holds only some credentials
+    // must not be blocked by a sibling tool's declaration.
+    const dir = await agentWorkspace("fa-tool-scope-", {
+      "tools/x-post.mjs":
+        `export default { name: "x-post", description: "p", parameters: { type: "object", properties: {} },\n` +
+        `  secrets: ["FA_TEST_TOOL_KEY"], execute: async () => ({ content: [{ type: "text", text: "x" }] }) };\n`,
+      "tools/echo.mjs":
+        `export default { name: "echo", description: "e", parameters: { type: "object", properties: {} },\n` +
+        `  execute: async () => ({ content: [{ type: "text", text: "echoed" }] }) };\n`,
+    });
+    const env = { ...process.env };
+    delete env.FA_TEST_TOOL_KEY;
+    const ok = await run(["tool", "echo", "{}", dir], undefined, env);
+    expect(ok.code).toBe(0);
+    expect(ok.stdout).toContain("echoed");
+    // The declaring tool itself still refuses, naming its file.
+    const gated = await run(["tool", "x-post", "{}", dir], undefined, env);
+    expect(gated.code).toBe(1);
+    expect(gated.stderr).toMatch(/FA_TEST_TOOL_KEY \(tools\/x-post\.mjs\)/);
+    expect(gated.stderr).toMatch(/^Error: missing required secrets/m); // the CLI's failure shape, not a stack
+    expect(gated.stderr).not.toMatch(/at gateSecrets|Node\.js v/);
+  });
+
+  it("fire asserts only the named schedule's secrets, not every sibling's", async () => {
+    // One manual trigger must not require the credentials of jobs it is not running: a laptop that
+    // has no reason to hold the digest channel can still fire `cleanup`.
+    const scheduleHref = new URL("../src/schedule/schedule.ts", import.meta.url).href;
+    const dir = await agentWorkspace("fa-fire-sibling-", {
+      "schedules/digest.ts":
+        `import { defineSchedule } from ${JSON.stringify(scheduleHref)};\n` +
+        `export default defineSchedule({ cron: "0 9 * * *", secrets: ["FA_TEST_FIRE_CHANNEL"],\n` +
+        `  prompt: (s) => \`Post to \${s.FA_TEST_FIRE_CHANNEL}\` });\n`,
+      "schedules/cleanup.ts":
+        `import { defineSchedule } from ${JSON.stringify(scheduleHref)};\n` +
+        `export default defineSchedule({ cron: "0 3 * * *", prompt: "tidy up" });\n`,
+    });
+    const env = { ...process.env };
+    delete env.FA_TEST_FIRE_CHANNEL;
+    const { stderr } = await run(["fire", "cleanup", dir], undefined, env);
+    expect(stderr).not.toMatch(/FA_TEST_FIRE_CHANNEL/); // got past the gate (it then needs a model/auth)
+  });
+
   it("never clobbers an existing Dockerfile: flags a stale generated one, warns on a hand-written one (G6)", async () => {
     // deploy KEEPS any existing Dockerfile without --force (no silent data loss). A generated one (marker)
     // that drifted from current config is flagged stale; a hand-written one is kept + warned (its apt won't

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -310,8 +310,9 @@ describe("cli papercuts", () => {
   });
 
   it("fire asserts only the named schedule's secrets, not every sibling's", async () => {
-    // One manual trigger must not require the credentials of jobs it is not running: a laptop that
-    // has no reason to hold the digest channel can still fire `cleanup`.
+    // One manual trigger must not require the credentials of the SCHEDULES it is not running: a laptop
+    // that has no reason to hold the digest channel can still fire `cleanup`. (The agent it then
+    // assembles still gates every mounted tool — a fired turn can call any of them.)
     const scheduleHref = new URL("../src/schedule/schedule.ts", import.meta.url).href;
     const dir = await agentWorkspace("fa-fire-sibling-", {
       "schedules/digest.ts":

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -273,6 +273,15 @@ describe("config: loadConfig", () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
     await writeFile(join(dir, "fastagent.config.mjs"), `export default { tools: [{}] };`);
     await expect(loadConfig(dir)).rejects.toThrow(/tools\[0\].*name.*execute/);
+
+    // A malformed `secrets` on a config tool is a CONFIG error, refused here with the entry named —
+    // not a fault thrown out of tool resolution later, where it would take `info`'s other reporting
+    // down with it. A `tools/x.ts` file with the same mistake stays that one file's load failure.
+    await writeFile(
+      join(dir, "fastagent.config.mjs"),
+      `export default { tools: [{ name: "gh", execute: async () => ({}), secrets: "GH_TOKEN" }] };`,
+    );
+    await expect(loadConfig(dir)).rejects.toThrow(/"tools\[0\]": secrets must be an array of env-var names/);
   });
 });
 

--- a/test/declared-secrets.test.ts
+++ b/test/declared-secrets.test.ts
@@ -264,6 +264,22 @@ describe("declared secrets: only what actually runs", () => {
       warn.mockRestore();
     }
   });
+
+  it("a channel that did not MOUNT does not gate — its own failure is the report the author needs", async () => {
+    // Otherwise the first thing the author reads is "missing required secrets" for a channel that was
+    // never going to serve, and the real cause (an invalid route table) waits behind it.
+    const dir = await agent({});
+    await writeFile(
+      join(dir, "channels", "broken-routes.mjs"),
+      `export default Object.assign(() => ({}), { secrets: ["FA_TEST_UNMOUNTED"] });\n`,
+    );
+    delete process.env.FA_TEST_UNMOUNTED;
+    const loaded = await loadChannels(dir, { agent: {} as never, stateRoot: dir });
+    expect(loaded.failures.map((f) => f.message)).toEqual([
+      'channels/broken-routes.mjs declared no routes — return a non-empty { "METHOD /path": handler } object',
+    ]);
+    expect(Object.keys(loaded.routes)).toEqual([]);
+  });
 });
 
 describe("declared secrets: the serving guarantee", () => {

--- a/test/declared-secrets.test.ts
+++ b/test/declared-secrets.test.ts
@@ -113,6 +113,22 @@ describe("declared secrets: where they are declared", () => {
       "tools/bad.mjs: secrets must be an array of env-var names",
     ]);
   });
+
+  it("a name that is not an env-var name is refused AT THE DECLARATION, naming the value", async () => {
+    // These names are written verbatim into a Compose file, a runbook and a CloudFormation parameter,
+    // so a stray space or quote has to fail here — not later, as a broken artifact whose error comes
+    // out of someone's cloud CLI pointing at nothing.
+    const dir = await agent({
+      "tools/typo.mjs": `export default { name: "t", description: "t", parameters: {},
+         secrets: ["X_API_KEY "], execute: async () => ({}) };\n`,
+      "tools/spaced.mjs": `export default { name: "s", description: "s", parameters: {},
+         secrets: ["my key"], execute: async () => ({}) };\n`,
+    });
+    expect((await loadTools(dir)).failures.map((f) => f.message)).toEqual([
+      'tools/spaced.mjs: secrets must be an array of env-var names — "my key" is not one',
+      'tools/typo.mjs: secrets must be an array of env-var names — "X_API_KEY " is not one',
+    ]);
+  });
 });
 
 describe("declared secrets: the values reach the code that declared them", () => {

--- a/test/declared-secrets.test.ts
+++ b/test/declared-secrets.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it, vi } from "vitest";
+import { log } from "../src/log.ts";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { allSecrets, describeSecrets, missingSecrets } from "../src/declared-secrets.ts";
+import { gateSecrets } from "../src/secrets-gate.ts";
+import { defineChannel, defineSchedule, defineTool, z } from "../src/index.ts";
+import { inspectChannels, loadChannels } from "../src/channels/discover.ts";
+import { loadTools } from "../src/engines/pi/tool.ts";
+import { resolveAgentTools } from "../src/engines/pi/create.ts";
+import { loadSchedules } from "../src/schedule/discover.ts";
+import { resolveAgentAssembly } from "../src/engines/pi/open.ts";
+
+/** An agent dir (nested layout, so `resolveAgentAssembly` reads it as the agent). */
+async function agent(files: Record<string, string>): Promise<string> {
+  const host = await mkdtemp(join(tmpdir(), "fa-declared-"));
+  const dir = join(host, "fastagent");
+  await mkdir(join(dir, "tools"), { recursive: true });
+  await mkdir(join(dir, "schedules"), { recursive: true });
+  await mkdir(join(dir, "channels"), { recursive: true });
+  await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai/gpt-4o-mini" };\n`);
+  for (const [name, content] of Object.entries(files)) await writeFile(join(dir, name), content);
+  return dir;
+}
+
+describe("declared secrets: the rule", () => {
+  it("reports only names with no value, grouped by the file to open", () => {
+    const declared = [
+      { name: "X_API_KEY", source: "tools/x-post.ts" },
+      { name: "X_API_SECRET", source: "tools/x-post.ts" },
+      { name: "SLACK_TOKEN", source: "schedules/digest.ts" },
+    ];
+    const env = { X_API_KEY: "k", X_API_SECRET: "" }; // empty counts as missing (an unset .env line)
+    expect(missingSecrets(declared, env).map((s) => s.name)).toEqual(["X_API_SECRET", "SLACK_TOKEN"]);
+    expect(describeSecrets(declared)).toBe(
+      "X_API_KEY, X_API_SECRET (tools/x-post.ts); SLACK_TOKEN (schedules/digest.ts)",
+    );
+  });
+
+  it("gates the OWNER about to run, and only that owner", () => {
+    // The three policies the gate owns, at their smallest: subset by owner, the refusal's wording,
+    // and (below, in the loader cases) reporting load failures before it throws.
+    const declared = new Map([
+      ["x-post", [{ name: "X_API_KEY", source: "tools/x-post.ts" }]],
+      ["digest", [{ name: "SLACK_TOKEN", source: "schedules/digest.ts" }]],
+    ]);
+    const env = { SLACK_TOKEN: "t" };
+    expect(() => gateSecrets({ declared, failures: [], env })).toThrow(/X_API_KEY \(tools\/x-post\.ts\)/);
+    expect(() => gateSecrets({ declared, failures: [], owner: "digest", env })).not.toThrow();
+    expect(() => gateSecrets({ declared, failures: [], owner: "x-post", env })).toThrow(/X_API_KEY/);
+    // An owner nobody declared for is not a refusal: it declared nothing, so nothing gates it.
+    expect(() => gateSecrets({ declared, failures: [], owner: "unknown", env })).not.toThrow();
+  });
+
+  it("reports load failures before refusing, so a broken file is never hidden by a missing value", () => {
+    const said: string[] = [];
+    const warn = vi.spyOn(log, "warn").mockImplementation((message: string) => void said.push(message));
+    try {
+      expect(() =>
+        gateSecrets({
+          declared: new Map([["needy", [{ name: "FA_TEST_UNSET", source: "tools/needy.ts" }]]]),
+          failures: [{ label: "tools/broken.ts", file: "/x/tools/broken.ts", message: "boom" }],
+          env: {},
+        }),
+      ).toThrow(/FA_TEST_UNSET/);
+      expect(said.join("\n")).toMatch(/tools\/broken\.ts failed to load/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("declared secrets: where they are declared", () => {
+  it("defineTool carries the declaration to the loader, attributed to the file", async () => {
+    const dir = await agent({
+      "tools/x-post.mjs": `export default { name: "x-post", description: "p", parameters: {},
+         secrets: ["X_API_KEY"], execute: async () => ({ content: [] }) };\n`,
+    });
+    expect([...(await loadTools(dir)).secrets]).toEqual([
+      ["x-post", [{ name: "X_API_KEY", source: "tools/x-post.mjs" }]],
+    ]);
+    // A programmatic tool declares the same way, so config.tools is not a hole in the list.
+    const configured = defineTool({
+      name: "gh",
+      description: "gh",
+      input: z.object({}),
+      secrets: ["GH_TOKEN"],
+      execute: () => "ok",
+    });
+    const resolved = await resolveAgentTools({ tools: [configured] }, dir, dir);
+    // BY TOOL, so a caller running one of them (`fastagent tool`) can ask for just that one.
+    expect([...resolved.toolSecrets]).toEqual([
+      ["x-post", [{ name: "X_API_KEY", source: "tools/x-post.mjs" }]],
+      ["gh", [{ name: "GH_TOKEN", source: 'config.tools "gh"' }]], // the ENTRY, not just the list
+    ]);
+    expect(allSecrets(resolved.toolSecrets)).toEqual([
+      { name: "X_API_KEY", source: "tools/x-post.mjs" },
+      { name: "GH_TOKEN", source: 'config.tools "gh"' },
+    ]);
+  });
+
+  it("defineSchedule declares too; a malformed declaration is a load failure, never dropped", async () => {
+    const dir = await agent({
+      "schedules/digest.mjs": `export default { cron: "0 9 * * *", prompt: "d", secrets: ["SLACK_TOKEN"] };\n`,
+      "schedules/bad.mjs": `export default { cron: "0 9 * * *", prompt: "d", secrets: "SLACK_TOKEN" };\n`,
+      "tools/bad.mjs": `export default { name: "b", description: "b", parameters: {}, secrets: "X", execute: async () => ({}) };\n`,
+    });
+    const loaded = await loadSchedules(dir);
+    expect([...loaded.secrets]).toEqual([["digest", [{ name: "SLACK_TOKEN", source: "schedules/digest.mjs" }]]]);
+    expect(loaded.failures.map((f) => f.label)).toEqual(["schedules/bad.mjs"]);
+    expect((await loadTools(dir)).failures.map((f) => f.message)).toEqual([
+      "tools/bad.mjs: secrets must be an array of env-var names",
+    ]);
+  });
+});
+
+describe("declared secrets: the values reach the code that declared them", () => {
+  it("a tool reads its own declaration through ctx.secrets, fresh per call", async () => {
+    const tool = defineTool({
+      name: "post",
+      description: "post",
+      input: z.object({}),
+      secrets: ["FA_TEST_POST_KEY"],
+      // Typed from the declaration: FA_TEST_POST_KEY is a known key here, a typo would not compile.
+      execute: (_input, ctx) => ctx.secrets.FA_TEST_POST_KEY,
+    });
+    process.env.FA_TEST_POST_KEY = "k1";
+    try {
+      expect((await tool.execute("c1", {})).details).toBe("k1");
+      process.env.FA_TEST_POST_KEY = "k2"; // rotated between calls, no restart
+      expect((await tool.execute("c2", {})).details).toBe("k2");
+    } finally {
+      delete process.env.FA_TEST_POST_KEY;
+    }
+  });
+
+  it("a channel declares through defineChannel, keeping its module form", async () => {
+    process.env.FA_TEST_BOT_TOKEN = "t0ken";
+    try {
+      const routeChannel = defineChannel({
+        secrets: ["FA_TEST_BOT_TOKEN"],
+        channel: (secrets) => () => ({ "POST /x": () => new Response(secrets.FA_TEST_BOT_TOKEN) }),
+      });
+      // Still a plain function (the route-channel module form) — the declaration rides as a property.
+      expect(typeof routeChannel).toBe("function");
+      expect(routeChannel.secrets).toEqual(["FA_TEST_BOT_TOKEN"]);
+      const dir = await agent({});
+      await writeFile(
+        join(dir, "channels", "custom.mjs"),
+        `export default Object.assign((ctx) => ({ "POST /x": () => new Response("ok") }), { secrets: ["FA_TEST_BOT_TOKEN"] });\n`,
+      );
+      // A CUSTOM channel's credentials exist nowhere else — this is the only way deploy learns them.
+      const inspected = await inspectChannels(dir);
+      expect([...inspected.secrets]).toEqual([
+        ["custom", [{ name: "FA_TEST_BOT_TOKEN", source: "channels/custom.mjs" }]],
+      ]);
+    } finally {
+      delete process.env.FA_TEST_BOT_TOKEN;
+    }
+  });
+
+  it("a schedule builds its prompt from the values it declared", async () => {
+    process.env.FA_TEST_DIGEST = "#ops";
+    try {
+      const schedule = defineSchedule({
+        cron: "0 9 * * *",
+        secrets: ["FA_TEST_DIGEST"],
+        prompt: (secrets) => `Post the digest to ${secrets.FA_TEST_DIGEST}`,
+      });
+      expect(schedule.prompt).toBe("Post the digest to #ops"); // resolved at load: consumers see one shape
+      expect(schedule.secrets).toEqual(["FA_TEST_DIGEST"]);
+    } finally {
+      delete process.env.FA_TEST_DIGEST;
+    }
+  });
+});
+
+describe("declared secrets: only what actually runs", () => {
+  it("drops the declaration of a discovered tool that is shadowed and never mounted", async () => {
+    // `tools/read.ts` loses its name to the coding tool `read`, so its body never executes — gating a
+    // start on a secret it declared would refuse to serve for a tool nobody can call.
+    const dir = await agent({
+      "tools/read.mjs": `export default { name: "read", description: "r", parameters: {},
+         secrets: ["FA_TEST_SHADOWED"], execute: async () => ({ content: [] }) };\n`,
+    });
+    const resolved = await resolveAgentTools({}, dir, dir);
+    expect(resolved.toolCollisions.map((c) => c.name)).toContain("read");
+    expect(allSecrets(resolved.toolSecrets)).toEqual([]);
+  });
+
+  it("drops the declaration of a config.tools entry shadowed by a coding tool", async () => {
+    // Same rule as a shadowed `tools/` file, and the reason it needs its own case: config.tools are
+    // dropped by a DIFFERENT branch (name already taken by a pi coding tool), which once bypassed
+    // the mounted-only filter and refused to start for a tool nobody could call.
+    const dir = await agent({});
+    const shadowed = defineTool({
+      name: "read",
+      description: "shadowed by the coding tool",
+      input: z.object({}),
+      secrets: ["FA_TEST_CONFIG_SHADOWED"],
+      execute: () => "ok",
+    });
+    const resolved = await resolveAgentTools({ tools: [shadowed] }, dir, dir);
+    expect(resolved.toolCollisions).toContainEqual({ name: "read", source: "config.tools" });
+    expect(allSecrets(resolved.toolSecrets)).toEqual([]);
+  });
+
+  it("a channel with a malformed declaration is ONE file's failure, not the whole directory", async () => {
+    const dir = await agent({});
+    await writeFile(
+      join(dir, "channels", "bad.mjs"),
+      `export default Object.assign(() => ({}), { secrets: "FOO" });\n`,
+    );
+    await writeFile(
+      join(dir, "channels", "ok.mjs"),
+      `export default () => ({ "POST /ok": () => new Response("ok") });\n`,
+    );
+    const agentStub = { invoke: () => ({ [Symbol.asyncIterator]: () => ({ next: async () => ({ done: true }) }) }) };
+    const loaded = await loadChannels(dir, { agent: agentStub as never, stateRoot: dir });
+    expect(loaded.failures.map((f) => f.message)).toEqual([
+      "channels/bad.mjs: secrets must be an array of env-var names",
+    ]);
+    expect(Object.keys(loaded.routes)).toEqual(["POST /ok"]); // the good one still mounted
+  });
+
+  it("a missing channel credential does not swallow the malformed file beside it", async () => {
+    // The assertion throws out of loadChannels, so a file failure collected on the way would be
+    // invisible until the operator fixed the environment and ran again. Both are reported.
+    const dir = await agent({});
+    await writeFile(
+      join(dir, "channels", "bad.mjs"),
+      `export default Object.assign(() => ({}), { secrets: "FOO" });\n`,
+    );
+    await writeFile(
+      join(dir, "channels", "needy.mjs"),
+      `export default Object.assign(() => ({ "POST /n": () => new Response("n") }), { secrets: ["FA_TEST_CH_TOKEN"] });\n`,
+    );
+    delete process.env.FA_TEST_CH_TOKEN;
+    const said: string[] = [];
+    const warn = vi.spyOn(log, "warn").mockImplementation((message: string) => void said.push(message));
+    try {
+      await expect(loadChannels(dir, { agent: {} as never, stateRoot: dir })).rejects.toThrow(
+        /FA_TEST_CH_TOKEN \(channels\/needy\.mjs\)/,
+      );
+      expect(said.join("\n")).toMatch(/channels\/bad\.mjs: secrets must be an array of env-var names/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("declared secrets: the serving guarantee", () => {
+  it("a missing tool credential does not swallow the broken tool file beside it", async () => {
+    // The assertion throws out of the opener, while the CLI prints `toolFailures` only after it gets
+    // an assembly back — so without reporting first, a broken tools/*.ts would stay invisible until
+    // the author fixed the environment and ran again. Same order `loadChannels` establishes.
+    const dir = await agent({
+      "tools/broken.mjs": `throw new Error("boom at import");\n`,
+      "tools/needy.mjs": `export default { name: "needy", description: "n", parameters: {},
+         secrets: ["FA_TEST_NEEDY_KEY"], execute: async () => ({ content: [] }) };\n`,
+    });
+    delete process.env.FA_TEST_NEEDY_KEY;
+    const said: string[] = [];
+    const warn = vi.spyOn(log, "warn").mockImplementation((message: string) => void said.push(message));
+    try {
+      await expect(resolveAgentAssembly(dir)).rejects.toThrow(/FA_TEST_NEEDY_KEY \(tools\/needy\.mjs\)/);
+      expect(said.join("\n")).toMatch(/tools\/broken\.mjs failed to load/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("the agent opener refuses to assemble while a declared value is unset, naming the file", async () => {
+    const dir = await agent({
+      "tools/x-post.mjs": `export default { name: "x-post", description: "p", parameters: {},
+         secrets: ["FA_TEST_X_API_KEY"], execute: async () => ({ content: [] }) };\n`,
+    });
+    delete process.env.FA_TEST_X_API_KEY;
+    await expect(resolveAgentAssembly(dir)).rejects.toThrow(/FA_TEST_X_API_KEY \(tools\/x-post\.mjs\)/);
+    process.env.FA_TEST_X_API_KEY = "k";
+    try {
+      // Same definition, value present: the assembly proceeds and reports what it asserted.
+      const assembly = await resolveAgentAssembly(dir);
+      expect(allSecrets(assembly.toolSecrets)).toEqual([{ name: "FA_TEST_X_API_KEY", source: "tools/x-post.mjs" }]);
+    } finally {
+      delete process.env.FA_TEST_X_API_KEY;
+    }
+  });
+});

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -524,6 +524,22 @@ describe("deploy/agentcore/run: helpers", () => {
 });
 
 describe("the post-deploy probe (verify restore + construction before registration)", () => {
+  it("names the secrets it carries — the list is no longer only what the author typed", async () => {
+    // A mounted tool/channel/schedule declares its own names, so what `--run` reads from THIS machine
+    // and puts on the runtime has to be visible on this host too.
+    const logs: string[] = [];
+    await deployAgentcoreRun(
+      plan({ secrets: { OPENAI_API_KEY: "sk", X_API_KEY: "x" } }),
+      fakeCli(happyAws).cli,
+      fakeCli().cli,
+      (m) => logs.push(m),
+      writeParams,
+      writeZip,
+      { telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered") },
+    );
+    expect(logs.join("\n")).toContain("2 secret(s): OPENAI_API_KEY, X_API_KEY");
+  });
+
   it("POSTs the reserved probe path with the ingress secret BEFORE registration and proceeds on ok:true", async () => {
     const requests: { url: string; body: string }[] = [];
     vi.stubGlobal(

--- a/test/deploy-agentcore-template.test.ts
+++ b/test/deploy-agentcore-template.test.ts
@@ -36,7 +36,7 @@ const CFN_TAGS = [
 ];
 
 interface Template {
-  Parameters?: Record<string, { Type: string; NoEcho?: boolean }>;
+  Parameters?: Record<string, { Type: string; NoEcho?: boolean; Description?: string }>;
   Resources: Record<string, { Type: string; Properties?: Record<string, unknown> }>;
   Outputs?: Record<string, unknown>;
 }
@@ -187,5 +187,13 @@ describe("the agentcore template (parsed)", () => {
     const env = (runtime.Properties as { EnvironmentVariables: Record<string, unknown> }).EnvironmentVariables;
     const [paramName] = secretParams.find(([n]) => n.toLowerCase().includes("telegram"))!;
     expect(env.TELEGRAM_BOT_TOKEN).toEqual({ Ref: paramName });
+  });
+
+  it("quotes the parameter description — a declaration source carrying `: ` is not a plain scalar", () => {
+    // The source is authored text (a file name, a config.tools key); unquoted it breaks the whole
+    // template, and the parse error names nothing the author can find.
+    const t = parseTemplate({ extraSecrets: [{ name: "FA_X_KEY", source: 'config.tools "a: b"' }] });
+    const param = Object.entries(t.Parameters ?? {}).find(([n]) => n.includes("FaXKey"))!;
+    expect(param[1].Description).toBe('required by config.tools "a: b"');
   });
 });

--- a/test/deploy-agentcore.test.ts
+++ b/test/deploy-agentcore.test.ts
@@ -221,9 +221,16 @@ describe("deploy agentcore: the plan", () => {
         }),
       ),
     ).toThrow(/same CloudFormation logical id/);
-    expect(() => planAgentcoreDeploy(baseInput({ extraSecrets: ["FOO_BAR", "FOO__BAR"] }))).toThrow(
-      /same CloudFormation parameter/,
-    );
+    expect(() =>
+      planAgentcoreDeploy(
+        baseInput({
+          extraSecrets: [
+            { name: "FOO_BAR", source: "fastagent.config deploy.secrets" },
+            { name: "FOO__BAR", source: "fastagent.config deploy.secrets" },
+          ],
+        }),
+      ),
+    ).toThrow(/same CloudFormation parameter/);
   });
 
   it("a schedule name with a quote cannot break the EventBridge Input YAML/JSON", () => {

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -225,6 +225,24 @@ describe("deploy/docker/run: local Compose journey", () => {
     expect(up.env).toEqual({ OPENAI_API_KEY: "sk-secret", FASTAGENT_AUTH_SEED: "base64-secret" });
   });
 
+  it("names the secrets it carries — the list is no longer only what the author typed", async () => {
+    // A mounted tool/channel/schedule declares its own names, so what `--run` reads from THIS machine
+    // and pushes to the host has to be visible, not a count.
+    const { docker } = fakeDocker((args) => {
+      if (args.includes("--services")) return { stdout: "agent\n" };
+      if (args.includes("port")) return { stdout: "127.0.0.1:8787\n" };
+      return {};
+    });
+    const logs: string[] = [];
+    await deployDockerRun(
+      plan({ secrets: { OPENAI_API_KEY: "sk", X_API_KEY: "x" } }),
+      docker,
+      (message) => logs.push(message),
+      healthy,
+    );
+    expect(logs.join("\n")).toContain("2 secret(s) to Compose: OPENAI_API_KEY, X_API_KEY");
+  });
+
   it("accepts a running custom topology with no host-published port (operator-owned ingress)", async () => {
     const logs: string[] = [];
     const { docker } = fakeDocker((args) => {

--- a/test/deploy-docker.test.ts
+++ b/test/deploy-docker.test.ts
@@ -90,7 +90,7 @@ describe("deploy/docker: planDockerDeploy", () => {
         ...base,
         modelAuth: "OPENAI_API_KEY",
         channels: declaredChannels(["telegram", "feishu"]),
-        extraSecrets: ["GH_TOKEN"],
+        extraSecrets: [{ name: "GH_TOKEN", source: "tools/gh.ts" }],
       }),
     );
     for (const name of [

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -328,7 +328,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
       modelAuth: "OPENAI_API_KEY",
       authFile: undefined,
       channels: [],
-      extraSecrets: ["GH_TOKEN"],
+      extraSecrets: [{ name: "GH_TOKEN", source: "fastagent.config deploy.secrets" }],
       env: { OPENAI_API_KEY: "k", GH_TOKEN: "ghp_x" },
     });
     expect(present.secrets.GH_TOKEN).toBe("ghp_x"); // value from the local env
@@ -337,7 +337,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
       modelAuth: "OPENAI_API_KEY",
       authFile: undefined,
       channels: [],
-      extraSecrets: ["GH_TOKEN"],
+      extraSecrets: [{ name: "GH_TOKEN", source: "fastagent.config deploy.secrets" }],
       env: { OPENAI_API_KEY: "k" },
     });
     expect(absent.missingSecrets).toEqual(["GH_TOKEN"]); // declared but no local value → gates --run
@@ -347,7 +347,7 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
       modelAuth: "OPENAI_API_KEY",
       authFile: undefined,
       channels: declaredChannels(["telegram"]),
-      extraSecrets: ["TELEGRAM_BOT_TOKEN"],
+      extraSecrets: [{ name: "TELEGRAM_BOT_TOKEN", source: "fastagent.config deploy.secrets" }],
       env: { OPENAI_API_KEY: "k" },
     });
     expect(dup.missingSecrets.filter((n) => n === "TELEGRAM_BOT_TOKEN")).toHaveLength(1);
@@ -360,17 +360,25 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
       channels: [] as const,
       env: { OPENAI_API_KEY: "k" },
     };
-    const absent = assembleSecrets({ ...base, channels: [], extraSecrets: [CONTROL_TOKEN_ENV] });
+    const absent = assembleSecrets({
+      ...base,
+      channels: [],
+      extraSecrets: [{ name: CONTROL_TOKEN_ENV, source: "fastagent.config sessionControl" }],
+    });
     expect(absent.missingSecrets).toEqual([]); // a deploy that worked before this existed still runs
     const present = assembleSecrets({
       ...base,
       channels: [],
-      extraSecrets: [CONTROL_TOKEN_ENV],
+      extraSecrets: [{ name: CONTROL_TOKEN_ENV, source: "fastagent.config sessionControl" }],
       env: { OPENAI_API_KEY: "k", [CONTROL_TOKEN_ENV]: "t0ken" },
     });
     expect(present.secrets[CONTROL_TOKEN_ENV]).toBe("t0ken");
     // The runbook lists it as optional for the same reason — required would gate every host.
-    const listed = deploymentSecrets("OPENAI_API_KEY", [], [CONTROL_TOKEN_ENV]);
+    const listed = deploymentSecrets(
+      "OPENAI_API_KEY",
+      [],
+      [{ name: CONTROL_TOKEN_ENV, source: "fastagent.config sessionControl" }],
+    );
     expect(listed.find((s) => s.name === CONTROL_TOKEN_ENV)?.required).toBe(false);
   });
 });

--- a/test/deploy-fly.test.ts
+++ b/test/deploy-fly.test.ts
@@ -100,7 +100,7 @@ describe("deploy/fly: planFlyDeploy", () => {
         ...base,
         modelAuth: "OPENAI_API_KEY",
         channels: declaredChannels(["telegram"]),
-        extraSecrets: ["GH_TOKEN"],
+        extraSecrets: [{ name: "GH_TOKEN", source: "tools/gh.ts" }],
       }),
     );
     expect(out).toContain("OPENAI_API_KEY=");

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { preflightDeploy } from "../src/deploy/preflight.ts";
+import { deploymentSecrets } from "../src/deploy/secrets.ts";
 import type { FastagentConfig } from "../src/engines/pi/config.ts";
 
 /** A workspace with an agent in it, as `init` produces (`<host>/fastagent/`); returns the AGENT DIR.
@@ -346,9 +347,28 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
       expect(pre.channels).toEqual([{ name: "discord", ingress: "webhook" }]);
       expect(pre.messages).toContainEqual({
         level: "note",
-        text: expect.stringContaining('route channel "discord" is custom'),
+        text: expect.stringContaining('route channel "discord" is custom — configure its secrets yourself'),
       });
     }
+  });
+
+  it("a custom channel that DECLARED its secrets is not told to configure them by hand", async () => {
+    // They are carried with every other declaration below; repeating "configure its secrets yourself"
+    // would send the author to copy the names into deploy.secrets — the duplicate list this replaced.
+    const dir = await workspace();
+    await mkdir(join(dir, "channels"), { recursive: true });
+    await writeFile(
+      join(dir, "channels", "discord.mjs"),
+      `export default Object.assign(() => ({}), { secrets: ["DISCORD_TOKEN"] });\n`,
+    );
+    const pre = await call(dir, { model: "openai/gpt-4o-mini" });
+    expect(pre.ok).toBe(true);
+    if (!pre.ok) return;
+    expect(pre.messages).toContainEqual({
+      level: "note",
+      text: expect.stringContaining('route channel "discord" is custom — its declared secrets travel with the deploy'),
+    });
+    expect(pre.extraSecrets).toContainEqual({ name: "DISCORD_TOKEN", source: "channels/discord.mjs" });
   });
 
   it("recognizes a long-connection module structurally and reports its always-on requirement", async () => {
@@ -476,6 +496,43 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
     if (pre.ok) expect(pre.modelKeyInDefinition).toBe(true);
   });
 
+  it("carries what tools and schedules DECLARED, without a second list to keep in sync", async () => {
+    const dir = await workspace();
+    await mkdir(join(dir, "tools"), { recursive: true });
+    await mkdir(join(dir, "schedules"), { recursive: true });
+    await writeFile(
+      join(dir, "tools", "x-post.mjs"),
+      `export default { name: "x-post", description: "post", parameters: {},
+         secrets: ["X_API_KEY", "X_API_SECRET"], execute: async () => ({ content: [] }) };\n`,
+    );
+    await writeFile(
+      join(dir, "schedules", "digest.mjs"),
+      `export default { cron: "0 9 * * *", prompt: "digest", secrets: ["SLACK_DIGEST_CHANNEL"] };\n`,
+    );
+    const pre = await call(dir, { model: "openai/gpt-4o-mini", deploy: { secrets: ["GH_TOKEN"] } });
+    expect(pre.ok).toBe(true);
+    if (!pre.ok) return;
+    expect(pre.extraSecrets).toEqual([
+      { name: "GH_TOKEN", source: "fastagent.config deploy.secrets" },
+      { name: "X_API_KEY", source: "tools/x-post.mjs" },
+      { name: "X_API_SECRET", source: "tools/x-post.mjs" },
+      { name: "SLACK_DIGEST_CHANNEL", source: "schedules/digest.mjs" },
+    ]);
+    // The runbook names the file to open, not a fixed "declared in fastagent.config" sentence.
+    const listed = deploymentSecrets(undefined, [], pre.extraSecrets);
+    expect(listed.find((s) => s.name === "X_API_KEY")?.hint).toBe("required by tools/x-post.mjs");
+  });
+
+  it("warns when a code input cannot be loaded — its declarations cannot be carried", async () => {
+    const dir = await workspace();
+    await mkdir(join(dir, "tools"), { recursive: true });
+    await writeFile(join(dir, "tools", "broken.mjs"), `throw new Error("boom");\n`);
+    const pre = await call(dir, { model: "openai/gpt-4o-mini" });
+    expect(pre.ok).toBe(true);
+    if (!pre.ok) return;
+    expect(pre.messages.some((m) => m.level === "warn" && /tools\/broken\.mjs failed to load/.test(m.text))).toBe(true);
+  });
+
   it("sessionControl carries the plane's token as a deploy secret — a minted one is unreadable off-box", async () => {
     const dir = await workspace();
     const off = await call(dir, { model: "openai/gpt-4o-mini" });
@@ -488,7 +545,10 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
     });
     expect(on.ok).toBe(true);
     if (on.ok) {
-      expect(on.extraSecrets).toEqual(["GH_TOKEN", "FASTAGENT_CONTROL_TOKEN"]);
+      expect(on.extraSecrets).toEqual([
+        { name: "GH_TOKEN", source: "fastagent.config deploy.secrets" },
+        { name: "FASTAGENT_CONTROL_TOKEN", source: "fastagent.config sessionControl" },
+      ]);
       expect(on.messages.some((m) => m.level === "warn" && /FASTAGENT_CONTROL_TOKEN/.test(m.text))).toBe(true);
     }
   });

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -523,14 +523,23 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
     expect(listed.find((s) => s.name === "X_API_KEY")?.hint).toBe("required by tools/x-post.mjs");
   });
 
-  it("warns when a code input cannot be loaded — its declarations cannot be carried", async () => {
+  it("warns when a code input cannot be loaded, and GATES --run on it", async () => {
+    // Generate-only warns: the operator may be producing artifacts on a machine that never installed
+    // the agent's deps. `--run` gates, because the BOX will load that file successfully and refuse to
+    // start on a declaration this deploy could not read — a crash loop after a "successful" deploy.
     const dir = await workspace();
     await mkdir(join(dir, "tools"), { recursive: true });
     await writeFile(join(dir, "tools", "broken.mjs"), `throw new Error("boom");\n`);
     const pre = await call(dir, { model: "openai/gpt-4o-mini" });
     expect(pre.ok).toBe(true);
-    if (!pre.ok) return;
-    expect(pre.messages.some((m) => m.level === "warn" && /tools\/broken\.mjs failed to load/.test(m.text))).toBe(true);
+    if (pre.ok) {
+      expect(pre.messages.some((m) => m.level === "warn" && /tools\/broken\.mjs failed to load/.test(m.text))).toBe(
+        true,
+      );
+    }
+    const run = await call(dir, { model: "openai/gpt-4o-mini" }, { run: true });
+    expect(run.ok).toBe(false);
+    if (!run.ok) expect(run.gate).toMatch(/tools\/broken\.mjs failed to load.*would refuse to start/);
   });
 
   it("sessionControl carries the plane's token as a deploy secret — a minted one is unreadable off-box", async () => {

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -133,6 +133,24 @@ describe("deploy/railway/run: the coding-agent deploy journey (benchmark)", () =
     expect(registerFeishu).toHaveBeenCalledWith("https://bot-production.up.railway.app", "feishu");
   });
 
+  it("names the secrets it sets — the list is no longer only what the author typed", async () => {
+    // A mounted tool/channel/schedule declares its own names, so a count is not enough for the
+    // operator to see what `--run` read from this machine and pushed to the host.
+    const { railway } = fakeRailway((args) => {
+      if (args[0] === "status") return { stdout: "" };
+      if (args[0] === "domain") return { stdout: DOMAIN_JSON };
+      return {};
+    });
+    const logs: string[] = [];
+    await deployRailwayRun(
+      plan({ secrets: { OPENAI_API_KEY: "sk", X_API_KEY: "x" } }),
+      railway,
+      (message) => logs.push(message),
+      { telegram: vi.fn(async (): Promise<RegistrationOutcome> => "registered") },
+    );
+    expect(logs.join("\n")).toContain("2 secret(s): OPENAI_API_KEY, X_API_KEY");
+  });
+
   it("secret values go over stdin (variable set --stdin), never argv", async () => {
     const { railway, calls } = fakeRailway((a) => {
       if (a[0] === "status") return { stdout: "" };

--- a/test/package-boundary.test.ts
+++ b/test/package-boundary.test.ts
@@ -190,7 +190,6 @@ describe("the assembly's parts stay out of the public surface", () => {
     "loadTools",
     "loadChannels",
     "loadSchedules",
-    "discoverScheduleFiles",
     "createScheduler",
     "scheduleSession",
     // pi-ai's own runtime function: forwarding it makes us answerable for an API we do not own.

--- a/test/schedule-discover.test.ts
+++ b/test/schedule-discover.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { discoverScheduleFiles, loadSchedules } from "../src/schedule/discover.ts";
+import { loadSchedules } from "../src/schedule/discover.ts";
 
 const scheduleHref = new URL("../src/schedule/schedule.ts", import.meta.url).href;
 const def = (cron: string, prompt = "go", tz?: string): string =>
@@ -22,7 +22,6 @@ describe("schedule/discover", () => {
     const { schedules, failures } = await loadSchedules(dir);
     expect(failures).toEqual([]);
     expect(schedules).toEqual([{ name: "daily", cron: "0 9 * * *", tz: "UTC", prompt: "digest" }]);
-    expect(await discoverScheduleFiles(dir)).toEqual(["daily"]);
   });
 
   it("isolates a file with an invalid cron — reported, not thrown (G2)", async () => {
@@ -41,7 +40,6 @@ describe("schedule/discover", () => {
 
   it("a missing schedules/ dir yields empty (no schedules is normal)", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-sd-empty-"));
-    expect(await discoverScheduleFiles(dir)).toEqual([]);
     expect((await loadSchedules(dir)).schedules).toEqual([]);
   });
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -562,6 +562,17 @@ describe("createAgentService", () => {
     await expect(createAgentService(dir)).rejects.toThrow(/ENOTDIR|not a directory/i);
   });
 
+  it("refuses to serve while a schedule's declared secret has no value", async () => {
+    // A schedule reads its env at IMPORT time, so an unset value has already produced a broken
+    // prompt by the time the scheduler starts — this is the last point it is still a startup failure
+    // rather than a wrong turn at 9am.
+    const dir = await agentDir({
+      "schedules/digest.mjs": `export default { cron: "0 9 * * *", prompt: "d", secrets: ["FA_TEST_DIGEST_CHANNEL"] };`,
+    });
+    delete process.env.FA_TEST_DIGEST_CHANNEL;
+    await expect(createAgentService(dir)).rejects.toThrow(/FA_TEST_DIGEST_CHANNEL \(schedules\/digest\.mjs\)/);
+  });
+
   it("surfaces a broken channel at open, rather than serving without it", async () => {
     const dir = await agentDir({ "channels/bad.mjs": `throw new Error("boom at import");` });
     await expect(createAgentService(dir)).rejects.toThrow(/channel setup is invalid|boom at import/);


### PR DESCRIPTION
Closes #473. Replaces #506, which reported the problem from outside the code instead of fixing where the knowledge lives.

## The hole this fills

"Which env vars does this agent need" had three declarations and one hole: a first-party channel declares its vars in the scaffold table, `config.deploy.secrets` lists names as bare strings, the model key is inferred — and a TOOL, the thing authors write most, declared nothing. Its need lived only inside `process.env.X` in its own body, so `deploy` could not carry it and nothing could check it: the name had to be copied by hand into `deploy.secrets`, and forgetting meant the deployed box read `undefined` on the first real call, days later, with the error only in the host's logs.

## The rule now

**Agent code declares what it needs and receives the values; it does not read `process.env`.** One shape (`{ name, source }`) in `src/declared-secrets.ts`, three authoring surfaces:

```ts
// tools/x-post.ts
export default defineTool({
  secrets: ["X_API_KEY", "X_API_SECRET"],
  async execute({ text }, ctx) { return post(text, ctx.secrets.X_API_KEY); },
});

// channels/acme.ts — a custom channel's credentials exist nowhere else
export default defineChannel({
  secrets: ["ACME_SECRET"],
  channel: (secrets) => acmeChannel({ secret: secrets.ACME_SECRET, on: … }),
});

// schedules/daily-digest.ts
export default defineSchedule({
  cron: "0 9 * * *",
  secrets: ["SLACK_DIGEST_CHANNEL"],
  prompt: (secrets) => `Post the digest to ${secrets.SLACK_DIGEST_CHANNEL}`,
});
```

Keys are typed from the list (a typo is a compile error), and a tool's values are read fresh per call, so a rotated credential needs no restart.

What the declaration buys:

- **`deploy` carries it.** No second list to sync. The runbook names the declaring file (`X_API_KEY: required by tools/x-post.ts`) and `--run` gates on a missing local value, as it already did for channel secrets. `config.deploy.secrets` now means "names no code declares" — a `models.json` header key, a value read by a third-party package.
- **`dev`/`start`/`fastagent tool` refuse to run** while a declared value is unset, naming the file — the contract a channel already had (an empty `botToken` fails `telegramChannel` at mount), extended to everything.
- **`fastagent info`** prints every declared name grouped by file, which have no local value, and which of those block boot. `--json` gains `declaredSecrets` / `unsetSecrets` / `channelFailures`.

A value that should be optional is simply not declared (the scaffolds keep `FEISHU_ENCRYPT_KEY` that way): the declaration is a request for a guarantee, not a description of the code.

## Placement

Loaders return declarations as DATA and never throw — `info` and the deploy pre-flight import the same files to report on them, on a machine that legitimately holds no secrets. The assertion runs on the paths that will execute the code (`resolveAgentAssembly`, `startSchedules`, `loadChannels`, `fastagent tool`) through one shared `assertSecretsSet`. A malformed `secrets:` is a load failure, not a silent drop.

## Two things that came with it

**The Feishu/Lark WebSocket scaffold is now a real template file** (`channel.websocket.ts`) instead of a text transform of the webhook one. The surgery — rename the factory, splice a header, delete the credential lines — had to be re-taught by hand on every template change, and a missed anchor scaffolded a channel configured for the wrong ingress with nothing failing.

**The deploy pre-flight loads schedules instead of listing filenames** (one read answers both "are there time triggers" and "what did they declare"). A file that fails to import still counts as a time trigger — the author will fix it, and a plan that scaled to zero because a cron was broken on deploy day would sleep through it afterwards — and any code input that fails to load is warned about, since its declarations cannot be carried.

## Limits

The process environment is still the transport, and it must be: a provider SDK reads its own variable, and the coding tools need `PATH` and `HOME`. What changes is that no authored file has a reason to reach into it. An author who writes `process.env.X` anyway gets today's behavior — nothing carries it, nothing checks it — and that is now off the documented path rather than the default one.

## Verification

`test/declared-secrets.test.ts` (the rule; all three declaration sites; typed injection and per-call freshness; a custom channel's declaration reaching `inspectChannels`; malformed declarations; the opener's refusal naming the file), `service.test.ts` for the schedule half, pre-flight cases for the carry and the load-failure warning, plus the existing scaffold/init suites. Manually: `add telegram` output, `info`, the fly runbook, and `start` refusing on an unset declared value.
