### PR TITLE
fix(cli): every command that enters an agent directory carries its proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,9 @@ src/
 ├── observe.ts              # turn-trace logging around an Agent
 ├── tunnel.ts               # `--tunnel`: cloudflared + per-channel webhook dispatch
 ├── dev-supervisor.ts       # `dev` supervisor: restart on code-input edits (definition is live-read per invoke)
-├── proxy.ts                # HTTPS_PROXY wiring
+├── proxy.ts                # the process's outbound-fetch policy: the declared proxy, loopback exempt by default
 ├── open-url.ts             # best-effort "open this in a browser" (callers still print the URL)
-├── env.ts                  # `.env` → process.env loading
+├── env.ts                  # ENTERING an agent's environment: its `.env` → process.env, and the egress that follows
 ├── runtime.ts              # agent runtime/package-manager detection (node vs bun) + readPackageJson
 ├── loader.ts               # neutral ESM discovery/loading + failure reporting for tools/ channels/ schedules/ config
 ├── paths.ts                # PLACEMENT (which directory is the agent, which is the workspace) + the shared

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -301,7 +301,13 @@ FastAgent CLI commands install proxy-aware fetch handling. Set standard proxy en
 HTTPS_PROXY=http://127.0.0.1:7890
 ```
 
-Then retry `fastagent login`, `fastagent dev`, or `fastagent start`.
+Then retry `fastagent login`, `fastagent dev`, or `fastagent start`. The variables may also live in the agent's
+`.secrets/.env` — every command reads it before deciding where its requests go, so a tool's `fetch`, a channel's
+app-creation flow and a skill download all follow the same proxy.
+
+Loopback (`localhost`, `127.0.0.1`, `::1`) stays direct unless you set `NO_PROXY` yourself, so a proxy variable does
+not break local health probes, `fastagent attach`, or an `ssh -L` forward. Setting `NO_PROXY` replaces that default
+entirely — include the loopback names in your own value.
 
 ## Need a machine-readable report
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -305,9 +305,10 @@ Then retry `fastagent login`, `fastagent dev`, or `fastagent start`. The variabl
 `.secrets/.env` — every command reads it before deciding where its requests go, so a tool's `fetch`, a channel's
 app-creation flow and a skill download all follow the same proxy.
 
-Loopback (`localhost`, `127.0.0.1`, `::1`) stays direct unless you set `NO_PROXY` yourself, so a proxy variable does
-not break local health probes, `fastagent attach`, or an `ssh -L` forward. Setting `NO_PROXY` replaces that default
-entirely — include the loopback names in your own value.
+Loopback (`localhost`, `127.0.0.1`, `::1`) always stays direct — it is added to whatever `NO_PROXY` you set, so a proxy
+variable does not break local health probes, `fastagent attach`, or an `ssh -L` forward. A LAN address is not loopback:
+if you run `fastagent dev --bind 192.168.1.5`, `fastagent attach` finds that address and sends it through the proxy —
+put it in `NO_PROXY` yourself.
 
 ## Need a machine-readable report
 

--- a/src/cli/add-slack.ts
+++ b/src/cli/add-slack.ts
@@ -3,7 +3,6 @@ import { basename } from "node:path";
 import { isCancel, log as clackLog, password, select, text as clackText } from "@clack/prompts";
 import { dotEnvPath, parseEnvContent } from "../env.ts";
 import { openExternalUrl } from "../open-url.ts";
-import { installProxyFetch } from "../proxy.ts";
 import { appendChannelDotEnv, type GroupBehaviorChoice } from "../scaffold/add-channel.ts";
 import { newSlackOnboardingState, onboardSlackApp } from "../channels/slack/onboard.ts";
 import {
@@ -78,7 +77,6 @@ export async function onboardSlackInternalApp(input: {
   /** `--replace-config`: go straight to replacing the local App Configuration token pair. */
   replaceConfig?: boolean;
 }): Promise<void> {
-  installProxyFetch();
   if (!(process.stdin.isTTY && process.stdout.isTTY)) {
     throw new Error(
       "`add slack` needs an interactive terminal for internal-app creation and OAuth — " +

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -278,6 +278,8 @@ export async function runAddSkill(
     );
   }
   // Skills are agent surface — vendored into the agent dir's `skills/`.
+  loadDotEnv(target); // a git-ref source is a network fetch (giget uses global fetch) — the proxy may be in .env
+  installProxyFetch();
   const { name, description, dest, hasScripts, diagnostics, overwritten } = await vendorSkill(target, source, {
     update: opts.update ?? false,
   }).catch(failStartup);

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -9,6 +9,7 @@ import { isCancel, select } from "@clack/prompts";
 import { onboardFeishuCloudApp } from "../add-feishu.ts";
 import type { FeishuSubscriptionMode } from "../../channels/feishu/setup-mode.ts";
 import { dotEnvPath, loadDotEnv } from "../../env.ts";
+import { installProxyFetch } from "../../proxy.ts";
 import { resolveStateRoot, SECRETS_DIRNAME, isUnderDir, displayPath } from "../../paths.ts";
 import { detectRuntime, readPackageJson } from "../../runtime.ts";
 import {
@@ -39,6 +40,7 @@ export async function runAddChannel(
   }
   const { agentDir: target } = placementOrExit(resolve(dirArg));
   loadDotEnv(target); // onboarding state follows the same FASTAGENT_STATE_DIR as serving/deploy
+  installProxyFetch(); // feishu/lark app creation talks to the platform — same proxy as everything else
   // Paths are printed to someone standing in their CWD, usually the workspace, while every file belongs to the AGENT
   // dir — prefix them, or they point at nothing.
   const agentFromCwd = displayPath(process.cwd(), target);

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -8,8 +8,7 @@ import { join, relative, resolve } from "node:path";
 import { isCancel, select } from "@clack/prompts";
 import { onboardFeishuCloudApp } from "../add-feishu.ts";
 import type { FeishuSubscriptionMode } from "../../channels/feishu/setup-mode.ts";
-import { dotEnvPath, loadDotEnv } from "../../env.ts";
-import { installProxyFetch } from "../../proxy.ts";
+import { dotEnvPath, enterAgentEnv } from "../../env.ts";
 import { resolveStateRoot, SECRETS_DIRNAME, isUnderDir, displayPath } from "../../paths.ts";
 import { detectRuntime, readPackageJson } from "../../runtime.ts";
 import {
@@ -39,8 +38,7 @@ export async function runAddChannel(
     failUsage("--replace-config replaces onboarding credentials; it cannot be combined with --no-onboard");
   }
   const { agentDir: target } = placementOrExit(resolve(dirArg));
-  loadDotEnv(target); // onboarding state follows the same FASTAGENT_STATE_DIR as serving/deploy
-  installProxyFetch(); // feishu/lark app creation talks to the platform — same proxy as everything else
+  enterAgentEnv(target); // onboarding state follows the same FASTAGENT_STATE_DIR as serving/deploy
   // Paths are printed to someone standing in their CWD, usually the workspace, while every file belongs to the AGENT
   // dir — prefix them, or they point at nothing.
   const agentFromCwd = displayPath(process.cwd(), target);
@@ -278,8 +276,7 @@ export async function runAddSkill(
     );
   }
   // Skills are agent surface — vendored into the agent dir's `skills/`.
-  loadDotEnv(target); // a git-ref source is a network fetch (giget uses global fetch) — the proxy may be in .env
-  installProxyFetch();
+  enterAgentEnv(target); // a git-ref source is a network fetch (giget uses global fetch)
   const { name, description, dest, hasScripts, diagnostics, overwritten } = await vendorSkill(target, source, {
     update: opts.update ?? false,
   }).catch(failStartup);

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -8,6 +8,7 @@ import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { loadDotEnv } from "../../env.ts";
 import { installProxyFetch } from "../../proxy.ts";
+import { classifyBind } from "../../bind.ts";
 import { resolveStateRoot } from "../../paths.ts";
 import { log, setLogLevel } from "../../log.ts";
 import { ABORTED_CODE, SESSION_BUSY_CODE } from "../../agent.ts";
@@ -122,13 +123,18 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
   // A REMOTE attach reads nothing under `dir`.
   const dir = remote ? resolve(dirArg ?? ".") : placementOrExit(resolve(dirArg ?? ".")).agentDir;
   if (!remote) loadDotEnv(dir);
-  // A remote endpoint is out on the internet, so its fetch/SSE must honour HTTP(S)_PROXY. Local discovery
-  // deliberately does not: it talks to 127.0.0.1, and proxying that breaks attach where no_proxy omits localhost.
-  if (remote) installProxyFetch();
   // For a discovered endpoint the FIRST read joins the startup budget below: the dev-watch restart window has two
   // halves.
   let endpoint!: { url: string; token: string };
   if (remote) endpoint = { url: opts.url as string, token: opts.token as string };
+  // The TARGET decides, not the flag: an endpoint out on the internet needs HTTP(S)_PROXY, while a loopback one (a
+  // discovered local serve, or an `ssh -L` forward given to --url) must stay direct — undici's EnvHttpProxyAgent
+  // proxies loopback too unless NO_PROXY happens to list it.
+  if (remote) {
+    const host = URL.parse(endpoint.url)?.hostname;
+    if (host === undefined) failStartup(new Error(`--url is not a valid URL: ${endpoint.url}`));
+    if (classifyBind(host) !== "loopback") installProxyFetch();
+  }
   const discovered = !remote;
   // ONE policy for both phases: startup and the round loop gather the same facts (errorFacts) and route them through
   // decideRound with their phase.

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -6,9 +6,8 @@
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
-import { loadDotEnv } from "../../env.ts";
+import { enterAgentEnv } from "../../env.ts";
 import { installProxyFetch } from "../../proxy.ts";
-import { classifyBind } from "../../bind.ts";
 import { resolveStateRoot } from "../../paths.ts";
 import { log, setLogLevel } from "../../log.ts";
 import { ABORTED_CODE, SESSION_BUSY_CODE } from "../../agent.ts";
@@ -122,19 +121,15 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
   }
   // A REMOTE attach reads nothing under `dir`.
   const dir = remote ? resolve(dirArg ?? ".") : placementOrExit(resolve(dirArg ?? ".")).agentDir;
-  if (!remote) loadDotEnv(dir);
+  // A remote attach has no agent directory to read, so its proxy can only come from the ambient environment; a
+  // discovered one enters the agent's. Either way the endpoint decides nothing here — loopback stays direct because
+  // the dispatcher exempts it, not because a command remembered to ask.
+  if (remote) installProxyFetch();
+  else enterAgentEnv(dir);
   // For a discovered endpoint the FIRST read joins the startup budget below: the dev-watch restart window has two
   // halves.
   let endpoint!: { url: string; token: string };
   if (remote) endpoint = { url: opts.url as string, token: opts.token as string };
-  // The TARGET decides, not the flag: an endpoint out on the internet needs HTTP(S)_PROXY, while a loopback one (a
-  // discovered local serve, or an `ssh -L` forward given to --url) must stay direct — undici's EnvHttpProxyAgent
-  // proxies loopback too unless NO_PROXY happens to list it.
-  if (remote) {
-    const host = URL.parse(endpoint.url)?.hostname;
-    if (host === undefined) failStartup(new Error(`--url is not a valid URL: ${endpoint.url}`));
-    if (classifyBind(host) !== "loopback") installProxyFetch();
-  }
   const discovered = !remote;
   // ONE policy for both phases: startup and the round loop gather the same facts (errorFacts) and route them through
   // decideRound with their phase.

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -7,6 +7,7 @@ import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { loadDotEnv } from "../../env.ts";
+import { installProxyFetch } from "../../proxy.ts";
 import { resolveStateRoot } from "../../paths.ts";
 import { log, setLogLevel } from "../../log.ts";
 import { ABORTED_CODE, SESSION_BUSY_CODE } from "../../agent.ts";
@@ -121,6 +122,9 @@ export async function runAttach(sessionArg: string, dirArg: string | undefined, 
   // A REMOTE attach reads nothing under `dir`.
   const dir = remote ? resolve(dirArg ?? ".") : placementOrExit(resolve(dirArg ?? ".")).agentDir;
   if (!remote) loadDotEnv(dir);
+  // A remote endpoint is out on the internet, so its fetch/SSE must honour HTTP(S)_PROXY. Local discovery
+  // deliberately does not: it talks to 127.0.0.1, and proxying that breaks attach where no_proxy omits localhost.
+  if (remote) installProxyFetch();
   // For a discovered endpoint the FIRST read joins the startup budget below: the dev-watch restart window has two
   // halves.
   let endpoint!: { url: string; token: string };

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -1,6 +1,6 @@
 /** `fastagent info [dir] [--json]`: print what the directory ASSEMBLES into, WITHOUT booting a server. */
 import { resolve } from "node:path";
-import { loadDotEnv } from "../../env.ts";
+import { enterAgentEnv } from "../../env.ts";
 import { inspectChannels } from "../../channels/discover.ts";
 import {
   defaultSessionsDir,
@@ -32,7 +32,7 @@ export interface InfoOptions {
 export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> {
   const dir = resolve(dirArg);
   const { agentDir, workspace } = placementOrExit(dir);
-  loadDotEnv(agentDir); // skills/tools may read env at load time
+  enterAgentEnv(agentDir); // skills/tools may read env — and fetch — at load time
   const { config, path: configPath } = await loadConfig(agentDir).catch(failStartup);
   const modelSpec = resolveModelSpec(opts.model, config);
   // agentDir = where the agent lives (definition + config + machinery); workspace = what it works ON (its cwd, whose

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -4,11 +4,10 @@
  */
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { loadDotEnv } from "../../env.ts";
+import { enterAgentEnv } from "../../env.ts";
 import { resolveAuthPath } from "../../engines/pi/config.ts";
 import { GLOBAL_HOME_DIR, findAgentDir, placementDeadEnd } from "../../paths.ts";
 import { LoginCancelled } from "../../engines/pi/login.ts";
-import { installProxyFetch } from "../../proxy.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
 import { isInteractive, loginWithKeyCheck } from "../shared.ts";
 
@@ -26,8 +25,9 @@ export async function runLogin(provider: string | undefined, opts: LoginOptions)
   // Outside any agent the target is the user-global machinery home — handed over explicitly, so the path resolvers
   // need no "is this $HOME?" special case to infer it.
   const loginDir = agentDir ?? join(homedir(), GLOBAL_HOME_DIR);
-  loadDotEnv(loginDir); // FASTAGENT_AUTH_PATH / a proxy (HTTPS_PROXY) may be configured in the project .env
-  installProxyFetch(); // the OAuth token exchange must go through HTTPS_PROXY (region-locked providers)
+  // FASTAGENT_AUTH_PATH and a proxy may both be configured in the project .env, and the OAuth token exchange must go
+  // through that proxy (region-locked providers).
+  enterAgentEnv(loginDir);
   const authPath = resolveAuthPath(loginDir, opts.authPath); // flag > FASTAGENT_AUTH_PATH > default — the one owner
   // Announce when the FALLBACK is what decided the target: outside an agent with no explicit path, the credential
   // lands somewhere no agent will read.

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -3,7 +3,7 @@ import { basename, resolve } from "node:path";
 import { agentcoreName } from "../../deploy/agentcore/plan.ts";
 import { type AgentcoreLogSource, tailAgentcoreLogs } from "../../deploy/agentcore/logs.ts";
 import { spawnRunner } from "../../deploy/runner.ts";
-import { loadDotEnv } from "../../env.ts";
+import { enterAgentEnv } from "../../env.ts";
 import { failStartup, failUsage, placementOrExit } from "../fail.ts";
 
 export interface AgentcoreLogsOptions {
@@ -16,7 +16,7 @@ export async function runLogs(host: string, dirArg: string, opts: AgentcoreLogsO
   // The host argument is DISPATCHED here, as in runDeploy.
   if (host !== "agentcore") failUsage(`logs: unsupported host "${host}" — only agentcore has remote logs`);
   const placement = placementOrExit(resolve(dirArg));
-  loadDotEnv(placement.agentDir); // AWS_PROFILE/region/proxy may be definition-local, as on deploy
+  enterAgentEnv(placement.agentDir); // AWS_PROFILE/region/proxy may be definition-local, as on deploy
   const source = opts.source ?? "runtime";
   if (source !== "runtime" && source !== "forwarder") {
     failUsage(`logs: --source must be "runtime" or "forwarder"`);

--- a/src/cli/commands/schedule.ts
+++ b/src/cli/commands/schedule.ts
@@ -1,6 +1,6 @@
 /** `fastagent schedule history|list|cancel`. */
 import { resolve } from "node:path";
-import { loadDotEnv } from "../../env.ts";
+import { enterAgentEnv } from "../../env.ts";
 import { resolveStateRoot } from "../../paths.ts";
 import { reportModuleLoadFailures } from "../../loader.ts";
 import { readRuns } from "../../schedule/audit.ts";
@@ -15,7 +15,7 @@ import { failStartup, placementOrExit } from "../fail.ts";
  */
 export function runScheduleHistory(name: string, dirArg: string, json: boolean): void {
   const { agentDir: target } = placementOrExit(resolve(dirArg));
-  loadDotEnv(target); // FASTAGENT_STATE_DIR may live in .env — read the SAME state root the scheduler wrote
+  enterAgentEnv(target); // FASTAGENT_STATE_DIR may live in .env — read the SAME state root the scheduler wrote
   const runs = readRuns(resolveStateRoot(target), name);
   if (json) {
     console.log(JSON.stringify(runs, null, 2));
@@ -42,7 +42,7 @@ export function runScheduleHistory(name: string, dirArg: string, json: boolean):
 /** `fastagent schedule list [dir]`: everything that will fire. */
 export async function runScheduleList(dirArg: string, json: boolean): Promise<void> {
   const { agentDir: target } = placementOrExit(resolve(dirArg));
-  loadDotEnv(target);
+  enterAgentEnv(target);
   const { schedules, failures } = await loadSchedules(target).catch(failStartup);
   reportModuleLoadFailures(failures);
   const wakeups = listWakeups(resolveStateRoot(target));
@@ -79,7 +79,7 @@ export async function runScheduleList(dirArg: string, json: boolean): Promise<vo
  */
 export function runScheduleCancel(id: string, dirArg: string): void {
   const { agentDir: target } = placementOrExit(resolve(dirArg));
-  loadDotEnv(target);
+  enterAgentEnv(target);
   if (removeWakeup(resolveStateRoot(target), id)) {
     // ponytail: the store's load→save is lock-free — a serving scheduler's claim-advance can race this write (window
     // = ms around each fire).

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -1,7 +1,6 @@
 /** `fastagent tool <name> '<json>' [dir]`: run one tool's body directly with JSON args — no model. */
 import { resolve } from "node:path";
-import { loadDotEnv } from "../../env.ts";
-import { installProxyFetch } from "../../proxy.ts";
+import { enterAgentEnv } from "../../env.ts";
 import { loadConfig } from "../../engines/pi/config.ts";
 
 import { resolveAgentTools } from "../../engines/pi/create.ts";
@@ -14,8 +13,7 @@ export async function runTool(name: string, argsJson: string, dirArg: string): P
   // (a runtime failure, exit 1).
   const args = parseToolArgs(argsJson);
   const { agentDir, workspace } = placementOrExit(resolve(dirArg));
-  loadDotEnv(agentDir); // a tool may read a key from .env
-  installProxyFetch(); // …and a tool that fetches needs the SAME proxy dev/start give it (.env may carry it)
+  enterAgentEnv(agentDir); // a tool may read a key from .env — and fetch through the proxy it declares
   const { config } = await loadConfig(agentDir).catch(failStartup);
   // The same tool set dev/start mount (all coding tools + config.tools + discovered, deduped), so the runner
   // exercises exactly what gets served.

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -1,6 +1,7 @@
 /** `fastagent tool <name> '<json>' [dir]`: run one tool's body directly with JSON args — no model. */
 import { resolve } from "node:path";
 import { loadDotEnv } from "../../env.ts";
+import { installProxyFetch } from "../../proxy.ts";
 import { loadConfig } from "../../engines/pi/config.ts";
 
 import { resolveAgentTools } from "../../engines/pi/create.ts";
@@ -14,6 +15,7 @@ export async function runTool(name: string, argsJson: string, dirArg: string): P
   const args = parseToolArgs(argsJson);
   const { agentDir, workspace } = placementOrExit(resolve(dirArg));
   loadDotEnv(agentDir); // a tool may read a key from .env
+  installProxyFetch(); // …and a tool that fetches needs the SAME proxy dev/start give it (.env may carry it)
   const { config } = await loadConfig(agentDir).catch(failStartup);
   // The same tool set dev/start mount (all coding tools + config.tools + discovered, deduped), so the runner
   // exercises exactly what gets served.

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -34,9 +34,8 @@ import type { ToolCollision } from "../engines/pi/tool.ts";
 import { reportFindingsIfChanged, reportToolCollisions } from "../engines/pi/report.ts";
 import { type ResolvedPlacement, workspaceHint } from "../paths.ts";
 import { log } from "../log.ts";
-import { loadDotEnv } from "../env.ts";
+import { enterAgentEnv } from "../env.ts";
 import { openExternalUrl } from "../open-url.ts";
-import { installProxyFetch } from "../proxy.ts";
 import { bindAddress, isBindAddress } from "../bind.ts";
 import { failStartup, failUsage, placementOrExit } from "./fail.ts";
 
@@ -46,8 +45,7 @@ export async function enterAgentCommand(
   opts: { model?: string; authPath?: string; input?: boolean },
 ): Promise<ResolvedPlacement> {
   const placement = placementOrExit(resolve(dirArg));
-  loadDotEnv(placement.agentDir);
-  installProxyFetch();
+  enterAgentEnv(placement.agentDir);
   await resolveFirstRunModel(placement.agentDir, opts);
   return placement;
 }

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -14,7 +14,6 @@ import {
 } from "./paths.ts";
 import { dotEnvPath } from "./env.ts";
 import { log } from "./log.ts";
-import { installProxyFetch } from "./proxy.ts";
 import { openExternalUrl } from "./open-url.ts";
 import { declaredChannels } from "./channels/discover.ts";
 import { type Tunnel, announceWebhooks, startCloudflareTunnel } from "./tunnel.ts";
@@ -60,9 +59,6 @@ export async function runDevSupervisor(
   // The supervisor owns the tunnel so the public URL survives worker reloads (a fresh tunnel per save would mean a
   // new URL + re-registering the webhook on every edit).
   let tunnel: Tunnel | undefined;
-  // The supervisor itself calls the channel webhook APIs (setWebhook) when announcing the tunnel, so it needs the
-  // proxy too (workers install their own).
-  if (options.tunnel) installProxyFetch();
 
   const spawnWorker = (): void => {
     // ipc fd so the worker can signal readiness once it binds; stdio otherwise inherited.

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { log } from "./log.ts";
+import { installProxyFetch } from "./proxy.ts";
 import { SECRETS_DIRNAME, resolveSecretsDir } from "./paths.ts";
 
 /**
@@ -42,8 +43,24 @@ export function envExamplePath(agentDir: string): string {
 }
 
 /**
+ * ENTER an agent directory's runtime environment: its `.env` becomes `process.env`, and this process's outbound fetch
+ * follows whatever proxy that (or the ambient environment) declares.
+ *
+ * ONE function because the two steps are one fact in a fixed order — the proxy can be declared in the `.env`, so it
+ * has to be read first, and `installProxyFetch` reads the environment at construction. Every command used to spell
+ * the pair out itself, and the ones that spelled out only half (`tool`, `add`, `attach`) shipped the bug this exists
+ * to make unrepresentable: an authored tool, a channel's app-creation flow, or a skill download connecting DIRECT on a
+ * machine that has no direct route. Whether a given request then uses the proxy is the dispatcher's decision, not the
+ * caller's — see {@link installProxyFetch} on loopback.
+ */
+export function enterAgentEnv(agentDir: string): void {
+  loadDotEnv(agentDir);
+  installProxyFetch();
+}
+
+/**
  * Load the agent's `.env` ({@link dotEnvPath}) into `process.env` ({@link loadEnvFile}), treating a MISSING file as
- * normal (no .env).
+ * normal (no .env). Commands want {@link enterAgentEnv}, which is this plus the proxy that `.env` may declare.
  */
 export function loadDotEnv(agentDir: string): void {
   const path = dotEnvPath(agentDir);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,9 +5,39 @@ import * as undici from "undici";
 /** The Bun runtime (`process.versions.bun` is set only there). */
 const isBun = typeof process.versions.bun === "string";
 
-/** Route fetch through HTTPS_PROXY and keep fetch + dispatcher on the SAME undici implementation. */
+/**
+ * What is exempt from the proxy when nobody said. `EnvHttpProxyAgent` proxies EVERYTHING while NO_PROXY is empty —
+ * loopback included ("Always proxy if NO_PROXY is not set or empty") — so installing a proxy would otherwise send this
+ * process's own local traffic through it: a Docker health probe on 127.0.0.1, a control-plane call to a local serve, an
+ * `ssh -L` forward given to `attach --url`. None of those are what a proxy variable is asking for.
+ */
+const LOOPBACK = "localhost,127.0.0.1,::1";
+
+/** The install is process-global and once is enough; a second call would only leak the first dispatcher (nothing
+ *  closes it) and re-read the same environment. */
+let installed = false;
+
+/** Whoever owned `fetch` before this module loaded. A caller that replaced it since (a test's mock, an embedder's
+ *  instrumentation) meant it, so the swap below leaves it alone — the dispatcher still routes everything that runs
+ *  on undici's global. */
+const originalFetch = globalThis.fetch;
+
+/**
+ * Point this process's fetch at the proxy the environment declares, with loopback exempt by default.
+ *
+ * Two jobs in one, and both are needed UNDER NODE: Node's fetch does not honor HTTP(S)_PROXY at all, and Node 26's
+ * bundled fetch skips gzip decompression when it dispatches through npm undici (empty `stopReason:"stop"`), so fetch
+ * and the dispatcher must come from the SAME undici. No-op under Bun, whose native fetch already does both (and
+ * lacks these entry points).
+ *
+ * Call it through `enterAgentEnv` (env.ts) rather than directly: the proxy may be declared in the agent's own `.env`,
+ * so it has to be read first. The only direct callers are the ones with no agent directory to read.
+ */
 export function installProxyFetch(): void {
-  if (isBun) return;
-  undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent());
-  undici.install();
+  if (isBun || installed) return;
+  installed = true;
+  // Mirroring undici's own precedence (lowercase first) so our default cannot disagree with the value it would read.
+  const noProxy = process.env.no_proxy ?? process.env.NO_PROXY ?? LOOPBACK;
+  undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent({ noProxy }));
+  if (globalThis.fetch === originalFetch) undici.install();
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,12 +6,32 @@ import * as undici from "undici";
 const isBun = typeof process.versions.bun === "string";
 
 /**
- * What is exempt from the proxy when nobody said. `EnvHttpProxyAgent` proxies EVERYTHING while NO_PROXY is empty —
- * loopback included ("Always proxy if NO_PROXY is not set or empty") — so installing a proxy would otherwise send this
- * process's own local traffic through it: a Docker health probe on 127.0.0.1, a control-plane call to a local serve, an
- * `ssh -L` forward given to `attach --url`. None of those are what a proxy variable is asking for.
+ * What is ALWAYS exempt from the proxy. `EnvHttpProxyAgent` proxies EVERYTHING while NO_PROXY is empty — loopback
+ * included ("Always proxy if NO_PROXY is not set or empty") — so installing a proxy would otherwise send this process's
+ * own local traffic through it: a Docker health probe on 127.0.0.1, a control-plane call to a local serve, an `ssh -L`
+ * forward given to `attach --url`. None of those are what a proxy variable is asking for.
+ *
+ * APPENDED to a declared NO_PROXY rather than used as its default, because `NO_PROXY=.corp.com` is the normal shape of
+ * a corporate environment and it is not a statement about 127.0.0.1: replacing would hand exactly the users who have a
+ * proxy back the failure this exists to remove, as a probe timeout rather than an error.
  */
 const LOOPBACK = "localhost,127.0.0.1,::1";
+
+/**
+ * The exemption list the dispatcher is built with: whatever the environment declares, plus {@link LOOPBACK}.
+ *
+ * Its own function because installing happens ONCE per process, so these branches are unreachable through
+ * {@link installProxyFetch} — and the wildcard one is the kind that is silently wrong until someone reads it.
+ */
+export function noProxyList(env: NodeJS.ProcessEnv = process.env): string {
+  // Mirroring undici's own precedence (lowercase first) so our value cannot disagree with the one it would read.
+  // `||`, not `??`: a `NO_PROXY=` line in a .env is an empty string, and undici treats it as "proxy everything".
+  const declared = (env.no_proxy || env.NO_PROXY)?.trim();
+  if (!declared) return LOOPBACK;
+  // `*` is undici's "never proxy anything", matched EXACTLY (`#noProxyValue === '*'`). Appending would demote it to a
+  // hostname that matches nothing — turning "disable the proxy" into "proxy everything but loopback".
+  return declared === "*" ? declared : `${declared},${LOOPBACK}`;
+}
 
 /** The install is process-global and once is enough; a second call would only leak the first dispatcher (nothing
  *  closes it) and re-read the same environment. */
