### PR TITLE
docs(schedule): declare the delivery target in secrets, not in the prompt text

### DIFF
--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -342,8 +342,10 @@ track it upstream and state the limitation instead of silently building a replac
 
 ## 7. Add clock triggers deliberately
 
-After adding Telegram and selecting an approved recipient, this is a schedule file. Replace
-`OWNER_APPROVED_CHAT_ID` before running it; no destination is inferred from a previous chat.
+After adding Telegram and selecting an approved recipient, this is a schedule file. The recipient is
+environment-specific, so declare it in `secrets` and build the prompt from it — set
+`OWNER_APPROVED_CHAT_ID` in `.secrets/.env` before running it; no destination is inferred from a
+previous chat.
 
 **`fastagent/schedules/daily-review.ts`**
 
@@ -353,7 +355,9 @@ import { defineSchedule } from "@fastagent-sh/fastagent";
 export default defineSchedule({
   cron: "0 9 * * *",
   tz: "America/New_York",
-  prompt: "Review pending proposals and use telegram-send to send a short digest to Telegram chat OWNER_APPROVED_CHAT_ID. Leave unapproved actions pending.",
+  secrets: ["OWNER_APPROVED_CHAT_ID"],
+  prompt: (secrets) =>
+    `Review pending proposals and use telegram-send to send a short digest to Telegram chat ${secrets.OWNER_APPROVED_CHAT_ID}. Leave unapproved actions pending.`,
 });
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -407,7 +407,8 @@ See [Channel development](channel-development.md).
 interface Schedule {
   cron: string; // 5-field cron expression
   tz?: string; // IANA timezone (default "UTC")
-  prompt: string; // the turn's text = the job's instruction
+  prompt: string | ((secrets: Record<string, string>) => string); // the turn's text = the job's instruction
+  secrets?: readonly string[]; // env vars this file needs, typed into the prompt builder
 }
 function defineSchedule(schedule: Schedule): Schedule;
 ```
@@ -422,10 +423,15 @@ import { defineSchedule } from "@fastagent-sh/fastagent";
 export default defineSchedule({
   cron: "0 9 * * *",
   tz: "America/New_York",
-  prompt: "Generate today's digest and send it to the team Telegram.",
   secrets: ["SLACK_DIGEST_CHANNEL"], // same contract as a tool's — carried by deploy, asserted at start
+  prompt: (secrets) => `Generate today's digest and send it with slack-send to channel ${secrets.SLACK_DIGEST_CHANNEL}.`,
 });
 ```
+
+**The delivery target belongs in `secrets`, not in the prompt text.** A chat/channel id is
+environment-specific, so declare it and build the prompt from it: the builder runs once at load, its
+keys are typed from the list, and `dev`/`start` refuse to boot while the name is unset — instead of a
+hardcoded id travelling to the wrong workspace.
 
 The scheduler is a time-trigger (the N axis, clock form): on each cron instant it invokes the agent
 with `prompt` — borrowing the same `Agent` contract as channels, adding none. It:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -407,10 +407,16 @@ See [Channel development](channel-development.md).
 interface Schedule {
   cron: string; // 5-field cron expression
   tz?: string; // IANA timezone (default "UTC")
-  prompt: string | ((secrets: Record<string, string>) => string); // the turn's text = the job's instruction
+  prompt: string; // the turn's text = the job's instruction (a builder is resolved at load)
   secrets?: readonly string[]; // env vars this file needs, typed into the prompt builder
 }
-function defineSchedule(schedule: Schedule): Schedule;
+// what an author writes: `prompt` may be built FROM the declared secrets, keys typed from `secrets`
+function defineSchedule<const S extends readonly string[]>(schedule: {
+  cron: string;
+  tz?: string;
+  prompt: string | ((secrets: Record<S[number], string>) => string);
+  secrets?: S;
+}): Schedule;
 ```
 
 An agent declares time-triggers by dropping `schedules/<name>.ts`, mirroring `tools/`/`channels/`;

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -196,14 +196,17 @@ import { defineSchedule } from "@fastagent-sh/fastagent";
 export default defineSchedule({
   cron: "0 9 * * *",
   tz: "America/New_York",
-  prompt: "Summarize yesterday's activity and send it to the team Telegram.",
+  secrets: ["TEAM_CHAT_ID"],
+  prompt: (secrets) => `Summarize yesterday's activity and send it with telegram-send to chat ${secrets.TEAM_CHAT_ID}.`,
 });
 ```
 
 The prompt must say where output goes — the scheduler only fires the agent; delivery is a send tool's
 job. `fastagent add telegram` scaffolds one (`tools/telegram-send.ts` sends a message or a file); and
-because a scheduled turn runs outside any chat, the agent has no chat context — **put the target chat
-id in the prompt** ("…send it to Telegram chat -100123456"). Test it immediately (without waiting for
+because a scheduled turn runs outside any chat, the agent has no chat context — **the prompt must name
+the target chat id**. That id is environment-specific, so declare it in `secrets` and build the prompt
+from it (as above) rather than hardcoding it: same contract as a tool's secrets — `deploy` carries the
+value and `dev`/`start` refuse to boot while it is unset. Test it immediately (without waiting for
 the cron, and without touching the real fire state):
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -206,7 +206,8 @@ job. `fastagent add telegram` scaffolds one (`tools/telegram-send.ts` sends a me
 because a scheduled turn runs outside any chat, the agent has no chat context — **the prompt must name
 the target chat id**. That id is environment-specific, so declare it in `secrets` and build the prompt
 from it (as above) rather than hardcoding it: same contract as a tool's secrets — `deploy` carries the
-value and `dev`/`start` refuse to boot while it is unset. Test it immediately (without waiting for
+value and `dev`/`start` refuse to boot while it is unset. Set `TEAM_CHAT_ID` in `.secrets/.env` first —
+the same gate refuses a run while the name is unset. Then test it immediately (without waiting for
 the cron, and without touching the real fire state):
 
 ```bash

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -277,12 +277,15 @@ file id) so the agent can record the outcome.
 The destination is what the turn's instruction names. A user id (`U…`) as `channelId` messages that
 user's DM — Slack opens it under `chat:write`, no `conversations.open` needed — and the result reports
 the DM channel id (`D…`), which is what a file upload to that user needs. A schedule that reports to its
