### PR TITLE
fix(deploy): refuse a literal apiKey that would ship inside the image

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,8 +145,16 @@ Custom endpoints are **additive** — built-in providers stay available alongsid
 ### Keys stay out of the file
 
 `apiKey` (and any `headers` value) resolves at request time: `"$MYGW_API_KEY"` reads an environment
-variable, `"!cmd"` runs a command and uses its stdout, anything else is a literal. Prefer the env
-form — the file then stays safe to commit and to bake into an image.
+variable, `"!cmd"` runs a command and uses its stdout, anything else is a literal.
+
+**Use one of the first two.** A literal credential in this file ships inside the image, where anyone
+who can pull it reads the layer — so `deploy` **refuses `--run`** on a literal `apiKey` for the
+selected model, and warns when only generating artifacts. This is the same rule that makes a
+`.dockerignore` which fails to exclude `.secrets/auth.json` stop a run: any configuration that would
+put a credential into the image gates `--run`. The general form of it: **literal credentials belong in
+`.secrets/` or the platform's secret storage, and every file inside the definition may only carry a
+reference.** `headers` values are not checked (FastAgent cannot tell a credential from an org id
+there), so apply the same rule by hand.
 
 `deploy` recognizes the variable backing the selected model and carries its value to the host like any
 provider key, listing it in the runbook and refusing `--run` when it has no local value. You do not

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,20 +148,19 @@ Custom endpoints are **additive** — built-in providers stay available alongsid
 variable, `"!cmd"` runs a command and uses its stdout, anything else is a literal.
 
 **Use one of the first two for a real key.** A literal credential in this file ships inside the image,
-where anyone who can pull it reads the layer — so `deploy` **refuses `--run`** on a literal `apiKey`
-whose `baseUrl` is reachable from outside the deployment, and warns when only generating artifacts.
-Every declared provider is checked, not just the selected model's: the file ships whole, so a literal
-on a provider nothing selects today is in the image all the same. This is the same rule that makes a
-`.dockerignore` which fails to exclude `.secrets/auth.json` stop a run: any configuration that would
-put a credential into the image gates `--run`. The general form of it: **literal credentials belong in
-`.secrets/` or the platform's secret storage, and every file inside the definition may only carry a
-reference.**
+where anyone who can pull it reads the layer, so `deploy` **warns** about every literal `apiKey` it
+finds — every declared provider, not just the selected model's, because the file ships whole.
 
-A literal against a **loopback or private-range `baseUrl`** only warns. A keyless local server needs a
-placeholder (`"apiKey": "ollama"` for `http://localhost:11434/v1` — omitting it loads the model but
-leaves it unusable), and a string presented only to an address nothing outside can reach is not a
-credential. `headers` values are not checked at all (FastAgent cannot tell a credential from an org id
-there), so apply the same rule to them by hand.
+It warns rather than refuses, and that line is deliberate: whether a given string is a credential is
+*your* knowledge, not FastAgent's. pi's own docs prescribe a placeholder for a keyless local server
+(`"apiKey": "ollama"` for `http://localhost:11434/v1` — omitting it loads the model but leaves it
+unusable), and no static rule separates that from a leaked key. **FastAgent gates what it causes and
+reports what you chose**: a `.dockerignore` that fails to exclude `.secrets/auth.json` *does* stop a
+run, because there a packing rule of ours would put a credential in the image. This file is yours.
+
+The rule to apply yourself: **literal credentials belong in `.secrets/` or the platform's secret
+storage, and every file inside the definition should carry only a reference.** `headers` values are not
+inspected at all (FastAgent cannot tell a credential from an org id there).
 
 `deploy` recognizes the variable backing the selected model and carries its value to the host like any
 provider key, listing it in the runbook and refusing `--run` when it has no local value. You do not

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,8 +148,10 @@ Custom endpoints are **additive** — built-in providers stay available alongsid
 variable, `"!cmd"` runs a command and uses its stdout, anything else is a literal.
 
 **Use one of the first two.** A literal credential in this file ships inside the image, where anyone
-who can pull it reads the layer — so `deploy` **refuses `--run`** on a literal `apiKey` for the
-selected model, and warns when only generating artifacts. This is the same rule that makes a
+who can pull it reads the layer — so `deploy` **refuses `--run`** on a literal `apiKey`, and warns when
+only generating artifacts. Every declared provider is checked, not just the selected model's: the file
+ships whole, so a literal on a provider nothing selects today is in the image all the same. This is the
+same rule that makes a
 `.dockerignore` which fails to exclude `.secrets/auth.json` stop a run: any configuration that would
 put a credential into the image gates `--run`. The general form of it: **literal credentials belong in
 `.secrets/` or the platform's secret storage, and every file inside the definition may only carry a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,16 +147,21 @@ Custom endpoints are **additive** — built-in providers stay available alongsid
 `apiKey` (and any `headers` value) resolves at request time: `"$MYGW_API_KEY"` reads an environment
 variable, `"!cmd"` runs a command and uses its stdout, anything else is a literal.
 
-**Use one of the first two.** A literal credential in this file ships inside the image, where anyone
-who can pull it reads the layer — so `deploy` **refuses `--run`** on a literal `apiKey`, and warns when
-only generating artifacts. Every declared provider is checked, not just the selected model's: the file
-ships whole, so a literal on a provider nothing selects today is in the image all the same. This is the
-same rule that makes a
+**Use one of the first two for a real key.** A literal credential in this file ships inside the image,
+where anyone who can pull it reads the layer — so `deploy` **refuses `--run`** on a literal `apiKey`
+whose `baseUrl` is reachable from outside the deployment, and warns when only generating artifacts.
+Every declared provider is checked, not just the selected model's: the file ships whole, so a literal
+on a provider nothing selects today is in the image all the same. This is the same rule that makes a
 `.dockerignore` which fails to exclude `.secrets/auth.json` stop a run: any configuration that would
 put a credential into the image gates `--run`. The general form of it: **literal credentials belong in
 `.secrets/` or the platform's secret storage, and every file inside the definition may only carry a
-reference.** `headers` values are not checked (FastAgent cannot tell a credential from an org id
-there), so apply the same rule by hand.
+reference.**
+
+A literal against a **loopback or private-range `baseUrl`** only warns. A keyless local server needs a
+placeholder (`"apiKey": "ollama"` for `http://localhost:11434/v1` — omitting it loads the model but
+leaves it unusable), and a string presented only to an address nothing outside can reach is not a
+credential. `headers` values are not checked at all (FastAgent cannot tell a credential from an org id
+there), so apply the same rule to them by hand.
 
 `deploy` recognizes the variable backing the selected model and carries its value to the host like any
 provider key, listing it in the runbook and refusing `--run` when it has no local value. You do not

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,14 +69,20 @@ fastagent deploy docker --run           # starts the existing app+tunnel topolog
 
 The Quick Tunnel URL is ephemeral. Its service deliberately has no restart policy: restarting that container or the Docker daemon creates a new URL that cannot silently replace the old webhook. Re-run `fastagent deploy docker --tunnel --run` to start it and register the new URL. For a fixed/restart-stable endpoint, edit the user-owned Compose topology to use your own named tunnel or reverse proxy.
 
-Operate the generated topology:
+Operate the generated topology. The generated Compose interpolates every declared name as `${NAME:-}`, and Compose
+fills those from the shell or the **project** `.env` — never from the agent's `.secrets/.env`. So a command that
+starts containers needs `--env-file`, or it starts them with every declared value empty and says nothing:
 
 ```bash
-docker compose -f fastagent.compose.yml logs -f agent
-docker compose -f fastagent.compose.yml ps
-docker compose -f fastagent.compose.yml down     # state volume is kept
-docker compose -f fastagent.compose.yml down -v  # destructive: deletes all state
+docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build
+docker compose -f fastagent/fastagent.compose.yml logs -f agent
+docker compose -f fastagent/fastagent.compose.yml ps
+docker compose -f fastagent/fastagent.compose.yml down     # state volume is kept
+docker compose -f fastagent/fastagent.compose.yml down -v  # destructive: deletes all state
 ```
+
+`--run` does the same thing for you, and additionally blanks every interpolated name the value file does not
+declare, so nothing exported on the build machine reaches the container.
 
 ### Taking ownership of Docker files
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -71,7 +71,9 @@ The Quick Tunnel URL is ephemeral. Its service deliberately has no restart polic
 
 Operate the generated topology. The generated Compose interpolates every declared name as `${NAME:-}`, and Compose
 fills those from the shell or the **project** `.env` — never from the agent's `.secrets/.env`. So a command that
-starts containers needs `--env-file`, or it starts them with every declared value empty and says nothing:
+starts containers needs `--env-file`, or it starts them with every declared value empty and says nothing. The
+other commands need no values, and `--env-file` is a hard failure on a missing path, so only `up` carries it (the
+generated runbook omits it entirely until the value file exists):
 
 ```bash
 docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -86,8 +86,21 @@ reads the same declaration by hand and under `--run` alike, so nothing has to be
 filtered, or blanked. The one value not in that file is `FASTAGENT_AUTH_SEED`, which `--run` mints from your local
 `auth.json`; it stays a seam in the committed topology so a hand-run `up` can supply it the same way.
 
-If the value file does not exist yet, the generated Compose omits the `env_file` entry (Compose refuses one pointing
-at a missing path) and the runbook says so — create the file and re-run `fastagent deploy docker`.
+The entry is a **fixed** path, `<agent>/.secrets/.env`, never whatever `FASTAGENT_SECRETS_DIR` resolves to on the
+build machine: this file is committed, so it has to mean the same thing everywhere. `deploy` creates the file when it
+is missing (empty — a deployment that declares nothing declares it in an empty file), because Compose refuses an
+`env_file` entry pointing at a path that does not exist. If `FASTAGENT_SECRETS_DIR` sends `--run` somewhere else,
+`deploy` warns: a hand-run `docker compose up` still reads only the fixed path.
+
+Two things follow from Compose's own behaviour and are worth knowing:
+
+- The machinery variables (`FASTAGENT_STATE_DIR`, `FASTAGENT_SECRETS_DIR`, `FASTAGENT_SESSIONS_DIR`,
+  `FASTAGENT_AUTH_PATH`) are pinned in `environment:`, which Compose applies **after** `env_file`. The scaffolded
+  `.env.example` lists some of them as local overrides; pinning keeps a laptop path from sending the container's
+  sessions or credentials outside the volume.
+- Compose expands `$VAR` **inside** `env_file` values (raw mode needs Compose 2.30, above our floor). A value
+  containing `$` reaches the container rewritten, and an undefined name becomes empty — so escape it as `$$`.
+  `deploy` warns when it finds one.
 
 ### Taking ownership of Docker files
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -84,13 +84,16 @@ docker compose -f fastagent/fastagent.compose.yml down -v  # destructive: delete
 the *project* `.env`, which is exactly the source a deployment must not have. Naming the file means the container
 reads the same declaration by hand and under `--run` alike, so nothing has to be carried through the build machine,
 filtered, or blanked. The one value not in that file is `FASTAGENT_AUTH_SEED`, which `--run` mints from your local
-`auth.json`; it stays a seam in the committed topology so a hand-run `up` can supply it the same way.
+`auth.json`; it stays a seam in the committed topology so a hand-run `up` can supply it **from that command's own
+environment**. Writing this one key into the value file has no effect: `environment:` is applied after `env_file`, so
+the pinned `${FASTAGENT_AUTH_SEED:-}` line blanks it and the container starts without seeding `auth.json`.
 
 The entry is a **fixed** path, `<agent>/.secrets/.env`, never whatever `FASTAGENT_SECRETS_DIR` resolves to on the
 build machine: this file is committed, so it has to mean the same thing everywhere. `deploy` creates the file when it
 is missing (empty — a deployment that declares nothing declares it in an empty file), because Compose refuses an
-`env_file` entry pointing at a path that does not exist. If `FASTAGENT_SECRETS_DIR` sends `--run` somewhere else,
-`deploy` warns: a hand-run `docker compose up` still reads only the fixed path.
+`env_file` entry pointing at a path that does not exist. If `FASTAGENT_SECRETS_DIR` sends this machine's read
+somewhere else, generating artifacts warns and `--run` gates: the credential check would pass on one file while the
+container reads the other and starts with nothing declared.
 
 Two things follow from Compose's own behaviour and are worth knowing:
 
@@ -99,8 +102,9 @@ Two things follow from Compose's own behaviour and are worth knowing:
   `.env.example` lists some of them as local overrides; pinning keeps a laptop path from sending the container's
   sessions or credentials outside the volume.
 - Compose expands `$VAR` **inside** `env_file` values (raw mode needs Compose 2.30, above our floor). A value
-  containing `$` reaches the container rewritten, and an undefined name becomes empty — so escape it as `$$`.
-  `deploy` warns when it finds one.
+  containing `$` reaches the container rewritten, and an undefined name becomes empty. `deploy` warns when it finds
+  one, and does not tell you to escape it: `$$` works for Compose only, while `fastagent dev`/`start` and every other
+  host read this same file literally and would keep the extra `$`. Prefer a value without `$`.
 
 ### Taking ownership of Docker files
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,24 +69,25 @@ fastagent deploy docker --run           # starts the existing app+tunnel topolog
 
 The Quick Tunnel URL is ephemeral. Its service deliberately has no restart policy: restarting that container or the Docker daemon creates a new URL that cannot silently replace the old webhook. Re-run `fastagent deploy docker --tunnel --run` to start it and register the new URL. For a fixed/restart-stable endpoint, edit the user-owned Compose topology to use your own named tunnel or reverse proxy.
 
-Operate the generated topology. The generated Compose interpolates every declared name as `${NAME:-}`, and Compose
-fills those from the shell or the **project** `.env` — never from the agent's `.secrets/.env`. So a command that
-starts containers needs `--env-file`, or it starts them with every declared value empty and says nothing. The
-other commands need no values, and `--env-file` is a hard failure on a missing path, so only `up` carries it (the
-generated runbook omits it entirely until the value file exists):
+Operate the generated topology. The generated Compose names the value file itself (`env_file`), so every command
+is spelled the same way and none needs a flag to reach the deployed environment's declaration:
 
 ```bash
-docker compose --env-file 'fastagent/.secrets/.env' -f fastagent/fastagent.compose.yml up -d --build
+docker compose -f fastagent/fastagent.compose.yml up -d --build
 docker compose -f fastagent/fastagent.compose.yml logs -f agent
 docker compose -f fastagent/fastagent.compose.yml ps
 docker compose -f fastagent/fastagent.compose.yml down     # state volume is kept
 docker compose -f fastagent/fastagent.compose.yml down -v  # destructive: deletes all state
 ```
 
-`--run` does the same thing for you, and additionally blanks every **declared credential name** the value file does
-not supply, so nothing exported on the build machine reaches the container as one. Two things stay inherited on
-purpose or by nature: `NO_PROXY`/`no_proxy` (the tunnel service interpolates them so your own bypass list survives),
-and any name a *kept older* Compose file still interpolates but the current definition no longer declares.
+`env_file` rather than per-name `${NAME:-}` interpolation is the point: interpolation resolves from your shell or
+the *project* `.env`, which is exactly the source a deployment must not have. Naming the file means the container
+reads the same declaration by hand and under `--run` alike, so nothing has to be carried through the build machine,
+filtered, or blanked. The one value not in that file is `FASTAGENT_AUTH_SEED`, which `--run` mints from your local
+`auth.json`; it stays a seam in the committed topology so a hand-run `up` can supply it the same way.
+
+If the value file does not exist yet, the generated Compose omits the `env_file` entry (Compose refuses one pointing
+at a missing path) and the runbook says so — create the file and re-run `fastagent deploy docker`.
 
 ### Taking ownership of Docker files
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -76,7 +76,7 @@ other commands need no values, and `--env-file` is a hard failure on a missing p
 generated runbook omits it entirely until the value file exists):
 
 ```bash
-docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build
+docker compose --env-file 'fastagent/.secrets/.env' -f fastagent/fastagent.compose.yml up -d --build
 docker compose -f fastagent/fastagent.compose.yml logs -f agent
 docker compose -f fastagent/fastagent.compose.yml ps
 docker compose -f fastagent/fastagent.compose.yml down     # state volume is kept

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -29,7 +29,7 @@ Three things must be true, or the deployed box crash-loops on boot:
 
 | Requirement | Why | How |
 |---|---|---|
-| **A model resolves** | The usual `flag > environment > config` chain, evaluated in **the environment being deployed** rather than this machine's. That environment is declared by `.secrets/.env`, so its `FASTAGENT_MODEL` wins and `deploy` records it in the release manifest (`fastagent.release.json`, rewritten by every deploy); `config.model` is the fallback and ships in the config file. Your shell is not part of the deployed environment, and `deploy` has no `--model` flag — a deployment's inputs are files, so that they survive the next deploy that omits them. | Either source. `deploy` prints the effective model and its source, and warns (or, under `--run`, gates) when neither resolves one. |
+| **A model resolves** | The usual `flag > environment > config` chain, evaluated in **the environment being deployed** rather than this machine's. That environment is declared by `.secrets/.env`, so its `FASTAGENT_MODEL` wins and `deploy` records it in the release manifest (`fastagent.release.json`, rewritten by every deploy); `config.model` is the fallback and ships in the config file. Your shell is not part of the deployed environment, and `deploy` has no `--model` flag — a deployment's inputs are files, so that they survive the next deploy that omits them. | Either source. `deploy` prints the effective model and its source, and warns (or, under `--run`, gates) when neither resolves one. A **hand-written** Dockerfile is read only if it sets `ENV FASTAGENT_RELEASE_FILE` — without it the manifest is never read, so a model that lives only in `.secrets/.env` would not reach the box; `deploy` gates that combination. |
 | **Secrets are declared, and their values are in the value file** | The host needs the model API key and every channel's verification secret. | Env-key model auth + channel secrets are auto-listed; declare anything else in `config.deploy.secrets` (see [Configuration](configuration.md)). `--run` reads the values from the agent's `.secrets/.env` and nowhere else — that file declares the deployed environment, so a variable exported in your shell does not reach the deployment. In CI, write the file before running the command. |
 | **Workspace, state and secrets are durable** | Local directories remain where you created them. | Docker, Fly and Railway keep `base/`, `.state/` and `.secrets/` on a volume at `/data`, and a new release replaces only the nested definition. AgentCore uses managed SessionStorage at `/mnt/data`, which the platform resets on every deploy. |
 