@@ -35,9 +55,8 @@ const originalFetch = globalThis.fetch;
  */
 export function installProxyFetch(): void {
   if (isBun || installed) return;
-  installed = true;
-  // Mirroring undici's own precedence (lowercase first) so our default cannot disagree with the value it would read.
-  const noProxy = process.env.no_proxy ?? process.env.NO_PROXY ?? LOOPBACK;
-  undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent({ noProxy }));
+  undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent({ noProxy: noProxyList() }));
+  // Skipping `install` leaves the caller's fetch in place, and with it Node 26's missing gzip decompression above.
   if (globalThis.fetch === originalFetch) undici.install();
+  installed = true; // last: a throw above must leave the latch open, or the process runs un-proxied forever
 }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -10,7 +10,8 @@ import { registerFeishuWebhook } from "./channels/feishu/register-webhook.ts";
 import { registerSlackWebhook } from "./channels/slack/register-webhook.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
 import { pointChannelsAt } from "./deploy/channel-ingress.ts";
-import { dotEnvPath, enterAgentEnv } from "./env.ts";
+import { dotEnvPath, loadDotEnv } from "./env.ts";
+import { installProxyFetch } from "./proxy.ts";
 import { resolveStateRoot } from "./paths.ts";
 import { log } from "./log.ts";
 
