### PR TITLE
refactor(pi): one admission rule for every run control

### DIFF
--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -131,39 +131,35 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
       }
     };
     const ready = Deferred.await(bound);
+    /**
+     * Every control command obeys one admission rule: wait for this run's binding, then refuse once it has settled.
+     * Kept in one place so a fourth command cannot arrive with a fifth spelling of it.
+     */
+    const command = (run: (session: AgentSession) => Effect.Effect<void, PortFailure>): Promise<void> =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const session = yield* ready;
+          if (settled)
+            return yield* Effect.fail(
+              new PortFailure(new Error("run already settled; the command cannot take effect")),
+            );
+          yield* run(session);
+        }),
+      );
+    // Image preparation is pure and runs after admission: a settled run must not pay for a resize nobody reads.
+    const enqueue = (p: Prompt, queue: "steer" | "followUp"): Promise<void> =>
+      command((session) =>
+        Effect.gen(function* () {
+          const opts = yield* port(() => toPiPromptOptions(p));
+          yield* port(() => session[queue](p.text, opts?.images));
+        }),
+      );
     const controls: RunControls = {
-      steer: (p) =>
-        Effect.runPromise(
-          Effect.gen(function* () {
-            const opts = yield* port(() => toPiPromptOptions(p));
-            const session = yield* ready;
-            if (settled)
-              return yield* Effect.fail(
-                new PortFailure(new Error("run already settled; the command cannot take effect")),
-              );
-            yield* port(() => session.steer(p.text, opts?.images));
-          }),
-        ),
-      followUp: (p) =>
-        Effect.runPromise(
-          Effect.gen(function* () {
-            const opts = yield* port(() => toPiPromptOptions(p));
-            const session = yield* ready;
-            if (settled)
-              return yield* Effect.fail(
-                new PortFailure(new Error("run already settled; the command cannot take effect")),
-              );
-            yield* port(() => session.followUp(p.text, opts?.images));
-          }),
-        ),
+      steer: (p) => enqueue(p, "steer"),
+      followUp: (p) => enqueue(p, "followUp"),
       abort: () =>
-        Effect.runPromise(
+        command((session) =>
           Effect.gen(function* () {
-            const session = yield* ready;
-            if (settled)
-              return yield* Effect.fail(
-                new PortFailure(new Error("run already settled; the command cannot take effect")),
-              );
             abortsInFlight++;
             yield* port(() => session.abort()).pipe(
               Effect.tap(() =>

--- a/src/engines/pi/invoke-session.ts
+++ b/src/engines/pi/invoke-session.ts
@@ -146,14 +146,14 @@ export function createPiAgentFromSession(options: CreatePiAgentFromSessionOption
           yield* run(session);
         }),
       );
-    // Image preparation is pure and runs after admission: a settled run must not pay for a resize nobody reads.
-    const enqueue = (p: Prompt, queue: "steer" | "followUp"): Promise<void> =>
-      command((session) =>
-        Effect.gen(function* () {
-          const opts = yield* port(() => toPiPromptOptions(p));
-          yield* port(() => session[queue](p.text, opts?.images));
-        }),
-      );
+    // Prompt preparation stays OUTSIDE admission. An await between the settled check and the enqueue would let the run
+    // end in between, and pi accepts a message for a finished run without complaint (`_steeringMessages.push`) — the
+    // command would be dropped and still reported as success. Image resizing is exactly such an await, hundreds of
+    // milliseconds of dynamic import and Photon work, and doing it here also keeps it overlapping session acquisition.
+    const enqueue = async (p: Prompt, kind: "steer" | "followUp"): Promise<void> => {
+      const opts = await toPiPromptOptions(p);
+      return command((session) => port(() => session[kind](p.text, opts?.images)));
+    };
     const controls: RunControls = {
       steer: (p) => enqueue(p, "steer"),
       followUp: (p) => enqueue(p, "followUp"),

--- a/test/invoke-session.test.ts
+++ b/test/invoke-session.test.ts
@@ -329,6 +329,46 @@ describe("AgentSession L0: the observation plane", () => {
     await expect(controls?.steer({ text: "too late" })).rejects.toThrow(/already settled/);
     await expect(controls?.abort()).rejects.toThrow(/already settled/);
   });
+
+  it("refuses a command whose own prompt preparation outlived the run", async () => {
+    // Admission and the enqueue must not be separated by an await: pi takes a steering message for a
+    // finished run without complaint, so a command admitted before the run settles and delivered after
+    // it would be dropped from the model call and still reported as success.
+    const steered: string[] = [];
+    const { session } = promptRecordingSession();
+    (session as unknown as { steer: (text: string) => Promise<void> }).steer = async (text) => {
+      steered.push(text);
+    };
+    let controls: RunControls | undefined;
+    const agent = createPiAgentFromSession({
+      observer: (_s, _e, run) => {
+        if (run) controls = run;
+      },
+      sessionFactory: async () => session,
+    });
+
+    const bound = Promise.withResolvers<void>();
+    const finishTurn = Promise.withResolvers<void>();
+    let preps = 0;
+    let turn: Promise<AgentEvent[]> | undefined;
+    duringPromptPrep.value = async () => {
+      if (preps++ === 0) {
+        bound.resolve(); // the run is live and its controls are published
+        await finishTurn.promise;
+        return;
+      }
+      // This is the steer's OWN preparation: let the run settle while it is in flight.
+      finishTurn.resolve();
+      await turn;
+    };
+
+    turn = drain(agent.invoke({ session: "settling" }, { text: "hi" }));
+    await bound.promise;
+
+    await expect(controls?.steer({ text: "late" })).rejects.toThrow(/already settled/);
+    expect(steered).toEqual([]);
+    await turn;
+  });
 });
 
 describe("invocation execution scope", () => {


### PR DESCRIPTION
## What changed

`createPiAgentFromSession`'s three run controls each carried their own copy of the same admission
rule (wait for this run's binding, then refuse once it has settled), including three copies of the
refusal message. `command(run)` now holds that rule, and `enqueue(prompt, kind)` collapses `steer`
and `followUp`, which differed only in which pi queue they name.

## Ordering the helper has to preserve

Admission and the enqueue must stay adjacent, with no await between them. `AgentSession.steer()`
pushes onto `_steeringMessages` for a finished run without complaining, so a command admitted while
the run is live and delivered after it settles is dropped from the model call and still reported as
`{ ok: true }` by `runAction`. Prompt preparation therefore stays outside `command()` — where it also
keeps overlapping session acquisition, so a first image-carrying `steer` does not serialize a resize
behind binding.

`abort`'s in-flight counter and success flag keep their exact positions: the increment happens after
admission and before the port call, inside the effect rather than at construction.

## Verification

`npm run lint && npm run typecheck && npm test`: 1,642 passing, 2 skipped, 127 files.

The settled-refusal rule keeps its existing coverage in `test/invoke-session.test.ts` and
`test/session-control.test.ts`; `followUp` reaches it through the same `enqueue` path as `steer`.
`refuses a command whose own prompt preparation outlived the run` covers the ordering constraint
above by settling the run from inside the steer's own preparation — it fails if preparation moves
behind the admission check.

Follow-up to the #480 Effect adoption review.