@@ -83,8 +83,10 @@ docker compose -f fastagent/fastagent.compose.yml down     # state volume is kep
 docker compose -f fastagent/fastagent.compose.yml down -v  # destructive: deletes all state
 ```
 
-`--run` does the same thing for you, and additionally blanks every interpolated name the value file does not
-declare, so nothing exported on the build machine reaches the container.
+`--run` does the same thing for you, and additionally blanks every **declared credential name** the value file does
+not supply, so nothing exported on the build machine reaches the container as one. Two things stay inherited on
+purpose or by nature: `NO_PROXY`/`no_proxy` (the tunnel service interpolates them so your own bypass list survives),
+and any name a *kept older* Compose file still interpolates but the current definition no longer declares.
 
 ### Taking ownership of Docker files
 

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -55,7 +55,13 @@ Where a credential's **literal value** may appear follows from B/C versus D/E, a
 
 > Literal credentials exist in exactly two places: `.secrets/` (0700, gitignored, excluded from the image) and the platform's secret storage. **Every file inside the definition may only carry a reference**: `"$MY_API_KEY"` or `!command` in `models.json` (pi resolves both), and a declared name everywhere else.
 
-A literal `apiKey` in `models.json` is therefore not an author's choice but an error — it ships inside the image, where any puller reads the layer. `deploy` gates `--run` on it, under the rule the `.dockerignore` check already enforces: **any configuration that would put a credential into the image gates `--run`.**
+That rule is advice to the author, and FastAgent can only report on it — which brings the executable form of question 4:
+
+> **Gate what FastAgent causes. Warn about what the author chose.**
+
+A `.dockerignore` that fails to exclude `.secrets/auth.json` **gates `--run`**: a packing rule of ours would put a credential in the image, and we can decide that with certainty. A literal `apiKey` in `models.json` only **warns**: the author wrote that string into their own committed file, and whether it is a credential is knowledge the framework does not have — pi's docs prescribe `"apiKey": "ollama"` for a keyless local server, and no static property separates that from a leaked key. (An endpoint's reachability is not one: `gw.example.com` may be internal DNS and `10.0.0.1` may be NAT-exposed.)
+
+This is the rule §3's question 4 already implied, written as something a reviewer can apply. It was learned the expensive way: a gate built on "is this string sensitive?" took five rounds of patches enumerating private address ranges before the premise itself turned out to be undecidable.
 
 ## 4. Files
 
@@ -203,8 +209,8 @@ Dropped from the RFC, and from earlier drafts of this document:
 | "credential present + ready" precondition | `src/deploy/registration-gate.ts` |
 | report the effective model **and its source**; validate that model's provider; gate `--run` when **no** source resolves a model (the replacement for the deleted gate — without it the deletion leaves a silent-degradation window) | `src/deploy/preflight.ts` (delete `modelTravelIssue`) |
 | carry the resolved model to the deployed environment | the release manifest (`DeploymentRelease.model` in `src/deploy/workspace.ts`), projected into `process.env` beside `FASTAGENT_AGENT` by `prepareStartWorkspace`. It is rewritten unconditionally by every deploy, so it cannot go stale, and nothing on the way in can interpolate the operator's shell. **Non-credential configuration only** — the manifest rides inside a readable image and is rebuilt every deploy, both of which are the opposite of what a credential needs (§8) |
-| class D reads the **value file only** (§9), so `assembleSecrets` takes that Map instead of `env: NodeJS.ProcessEnv` | `src/deploy/secrets.ts` + `src/cli/commands/deploy/shared.ts`; every host's runbook then tells CI to write the file rather than export variables |
-| a literal `apiKey` in `models.json` gates `--run` (§3); a `$NAME` reference is an ordinary declared secret and belongs in the runbook's required list, not in `modelKeyInDefinition` | `src/engines/pi/models.ts` (`modelCredentialCarry`) + `src/deploy/preflight.ts` |
+| class D reads the **value file only** (§9), so `assembleSecrets` takes that Map instead of `env: NodeJS.ProcessEnv` | `src/deploy/secrets.ts` + `src/cli/commands/deploy/shared.ts`; every host's runbook then tells CI to write the file rather than export variables. Docker reaches it through Compose's own `env_file`, not per-name interpolation — interpolation resolves from the shell, the one source §9 excludes |
+| a literal `apiKey` in `models.json` WARNS (§3: gate what we cause, warn what the author chose); a `$NAME` reference is an ordinary declared secret and belongs in the runbook's required list, not in `modelKeyInDefinition` | `src/engines/pi/models.ts` (`literalKeyProviders`) + `src/deploy/preflight.ts` |
 | `.secrets/<env>/` path derivation | `src/paths.ts` |
 | Per-env artifact names (`fly.<env>.toml`) under `--env` | `src/deploy/container.ts` + each host's `plan.ts` |
 | Unchanged | `FASTAGENT_AUTH_SEED` + chunking + `collectAuthSeed` + `authSeedBytes`, `.secrets/` 0700, `secrets-gate`, `deploy.secrets` / `deploy.apt` |
@@ -214,7 +220,7 @@ Dropped from the RFC, and from earlier drafts of this document:
 | 1 | Deployment phase ordering: no entrance opens before credential + readiness | A correctness fix unrelated to env; worth having today |
 | 2 | `config.name` + one model chain (`FASTAGENT_MODEL` travels with the value file; delete `modelTravelIssue`) | All of day one; the single-instance path is unchanged |
 | 2b | class D reads the value file only — the same rule the model already follows | Removes the last path by which the builder's environment reaches a deployment |
-| 2c | literal-`apiKey` gate + `$NAME` references treated as declared secrets | Closes the second route by which a credential enters the image |
+| 2c | literal-`apiKey` **warning** + `$NAME` references treated as declared secrets | Reports the second route by which a credential enters the image, without the framework deciding what is one |
 | 3 | Credential project > global fallback + `login -g` + drop `--auth-path` | One global login serves every project |
 | 4 | The env addition: `--env` + `.secrets/<env>/.env` + `<name>-<env>` prefix | Pure addition; day-two capability |
 

--- a/src/cli/commands/deploy/agentcore.ts
+++ b/src/cli/commands/deploy/agentcore.ts
@@ -33,7 +33,7 @@ export const agentcoreHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith(TEMPLATE_FILE) && isGeneratedAgentcoreTemplate(content),
   async deploy(ctx) {
     const { opts, agentDir, workspace, config, channels, longConnectionChannels, pre, write } = ctx;
-    const { modelAuth, modelKeyInDefinition, authPath, container, extraSecrets, values } = pre;
+    const { modelAuth, modelKeyInDefinition, authPath, container, extraSecrets, values, valueFile } = pre;
     // Long-connection channels are STRUCTURALLY unsupported: the connection is the ingress, and a reclaimed session
     // has nothing to wake it.
     if (longConnectionChannels.length > 0) {
@@ -121,6 +121,7 @@ export const agentcoreHost: HostDeploy = {
         channels,
         extraSecrets,
         values,
+        valueFile,
         topology: plan.topology,
       });
     }
@@ -140,6 +141,7 @@ async function runDeployAgentcore(
     channels: readonly DeclaredChannel[];
     extraSecrets: readonly DeclaredSecret[];
     values: ReadonlyMap<string, string>;
+    valueFile: string;
     topology: AgentcoreTopology;
   },
 ): Promise<void> {
@@ -166,6 +168,7 @@ async function runDeployAgentcore(
         region: process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION,
         secrets,
         missingSecrets,
+        valueFile: params.valueFile,
         channels,
         topology,
       },

--- a/src/cli/commands/deploy/docker.ts
+++ b/src/cli/commands/deploy/docker.ts
@@ -3,7 +3,6 @@ import { basename, join } from "node:path";
 import { webhookPaths } from "../../../deploy/channel-ingress.ts";
 import {
   composeHasTunnelService,
-  composeInterpolatedNames,
   isGeneratedCompose,
   planDockerDeploy,
   toDockerProjectName,
@@ -110,12 +109,11 @@ async function runDeployDocker(
     valueFile: string;
   },
 ): Promise<void> {
-  const { agentDir, workspace, composeFile, port, requireTunnel, channels, modelAuth, extraSecrets } = params;
+  const { agentDir, workspace, composeFile, port, requireTunnel, channels } = params;
   const { secrets, missingSecrets, needsModelCredential } = await carryCredentials(params);
   const outcome = await deployDockerRun(
     {
       composeFile,
-      interpolated: composeInterpolatedNames({ modelAuth, channels, extraSecrets }),
       port,
       secrets,
       missingSecrets,

--- a/src/cli/commands/deploy/docker.ts
+++ b/src/cli/commands/deploy/docker.ts
@@ -1,5 +1,6 @@
 /** `deploy docker`: one app service + loopback port + state volume, as a user-owned Compose file. */
-import { basename, join } from "node:path";
+import { writeFile } from "node:fs/promises";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { webhookPaths } from "../../../deploy/channel-ingress.ts";
 import {
   composeHasTunnelService,
@@ -10,7 +11,16 @@ import {
 import { deployDockerRun } from "../../../deploy/docker/run.ts";
 import { spawnRunner } from "../../../deploy/runner.ts";
 import { openExternalUrl } from "../../../open-url.ts";
-import { type ResolvedPlacement, readTextIfExists, resolveStateRoot } from "../../../paths.ts";
+import {
+  type ResolvedPlacement,
+  SECRETS_DIRNAME,
+  SECRET_FILE_MODE,
+  ensureSecretsDir,
+  exists,
+  readTextIfExists,
+  resolveStateRoot,
+} from "../../../paths.ts";
+import { dotEnvPath } from "../../../env.ts";
 import { announceWebhooks } from "../../../tunnel.ts";
 import { failStartup } from "../../fail.ts";
 import { type HostDeploy, carryCredentials } from "./shared.ts";
@@ -21,17 +31,31 @@ export const dockerHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith("fastagent.compose.yml") && isGeneratedCompose(content),
   async deploy(ctx) {
     const { opts, agentDir, workspace, channels, webhookChannels, pre, write } = ctx;
-    const {
-      modelAuth,
-      modelKeyInDefinition,
-      authPath,
-      container,
-      port,
-      extraSecrets,
-      values,
-      valueFile,
-      valueFileExists,
-    } = pre;
+    const { modelAuth, modelKeyInDefinition, authPath, container, port, extraSecrets, values, valueFile } = pre;
+    // The generated Compose names `<agent>/.secrets/.env` unconditionally, so it has to be there — Compose refuses
+    // an `env_file` entry pointing at a missing path, and this floor predates `required: false` (Compose 2.24).
+    // Creating it empty is honest: a deployment that declares nothing declares it in an empty file.
+    const composeValueFile = join(agentDir, SECRETS_DIRNAME, ".env");
+    await ensureSecretsDir(dirname(composeValueFile));
+    if (!(await exists(composeValueFile))) await writeFile(composeValueFile, "", { mode: SECRET_FILE_MODE });
+    // `--run` reads whatever `FASTAGENT_SECRETS_DIR` resolved to; the committed Compose cannot, because a builder's
+    // path would not mean the same thing anywhere else.
+    if (resolve(dotEnvPath(agentDir)) !== resolve(composeValueFile)) {
+      console.error(
+        `[fastagent] warn: FASTAGENT_SECRETS_DIR points --run at ${valueFile}, but the generated Compose reads ` +
+          `${relative(workspace, composeValueFile)} (a committed artifact cannot carry this machine's path). A ` +
+          `hand-run \`docker compose up\` sees only the latter.`,
+      );
+    }
+    // Compose interpolates `$VAR` INSIDE env_file values (`format: raw` needs Compose 2.30), so a credential
+    // containing `$` reaches the container rewritten — silently, and differently from what this pre-flight read.
+    const dollarValues = [...values].filter(([, value]) => value.includes("$")).map(([name]) => name);
+    if (dollarValues.length > 0) {
+      console.error(
+        `[fastagent] warn: ${dollarValues.join(", ")} contain "$", which Compose expands when reading the value ` +
+          `file (an undefined name becomes empty). Escape each one as "$$" in ${valueFile}.`,
+      );
+    }
     const hasDeclaredChannels = channels.length > 0;
     const projectName = toDockerProjectName(basename(workspace));
     const dockerPlan = (tunnel: boolean) =>
@@ -43,7 +67,6 @@ export const dockerHost: HostDeploy = {
         tunnel,
         extraSecrets,
         valueFile,
-        valueFileExists,
         ...container,
       });
     const requestedTunnel = !!opts.tunnel && (!hasDeclaredChannels || webhookChannels.length > 0);