@@ -163,11 +164,13 @@ export async function announceWebhooks(
 ): Promise<{ kind: string; outcome: RegistrationOutcome }[]> {
   log.info(`[fastagent] public URL: ${baseUrl}`);
   try {
-    enterAgentEnv(dir); // webhook registrars read channel credentials from .env
+    loadDotEnv(dir); // webhook registrars read channel credentials from .env
   } catch (error) {
-    // best-effort boundary: a MISSING .env is already tolerated by enterAgentEnv.
+    // best-effort boundary: an unreadable .env (a MISSING one is already tolerated) still leaves registrars that can
+    // report their own missing credentials, so this one names the file instead of aborting the tunnel announcement.
     log.warn(`[fastagent] could not read ${dotEnvPath(dir)}: ${(error as Error).message} — continuing without it`);
   }
+  installProxyFetch(); // the registrars' platform calls follow the proxy that .env may declare
   // Readiness is the registrar's job: a fresh quick tunnel returns Cloudflare 530 for ~20-30s before its origin
   // connects, and each registrar absorbs that by retrying the platform call whose own URL verification reports it.
   const feishuOptions = {

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -10,7 +10,7 @@ import { registerFeishuWebhook } from "./channels/feishu/register-webhook.ts";
 import { registerSlackWebhook } from "./channels/slack/register-webhook.ts";
 import { registerTelegramWebhook } from "./channels/telegram/register-webhook.ts";
 import { pointChannelsAt } from "./deploy/channel-ingress.ts";
-import { dotEnvPath, loadDotEnv } from "./env.ts";
+import { dotEnvPath, enterAgentEnv } from "./env.ts";
 import { resolveStateRoot } from "./paths.ts";
 import { log } from "./log.ts";
 
@@ -163,9 +163,9 @@ export async function announceWebhooks(
 ): Promise<{ kind: string; outcome: RegistrationOutcome }[]> {
   log.info(`[fastagent] public URL: ${baseUrl}`);
   try {
-    loadDotEnv(dir); // webhook registrars read channel credentials from .env
+    enterAgentEnv(dir); // webhook registrars read channel credentials from .env
   } catch (error) {
-    // best-effort boundary: a MISSING .env is already tolerated by loadDotEnv.
+    // best-effort boundary: a MISSING .env is already tolerated by enterAgentEnv.
     log.warn(`[fastagent] could not read ${dotEnvPath(dir)}: ${(error as Error).message} — continuing without it`);
   }
   // Readiness is the registrar's job: a fresh quick tunnel returns Cloudflare 530 for ~20-30s before its origin

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -188,6 +188,47 @@ describe("cli papercuts", () => {
     }
   });
 
+  it("tool runs an authored tool through the agent's proxy, not a direct connection", async () => {
+    // Regression (#474): `tool` loaded .env but skipped installProxyFetch(), so an authored tool built on
+    // fetch failed with a bare undici connect timeout on a machine that needs a proxy — while dev/start ran
+    // the same tool fine. Same probe as the deploy test: the reserved .invalid host resolves only via the
+    // local proxy, so a direct connection cannot pass.
+    const requests: string[] = [];
+    const proxy = createServer((req, res) => {
+      requests.push(req.url ?? "");
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("proxied");
+    });
+    await new Promise<void>((resolve, reject) => {
+      proxy.once("error", reject);
+      proxy.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = proxy.address();
+      if (!address || typeof address === "string") throw new Error("proxy did not bind a TCP port");
+      const proxyUrl = `http://127.0.0.1:${address.port}`;
+      const dir = await agentWorkspace("fa-tool-proxy-", {
+        ".secrets/.env": `HTTP_PROXY=${proxyUrl}\nHTTPS_PROXY=${proxyUrl}\n`,
+        "tools/probe.mjs":
+          `export default { description: "Probe", parameters: { type: "object" }, async execute() {\n` +
+          `  const res = await fetch("http://tool-proxy.invalid/probe");\n` +
+          `  return await res.text();\n` +
+          `} };\n`,
+      });
+      const env = { ...process.env };
+      for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]) {
+        delete env[key]; // the proxy must come from the agent's .env, loaded inside runTool()
+      }
+
+      const { code, stderr } = await run(["tool", "probe", "{}", dir], undefined, env);
+      expect(code, stderr).toBe(0);
+      expect(requests).toContain("http://tool-proxy.invalid/probe");
+    } finally {
+      await new Promise<void>((resolve, reject) => proxy.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
   it("--version / -v prints the version to stdout and exits 0 (no parse crash)", async () => {
     const v = await run(["--version"]);
     expect(v.code).toBe(0);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -41,6 +41,35 @@ function run(
   });
 }
 
+/** Run `body` against a local HTTP proxy that answers everything 200 and records the URLs it was asked for. The
+ *  `env` it hands over has every proxy variable stripped, so a command can only find one by loading the agent's
+ *  own `.env` — which is what these tests are about. */
+async function withLocalProxy(
+  body: (proxyUrl: string, env: NodeJS.ProcessEnv, requests: string[]) => Promise<void>,
+): Promise<void> {
+  const requests: string[] = [];
+  const proxy = createServer((req, res) => {
+    requests.push(req.url ?? "");
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("proxied");
+  });
+  await new Promise<void>((resolve, reject) => {
+    proxy.once("error", reject);
+    proxy.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const address = proxy.address();
+    if (!address || typeof address === "string") throw new Error("proxy did not bind a TCP port");
+    const env = { ...process.env };
+    for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]) {
+      delete env[key];
+    }
+    await body(`http://127.0.0.1:${address.port}`, env, requests);
+  } finally {
+    await new Promise<void>((resolve, reject) => proxy.close((error) => (error ? reject(error) : resolve())));
+  }
+}
+
 describe("cli papercuts", () => {
   it("deploy WIRES the ownership rule — the real command keeps a file it did not generate", async () => {
     // The rule itself (exists x ours x force) is a state machine, tested at its own level in
@@ -152,21 +181,7 @@ describe("cli papercuts", () => {
     // Regression: the Node CLI used to load .env but omit installProxyFetch(), so post-deploy channel
     // calls bypassed HTTP(S)_PROXY. A config-time fetch gives the real CLI path an early network probe;
     // the reserved .invalid host can succeed only when the .env-only local proxy was installed first.
-    const requests: string[] = [];
-    const proxy = createServer((req, res) => {
-      requests.push(req.url ?? "");
-      res.writeHead(200, { "content-type": "text/plain" });
-      res.end("proxied");
-    });
-    await new Promise<void>((resolve, reject) => {
-      proxy.once("error", reject);
-      proxy.listen(0, "127.0.0.1", resolve);
-    });
-
-    try {
-      const address = proxy.address();
-      if (!address || typeof address === "string") throw new Error("proxy did not bind a TCP port");
-      const proxyUrl = `http://127.0.0.1:${address.port}`;
+    await withLocalProxy(async (proxyUrl, env, requests) => {
       const dir = await agentWorkspace("fa-deploy-proxy-", {
         ".secrets/.env": `HTTP_PROXY=${proxyUrl}\nHTTPS_PROXY=${proxyUrl}\n`,
         "fastagent.config.mjs":
@@ -175,17 +190,11 @@ describe("cli papercuts", () => {
           `export default { model: "openai-codex/gpt-5.5" };\n`,
       });
       await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
-      const env = { ...process.env };
-      for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]) {
-        delete env[key]; // the proxy must come from the agent's .env, loaded inside runDeploy()
-      }
 
       const { code, stderr } = await run(["deploy", "fly", dir], undefined, env);
       expect(code, stderr).toBe(0);
       expect(requests).toContain("http://deploy-proxy.invalid/probe");
-    } finally {
-      await new Promise<void>((resolve, reject) => proxy.close((error) => (error ? reject(error) : resolve())));
-    }
+    });
   });
 
   it("tool runs an authored tool through the agent's proxy, not a direct connection", async () => {
@@ -193,21 +202,7 @@ describe("cli papercuts", () => {
     // fetch failed with a bare undici connect timeout on a machine that needs a proxy — while dev/start ran
     // the same tool fine. Same probe as the deploy test: the reserved .invalid host resolves only via the
     // local proxy, so a direct connection cannot pass.
-    const requests: string[] = [];
-    const proxy = createServer((req, res) => {
-      requests.push(req.url ?? "");
-      res.writeHead(200, { "content-type": "text/plain" });
-      res.end("proxied");
-    });
-    await new Promise<void>((resolve, reject) => {
-      proxy.once("error", reject);
-      proxy.listen(0, "127.0.0.1", resolve);
-    });
-
-    try {
-      const address = proxy.address();
-      if (!address || typeof address === "string") throw new Error("proxy did not bind a TCP port");
-      const proxyUrl = `http://127.0.0.1:${address.port}`;
+    await withLocalProxy(async (proxyUrl, env, requests) => {
       const dir = await agentWorkspace("fa-tool-proxy-", {
         ".secrets/.env": `HTTP_PROXY=${proxyUrl}\nHTTPS_PROXY=${proxyUrl}\n`,
         "tools/probe.mjs":
@@ -216,17 +211,26 @@ describe("cli papercuts", () => {
           `  return await res.text();\n` +
           `} };\n`,
       });
-      const env = { ...process.env };
-      for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]) {
-        delete env[key]; // the proxy must come from the agent's .env, loaded inside runTool()
-      }
 
       const { code, stderr } = await run(["tool", "probe", "{}", dir], undefined, env);
       expect(code, stderr).toBe(0);
       expect(requests).toContain("http://tool-proxy.invalid/probe");
-    } finally {
-      await new Promise<void>((resolve, reject) => proxy.close((error) => (error ? reject(error) : resolve())));
-    }
+    });
+  });
+
+  it("add skill downloads a remote source through the agent's proxy", async () => {
+    // The vendor path fetches with giget, which is built on global fetch — so it needs the same proxy the rest of
+    // the CLI installs. The download is REACHED here, not completed: the stub proxy answers text/plain, so giget
+    // fails to unpack and the command exits 1 — what is asserted is which route the request took.
+    await withLocalProxy(async (proxyUrl, env, requests) => {
+      const dir = await agentWorkspace("fa-skill-proxy-", {
+        ".secrets/.env": `HTTP_PROXY=${proxyUrl}\nHTTPS_PROXY=${proxyUrl}\n`,
+      });
+
+      const { code } = await run(["add", "skill", "http://skill-proxy.invalid/skill.tar.gz", dir], undefined, env);
+      expect(code).toBe(1);
+      expect(requests).toContain("http://skill-proxy.invalid/skill.tar.gz");
+    });
   });
 
   it("--version / -v prints the version to stdout and exits 0 (no parse crash)", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -41,35 +41,6 @@ function run(
   });
 }
 
-/** Run `body` against a local HTTP proxy that answers everything 200 and records the URLs it was asked for. The
- *  `env` it hands over has every proxy variable stripped, so a command can only find one by loading the agent's
- *  own `.env` — which is what these tests are about. */
-async function withLocalProxy(
-  body: (proxyUrl: string, env: NodeJS.ProcessEnv, requests: string[]) => Promise<void>,
-): Promise<void> {
-  const requests: string[] = [];
-  const proxy = createServer((req, res) => {
-    requests.push(req.url ?? "");
-    res.writeHead(200, { "content-type": "text/plain" });
-    res.end("proxied");
-  });
-  await new Promise<void>((resolve, reject) => {
-    proxy.once("error", reject);
-    proxy.listen(0, "127.0.0.1", resolve);
-  });
-  try {
-    const address = proxy.address();
-    if (!address || typeof address === "string") throw new Error("proxy did not bind a TCP port");
-    const env = { ...process.env };
-    for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]) {
-      delete env[key];
-    }
-    await body(`http://127.0.0.1:${address.port}`, env, requests);
-  } finally {
-    await new Promise<void>((resolve, reject) => proxy.close((error) => (error ? reject(error) : resolve())));
-  }
-}
-
 describe("cli papercuts", () => {
   it("deploy WIRES the ownership rule — the real command keeps a file it did not generate", async () => {
     // The rule itself (exists x ours x force) is a state machine, tested at its own level in
@@ -177,32 +148,26 @@ describe("cli papercuts", () => {
     expect(await readFile(join(dir, "fastagent", "fastagent.compose.yml"), "utf8")).toBe(compose);
   });
 
-  it("deploy loads .env and installs its proxy before config-time network work", async () => {
-    // Regression: the Node CLI used to load .env but omit installProxyFetch(), so post-deploy channel
-    // calls bypassed HTTP(S)_PROXY. A config-time fetch gives the real CLI path an early network probe;
-    // the reserved .invalid host can succeed only when the .env-only local proxy was installed first.
-    await withLocalProxy(async (proxyUrl, env, requests) => {
-      const dir = await agentWorkspace("fa-deploy-proxy-", {
-        ".secrets/.env": `HTTP_PROXY=${proxyUrl}\nHTTPS_PROXY=${proxyUrl}\n`,
-        "fastagent.config.mjs":
-          `const response = await fetch("http://deploy-proxy.invalid/probe");\n` +
-          `if (!response.ok) throw new Error("proxy probe failed");\n` +
-          `export default { model: "openai-codex/gpt-5.5" };\n`,
-      });
-      await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
-
-      const { code, stderr } = await run(["deploy", "fly", dir], undefined, env);
-      expect(code, stderr).toBe(0);
-      expect(requests).toContain("http://deploy-proxy.invalid/probe");
+  it("a command ENTERS the agent's environment: a proxy declared only in .env carries a tool's fetch", async () => {
+    // The WIRING half of #474 (the policy itself is test/proxy.test.ts): a real CLI process, a proxy that exists
+    // nowhere but the agent's `.env`, and an authored tool that fetches. `enterAgentEnv` is what makes the two
+    // steps inseparable — the bug was commands that did only the first. The reserved .invalid host resolves
+    // nowhere, so a direct connection cannot pass.
+    const requests: string[] = [];
+    const proxy = createServer((req, res) => {
+      requests.push(req.url ?? "");
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("proxied");
     });
-  });
+    await new Promise<void>((resolve, reject) => {
+      proxy.once("error", reject);
+      proxy.listen(0, "127.0.0.1", resolve);
+    });
 
-  it("tool runs an authored tool through the agent's proxy, not a direct connection", async () => {
-    // Regression (#474): `tool` loaded .env but skipped installProxyFetch(), so an authored tool built on
-    // fetch failed with a bare undici connect timeout on a machine that needs a proxy — while dev/start ran
-    // the same tool fine. Same probe as the deploy test: the reserved .invalid host resolves only via the
-    // local proxy, so a direct connection cannot pass.
-    await withLocalProxy(async (proxyUrl, env, requests) => {
+    try {
+      const address = proxy.address();
+      if (!address || typeof address === "string") throw new Error("proxy did not bind a TCP port");
+      const proxyUrl = `http://127.0.0.1:${address.port}`;
       const dir = await agentWorkspace("fa-tool-proxy-", {
         ".secrets/.env": `HTTP_PROXY=${proxyUrl}\nHTTPS_PROXY=${proxyUrl}\n`,
         "tools/probe.mjs":
@@ -211,26 +176,17 @@ describe("cli papercuts", () => {
           `  return await res.text();\n` +
           `} };\n`,
       });
+      const env = { ...process.env };
+      for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]) {
+        delete env[key]; // the proxy must come from the agent's .env, read inside the command
+      }
 
       const { code, stderr } = await run(["tool", "probe", "{}", dir], undefined, env);
       expect(code, stderr).toBe(0);
       expect(requests).toContain("http://tool-proxy.invalid/probe");
-    });
-  });
-
-  it("add skill downloads a remote source through the agent's proxy", async () => {
-    // The vendor path fetches with giget, which is built on global fetch — so it needs the same proxy the rest of
-    // the CLI installs. The download is REACHED here, not completed: the stub proxy answers text/plain, so giget
-    // fails to unpack and the command exits 1 — what is asserted is which route the request took.
-    await withLocalProxy(async (proxyUrl, env, requests) => {
-      const dir = await agentWorkspace("fa-skill-proxy-", {
-        ".secrets/.env": `HTTP_PROXY=${proxyUrl}\nHTTPS_PROXY=${proxyUrl}\n`,
-      });
-
-      const { code } = await run(["add", "skill", "http://skill-proxy.invalid/skill.tar.gz", dir], undefined, env);
-      expect(code).toBe(1);
-      expect(requests).toContain("http://skill-proxy.invalid/skill.tar.gz");
-    });
+    } finally {
+      await new Promise<void>((resolve, reject) => proxy.close((error) => (error ? reject(error) : resolve())));
+    }
   });
 
   it("--version / -v prints the version to stdout and exits 0 (no parse crash)", async () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { installProxyFetch } from "../src/proxy.ts";
+
+/**
+ * The egress POLICY itself, in-process: which destinations the installed dispatcher sends through the proxy.
+ *
+ * This is the level the per-command subprocess tests were standing in for. `installProxyFetch` is process-global and
+ * installs once, so this file gets one install and asks it both questions — which is also why the policy lives in one
+ * function: a caller cannot ask for half of it.
+ */
+
+/** A server that records the request lines it was asked for and answers 200. As a proxy it sees absolute-form URLs
+ *  ("http://host/path"); as an origin it sees the path. */
+function recordingServer(seen: string[]): Promise<{ server: Server; port: number }> {
+  const server = createServer((req, res) => {
+    seen.push(req.url ?? "");
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("ok");
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") return reject(new Error("no TCP port"));
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+const proxied: string[] = [];
+const direct: string[] = [];
+let proxy!: Server;
+let origin!: Server;
+let originUrl!: string;
+
+beforeAll(async () => {
+  const p = await recordingServer(proxied);
+  const o = await recordingServer(direct);
+  proxy = p.server;
+  origin = o.server;
+  originUrl = `http://127.0.0.1:${o.port}/local`;
+  process.env.HTTP_PROXY = `http://127.0.0.1:${p.port}`;
+  process.env.HTTPS_PROXY = process.env.HTTP_PROXY;
+  for (const key of ["NO_PROXY", "no_proxy", "http_proxy", "https_proxy"]) delete process.env[key];
+  installProxyFetch();
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => proxy.close(() => resolve()));
+  await new Promise<void>((resolve) => origin.close(() => resolve()));
+});
+
+describe("installProxyFetch: what the process's fetch does with a declared proxy", () => {
+  it("sends an external destination through the proxy", async () => {
+    const res = await fetch("http://external.invalid/probe");
+    expect(res.status).toBe(200);
+    expect(proxied).toContain("http://external.invalid/probe");
+  });
+
+  it("leaves loopback direct even though NO_PROXY is unset", async () => {
+    // undici's EnvHttpProxyAgent proxies EVERYTHING while NO_PROXY is empty. Without our default, installing a proxy
+    // would break this process's own local traffic: health probes, control-plane calls, an `ssh -L` forward.
+    const res = await fetch(originUrl);
+    expect(res.status).toBe(200);
+    expect(direct).toContain("/local");
+    expect(proxied.some((url) => url.includes("127.0.0.1"))).toBe(false);
+  });
+});

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createServer, type Server } from "node:http";
-import { installProxyFetch } from "../src/proxy.ts";
+import { installProxyFetch, noProxyList } from "../src/proxy.ts";
 
 /**
  * The egress POLICY itself, in-process: which destinations the installed dispatcher sends through the proxy.
@@ -42,13 +42,31 @@ beforeAll(async () => {
   originUrl = `http://127.0.0.1:${o.port}/local`;
   process.env.HTTP_PROXY = `http://127.0.0.1:${p.port}`;
   process.env.HTTPS_PROXY = process.env.HTTP_PROXY;
-  for (const key of ["NO_PROXY", "no_proxy", "http_proxy", "https_proxy"]) delete process.env[key];
+  for (const key of ["no_proxy", "http_proxy", "https_proxy"]) delete process.env[key];
+  // The shape a corporate environment actually has: a declared exemption that says nothing about 127.0.0.1.
+  process.env.NO_PROXY = ".corp.invalid";
   installProxyFetch();
 });
 
 afterAll(async () => {
   await new Promise<void>((resolve) => proxy.close(() => resolve()));
   await new Promise<void>((resolve) => origin.close(() => resolve()));
+});
+
+describe("noProxyList: what the dispatcher is told to exempt", () => {
+  it("exempts loopback when nothing is declared, including a `NO_PROXY=` line in a .env", () => {
+    expect(noProxyList({})).toBe("localhost,127.0.0.1,::1");
+    expect(noProxyList({ NO_PROXY: "" })).toBe("localhost,127.0.0.1,::1");
+  });
+
+  it("APPENDS to a declared value instead of replacing it (lowercase wins, as in undici)", () => {
+    expect(noProxyList({ NO_PROXY: ".corp.com" })).toBe(".corp.com,localhost,127.0.0.1,::1");
+    expect(noProxyList({ no_proxy: ".a.com", NO_PROXY: ".b.com" })).toBe(".a.com,localhost,127.0.0.1,::1");
+  });
+
+  it("leaves the `*` wildcard exact — appending would turn “no proxy at all” into “proxy everything but loopback”", () => {
+    expect(noProxyList({ NO_PROXY: "*" })).toBe("*");
+  });
 });
 
 describe("installProxyFetch: what the process's fetch does with a declared proxy", () => {
@@ -58,9 +76,10 @@ describe("installProxyFetch: what the process's fetch does with a declared proxy
     expect(proxied).toContain("http://external.invalid/probe");
   });
 
-  it("leaves loopback direct even though NO_PROXY is unset", async () => {
-    // undici's EnvHttpProxyAgent proxies EVERYTHING while NO_PROXY is empty. Without our default, installing a proxy
-    // would break this process's own local traffic: health probes, control-plane calls, an `ssh -L` forward.
+  it("leaves loopback direct alongside a declared NO_PROXY", async () => {
+    // undici's EnvHttpProxyAgent proxies EVERYTHING not named in NO_PROXY. Our loopback exemption is APPENDED to the
+    // declared value, so a `NO_PROXY=.corp.com` machine keeps its own local traffic direct: health probes,
+    // control-plane calls, an `ssh -L` forward.
     const res = await fetch(originUrl);
     expect(res.status).toBe(200);
     expect(direct).toContain("/local");


### PR DESCRIPTION
Fixes #474.

On a machine that needs a proxy, `fastagent tool`, `add <channel>`, `add skill` and `attach --url` connected direct and failed with a bare undici connect timeout, while `dev`/`start` ran the same code fine. Each read the agent's `.env` and then did not install the proxy-aware fetch that goes with it — the pairing was a step every command performed by hand, and six more `loadDotEnv` call sites were unpaired with nothing distinguishing deliberate from forgotten.

## Behavior

**`enterAgentEnv(agentDir)`** (`src/env.ts`) is now the single way into an agent directory's runtime environment: its `.env` becomes `process.env`, then the process's outbound fetch follows what that (or the ambient environment) declares — one order, one place, no way to do half of it. `enterAgentCommand` is that plus model resolution, so the commands that need the environment but not the model (`tool`, `add`, `add skill`, `info`, `schedule`, `logs`, `attach`, tunnel announcement) stop copying its first half.

**Egress policy lives in `src/proxy.ts`:**

- **Loopback is always exempt.** undici's `EnvHttpProxyAgent` proxies everything not named in `NO_PROXY`, and treats an empty `NO_PROXY` as "proxy everything" — so installing a proxy diverted this process's own local traffic: the Docker health probe on `127.0.0.1`, control-plane calls to a local serve, an `ssh -L` forward given to `attach --url`. `localhost,127.0.0.1,::1` is **appended** to whatever is declared, because `NO_PROXY=.corp.com` is the normal shape of an environment that has a proxy at all and says nothing about `127.0.0.1`. `NO_PROXY=*` is left exact — undici matches that wildcard by identity, so appending would turn "never proxy anything" into "proxy everything but loopback".
- **The install is idempotent** and its latch is set after the install, so entering an environment is free to repeat and a throw cannot leave a process permanently un-proxied.
- **A `fetch` someone deliberately replaced is left alone** (a test's mock, an embedder's instrumentation); the dispatcher still routes undici's global. The cost is stated at the guard: skipping `undici.install()` forfeits the Node 26 gzip fix.

`tunnel.ts` keeps its best-effort `try` around `.env` alone, so a proxy failure cannot be reported as "could not read .secrets/.env".

## Not done, deliberately

- **`NODE_USE_ENV_PROXY=1`** (the issue's suggestion): the weaker half of what `installProxyFetch()` already does — needs Node >= 24, does not fix the gzip half — plus a global env mutation.
- **A hint on `UND_ERR_CONNECT_TIMEOUT`**: with the coverage closed, a timeout means the proxy itself is failing, so that hint would point at the wrong thing.
- **Dispatcher options pi sets and we do not** (`proxyTunnel`, `allowH2`, timeouts, the Client `error` listener): tracked in #513, no reproduction yet.

## Tests

`test/proxy.test.ts` pins the policy in-process: two real HTTP servers assert external → proxy and loopback → direct, and `noProxyList` covers unset / empty / declared / `*`. One CLI test proves a real command enters the environment (a proxy that exists nowhere but the agent's `.env` carries an authored tool's `fetch`). That replaces three per-command subprocess tests that were one assertion repeated per command; `deploy` and `add skill` no longer have their own spawned proxy test.

`docs/troubleshooting.md` states the loopback default and that a LAN `--bind` address is not loopback.

## Known limitations

Not verified against a real corporate proxy, and the Bun early-return in `installProxyFetch` has no test coverage.
