### PR TITLE
feat(tool): report how much of a result the model would receive

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -323,6 +323,31 @@ ride `AsyncLocalStorage`, not definition closures, because a tool is built once 
 The built-in **`wake`** tool uses `sessionManager.getSessionId()` to schedule a follow-up in the same
 conversation.
 
+### Output budget
+
+Everything a tool returns is spent from the model's context, on every turn that keeps the result in
+view. One GitHub repository object is ~6 KB, so returning a raw `/search/repositories` page (30
+results) costs ~180 KB — roughly 45k tokens for one call.
+
+Return what the model needs, not what the API sent:
+
+- **Project the fields.** A name, a URL and a description usually replace the whole object.
+- **Truncate, and say so.** The scaffolded `tools/fetch-url.ts` is the pattern: a `MAX_TEXT` ceiling
+  plus a `truncated: true` flag, so the model knows the text was cut rather than guessing.
+- **Expose the paging knob** (`per_page`, `limit`) as an input, so the model can ask for less.
+
+`fastagent tool <name> '<json>'` reports the size of what the model would receive:
+
+```
+[fastagent] result: 143910 chars ≈ 35978 tokens to the model
+```
+
+That measures the tool result's content text, which is not what the command prints — the printed form
+is the indented `details`, so measuring the piped stdout answers a different question.
+
+Tools are plain ES modules, so they can be imported and tested without fastagent: `node --test
+test/my-tool.test.ts` on Node 22+ needs no framework and no test script.
+
 ### Deferred tools
 
 For tool-heavy agents, `defineTool({ ..., deferred: true })` registers a tool without activating it:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,6 +243,10 @@ Example:
 fastagent tool fetch-url '{"url":"https://example.com"}'
 ```
 
+The result goes to stdout as data; stderr reports how much of it the model would receive
+(`result: 143910 chars ≈ 35978 tokens to the model`). See
+[Output budget](api-reference.md#output-budget) for what to do about a large one.
+
 ## `fastagent add github|telegram|slack|feishu|lark`
 
 ```bash

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -44,11 +44,17 @@ export async function runTool(name: string, argsJson: string, dirArg: string): P
   gateSecretsOrExit({ declared: toolSecrets, failures: toolFailures, owner: name });
   // Authored tools read cwd from turnContext; coding tools are already rooted at the workspace.
   const result = await turnContext.run({ cwd: workspace }, () => tool.execute(`cli-${name}`, args)).catch(failStartup);
-  const out =
-    result?.details !== undefined
-      ? result.details
-      : (result?.content ?? []).map((c) => ("text" in c ? c.text : "")).join("");
-  console.log(typeof out === "string" ? out : JSON.stringify(out, null, 2));
+  // What the MODEL receives, which is not what is printed below: the printed form is `details` (readable, indented),
+  // the model's is the content text (compact JSON). Piping stdout through `wc -c` therefore answers the wrong
+  // question, and there is nowhere else to ask this one — so the run that a tool author already does reports it.
+  const modelText = (result?.content ?? []).map((c) => ("text" in c ? c.text : "")).join("");
+  const out = result?.details !== undefined ? result.details : modelText;
+  console.log(typeof out === "string" ? out : JSON.stringify(out, null, 2)); // stdout stays DATA
+  // No threshold warning: context windows run from 128k to 1M, so any fixed ceiling here would be invented. The
+  // number is the signal; docs/api-reference.md carries the judgement. ~4 chars/token is the usual rough figure.
+  console.error(
+    `[fastagent] result: ${modelText.length} chars ≈ ${Math.ceil(modelText.length / 4)} tokens to the model`,
+  );
 }
 
 /** Parse the CLI's JSON args blob; malformed input syntax is a usage error (exit 2). */

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -286,6 +286,24 @@ describe("cli papercuts", () => {
     expect(stderr).not.toMatch(/at gateSecrets|Node\.js v/);
   });
 
+  it("tool reports the size the MODEL sees, which is not the size it prints", async () => {
+    // The printed form is `details`, indented for a human; the model gets the content text (compact JSON). Measuring
+    // the piped stdout therefore answers a different question, which is why the run reports this one itself.
+    const value = { note: "x".repeat(200) };
+    const dir = await agentWorkspace("fa-tool-size-", {
+      "tools/big.mjs":
+        `export default { name: "big", description: "b", parameters: { type: "object", properties: {} },\n` +
+        `  execute: async () => ({ content: [{ type: "text", text: ${JSON.stringify(JSON.stringify(value))} }],\n` +
+        `    details: ${JSON.stringify(value)} }) };\n`,
+    });
+
+    const { code, stdout, stderr } = await run(["tool", "big", "{}", dir]);
+    expect(code, stderr).toBe(0);
+    const modelChars = JSON.stringify(value).length;
+    expect(stderr).toContain(`result: ${modelChars} chars \u2248 ${Math.ceil(modelChars / 4)} tokens to the model`);
+    expect(stdout.trim().length).toBeGreaterThan(modelChars); // the indented print is the bigger one
+  });
+
   it("tool asserts only the named tool's secrets, not every mounted tool's", async () => {
     // Same scoping as `fire`: running one tool by hand on a machine that holds only some credentials
     // must not be blocked by a sibling tool's declaration.


### PR DESCRIPTION
Closes #479.

A tool that returns a raw API response floods the model's context, and nothing tells the author: one GitHub repository object is ~6 KB, so a `/search/repositories` page is ~180 KB per call.

## `fastagent tool` reports the model's size

```
[fastagent] result: 143910 chars ≈ 35978 tokens to the model
```

On stderr; stdout stays the data it was. The number is **not** obtainable outside the command: what is printed is `details` (indented, for a human) while the model receives the content text (compact JSON), so `fastagent tool … | wc -c` measures a different string. A tool that returns no content reports 0 — which is also what the model gets (`pi-agent-core` normalizes a missing `content` to `[]`).

No threshold warning: context windows run from 128k to 1M, so a fixed ceiling here would be invented. The number is the signal; the judgement lives in the docs.

## Docs

`docs/api-reference.md` gains an **Output budget** section: project the fields, truncate with a `truncated: true` flag (the scaffolded `fetch-url.ts` is the pattern), expose the paging knob as an input. It also notes that tools are plain ES modules, so `node --test test/my-tool.test.ts` works on Node 22+ with no framework. `docs/cli.md` points at it from the `fastagent tool` entry.

## Not done

The issue also suggests scaffolding `test/fetch-url.test.ts` plus a `"test": "node --test test/"` script into every `init`. Declined: it leaves an orphan test in every agent that deletes the example tool, and the script fails once `test/` is gone — a new failure surface in every new workspace for something fastagent never runs. The one sentence in the docs carries the same information.

## Tests

One CLI case pins the claim that makes this worth a line of output: the reported size is the compact content text, and the printed form is the larger one.
