### PR TITLE
test: raise the two cold-start-bound test budgets so a contended machine is not a failure

### DIFF
--- a/test/agentcore-service.test.ts
+++ b/test/agentcore-service.test.ts
@@ -44,7 +44,7 @@ describe("deferred AgentCore initialization", () => {
     // 30s ceiling never absorbed and 60s stopped absorbing too — a full `npm test` run puts a fork on
     // every core, and this stage is import-bound, so contention scales it by more than 3x. Raise the
     // budget rather than cap parallelism (vitest.config.ts states why). It still bounds a genuine hang:
-    // the file's other eleven tests answer in single-digit milliseconds, so only THIS one can spend it.
+    // the file's other ten tests answer in ~10ms or less, so only THIS one can spend it.
   }, 120_000);
 
   it("returns authenticated probe failures as structured transport-200 diagnostics", async () => {

--- a/test/agentcore-service.test.ts
+++ b/test/agentcore-service.test.ts
@@ -40,10 +40,12 @@ describe("deferred AgentCore initialization", () => {
     } finally {
       exit.mockRestore();
     }
-    // The one test here that pays a full cold engine assembly: ~16s idle (measured), which the suite's
-    // 30s ceiling absorbs until the machine is contended. 60s covers that without letting a genuine
-    // hang burn two minutes of CI before it reports (vitest.config.ts states the same reasoning).
-  }, 60_000);
+    // The one test here that pays a full cold engine assembly: ~21s idle (measured), which the suite's
+    // 30s ceiling never absorbed and 60s stopped absorbing too — a full `npm test` run puts a fork on
+    // every core, and this stage is import-bound, so contention scales it by more than 3x. Raise the
+    // budget rather than cap parallelism (vitest.config.ts states why). It still bounds a genuine hang:
+    // the file's other eleven tests answer in single-digit milliseconds, so only THIS one can spend it.
+  }, 120_000);
 
   it("returns authenticated probe failures as structured transport-200 diagnostics", async () => {
     vi.stubEnv("FASTAGENT_INGRESS_SECRET", "trusted-probe");

--- a/test/deployment-start.test.ts
+++ b/test/deployment-start.test.ts
@@ -7,94 +7,108 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { expect, it } from "vitest";
 
-it("retries interrupted installs, opens the workspace's runtime and preserves tool context and rotated credentials", async () => {
-  const repo = dirname(dirname(fileURLToPath(import.meta.url)));
-  const dir = await mkdtemp(join(tmpdir(), "fa-deployment-start-"));
-  const image = join(dir, "image"),
-    root = join(dir, "data"),
-    agent = join(image, "fastagent");
-  const packageDir = join(agent, "node_modules/@fastagent-sh/fastagent");
-  const exec = promisify(execFile);
-  let requests = 0;
-  const server = createServer(async (req, res) => {
-    for await (const _chunk of req) {
-      /* Drain the model request before replying. */
-    }
-    const tool = requests++ === 0;
-    res.writeHead(200, { "content-type": "text/event-stream" });
-    const delta = tool
-      ? {
-          role: "assistant",
-          tool_calls: [
-            { index: 0, id: "call_context", type: "function", function: { name: "context", arguments: "{}" } },
-          ],
-        }
-      : { role: "assistant", content: "done" };
-    for (const choice of [
-      { index: 0, delta, finish_reason: null },
-      { index: 0, delta: {}, finish_reason: tool ? "tool_calls" : "stop" },
-    ]) {
-      res.write(
-        `data: ${JSON.stringify({ id: "reply", object: "chat.completion.chunk", created: 1, model: "test", choices: [choice] })}\n\n`,
+// This test pays a project compile plus TWO cold engine starts in child processes: ~3s on an idle
+// machine, but a full `npm test` run puts a fork on every core and has been measured past the old 30s
+// ceiling. The budget is raised, not the parallelism (vitest.config.ts states why). The child ceiling
+// stays the tighter of the two so a hung child is reported as itself, not as an opaque test timeout.
+const CHILD_TIMEOUT_MS = 45_000;
+const TEST_TIMEOUT_MS = 120_000;
+
+it(
+  "retries interrupted installs, opens the workspace's runtime and preserves tool context and rotated credentials",
+  async () => {
+    const repo = dirname(dirname(fileURLToPath(import.meta.url)));
+    const dir = await mkdtemp(join(tmpdir(), "fa-deployment-start-"));
+    const image = join(dir, "image"),
+      root = join(dir, "data"),
+      agent = join(image, "fastagent");
+    const packageDir = join(agent, "node_modules/@fastagent-sh/fastagent");
+    const exec = promisify(execFile);
+    let requests = 0;
+    const server = createServer(async (req, res) => {
+      for await (const _chunk of req) {
+        /* Drain the model request before replying. */
+      }
+      const tool = requests++ === 0;
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      const delta = tool
+        ? {
+            role: "assistant",
+            tool_calls: [
+              { index: 0, id: "call_context", type: "function", function: { name: "context", arguments: "{}" } },
+            ],
+          }
+        : { role: "assistant", content: "done" };
+      for (const choice of [
+        { index: 0, delta, finish_reason: null },
+        { index: 0, delta: {}, finish_reason: tool ? "tool_calls" : "stop" },
+      ]) {
+        res.write(
+          `data: ${JSON.stringify({ id: "reply", object: "chat.completion.chunk", created: 1, model: "test", choices: [choice] })}\n\n`,
+        );
+      }
+      res.end("data: [DONE]\n\n");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+      await mkdir(packageDir, { recursive: true });
+      await exec(process.execPath, [
+        join(repo, "node_modules/typescript/bin/tsc"),
+        "-p",
+        join(repo, "tsconfig.build.json"),
+        "--outDir",
+        join(packageDir, "dist"),
+      ]);
+      await symlink(join(repo, "node_modules"), join(packageDir, "node_modules"), "dir");
+      await writeFile(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "@fastagent-sh/fastagent",
+          version: "0.0.0",
+          type: "module",
+          exports: "./dist/index.js",
+        }),
       );
-    }
-    res.end("data: [DONE]\n\n");
-  });
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-  const port = (server.address() as { port: number }).port;
-  try {
-    await mkdir(packageDir, { recursive: true });
-    await exec(process.execPath, [
-      join(repo, "node_modules/typescript/bin/tsc"),
-      "-p",
-      join(repo, "tsconfig.build.json"),
-      "--outDir",
-      join(packageDir, "dist"),
-    ]);
-    await symlink(join(repo, "node_modules"), join(packageDir, "node_modules"), "dir");
-    await writeFile(
-      join(packageDir, "package.json"),
-      JSON.stringify({ name: "@fastagent-sh/fastagent", version: "0.0.0", type: "module", exports: "./dist/index.js" }),
-    );
-    await mkdir(join(agent, "node_modules/.bin"));
-    await writeFile(join(agent, "package.json"), '{"type":"module"}');
-    await writeFile(join(agent, "fastagent.config.mjs"), 'export default { model: "local/test" };');
-    await writeFile(join(agent, "persona.md"), "Use the context tool.");
-    await writeFile(
-      join(agent, "models.json"),
-      JSON.stringify({
-        providers: {
-          local: {
-            baseUrl: `http://127.0.0.1:${port}/v1`,
-            api: "openai-completions",
-            apiKey: "test",
-            models: [{ id: "test", contextWindow: 32768 }],
+      await mkdir(join(agent, "node_modules/.bin"));
+      await writeFile(join(agent, "package.json"), '{"type":"module"}');
+      await writeFile(join(agent, "fastagent.config.mjs"), 'export default { model: "local/test" };');
+      await writeFile(join(agent, "persona.md"), "Use the context tool.");
+      await writeFile(
+        join(agent, "models.json"),
+        JSON.stringify({
+          providers: {
+            local: {
+              baseUrl: `http://127.0.0.1:${port}/v1`,
+              api: "openai-completions",
+              apiKey: "test",
+              models: [{ id: "test", contextWindow: 32768 }],
+            },
           },
-        },
-      }),
-    );
-    await mkdir(join(agent, "tools"));
-    await writeFile(
-      join(agent, "tools/context.mjs"),
-      `import { defineTool, z } from "@fastagent-sh/fastagent";
+        }),
+      );
+      await mkdir(join(agent, "tools"));
+      await writeFile(
+        join(agent, "tools/context.mjs"),
+        `import { defineTool, z } from "@fastagent-sh/fastagent";
 export default defineTool({ name: "context", description: "Read invocation context", input: z.object({}), execute: (_, ctx) => ({ session: ctx.sessionManager?.getSessionId() ?? "missing", cwd: ctx.cwd }) });`,
-    );
-    const manifest = join(dir, "release.json");
-    await writeFile(manifest, JSON.stringify({ version: 1, id: "one", agent: "fastagent" }));
-    await mkdir(join(root, ".secrets"), { recursive: true });
-    const rotated = JSON.stringify({ openai: { type: "api_key", key: "rotated" } });
-    await writeFile(join(root, ".secrets/auth.json"), rotated);
-    const env = { ...process.env };
-    for (const key of Object.keys(env)) {
-      if (key.startsWith("FASTAGENT_") || ["https_proxy", "http_proxy", "all_proxy"].includes(key.toLowerCase()))
-        delete env[key];
-    }
-    const bin = join(dir, "bin");
-    const attempts = join(dir, "install-attempts");
-    await mkdir(bin);
-    await writeFile(
-      join(bin, "npm"),
-      `#!/bin/sh
+      );
+      const manifest = join(dir, "release.json");
+      await writeFile(manifest, JSON.stringify({ version: 1, id: "one", agent: "fastagent" }));
+      await mkdir(join(root, ".secrets"), { recursive: true });
+      const rotated = JSON.stringify({ openai: { type: "api_key", key: "rotated" } });
+      await writeFile(join(root, ".secrets/auth.json"), rotated);
+      const env = { ...process.env };
+      for (const key of Object.keys(env)) {
+        if (key.startsWith("FASTAGENT_") || ["https_proxy", "http_proxy", "all_proxy"].includes(key.toLowerCase()))
+          delete env[key];
+      }
+      const bin = join(dir, "bin");
+      const attempts = join(dir, "install-attempts");
+      await mkdir(bin);
+      await writeFile(
+        join(bin, "npm"),
+        `#!/bin/sh
 mkdir -p node_modules/.bin
 printf installed > node_modules/.bin/fastagent
 if [ -f "$INSTALL_ATTEMPTS" ]; then
@@ -105,19 +119,19 @@ else
   exit 1
 fi
 `,
-      { mode: 0o755 },
-    );
-    Object.assign(env, {
-      PATH: `${bin}:${env.PATH}`,
-      INSTALL_ATTEMPTS: attempts,
-      FASTAGENT_RELEASE_FILE: manifest,
-      FASTAGENT_STORAGE_DIR: root,
-      FASTAGENT_AUTH_SEED: Buffer.from('{"openai":{"type":"api_key","key":"old"}}').toString("base64"),
-    });
-    const workspaceUrl = pathToFileURL(join(packageDir, "dist/deploy/workspace.js")).href;
-    const startUrl = pathToFileURL(join(packageDir, "dist/cli/commands/start.js")).href;
-    // Native Node resolution is essential: a test loader can deduplicate the two package installations.
-    const script = `
+        { mode: 0o755 },
+      );
+      Object.assign(env, {
+        PATH: `${bin}:${env.PATH}`,
+        INSTALL_ATTEMPTS: attempts,
+        FASTAGENT_RELEASE_FILE: manifest,
+        FASTAGENT_STORAGE_DIR: root,
+        FASTAGENT_AUTH_SEED: Buffer.from('{"openai":{"type":"api_key","key":"old"}}').toString("base64"),
+      });
+      const workspaceUrl = pathToFileURL(join(packageDir, "dist/deploy/workspace.js")).href;
+      const startUrl = pathToFileURL(join(packageDir, "dist/cli/commands/start.js")).href;
+      // Native Node resolution is essential: a test loader can deduplicate the two package installations.
+      const script = `
 import { mock } from "node:test";
 import { strict as assert } from "node:assert";
 const storage = await import(${JSON.stringify(`${workspaceUrl}?actual`)});
@@ -138,26 +152,28 @@ try {
 }
 }
 `;
-    await exec(process.execPath, ["--experimental-test-module-mocks", "--input-type=module", "-e", script, "fail"], {
-      env,
-      timeout: 20_000,
-    });
-    const out = await exec(
-      process.execPath,
-      ["--experimental-test-module-mocks", "--input-type=module", "-e", script],
-      { env, timeout: 20_000 },
-    );
-    const events = JSON.parse(out.stdout.trim().split("\n").at(-1)!) as { type: string; content?: unknown }[];
-    expect(events.at(-1)).toEqual({ type: "completed" });
-    const result = events.find((event) => event.type === "tool_ended");
-    expect(JSON.stringify(result)).toContain("workspace-conversation");
-    expect(JSON.stringify(result)).toContain(join(root, "base"));
-    expect(await readFile(join(root, ".secrets/auth.json"), "utf8")).toBe(rotated);
-    expect(requests).toBe(2);
-    expect(await readFile(attempts, "utf8")).toBe("failed\nretry\n");
-  } finally {
-    server.closeAllConnections();
-    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
-    await rm(dir, { recursive: true, force: true });
-  }
-}, 30_000);
+      await exec(process.execPath, ["--experimental-test-module-mocks", "--input-type=module", "-e", script, "fail"], {
+        env,
+        timeout: CHILD_TIMEOUT_MS,
+      });
+      const out = await exec(
+        process.execPath,
+        ["--experimental-test-module-mocks", "--input-type=module", "-e", script],
+        { env, timeout: CHILD_TIMEOUT_MS },
+      );
+      const events = JSON.parse(out.stdout.trim().split("\n").at(-1)!) as { type: string; content?: unknown }[];
+      expect(events.at(-1)).toEqual({ type: "completed" });
+      const result = events.find((event) => event.type === "tool_ended");
+      expect(JSON.stringify(result)).toContain("workspace-conversation");
+      expect(JSON.stringify(result)).toContain(join(root, "base"));
+      expect(await readFile(join(root, ".secrets/auth.json"), "utf8")).toBe(rotated);
+      expect(requests).toBe(2);
+      expect(await readFile(attempts, "utf8")).toBe("failed\nretry\n");
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+  TEST_TIMEOUT_MS,
+);

--- a/test/deployment-start.test.ts
+++ b/test/deployment-start.test.ts
@@ -12,103 +12,95 @@ import { expect, it } from "vitest";
 // ceiling. The budget is raised, not the parallelism (vitest.config.ts states why). The child ceiling
 // stays the tighter of the two so a hung child is reported as itself, not as an opaque test timeout.
 const CHILD_TIMEOUT_MS = 45_000;
-const TEST_TIMEOUT_MS = 120_000;
 
-it(
-  "retries interrupted installs, opens the workspace's runtime and preserves tool context and rotated credentials",
-  async () => {
-    const repo = dirname(dirname(fileURLToPath(import.meta.url)));
-    const dir = await mkdtemp(join(tmpdir(), "fa-deployment-start-"));
-    const image = join(dir, "image"),
-      root = join(dir, "data"),
-      agent = join(image, "fastagent");
-    const packageDir = join(agent, "node_modules/@fastagent-sh/fastagent");
-    const exec = promisify(execFile);
-    let requests = 0;
-    const server = createServer(async (req, res) => {
-      for await (const _chunk of req) {
-        /* Drain the model request before replying. */
-      }
-      const tool = requests++ === 0;
-      res.writeHead(200, { "content-type": "text/event-stream" });
-      const delta = tool
-        ? {
-            role: "assistant",
-            tool_calls: [
-              { index: 0, id: "call_context", type: "function", function: { name: "context", arguments: "{}" } },
-            ],
-          }
-        : { role: "assistant", content: "done" };
-      for (const choice of [
-        { index: 0, delta, finish_reason: null },
-        { index: 0, delta: {}, finish_reason: tool ? "tool_calls" : "stop" },
-      ]) {
-        res.write(
-          `data: ${JSON.stringify({ id: "reply", object: "chat.completion.chunk", created: 1, model: "test", choices: [choice] })}\n\n`,
-        );
-      }
-      res.end("data: [DONE]\n\n");
-    });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    const port = (server.address() as { port: number }).port;
-    try {
-      await mkdir(packageDir, { recursive: true });
-      await exec(process.execPath, [
-        join(repo, "node_modules/typescript/bin/tsc"),
-        "-p",
-        join(repo, "tsconfig.build.json"),
-        "--outDir",
-        join(packageDir, "dist"),
-      ]);
-      await symlink(join(repo, "node_modules"), join(packageDir, "node_modules"), "dir");
-      await writeFile(
-        join(packageDir, "package.json"),
-        JSON.stringify({
-          name: "@fastagent-sh/fastagent",
-          version: "0.0.0",
-          type: "module",
-          exports: "./dist/index.js",
-        }),
+it("retries interrupted installs, opens the workspace's runtime and preserves tool context and rotated credentials", async () => {
+  const repo = dirname(dirname(fileURLToPath(import.meta.url)));
+  const dir = await mkdtemp(join(tmpdir(), "fa-deployment-start-"));
+  const image = join(dir, "image"),
+    root = join(dir, "data"),
+    agent = join(image, "fastagent");
+  const packageDir = join(agent, "node_modules/@fastagent-sh/fastagent");
+  const exec = promisify(execFile);
+  let requests = 0;
+  const server = createServer(async (req, res) => {
+    for await (const _chunk of req) {
+      /* Drain the model request before replying. */
+    }
+    const tool = requests++ === 0;
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    const delta = tool
+      ? {
+          role: "assistant",
+          tool_calls: [
+            { index: 0, id: "call_context", type: "function", function: { name: "context", arguments: "{}" } },
+          ],
+        }
+      : { role: "assistant", content: "done" };
+    for (const choice of [
+      { index: 0, delta, finish_reason: null },
+      { index: 0, delta: {}, finish_reason: tool ? "tool_calls" : "stop" },
+    ]) {
+      res.write(
+        `data: ${JSON.stringify({ id: "reply", object: "chat.completion.chunk", created: 1, model: "test", choices: [choice] })}\n\n`,
       );
-      await mkdir(join(agent, "node_modules/.bin"));
-      await writeFile(join(agent, "package.json"), '{"type":"module"}');
-      await writeFile(join(agent, "fastagent.config.mjs"), 'export default { model: "local/test" };');
-      await writeFile(join(agent, "persona.md"), "Use the context tool.");
-      await writeFile(
-        join(agent, "models.json"),
-        JSON.stringify({
-          providers: {
-            local: {
-              baseUrl: `http://127.0.0.1:${port}/v1`,
-              api: "openai-completions",
-              apiKey: "test",
-              models: [{ id: "test", contextWindow: 32768 }],
-            },
+    }
+    res.end("data: [DONE]\n\n");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+  try {
+    await mkdir(packageDir, { recursive: true });
+    await exec(process.execPath, [
+      join(repo, "node_modules/typescript/bin/tsc"),
+      "-p",
+      join(repo, "tsconfig.build.json"),
+      "--outDir",
+      join(packageDir, "dist"),
+    ]);
+    await symlink(join(repo, "node_modules"), join(packageDir, "node_modules"), "dir");
+    await writeFile(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: "@fastagent-sh/fastagent", version: "0.0.0", type: "module", exports: "./dist/index.js" }),
+    );
+    await mkdir(join(agent, "node_modules/.bin"));
+    await writeFile(join(agent, "package.json"), '{"type":"module"}');
+    await writeFile(join(agent, "fastagent.config.mjs"), 'export default { model: "local/test" };');
+    await writeFile(join(agent, "persona.md"), "Use the context tool.");
+    await writeFile(
+      join(agent, "models.json"),
+      JSON.stringify({
+        providers: {
+          local: {
+            baseUrl: `http://127.0.0.1:${port}/v1`,
+            api: "openai-completions",
+            apiKey: "test",
+            models: [{ id: "test", contextWindow: 32768 }],
           },
-        }),
-      );
-      await mkdir(join(agent, "tools"));
-      await writeFile(
-        join(agent, "tools/context.mjs"),
-        `import { defineTool, z } from "@fastagent-sh/fastagent";
+        },
+      }),
+    );
+    await mkdir(join(agent, "tools"));
+    await writeFile(
+      join(agent, "tools/context.mjs"),
+      `import { defineTool, z } from "@fastagent-sh/fastagent";
 export default defineTool({ name: "context", description: "Read invocation context", input: z.object({}), execute: (_, ctx) => ({ session: ctx.sessionManager?.getSessionId() ?? "missing", cwd: ctx.cwd }) });`,
-      );
-      const manifest = join(dir, "release.json");
-      await writeFile(manifest, JSON.stringify({ version: 1, id: "one", agent: "fastagent" }));
-      await mkdir(join(root, ".secrets"), { recursive: true });
-      const rotated = JSON.stringify({ openai: { type: "api_key", key: "rotated" } });
-      await writeFile(join(root, ".secrets/auth.json"), rotated);
-      const env = { ...process.env };
-      for (const key of Object.keys(env)) {
-        if (key.startsWith("FASTAGENT_") || ["https_proxy", "http_proxy", "all_proxy"].includes(key.toLowerCase()))
-          delete env[key];
-      }
-      const bin = join(dir, "bin");
-      const attempts = join(dir, "install-attempts");
-      await mkdir(bin);
-      await writeFile(
-        join(bin, "npm"),
-        `#!/bin/sh
+    );
+    const manifest = join(dir, "release.json");
+    await writeFile(manifest, JSON.stringify({ version: 1, id: "one", agent: "fastagent" }));
+    await mkdir(join(root, ".secrets"), { recursive: true });
+    const rotated = JSON.stringify({ openai: { type: "api_key", key: "rotated" } });
+    await writeFile(join(root, ".secrets/auth.json"), rotated);
+    const env = { ...process.env };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith("FASTAGENT_") || ["https_proxy", "http_proxy", "all_proxy"].includes(key.toLowerCase()))
+        delete env[key];
+    }
+    const bin = join(dir, "bin");
+    const attempts = join(dir, "install-attempts");
+    await mkdir(bin);
+    await writeFile(
+      join(bin, "npm"),
+      `#!/bin/sh
 mkdir -p node_modules/.bin
 printf installed > node_modules/.bin/fastagent
 if [ -f "$INSTALL_ATTEMPTS" ]; then
@@ -119,19 +111,19 @@ else
   exit 1
 fi
 `,
-        { mode: 0o755 },
-      );
-      Object.assign(env, {
-        PATH: `${bin}:${env.PATH}`,
-        INSTALL_ATTEMPTS: attempts,
-        FASTAGENT_RELEASE_FILE: manifest,
-        FASTAGENT_STORAGE_DIR: root,
-        FASTAGENT_AUTH_SEED: Buffer.from('{"openai":{"type":"api_key","key":"old"}}').toString("base64"),
-      });
-      const workspaceUrl = pathToFileURL(join(packageDir, "dist/deploy/workspace.js")).href;
-      const startUrl = pathToFileURL(join(packageDir, "dist/cli/commands/start.js")).href;
-      // Native Node resolution is essential: a test loader can deduplicate the two package installations.
-      const script = `
+      { mode: 0o755 },
+    );
+    Object.assign(env, {
+      PATH: `${bin}:${env.PATH}`,
+      INSTALL_ATTEMPTS: attempts,
+      FASTAGENT_RELEASE_FILE: manifest,
+      FASTAGENT_STORAGE_DIR: root,
+      FASTAGENT_AUTH_SEED: Buffer.from('{"openai":{"type":"api_key","key":"old"}}').toString("base64"),
+    });
+    const workspaceUrl = pathToFileURL(join(packageDir, "dist/deploy/workspace.js")).href;
+    const startUrl = pathToFileURL(join(packageDir, "dist/cli/commands/start.js")).href;
+    // Native Node resolution is essential: a test loader can deduplicate the two package installations.
+    const script = `
 import { mock } from "node:test";
 import { strict as assert } from "node:assert";
 const storage = await import(${JSON.stringify(`${workspaceUrl}?actual`)});
@@ -152,28 +144,26 @@ try {
 }
 }
 `;
-      await exec(process.execPath, ["--experimental-test-module-mocks", "--input-type=module", "-e", script, "fail"], {
-        env,
-        timeout: CHILD_TIMEOUT_MS,
-      });
-      const out = await exec(
-        process.execPath,
-        ["--experimental-test-module-mocks", "--input-type=module", "-e", script],
-        { env, timeout: CHILD_TIMEOUT_MS },
-      );
-      const events = JSON.parse(out.stdout.trim().split("\n").at(-1)!) as { type: string; content?: unknown }[];
-      expect(events.at(-1)).toEqual({ type: "completed" });
-      const result = events.find((event) => event.type === "tool_ended");
-      expect(JSON.stringify(result)).toContain("workspace-conversation");
-      expect(JSON.stringify(result)).toContain(join(root, "base"));
-      expect(await readFile(join(root, ".secrets/auth.json"), "utf8")).toBe(rotated);
-      expect(requests).toBe(2);
-      expect(await readFile(attempts, "utf8")).toBe("failed\nretry\n");
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
-      await rm(dir, { recursive: true, force: true });
-    }
-  },
-  TEST_TIMEOUT_MS,
-);
+    await exec(process.execPath, ["--experimental-test-module-mocks", "--input-type=module", "-e", script, "fail"], {
+      env,
+      timeout: CHILD_TIMEOUT_MS,
+    });
+    const out = await exec(
+      process.execPath,
+      ["--experimental-test-module-mocks", "--input-type=module", "-e", script],
+      { env, timeout: CHILD_TIMEOUT_MS },
+    );
+    const events = JSON.parse(out.stdout.trim().split("\n").at(-1)!) as { type: string; content?: unknown }[];
+    expect(events.at(-1)).toEqual({ type: "completed" });
+    const result = events.find((event) => event.type === "tool_ended");
+    expect(JSON.stringify(result)).toContain("workspace-conversation");
+    expect(JSON.stringify(result)).toContain(join(root, "base"));
+    expect(await readFile(join(root, ".secrets/auth.json"), "utf8")).toBe(rotated);
+    expect(requests).toBe(2);
+    expect(await readFile(attempts, "utf8")).toBe("failed\nretry\n");
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 120_000);


### PR DESCRIPTION
Two tests time out during a full `npm test` on a busy machine and pass in isolation, which makes the local gate — the thing `CONTRIBUTING.md` asks you to trust before opening a PR — unreliable. Both are import-bound cold starts, so their cost scales with how contended the machine is, not with anything they assert.

Measured on an 8-core laptop, full suite:

| test | idle | every core saturated | old ceiling | new |
|---|---|---|---|---|
| `deployment-start` (project compile + two cold engine starts in children) | 2.9 s | **31.2 s** | 30 s | 120 s (child `execFile` 20 s → 45 s) |
| `agentcore-service` "the assemble stage REJECTS" (one full cold engine assembly) | 21.0 s | **47.8 s** | 60 s | 120 s |

`deployment-start` crossed its ceiling under synthetic load; `agentcore-service` was observed failing at 60 s during a real full-suite run with Docker and a browser resident.

Raising the budget rather than capping parallelism is the policy `vitest.config.ts` already states: `maxWorkers` was measured and rejected there (17 s → ~60 s, no-op on a small CI runner, and powerless against external load anyway).

The budgets still bound a genuine hang. In `agentcore-service` the file's other eleven tests answer in single-digit milliseconds, so only the cold-assembly one can spend the 120 s. In `deployment-start` the child `execFile` ceiling stays the tighter of the two, so a hung child is still reported as a child timeout rather than an opaque test timeout.

### Verification

`npm run lint && npm run typecheck` clean. Full suite green (125 files / 1607 tests) both idle and with every core saturated by busy loops — the loaded run is where the numbers above come from.