--- a/src/cli/commands/deploy/docker.ts
+++ b/src/cli/commands/deploy/docker.ts
@@ -38,22 +38,29 @@ export const dockerHost: HostDeploy = {
     const composeValueFile = join(agentDir, SECRETS_DIRNAME, ".env");
     await ensureSecretsDir(dirname(composeValueFile));
     if (!(await exists(composeValueFile))) await writeFile(composeValueFile, "", { mode: SECRET_FILE_MODE });
-    // `--run` reads whatever `FASTAGENT_SECRETS_DIR` resolved to; the committed Compose cannot, because a builder's
-    // path would not mean the same thing anywhere else.
+    // The pre-flight read whatever `FASTAGENT_SECRETS_DIR` resolved to; the committed Compose cannot, because a
+    // builder's path would not mean the same thing anywhere else. Under `--run` the two files disagreeing is a
+    // DETERMINISTIC failure and gates like every other one: the missing-values gate would pass on the file this
+    // machine reads while `compose up` starts a container whose declared secrets and model are all absent.
     if (resolve(dotEnvPath(agentDir)) !== resolve(composeValueFile)) {
-      console.error(
-        `[fastagent] warn: FASTAGENT_SECRETS_DIR points --run at ${valueFile}, but the generated Compose reads ` +
-          `${relative(workspace, composeValueFile)} (a committed artifact cannot carry this machine's path). A ` +
-          `hand-run \`docker compose up\` sees only the latter.`,
-      );
+      const issue =
+        `FASTAGENT_SECRETS_DIR points this run's values at ${valueFile}, but the generated Compose reads ` +
+        `${relative(workspace, composeValueFile)} (a committed artifact cannot carry this machine's path), so the ` +
+        `container would start with none of them. Unset FASTAGENT_SECRETS_DIR, or put the values in that file.`;
+      if (opts.run) failStartup(new Error(`deploy stopped: ${issue}`));
+      console.error(`[fastagent] warn: ${issue}`);
     }
     // Compose interpolates `$VAR` INSIDE env_file values (`format: raw` needs Compose 2.30), so a credential
     // containing `$` reaches the container rewritten — silently, and differently from what this pre-flight read.
+    // No escaping advice: this ONE file is also read literally by `dev`/`start` (`parseEnvContent`) and pushed
+    // as-is by every other host, so `$$` would fix Docker by corrupting all of them.
     const dollarValues = [...values].filter(([, value]) => value.includes("$")).map(([name]) => name);
     if (dollarValues.length > 0) {
       console.error(
-        `[fastagent] warn: ${dollarValues.join(", ")} contain "$", which Compose expands when reading the value ` +
-          `file (an undefined name becomes empty). Escape each one as "$$" in ${valueFile}.`,
+        `[fastagent] warn: ${dollarValues.join(", ")} contain "$", which Compose expands when reading ${valueFile} ` +
+          `(an undefined name becomes empty), so the container sees a different value. "$$" escapes it for Compose ` +
+          `ONLY — \`fastagent dev\`/\`start\` and the other hosts read this file literally and would keep the extra ` +
+          `"$". Prefer a value without "$".`,
       );
     }
     const hasDeclaredChannels = channels.length > 0;

--- a/src/cli/commands/deploy/docker.ts
+++ b/src/cli/commands/deploy/docker.ts
@@ -21,7 +21,7 @@ export const dockerHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith("fastagent.compose.yml") && isGeneratedCompose(content),
   async deploy(ctx) {
     const { opts, agentDir, workspace, channels, webhookChannels, pre, write } = ctx;
-    const { modelAuth, modelKeyInDefinition, authPath, container, port, extraSecrets, values } = pre;
+    const { modelAuth, modelKeyInDefinition, authPath, container, port, extraSecrets, values, valueFile } = pre;
     const hasDeclaredChannels = channels.length > 0;
     const projectName = toDockerProjectName(basename(workspace));
     const dockerPlan = (tunnel: boolean) =>
@@ -65,6 +65,7 @@ export const dockerHost: HostDeploy = {
         channels,
         extraSecrets,
         values,
+        valueFile,
       });
     }
     if (keptWithoutRequestedTunnel) {
@@ -93,6 +94,7 @@ async function runDeployDocker(
     channels: readonly DeclaredChannel[];
     extraSecrets: readonly DeclaredSecret[];
     values: ReadonlyMap<string, string>;
+    valueFile: string;
   },
 ): Promise<void> {
   const { agentDir, workspace, composeFile, port, requireTunnel, channels } = params;
@@ -103,6 +105,7 @@ async function runDeployDocker(
       port,
       secrets,
       missingSecrets,
+      valueFile: params.valueFile,
       needsModelCredential,
       requireTunnel,
       announce: (tunnelUrl) =>

--- a/src/cli/commands/deploy/docker.ts
+++ b/src/cli/commands/deploy/docker.ts
@@ -22,7 +22,17 @@ export const dockerHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith("fastagent.compose.yml") && isGeneratedCompose(content),
   async deploy(ctx) {
     const { opts, agentDir, workspace, channels, webhookChannels, pre, write } = ctx;
-    const { modelAuth, modelKeyInDefinition, authPath, container, port, extraSecrets, values, valueFile } = pre;
+    const {
+      modelAuth,
+      modelKeyInDefinition,
+      authPath,
+      container,
+      port,
+      extraSecrets,
+      values,
+      valueFile,
+      valueFileExists,
+    } = pre;
     const hasDeclaredChannels = channels.length > 0;
     const projectName = toDockerProjectName(basename(workspace));
     const dockerPlan = (tunnel: boolean) =>
@@ -33,6 +43,8 @@ export const dockerHost: HostDeploy = {
         channels,
         tunnel,
         extraSecrets,
+        valueFile,
+        valueFileExists,
         ...container,
       });
     const requestedTunnel = !!opts.tunnel && (!hasDeclaredChannels || webhookChannels.length > 0);

--- a/src/cli/commands/deploy/docker.ts
+++ b/src/cli/commands/deploy/docker.ts
@@ -3,6 +3,7 @@ import { basename, join } from "node:path";
 import { webhookPaths } from "../../../deploy/channel-ingress.ts";
 import {
   composeHasTunnelService,
+  composeInterpolatedNames,
   isGeneratedCompose,
   planDockerDeploy,
   toDockerProjectName,
@@ -97,11 +98,12 @@ async function runDeployDocker(
     valueFile: string;
   },
 ): Promise<void> {
-  const { agentDir, workspace, composeFile, port, requireTunnel, channels } = params;
+  const { agentDir, workspace, composeFile, port, requireTunnel, channels, modelAuth, extraSecrets } = params;
   const { secrets, missingSecrets, needsModelCredential } = await carryCredentials(params);
   const outcome = await deployDockerRun(
     {
       composeFile,
+      interpolated: composeInterpolatedNames({ modelAuth, channels, extraSecrets }),
       port,
       secrets,
       missingSecrets,

--- a/src/cli/commands/deploy/fly.ts
+++ b/src/cli/commands/deploy/fly.ts
@@ -21,7 +21,17 @@ export const flyHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith("fly.toml") && isGeneratedFlyToml(content),
   async deploy(ctx) {
     const { opts, agentDir, workspace, channels, longConnectionChannels, pre, write } = ctx;
-    const { hasTimeTriggers, modelAuth, modelKeyInDefinition, authPath, container, port, extraSecrets, values } = pre;
+    const {
+      hasTimeTriggers,
+      modelAuth,
+      modelKeyInDefinition,
+      authPath,
+      container,
+      port,
+      extraSecrets,
+      values,
+      valueFile,
+    } = pre;
     // The replay floor that makes scale-to-zero safe is Telegram-only (its L1 turn store).
     if (channels.some((channel) => channel.name === "github")) {
       console.error(
@@ -91,6 +101,7 @@ export const flyHost: HostDeploy = {
         flyTomlPath,
         extraSecrets,
         values,
+        valueFile,
       });
     }
     console.log(plan.runbook.join("\n"));
@@ -110,6 +121,7 @@ async function runDeployFly(
     flyTomlPath: string;
     extraSecrets: readonly DeclaredSecret[];
     values: ReadonlyMap<string, string>;
+    valueFile: string;
   },
 ): Promise<void> {
   const { agentDir, workspace, agentPrefix, appName, channels, flyTomlPath } = params;
@@ -129,6 +141,7 @@ async function runDeployFly(
       region,
       secrets,
       missingSecrets,
+      valueFile: params.valueFile,
       channels,
       flyConfig: `${agentPrefix}fly.toml`,
       dockerfile: `${agentPrefix}Dockerfile`,

--- a/src/cli/commands/deploy/railway.ts
+++ b/src/cli/commands/deploy/railway.ts
@@ -21,7 +21,8 @@ export const railwayHost: HostDeploy = {
   isOurs: (path, content) => path.endsWith("railway.json") && isGeneratedRailwayJson(content),
   async deploy(ctx) {
     const { opts, agentDir, workspace, pre, channels, write } = ctx;
-    const { hasTimeTriggers, modelAuth, modelKeyInDefinition, authPath, container, extraSecrets, values } = pre;
+    const { hasTimeTriggers, modelAuth, modelKeyInDefinition, authPath, container, extraSecrets, values, valueFile } =
+      pre;
     const serviceName = toRailwayName(basename(workspace));
     const plan = planRailwayDeploy({
       serviceName,
@@ -52,6 +53,7 @@ export const railwayHost: HostDeploy = {
         channels,
         extraSecrets,
         values,
+        valueFile,
         intoLinked: !!opts.intoLinked,
         dockerfilePath: dockerfilePathVar(pre.container.agentPrefix),
       });
@@ -71,6 +73,7 @@ async function runDeployRailway(
     channels: readonly DeclaredChannel[];
     extraSecrets: readonly DeclaredSecret[];
     values: ReadonlyMap<string, string>;
+    valueFile: string;
     intoLinked: boolean;
     /** RAILWAY_DOCKERFILE_PATH — the scriptable route to the agent's non-root Dockerfile. */
     dockerfilePath: string;
@@ -87,7 +90,16 @@ async function runDeployRailway(
   gateOnModelCredential(needsModelCredential);
 
   const outcome = await deployRailwayRun(
-    { name, mountPath: "/data", secrets, missingSecrets, channels, intoLinked, dockerfilePath },
+    {
+      name,
+      mountPath: "/data",
+      secrets,
+      missingSecrets,
+      valueFile: params.valueFile,
+      channels,
+      intoLinked,
+      dockerfilePath,
+    },
     railway,
     (m) => console.error(`[fastagent] ${m}`),
     registrarsFor(agentDir),

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -128,7 +128,11 @@ export async function prepareStartWorkspace(dirArg: string): Promise<PreparedWor
     log.info(
       `[fastagent] model ${process.env.FASTAGENT_MODEL} — from ${
         platformModel
-          ? "a FASTAGENT_MODEL already set in this environment, which outranks the release manifest"
+          ? `a FASTAGENT_MODEL already set in this environment${
+              // Only claim it beat the manifest when the manifest actually named one; otherwise a redeploy would
+              // look like the remedy for a value no deployment ever declared.
+              manifest.model ? ", which outranks the release manifest" : ""
+            }`
           : "the release manifest (redeploy to change it)"
       }; editing FASTAGENT_MODEL in this workspace's .env does not override it`,
     );

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -8,7 +8,7 @@ import { once } from "node:events";
 import * as Effect from "effect/Effect";
 import { writeFileAtomic } from "../../atomic-write.ts";
 import { authSeedBytes, collectAuthSeed } from "../../deploy/secrets.ts";
-import { parseDeploymentRelease, prepareDeployment } from "../../deploy/workspace.ts";
+import { applyReleaseEnv, parseDeploymentRelease, prepareDeployment } from "../../deploy/workspace.ts";
 import { detectRuntime, readPackageJson } from "../../runtime.ts";
 import { resolveAuthPath, resolveSessionsDirOverride } from "../../engines/pi/config.ts";
 import {
@@ -115,28 +115,10 @@ export async function prepareStartWorkspace(dirArg: string): Promise<PreparedWor
   process.env.FASTAGENT_STATE_DIR ||= join(root, ".state");
   process.env.FASTAGENT_SECRETS_DIR ||= join(root, ".secrets");
   process.env.FASTAGENT_AGENT = manifest.agent;
-  // The release's own answer for the one chain (`flag > environment > config`), projected into the environment it was
-  // resolved FOR. `||=`, so a variable the platform already holds still wins — the deployment declares the half of
-  // this environment it can, and never more.
-  const platformModel = process.env.FASTAGENT_MODEL;
-  if (manifest.model) process.env.FASTAGENT_MODEL ||= manifest.model;
-  // Both of these land BEFORE the workspace's own `.env` is read, so either one outranks a FASTAGENT_MODEL edited on
-  // the box — and an operator who edits that file and restarts has no other way to see why nothing changed. Report
-  // the source that actually won, because the remedy differs: a redeploy replaces the manifest's answer and does
-  // nothing at all to a platform-set variable.
-  if (process.env.FASTAGENT_MODEL) {
-    log.info(
-      `[fastagent] model ${process.env.FASTAGENT_MODEL} — from ${
-        platformModel
-          ? `a FASTAGENT_MODEL already set in this environment${
-              // Only claim it beat the manifest when the manifest actually named one; otherwise a redeploy would
-              // look like the remedy for a value no deployment ever declared.
-              manifest.model ? ", which outranks the release manifest" : ""
-            }`
-          : "the release manifest (redeploy to change it)"
-      }; editing FASTAGENT_MODEL in this workspace's .env does not override it`,
-    );
-  }
+  // The release's own declarations, projected into the environment it was resolved FOR. This must stay BEFORE
+  // `enterAgentEnv` reads the workspace's `.env`, which is what makes either source outrank a value edited on the
+  // box (applyReleaseEnv's own tests pin the precedence).
+  applyReleaseEnv(manifest);
   process.chdir(dir);
   return { dir, deployed: { root, agent: manifest.agent } };
 }

--- a/src/deploy/agentcore/run.ts
+++ b/src/deploy/agentcore/run.ts
@@ -15,6 +15,7 @@ import {
   deploymentBucketName,
 } from "./plan.ts";
 import { zipSingleFile } from "./zip.ts";
+import { missingValuesGate } from "../secrets.ts";
 
 export interface AgentcoreRunPlan {
   /** The base name — stack `fastagent-<name>`, ECR repo `fastagent/<name>`. */
@@ -32,8 +33,10 @@ export interface AgentcoreRunPlan {
   region?: string;
   /** Secret env-var name → value (model key or FASTAGENT_AUTH_SEED + channel secrets). */
   secrets: Record<string, string>;
-  /** Required secret names with NO local value — gated before any side effect. */
+  /** Declared names the value file supplies no value for — the run gates on these before any side effect. */
   missingSecrets: string[];
+  /** That value file, workspace-relative, so the gate names the file this deploy actually read. */
+  valueFile: string;
   /** Every declared channel and its ingress — the driver asks which of them have a webhook. */
   channels: readonly DeclaredChannel[];
   /**
@@ -190,13 +193,8 @@ export async function deployAgentcoreRun(
   }
 
   // 3. Gate missing required secret VALUES before any side effect (no half-created infra).
-  if (plan.missingSecrets.length > 0) {
-    return gate(
-      `no value for: ${plan.missingSecrets.join(", ")} — the deployed environment is declared by the agent's
-        .secrets/.env, and this deploy reads only that file (exporting the variable here does not reach the
-        deployment). Add them there and re-run`,
-    );
-  }
+  const missingValues = missingValuesGate(plan.missingSecrets, plan.valueFile);
+  if (missingValues) return gate(missingValues);
   // 3b.
   const seed = plan.secrets.FASTAGENT_AUTH_SEED;
   if (seed && seed.length > AUTH_SEED_CHUNK_SIZE * AUTH_SEED_MAX_CHUNKS) {
@@ -210,8 +208,8 @@ export async function deployAgentcoreRun(
       return gate(`secret ${k} is ${v.length} chars — AgentCore environment values cap at 2048; shorten it`);
     }
   }
-  // Name what travels from THIS machine's environment onto the runtime: the list is no longer only
-  // what the author typed in deploy.secrets (a mounted tool/channel/schedule declares its own).
+  // Name what travels from the value file onto the runtime: the list is no longer only what the
+  // author typed in deploy.secrets (a mounted tool/channel/schedule declares its own).
   const secretNames = Object.keys(plan.secrets);
   if (secretNames.length > 0) log(`carrying ${secretNames.length} secret(s): ${secretNames.join(", ")}`);
 

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -3,7 +3,6 @@ import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookPaths } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
-import { SECRETS_DIRNAME } from "../../paths.ts";
 import type { DeclaredSecret } from "../../declared-secrets.ts";
 
 export interface DockerPlanInput extends ContainerInput {
@@ -19,6 +18,10 @@ export interface DockerPlanInput extends ContainerInput {
   tunnel: boolean;
   /** Everything the definition declared it needs (deploy.secrets + tool/schedule declarations). */
   extraSecrets?: readonly DeclaredSecret[];
+  /** The value file as the pre-flight resolved it (it follows `FASTAGENT_SECRETS_DIR`), workspace-relative. */
+  valueFile: string;
+  /** Whether that file is on disk — `--env-file` fails outright on a missing path. */
+  valueFileExists: boolean;
 }
 
 export interface DockerPlan {
@@ -138,11 +141,13 @@ volumes:
 export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
   const composePath = `${input.agentPrefix}${DOCKER_COMPOSE_FILE}`;
   const artifacts: Artifact[] = [{ path: composePath, content: composeYaml(input) }, ...containerArtifacts(input)];
-  // `--env-file`, not a bare `-f`: Compose interpolates `${NAME:-}` from the shell or the PROJECT `.env` and
-  // substitutes `""` for anything it cannot find, so a hand-run command without it starts a container whose
-  // declared values are all empty — no error, no log line. Pointing it at the value file makes the manual path read
-  // the same declaration `--run` does.
-  const compose = `docker compose --env-file ${input.agentPrefix}${SECRETS_DIRNAME}/.env -f ${composePath}`;
+  const compose = `docker compose -f ${composePath}`;
+  // Only the command that STARTS containers interpolates, and only it gets `--env-file`: Compose fills `${NAME:-}`
+  // from the shell or the PROJECT `.env` and substitutes `""` for anything it cannot find, so a hand-run `up`
+  // without it boots an agent whose declared values are all empty — no error, no log line. `logs`/`ps`/`down` need
+  // no values, and `--env-file` is a HARD failure on a missing path (`couldn't find env file: …`), which would take
+  // the whole runbook down with it on an agent that has no value file yet.
+  const composeUp = input.valueFileExists ? `docker compose --env-file ${input.valueFile} -f ${composePath}` : compose;
   const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
   const required = secrets.filter((secret) => secret.required);
   const optional = secrets.filter((secret) => !secret.required);
@@ -156,10 +161,15 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
 
   if (required.length > 0) {
     runbook.push(
-      `# Required environment values. Put them in ${input.agentPrefix}${SECRETS_DIRNAME}/.env — that file declares`,
-      `# the deployed environment, and every command below reads it through --env-file (in CI, write the file`,
-      `# before running the command):`,
+      `# Required environment values. Put them in ${input.valueFile} — that file declares the deployed`,
+      `# environment (in CI, write it before running the command):`,
       ...required.map((secret) => `#   ${secret.name}: ${secret.hint}`),
+      ...(input.valueFileExists
+        ? []
+        : [
+            `# It does not exist yet, so the \`up\` below cannot read it (--env-file fails on a missing path).`,
+            `# Create it, then re-run \`fastagent deploy docker\` for an \`up\` that reads it.`,
+          ]),
     );
   }
   if (optional.length > 0) {
@@ -184,7 +194,7 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
     ``,
     `# Before building a new definition release, run \`fastagent deploy docker\` to refresh its manifest.`,
     `# The Compose volume at ${MOUNT} retains the workspace, state and credentials.`,
-    `${compose} up -d --build`,
+    `${composeUp} up -d --build`,
     `curl --fail http://127.0.0.1:${input.port}/health`,
     ``,
     `# Operate it:`,

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -67,9 +67,13 @@ function composeInterpolation(name: string): string {
 }
 
 /**
- * Every name the generated Compose interpolates. Compose fills each from the shell or the project `.env` and
- * silently substitutes `""` for the rest, so this list is BOTH what the file declares and what the run path must
- * neutralize before handing the child an environment (see `deployDockerRun`).
+ * Every DECLARED CREDENTIAL name the generated Compose interpolates. Compose fills each from the shell or the
+ * project `.env` and silently substitutes `""` for the rest, so this list is BOTH what the file declares and what
+ * the run path must neutralize before handing the child an environment (see `deployDockerRun`).
+ *
+ * Not every interpolation: the tunnel service also interpolates `NO_PROXY`/`no_proxy`, deliberately, so the
+ * operator's own bypass list survives into the container. Those are not credentials and carry nothing from the
+ * definition, so they stay inherited.
  */
 export function composeInterpolatedNames(input: {
   modelAuth: string | undefined;

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -151,7 +151,11 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
   // without it boots an agent whose declared values are all empty — no error, no log line. `logs`/`ps`/`down` need
   // no values, and `--env-file` is a HARD failure on a missing path (`couldn't find env file: …`), which would take
   // the whole runbook down with it on an agent that has no value file yet.
-  const composeUp = input.valueFileExists ? `docker compose --env-file ${input.valueFile} -f ${composePath}` : compose;
+  // Quoted: `valueFile` follows `FASTAGENT_SECRETS_DIR` and may contain spaces, which would split into a
+  // `couldn't find env file` for whoever pastes the line. `composePath` cannot — `isReleaseAgentName` gates it.
+  const composeUp = input.valueFileExists
+    ? `docker compose --env-file '${input.valueFile}' -f ${composePath}`
+    : compose;
   const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
   const required = secrets.filter((secret) => secret.required);
   const optional = secrets.filter((secret) => !secret.required);

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -3,6 +3,7 @@ import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookPaths } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
+import { SECRETS_DIRNAME } from "../../paths.ts";
 import type { DeclaredSecret } from "../../declared-secrets.ts";
 
 export interface DockerPlanInput extends ContainerInput {
@@ -62,11 +63,25 @@ function composeInterpolation(name: string): string {
   return `\${${name}:-}`;
 }
 
-function composeYaml(input: DockerPlanInput): string {
+/**
+ * Every name the generated Compose interpolates. Compose fills each from the shell or the project `.env` and
+ * silently substitutes `""` for the rest, so this list is BOTH what the file declares and what the run path must
+ * neutralize before handing the child an environment (see `deployDockerRun`).
+ */
+export function composeInterpolatedNames(input: {
+  modelAuth: string | undefined;
+  channels: readonly DeclaredChannel[];
+  extraSecrets?: readonly DeclaredSecret[];
+}): string[] {
   const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
   // Always leave the auth-seed seam in the committed topology.
-  const envNames = [...new Set([...secrets.map((secret) => secret.name), "FASTAGENT_AUTH_SEED"])];
-  const secretEnv = envNames.map((name) => `      ${name}: "${composeInterpolation(name)}"`).join("\n");
+  return [...new Set([...secrets.map((secret) => secret.name), "FASTAGENT_AUTH_SEED"])];
+}
+
+function composeYaml(input: DockerPlanInput): string {
+  const secretEnv = composeInterpolatedNames(input)
+    .map((name) => `      ${name}: "${composeInterpolation(name)}"`)
+    .join("\n");
   // Compose sits beside the Dockerfile, under the agent prefix; the build context is always the WORKSPACE, so it
   // climbs back out of the one-level prefix deploy requires.
   const context = "..";
@@ -123,7 +138,11 @@ volumes:
 export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
   const composePath = `${input.agentPrefix}${DOCKER_COMPOSE_FILE}`;
   const artifacts: Artifact[] = [{ path: composePath, content: composeYaml(input) }, ...containerArtifacts(input)];
-  const compose = `docker compose -f ${composePath}`;
+  // `--env-file`, not a bare `-f`: Compose interpolates `${NAME:-}` from the shell or the PROJECT `.env` and
+  // substitutes `""` for anything it cannot find, so a hand-run command without it starts a container whose
+  // declared values are all empty — no error, no log line. Pointing it at the value file makes the manual path read
+  // the same declaration `--run` does.
+  const compose = `docker compose --env-file ${input.agentPrefix}${SECRETS_DIRNAME}/.env -f ${composePath}`;
   const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
   const required = secrets.filter((secret) => secret.required);
   const optional = secrets.filter((secret) => !secret.required);
@@ -137,8 +156,9 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
 
   if (required.length > 0) {
     runbook.push(
-      `# Required environment values. Put them in the agent's .secrets/.env — that file declares the deployed`,
-      `# environment, and \`--run\` reads only it (in CI, write the file before running the command):`,
+      `# Required environment values. Put them in ${input.agentPrefix}${SECRETS_DIRNAME}/.env — that file declares`,
+      `# the deployed environment, and every command below reads it through --env-file (in CI, write the file`,
+      `# before running the command):`,
       ...required.map((secret) => `#   ${secret.name}: ${secret.hint}`),
     );
   }

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -1,4 +1,5 @@
 /** `fastagent deploy docker` — the local-Docker plan. */
+import { dirname, relative } from "node:path";
 import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookPaths } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
@@ -20,7 +21,7 @@ export interface DockerPlanInput extends ContainerInput {
   extraSecrets?: readonly DeclaredSecret[];
   /** The value file as the pre-flight resolved it (it follows `FASTAGENT_SECRETS_DIR`), workspace-relative. */
   valueFile: string;
-  /** Whether that file is on disk — `--env-file` fails outright on a missing path. */
+  /** Whether that file is on disk: Compose refuses an `env_file` entry pointing at a missing path. */
   valueFileExists: boolean;
 }
 
@@ -66,29 +67,15 @@ function composeInterpolation(name: string): string {
   return `\${${name}:-}`;
 }
 
-/**
- * Every DECLARED CREDENTIAL name the generated Compose interpolates. Compose fills each from the shell or the
- * project `.env` and silently substitutes `""` for the rest, so this list is BOTH what the file declares and what
- * the run path must neutralize before handing the child an environment (see `deployDockerRun`).
- *
- * Not every interpolation: the tunnel service also interpolates `NO_PROXY`/`no_proxy`, deliberately, so the
- * operator's own bypass list survives into the container. Those are not credentials and carry nothing from the
- * definition, so they stay inherited.
- */
-export function composeInterpolatedNames(input: {
-  modelAuth: string | undefined;
-  channels: readonly DeclaredChannel[];
-  extraSecrets?: readonly DeclaredSecret[];
-}): string[] {
-  const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
-  // Always leave the auth-seed seam in the committed topology.
-  return [...new Set([...secrets.map((secret) => secret.name), "FASTAGENT_AUTH_SEED"])];
-}
-
 function composeYaml(input: DockerPlanInput): string {
-  const secretEnv = composeInterpolatedNames(input)
-    .map((name) => `      ${name}: "${composeInterpolation(name)}"`)
-    .join("\n");
+  // `env_file`, not per-name `${NAME:-}` interpolation: interpolation resolves from the SHELL or the project `.env`,
+  // which is exactly the source a deployment must not have (docs/design/configuration.md §9). Naming the value file
+  // here makes `docker compose up` read the deployed environment's own declaration directly — by hand and under
+  // `--run` alike — so nothing has to be carried through, filtered, or blanked. Written only when the file exists:
+  // `env_file`'s `required: false` needs Compose 2.24 and the floor here is ${MIN_DOCKER_COMPOSE_VERSION}.
+  const valueFileEntry = input.valueFileExists
+    ? `    env_file:\n      - ${relative(dirname(`${input.agentPrefix}${DOCKER_COMPOSE_FILE}`), input.valueFile)}\n`
+    : "";
   // Compose sits beside the Dockerfile, under the agent prefix; the build context is always the WORKSPACE, so it
   // climbs back out of the one-level prefix deploy requires.
   const context = "..";
@@ -126,12 +113,14 @@ services:
       dockerfile: ${dockerfile}
     ports:
       - "127.0.0.1:${input.port}:${input.port}"
-    environment:
+${valueFileEntry}    environment:
       PORT: "${input.port}"
       # Machinery on the ONE state volume: mutable state and (seeded, possibly rotated) secrets.
       FASTAGENT_STATE_DIR: "${MOUNT}/.state"
       FASTAGENT_SECRETS_DIR: "${MOUNT}/.secrets"
-${secretEnv}
+      # The ONE value that is not in the value file: \`--run\` mints it from the local auth.json. Left as a seam in
+      # the committed topology so a hand-run \`up\` can supply it the same way.
+      FASTAGENT_AUTH_SEED: "${composeInterpolation("FASTAGENT_AUTH_SEED")}"
     volumes:
       - state:${MOUNT}
     restart: unless-stopped
@@ -145,17 +134,9 @@ volumes:
 export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
   const composePath = `${input.agentPrefix}${DOCKER_COMPOSE_FILE}`;
   const artifacts: Artifact[] = [{ path: composePath, content: composeYaml(input) }, ...containerArtifacts(input)];
+  // One spelling for every command: the generated file names the value file itself (`env_file`), so no command
+  // needs a flag to reach the deployed environment's declaration.
   const compose = `docker compose -f ${composePath}`;
-  // Only the command that STARTS containers interpolates, and only it gets `--env-file`: Compose fills `${NAME:-}`
-  // from the shell or the PROJECT `.env` and substitutes `""` for anything it cannot find, so a hand-run `up`
-  // without it boots an agent whose declared values are all empty — no error, no log line. `logs`/`ps`/`down` need
-  // no values, and `--env-file` is a HARD failure on a missing path (`couldn't find env file: …`), which would take
-  // the whole runbook down with it on an agent that has no value file yet.
-  // Quoted: `valueFile` follows `FASTAGENT_SECRETS_DIR` and may contain spaces, which would split into a
-  // `couldn't find env file` for whoever pastes the line. `composePath` cannot — `isReleaseAgentName` gates it.
-  const composeUp = input.valueFileExists
-    ? `docker compose --env-file '${input.valueFile}' -f ${composePath}`
-    : compose;
   const secrets = deploymentSecrets(input.modelAuth, input.channels, input.extraSecrets);
   const required = secrets.filter((secret) => secret.required);
   const optional = secrets.filter((secret) => !secret.required);
@@ -175,8 +156,8 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
       ...(input.valueFileExists
         ? []
         : [
-            `# It does not exist yet, so the \`up\` below cannot read it (--env-file fails on a missing path).`,
-            `# Create it, then re-run \`fastagent deploy docker\` for an \`up\` that reads it.`,
+            `# It does not exist yet, so ${composePath} does not reference it. Create it, then re-run`,
+            `# \`fastagent deploy docker\` to regenerate a Compose file that reads it.`,
           ]),
     );
   }
@@ -202,7 +183,7 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
     ``,
     `# Before building a new definition release, run \`fastagent deploy docker\` to refresh its manifest.`,
     `# The Compose volume at ${MOUNT} retains the workspace, state and credentials.`,
-    `${composeUp} up -d --build`,
+    `${compose} up -d --build`,
     `curl --fail http://127.0.0.1:${input.port}/health`,
     ``,
     `# Operate it:`,

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -119,7 +119,9 @@ services:
       FASTAGENT_SESSIONS_DIR: "${MOUNT}/.state/sessions"
       FASTAGENT_AUTH_PATH: "${MOUNT}/.secrets/auth.json"
       # The ONE value that is not in the value file: \`--run\` mints it from the local auth.json. Left as a seam in
-      # the committed topology so a hand-run \`up\` can supply it the same way.
+      # the committed topology so a hand-run \`up\` can supply it the same way — from the ENVIRONMENT of that \`up\`.
+      # Writing this one key into the value file does nothing: \`environment:\` is applied after \`env_file\`, so the
+      # line below would blank it and the container would start without seeding auth.json.
       FASTAGENT_AUTH_SEED: "${composeInterpolation("FASTAGENT_AUTH_SEED")}"
     volumes:
       - state:${MOUNT}

--- a/src/deploy/docker/plan.ts
+++ b/src/deploy/docker/plan.ts
@@ -1,9 +1,9 @@
 /** `fastagent deploy docker` — the local-Docker plan. */
-import { dirname, relative } from "node:path";
 import type { DeclaredChannel } from "../../channels/discover.ts";
 import { webhookPaths } from "../channel-ingress.ts";
 import { type Artifact, type ContainerInput, containerArtifacts } from "../container.ts";
 import { deploymentSecrets, isEnvKey } from "../secrets.ts";
+import { SECRETS_DIRNAME } from "../../paths.ts";
 import type { DeclaredSecret } from "../../declared-secrets.ts";
 
 export interface DockerPlanInput extends ContainerInput {
@@ -21,8 +21,6 @@ export interface DockerPlanInput extends ContainerInput {
   extraSecrets?: readonly DeclaredSecret[];
   /** The value file as the pre-flight resolved it (it follows `FASTAGENT_SECRETS_DIR`), workspace-relative. */
   valueFile: string;
-  /** Whether that file is on disk: Compose refuses an `env_file` entry pointing at a missing path. */
-  valueFileExists: boolean;
 }
 
 export interface DockerPlan {
@@ -68,14 +66,6 @@ function composeInterpolation(name: string): string {
 }
 
 function composeYaml(input: DockerPlanInput): string {
-  // `env_file`, not per-name `${NAME:-}` interpolation: interpolation resolves from the SHELL or the project `.env`,
-  // which is exactly the source a deployment must not have (docs/design/configuration.md §9). Naming the value file
-  // here makes `docker compose up` read the deployed environment's own declaration directly — by hand and under
-  // `--run` alike — so nothing has to be carried through, filtered, or blanked. Written only when the file exists:
-  // `env_file`'s `required: false` needs Compose 2.24 and the floor here is ${MIN_DOCKER_COMPOSE_VERSION}.
-  const valueFileEntry = input.valueFileExists
-    ? `    env_file:\n      - ${relative(dirname(`${input.agentPrefix}${DOCKER_COMPOSE_FILE}`), input.valueFile)}\n`
-    : "";
   // Compose sits beside the Dockerfile, under the agent prefix; the build context is always the WORKSPACE, so it
   // climbs back out of the one-level prefix deploy requires.
   const context = "..";
@@ -113,11 +103,21 @@ services:
       dockerfile: ${dockerfile}
     ports:
       - "127.0.0.1:${input.port}:${input.port}"
-${valueFileEntry}    environment:
+    # The deployed environment's own declaration, read by the container itself. \`env_file\`, not per-name
+    # \${NAME:-} interpolation: interpolation resolves from the SHELL or the project .env, which is exactly the
+    # source a deployment must not have. A FIXED path, never the builder's FASTAGENT_SECRETS_DIR — this file is a
+    # committed artifact and must mean the same thing on every machine. \`deploy\` creates it if it is missing.
+    env_file:
+      - ${SECRETS_DIRNAME}/.env
+    environment:
       PORT: "${input.port}"
-      # Machinery on the ONE state volume: mutable state and (seeded, possibly rotated) secrets.
+      # Machinery on the ONE state volume: mutable state and (seeded, possibly rotated) secrets. Pinned AFTER
+      # env_file so a local path in that file (the scaffold lists these) cannot send the container's state, sessions
+      # or credentials somewhere outside the volume — or at a host path that does not exist here at all.
       FASTAGENT_STATE_DIR: "${MOUNT}/.state"
       FASTAGENT_SECRETS_DIR: "${MOUNT}/.secrets"
+      FASTAGENT_SESSIONS_DIR: "${MOUNT}/.state/sessions"
+      FASTAGENT_AUTH_PATH: "${MOUNT}/.secrets/auth.json"
       # The ONE value that is not in the value file: \`--run\` mints it from the local auth.json. Left as a seam in
       # the committed topology so a hand-run \`up\` can supply it the same way.
       FASTAGENT_AUTH_SEED: "${composeInterpolation("FASTAGENT_AUTH_SEED")}"
@@ -153,12 +153,6 @@ export function planDockerDeploy(input: DockerPlanInput): DockerPlan {
       `# Required environment values. Put them in ${input.valueFile} — that file declares the deployed`,
       `# environment (in CI, write it before running the command):`,
       ...required.map((secret) => `#   ${secret.name}: ${secret.hint}`),
-      ...(input.valueFileExists
-        ? []
-        : [
-            `# It does not exist yet, so ${composePath} does not reference it. Create it, then re-run`,
-            `# \`fastagent deploy docker\` to regenerate a Compose file that reads it.`,
-          ]),
     );
   }
   if (optional.length > 0) {

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -12,14 +12,12 @@ export interface DockerRunPlan {
   composeFile: string;
   /** Container port from config; used to ask Compose for the effective published host port. */
   port: number;
-  /** Values interpolated by Compose. */
-  secrets: Record<string, string>;
   /**
-   * Every name the generated Compose interpolates (`composeInterpolatedNames`). The child's environment inherits
-   * this process's, so any of these left unset here would be filled from the BUILDER'S SHELL — exactly the source
-   * the value file replaced. They are blanked first, then overwritten by `secrets`.
+   * What `--run` assembled. The container reads the value file itself through the generated `env_file`, so the only
+   * entry that has to travel through this process is `FASTAGENT_AUTH_SEED`, which is minted here; the rest is
+   * reported to the operator and otherwise unused.
    */
-  interpolated: readonly string[];
+  secrets: Record<string, string>;
   /** Declared names the value file supplies no value for — the run gates on these before any side effect. */
   missingSecrets: string[];
   /** That value file, workspace-relative, so the gate names the file this deploy actually read. */
@@ -116,16 +114,10 @@ export async function deployDockerRun(
 ): Promise<DockerRunOutcome> {
   const gate = (message: string): DockerRunOutcome => ({ ok: false, gate: message });
   const compose = ["compose", "-f", plan.composeFile];
-  // Blank-then-override: `spawnRunner` merges over `process.env`, so a declared credential name the value file does
-  // not supply would otherwise inherit the builder's shell and reach the container. A deployment carries what the
-  // value file says and nothing else — including for the optional names the missing-values gate never sees
-  // (FASTAGENT_CONTROL_TOKEN, *_ENCRYPT_KEY, FASTAGENT_AUTH_SEED). `NO_PROXY`/`no_proxy` are deliberately NOT in
-  // this list (the operator's bypass list is meant to survive), and a KEPT older compose file may interpolate names
-  // this definition no longer declares — those still inherit.
-  const env: Record<string, string> = {
-    ...Object.fromEntries(plan.interpolated.map((name) => [name, ""])),
-    ...plan.secrets,
-  };
+  // The ONE value that is not in the value file, so the ONE that has to cross this process. Set even when absent, so
+  // a same-named variable in the builder's shell cannot interpolate into the container in its place — `spawnRunner`
+  // merges over `process.env`.
+  const env: Record<string, string> = { FASTAGENT_AUTH_SEED: plan.secrets.FASTAGENT_AUTH_SEED ?? "" };
 
   // CLI/plugin gate first: unlike a daemon error, spawn ENOENT becomes 127 at the shared runner seam.
   const version = await docker(["compose", "version"], { capture: true });

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -135,10 +135,14 @@ export async function deployDockerRun(
   const missingValues = missingValuesGate(plan.missingSecrets, plan.valueFile);
   if (missingValues) return gate(missingValues);
 
-  // Name what travels from the value file into the container: the list is no longer only what the
-  // author typed in deploy.secrets (a mounted tool/channel/schedule declares its own).
-  const secretNames = Object.keys(plan.secrets);
-  if (secretNames.length > 0) log(`passing ${secretNames.length} secret(s) to Compose: ${secretNames.join(", ")}`);
+  // Name what the container must find, and WHERE — the generated Compose reads the value file itself, so this run
+  // hands Compose nothing but the seed. Saying "passing N secrets to Compose" would be false, and doubly so on a
+  // hand-owned Compose file that has no `env_file` entry at all. The list is no longer only what the author typed
+  // in deploy.secrets (a mounted tool/channel/schedule declares its own).
+  const secretNames = Object.keys(plan.secrets).filter((name) => name !== "FASTAGENT_AUTH_SEED");
+  if (secretNames.length > 0) {
+    log(`${secretNames.length} value(s) the container reads from ${plan.valueFile}: ${secretNames.join(", ")}`);
+  }
 
   if ((await docker(["info"], { capture: true })).code !== 0) {
     return gate("Docker daemon is unavailable — start Docker Engine/Desktop, then re-run");

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -5,6 +5,7 @@ import type { RegistrationOutcome } from "../../channels/registration.ts";
 import { registrationGate } from "../registration-gate.ts";
 import { MIN_DOCKER_COMPOSE_VERSION } from "./plan.ts";
 import type { CliRunner } from "../runner.ts";
+import { missingValuesGate } from "../secrets.ts";
 
 export interface DockerRunPlan {
   /** Compose file relative to the runner cwd (the workspace root). */
@@ -13,8 +14,10 @@ export interface DockerRunPlan {
   port: number;
   /** Values interpolated by Compose. */
   secrets: Record<string, string>;
-  /** Required names with no local value; gate before build/create. */
+  /** Declared names the value file supplies no value for — the run gates on these before any side effect. */
   missingSecrets: string[];
+  /** That value file, workspace-relative, so the gate names the file this deploy actually read. */
+  valueFile: string;
   /** Neither an env-key credential nor a readable auth.json is available. */
   needsModelCredential: boolean;
   /** Register the deployment's webhooks against the tunnel URL, reporting what each registrar answered. */
@@ -122,16 +125,11 @@ export async function deployDockerRun(
   if (plan.needsModelCredential) {
     return gate("no model credential — run `fastagent login`, or set a provider API key in .env, then re-run");
   }
-  if (plan.missingSecrets.length > 0) {
-    return gate(
-      `no value for: ${plan.missingSecrets.join(", ")} — the deployed environment is declared by the agent's
-        .secrets/.env, and this deploy reads only that file (exporting the variable here does not reach the
-        deployment). Add them there and re-run`,
-    );
-  }
+  const missingValues = missingValuesGate(plan.missingSecrets, plan.valueFile);
+  if (missingValues) return gate(missingValues);
 
-  // Name what travels from THIS machine's environment into the container: the list is no longer
-  // only what the author typed in deploy.secrets (a mounted tool/channel/schedule declares its own).
+  // Name what travels from the value file into the container: the list is no longer only what the
+  // author typed in deploy.secrets (a mounted tool/channel/schedule declares its own).
   const secretNames = Object.keys(plan.secrets);
   if (secretNames.length > 0) log(`passing ${secretNames.length} secret(s) to Compose: ${secretNames.join(", ")}`);
 

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -116,10 +116,12 @@ export async function deployDockerRun(
 ): Promise<DockerRunOutcome> {
   const gate = (message: string): DockerRunOutcome => ({ ok: false, gate: message });
   const compose = ["compose", "-f", plan.composeFile];
-  // Blank-then-override: `spawnRunner` merges over `process.env`, so an interpolated name the value file does not
-  // declare would otherwise inherit the builder's shell and reach the container. A deployment carries what the
+  // Blank-then-override: `spawnRunner` merges over `process.env`, so a declared credential name the value file does
+  // not supply would otherwise inherit the builder's shell and reach the container. A deployment carries what the
   // value file says and nothing else — including for the optional names the missing-values gate never sees
-  // (FASTAGENT_CONTROL_TOKEN, *_ENCRYPT_KEY, FASTAGENT_AUTH_SEED).
+  // (FASTAGENT_CONTROL_TOKEN, *_ENCRYPT_KEY, FASTAGENT_AUTH_SEED). `NO_PROXY`/`no_proxy` are deliberately NOT in
+  // this list (the operator's bypass list is meant to survive), and a KEPT older compose file may interpolate names
+  // this definition no longer declares — those still inherit.
   const env: Record<string, string> = {
     ...Object.fromEntries(plan.interpolated.map((name) => [name, ""])),
     ...plan.secrets,

--- a/src/deploy/docker/run.ts
+++ b/src/deploy/docker/run.ts
@@ -14,6 +14,12 @@ export interface DockerRunPlan {
   port: number;
   /** Values interpolated by Compose. */
   secrets: Record<string, string>;
+  /**
+   * Every name the generated Compose interpolates (`composeInterpolatedNames`). The child's environment inherits
+   * this process's, so any of these left unset here would be filled from the BUILDER'S SHELL — exactly the source
+   * the value file replaced. They are blanked first, then overwritten by `secrets`.
+   */
+  interpolated: readonly string[];
   /** Declared names the value file supplies no value for — the run gates on these before any side effect. */
   missingSecrets: string[];
   /** That value file, workspace-relative, so the gate names the file this deploy actually read. */
@@ -110,7 +116,14 @@ export async function deployDockerRun(
 ): Promise<DockerRunOutcome> {
   const gate = (message: string): DockerRunOutcome => ({ ok: false, gate: message });
   const compose = ["compose", "-f", plan.composeFile];
-  const env = plan.secrets;
+  // Blank-then-override: `spawnRunner` merges over `process.env`, so an interpolated name the value file does not
+  // declare would otherwise inherit the builder's shell and reach the container. A deployment carries what the
+  // value file says and nothing else — including for the optional names the missing-values gate never sees
+  // (FASTAGENT_CONTROL_TOKEN, *_ENCRYPT_KEY, FASTAGENT_AUTH_SEED).
+  const env: Record<string, string> = {
+    ...Object.fromEntries(plan.interpolated.map((name) => [name, ""])),
+    ...plan.secrets,
+  };
 
   // CLI/plugin gate first: unlike a daemon error, spawn ENOENT becomes 127 at the shared runner seam.
   const version = await docker(["compose", "version"], { capture: true });

--- a/src/deploy/fly/run.ts
+++ b/src/deploy/fly/run.ts
@@ -2,14 +2,17 @@
 import { type PublicHealthProbe, type Registrars, publicHealthGate, registerWebhooks } from "../channel-ingress.ts";
 import type { DeclaredChannel } from "../../channels/discover.ts";
 import type { CliRunner } from "../runner.ts";
+import { missingValuesGate } from "../secrets.ts";
 
 export interface FlyRunPlan {
   appName: string;
   region: string;
   /** `KEY=value` secrets to set on Fly: model key (env auth) or `FASTAGENT_AUTH_SEED` (file auth) + channel secrets. */
   secrets: Record<string, string>;
-  /** Required secret names with NO local value — the run gates on these before any side effect. */
+  /** Declared names the value file supplies no value for — the run gates on these before any side effect. */
   missingSecrets: string[];
+  /** That value file, workspace-relative, so the gate names the file this deploy actually read. */
+  valueFile: string;
   /** Every declared channel and its ingress — the driver asks which of them have a webhook. */
   channels: readonly DeclaredChannel[];
   /** fly.toml path passed to `fly deploy -c` (relative to the run cwd = the workspace root). */
@@ -93,13 +96,8 @@ export async function deployFlyRun(
   }
 
   // 2. Gate missing required secret VALUES before any side effect (no half-created infra).
-  if (plan.missingSecrets.length > 0) {
-    return gate(
-      `no value for: ${plan.missingSecrets.join(", ")} — the deployed environment is declared by the agent's
-        .secrets/.env, and this deploy reads only that file (exporting the variable here does not reach the
-        deployment). Add them there and re-run`,
-    );
-  }
+  const missingValues = missingValuesGate(plan.missingSecrets, plan.valueFile);
+  if (missingValues) return gate(missingValues);
 
   // 3.
   const appExists = await readList(fly, ["apps", "list", "--json"], (out) => listHasName(out, plan.appName));

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -512,7 +512,10 @@ export async function preflightDeploy(input: {
     // FASTAGENT_RELEASE_FILE, so a Dockerfile that sets it reads the manifest whoever wrote it. This gates rather
     // than warns because it is about FastAgent's OWN delivery arriving — the model would be reported here and
     // missing on the box.
-    if (model.envValue !== undefined && !/^\s*ENV\s+FASTAGENT_RELEASE_FILE[=\s]/m.test(dockerfileText)) {
+    // Anywhere in an `ENV` instruction, not just first: `ENV A=1 FASTAGENT_RELEASE_FILE=/app/x` is ordinary
+    // Dockerfile style and hard-refusing it would be a false gate. A backslash continuation still reads as absent
+    // (covering it means joining lines first) — the remaining over-strict edge.
+    if (model.envValue !== undefined && !/^\s*ENV\s[^\n]*\bFASTAGENT_RELEASE_FILE[=\s]/m.test(dockerfileText)) {
       const issue =
         `your Dockerfile does not set FASTAGENT_RELEASE_FILE, and the model comes from ${valueFile} — it travels ` +
         `in the release manifest, which is only read when that ENV points at it. Add it (see a generated ` +

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -254,7 +254,7 @@ export async function preflightDeploy(input: {
   // `--run`. Asked of EVERY provider, not just the selected model's — the file ships whole, so a literal on a
   // provider nothing selects today is in the image all the same. A literal has no legitimate use: an endpoint that
   // needs no key omits it, and one that needs a key has two forms that do not ship it.
-  const literalKeys = literalKeyProviders(models);
+  const literalKeys = await literalKeyProviders(agentDir);
   if (literalKeys.length > 0) {
     const issue =
       `${AGENT_MODELS_FILE} carries a literal apiKey for ${literalKeys.map((id) => `"${id}"`).join(", ")} — that ` +

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -55,8 +55,6 @@ interface DeployFacts {
   values: ReadonlyMap<string, string>;
   /** That file, workspace-relative — the name every "set it here" message must use. */
   valueFile: string;
-  /** Whether it is on disk. `--env-file` is a hard failure on a missing path, so a runbook must not assume one. */
-  valueFileExists: boolean;
   /** What satisfies model auth locally — an env-var name, an OAuth/stored label, or undefined. */
   modelAuth: string | undefined;
   /**
@@ -147,7 +145,6 @@ export async function preflightDeploy(input: {
   // The model this deployment will run on, and where it came from. Resolved HERE so the plan side and the run side
   // cannot disagree about it.
   const valueFile = relative(workspace, dotEnvPath(agentDir));
-  const valueFileExists = await exists(dotEnvPath(agentDir));
   const values = loadEnvValues(dotEnvPath(agentDir));
   const model = resolveDeployModel(config, values, valueFile);
   if (model.invalid !== undefined) {
@@ -532,7 +529,6 @@ export async function preflightDeploy(input: {
     hasTimeTriggers,
     values,
     valueFile,
-    valueFileExists,
     modelAuth,
     modelKeyInDefinition,
     authPath,

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -497,17 +497,29 @@ export async function preflightDeploy(input: {
   if (config.sessionControl === true) {
     extraSecrets.push({ name: CONTROL_TOKEN_ENV, source: "fastagent.config sessionControl" });
   }
-  // deploy.apt only shapes the GENERATED Dockerfile. (The resolved model does not: it rides the release manifest,
-  // which every host writes unconditionally, so a hand-written Dockerfile changes nothing about it.)
+  // What a KEPT hand-written Dockerfile drops. `deploy.apt` is the obvious one; the resolved model is the one that
+  // looks safe and is not: the manifest is always written, but only the generated Dockerfile sets
+  // FASTAGENT_RELEASE_FILE, and without it `prepareStartWorkspace` never reads the manifest — so a model that lives
+  // ONLY in the value file would be reported here and absent on the box.
   const dockerfileHome = join(agentDir, "Dockerfile");
-  if (config.deploy?.apt?.length && !force && (await exists(dockerfileHome))) {
+  if ((config.deploy?.apt?.length || model.envValue !== undefined) && !force && (await exists(dockerfileHome))) {
     if (!isGeneratedDockerfile(await readFile(dockerfileHome, "utf8"))) {
-      messages.push({
-        level: "warn",
-        text:
-          `kept your hand-written Dockerfile — deploy.apt (${config.deploy.apt.join(", ")}) is ` +
-          `NOT applied; install those packages in your Dockerfile.`,
-      });
+      if (config.deploy?.apt?.length) {
+        messages.push({
+          level: "warn",
+          text:
+            `kept your hand-written Dockerfile — deploy.apt (${config.deploy.apt.join(", ")}) is ` +
+            `NOT applied; install those packages in your Dockerfile.`,
+        });
+      }
+      if (model.envValue !== undefined) {
+        const issue =
+          `kept your hand-written Dockerfile, and the model comes from ${valueFile} — it travels in the release ` +
+          `manifest, which only a Dockerfile setting FASTAGENT_RELEASE_FILE is read from. Add that ENV (see a ` +
+          `generated Dockerfile), or set \`model\` in fastagent.config.* so it ships in the config instead.`;
+        if (run) return { ok: false, gate: issue };
+        messages.push({ level: "warn", text: issue });
+      }
     }
   }
 

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -15,6 +15,8 @@ import { loadSchedules } from "../schedule/discover.ts";
 import { resolveAgentTools } from "../engines/pi/create.ts";
 import { type DeclaredSecret, allSecrets } from "../declared-secrets.ts";
 import { createPiModelRuntime, modelCredentialCarry, probeAuthSource } from "../engines/pi/models.ts";
+import { providerOf } from "../engines/pi/config.ts";
+import { AGENT_MODELS_FILE } from "../paths.ts";
 import { CHANNEL_KINDS } from "../scaffold/add-channel.ts";
 import { detectRuntime, readPackageJson } from "../runtime.ts";
 import { fastagentVersion } from "../version.ts";
@@ -243,6 +245,17 @@ export async function preflightDeploy(input: {
     const carry = modelCredentialCarry(models, modelSpec);
     if (carry.envVar) modelAuth = carry.envVar;
     else modelKeyInDefinition = carry.inDefinition;
+    if (carry.literalKey) {
+      // Same rule the `.dockerignore` check enforces: any configuration that would put a credential into the image
+      // gates `--run`. A literal has no legitimate use here — an endpoint that needs no key can omit it, and one
+      // that needs a key has two forms that do not ship it.
+      const issue =
+        `${AGENT_MODELS_FILE} carries a literal apiKey for "${providerOf(modelSpec)}" — that file ships inside the ` +
+        `image, where anyone who can pull it reads the layer. Use "$YOUR_ENV_VAR" (deploy carries it like any ` +
+        `provider key) or "!command" (it runs on the box and never travels).`;
+      if (run) return { ok: false, gate: issue };
+      messages.push({ level: "warn", text: issue });
+    }
   }
 
   // Container facts (shared by every host) + the warnings that follow.

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -9,7 +9,14 @@ import ignore from "ignore";
 import { classifyBind } from "../bind.ts";
 import { isModelSpec, isReleaseAgentName } from "./workspace.ts";
 import { type FastagentConfig, resolveAuthPath } from "../engines/pi/config.ts";
-import { type ResolvedPlacement, resolveSecretsDir, resolveStateRoot, exists, readTextIfExists } from "../paths.ts";
+import {
+  AGENT_MODELS_FILE,
+  type ResolvedPlacement,
+  resolveSecretsDir,
+  resolveStateRoot,
+  exists,
+  readTextIfExists,
+} from "../paths.ts";
 import { type DeclaredChannel, inspectChannels } from "../channels/discover.ts";
 import { loadSchedules } from "../schedule/discover.ts";
 import { resolveAgentTools } from "../engines/pi/create.ts";
@@ -20,7 +27,6 @@ import {
   modelCredentialCarry,
   probeAuthSource,
 } from "../engines/pi/models.ts";
-import { AGENT_MODELS_FILE } from "../paths.ts";
 import { CHANNEL_KINDS } from "../scaffold/add-channel.ts";
 import { detectRuntime, readPackageJson } from "../runtime.ts";
 import { fastagentVersion } from "../version.ts";
@@ -98,7 +104,7 @@ export async function preflightDeploy(input: {
   config: FastagentConfig;
   /** `--run` fully deploys, so a definition that resolves NO model is a GATE (a known crash-loop); else it warns. */
   run: boolean;
-  /** `--force` regenerates artifacts, so the kept-hand-written-Dockerfile apt warning does not apply. */
+  /** `--force` regenerates the artifacts fastagent OWNS, so a kept `.dockerignore`'s content checks do not apply. */
   force: boolean;
   /** The target delivers cron slots from an external clock and holds no resident process (AgentCore). */
   externalClock?: boolean;
@@ -501,8 +507,11 @@ export async function preflightDeploy(input: {
   // looks safe and is not: the manifest is always written, but only the generated Dockerfile sets
   // FASTAGENT_RELEASE_FILE, and without it `prepareStartWorkspace` never reads the manifest — so a model that lives
   // ONLY in the value file would be reported here and absent on the box.
+  // NOT conditioned on `!force`: `writeArtifacts` refuses a file it did not generate whatever the flag says, so a
+  // hand-written Dockerfile survives `--force` and drops exactly the same things. Short-circuiting here let
+  // `--run --force` ship the crash-loop this gate exists to stop.
   const dockerfileHome = join(agentDir, "Dockerfile");
-  if ((config.deploy?.apt?.length || model.envValue !== undefined) && !force && (await exists(dockerfileHome))) {
+  if ((config.deploy?.apt?.length || model.envValue !== undefined) && (await exists(dockerfileHome))) {
     if (!isGeneratedDockerfile(await readFile(dockerfileHome, "utf8"))) {
       if (config.deploy?.apt?.length) {
         messages.push({

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -49,6 +49,8 @@ interface DeployFacts {
   values: ReadonlyMap<string, string>;
   /** That file, workspace-relative — the name every "set it here" message must use. */
   valueFile: string;
+  /** Whether it is on disk. `--env-file` is a hard failure on a missing path, so a runbook must not assume one. */
+  valueFileExists: boolean;
   /** What satisfies model auth locally — an env-var name, an OAuth/stored label, or undefined. */
   modelAuth: string | undefined;
   /**
@@ -139,6 +141,7 @@ export async function preflightDeploy(input: {
   // The model this deployment will run on, and where it came from. Resolved HERE so the plan side and the run side
   // cannot disagree about it.
   const valueFile = relative(workspace, dotEnvPath(agentDir));
+  const valueFileExists = await exists(dotEnvPath(agentDir));
   const values = loadEnvValues(dotEnvPath(agentDir));
   const model = resolveDeployModel(config, values, valueFile);
   if (model.invalid !== undefined) {
@@ -252,16 +255,29 @@ export async function preflightDeploy(input: {
   }
   // Same rule the `.dockerignore` check enforces: any configuration that would put a credential into the image gates
   // `--run`. Asked of EVERY provider, not just the selected model's — the file ships whole, so a literal on a
-  // provider nothing selects today is in the image all the same. A literal has no legitimate use: an endpoint that
-  // needs no key omits it, and one that needs a key has two forms that do not ship it.
+  // provider nothing selects today is in the image all the same. A literal aimed at a PRIVATE endpoint is not a
+  // credential, though: pi's docs tell you to write `"apiKey": "ollama"` for a keyless local server, so that one
+  // only warns — gating it would make a "local ollama for dev, cloud model for deploy" definition undeployable.
   const literalKeys = await literalKeyProviders(agentDir);
-  if (literalKeys.length > 0) {
+  const named = (ids: { id: string }[]) => ids.map(({ id }) => `"${id}"`).join(", ");
+  const exposed = literalKeys.filter((provider) => provider.public);
+  if (exposed.length > 0) {
     const issue =
-      `${AGENT_MODELS_FILE} carries a literal apiKey for ${literalKeys.map((id) => `"${id}"`).join(", ")} — that ` +
-      `file ships inside the image, where anyone who can pull it reads the layer. Use "$YOUR_ENV_VAR" (deploy ` +
-      `carries it like any provider key) or "!command" (it runs on the box and never travels).`;
+      `${AGENT_MODELS_FILE} carries a literal apiKey for ${named(exposed)} — that file ships inside the image, ` +
+      `where anyone who can pull it reads the layer. Use "$YOUR_ENV_VAR" (deploy carries it like any provider key) ` +
+      `or "!command" (it runs on the box and never travels).`;
     if (run) return { ok: false, gate: issue };
     messages.push({ level: "warn", text: issue });
+  }
+  const placeholders = literalKeys.filter((provider) => !provider.public);
+  if (placeholders.length > 0) {
+    messages.push({
+      level: "warn",
+      text:
+        `${AGENT_MODELS_FILE} carries a literal apiKey for ${named(placeholders)}, whose baseUrl is not reachable ` +
+        `from outside the deployment — read as a placeholder for a keyless server, not a credential. If it IS one, ` +
+        `move it to "$YOUR_ENV_VAR" or "!command": the file ships inside the image.`,
+    });
   }
 
   // Container facts (shared by every host) + the warnings that follow.
@@ -502,6 +518,7 @@ export async function preflightDeploy(input: {
     hasTimeTriggers,
     values,
     valueFile,
+    valueFileExists,
     modelAuth,
     modelKeyInDefinition,
     authPath,

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -259,30 +259,20 @@ export async function preflightDeploy(input: {
     if (carry.envVar) modelAuth = carry.envVar;
     else modelKeyInDefinition = carry.inDefinition;
   }
-  // Same rule the `.dockerignore` check enforces: any configuration that would put a credential into the image gates
-  // `--run`. Asked of EVERY provider, not just the selected model's — the file ships whole, so a literal on a
-  // provider nothing selects today is in the image all the same. A literal aimed at a PRIVATE endpoint is not a
-  // credential, though: pi's docs tell you to write `"apiKey": "ollama"` for a keyless local server, so that one
-  // only warns — gating it would make a "local ollama for dev, cloud model for deploy" definition undeployable.
+  // Reported, not refused. Whether a string is a credential is the AUTHOR's knowledge: pi's docs prescribe
+  // `"apiKey": "ollama"` for a keyless local server, and no static rule separates that from a leaked key. The
+  // `.dockerignore` check next to this one IS a gate because it catches a packing rule putting FastAgent's OWN
+  // `.secrets/auth.json` into the image — the framework's doing. This is the author's own committed file.
+  // Asked of EVERY provider, not just the selected model's: the file ships whole.
   const literalKeys = await literalKeyProviders(agentDir);
-  const named = (ids: { id: string }[]) => ids.map(({ id }) => `"${id}"`).join(", ");
-  const exposed = literalKeys.filter((provider) => provider.public);
-  if (exposed.length > 0) {
-    const issue =
-      `${AGENT_MODELS_FILE} carries a literal apiKey for ${named(exposed)} — that file ships inside the image, ` +
-      `where anyone who can pull it reads the layer. Use "$YOUR_ENV_VAR" (deploy carries it like any provider key) ` +
-      `or "!command" (it runs on the box and never travels).`;
-    if (run) return { ok: false, gate: issue };
-    messages.push({ level: "warn", text: issue });
-  }
-  const placeholders = literalKeys.filter((provider) => !provider.public);
-  if (placeholders.length > 0) {
+  if (literalKeys.length > 0) {
     messages.push({
       level: "warn",
       text:
-        `${AGENT_MODELS_FILE} carries a literal apiKey for ${named(placeholders)}, whose baseUrl is not reachable ` +
-        `from outside the deployment — read as a placeholder for a keyless server, not a credential. If it IS one, ` +
-        `move it to "$YOUR_ENV_VAR" or "!command": the file ships inside the image.`,
+        `${AGENT_MODELS_FILE} carries a literal apiKey for ${literalKeys.map((id) => `"${id}"`).join(", ")} — that ` +
+        `file ships inside the image, where anyone who can pull it reads the layer. If it is a credential, use ` +
+        `"$YOUR_ENV_VAR" (deploy carries it like any provider key) or "!command" (it runs on the box and never ` +
+        `travels); a placeholder for a keyless local server is fine as it is.`,
     });
   }
 
@@ -511,24 +501,27 @@ export async function preflightDeploy(input: {
   // hand-written Dockerfile survives `--force` and drops exactly the same things. Short-circuiting here let
   // `--run --force` ship the crash-loop this gate exists to stop.
   const dockerfileHome = join(agentDir, "Dockerfile");
-  if ((config.deploy?.apt?.length || model.envValue !== undefined) && (await exists(dockerfileHome))) {
-    if (!isGeneratedDockerfile(await readFile(dockerfileHome, "utf8"))) {
-      if (config.deploy?.apt?.length) {
-        messages.push({
-          level: "warn",
-          text:
-            `kept your hand-written Dockerfile — deploy.apt (${config.deploy.apt.join(", ")}) is ` +
-            `NOT applied; install those packages in your Dockerfile.`,
-        });
-      }
-      if (model.envValue !== undefined) {
-        const issue =
-          `kept your hand-written Dockerfile, and the model comes from ${valueFile} — it travels in the release ` +
-          `manifest, which only a Dockerfile setting FASTAGENT_RELEASE_FILE is read from. Add that ENV (see a ` +
-          `generated Dockerfile), or set \`model\` in fastagent.config.* so it ships in the config instead.`;
-        if (run) return { ok: false, gate: issue };
-        messages.push({ level: "warn", text: issue });
-      }
+  const dockerfileText = (await exists(dockerfileHome)) ? await readFile(dockerfileHome, "utf8") : undefined;
+  if (dockerfileText !== undefined && !isGeneratedDockerfile(dockerfileText)) {
+    if (config.deploy?.apt?.length) {
+      messages.push({
+        level: "warn",
+        text:
+          `kept your hand-written Dockerfile — deploy.apt (${config.deploy.apt.join(", ")}) is ` +
+          `NOT applied; install those packages in your Dockerfile.`,
+      });
+    }
+    // The INSTRUCTION is the question, not the file's authorship: `prepareStartWorkspace` returns early without
+    // FASTAGENT_RELEASE_FILE, so a Dockerfile that sets it reads the manifest whoever wrote it. This gates rather
+    // than warns because it is about FastAgent's OWN delivery arriving — the model would be reported here and
+    // missing on the box.
+    if (model.envValue !== undefined && !/^\s*ENV\s+FASTAGENT_RELEASE_FILE[=\s]/m.test(dockerfileText)) {
+      const issue =
+        `your Dockerfile does not set FASTAGENT_RELEASE_FILE, and the model comes from ${valueFile} — it travels ` +
+        `in the release manifest, which is only read when that ENV points at it. Add it (see a generated ` +
+        `Dockerfile), or set \`model\` in fastagent.config.* so it ships in the config instead.`;
+      if (run) return { ok: false, gate: issue };
+      messages.push({ level: "warn", text: issue });
     }
   }
 

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -14,8 +14,12 @@ import { type DeclaredChannel, inspectChannels } from "../channels/discover.ts";
 import { loadSchedules } from "../schedule/discover.ts";
 import { resolveAgentTools } from "../engines/pi/create.ts";
 import { type DeclaredSecret, allSecrets } from "../declared-secrets.ts";
-import { createPiModelRuntime, modelCredentialCarry, probeAuthSource } from "../engines/pi/models.ts";
-import { providerOf } from "../engines/pi/config.ts";
+import {
+  createPiModelRuntime,
+  literalKeyProviders,
+  modelCredentialCarry,
+  probeAuthSource,
+} from "../engines/pi/models.ts";
 import { AGENT_MODELS_FILE } from "../paths.ts";
 import { CHANNEL_KINDS } from "../scaffold/add-channel.ts";
 import { detectRuntime, readPackageJson } from "../runtime.ts";
@@ -245,17 +249,19 @@ export async function preflightDeploy(input: {
     const carry = modelCredentialCarry(models, modelSpec);
     if (carry.envVar) modelAuth = carry.envVar;
     else modelKeyInDefinition = carry.inDefinition;
-    if (carry.literalKey) {
-      // Same rule the `.dockerignore` check enforces: any configuration that would put a credential into the image
-      // gates `--run`. A literal has no legitimate use here — an endpoint that needs no key can omit it, and one
-      // that needs a key has two forms that do not ship it.
-      const issue =
-        `${AGENT_MODELS_FILE} carries a literal apiKey for "${providerOf(modelSpec)}" — that file ships inside the ` +
-        `image, where anyone who can pull it reads the layer. Use "$YOUR_ENV_VAR" (deploy carries it like any ` +
-        `provider key) or "!command" (it runs on the box and never travels).`;
-      if (run) return { ok: false, gate: issue };
-      messages.push({ level: "warn", text: issue });
-    }
+  }
+  // Same rule the `.dockerignore` check enforces: any configuration that would put a credential into the image gates
+  // `--run`. Asked of EVERY provider, not just the selected model's — the file ships whole, so a literal on a
+  // provider nothing selects today is in the image all the same. A literal has no legitimate use: an endpoint that
+  // needs no key omits it, and one that needs a key has two forms that do not ship it.
+  const literalKeys = literalKeyProviders(models);
+  if (literalKeys.length > 0) {
+    const issue =
+      `${AGENT_MODELS_FILE} carries a literal apiKey for ${literalKeys.map((id) => `"${id}"`).join(", ")} — that ` +
+      `file ships inside the image, where anyone who can pull it reads the layer. Use "$YOUR_ENV_VAR" (deploy ` +
+      `carries it like any provider key) or "!command" (it runs on the box and never travels).`;
+    if (run) return { ok: false, gate: issue };
+    messages.push({ level: "warn", text: issue });
   }
 
   // Container facts (shared by every host) + the warnings that follow.

--- a/src/deploy/railway/run.ts
+++ b/src/deploy/railway/run.ts
@@ -2,6 +2,7 @@
 import { type PublicHealthProbe, type Registrars, publicHealthGate, registerWebhooks } from "../channel-ingress.ts";
 import type { DeclaredChannel } from "../../channels/discover.ts";
 import type { CliRunner } from "../runner.ts";
+import { missingValuesGate } from "../secrets.ts";
 
 export interface RailwayRunPlan {
   /** Names both the project (`railway init --name`) and the service (`railway add --service`). */
@@ -16,8 +17,10 @@ export interface RailwayRunPlan {
    * + channel secrets.
    */
   secrets: Record<string, string>;
-  /** Required secret names with NO local value — the run gates on these before any side effect. */
+  /** Declared names the value file supplies no value for — the run gates on these before any side effect. */
   missingSecrets: string[];
+  /** That value file, workspace-relative, so the gate names the file this deploy actually read. */
+  valueFile: string;
   /** Every declared channel and its ingress — the driver asks which of them have a webhook. */
   channels: readonly DeclaredChannel[];
   /** Opt-in (CLI `--into-linked`) to provision INTO the project this directory is already linked to. */
@@ -101,13 +104,8 @@ export async function deployRailwayRun(
   }
 
   // 2. Gate missing required secret VALUES before any side effect (no half-created infra).
-  if (plan.missingSecrets.length > 0) {
-    return gate(
-      `no value for: ${plan.missingSecrets.join(", ")} — the deployed environment is declared by the agent's
-        .secrets/.env, and this deploy reads only that file (exporting the variable here does not reach the
-        deployment). Add them there and re-run`,
-    );
-  }
+  const missingValues = missingValuesGate(plan.missingSecrets, plan.valueFile);
+  if (missingValues) return gate(missingValues);
 
   // 3.
   const status = await railway(["status", "--json"], { capture: true });
@@ -153,9 +151,9 @@ export async function deployRailwayRun(
     `FASTAGENT_SECRETS_DIR=${plan.mountPath}/.secrets`,
     `RAILWAY_DOCKERFILE_PATH=${plan.dockerfilePath}`,
   ];
-  // The secret NAMES, not a count: what `--run` uploads is read from THIS machine's environment and
-  // is no longer only what the author typed in deploy.secrets (a mounted tool/channel/schedule
-  // declares its own), so the operator has to be able to see the list on every host.
+  // The secret NAMES, not a count: what `--run` uploads is read from the value file and is no longer
+  // only what the author typed in deploy.secrets (a mounted tool/channel/schedule declares its own),
+  // so the operator has to be able to see the list on every host.
   const secretNames = Object.keys(plan.secrets);
   log(
     `setting ${machineryVars.map((v) => v.split("=")[0]).join("/")} + ${secretNames.length} secret(s)` +

--- a/src/deploy/secrets.ts
+++ b/src/deploy/secrets.ts
@@ -126,6 +126,19 @@ export function assembleSecrets(input: {
   return { secrets, missingSecrets, needsModelCredential };
 }
 
+/**
+ * The ONE refusal for declared names the deployed environment does not supply a value for — every host reaches it
+ * before its first side effect. Host-neutral because the reason is: the value file IS the declaration, so a name
+ * missing from it is missing from the deployment, whatever platform receives it.
+ */
+export function missingValuesGate(missing: readonly string[], valueFile: string): string | undefined {
+  if (missing.length === 0) return undefined;
+  return (
+    `no value for: ${missing.join(", ")} — the deployed environment is declared by ${valueFile}, and this deploy ` +
+    `reads only that file (exporting the variable here does not reach the deployment). Add them there and re-run`
+  );
+}
+
 /** The bytes to seed to the auth file, or undefined to leave it alone. */
 export function authSeedBytes(seed: string | undefined, fileExists: boolean): Buffer | undefined {
   return !seed || fileExists ? undefined : Buffer.from(seed, "base64");

--- a/src/deploy/workspace.ts
+++ b/src/deploy/workspace.ts
@@ -46,6 +46,31 @@ export function parseDeploymentRelease(raw: string): DeploymentRelease {
   return r;
 }
 
+/**
+ * Project a release's own declarations into the environment it was resolved FOR — the receiving half of the model
+ * chain, run by `prepareStartWorkspace` BEFORE the workspace's `.env` is read (so either source outranks a value
+ * edited on the box).
+ *
+ * `||=`: a variable the platform already holds still wins, because the deployment declares only the half of this
+ * environment it can. The log names whichever source actually won — the remedies differ, and a redeploy does
+ * nothing at all to a platform-set variable.
+ */
+export function applyReleaseEnv(release: DeploymentRelease, env: NodeJS.ProcessEnv = process.env): void {
+  const fromPlatform = env.FASTAGENT_MODEL;
+  if (release.model && !fromPlatform) env.FASTAGENT_MODEL = release.model;
+  const effective = env.FASTAGENT_MODEL;
+  if (!effective) return;
+  log.info(
+    `[fastagent] model ${effective} — from ${
+      fromPlatform
+        ? `a FASTAGENT_MODEL already set in this environment${
+            release.model ? ", which outranks the release manifest" : ""
+          }`
+        : "the release manifest (redeploy to change it)"
+    }; editing FASTAGENT_MODEL in this workspace's .env does not override it`,
+  );
+}
+
 /** A `provider/modelId` spec. The id itself may carry `/` and `~` (`baseten/zai-org/GLM-5.3`, openrouter aliases);
  *  resolution only ever splits on the first slash. */
 export function isModelSpec(value: string): boolean {

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -202,8 +202,8 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
   if (idle !== undefined && (!Number.isInteger(idle) || idle < 60 || idle > 1209600)) {
     throw new Error(`${path}: "deploy.agentcore.idleTimeoutSeconds" must be an integer 60-1209600 (seconds)`);
   }
-  // secrets are UPPER_SNAKE env-var names (deploy reads their VALUES from the local env); apt entries are Debian
-  // package names.
+  // secrets are UPPER_SNAKE env-var names (deploy reads their VALUES from the agent's .secrets/.env); apt entries
+  // are Debian package names.
   validateStringList(c.deploy?.secrets, "deploy.secrets", /^[A-Z_][A-Z0-9_]*$/, "an UPPER_SNAKE env-var name", path);
   validateStringList(c.deploy?.apt, "deploy.apt", /^[a-z0-9][a-z0-9.+-]*$/, "a Debian package name", path);
   return { config: c, path };

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -93,6 +93,17 @@ export function modelCredentialCarry(
   return { inDefinition: status.source !== "stored", literalKey: status.source === "models_json_key" };
 }
 
+/**
+ * EVERY provider whose key is a literal in `models.json`, not just the selected model's. The file ships whole, so a
+ * literal on a provider nothing currently selects is in the image all the same.
+ */
+export function literalKeyProviders(runtime: ModelRuntime): string[] {
+  return runtime
+    .getProviders()
+    .filter((provider) => runtime.getProviderAuthStatus(provider.id).source === "models_json_key")
+    .map((provider) => provider.id);
+}
+
 /** Per-provider auth status for the first-run model picker. */
 export type ProviderAuthStatus =
   | { state: "ready"; source?: string }

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -145,11 +145,19 @@ function isPublicEndpoint(baseUrl: unknown): boolean {
   if (host === "localhost" || host === "::1" || host.endsWith(".localhost") || host.endsWith(".internal")) {
     return false; // names that resolve inside the deployment only
   }
+  // A single-label host is a Compose/K8s service name (`http://ollama:11434/v1`) — resolvable only on the
+  // deployment's own network, and the most common shape for exactly the keyless local server this exempts.
+  if (!host.includes(".") && !host.includes(":")) return false;
   return !(
-    /^127\./.test(host) ||
-    /^10\./.test(host) ||
-    /^192\.168\./.test(host) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+    (
+      /^127\./.test(host) ||
+      /^10\./.test(host) ||
+      /^192\.168\./.test(host) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+      /^169\.254\./.test(host) || // link-local
+      /^f[cd][0-9a-f]{2}:/i.test(host) || // IPv6 unique local (fc00::/7)
+      /^fe80:/i.test(host)
+    ) // IPv6 link-local
   );
 }
 

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -85,20 +85,20 @@ export function modelCredentialCarry(runtime: ModelRuntime, spec: string): { env
 }
 
 /**
- * EVERY provider whose `models.json` entry writes its key as a LITERAL, and whether that provider is reachable from
- * outside the deployment. `"$NAME"` is an ordinary declared secret and `"!cmd"` runs on the box, so neither
- * qualifies.
+ * EVERY provider whose `models.json` entry writes its key as a LITERAL rather than a `"$NAME"` reference or a
+ * `"!cmd"`. The file ships inside the image, so a literal there is a credential in a readable layer.
  *
  * Read from the FILE, not from `getProviderAuthStatus`: that answers "what satisfies this provider right now" and
  * returns `stored` first, so a provider that has both an `auth.json` entry and a literal in the file would report
- * `stored` and the literal would ship unreported. The question here is what the definition DECLARES, and only the
- * file answers it. The three-way split mirrors pi's `configuredRequestAuthStatus`, which is not exported.
+ * `stored` and the literal would go unreported. The question is what the definition DECLARES, and only the file
+ * answers it. The three-way split mirrors pi's `configuredRequestAuthStatus`, which is not exported.
  *
- * `public` is what separates a leaked credential from a placeholder: pi's own docs tell you to write `"apiKey":
- * "ollama"` for a keyless local server (omitting it makes the model load but stay unusable), and a string presented
- * only to `http://localhost:11434` is not a credential at all. A literal sent to an endpoint anyone can reach is.
+ * The caller WARNS on this; it does not refuse. Whether a given string is a credential is the author's knowledge,
+ * not the framework's — pi's own docs prescribe `"apiKey": "ollama"` for a keyless local server, and no static rule
+ * separates that from a leaked key (an endpoint's reachability is not decidable from its URL either). FastAgent
+ * gates what IT causes; what the author wrote into their own committed file, it reports.
  */
-export async function literalKeyProviders(agentDir: string): Promise<{ id: string; public: boolean }[]> {
+export async function literalKeyProviders(agentDir: string): Promise<string[]> {
   const file = join(agentDir, AGENT_MODELS_FILE);
   let raw: string;
   try {
@@ -110,55 +110,21 @@ export async function literalKeyProviders(agentDir: string): Promise<{ id: strin
   }
   // Malformed JSON already threw out of createPiModelRuntime before this runs, so a parse failure here would be a
   // genuine surprise and must not be swallowed.
-  const providers =
-    (JSON.parse(raw) as { providers?: Record<string, { apiKey?: unknown; baseUrl?: unknown }> }).providers ?? {};
+  const providers = (JSON.parse(raw) as { providers?: Record<string, { apiKey?: unknown }> }).providers ?? {};
   return Object.entries(providers)
     .filter(([, provider]) => isLiteralKey(provider?.apiKey))
-    .map(([id, provider]) => ({ id, public: isPublicEndpoint(provider?.baseUrl) }));
+    .map(([id]) => id);
 }
 
 /**
  * `!cmd` runs on the box; `$NAME` / `${NAME}` reads the environment; anything else is the key itself.
  *
  * `$$` is pi's escape for a literal `$`, so it is removed BEFORE looking for a reference — otherwise `"sk$$abc"`
- * (which resolves to the literal `sk$abc`) would read as a reference and a real credential would ship unreported.
- * This gate may over-report; it must never under-report.
+ * (which resolves to the literal `sk$abc`) would read as a reference and go unmentioned.
  */
 function isLiteralKey(apiKey: unknown): boolean {
   if (typeof apiKey !== "string" || apiKey === "" || apiKey.startsWith("!")) return false;
   return !/\$\{?[A-Za-z_]/.test(apiKey.replaceAll("$$", ""));
-}
-
-/**
- * Can something outside this deployment reach `baseUrl`? Loopback and the private ranges cannot be, so a literal
- * sent there is a placeholder for a keyless server rather than a credential. An unparseable or absent URL counts as
- * public: the gate must not be opened by a value it failed to understand.
- */
-function isPublicEndpoint(baseUrl: unknown): boolean {
-  if (typeof baseUrl !== "string") return true;
-  let host: string;
-  try {
-    host = new URL(baseUrl).hostname.replace(/^\[|\]$/g, "");
-  } catch {
-    return true; // not a URL we can classify — treat it as reachable
-  }
-  if (host === "localhost" || host === "::1" || host.endsWith(".localhost") || host.endsWith(".internal")) {
-    return false; // names that resolve inside the deployment only
-  }
-  // A single-label host is a Compose/K8s service name (`http://ollama:11434/v1`) — resolvable only on the
-  // deployment's own network, and the most common shape for exactly the keyless local server this exempts.
-  if (!host.includes(".") && !host.includes(":")) return false;
-  return !(
-    (
-      /^127\./.test(host) ||
-      /^10\./.test(host) ||
-      /^192\.168\./.test(host) ||
-      /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-      /^169\.254\./.test(host) || // link-local
-      /^f[cd][0-9a-f]{2}:/i.test(host) || // IPv6 unique local (fc00::/7)
-      /^fe80:/i.test(host)
-    ) // IPv6 link-local
-  );
 }
 
 /** Per-provider auth status for the first-run model picker. */

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -72,15 +72,25 @@ export async function createPiModelRuntime(
   return runtime;
 }
 
-/** How a model's credential will REACH a deployed agent. */
-export function modelCredentialCarry(runtime: ModelRuntime, spec: string): { envVar?: string; inDefinition: boolean } {
+/**
+ * How a model's credential will REACH a deployed agent — and whether the way it does so is legitimate.
+ *
+ * `models.json` resolves an `apiKey` three ways, and they are NOT interchangeable for a deployment: `"$NAME"` is an
+ * ordinary declared secret, `"!cmd"` runs on the box and never travels, and a literal is a credential written into a
+ * file that ships inside the image — readable by anyone who can pull it. pi already tells the three apart
+ * (`models_json_key` vs `models_json_command` vs `environment`), so the distinction costs nothing to make here.
+ */
+export function modelCredentialCarry(
+  runtime: ModelRuntime,
+  spec: string,
+): { envVar?: string; inDefinition: boolean; literalKey: boolean } {
   const status = runtime.getProviderAuthStatus(providerOf(spec));
-  if (!status.configured) return { inDefinition: false };
+  if (!status.configured) return { inDefinition: false, literalKey: false };
   // An env-var name is only useful downstream if it IS one.
   if (status.source === "environment" && status.label && /^[A-Z][A-Z0-9_]*$/.test(status.label)) {
-    return { envVar: status.label, inDefinition: false };
+    return { envVar: status.label, inDefinition: false, literalKey: false };
   }
-  return { inDefinition: status.source !== "stored" };
+  return { inDefinition: status.source !== "stored", literalKey: status.source === "models_json_key" };
 }
 
 /** Per-provider auth status for the first-run model picker. */

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -3,6 +3,7 @@
  * (per-request credential resolution). fastagent builds one per opener and threads it into the engine alongside the
  * selected `model`; the two must come from the same collection so the model's provider auth is in scope.
  */
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { type Api, type Model, type Models, type Provider, defaultProviderAuthContext } from "@earendil-works/pi-ai";
@@ -72,36 +73,47 @@ export async function createPiModelRuntime(
   return runtime;
 }
 
-/**
- * How a model's credential will REACH a deployed agent — and whether the way it does so is legitimate.
- *
- * `models.json` resolves an `apiKey` three ways, and they are NOT interchangeable for a deployment: `"$NAME"` is an
- * ordinary declared secret, `"!cmd"` runs on the box and never travels, and a literal is a credential written into a
- * file that ships inside the image — readable by anyone who can pull it. pi already tells the three apart
- * (`models_json_key` vs `models_json_command` vs `environment`), so the distinction costs nothing to make here.
- */
-export function modelCredentialCarry(
-  runtime: ModelRuntime,
-  spec: string,
-): { envVar?: string; inDefinition: boolean; literalKey: boolean } {
+/** How a model's credential will REACH a deployed agent. */
+export function modelCredentialCarry(runtime: ModelRuntime, spec: string): { envVar?: string; inDefinition: boolean } {
   const status = runtime.getProviderAuthStatus(providerOf(spec));
-  if (!status.configured) return { inDefinition: false, literalKey: false };
+  if (!status.configured) return { inDefinition: false };
   // An env-var name is only useful downstream if it IS one.
   if (status.source === "environment" && status.label && /^[A-Z][A-Z0-9_]*$/.test(status.label)) {
-    return { envVar: status.label, inDefinition: false, literalKey: false };
+    return { envVar: status.label, inDefinition: false };
   }
-  return { inDefinition: status.source !== "stored", literalKey: status.source === "models_json_key" };
+  return { inDefinition: status.source !== "stored" };
 }
 
 /**
- * EVERY provider whose key is a literal in `models.json`, not just the selected model's. The file ships whole, so a
- * literal on a provider nothing currently selects is in the image all the same.
+ * EVERY provider whose `models.json` entry writes its key as a LITERAL — the form that ships the credential inside
+ * the image. `"$NAME"` is an ordinary declared secret and `"!cmd"` runs on the box, so neither qualifies.
+ *
+ * Read from the FILE, not from `getProviderAuthStatus`: that answers "what satisfies this provider right now" and
+ * returns `stored` first, so a provider that has both an `auth.json` entry and a literal in the file would report
+ * `stored` and the literal would ship unreported. The question here is what the definition DECLARES, and only the
+ * file answers it. The three-way split mirrors pi's `configuredRequestAuthStatus`, which is not exported.
  */
-export function literalKeyProviders(runtime: ModelRuntime): string[] {
-  return runtime
-    .getProviders()
-    .filter((provider) => runtime.getProviderAuthStatus(provider.id).source === "models_json_key")
-    .map((provider) => provider.id);
+export async function literalKeyProviders(agentDir: string): Promise<string[]> {
+  const file = join(agentDir, AGENT_MODELS_FILE);
+  let raw: string;
+  try {
+    raw = await readFile(file, "utf8");
+  } catch (error) {
+    // No custom endpoints is the normal case; anything else (unreadable, a directory) is the caller's problem.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  // Malformed JSON already threw out of createPiModelRuntime before this runs, so a parse failure here would be a
+  // genuine surprise and must not be swallowed.
+  const providers = (JSON.parse(raw) as { providers?: Record<string, { apiKey?: unknown }> }).providers ?? {};
+  return Object.entries(providers)
+    .filter(([, provider]) => isLiteralKey(provider?.apiKey))
+    .map(([id]) => id);
+}
+
+/** `!cmd` runs on the box; `$NAME` / `${NAME}` reads the environment; anything else is the key itself. */
+function isLiteralKey(apiKey: unknown): boolean {
+  return typeof apiKey === "string" && apiKey !== "" && !apiKey.startsWith("!") && !/\$\{?[A-Za-z_]/.test(apiKey);
 }
 
 /** Per-provider auth status for the first-run model picker. */

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -85,15 +85,20 @@ export function modelCredentialCarry(runtime: ModelRuntime, spec: string): { env
 }
 
 /**
- * EVERY provider whose `models.json` entry writes its key as a LITERAL — the form that ships the credential inside
- * the image. `"$NAME"` is an ordinary declared secret and `"!cmd"` runs on the box, so neither qualifies.
+ * EVERY provider whose `models.json` entry writes its key as a LITERAL, and whether that provider is reachable from
+ * outside the deployment. `"$NAME"` is an ordinary declared secret and `"!cmd"` runs on the box, so neither
+ * qualifies.
  *
  * Read from the FILE, not from `getProviderAuthStatus`: that answers "what satisfies this provider right now" and
  * returns `stored` first, so a provider that has both an `auth.json` entry and a literal in the file would report
  * `stored` and the literal would ship unreported. The question here is what the definition DECLARES, and only the
  * file answers it. The three-way split mirrors pi's `configuredRequestAuthStatus`, which is not exported.
+ *
+ * `public` is what separates a leaked credential from a placeholder: pi's own docs tell you to write `"apiKey":
+ * "ollama"` for a keyless local server (omitting it makes the model load but stay unusable), and a string presented
+ * only to `http://localhost:11434` is not a credential at all. A literal sent to an endpoint anyone can reach is.
  */
-export async function literalKeyProviders(agentDir: string): Promise<string[]> {
+export async function literalKeyProviders(agentDir: string): Promise<{ id: string; public: boolean }[]> {
   const file = join(agentDir, AGENT_MODELS_FILE);
   let raw: string;
   try {
@@ -105,15 +110,47 @@ export async function literalKeyProviders(agentDir: string): Promise<string[]> {
   }
   // Malformed JSON already threw out of createPiModelRuntime before this runs, so a parse failure here would be a
   // genuine surprise and must not be swallowed.
-  const providers = (JSON.parse(raw) as { providers?: Record<string, { apiKey?: unknown }> }).providers ?? {};
+  const providers =
+    (JSON.parse(raw) as { providers?: Record<string, { apiKey?: unknown; baseUrl?: unknown }> }).providers ?? {};
   return Object.entries(providers)
     .filter(([, provider]) => isLiteralKey(provider?.apiKey))
-    .map(([id]) => id);
+    .map(([id, provider]) => ({ id, public: isPublicEndpoint(provider?.baseUrl) }));
 }
 
-/** `!cmd` runs on the box; `$NAME` / `${NAME}` reads the environment; anything else is the key itself. */
+/**
+ * `!cmd` runs on the box; `$NAME` / `${NAME}` reads the environment; anything else is the key itself.
+ *
+ * `$$` is pi's escape for a literal `$`, so it is removed BEFORE looking for a reference — otherwise `"sk$$abc"`
+ * (which resolves to the literal `sk$abc`) would read as a reference and a real credential would ship unreported.
+ * This gate may over-report; it must never under-report.
+ */
 function isLiteralKey(apiKey: unknown): boolean {
-  return typeof apiKey === "string" && apiKey !== "" && !apiKey.startsWith("!") && !/\$\{?[A-Za-z_]/.test(apiKey);
+  if (typeof apiKey !== "string" || apiKey === "" || apiKey.startsWith("!")) return false;
+  return !/\$\{?[A-Za-z_]/.test(apiKey.replaceAll("$$", ""));
+}
+
+/**
+ * Can something outside this deployment reach `baseUrl`? Loopback and the private ranges cannot be, so a literal
+ * sent there is a placeholder for a keyless server rather than a credential. An unparseable or absent URL counts as
+ * public: the gate must not be opened by a value it failed to understand.
+ */
+function isPublicEndpoint(baseUrl: unknown): boolean {
+  if (typeof baseUrl !== "string") return true;
+  let host: string;
+  try {
+    host = new URL(baseUrl).hostname.replace(/^\[|\]$/g, "");
+  } catch {
+    return true; // not a URL we can classify — treat it as reachable
+  }
+  if (host === "localhost" || host === "::1" || host.endsWith(".localhost") || host.endsWith(".internal")) {
+    return false; // names that resolve inside the deployment only
+  }
+  return !(
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+  );
 }
 
 /** Per-provider auth status for the first-run model picker. */

--- a/src/scaffold/templates/fastagent.config.mjs
+++ b/src/scaffold/templates/fastagent.config.mjs
@@ -17,7 +17,7 @@ export default {
   // deploy: what the agent needs on the box (so `fastagent deploy` doesn't need a hand-written Dockerfile
   // or hand-set host variables). Uncomment as needed:
   // deploy: {
-  //   secrets: ["GH_TOKEN"], // extra secret env vars your tools use — deploy carries them from your local env
+  //   secrets: ["GH_TOKEN"], // extra secret env vars your tools use — deploy reads their values from .secrets/.env
   //   apt: ["git"],          // extra apt packages baked into the image (git, ripgrep, …; default repos only)
   // },
 };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -94,7 +94,7 @@ describe("cli papercuts", () => {
     const first = await run(["deploy", "docker", dir]);
     expect(first.code).toBe(0);
     expect(first.stdout).toContain(
-      "docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build",
+      "docker compose -f fastagent/fastagent.compose.yml up -d --build", // no value file yet → no --env-file
     );
     const generatedCompose = await readFile(join(dir, "fastagent", "fastagent.compose.yml"), "utf8");
     expect(generatedCompose).toContain('"127.0.0.1:8787:8787"');
@@ -127,7 +127,7 @@ describe("cli papercuts", () => {
     expect(result.stderr).toMatch(/edit it, delete it and regenerate, or pass --force/);
     expect(result.stdout).not.toContain("logs -f tunnel");
     expect(result.stdout).toContain(
-      "docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build",
+      "docker compose -f fastagent/fastagent.compose.yml up -d --build", // no value file yet → no --env-file
     );
     expect(await readFile(composePath, "utf8")).toBe(compose);
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -94,7 +94,7 @@ describe("cli papercuts", () => {
     const first = await run(["deploy", "docker", dir]);
     expect(first.code).toBe(0);
     expect(first.stdout).toContain(
-      "docker compose -f fastagent/fastagent.compose.yml up -d --build", // no value file yet → no --env-file
+      "docker compose -f fastagent/fastagent.compose.yml up -d --build", // one spelling: the generated Compose names the value file itself
     );
     const generatedCompose = await readFile(join(dir, "fastagent", "fastagent.compose.yml"), "utf8");
     expect(generatedCompose).toContain('"127.0.0.1:8787:8787"');
@@ -127,9 +127,29 @@ describe("cli papercuts", () => {
     expect(result.stderr).toMatch(/edit it, delete it and regenerate, or pass --force/);
     expect(result.stdout).not.toContain("logs -f tunnel");
     expect(result.stdout).toContain(
-      "docker compose -f fastagent/fastagent.compose.yml up -d --build", // no value file yet → no --env-file
+      "docker compose -f fastagent/fastagent.compose.yml up -d --build", // one spelling: the generated Compose names the value file itself
     );
     expect(await readFile(composePath, "utf8")).toBe(compose);
+  });
+
+  it("deploy docker gates --run when FASTAGENT_SECRETS_DIR sends the values away from the committed env_file", async () => {
+    // The generated Compose names a FIXED `.secrets/.env`, so a relocated secrets dir means the pre-flight checks
+    // one file while the container reads another: every declared value is silently absent. Deterministic, so `--run`
+    // refuses before Docker is touched; generating artifacts only warns.
+    const dir = await agentWorkspace("fa-deploy-secrets-dir-", {
+      "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n`,
+    });
+    const elsewhere = await mkdtemp(join(tmpdir(), "fa-secrets-elsewhere-"));
+    const env = { ...process.env, FASTAGENT_SECRETS_DIR: elsewhere };
+
+    const planned = await run(["deploy", "docker", dir], undefined, env);
+    expect(planned.code).toBe(0);
+    expect(planned.stderr).toMatch(/warn: FASTAGENT_SECRETS_DIR points this run's values at/);
+
+    const gated = await run(["deploy", "docker", dir, "--run"], undefined, env);
+    expect(gated.code).toBe(1);
+    expect(gated.stderr).toMatch(/deploy stopped: FASTAGENT_SECRETS_DIR points this run's values at/);
+    expect(gated.stderr).not.toMatch(/Docker CLI not found|Docker daemon/); // refused before any Docker work
   });
 
   it("deploy docker --tunnel shapes Compose but does not run Docker without --run", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -93,7 +93,9 @@ describe("cli papercuts", () => {
 
     const first = await run(["deploy", "docker", dir]);
     expect(first.code).toBe(0);
-    expect(first.stdout).toContain("docker compose -f fastagent/fastagent.compose.yml up -d --build");
+    expect(first.stdout).toContain(
+      "docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build",
+    );
     const generatedCompose = await readFile(join(dir, "fastagent", "fastagent.compose.yml"), "utf8");
     expect(generatedCompose).toContain('"127.0.0.1:8787:8787"');
     expect(generatedCompose).not.toContain("cloudflared");
@@ -124,7 +126,9 @@ describe("cli papercuts", () => {
     expect(result.stderr).toMatch(/--tunnel.*kept fastagent\/fastagent\.compose\.yml.*no "tunnel" service/);
     expect(result.stderr).toMatch(/edit it, delete it and regenerate, or pass --force/);
     expect(result.stdout).not.toContain("logs -f tunnel");
-    expect(result.stdout).toContain("docker compose -f fastagent/fastagent.compose.yml up -d --build");
+    expect(result.stdout).toContain(
+      "docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build",
+    );
     expect(await readFile(composePath, "utf8")).toBe(compose);
   });
 

--- a/test/deploy-agentcore-run.test.ts
+++ b/test/deploy-agentcore-run.test.ts
@@ -45,6 +45,7 @@ const plan = (over: Partial<AgentcoreRunPlan> = {}): AgentcoreRunPlan => ({
   region: "us-west-2",
   secrets: {},
   missingSecrets: [],
+  valueFile: "fastagent/.secrets/.env",
   channels: [],
   topology: NO_FORWARDER,
   ...over,

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -24,7 +24,6 @@ const plan = (override: Partial<DockerRunPlan> = {}): DockerRunPlan => ({
   secrets: {},
   missingSecrets: [],
   valueFile: "fastagent/.secrets/.env",
-  interpolated: [],
   needsModelCredential: false,
   requireTunnel: false,
   announce: async () => [],
@@ -63,28 +62,28 @@ describe("deploy/docker/run: local Compose journey", () => {
     expect(healthUrls).toEqual(["http://127.0.0.1:9876/health"]);
   });
 
-  it("blanks every interpolated name, so the builder's shell cannot reach the container", async () => {
-    // Compose fills `${NAME:-}` from the environment it is spawned with, and that environment inherits this
-    // process's. Without the blanking, any interpolated name the value file does not declare would be filled from
-    // the builder's shell — including the ones the missing-values gate never sees (optional channel keys, the
-    // control token, the auth seed), which is exactly the source the value file replaced.
-    const before = process.env.FA_TEST_LEAK;
-    process.env.FA_TEST_LEAK = "from-the-builders-shell";
+  it("passes ONLY the auth seed, and sets it even when absent", async () => {
+    // The container reads the value file itself through the generated `env_file`, so nothing else has to cross this
+    // process. The seed is the exception (`--run` mints it from the local auth.json) and is set unconditionally:
+    // `spawnRunner` merges over `process.env`, so leaving it unset would let a same-named variable in the builder's
+    // shell interpolate into the container in its place.
+    const before = process.env.FASTAGENT_AUTH_SEED;
+    process.env.FASTAGENT_AUTH_SEED = "from-the-builders-shell";
     try {
       const { docker, calls } = fakeDocker((args) => (args[1] === "port" ? { code: 1 } : {}));
-      await deployDockerRun(
-        plan({ interpolated: ["FA_TEST_LEAK", "FA_TEST_DECLARED"], secrets: { FA_TEST_DECLARED: "from-the-file" } }),
-        docker,
-        () => {},
-        healthy,
-      );
+      await deployDockerRun(plan({ secrets: { TELEGRAM_BOT_TOKEN: "t" } }), docker, () => {}, healthy);
       const passed = calls.find((call) => call.env)?.env;
-      expect(passed?.FA_TEST_LEAK).toBe(""); // present but empty — never the shell's value
-      expect(passed?.FA_TEST_DECLARED).toBe("from-the-file");
+      expect(passed).toEqual({ FASTAGENT_AUTH_SEED: "" }); // blanked, and nothing else travels
     } finally {
-      if (before === undefined) delete process.env.FA_TEST_LEAK;
-      else process.env.FA_TEST_LEAK = before;
+      if (before === undefined) delete process.env.FASTAGENT_AUTH_SEED;
+      else process.env.FASTAGENT_AUTH_SEED = before;
     }
+  });
+
+  it("carries the minted auth seed when there is one", async () => {
+    const { docker, calls } = fakeDocker((args) => (args[1] === "port" ? { code: 1 } : {}));
+    await deployDockerRun(plan({ secrets: { FASTAGENT_AUTH_SEED: "b64" } }), docker, () => {}, healthy);
+    expect(calls.find((call) => call.env)?.env).toEqual({ FASTAGENT_AUTH_SEED: "b64" });
   });
 
   it("tells the health probe when the agent container is gone (a crashed boot must not spend the budget)", async () => {
@@ -233,7 +232,7 @@ describe("deploy/docker/run: local Compose journey", () => {
     expect(lines.filter((line) => line.startsWith("warn:"))).toEqual([]);
   });
 
-  it("passes secret values through the child environment, never argv", async () => {
+  it("never puts a secret value in argv — the container reads the value file itself", async () => {
     const { docker, calls } = fakeDocker((args) => {
       if (args.includes("--services")) return { stdout: "agent\n" };
       if (args.includes("port")) return { stdout: "127.0.0.1:8787\n" };
@@ -248,7 +247,8 @@ describe("deploy/docker/run: local Compose journey", () => {
 
     expect(calls.some((call) => call.args.join(" ").includes("sk-secret"))).toBe(false);
     const up = calls.find((call) => call.args.includes("up"))!;
-    expect(up.env).toEqual({ OPENAI_API_KEY: "sk-secret", FASTAGENT_AUTH_SEED: "base64-secret" });
+    // The declared key rides `env_file` in the generated Compose, so it does not travel through this process at all.
+    expect(up.env).toEqual({ FASTAGENT_AUTH_SEED: "base64-secret" });
   });
 
   it("names the secrets it carries — the list is no longer only what the author typed", async () => {

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -24,6 +24,7 @@ const plan = (override: Partial<DockerRunPlan> = {}): DockerRunPlan => ({
   secrets: {},
   missingSecrets: [],
   valueFile: "fastagent/.secrets/.env",
+  interpolated: [],
   needsModelCredential: false,
   requireTunnel: false,
   announce: async () => [],
@@ -60,6 +61,30 @@ describe("deploy/docker/run: local Compose journey", () => {
       "compose -f fastagent.compose.yml port agent 8787",
     ]);
     expect(healthUrls).toEqual(["http://127.0.0.1:9876/health"]);
+  });
+
+  it("blanks every interpolated name, so the builder's shell cannot reach the container", async () => {
+    // Compose fills `${NAME:-}` from the environment it is spawned with, and that environment inherits this
+    // process's. Without the blanking, any interpolated name the value file does not declare would be filled from
+    // the builder's shell — including the ones the missing-values gate never sees (optional channel keys, the
+    // control token, the auth seed), which is exactly the source the value file replaced.
+    const before = process.env.FA_TEST_LEAK;
+    process.env.FA_TEST_LEAK = "from-the-builders-shell";
+    try {
+      const { docker, calls } = fakeDocker((args) => (args[1] === "port" ? { code: 1 } : {}));
+      await deployDockerRun(
+        plan({ interpolated: ["FA_TEST_LEAK", "FA_TEST_DECLARED"], secrets: { FA_TEST_DECLARED: "from-the-file" } }),
+        docker,
+        () => {},
+        healthy,
+      );
+      const passed = calls.find((call) => call.env)?.env;
+      expect(passed?.FA_TEST_LEAK).toBe(""); // present but empty — never the shell's value
+      expect(passed?.FA_TEST_DECLARED).toBe("from-the-file");
+    } finally {
+      if (before === undefined) delete process.env.FA_TEST_LEAK;
+      else process.env.FA_TEST_LEAK = before;
+    }
   });
 
   it("tells the health probe when the agent container is gone (a crashed boot must not spend the budget)", async () => {

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -251,9 +251,10 @@ describe("deploy/docker/run: local Compose journey", () => {
     expect(up.env).toEqual({ FASTAGENT_AUTH_SEED: "base64-secret" });
   });
 
-  it("names the secrets it carries — the list is no longer only what the author typed", async () => {
-    // A mounted tool/channel/schedule declares its own names, so what `--run` reads from THIS machine
-    // and pushes to the host has to be visible, not a count.
+  it("names the values the container must find, and the file it reads them from", async () => {
+    // A mounted tool/channel/schedule declares its own names, so the list has to be visible, not a count. It is
+    // NOT "passing N secrets to Compose": the container reads the value file itself, and a hand-owned Compose
+    // file may have no `env_file` entry at all — saying we handed them over would be false.
     const { docker } = fakeDocker((args) => {
       if (args.includes("--services")) return { stdout: "agent\n" };
       if (args.includes("port")) return { stdout: "127.0.0.1:8787\n" };
@@ -266,7 +267,9 @@ describe("deploy/docker/run: local Compose journey", () => {
       (message) => logs.push(message),
       healthy,
     );
-    expect(logs.join("\n")).toContain("2 secret(s) to Compose: OPENAI_API_KEY, X_API_KEY");
+    expect(logs.join("\n")).toContain(
+      "2 value(s) the container reads from fastagent/.secrets/.env: OPENAI_API_KEY, X_API_KEY",
+    );
   });
 
   it("accepts a running custom topology with no host-published port (operator-owned ingress)", async () => {

--- a/test/deploy-docker-run.test.ts
+++ b/test/deploy-docker-run.test.ts
@@ -23,6 +23,7 @@ const plan = (override: Partial<DockerRunPlan> = {}): DockerRunPlan => ({
   port: 8787,
   secrets: {},
   missingSecrets: [],
+  valueFile: "fastagent/.secrets/.env",
   needsModelCredential: false,
   requireTunnel: false,
   announce: async () => [],

--- a/test/deploy-docker.test.ts
+++ b/test/deploy-docker.test.ts
@@ -127,7 +127,9 @@ describe("deploy/docker: planDockerDeploy", () => {
       planDockerDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: declaredChannels(["telegram", "github"]) }),
     );
     expect(out).toContain(`Docker Engine/Desktop with Compose >= ${MIN_DOCKER_COMPOSE_VERSION}`);
-    expect(out).toContain("docker compose -f fastagent/fastagent.compose.yml up -d --build");
+    expect(out).toContain(
+      "docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build",
+    );
     expect(out).toContain("down        # stops containers; keeps the state volume");
     expect(out).toContain("down -v   # DESTRUCTIVE");
     expect(out).toContain("Public ingress is operator-owned");

--- a/test/deploy-docker.test.ts
+++ b/test/deploy-docker.test.ts
@@ -16,6 +16,8 @@ const runbook = (plan: ReturnType<typeof planDockerDeploy>) => plan.runbook.join
 const base = {
   releaseId: "release-one",
   agentPrefix: "fastagent/",
+  valueFile: "fastagent/.secrets/.env",
+  valueFileExists: true,
   projectName: "fastagent-bot",
   port: 8787,
   hasPackageJson: true,
@@ -122,6 +124,22 @@ describe("deploy/docker: planDockerDeploy", () => {
     expect(runbook(plan)).toContain("Run from the WORKSPACE ROOT");
   });
 
+  it("omits --env-file when the value file does not exist yet, and says why", () => {
+    // `fastagent init` writes .env.example, not .env, so an OAuth-only agent has no value file. `--env-file` on a
+    // missing path is `couldn't find env file: …`, which would take the whole runbook's `up` down with it.
+    const out = runbook(
+      planDockerDeploy({
+        ...base,
+        valueFileExists: false,
+        modelAuth: "OPENAI_API_KEY",
+        channels: declaredChannels(["telegram"]),
+      }),
+    );
+    expect(out).toContain("docker compose -f fastagent/fastagent.compose.yml up -d --build");
+    expect(out).not.toContain("docker compose --env-file"); // the note mentions the flag; no command uses it
+    expect(out).toMatch(/does not exist yet.*--env-file fails on a missing path/s);
+  });
+
   it("prints lifecycle + operator-owned ingress guidance for detected webhook channels", () => {
     const out = runbook(
       planDockerDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: declaredChannels(["telegram", "github"]) }),
@@ -130,6 +148,11 @@ describe("deploy/docker: planDockerDeploy", () => {
     expect(out).toContain(
       "docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build",
     );
+    // ONLY `up` interpolates, so only `up` carries --env-file: `--env-file` is a hard failure on a missing path,
+    // and these three need no values at all.
+    for (const cmd of ["logs -f agent", "ps", "down"]) {
+      expect(out).toContain(`docker compose -f fastagent/fastagent.compose.yml ${cmd}`);
+    }
     expect(out).toContain("down        # stops containers; keeps the state volume");
     expect(out).toContain("down -v   # DESTRUCTIVE");
     expect(out).toContain("Public ingress is operator-owned");

--- a/test/deploy-docker.test.ts
+++ b/test/deploy-docker.test.ts
@@ -17,7 +17,6 @@ const base = {
   releaseId: "release-one",
   agentPrefix: "fastagent/",
   valueFile: "fastagent/.secrets/.env",
-  valueFileExists: true,
   projectName: "fastagent-bot",
   port: 8787,
   hasPackageJson: true,
@@ -106,10 +105,16 @@ describe("deploy/docker: planDockerDeploy", () => {
     expect(yaml).not.toContain("<value>");
     expect(yaml).not.toContain("sk-");
 
-    // No value file yet → no entry pointing at a missing path (Compose refuses one), and the runbook says so.
-    const absent = planDockerDeploy({ ...base, valueFileExists: false, modelAuth: "OPENAI_API_KEY", channels: [] });
-    expect(compose(absent)).not.toContain("env_file");
-    expect(runbook(absent)).toMatch(/does not exist yet.*regenerate a Compose file that reads it/s);
+    // The path is FIXED, never the builder's FASTAGENT_SECRETS_DIR: this file is committed and must mean the same
+    // thing on every machine. `deploy` creates the file so the entry is never a missing path.
+    expect(
+      compose(planDockerDeploy({ ...base, modelAuth: undefined, channels: [], valueFile: "somewhere/else/.env" })),
+    ).toContain("env_file:\n      - .secrets/.env");
+
+    // Machinery pinned AFTER env_file, so a local path in that file (the scaffold lists these) cannot send the
+    // container's sessions or credentials to a host path that does not exist inside it.
+    expect(yaml).toContain('FASTAGENT_SESSIONS_DIR: "/data/.state/sessions"');
+    expect(yaml).toContain('FASTAGENT_AUTH_PATH: "/data/.secrets/auth.json"');
   });
 
   it("namespaces artifacts under fastagent/ and builds from the workspace root", () => {

--- a/test/deploy-docker.test.ts
+++ b/test/deploy-docker.test.ts
@@ -79,14 +79,17 @@ describe("deploy/docker: planDockerDeploy", () => {
       modelAuth: undefined,
       channels: [...declaredChannels(["feishu"], "long-connection")],
     });
-    const yaml = compose(plan);
-    expect(yaml).toContain("FEISHU_APP_ID");
-    expect(yaml).toContain("FEISHU_APP_SECRET");
-    expect(yaml).not.toContain("FEISHU_VERIFICATION_TOKEN");
-    expect(runbook(plan)).not.toContain("https://<your-domain>/feishu");
+    const out = runbook(plan);
+    expect(out).toContain("FEISHU_APP_ID");
+    expect(out).toContain("FEISHU_APP_SECRET");
+    expect(out).not.toContain("FEISHU_VERIFICATION_TOKEN");
+    expect(out).not.toContain("https://<your-domain>/feishu");
   });
 
-  it("commits secret NAMES/interpolation only, including the absent-only auth seed seam", () => {
+  it("names the value file instead of interpolating each secret, and keeps only the auth-seed seam", () => {
+    // Interpolation resolves from the SHELL or the project `.env` — exactly the source a deployment must not have.
+    // `env_file` points Compose at the deployed environment's own declaration, so no declared name appears here at
+    // all, by hand or under `--run`. The seed is the one value that is not in that file.
     const yaml = compose(
       planDockerDeploy({
         ...base,
@@ -95,18 +98,18 @@ describe("deploy/docker: planDockerDeploy", () => {
         extraSecrets: [{ name: "GH_TOKEN", source: "tools/gh.ts" }],
       }),
     );
-    for (const name of [
-      "OPENAI_API_KEY",
-      "TELEGRAM_BOT_TOKEN",
-      "TELEGRAM_SECRET_TOKEN",
-      "FEISHU_APP_ID",
-      "GH_TOKEN",
-      "FASTAGENT_AUTH_SEED",
-    ]) {
-      expect(yaml).toContain(`${name}: "\${${name}:-}"`);
+    expect(yaml).toContain("env_file:\n      - .secrets/.env");
+    for (const name of ["OPENAI_API_KEY", "TELEGRAM_BOT_TOKEN", "FEISHU_APP_ID", "GH_TOKEN"]) {
+      expect(yaml).not.toContain(name);
     }
+    expect(yaml).toContain(`FASTAGENT_AUTH_SEED: "\${FASTAGENT_AUTH_SEED:-}"`);
     expect(yaml).not.toContain("<value>");
     expect(yaml).not.toContain("sk-");
+
+    // No value file yet → no entry pointing at a missing path (Compose refuses one), and the runbook says so.
+    const absent = planDockerDeploy({ ...base, valueFileExists: false, modelAuth: "OPENAI_API_KEY", channels: [] });
+    expect(compose(absent)).not.toContain("env_file");
+    expect(runbook(absent)).toMatch(/does not exist yet.*regenerate a Compose file that reads it/s);
   });
 
   it("namespaces artifacts under fastagent/ and builds from the workspace root", () => {
@@ -124,33 +127,13 @@ describe("deploy/docker: planDockerDeploy", () => {
     expect(runbook(plan)).toContain("Run from the WORKSPACE ROOT");
   });
 
-  it("omits --env-file when the value file does not exist yet, and says why", () => {
-    // `fastagent init` writes .env.example, not .env, so an OAuth-only agent has no value file. `--env-file` on a
-    // missing path is `couldn't find env file: …`, which would take the whole runbook's `up` down with it.
-    const out = runbook(
-      planDockerDeploy({
-        ...base,
-        valueFileExists: false,
-        modelAuth: "OPENAI_API_KEY",
-        channels: declaredChannels(["telegram"]),
-      }),
-    );
-    expect(out).toContain("docker compose -f fastagent/fastagent.compose.yml up -d --build");
-    expect(out).not.toContain("docker compose --env-file"); // the note mentions the flag; no command uses it
-    expect(out).toMatch(/does not exist yet.*--env-file fails on a missing path/s);
-  });
-
   it("prints lifecycle + operator-owned ingress guidance for detected webhook channels", () => {
     const out = runbook(
       planDockerDeploy({ ...base, modelAuth: "OPENAI_API_KEY", channels: declaredChannels(["telegram", "github"]) }),
     );
     expect(out).toContain(`Docker Engine/Desktop with Compose >= ${MIN_DOCKER_COMPOSE_VERSION}`);
-    expect(out).toContain(
-      "docker compose --env-file 'fastagent/.secrets/.env' -f fastagent/fastagent.compose.yml up -d --build",
-    );
-    // ONLY `up` interpolates, so only `up` carries --env-file: `--env-file` is a hard failure on a missing path,
-    // and these three need no values at all.
-    for (const cmd of ["logs -f agent", "ps", "down"]) {
+    // One spelling everywhere: the generated file names the value file itself, so no command needs a flag.
+    for (const cmd of ["up -d --build", "logs -f agent", "ps", "down"]) {
       expect(out).toContain(`docker compose -f fastagent/fastagent.compose.yml ${cmd}`);
     }
     expect(out).toContain("down        # stops containers; keeps the state volume");

--- a/test/deploy-docker.test.ts
+++ b/test/deploy-docker.test.ts
@@ -146,7 +146,7 @@ describe("deploy/docker: planDockerDeploy", () => {
     );
     expect(out).toContain(`Docker Engine/Desktop with Compose >= ${MIN_DOCKER_COMPOSE_VERSION}`);
     expect(out).toContain(
-      "docker compose --env-file fastagent/.secrets/.env -f fastagent/fastagent.compose.yml up -d --build",
+      "docker compose --env-file 'fastagent/.secrets/.env' -f fastagent/fastagent.compose.yml up -d --build",
     );
     // ONLY `up` interpolates, so only `up` carries --env-file: `--env-file` is a hard failure on a missing path,
     // and these three need no values at all.

--- a/test/deploy-fly-run.test.ts
+++ b/test/deploy-fly-run.test.ts
@@ -3,7 +3,13 @@ import { type FlyRunPlan, deployFlyRun } from "../src/deploy/fly/run.ts";
 import type { RegistrationOutcome } from "../src/channels/registration.ts";
 import type { CliRunner } from "../src/deploy/runner.ts";
 import { CONTROL_TOKEN_ENV } from "../src/channels/control.ts";
-import { assembleSecrets, authSeedBytes, collectAuthSeed, deploymentSecrets } from "../src/deploy/secrets.ts";
+import {
+  assembleSecrets,
+  authSeedBytes,
+  collectAuthSeed,
+  deploymentSecrets,
+  missingValuesGate,
+} from "../src/deploy/secrets.ts";
 import { declaredChannels } from "../src/channels/discover.ts";
 
 /** A fake flyctl: records every call, returns per-command scripted results (default code 0, empty out). */
@@ -24,6 +30,7 @@ const plan = (over: Partial<FlyRunPlan> = {}): FlyRunPlan => ({
   region: "iad",
   secrets: {},
   missingSecrets: [],
+  valueFile: "fastagent/.secrets/.env",
   channels: [],
   flyConfig: "fastagent/fly.toml",
   dockerfile: "fastagent/Dockerfile",
@@ -431,6 +438,18 @@ describe("deploy/secrets: assembleSecrets (credential wiring)", () => {
       [{ name: CONTROL_TOKEN_ENV, source: "fastagent.config sessionControl" }],
     );
     expect(listed.find((s) => s.name === CONTROL_TOKEN_ENV)?.required).toBe(false);
+  });
+});
+
+describe("deploy/secrets: missingValuesGate (one refusal, every host)", () => {
+  it("names the file this deploy actually read, not a hardcoded path", () => {
+    // `FASTAGENT_SECRETS_DIR` moves the value file, and four hosts each spelling the message would each have to
+    // remember that. The gate takes the resolved name so it cannot point at a file deploy never opened.
+    expect(missingValuesGate([], "fastagent/.secrets/.env")).toBeUndefined();
+    const gate = missingValuesGate(["GH_TOKEN", "X_API_KEY"], "/data/.secrets/.env");
+    expect(gate).toContain("GH_TOKEN, X_API_KEY");
+    expect(gate).toContain("/data/.secrets/.env");
+    expect(gate).not.toMatch(/\n/); // one line: it is printed straight into an Error
   });
 });
 

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -136,12 +136,16 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     const planned = await call(dir, {});
     expect(planned.ok && planned.messages.some((m) => /FASTAGENT_RELEASE_FILE/.test(m.text))).toBe(true);
 
-    // A hand-written Dockerfile that DOES set it is fine — the manifest is read whoever wrote the file.
-    const own = await workspace({
-      Dockerfile: "FROM node:22-slim\nENV FASTAGENT_RELEASE_FILE=/app/fastagent/fastagent.release.json\n",
-    });
-    await writeFile(join(own, ".secrets", ".env"), "FASTAGENT_MODEL=openai/gpt-4o-mini\n");
-    expect((await call(own, {}, { run: true })).ok).toBe(true);
+    // A hand-written Dockerfile that DOES set it is fine — the manifest is read whoever wrote the file. Including
+    // the ordinary multi-variable spelling: reading only the first name after `ENV` false-gates a working file.
+    for (const env of [
+      "ENV FASTAGENT_RELEASE_FILE=/app/fastagent/fastagent.release.json",
+      "ENV FASTAGENT_STORAGE_DIR=/data FASTAGENT_RELEASE_FILE=/app/fastagent/fastagent.release.json",
+    ]) {
+      const own = await workspace({ Dockerfile: `FROM node:22-slim\n${env}\n` });
+      await writeFile(join(own, ".secrets", ".env"), "FASTAGENT_MODEL=openai/gpt-4o-mini\n");
+      expect((await call(own, {}, { run: true })).ok).toBe(true);
+    }
 
     // And a config model needs no manifest at all.
     const fromConfig = await workspace({ Dockerfile: "FROM node:22-slim\n" });

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -129,6 +129,9 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     expect(gated.ok).toBe(false);
     if (!gated.ok) expect(gated.gate).toMatch(/hand-written Dockerfile.*FASTAGENT_RELEASE_FILE/s);
 
+    // `--force` does not rescue it either: the hand-written file stays, so the gate must still fire.
+    expect((await call(dir, {}, { run: true, force: true })).ok).toBe(false);
+
     // Generate-only warns; and a config model needs no manifest at all, so it is unaffected.
     const planned = await call(dir, {});
     expect(planned.ok && planned.messages.some((m) => /FASTAGENT_RELEASE_FILE/.test(m.text))).toBe(true);
@@ -489,20 +492,19 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     await expect(call(dir, { model: "openai/gpt-4o-mini" })).rejects.toThrow(/cannot inspect.*import exploded/);
   });
 
-  it("warns a KEPT hand-written Dockerfile that deploy.apt won't reach; --force suppresses it", async () => {
+  it("warns a KEPT hand-written Dockerfile that deploy.apt won't reach, --force included", async () => {
+    // `--force` does not rescue it: writeArtifacts refuses a file it did not generate whatever the flag says, so the
+    // packages are dropped either way. Suppressing the warning under `--force` only hid that.
     const dir = await workspace({ Dockerfile: "FROM python:3.12\n" }); // no generated marker → hand-written
     const config: FastagentConfig = { model: "openai/gpt-4o-mini", deploy: { apt: ["git"] } };
 
-    const kept = await call(dir, config, { force: false });
-    expect(kept.ok).toBe(true);
-    if (kept.ok) {
-      expect(kept.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/deploy\.apt.*NOT applied/) });
+    for (const force of [false, true]) {
+      const pre = await call(dir, config, { force });
+      expect(pre.ok).toBe(true);
+      if (pre.ok) {
+        expect(pre.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/deploy\.apt.*NOT applied/) });
+      }
     }
-
-    // --force regenerates the Dockerfile, so the kept-hand-written warning does not apply.
-    const forced = await call(dir, config, { force: true });
-    expect(forced.ok).toBe(true);
-    if (forced.ok) expect(forced.messages.some((m) => /NOT applied/.test(m.text))).toBe(false);
   });
 
   it("detects time triggers: schedules/ files OR config.selfSchedule → hasTimeTriggers + a keep-1 note", async () => {

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -560,11 +560,32 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
     }
   });
 
-  it("a key written into the file is reported as definition-carried (nothing to carry, nothing to gate)", async () => {
+  it("a LITERAL key gates --run: the file ships inside the image, where any puller reads the layer", async () => {
+    // Same rule the `.dockerignore` check enforces — any configuration that would put a credential into the image
+    // stops `--run`. A literal has no legitimate use: an endpoint needing no key omits it, and one that needs a key
+    // has two forms (`$NAME`, `!command`) that do not ship it.
     const dir = await workspace({ "models.json": GATEWAY("sk-literal-in-file") });
-    const pre = await call(dir, { model: "mygw/m1" });
+    const gated = await call(dir, { model: "mygw/m1" }, { run: true });
+    expect(gated.ok).toBe(false);
+    if (!gated.ok) expect(gated.gate).toMatch(/literal apiKey for "mygw".*ships inside the image/s);
+
+    // Generate-only warns: the operator may be producing artifacts they will not deploy from here.
+    const planned = await call(dir, { model: "mygw/m1" });
+    expect(planned.ok).toBe(true);
+    if (planned.ok) {
+      expect(planned.modelKeyInDefinition).toBe(true); // still nothing for `--run` to carry
+      expect(planned.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/literal apiKey/) });
+    }
+  });
+
+  it("a !command key is NOT gated — it runs on the box and the credential never travels", async () => {
+    const dir = await workspace({ "models.json": GATEWAY("!printf sk-from-a-command") });
+    const pre = await call(dir, { model: "mygw/m1" }, { run: true });
     expect(pre.ok).toBe(true);
-    if (pre.ok) expect(pre.modelKeyInDefinition).toBe(true);
+    if (pre.ok) {
+      expect(pre.modelKeyInDefinition).toBe(true);
+      expect(pre.messages.some((m) => /literal apiKey/.test(m.text))).toBe(false);
+    }
   });
 
   it("carries what tools and schedules DECLARED, without a second list to keep in sync", async () => {

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -119,22 +119,31 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     expect(pre.ok && pre.container.modelSpec).toBe("baseten/zai-org/GLM-5.3");
   });
 
-  it("gates a hand-written Dockerfile when the model lives ONLY in the value file", async () => {
-    // The manifest is always written, but only a Dockerfile setting FASTAGENT_RELEASE_FILE is read from —
-    // `prepareStartWorkspace` returns early without it. So this combination reports a model here and crash-loops
-    // there: exactly the silent degradation this chain exists to remove.
+  it("gates a Dockerfile that cannot read the manifest — by the INSTRUCTION, not by who wrote the file", async () => {
+    // `prepareStartWorkspace` returns early without FASTAGENT_RELEASE_FILE, so a model living only in the value
+    // file would be reported here and missing on the box. The question is whether that ENV is set, not whether we
+    // generated the file: a hand-written Dockerfile that sets it works, and must not be refused.
     const dir = await workspace({ Dockerfile: "FROM node:22-slim\n" });
     await writeFile(join(dir, ".secrets", ".env"), "FASTAGENT_MODEL=openai/gpt-4o-mini\n");
     const gated = await call(dir, {}, { run: true });
     expect(gated.ok).toBe(false);
-    if (!gated.ok) expect(gated.gate).toMatch(/hand-written Dockerfile.*FASTAGENT_RELEASE_FILE/s);
+    if (!gated.ok) expect(gated.gate).toMatch(/does not set FASTAGENT_RELEASE_FILE/);
 
-    // `--force` does not rescue it either: the hand-written file stays, so the gate must still fire.
+    // `--force` does not rescue it: writeArtifacts keeps a file it did not generate whatever the flag says.
     expect((await call(dir, {}, { run: true, force: true })).ok).toBe(false);
 
-    // Generate-only warns; and a config model needs no manifest at all, so it is unaffected.
+    // Generate-only warns instead of refusing.
     const planned = await call(dir, {});
     expect(planned.ok && planned.messages.some((m) => /FASTAGENT_RELEASE_FILE/.test(m.text))).toBe(true);
+
+    // A hand-written Dockerfile that DOES set it is fine — the manifest is read whoever wrote the file.
+    const own = await workspace({
+      Dockerfile: "FROM node:22-slim\nENV FASTAGENT_RELEASE_FILE=/app/fastagent/fastagent.release.json\n",
+    });
+    await writeFile(join(own, ".secrets", ".env"), "FASTAGENT_MODEL=openai/gpt-4o-mini\n");
+    expect((await call(own, {}, { run: true })).ok).toBe(true);
+
+    // And a config model needs no manifest at all.
     const fromConfig = await workspace({ Dockerfile: "FROM node:22-slim\n" });
     expect((await call(fromConfig, { model: "openai/gpt-4o-mini" }, { run: true })).ok).toBe(true);
   });
@@ -567,25 +576,24 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
     }
   });
 
-  it("a LITERAL key for a REACHABLE endpoint gates --run: the file ships inside the image", async () => {
-    // Same rule the `.dockerignore` check enforces — any configuration that would put a credential into the image
-    // stops `--run`. A key presented to an endpoint anyone can reach is a credential, and it has two forms
-    // (`$NAME`, `!command`) that do not ship.
-    const dir = await workspace({ "models.json": GATEWAY("sk-literal-in-file") });
-    const gated = await call(dir, { model: "mygw/m1" }, { run: true });
-    expect(gated.ok).toBe(false);
-    if (!gated.ok) expect(gated.gate).toMatch(/literal apiKey for "mygw".*ships inside the image/s);
-
-    // Generate-only warns: the operator may be producing artifacts they will not deploy from here.
-    const planned = await call(dir, { model: "mygw/m1" });
-    expect(planned.ok).toBe(true);
-    if (planned.ok) {
-      expect(planned.modelKeyInDefinition).toBe(true); // still nothing for `--run` to carry
-      expect(planned.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/literal apiKey/) });
-    }
+  it("a literal key WARNS, whatever it points at — the framework does not decide what is a credential", () => {
+    // FastAgent gates what IT causes (a packing rule that would put `.secrets/auth.json` in the image); this is the
+    // author's own committed file, and no static rule separates a leaked key from the placeholder pi's docs
+    // prescribe for a keyless local server (`"apiKey": "ollama"`). So: report, never refuse.
+    return (async () => {
+      for (const baseUrl of ["https://gw.example.com/v1", "http://localhost:11434/v1"]) {
+        const dir = await workspace({ "models.json": GATEWAY("sk-literal-in-file", baseUrl) });
+        const pre = await call(dir, { model: "mygw/m1" }, { run: true });
+        expect(pre.ok).toBe(true);
+        if (pre.ok) {
+          expect(pre.modelKeyInDefinition).toBe(true); // still nothing for `--run` to carry
+          expect(pre.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/literal apiKey/) });
+        }
+      }
+    })();
   });
 
-  it("a literal on a provider NOTHING selects is gated too — the file ships whole", async () => {
+  it("every provider is reported, not just the selected model's — the file ships whole", async () => {
     const dir = await workspace({
       "models.json": JSON.stringify({
         providers: {
@@ -605,23 +613,11 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
       }),
     });
     const pre = await call(dir, { model: "mygw/m1" }, { run: true });
-    expect(pre.ok).toBe(false);
-    if (!pre.ok) expect(pre.gate).toMatch(/literal apiKey for "unused"/);
-  });
-
-  it("a literal for an UNREACHABLE endpoint only warns — pi's docs prescribe it for a keyless local server", async () => {
-    // `"apiKey": "ollama"` against http://localhost:11434 is the documented way to make a keyless server's models
-    // usable. Gating it would make "local ollama for dev, cloud model for deploy" undeployable, and that string is
-    // not a credential: nothing outside the deployment can be reached with it.
-    const dir = await workspace({ "models.json": GATEWAY("ollama", "http://localhost:11434/v1") });
-    const pre = await call(dir, { model: "mygw/m1" }, { run: true });
     expect(pre.ok).toBe(true);
-    if (pre.ok) {
-      expect(pre.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/not reachable from outside/) });
-    }
+    if (pre.ok) expect(pre.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/"unused"/) });
   });
 
-  it("a !command key is NOT gated — it runs on the box and the credential never travels", async () => {
+  it("a !command key is not reported — it runs on the box and the credential never travels", async () => {
     const dir = await workspace({ "models.json": GATEWAY("!printf sk-from-a-command") });
     const pre = await call(dir, { model: "mygw/m1" }, { run: true });
     expect(pre.ok).toBe(true);

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -119,14 +119,21 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     expect(pre.ok && pre.container.modelSpec).toBe("baseten/zai-org/GLM-5.3");
   });
 
-  it("a hand-written Dockerfile does not affect the model — the manifest carries it either way", async () => {
-    // The carrier is the release manifest, which every host writes unconditionally (`alwaysWrite`), so owning the
-    // Dockerfile costs the operator `deploy.apt` and nothing else.
+  it("gates a hand-written Dockerfile when the model lives ONLY in the value file", async () => {
+    // The manifest is always written, but only a Dockerfile setting FASTAGENT_RELEASE_FILE is read from —
+    // `prepareStartWorkspace` returns early without it. So this combination reports a model here and crash-loops
+    // there: exactly the silent degradation this chain exists to remove.
     const dir = await workspace({ Dockerfile: "FROM node:22-slim\n" });
     await writeFile(join(dir, ".secrets", ".env"), "FASTAGENT_MODEL=openai/gpt-4o-mini\n");
-    const pre = await call(dir, {}, { run: true });
-    expect(pre.ok).toBe(true);
-    if (pre.ok) expect(pre.container.modelSpec).toBe("openai/gpt-4o-mini");
+    const gated = await call(dir, {}, { run: true });
+    expect(gated.ok).toBe(false);
+    if (!gated.ok) expect(gated.gate).toMatch(/hand-written Dockerfile.*FASTAGENT_RELEASE_FILE/s);
+
+    // Generate-only warns; and a config model needs no manifest at all, so it is unaffected.
+    const planned = await call(dir, {});
+    expect(planned.ok && planned.messages.some((m) => /FASTAGENT_RELEASE_FILE/.test(m.text))).toBe(true);
+    const fromConfig = await workspace({ Dockerfile: "FROM node:22-slim\n" });
+    expect((await call(fromConfig, { model: "openai/gpt-4o-mini" }, { run: true })).ok).toBe(true);
   });
 
   it("container facts come from the AGENT DIR; git auto-baked when the workspace ships .git", async () => {

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -535,11 +535,9 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
 });
 
 describe("preflight: how a models.json endpoint's credential reaches the host", () => {
-  const GATEWAY = (apiKey: string) =>
+  const GATEWAY = (apiKey: string, baseUrl = "https://gw.example.com/v1") =>
     JSON.stringify({
-      providers: {
-        mygw: { baseUrl: "http://vllm.internal:8000/v1", api: "openai-completions", apiKey, models: [{ id: "m1" }] },
-      },
+      providers: { mygw: { baseUrl, api: "openai-completions", apiKey, models: [{ id: "m1" }] } },
     });
 
   it("an env-keyed endpoint reports the VARIABLE NAME, so the value carries like any provider key", async () => {
@@ -560,10 +558,10 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
     }
   });
 
-  it("a LITERAL key gates --run: the file ships inside the image, where any puller reads the layer", async () => {
+  it("a LITERAL key for a REACHABLE endpoint gates --run: the file ships inside the image", async () => {
     // Same rule the `.dockerignore` check enforces — any configuration that would put a credential into the image
-    // stops `--run`. A literal has no legitimate use: an endpoint needing no key omits it, and one that needs a key
-    // has two forms (`$NAME`, `!command`) that do not ship it.
+    // stops `--run`. A key presented to an endpoint anyone can reach is a credential, and it has two forms
+    // (`$NAME`, `!command`) that do not ship.
     const dir = await workspace({ "models.json": GATEWAY("sk-literal-in-file") });
     const gated = await call(dir, { model: "mygw/m1" }, { run: true });
     expect(gated.ok).toBe(false);
@@ -582,14 +580,36 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
     const dir = await workspace({
       "models.json": JSON.stringify({
         providers: {
-          mygw: { baseUrl: "http://a/v1", api: "openai-completions", apiKey: "$FA_GW_KEY", models: [{ id: "m1" }] },
-          unused: { baseUrl: "http://b/v1", api: "openai-completions", apiKey: "sk-unused", models: [{ id: "m2" }] },
+          mygw: {
+            baseUrl: "https://a.example.com/v1",
+            api: "openai-completions",
+            apiKey: "$K",
+            models: [{ id: "m1" }],
+          },
+          unused: {
+            baseUrl: "https://b.example.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-u",
+            models: [{ id: "m2" }],
+          },
         },
       }),
     });
     const pre = await call(dir, { model: "mygw/m1" }, { run: true });
     expect(pre.ok).toBe(false);
     if (!pre.ok) expect(pre.gate).toMatch(/literal apiKey for "unused"/);
+  });
+
+  it("a literal for an UNREACHABLE endpoint only warns — pi's docs prescribe it for a keyless local server", async () => {
+    // `"apiKey": "ollama"` against http://localhost:11434 is the documented way to make a keyless server's models
+    // usable. Gating it would make "local ollama for dev, cloud model for deploy" undeployable, and that string is
+    // not a credential: nothing outside the deployment can be reached with it.
+    const dir = await workspace({ "models.json": GATEWAY("ollama", "http://localhost:11434/v1") });
+    const pre = await call(dir, { model: "mygw/m1" }, { run: true });
+    expect(pre.ok).toBe(true);
+    if (pre.ok) {
+      expect(pre.messages).toContainEqual({ level: "warn", text: expect.stringMatching(/not reachable from outside/) });
+    }
   });
 
   it("a !command key is NOT gated — it runs on the box and the credential never travels", async () => {

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -578,6 +578,20 @@ describe("preflight: how a models.json endpoint's credential reaches the host", 
     }
   });
 
+  it("a literal on a provider NOTHING selects is gated too — the file ships whole", async () => {
+    const dir = await workspace({
+      "models.json": JSON.stringify({
+        providers: {
+          mygw: { baseUrl: "http://a/v1", api: "openai-completions", apiKey: "$FA_GW_KEY", models: [{ id: "m1" }] },
+          unused: { baseUrl: "http://b/v1", api: "openai-completions", apiKey: "sk-unused", models: [{ id: "m2" }] },
+        },
+      }),
+    });
+    const pre = await call(dir, { model: "mygw/m1" }, { run: true });
+    expect(pre.ok).toBe(false);
+    if (!pre.ok) expect(pre.gate).toMatch(/literal apiKey for "unused"/);
+  });
+
   it("a !command key is NOT gated — it runs on the box and the credential never travels", async () => {
     const dir = await workspace({ "models.json": GATEWAY("!printf sk-from-a-command") });
     const pre = await call(dir, { model: "mygw/m1" }, { run: true });

--- a/test/deploy-railway-run.test.ts
+++ b/test/deploy-railway-run.test.ts
@@ -27,6 +27,7 @@ const plan = (over: Partial<RailwayRunPlan> = {}): RailwayRunPlan => ({
   mountPath: "/data",
   secrets: {},
   missingSecrets: [],
+  valueFile: "fastagent/.secrets/.env",
   channels: [],
   intoLinked: false,
   dockerfilePath: "/fastagent/Dockerfile",

--- a/test/deployment-workspace.test.ts
+++ b/test/deployment-workspace.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   applyDeploymentRelease,
+  applyReleaseEnv,
   assertStorageMounted,
   leaseDeployment,
   parseDeploymentRelease,
@@ -175,5 +176,56 @@ describe("storage boundary", () => {
     const { root } = await fixture();
     await mkdir(root);
     await expect(assertStorageMounted(root)).rejects.toThrow();
+  });
+});
+
+describe("applyReleaseEnv: the receiving half of the model chain", () => {
+  // The deploy side decides the model; this is what makes it reach the process. It runs BEFORE the workspace's
+  // own `.env` is read, so whatever it sets outranks a FASTAGENT_MODEL edited on the box.
+  const withModel = (model?: string): DeploymentRelease => ({
+    version: 1,
+    id: "r1",
+    agent: "fastagent",
+    ...(model ? { model } : {}),
+  });
+
+  it("projects the release's model when the environment declares none", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    applyReleaseEnv(withModel("p/m"), env);
+    expect(env.FASTAGENT_MODEL).toBe("p/m");
+  });
+
+  it("never overwrites a platform-set variable — the deployment declares only the half of the environment it can", () => {
+    const env = { FASTAGENT_MODEL: "platform/one" } as NodeJS.ProcessEnv;
+    applyReleaseEnv(withModel("p/m"), env);
+    expect(env.FASTAGENT_MODEL).toBe("platform/one");
+  });
+
+  it("is a no-op when the release names no model", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    applyReleaseEnv(withModel(), env);
+    expect(env.FASTAGENT_MODEL).toBeUndefined();
+  });
+
+  it("reports the source that actually won, because the remedies differ", async () => {
+    const { log } = await import("../src/log.ts");
+    const info = vi.spyOn(log, "info").mockImplementation(() => {});
+    try {
+      applyReleaseEnv(withModel("p/m"), {} as NodeJS.ProcessEnv);
+      expect(info.mock.calls.flat().join(" ")).toMatch(/the release manifest \(redeploy to change it\)/);
+
+      info.mockClear();
+      applyReleaseEnv(withModel("p/m"), { FASTAGENT_MODEL: "platform/one" } as NodeJS.ProcessEnv);
+      expect(info.mock.calls.flat().join(" ")).toMatch(/outranks the release manifest/);
+
+      // A redeploy would not change a value no release ever declared, so that half is dropped.
+      info.mockClear();
+      applyReleaseEnv(withModel(), { FASTAGENT_MODEL: "platform/one" } as NodeJS.ProcessEnv);
+      const said = info.mock.calls.flat().join(" ");
+      expect(said).toMatch(/already set in this environment/);
+      expect(said).not.toMatch(/outranks the release manifest/);
+    } finally {
+      info.mockRestore();
+    }
   });
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -184,16 +184,25 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
     const dir = await agentWith(
       JSON.stringify({
         providers: {
-          literal: { baseUrl: "http://a/v1", api: "openai-completions", apiKey: "sk-in-file", models: [{ id: "m" }] },
-          reference: { baseUrl: "http://b/v1", api: "openai-completions", apiKey: "$GW_KEY", models: [{ id: "m" }] },
-          braced: { baseUrl: "http://c/v1", api: "openai-completions", apiKey: `\${GW_KEY}`, models: [{ id: "m" }] },
-          command: { baseUrl: "http://d/v1", api: "openai-completions", apiKey: "!echo sk", models: [{ id: "m" }] },
-          none: { baseUrl: "http://e/v1", api: "openai-completions", models: [{ id: "m" }] },
+          literal: { baseUrl: "https://a.example.com/v1", api: "o", apiKey: "sk-in-file", models: [{ id: "m" }] },
+          // `$$` is pi's escape for a literal `$`, so this resolves to `sk$abc` — a credential, not a reference.
+          escaped: { baseUrl: "https://f.example.com/v1", api: "o", apiKey: "sk$$abc", models: [{ id: "m" }] },
+          local: { baseUrl: "http://localhost:11434/v1", api: "o", apiKey: "ollama", models: [{ id: "m" }] },
+          lan: { baseUrl: "http://10.0.0.7:8000/v1", api: "o", apiKey: "placeholder", models: [{ id: "m" }] },
+          reference: { baseUrl: "https://b.example.com/v1", api: "o", apiKey: "$GW_KEY", models: [{ id: "m" }] },
+          braced: { baseUrl: "https://c.example.com/v1", api: "o", apiKey: `\${GW_KEY}`, models: [{ id: "m" }] },
+          command: { baseUrl: "https://d.example.com/v1", api: "o", apiKey: "!echo sk", models: [{ id: "m" }] },
+          none: { baseUrl: "https://e.example.com/v1", api: "o", models: [{ id: "m" }] },
         },
       }),
     );
     await writeFile(join(dir, "auth.json"), JSON.stringify({ literal: { type: "api_key", key: "sk-stored" } }));
-    expect(await literalKeyProviders(dir)).toEqual(["literal"]);
+    expect(await literalKeyProviders(dir)).toEqual([
+      { id: "literal", public: true },
+      { id: "escaped", public: true },
+      { id: "local", public: false }, // a keyless server's placeholder, not a credential
+      { id: "lan", public: false },
+    ]);
     expect(await literalKeyProviders(join(dir, "no-such-dir"))).toEqual([]); // no models.json is the normal case
   });
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -197,12 +197,9 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
       }),
     );
     await writeFile(join(dir, "auth.json"), JSON.stringify({ literal: { type: "api_key", key: "sk-stored" } }));
-    expect(await literalKeyProviders(dir)).toEqual([
-      { id: "literal", public: true },
-      { id: "escaped", public: true },
-      { id: "local", public: false }, // a keyless server's placeholder, not a credential
-      { id: "lan", public: false },
-    ]);
+    // Every literal is reported, wherever it points: the caller warns, and whether a given string is a credential
+    // is the author's knowledge. `escaped` is the one that would slip through a naive reference check.
+    expect(await literalKeyProviders(dir)).toEqual(["literal", "escaped", "local", "lan"]);
     expect(await literalKeyProviders(join(dir, "no-such-dir"))).toEqual([]); // no models.json is the normal case
   });
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -153,17 +153,22 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
       expect(modelCredentialCarry(runtime, "mygw/deepseek-v3")).toEqual({
         envVar: "FASTAGENT_TEST_GW_KEY",
         inDefinition: false,
+        literalKey: false,
       });
     } finally {
       delete process.env.FASTAGENT_TEST_GW_KEY;
     }
   });
 
-  it("a key written into models.json (literal or command) is carried BY the definition, not by deploy", async () => {
-    // These travel inside the image with the file itself. Reported as such so the deploy gate does not
-    // demand a credential that is already there — its remedies (`fastagent login`, a provider env key)
-    // are both impossible for a custom provider.
-    for (const apiKey of ["sk-literal-in-file", "!echo sk-from-command"]) {
+  it("a key written into models.json is definition-carried, and a LITERAL one is reported as such", async () => {
+    // Both travel inside the image with the file itself, so neither gives `deploy` anything to carry — its
+    // remedies (`fastagent login`, a provider env key) are both impossible for a custom provider. But only the
+    // literal puts a CREDENTIAL in the image, and preflight gates `--run` on that, so the two must be told apart
+    // here: pi already does (`models_json_key` vs `models_json_command`).
+    for (const [apiKey, literalKey] of [
+      ["sk-literal-in-file", true],
+      ["!echo sk-from-command", false],
+    ] as const) {
       const dir = await agentWith(
         JSON.stringify({
           providers: {
@@ -172,7 +177,7 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
         }),
       );
       const runtime = await createPiModelRuntime({ agentDir: dir, authPath: join(dir, "auth.json") });
-      expect(modelCredentialCarry(runtime, "mygw/m1")).toEqual({ inDefinition: true });
+      expect(modelCredentialCarry(runtime, "mygw/m1")).toEqual({ inDefinition: true, literalKey });
     }
   });
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { type Api, type Model, type Models, createProvider } from "@earendil-works/pi-ai";
 import {
   createPiModelRuntime,
+  literalKeyProviders,
   modelCredentialCarry,
   probeApiKey,
   probeAuthSource,
@@ -153,22 +154,17 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
       expect(modelCredentialCarry(runtime, "mygw/deepseek-v3")).toEqual({
         envVar: "FASTAGENT_TEST_GW_KEY",
         inDefinition: false,
-        literalKey: false,
       });
     } finally {
       delete process.env.FASTAGENT_TEST_GW_KEY;
     }
   });
 
-  it("a key written into models.json is definition-carried, and a LITERAL one is reported as such", async () => {
-    // Both travel inside the image with the file itself, so neither gives `deploy` anything to carry — its
-    // remedies (`fastagent login`, a provider env key) are both impossible for a custom provider. But only the
-    // literal puts a CREDENTIAL in the image, and preflight gates `--run` on that, so the two must be told apart
-    // here: pi already does (`models_json_key` vs `models_json_command`).
-    for (const [apiKey, literalKey] of [
-      ["sk-literal-in-file", true],
-      ["!echo sk-from-command", false],
-    ] as const) {
+  it("a key written into models.json (literal or command) is carried BY the definition, not by deploy", async () => {
+    // These travel inside the image with the file itself. Reported as such so the deploy gate does not
+    // demand a credential that is already there — its remedies (`fastagent login`, a provider env key)
+    // are both impossible for a custom provider.
+    for (const apiKey of ["sk-literal-in-file", "!echo sk-from-command"]) {
       const dir = await agentWith(
         JSON.stringify({
           providers: {
@@ -177,8 +173,28 @@ describe("models.json: definition-local custom endpoints (createPiModelRuntime)"
         }),
       );
       const runtime = await createPiModelRuntime({ agentDir: dir, authPath: join(dir, "auth.json") });
-      expect(modelCredentialCarry(runtime, "mygw/m1")).toEqual({ inDefinition: true, literalKey });
+      expect(modelCredentialCarry(runtime, "mygw/m1")).toEqual({ inDefinition: true });
     }
+  });
+
+  it("literalKeyProviders reads the FILE, so a stored credential cannot hide a literal that still ships", async () => {
+    // getProviderAuthStatus answers "what satisfies this provider now" and returns `stored` first, so a provider
+    // with both an auth.json entry and a literal in the file would report `stored` — and the literal would ship
+    // unreported. The gate asks what the definition DECLARES, which only the file answers.
+    const dir = await agentWith(
+      JSON.stringify({
+        providers: {
+          literal: { baseUrl: "http://a/v1", api: "openai-completions", apiKey: "sk-in-file", models: [{ id: "m" }] },
+          reference: { baseUrl: "http://b/v1", api: "openai-completions", apiKey: "$GW_KEY", models: [{ id: "m" }] },
+          braced: { baseUrl: "http://c/v1", api: "openai-completions", apiKey: `\${GW_KEY}`, models: [{ id: "m" }] },
+          command: { baseUrl: "http://d/v1", api: "openai-completions", apiKey: "!echo sk", models: [{ id: "m" }] },
+          none: { baseUrl: "http://e/v1", api: "openai-completions", models: [{ id: "m" }] },
+        },
+      }),
+    );
+    await writeFile(join(dir, "auth.json"), JSON.stringify({ literal: { type: "api_key", key: "sk-stored" } }));
+    expect(await literalKeyProviders(dir)).toEqual(["literal"]);
+    expect(await literalKeyProviders(join(dir, "no-such-dir"))).toEqual([]); // no models.json is the normal case
   });
 
   it("on an id collision the file wins over an injected Provider (models.json composes over the native base)", async () => {


### PR DESCRIPTION
Step 2c of [docs/design/configuration.md §12](../blob/main/docs/design/configuration.md). Stacked on #522.

## The gap

`models.json` resolves an `apiKey` three ways, and a deployment cannot treat them alike:

| Form | What travels |
|---|---|
| `"$MY_KEY"` | an ordinary declared secret — `deploy` carries the value to the platform |
| `"!cmd"` | nothing; the command runs on the box |
| `"sk-…"` | **the credential itself, inside the image**, readable by anyone who can pull it |

`modelCredentialCarry` collapsed the last two into one answer (`inDefinition: true`, meaning "nothing for `--run` to carry"), so a literal key deployed silently. Meanwhile preflight already refuses `--run` when a `.dockerignore` would fail to exclude `.secrets/auth.json` — the same outcome by a different route, gated in one case and not the other.

## The rule, now stated once

> Any configuration that would put a credential into the image gates `--run`.

Generally: literal credentials belong in `.secrets/` or the platform's secret storage, and **every file inside the definition may only carry a reference**.

A literal has no legitimate use here — an endpoint that needs no key omits it, and one that needs a key has two forms that do not ship it — so this is a gate under `--run` and a warning when only generating artifacts.

## Changes

- `modelCredentialCarry` returns `literalKey`, distinguishing the two definition-carried forms. pi already separates them (`models_json_key` vs `models_json_command`), so nothing is parsed here.
- `preflightDeploy` gates `--run` on a literal and warns otherwise, naming both remedies.
- `docs/configuration.md` "Keys stay out of the file" now states the rule and its general form, and notes that `headers` values are not checked (FastAgent cannot tell a credential from an org id there).

`$NAME` references needed no change: they already become `modelAuth`, land in the runbook's required list, and are carried by `--run`.

## Verification

`test/deploy-preflight.test.ts`: a literal gates `--run` and warns in plan mode while still reporting `modelKeyInDefinition`; a `!command` key does neither. `test/models.test.ts` pins the two forms apart at the source. `npm run lint && npm run typecheck && npm test` pass (1657 passed).
