### PR TITLE
dev: default the bind to loopback

### DIFF
--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -278,7 +278,7 @@ This makes a real model request and may incur cost. Verify tool use and the answ
 process exit. For continuous local development, ask the owner to run:
 
 ```bash
-fastagent dev --bind 127.0.0.1
+fastagent dev
 ```
 
 `dev` is a long-running server. Edits to `persona.md`, `AGENTS.md`, and skills are read on the next turn.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -360,7 +360,7 @@ Recurring per-command options (same meaning everywhere they appear):
 
 | Option | Commands | Meaning |
 |---|---|---|
-| `--bind <addr>` | `dev`, `start` | Bind address — an IP literal, or `localhost` (read as `127.0.0.1`). Default: `127.0.0.1` for `dev`, all interfaces for `start` (containers need it); `--bind 0.0.0.0` opens a dev serve to the LAN. Prefer this flag over `http.host` for either choice — config travels into a deployed image, where `deploy` gates it. See [Bind address](configuration.md#bind-address). |
+| `--bind <addr>` | `dev`, `start` | Bind address — an IP literal, or `localhost` (read as `127.0.0.1`). Default: `127.0.0.1` for `dev`, all interfaces for `start` (containers need it); `--bind 0.0.0.0` opens a dev serve to the LAN. Prefer this flag over `http.host` for a non-wildcard bind — that value travels into a deployed image, where `deploy` gates it. See [Bind address](configuration.md#bind-address). |
 | `--no-input` | `dev`, `start`, `invoke`, `fire`, `login`, `deploy` | Never prompt; missing information becomes an error with the flag to pass (`deploy` plan mode only warns on a missing model — `--run` gates). |
 | `--model <provider/modelId>` | assembly commands | Model override (`--model > FASTAGENT_MODEL > config`). |
 | `--auth-path <file>` | assembly commands, `login` | Credentials file override. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -311,11 +311,13 @@ Port precedence:
 --port > PORT > fastagent.config.* http.port > 8787
 ```
 
-Bind precedence (same for `dev`):
+Bind precedence:
 
 ```txt
 --bind > fastagent.config.* http.host > all interfaces
 ```
+
+`dev` reads the same chain but ends it at `127.0.0.1` — see [Bind address](configuration.md#bind-address).
 
 Session directory precedence:
 
@@ -358,7 +360,7 @@ Recurring per-command options (same meaning everywhere they appear):
 
 | Option | Commands | Meaning |
 |---|---|---|
-| `--bind <addr>` | `dev`, `start` | Bind address — an IP literal, or `localhost` (read as `127.0.0.1`). Default: all interfaces (containers need it); `127.0.0.1` keeps the port, `/control/*` included, off the LAN. Prefer this flag over `http.host` for a local-only bind — config travels into a deployed image, where `deploy` gates it. See [Bind address](configuration.md#bind-address). |
+| `--bind <addr>` | `dev`, `start` | Bind address — an IP literal, or `localhost` (read as `127.0.0.1`). Default: `127.0.0.1` for `dev`, all interfaces for `start` (containers need it); `--bind 0.0.0.0` opens a dev serve to the LAN. Prefer this flag over `http.host` for either choice — config travels into a deployed image, where `deploy` gates it. See [Bind address](configuration.md#bind-address). |
 | `--no-input` | `dev`, `start`, `invoke`, `fire`, `login`, `deploy` | Never prompt; missing information becomes an error with the flag to pass (`deploy` plan mode only warns on a missing model — `--run` gates). |
 | `--model <provider/modelId>` | assembly commands | Model override (`--model > FASTAGENT_MODEL > config`). |
 | `--auth-path <file>` | assembly commands, `login` | Credentials file override. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,9 +41,9 @@ Supported keys:
 | `thinkingLevel` | Reasoning effort for the model, on pi's scale: `off` \| `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max`. Default: `medium` — pinned by fastagent to match the pi TUI's default (authors vibe at `medium`, so serving must match; the pin also means an upstream default change cannot silently alter deployments). Levels a model doesn't support are clamped by the engine. |
 | `tools` | Extra programmatic tools appended after the pi coding tools. Most users should prefer `tools/` discovery. |
 | `http.port` | Default port for `dev` / `start`. |
-| `http.host` | Bind address for `dev` / `start`. Unset (or `0.0.0.0`) binds all interfaces — what containers need. `--bind` overrides it; prefer the flag for a local-only bind, since this value travels into a deployed image (see [Bind address](#bind-address)). |
+| `http.host` | Bind address for `dev` / `start`. Unset leaves the default to the command: `start` binds all interfaces (what containers need), `dev` binds `127.0.0.1`. `--bind` overrides it; prefer the flag for a local-only bind, since this value travels into a deployed image (see [Bind address](#bind-address)). |
 | `selfSchedule` | Mount the built-in `wake` tool so the agent can schedule its own follow-up turns (self-scheduling). Off by default — an autonomy capability, opt in when you want it; only active on the serving path (`dev`/`start` or `createAgentService`). Resident hosts poll locally; [AgentCore ingress](deploy.md#aws-bedrock-agentcore) uses external wake alarms. |
-| `sessionControl` | Serve the session control plane at `/control/*` (a session's state/entries/live events, its actions — steer/abort/compact — its properties, and the deployment's session list) for remote consumers — a Web panel, a desktop app, `fastagent attach`. Off by default (it is a remote-control surface). When on, `dev`/`start` mint a per-boot bearer token into `<stateRoot>/control.json`; the serve binds all interfaces by default, so the routes are LAN-reachable with the token as the only protection — bind loopback (`--bind 127.0.0.1` — not `http.host`, which travels into a deployed image), firewall the port, or wrap it. On a deployed box (`fastagent deploy`) the routes ride the public host URL, so the token comes from outside instead: set `FASTAGENT_CONTROL_TOKEN` as a deploy secret (`deploy` lists it and warns) and the serve uses that value rather than minting one nothing outside can read. |
+| `sessionControl` | Serve the session control plane at `/control/*` (a session's state/entries/live events, its actions — steer/abort/compact — its properties, and the deployment's session list) for remote consumers — a Web panel, a desktop app, `fastagent attach`. Off by default (it is a remote-control surface). When on, `dev`/`start` mint a per-boot bearer token into `<stateRoot>/control.json`; `start` binds all interfaces by default, so the routes are LAN-reachable with the token as the only protection — bind loopback (`--bind 127.0.0.1` — not `http.host`, which travels into a deployed image), firewall the port, or wrap it (`dev` binds loopback already). On a deployed box (`fastagent deploy`) the routes ride the public host URL, so the token comes from outside instead: set `FASTAGENT_CONTROL_TOKEN` as a deploy secret (`deploy` lists it and warns) and the serve uses that value rather than minting one nothing outside can read. |
 | `deploy.secrets` | Secret env-var names **no code declares** — a value read outside `tools/`/`schedules/`, or a key used only in a `models.json` header. A tool or schedule that needs a var declares it itself (`defineTool({ secrets: […] })`, see [API reference](api-reference.md#declaring-the-secrets-a-tool-needs)) and `deploy` carries it without it being listed here. Every declared name, from either source, is listed in the runbook against its declaring file and carried from your local env under `--run`; a missing value gates the run. |
 | `deploy.agentcore.idleTimeoutSeconds` | `deploy agentcore` only: how long an idle session keeps its microVM, 60–1209600 seconds. Default `180`. Memory bills for the whole idle tail and a session past it cold-starts, so the workload picks the trade — raise it for a chat agent talked to in bursts, lower it for a schedule-only one. Changing it changes the generated template, so an existing `agentcore.template.yaml` needs `--force` to pick it up. See [AgentCore](deploy.md#aws-bedrock-agentcore). |
 | `deploy.apt` | Extra apt packages baked into the generated image (`["git", "ripgrep"]` — Debian default repos). For a package needing a custom apt repo (e.g. `gh`) or a different base image, provide your own `Dockerfile` — `deploy` keeps an existing one (and warns that `deploy.apt` isn't applied to a hand-written Dockerfile). A `Dockerfile` fastagent generated that later drifts from the current config (a changed `deploy.apt`, a new lockfile) is kept but flagged stale; `--force` regenerates it. |
@@ -219,24 +219,28 @@ Use `PORT` in hosted environments that inject a port.
 ## Bind address
 
 ```txt
---bind > fastagent.config.* http.host > all interfaces
+dev:   --bind > fastagent.config.* http.host > 127.0.0.1
+start: --bind > fastagent.config.* http.host > all interfaces
 ```
 
 `localhost` is accepted and resolved to `127.0.0.1` as it is read, so what binds, what the startup
 lines print and what `control.json` records are the same address — a name would leave that to
 `dns.lookup` on one side and to the client's resolver on the other, which can disagree.
 
-All interfaces is the default because containers require it. A desktop app driving a local agent wants
-the opposite: `--bind 127.0.0.1` keeps the port — `/control/*` with it — unreachable from the LAN.
-`<stateRoot>/control.json` records the address a client should dial, so clients read it rather than
-assume one.
+The chain is one; only its last rung differs, because the two commands sit in different places.
+`start` is the container/server posture, where all interfaces is what makes the port reachable at all.
+`dev` runs on a laptop, on networks its author does not own, and serves the agent's full tool
+authority — so it ends at loopback, and `--bind 0.0.0.0` gives back the reach a container, a phone on
+the LAN, or a colleague needs. `<stateRoot>/control.json` records the address a client should dial,
+so clients read it rather than assume one.
 
 **FastAgent does not provide a security boundary, and a default cannot be one.** The built-in
 `POST /invoke` has no authentication; author-written `tools/` can import anything; a WebSocket or
 Socket-Mode channel dials OUT, so no bind address constrains who can message the agent. Whoever can
-reach an agent can use everything it mounts. Put it behind an application, a gateway, or a network
-you control — that is where the boundary belongs, and a narrower default here would substitute a
-feeling for one.
+reach an agent can use everything it mounts. A bind address decides who can reach the port by
+accident, nothing more. Authentication belongs where the request is still a request: a channel's own
+handler (declaring any channel also replaces the built-in `/invoke`), or your host framework's
+middleware when you [embed](embedding.md) — that is where the boundary lives.
 
 Two edges: `--tunnel` reaches the serve by dialing `localhost`, so a bind that name never resolves to
 (`--bind 192.168.1.5`, or even `--bind 127.0.0.2`) is refused with it; and `http.host` travels into a deployed image, where any non-wildcard bind

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -12,6 +12,13 @@ import { failStartup } from "../fail.ts";
 import { assertTunnelBindable, cliMountOptions, resolveBindHost, serveService } from "../serve.ts";
 import { enterAgentCommand, parseBind, parsePort, reportAssembly } from "../shared.ts";
 
+/**
+ * What `dev` binds when nothing else says: loopback. The bind is not a security boundary — the built-in `POST
+ * /invoke` has no auth either way — but a dev serve carries the agent's full tool authority, and putting it on the
+ * café LAN is not a choice anyone made. `--bind 0.0.0.0` restores the reach a container or a phone needs.
+ */
+const DEV_FALLBACK_BIND = "127.0.0.1";
+
 export interface DevOptions {
   port?: string;
   bind?: string;
@@ -51,7 +58,7 @@ async function serveOnce(placement: ResolvedPlacement, opts: DevOptions): Promis
   }).catch(failStartup);
   // The same report `start` prints; `config:` is dev's own extra (see reportAssembly on the asymmetry).
   await reportAssembly(a, { beforeModel: [["config", a.configPath ?? "(none)"]] });
-  const host = resolveBindHost(bindFlag, a.config.http?.host, tunnel);
+  const host = resolveBindHost(bindFlag, a.config.http?.host, tunnel, DEV_FALLBACK_BIND);
   // The SAME assembly an embedder gets from `createAgentService` — channels, control plane, schedules, long
   // connections.
   const service = await mountAgentService(a, cliMountOptions(logAgentLoop)).catch(failStartup);

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -13,11 +13,18 @@ import { assertTunnelBindable, cliMountOptions, resolveBindHost, serveService } 
 import { enterAgentCommand, parseBind, parsePort, reportAssembly } from "../shared.ts";
 
 /**
- * What `dev` binds when nothing else says: loopback. The bind is not a security boundary — the built-in `POST
- * /invoke` has no auth either way — but a dev serve carries the agent's full tool authority, and putting it on the
- * café LAN is not a choice anyone made. `--bind 0.0.0.0` restores the reach a container or a phone needs.
+ * `dev`'s bind chain — the same one `start` reads, ending at loopback instead of the wildcard. The bind is not a
+ * security boundary (the built-in `POST /invoke` has no auth either way), but a dev serve carries the agent's full
+ * tool authority and lands on networks its author does not own, so reaching the LAN is a choice to make rather than
+ * one to inherit: `--bind 0.0.0.0` gives back the reach a container or a phone needs.
  */
-const DEV_FALLBACK_BIND = "127.0.0.1";
+export function devBindHost(
+  bindFlag: string | undefined,
+  configured: string | undefined,
+  tunnel: boolean,
+): string | undefined {
+  return resolveBindHost(bindFlag, configured, tunnel, "127.0.0.1");
+}
 
 export interface DevOptions {
   port?: string;
@@ -58,7 +65,7 @@ async function serveOnce(placement: ResolvedPlacement, opts: DevOptions): Promis
   }).catch(failStartup);
   // The same report `start` prints; `config:` is dev's own extra (see reportAssembly on the asymmetry).
   await reportAssembly(a, { beforeModel: [["config", a.configPath ?? "(none)"]] });