-owner therefore needs only the owner's user id in its prompt:
+owner therefore needs only the owner's user id — declared in `secrets`, since it is
+environment-specific, and built into the prompt:
 
 ```ts
 export default defineSchedule({
   cron: "0 9 * * 1-5",
-  prompt: "Summarize yesterday's growth notes and send them with slack-send to user U0123456789.",
+  secrets: ["OWNER_SLACK_USER_ID"],
+  prompt: (secrets) =>
+    `Summarize yesterday's growth notes and send them with slack-send to user ${secrets.OWNER_SLACK_USER_ID}.`,
 });
 ```
 


### PR DESCRIPTION
Closes #478.

`defineSchedule` already takes `secrets: [...]` with a `prompt` builder, so a schedule's delivery
target has a first-class home. The docs did not say so:

- `docs/api-reference.md` printed a `Schedule` interface without `secrets` or the builder form, and its
  example declared `SLACK_DIGEST_CHANNEL` while never reading it — demonstrating a declaration that does
  nothing.
- `docs/quickstart.md` instructed **put the target chat id in the prompt** ("…send it to Telegram chat
  -100123456"), i.e. hardcode an environment-specific id in source.

Both now show the declaration plus the builder, and state why: `deploy` carries the value, `dev`/`start`
refuse to boot while the name is unset, and the keys are typed from the list.

No `deliver` field. Delivery is a send tool's job (the scheduler "delivers nothing" by design); a
platform-shaped field would only splice a sentence into the prompt while pulling channel knowledge into
the scheduler, and a generic `{ tool, args }` form would invent a second post-turn execution model with
its own failure semantics.

Docs only; no source change. `npm run lint` (includes the doc-link check) passes.
