### PR TITLE
deploy agentcore --run: announce account/region/image before any side effect

### DIFF
--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -220,10 +220,15 @@ export async function deployAgentcoreRun(
   }
   // Warn, never gate: an aws CLI too old to know the service, or a role without ListAgentRuntimes, would make a gate
   // refuse a valid deploy. The point is to say it BEFORE the multi-minute arm64 build, not to be authoritative.
-  const service = await aws(["bedrock-agentcore-control", "list-agent-runtimes", "--max-results", "1"], {
-    capture: true,
-    captureStderr: true,
-  });
+  // `--region` explicitly: every other region-dependent call here writes it out (the ECR registry URI, the bucket's
+  // LocationConstraint), and the warning below names ${region} — the probe must be about the SAME region it names.
+  const service = await aws(
+    ["bedrock-agentcore-control", "list-agent-runtimes", "--max-items", "1", "--region", region],
+    {
+      capture: true,
+      captureStderr: true,
+    },
+  );
   if (service.code !== 0) {
     const why = (service.stderr ?? "").trim().split("\n")[0];
     log(

--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -157,10 +157,12 @@ export async function deployAgentcoreRun(
     return gate("no working AWS credentials — run `aws configure` (or set AWS_ACCESS_KEY_ID/…), then re-run");
   }
   let account: string;
+  let principal: string | undefined;
   try {
-    const parsed = JSON.parse(identity.stdout) as { Account?: unknown };
+    const parsed = JSON.parse(identity.stdout) as { Account?: unknown; Arn?: unknown };
     if (typeof parsed.Account !== "string") throw new Error("no Account");
     account = parsed.Account;
+    principal = typeof parsed.Arn === "string" ? parsed.Arn : undefined;
   } catch {
     return gate("could not read the account id from `aws sts get-caller-identity` — see the output above");
   }
@@ -205,6 +207,30 @@ export async function deployAgentcoreRun(
     if (k !== "FASTAGENT_AUTH_SEED" && v.length > 2048) {
       return gate(`secret ${k} is ${v.length} chars — AgentCore environment values cap at 2048; shorten it`);
     }
+  }
+
+  // 3c. Say what this deploy is ABOUT TO TOUCH while it can still be stopped for free: until here the account and
+  // region only surfaced several hundred log lines in, inside the ECR image URI.
+  const source = plan.region ? "the environment" : "aws configure";
+  log(
+    `account ${account}${principal ? ` (${principal})` : ""}, region ${region} (from ${source}), image ${repo}:${plan.tag}`,
+  );
+  if (principal?.endsWith(":root")) {
+    log(`warn: deploying as the account root user — this stack's IAM roles are created under it; prefer an IAM role`);
+  }
+  // Warn, never gate: an aws CLI too old to know the service, or a role without ListAgentRuntimes, would make a gate
+  // refuse a valid deploy. The point is to say it BEFORE the multi-minute arm64 build, not to be authoritative.
+  const service = await aws(["bedrock-agentcore-control", "list-agent-runtimes", "--max-results", "1"], {
+    capture: true,
+    captureStderr: true,
+  });
+  if (service.code !== 0) {
+    const why = (service.stderr ?? "").trim().split("\n")[0];
+    log(
+      `warn: could not confirm AgentCore is available in ${region}${why ? ` (${why})` : ""} — if it is not, ` +
+        `cloudformation deploy fails minutes from now, after the image build: ` +
+        `https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html`,
+    );
   }
 
   // 4.

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -168,7 +168,7 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
     expect(awsCmds()).toEqual([
       "sts get-caller-identity --output json",
       // The pre-flight region probe: cheap, and BEFORE the multi-minute build it would otherwise waste.
-      "bedrock-agentcore-control list-agent-runtimes --max-results 1",
+      "bedrock-agentcore-control list-agent-runtimes --max-items 1 --region us-west-2",
       "ecr describe-repositories --repository-names fastagent/my-agent",
       // The deployment bucket: created if absent, its safety/durability properties re-converged every
       // deploy, then the content-hashed forwarder package uploaded.
@@ -339,14 +339,24 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
     expect(calls.slice(0, spoken).every((c) => c.args[0] === "sts" || c.args[0] === "configure")).toBe(true);
   });
 
-  it("stays quiet about the principal when the identity carries no Arn", async () => {
+  it("stays quiet about the principal when the identity carries no Arn, and names where the region came from", async () => {
     const logs: string[] = [];
-    await deployAgentcoreRun(plan(), fakeCli(happyAws).cli, fakeCli().cli, (m) => logs.push(m), writeParams, writeZip, {
-      telegram: async () => "registered",
-    });
-    expect(logs[0]).toBe(
-      "account 123456789012, region us-west-2 (from the environment), image fastagent/my-agent:20260728",
+    // No AWS_REGION: the region (and so the source label an operator reads to answer "where did this come from?")
+    // is the one `aws configure get region` gave.
+    const aws = fakeCli((a) => (a[0] === "configure" ? { stdout: "eu-west-1\n" } : happyAws(a)));
+    await deployAgentcoreRun(
+      plan({ region: undefined }),
+      aws.cli,
+      fakeCli().cli,
+      (m) => logs.push(m),
+      writeParams,
+      writeZip,
+      { telegram: async () => "registered" },
     );
+    expect(logs[0]).toBe(
+      "account 123456789012, region eu-west-1 (from aws configure), image fastagent/my-agent:20260728",
+    );
+    expect(aws.cmds()).toContain("bedrock-agentcore-control list-agent-runtimes --max-items 1 --region eu-west-1");
     expect(logs.join("\n")).not.toContain("root user");
     expect(logs.join("\n")).not.toContain("could not confirm");
   });

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -167,6 +167,8 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
     });
     expect(awsCmds()).toEqual([
       "sts get-caller-identity --output json",
+      // The pre-flight region probe: cheap, and BEFORE the multi-minute build it would otherwise waste.
+      "bedrock-agentcore-control list-agent-runtimes --max-results 1",
       "ecr describe-repositories --repository-names fastagent/my-agent",
       // The deployment bucket: created if absent, its safety/durability properties re-converged every
       // deploy, then the content-hashed forwarder package uploaded.
@@ -300,6 +302,53 @@ describe("deploy/agentcore/run: the coding-agent deploy journey", () => {
       fakeCli().cli,
     );
     expect(tooBigSecret).toMatchObject({ ok: false, gate: expect.stringContaining("SOME_BLOB") });
+  });
+
+  it("announces account/principal/region/image and flags an unavailable region BEFORE any side effect", async () => {
+    const logs: string[] = [];
+    const { cli: aws, calls } = fakeCli((a) => {
+      if (a[0] === "sts") {
+        return { stdout: JSON.stringify({ Account: "123456789012", Arn: "arn:aws:iam::123456789012:root" }) };
+      }
+      if (a[0] === "bedrock-agentcore-control") {
+        return { code: 254, stderr: "SSL validation failed for https://bedrock-agentcore-control.ca-west-1…" };
+      }
+      return happyAws(a);
+    });
+    const out = await deployAgentcoreRun(
+      plan({ region: "ca-west-1" }),
+      aws,
+      fakeCli().cli,
+      (m) => logs.push(m),
+      writeParams,
+      writeZip,
+      { telegram: async () => "registered" },
+    );
+
+    expect(out).toMatchObject({ ok: true }); // the region probe WARNS, it never refuses the deploy
+    const header = logs[0]!;
+    expect(header).toBe(
+      "account 123456789012 (arn:aws:iam::123456789012:root), region ca-west-1 (from the environment), " +
+        "image fastagent/my-agent:20260728",
+    );
+    expect(logs[1]).toContain("root user");
+    expect(logs[2]).toContain("could not confirm AgentCore is available in ca-west-1");
+    expect(logs[2]).toContain("SSL validation failed"); // the CLI's own reason, not our guess
+    // "Before any side effect" is the whole point: nothing was created by the time it printed.
+    const spoken = calls.findIndex((c) => c.args[0] === "bedrock-agentcore-control");
+    expect(calls.slice(0, spoken).every((c) => c.args[0] === "sts" || c.args[0] === "configure")).toBe(true);
+  });
+
+  it("stays quiet about the principal when the identity carries no Arn", async () => {
+    const logs: string[] = [];
+    await deployAgentcoreRun(plan(), fakeCli(happyAws).cli, fakeCli().cli, (m) => logs.push(m), writeParams, writeZip, {
+      telegram: async () => "registered",
+    });
+    expect(logs[0]).toBe(
+      "account 123456789012, region us-west-2 (from the environment), image fastagent/my-agent:20260728",
+    );
+    expect(logs.join("\n")).not.toContain("root user");
+    expect(logs.join("\n")).not.toContain("could not confirm");
   });
 
   it("a failed cfn deploy gates with the stack-events pointer", async () => {


### PR DESCRIPTION
Closes #475.

`deploy agentcore --run` resolved the account and region silently: both first surfaced several hundred log lines in, inside the ECR image URI. A wrong account, a wrong region or a root principal was therefore only discoverable *after* the arm64 build and push.

Three lines now print at the last point where stopping is free — after every local gate (aws/docker/secrets), before the first side effect (`ecr create-repository`):

```
[fastagent] account 851725512787 (arn:aws:iam::851725512787:root), region ap-southeast-1 (from aws configure), image fastagent/x-growth:20260906172244
[fastagent] warn: deploying as the account root user — this stack's IAM roles are created under it; prefer an IAM role
[fastagent] warn: could not confirm AgentCore is available in ca-west-1 (SSL validation failed for https://bedrock-agentcore-control.ca-west-1…) — if it is not, cloudformation deploy fails minutes from now, after the image build: <agentcore-regions doc>
```

The principal comes from the `sts get-caller-identity` JSON the driver already parses for the account.

### Why a live probe and not a region list

The issue suggested checking the region against the AgentCore Runtime region list. A hardcoded list goes stale in the wrong direction: AgentCore keeps adding regions, so a stale list refuses deploys that would have worked. One `aws bedrock-agentcore-control list-agent-runtimes --max-results 1` costs ~1s, never goes stale, and separates the cases cleanly (verified against a real account):

| region | result |
|---|---|
| `us-west-2`, `ap-southeast-1` | exit 0 |
| `ca-west-1`, `ap-northeast-3` | `SSL validation failed …` (no endpoint) |
| `eu-south-2` | `UnrecognizedClientException` (opt-in region not enabled — equally undeployable) |

It **warns and continues**, never gates: an `aws` CLI too old to know the service, or a role without `ListAgentRuntimes`, would otherwise refuse a valid deploy. The value is being said before the multi-minute build, not being authoritative.

### Verification

`npm run lint && npm run typecheck && npm test` (1607 passed). Two new cases in `test/deploy-agentcore-run.test.ts` cover the header wording, the root warning, the probe warning carrying the CLI's own reason, and that nothing but `sts`/`configure` has run by the time it prints; the strict command-sequence assertion pins the probe's position.