-  const host = resolveBindHost(bindFlag, a.config.http?.host, tunnel, DEV_FALLBACK_BIND);
+  const host = devBindHost(bindFlag, a.config.http?.host, tunnel);
   // The SAME assembly an embedder gets from `createAgentService` — channels, control plane, schedules, long
   // connections.
   const service = await mountAgentService(a, cliMountOptions(logAgentLoop)).catch(failStartup);

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -81,6 +81,7 @@ export async function runStart(dirArg: string, opts: StartOptions): Promise<void
   // clue in a crash-looping container.
   const service = await openStartService(dirArg, opts).catch(failStartup);
   const tunnel = opts.tunnel ?? false;
+  // No fallback: this is the container posture, so an unset bind stays the wildcard a published port needs.
   const host = resolveBindHost(bindFlag, service.bindHost, tunnel);
   serveService(
     service,

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -28,7 +28,7 @@ const NO_INPUT: FlagSpec = {
 const PORT: FlagSpec = { flags: "--port <n>", description: "HTTP port" };
 const BIND: FlagSpec = {
   flags: "--bind <addr>",
-  description: "bind address (default: all interfaces; 127.0.0.1 keeps it off the LAN)",
+  description: "bind address (dev defaults to 127.0.0.1; start defaults to all interfaces, which containers need)",
 };
 const TUNNEL: FlagSpec = {
   flags: "--tunnel",

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -28,13 +28,18 @@ export function assertTunnelBindable(host: string | undefined, tunnel: boolean, 
   failStartup(new Error(message));
 }
 
-/** The bind address a serve uses: the flag, else `http.host` from the config. */
+/**
+ * The bind address a serve uses: the flag, else `http.host` from the config, else `fallback` — which is where `dev`
+ * and `start` differ. `dev` is a laptop posture on networks its author does not own, and the surface it serves has
+ * shell authority, so it falls back to loopback; `start` keeps the wildcard a container needs.
+ */
 export function resolveBindHost(
   bindFlag: string | undefined,
   configured: string | undefined,
   tunnel: boolean,
+  fallback?: string,
 ): string | undefined {
-  const host = bindFlag ?? (configured === undefined ? undefined : bindAddress(configured));
+  const host = bindFlag ?? (configured === undefined ? fallback : bindAddress(configured));
   assertTunnelBindable(host, tunnel, bindFlag ? "flag" : "config");
   return host;
 }

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -29,9 +29,9 @@ export function assertTunnelBindable(host: string | undefined, tunnel: boolean, 
 }
 
 /**
- * The bind address a serve uses: the flag, else `http.host` from the config, else `fallback` — which is where `dev`
- * and `start` differ. `dev` is a laptop posture on networks its author does not own, and the surface it serves has
- * shell authority, so it falls back to loopback; `start` keeps the wildcard a container needs.
+ * The bind address a serve uses: the flag, else `http.host` from the config, else the caller's `fallback` (omitted =
+ * the wildcard). Only that last rung differs between the commands; why each ends where it does lives with the
+ * command — `devBindHost` in commands/dev.ts, the wildcard `start` needs for a container in commands/start.ts.
  */
 export function resolveBindHost(
   bindFlag: string | undefined,

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -26,8 +26,9 @@ export interface FastagentConfig {
   /** Extra custom tools, appended after the pi coding tools — never replaces them. */
   tools?: FastagentTool[];
   /**
-   * `host` is the bind address: unset (or `0.0.0.0`) binds all interfaces — what containers need; `127.0.0.1` keeps
-   * the serve (including `/control/*`) off the LAN.
+   * `host` is the bind address. Unset leaves the last rung to the command: `start` binds all interfaces (what
+   * containers need), `dev` binds `127.0.0.1`. `0.0.0.0` is all interfaces either way; `127.0.0.1` keeps the serve
+   * (including `/control/*`) off the LAN.
    */
   http?: { port?: number; host?: string };
   /** Mount the built-in `wake` tool so the agent can schedule its OWN follow-up turns (self-scheduling). */

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -240,15 +240,18 @@ describe("cli: bind address policy", () => {
     expect(exits(() => parseBind("banana"))).toBe(2);
   });
 
-  it("resolveBindHost: flag > http.host > the command's fallback (dev loopback, start wildcard)", async () => {
+  it("the bind chain: flag > http.host > the command's last rung (dev loopback, start wildcard)", async () => {
+    // Both commands read ONE chain and differ only in where it ends, so both ends are asserted here: `devBindHost`
+    // is dev's whole policy (its call site passes the parsed flag and `http.host` straight through), and start's
+    // end is `resolveBindHost` with no fallback.
     const { resolveBindHost } = await import("../src/cli/serve.ts");
-    expect(resolveBindHost("192.168.1.5", "0.0.0.0", false, "127.0.0.1")).toBe("192.168.1.5");
-    expect(resolveBindHost(undefined, "0.0.0.0", false, "127.0.0.1")).toBe("0.0.0.0"); // a configured bind beats it
-    expect(resolveBindHost(undefined, "localhost", false, "127.0.0.1")).toBe("127.0.0.1"); // read as an address
-    expect(resolveBindHost(undefined, undefined, false, "127.0.0.1")).toBe("127.0.0.1"); // dev's default
+    const { devBindHost } = await import("../src/cli/commands/dev.ts");
+    expect(devBindHost("192.168.1.5", "0.0.0.0", false)).toBe("192.168.1.5");
+    expect(devBindHost(undefined, "0.0.0.0", false)).toBe("0.0.0.0"); // a configured bind beats the default
+    expect(devBindHost(undefined, "localhost", false)).toBe("127.0.0.1"); // read as an address
+    expect(devBindHost(undefined, undefined, false)).toBe("127.0.0.1"); // dev ends at loopback
+    expect(devBindHost(undefined, undefined, true)).toBe("127.0.0.1"); // a bind `localhost` resolves to: --tunnel ok
     expect(resolveBindHost(undefined, undefined, false)).toBeUndefined(); // start: the wildcard a container needs
-    // dev's fallback is a bind `localhost` resolves to, so --tunnel is not refused by the new default.
-    expect(resolveBindHost(undefined, undefined, true, "127.0.0.1")).toBe("127.0.0.1");
   });
 
   it("assertTunnelBindable: --tunnel refuses a bind localhost cannot reach; the source picks the exit code", async () => {

--- a/test/cli-serve.test.ts
+++ b/test/cli-serve.test.ts
@@ -240,6 +240,17 @@ describe("cli: bind address policy", () => {
     expect(exits(() => parseBind("banana"))).toBe(2);
   });
 
+  it("resolveBindHost: flag > http.host > the command's fallback (dev loopback, start wildcard)", async () => {
+    const { resolveBindHost } = await import("../src/cli/serve.ts");
+    expect(resolveBindHost("192.168.1.5", "0.0.0.0", false, "127.0.0.1")).toBe("192.168.1.5");
+    expect(resolveBindHost(undefined, "0.0.0.0", false, "127.0.0.1")).toBe("0.0.0.0"); // a configured bind beats it
+    expect(resolveBindHost(undefined, "localhost", false, "127.0.0.1")).toBe("127.0.0.1"); // read as an address
+    expect(resolveBindHost(undefined, undefined, false, "127.0.0.1")).toBe("127.0.0.1"); // dev's default
+    expect(resolveBindHost(undefined, undefined, false)).toBeUndefined(); // start: the wildcard a container needs
+    // dev's fallback is a bind `localhost` resolves to, so --tunnel is not refused by the new default.
+    expect(resolveBindHost(undefined, undefined, true, "127.0.0.1")).toBe("127.0.0.1");
+  });
+
   it("assertTunnelBindable: --tunnel refuses a bind localhost cannot reach; the source picks the exit code", async () => {
     const { assertTunnelBindable } = await import("../src/cli/serve.ts");
     expect(exits(() => assertTunnelBindable("192.168.1.5", true, "config"))).toBe(1); // startup failure


### PR DESCRIPTION
Closes #485.

`fastagent dev` now ends its bind chain at `127.0.0.1` instead of the wildcard. `start` is unchanged:

```txt
dev:   --bind > fastagent.config.* http.host > 127.0.0.1
start: --bind > fastagent.config.* http.host > all interfaces
```

One chain, one flag, one config key — only the last rung differs, which is where the two commands
sit: `start` is the container posture, where all interfaces is what makes a published port reachable
at all; `dev` runs on a laptop, on networks its author does not own, and serves the agent's full tool
authority over an unauthenticated built-in `POST /invoke`. Rails derives the same default from the
environment (`localhost` in development, `0.0.0.0` elsewhere), FastAPI splits it across `fastapi dev`
and `fastapi run`.

`http.host` still overrides the default, so an explicit config or `--bind` behaves exactly as before,
and the deploy path (which runs `start` in the image) is untouched. `--tunnel` is unaffected:
cloudflared dials the name `localhost`, which `127.0.0.1` answers, so `assertTunnelBindable` does not
refuse the new default. The startup lines, `control.json`, the EADDRINUSE message and the `/control/*`
LAN warning all read the bind through `classifyBind`/`clientHost`, so they follow automatically — dev
now reports `127.0.0.1:8787` and no longer warns about LAN reach.

The docs said a narrower default "would substitute a feeling for" a security boundary. That claim is
now stated the way it actually holds: a bind address decides who can reach the port by accident,
nothing more, and authentication belongs where the request is still a request — a channel's own
handler (declaring any channel also replaces the built-in `/invoke`), or the host framework's
middleware when embedding. `docs/configuration.md`, `docs/cli.md` and the `http.host` doc comment
carry the same chain.

**Breaking:** running `fastagent dev` inside a container or a remote VM and reaching it from outside
(a published `-p` port, a phone on the LAN, a colleague's machine) now fails with connection refused.
`--bind 0.0.0.0` restores it.
