### PR TITLE
feat(auth): read a provider the project lacks from the global store

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,10 +98,14 @@ Use a listed spec with `--model`, `FASTAGENT_MODEL`, or `fastagent.config.*`.
 ## `fastagent login`
 
 ```bash
-fastagent login [provider] [--auth-path file] [--no-input]
+fastagent login [provider] [-g|--global] [--auth-path file] [--no-input]
 ```
 
-Authenticates a model provider and stores credentials in the **project-level** `<agent dir>/.secrets/auth.json` (dir override: `FASTAGENT_SECRETS_DIR`; file override: `--auth-path` / `FASTAGENT_AUTH_PATH`; run it OUTSIDE any agent — no `./fastagent/` in the current directory — to write the global `~/.fastagent/.secrets/auth.json`, which it announces on stderr). Inside an agent but not at its root (`fastagent/tools/`), it refuses and tells you where to `cd`. There is no implicit fallback between the project and global files — the default is project-level for **isolation** (different agents can use different accounts) and **fail-visibly** (a missing credential surfaces instead of being masked by a machine-global one absent on a fresh box). So `cd` into your agent before logging in. FastAgent uses its own credential file, separate from pi's CLI state.
+Authenticates a model provider and **writes** to the project-level `<agent dir>/.secrets/auth.json` (dir override: `FASTAGENT_SECRETS_DIR`; file override: `--auth-path` / `FASTAGENT_AUTH_PATH`). `-g` writes the user-global `~/.fastagent/.secrets/auth.json` instead, as does running outside any agent (announced on stderr). Inside an agent but not at its root (`fastagent/tools/`), it refuses and tells you where to `cd`. FastAgent uses its own credential file, separate from pi's CLI state.
+
+**Writing and reading are deliberately asymmetric**, the shape npm uses for `-g`. An agent READS the global file for any provider its own file does not have, so one `fastagent login -g openai-codex` serves every agent on the machine. Writing defaults to the project so that giving *one* agent a different account is the explicit act, and so a `login` cannot silently rewrite a credential another agent depends on.
+
+The fallback is **per provider, not per file**: logging Anthropic into a project does not hide the OpenAI credential you have globally. And a refresh is written back to the layer it was read from — a global credential stays global. That matters because both providers rotate refresh tokens: two copies of one grant each invalidate the other, so FastAgent never creates a second copy.
 
 An API-key login is verified immediately with one minimal request (OAuth needs no check — completing
 the flow proves the credential): a definitive rejection (HTTP 401) removes the bad key and prompts

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,6 +107,8 @@ Authenticates a model provider and **writes** to the project-level `<agent dir>/
 
 The fallback is **per provider, not per file**: logging Anthropic into a project does not hide the OpenAI credential you have globally. And a refresh is written back to the layer it was read from — a global credential stays global. That matters because both providers rotate refresh tokens: two copies of one grant each invalidate the other, so FastAgent never creates a second copy.
 
+**`deploy` does not read the global file.** A deployment carries the project-level `auth.json` only — the artifact is the truth, never the builder machine's state — so after a `login -g` a `deploy … --run` still reports `no model credential`. Carry the global one explicitly with `--auth-path ~/.fastagent/.secrets/auth.json`, or `fastagent login` (no `-g`) in the agent dir. Note this moves an OAuth grant into a second file: see the warning at the end of this section.
+
 An API-key login is verified immediately with one minimal request (OAuth needs no check — completing
 the flow proves the credential): a definitive rejection (HTTP 401) removes the bad key and prompts
 for it again on the spot (cancel to stop), so a mistyped key is corrected at login time instead of

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,7 +224,7 @@ FastAgent resolves model credentials through the model provider layer. Common op
 
 | Source | Use case |
 |---|---|
-| `fastagent login` | Stores OAuth/API-key credentials in the project-level `<agent dir>/.secrets/auth.json` (override: `--auth-path` / `FASTAGENT_AUTH_PATH`, a leading `~` is expanded; run outside any agent for the global `~/.fastagent/.secrets/auth.json` — announced on stderr). |
+| `fastagent login` | Writes OAuth/API-key credentials to the project-level `<agent dir>/.secrets/auth.json` (override: `--auth-path` / `FASTAGENT_AUTH_PATH`, a leading `~` is expanded); `-g` (or running outside any agent) writes the user-global `~/.fastagent/.secrets/auth.json`. An agent **reads** that global file for any provider its own lacks, per provider, and writes a refresh back to the layer it read from. |
 | Provider env vars | Good for servers and CI, e.g. `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`. |
 | Agent `.env` | Local development secrets at `<agent dir>/.secrets/.env`, loaded by CLI commands. Excluded by the `.secrets/.gitignore` that `init` scaffolds. |
 

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -221,7 +221,7 @@ Dropped from the RFC, and from earlier drafts of this document:
 | 2 | `config.name` + one model chain (`FASTAGENT_MODEL` travels with the value file; delete `modelTravelIssue`) | All of day one; the single-instance path is unchanged |
 | 2b | class D reads the value file only — the same rule the model already follows | Removes the last path by which the builder's environment reaches a deployment |
 | 2c | literal-`apiKey` **warning** + `$NAME` references treated as declared secrets | Reports the second route by which a credential enters the image, without the framework deciding what is one |
-| 3 | Credential project > global fallback + `login -g` + drop `--auth-path` | One global login serves every project |
+| 3 | Credential project > global fallback (per provider, refresh written back to the layer read) + `login -g` | One global login serves every project |
 | 4 | The env addition: `--env` + `.secrets/<env>/.env` + `<name>-<env>` prefix | Pure addition; day-two capability |
 
 Each step is usable on its own and is its own PR. 1 and 3 are small, 2 and 4 are medium.

--- a/src/cli/commands/fire.ts
+++ b/src/cli/commands/fire.ts
@@ -48,12 +48,12 @@ export async function runFire(name: string, dirArg: string, opts: FireOptions): 
   // were printed above: its guarantee must not depend on this call site remembering (a repeated line
   // on the refusal path is the cheaper failure).
   gateSecretsOrExit({ declared: secrets, failures, owner: name });
-  const { agent, modelSpec, authPath } = await createPiAgentFromDir(placement.workspace, {
+  const { agent, modelSpec, authPath, fallbackAuthPath } = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
     authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
   }).catch(failStartup);
   console.error(`[fastagent] fire: ${name} (${modelSpec})`);
-  await reportAuth(placement.agentDir, modelSpec, authPath);
+  await reportAuth(placement.agentDir, modelSpec, authPath, fallbackAuthPath);
   const exitCode = await runInvokeStream(
     agent.invoke({ session: scheduleSession(name) }, { text: schedule.prompt }),
     (text) => process.stdout.write(text),

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -5,6 +5,7 @@ import { inspectChannels } from "../../channels/discover.ts";
 import {
   defaultSessionsDir,
   loadConfig,
+  resolveAuthFallback,
   resolveAuthPath,
   resolveModel,
   resolveModelSpec,
@@ -92,11 +93,18 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   const stateRoot = resolveStateRoot(agentDir);
   const sessionsDir = resolveSessionsDirOverride(opts.sessionsDir) ?? defaultSessionsDir(stateRoot);
   const authPath = resolveAuthPath(agentDir, opts.authPath); // flag > FASTAGENT_AUTH_PATH > default — the one owner
+  // The second layer this agent reads through: "what is this agent's state" is the question `info` answers, and a
+  // credential it runs on can live in a file the agent dir does not contain.
+  const fallbackAuthPath = resolveAuthFallback(opts.authPath);
 
   // RESOLVE the spec, do not just echo it: a spec is only real once its provider/model exist in the agent's own
   // surface (built-ins + its models.json), which is exactly what a custom endpoint changes.
   const modelError = modelSpec
-    ? await createPiModelRuntime({ agentDir, authPath })
+    ? await createPiModelRuntime({
+        agentDir,
+        authPath,
+        ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
+      })
         .then((models) => {
           resolveModel(models, modelSpec);
           return undefined as string | undefined;
@@ -129,6 +137,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
           stateRoot,
           sessionsDir,
           authPath,
+          fallbackAuthPath: fallbackAuthPath ?? null,
           diagnostics: definition.diagnostics,
           skillCollisions: definition.collisions,
           toolCollisions: tools.collisions,
@@ -177,7 +186,7 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
     cont(`⚠ no value here (carried by deploy only): ${unsetElsewhere.map((s) => s.name).join(", ")}`);
   line("state", stateRoot);
   line("sessions", sessionsDir);
-  line("auth", authPath);
+  line("auth", fallbackAuthPath === undefined ? authPath : `${authPath} (then ${fallbackAuthPath})`);
   reportToolCollisions(tools.collisions);
   reportModuleLoadFailures(tools.failures);
   reportModuleLoadFailures(sched.failures);

--- a/src/cli/commands/invoke.ts
+++ b/src/cli/commands/invoke.ts
@@ -14,14 +14,14 @@ export interface InvokeOptions {
 
 export async function runInvoke(message: string, dirArg: string, opts: InvokeOptions): Promise<void> {
   const placement = await enterAgentCommand(dirArg, opts);
-  const { agent, modelSpec, authPath } = await createPiAgentFromDir(placement.workspace, {
+  const { agent, modelSpec, authPath, fallbackAuthPath } = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
     authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
   }).catch(failStartup);
   // BOTH directories, like dev/start: from the workspace, `placement.workspace` alone equals the dir you typed, so it
   // cannot tell you which agent actually ran.
   console.error(`[fastagent] invoke: ${placement.agentDir} (workspace ${placement.workspace}, ${modelSpec})`);
-  await reportAuth(placement.agentDir, modelSpec, authPath);
+  await reportAuth(placement.agentDir, modelSpec, authPath, fallbackAuthPath);
   // Fresh session per invoke (one-shot, no resume). runInvokeStream maps events→IO: reply→stdout,
   // tool/failure→stderr, exit 1 iff the turn failed (so CI can gate on it).
   const exitCode = await runInvokeStream(

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { enterAgentEnv } from "../../env.ts";
 import { resolveAuthPath } from "../../engines/pi/config.ts";
+import { GLOBAL_AUTH_PATH } from "../../engines/pi/auth.ts";
 import { GLOBAL_HOME_DIR, findAgentDir, placementDeadEnd } from "../../paths.ts";
 import { LoginCancelled } from "../../engines/pi/login.ts";
 import { failStartup, placementOrExit } from "../fail.ts";
@@ -13,6 +14,8 @@ import { isInteractive, loginWithKeyCheck } from "../shared.ts";
 
 export interface LoginOptions {
   authPath?: string;
+  /** `-g`: store in the user-global file every agent on this machine falls back to. */
+  global?: boolean;
   /** false ⇔ `--no-input`. */
   input?: boolean;
 }
@@ -28,14 +31,19 @@ export async function runLogin(provider: string | undefined, opts: LoginOptions)
   // FASTAGENT_AUTH_PATH and a proxy may both be configured in the project .env, and the OAuth token exchange must go
   // through that proxy (region-locked providers).
   enterAgentEnv(loginDir);
-  const authPath = resolveAuthPath(loginDir, opts.authPath); // flag > FASTAGENT_AUTH_PATH > default — the one owner
+  // `-g` names the global file outright. Otherwise: flag > FASTAGENT_AUTH_PATH > default — the one owner. The
+  // store built here is deliberately UNLAYERED: reading falls back to the global file, but writing must land
+  // exactly where the operator said, or a second `login` for a provider they already have globally would silently
+  // rewrite the global credential instead of creating the project-level override they asked for.
+  const authPath = opts.global ? GLOBAL_AUTH_PATH : resolveAuthPath(loginDir, opts.authPath);
   // Announce when the FALLBACK is what decided the target: outside an agent with no explicit path, the credential
   // lands somewhere no agent will read.
-  if (!agentDir && !opts.authPath && !process.env.FASTAGENT_AUTH_PATH) {
+  if (!agentDir && !opts.global && !opts.authPath && !process.env.FASTAGENT_AUTH_PATH) {
     console.error(
       `[fastagent] no agent here (no fastagent.config.*, here or one level inside) — ` +
-        `logging in GLOBALLY (${authPath}). An agent reads its own .secrets/auth.json: \`cd\` into one ` +
-        `first, or point this run at it with --auth-path.`,
+        `logging in GLOBALLY (${authPath}). Every agent on this machine reads this file for providers its own ` +
+        `.secrets/auth.json does not have, so this is usually what you want; \`cd\` into an agent to give that ` +
+        `one its own account instead.`,
     );
   }
   // login is inherently interactive — loginFlow renders provider/method menus and opens a browser (or prompts for a

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -570,14 +570,23 @@ const login: CommandSpec = {
     "agent it writes the global ~/.fastagent/.secrets/auth.json, and says so): pick a method " +
     "(subscription/OAuth or API " +
     "key), then a provider that offers it (configured status shown). [provider] takes the method from " +
-    "what that provider supports, asked only when both.",
+    "what that provider supports, asked only when both. An agent READS the global store for any provider " +
+    "its own file does not have, so `-g` logs in once for every agent on this machine.",
   args: [{ name: "[provider]", description: "provider id (skip the provider menu)" }],
-  flags: [AUTH_PATH, NO_INPUT],
-  examples: [{ cmd: "fastagent login" }, { cmd: "fastagent login openai" }],
+  flags: [
+    {
+      flags: "-g, --global",
+      description: `store in ~/.fastagent/.secrets/auth.json — every agent here reads it for providers its own file lacks`,
+    },
+    AUTH_PATH,
+    NO_INPUT,
+  ],
+  examples: [{ cmd: "fastagent login" }, { cmd: "fastagent login openai" }, { cmd: "fastagent login openai -g" }],
   notes: "The positional is the PROVIDER (not a dir) — `cd` into your agent before logging in.",
   run: async (args, f) =>
     (await import("./commands/login.ts")).runLogin(args[0], {
       authPath: f.authPath as string | undefined,
+      global: f.global === true,
       input: f.input !== false,
     }),
 };

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -13,6 +13,7 @@ import {
   listModels,
   loadConfig,
   providerOf,
+  resolveAuthFallback,
   resolveAuthPath,
   resolveModel,
   resolveModelSpec,
@@ -66,6 +67,7 @@ export interface ReportableAssembly {
   workspace: string;
   modelSpec: string;
   authPath: string;
+  fallbackAuthPath?: string;
   config: { thinkingLevel?: string };
   definition: LoadedDefinition;
   toolNames: string[];
@@ -89,7 +91,7 @@ export async function reportAssembly(
   reportWorkspaceHint(workspaceHint(a));
   for (const [label, value] of extras.beforeModel ?? []) reportLine(label, value);
   reportLine("model", `${a.modelSpec}${a.config.thinkingLevel ? ` (thinking: ${a.config.thinkingLevel})` : ""}`);
-  await reportAuth(a.agentDir, a.modelSpec, a.authPath);
+  await reportAuth(a.agentDir, a.modelSpec, a.authPath, a.fallbackAuthPath);
   reportLine("context", a.definition.contextFiles.map((f) => f.path).join(", ") || "(none)");
   if (a.definition.persona) reportLine("persona", "persona.md");
   reportLine("skills", a.definition.skills.map((s) => s.name).join(", ") || "(none)");
@@ -134,19 +136,38 @@ export function parseBind(value: string | undefined): string | undefined {
 }
 
 /** Report which source provides the model's credentials, surfacing a remediation hint at startup. */
-export async function reportAuth(agentDir: string, modelSpec: string, authPath: string): Promise<void> {
+export async function reportAuth(
+  agentDir: string,
+  modelSpec: string,
+  authPath: string,
+  fallbackAuthPath?: string,
+): Promise<void> {
+  const layers = fallbackAuthPath !== undefined ? { fallbackPath: fallbackAuthPath } : {};
   const provider = providerOf(modelSpec);
-  const models = await createPiModelRuntime({ agentDir, authPath }).catch(failStartup);
+  const models = await createPiModelRuntime({
+    agentDir,
+    authPath,
+    ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
+  }).catch(failStartup);
   const source = await probeAuthSource(models, modelSpec);
   // Only when nothing satisfies auth do we read the store (refresh-FREE) to tell "nothing stored" from "stored but
   // unusable".
   const stored =
     source === undefined
-      ? await fastagentCredentialStore(authPath)
+      ? await fastagentCredentialStore(authPath, layers)
           .read(provider)
           .catch(() => undefined)
       : undefined;
-  const report = formatAuthReport(provider, authPath, source, stored);
+  // Name the layer the credential actually came from: "which file do I edit" is the question this line answers, and
+  // a global credential lives in a file the agent dir does not contain.
+  const found =
+    fallbackAuthPath !== undefined &&
+    !(await fastagentCredentialStore(authPath)
+      .read(provider)
+      .catch(() => undefined))
+      ? fallbackAuthPath
+      : authPath;
+  const report = formatAuthReport(provider, found, source, stored);
   log.info(`[fastagent] ${report.line}`);
   if (report.warn) log.warn(`[fastagent] ${report.warn}`);
 }
@@ -164,9 +185,14 @@ async function resolveFirstRunModel(
   if (!isInteractive()) return; // CI/deploy: the opener throws the actionable missing-model error
 
   const authPath = resolveAuthPath(agentDir, options.authPath);
+  const fallbackAuthPath = resolveAuthFallback(options.authPath);
   // The picker lists the AGENT's surface: built-ins plus whatever its models.json declares, so a self-hosted endpoint
   // is pickable on first run instead of being invisible until hand-set.
-  const models = await createPiModelRuntime({ agentDir, authPath }).catch(failStartup);
+  const models = await createPiModelRuntime({
+    agentDir,
+    authPath,
+    ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
+  }).catch(failStartup);
   const chosen = await pickWithCredentials(models, authPath);
   if (chosen === undefined) return; // cancelled (or auth probe failed): the caller raises its clear missing-model error
   process.env.FASTAGENT_MODEL = chosen; // this process + any spawned dev worker inherits it

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -142,7 +142,6 @@ export async function reportAuth(
   authPath: string,
   fallbackAuthPath?: string,
 ): Promise<void> {
-  const layers = fallbackAuthPath !== undefined ? { fallbackPath: fallbackAuthPath } : {};
   const provider = providerOf(modelSpec);
   const models = await createPiModelRuntime({
     agentDir,
@@ -150,23 +149,21 @@ export async function reportAuth(
     ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
   }).catch(failStartup);
   const source = await probeAuthSource(models, modelSpec);
-  // Only when nothing satisfies auth do we read the store (refresh-FREE) to tell "nothing stored" from "stored but
-  // unusable".
-  const stored =
-    source === undefined
-      ? await fastagentCredentialStore(authPath, layers)
-          .read(provider)
-          .catch(() => undefined)
-      : undefined;
-  // Name the layer the credential actually came from: "which file do I edit" is the question this line answers, and
-  // a global credential lives in a file the agent dir does not contain.
-  const found =
-    fallbackAuthPath !== undefined &&
-    !(await fastagentCredentialStore(authPath)
+  // One refresh-FREE read per layer, serving both questions below. A read failure is already warned about by the
+  // store itself; this line degrades to "nothing stored" rather than taking down the startup report.
+  const readFrom = (path: string) =>
+    fastagentCredentialStore(path)
       .read(provider)
-      .catch(() => undefined))
-      ? fallbackAuthPath
-      : authPath;
+      .catch(() => undefined);
+  const inPrimary = await readFrom(authPath);
+  const inFallback = inPrimary || fallbackAuthPath === undefined ? undefined : await readFrom(fallbackAuthPath);
+  // Name the layer the credential actually came from: "which file do I edit" is the question this line answers, and
+  // a global credential lives in a file the agent dir does not contain. With NEITHER layer holding it, the answer is
+  // the primary — that is the file the `fastagent login` this report recommends writes.
+  const found = fallbackAuthPath !== undefined && inFallback ? fallbackAuthPath : authPath;
+  // Only when nothing satisfies auth does the stored credential matter: it tells "nothing stored" from "stored but
+  // unusable".
+  const stored = source === undefined ? (inPrimary ?? inFallback) : undefined;
   const report = formatAuthReport(provider, found, source, stored);
   log.info(`[fastagent] ${report.line}`);
   if (report.warn) log.warn(`[fastagent] ${report.warn}`);

--- a/src/engines/pi/auth.ts
+++ b/src/engines/pi/auth.ts
@@ -157,7 +157,14 @@ export function fastagentCredentialStore(
   const warn = options.warn ?? ((message: string) => log.warn(message));
   const fallback =
     options.fallbackPath !== undefined && options.fallbackPath !== authPath ? options.fallbackPath : undefined;
-  /** The file that owns this provider: where it already is, else the primary. */
+  /**
+   * The file that owns this provider: where it already is, else the primary.
+   *
+   * Known ceiling: this read is UNLOCKED, so a concurrent `fastagent login` writing the same provider into the
+   * primary between here and the lock below sends this refresh to the fallback instead — the one window in which the
+   * "one grant, one copy" rule can be lost. Re-checking under the lock means locking both files in a fixed order;
+   * worth it only if concurrent logins stop being a rounding error.
+   */
   const owner = (providerId: string): string => {
     if (fallback === undefined) return authPath;
     const primary = readCreds(authPath, warn);

--- a/src/engines/pi/auth.ts
+++ b/src/engines/pi/auth.ts
@@ -142,35 +142,55 @@ function parseForWrite(raw: string | undefined, where: string): Creds {
 }
 
 /**
- * A read-write `CredentialStore` backed by the given credentials file (default {@link GLOBAL_AUTH_PATH}; the directory
- * opener passes the project-level `<root>/.secrets/auth.json`).
+ * A read-write `CredentialStore` over the given credentials file (default {@link GLOBAL_AUTH_PATH}; the directory
+ * opener passes the project-level `<root>/.secrets/auth.json`), optionally falling back to a second file.
+ *
+ * The fallback is PER PROVIDER, not per file: logging one provider into a project must not hide the others a person
+ * already has globally. And the layer a credential was READ from is the layer its refresh is written back to —
+ * anything else would conjure a second holder of the same OAuth grant, which is the failure this whole area exists
+ * to avoid. A provider present in neither layer is new, and new credentials belong to the primary.
  */
 export function fastagentCredentialStore(
   authPath: string = GLOBAL_AUTH_PATH,
-  options: FastagentAuthOptions = {},
+  options: FastagentAuthOptions & { fallbackPath?: string } = {},
 ): CredentialStore {
   const warn = options.warn ?? ((message: string) => log.warn(message));
+  const fallback =
+    options.fallbackPath !== undefined && options.fallbackPath !== authPath ? options.fallbackPath : undefined;
+  /** The file that owns this provider: where it already is, else the primary. */
+  const owner = (providerId: string): string => {
+    if (fallback === undefined) return authPath;
+    const primary = readCreds(authPath, warn);
+    if (primary && pick(primary, providerId)) return authPath;
+    const secondary = readCreds(fallback, warn);
+    return secondary && pick(secondary, providerId) ? fallback : authPath;
+  };
 
   return {
     async read(providerId) {
-      const creds = readCreds(authPath, warn);
-      return creds ? pick(creds, providerId) : undefined;
+      for (const path of fallback === undefined ? [authPath] : [authPath, fallback]) {
+        const creds = readCreds(path, warn);
+        const found = creds && pick(creds, providerId);
+        if (found) return found;
+      }
+      return undefined;
     },
     async list() {
-      // Metadata only, never secrets (the pi-ai `list` contract).
-      const creds = readCreds(authPath, warn);
-      if (!creds) return [];
-      const infos: CredentialInfo[] = [];
-      for (const [providerId, cred] of Object.entries(creds)) {
-        if (cred && (cred.type === "oauth" || cred.type === "api_key")) {
-          infos.push({ providerId, type: cred.type });
+      // Metadata only, never secrets (the pi-ai `list` contract). Reverse order, so the primary's entry for a
+      // provider present in both overwrites the fallback's — the same precedence `read` applies.
+      const infos = new Map<string, CredentialInfo>();
+      for (const path of fallback === undefined ? [authPath] : [fallback, authPath]) {
+        for (const [providerId, cred] of Object.entries(readCreds(path, warn) ?? {})) {
+          if (cred && (cred.type === "oauth" || cred.type === "api_key"))
+            infos.set(providerId, { providerId, type: cred.type });
         }
       }
-      return infos;
+      return [...infos.values()];
     },
     modify(providerId, fn) {
-      return withLockedAuthFile(authPath, async (current) => {
-        const creds = parseForWrite(current, authPath); // corrupt → throw → no clobber
+      const path = owner(providerId);
+      return withLockedAuthFile(path, async (current) => {
+        const creds = parseForWrite(current, path); // corrupt → throw → no clobber
         const next = await fn(pick(creds, providerId));
         if (next === undefined) return { result: pick(creds, providerId) }; // unchanged: no write
         creds[providerId] = next;
@@ -178,11 +198,12 @@ export function fastagentCredentialStore(
       });
     },
     async delete(providerId) {
+      const path = owner(providerId);
       // No-op when nothing is stored: do NOT take the lock (which would create the file) on a machine that never
       // stored this provider.
-      if (!existsSync(authPath)) return;
-      await withLockedAuthFile(authPath, async (current) => {
-        const creds = parseForWrite(current, authPath);
+      if (!existsSync(path)) return;
+      await withLockedAuthFile(path, async (current) => {
+        const creds = parseForWrite(current, path);
         if (!(providerId in creds)) return { result: undefined }; // absent: no write
         delete creds[providerId];
         return { result: undefined, next: `${JSON.stringify(creds, null, 2)}\n` };

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -10,6 +10,7 @@ import type { FastagentTool } from "./tool.ts";
 import type { Models } from "@earendil-works/pi-ai";
 import type { AnyModel } from "./models.ts";
 import { THINKING_LEVELS } from "./session-settings.ts";
+import { GLOBAL_AUTH_PATH } from "./auth.ts";
 import { readSecretDeclaration } from "../../declared-secrets.ts";
 import { isBindAddress } from "../../bind.ts";
 import { moduleLoadHint } from "../../loader.ts";
@@ -295,6 +296,18 @@ export function defaultAuthPath(secretsDir: string): string {
 /** The effective auth file for an agent: override if present, else `<secrets dir>/auth.json`. */
 export function resolveAuthPath(dir: string, flag: string | undefined, env: NodeJS.ProcessEnv = process.env): string {
   return resolveAuthPathOverride(flag, env) ?? defaultAuthPath(resolveSecretsDir(dir, env));
+}
+
+/**
+ * Where a credential the project does not have is read from instead: the user-global store, because a login is a
+ * PERSON on a machine and not a project — one `login -g` then serves every agent here. Undefined when an explicit
+ * path was named: "use this file" is an instruction, not a preference, so it gets no second layer.
+ */
+export function resolveAuthFallback(
+  flag: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return resolveAuthPathOverride(flag, env) === undefined ? GLOBAL_AUTH_PATH : undefined;
 }
 
 /** The default sessions dir under a resolved state root ({@link resolveStateRoot}). */

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -302,12 +302,17 @@ export function resolveAuthPath(dir: string, flag: string | undefined, env: Node
  * Where a credential the project does not have is read from instead: the user-global store, because a login is a
  * PERSON on a machine and not a project — one `login -g` then serves every agent here. Undefined when an explicit
  * path was named: "use this file" is an instruction, not a preference, so it gets no second layer.
+ *
+ * BOTH knobs {@link resolveAuthPath} reads count as that instruction, `FASTAGENT_SECRETS_DIR` included — it is what
+ * the Fly/Railway/AgentCore artifacts set, and a deployed container must read its mounted credentials and nothing
+ * else (the artifact is the truth).
  */
 export function resolveAuthFallback(
   flag: string | undefined,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-  return resolveAuthPathOverride(flag, env) === undefined ? GLOBAL_AUTH_PATH : undefined;
+  const explicit = resolveAuthPathOverride(flag, env) ?? resolveOverridePath(env.FASTAGENT_SECRETS_DIR);
+  return explicit === undefined ? GLOBAL_AUTH_PATH : undefined;
 }
 
 /** The default sessions dir under a resolved state root ({@link resolveStateRoot}). */

--- a/src/engines/pi/create.ts
+++ b/src/engines/pi/create.ts
@@ -14,6 +14,7 @@ import {
 import type { Provider } from "@earendil-works/pi-ai";
 import type { Agent } from "../../agent.ts";
 import { type FastagentConfig, defaultAuthPath, resolveModel } from "./config.ts";
+import { GLOBAL_AUTH_PATH } from "./auth.ts";
 import { isAgentcoreRuntime, isDeployedWorkspace, resolveSecretsDir } from "../../paths.ts";
 import { type LoadedDefinition, loadAgentDefinition, loadExtensionPaths } from "./definition.ts";
 import { reportFindingsIfChanged } from "./report.ts";
@@ -254,6 +255,8 @@ function assemblePi(opts: {
   thinkingLevel?: ThinkingLevel;
   providers?: Provider[];
   authPath?: string;
+  /** Read a provider `authPath` lacks from here instead; unset when an explicit path was named. */
+  fallbackAuthPath?: string;
   /** The model registry to run on, used verbatim. */
   models?: ModelRuntime;
   readDefinition: PiAgentSessionFactoryOptions["readDefinition"];
@@ -283,7 +286,12 @@ function assemblePi(opts: {
     engine ??= (async () => {
       // The caller's registry when there is one — the directory rung builds it from the agent's own models.json, so a
       // custom endpoint declared there is the one a turn resolves against.
-      const modelRuntime = opts.models ?? (await createPiModelRuntime({ authPath: opts.authPath }));
+      const modelRuntime =
+        opts.models ??
+        (await createPiModelRuntime({
+          authPath: opts.authPath,
+          ...(opts.fallbackAuthPath !== undefined ? { fallbackAuthPath: opts.fallbackAuthPath } : {}),
+        }));
       // ModelRuntime registers providers by config record, so an injected Provider INSTANCE (a gateway, a self-hosted
       // endpoint, a test fake) goes in through its native seam.
       for (const provider of opts.providers ?? []) modelRuntime.registerNativeProvider(provider);
@@ -339,6 +347,9 @@ export interface CreatePiAgentOptions {
   providers?: Provider[];
   /** Credentials file for stored OAuth/API-key auth. */
   authPath?: string;
+  /** Read a provider `authPath` lacks from here instead; unset when an explicit path was named. */
+  fallbackAuthPath?: string;
+
   sessions?: PiSessionRecordStore;
   /** Supplies the working directory at L1 (default: process.cwd()), which loads no definition. */
   env?: ExecutionEnv;
@@ -357,6 +368,7 @@ export function createPiAgent(options: CreatePiAgentOptions): Agent {
       thinkingLevel: options.thinkingLevel,
       providers: options.providers,
       authPath: options.authPath,
+      ...(options.fallbackAuthPath !== undefined ? { fallbackAuthPath: options.fallbackAuthPath } : {}),
       readDefinition: () => ({
         systemPrompt: typeof instructions === "function" ? instructions() : instructions,
         skills,
@@ -389,6 +401,9 @@ export interface CreatePiAgentFromDefinitionOptions {
   providers?: Provider[];
   /** Credentials file (see {@link CreatePiAgentOptions.authPath}). */
   authPath?: string;
+  /** Read a provider `authPath` lacks from here instead; unset when an explicit path was named. */
+  fallbackAuthPath?: string;
+
   sessions?: PiSessionRecordStore;
   /** Filesystem/process environment; see {@link CreatePiAgentOptions.env}. */
   env?: ExecutionEnv;
@@ -417,13 +432,21 @@ export async function assemblePiFromDefinition(
   reportFindingsIfChanged(definition.dir, definition);
   // Dir-aware default: the same secrets-dir-derived file the opener uses for this dir (the opener passes an explicit
   // authPath, so this only affects direct L2 callers).
+  // A path the CALLER named is an instruction; the default location is a preference, so only that one layers over
+  // the user-global store (resolveAuthFallback says the same thing for the CLI).
   const authPath = options.authPath ?? defaultAuthPath(resolveSecretsDir(dir));
+  const fallbackAuthPath = options.fallbackAuthPath ?? (options.authPath === undefined ? GLOBAL_AUTH_PATH : undefined);
   const assembly = assemblePi({
     model: options.model,
     thinkingLevel: options.thinkingLevel,
     // THE directory rung's model surface: built-ins + the agent's own models.json (custom endpoints, which are
     // definition data and travel with the artifact) + any injected Provider instance.
-    models: await createPiModelRuntime({ agentDir: dir, authPath, providers: options.providers }),
+    models: await createPiModelRuntime({
+      agentDir: dir,
+      authPath,
+      ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
+      providers: options.providers,
+    }),
     authPath,
     // The directory is the agent, LIVE: re-read the definition on every invoke, so AGENTS.md/skills edits (the
     // author's, or the agent's own self-modification) take effect on the next turn with no process restart — restarts

--- a/src/engines/pi/models.ts
+++ b/src/engines/pi/models.ts
@@ -18,6 +18,11 @@ import { AGENT_MODELS_FILE, resolveStateRoot } from "../../paths.ts";
 
 export interface CreatePiModelsOptions extends FastagentAuthOptions {
   authPath?: string;
+  /**
+   * Read a provider the primary file does not have from here instead (`resolveAuthFallback`: the user-global store).
+   * Omitted by an embedder that named its own store — "use this file" is an instruction, not a preference.
+   */
+  fallbackAuthPath?: string;
   /** Extra providers registered on top of the built-ins (same id overrides a built-in). */
   providers?: Provider[];
 }
@@ -25,7 +30,10 @@ export interface CreatePiModelsOptions extends FastagentAuthOptions {
 /** A `Models` with every built-in pi provider, wired to fastagent's auth. */
 export function createPiModels(options: CreatePiModelsOptions = {}): Models {
   const models = builtinModels({
-    credentials: fastagentCredentialStore(options.authPath, { warn: options.warn }),
+    credentials: fastagentCredentialStore(options.authPath, {
+      warn: options.warn,
+      ...(options.fallbackAuthPath !== undefined ? { fallbackPath: options.fallbackAuthPath } : {}),
+    }),
     authContext: defaultProviderAuthContext(),
   });
   for (const provider of options.providers ?? []) models.setProvider(provider);
@@ -46,6 +54,8 @@ export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";
 export async function createPiModelRuntime(
   options: FastagentAuthOptions & {
     authPath?: string;
+    /** Read a provider the primary file does not have from here instead ({@link CreatePiModelsOptions}). */
+    fallbackAuthPath?: string;
     /** The agent dir, whose {@link AGENT_MODELS_FILE} declares custom endpoints. */
     agentDir?: string;
     /** Where the dynamic model-catalog cache goes; defaults to the agent's resolved state root. */
@@ -56,7 +66,10 @@ export async function createPiModelRuntime(
 ): Promise<ModelRuntime> {
   const { agentDir } = options;
   const runtime = await ModelRuntime.create({
-    credentials: fastagentCredentialStore(options.authPath, { warn: options.warn }),
+    credentials: fastagentCredentialStore(options.authPath, {
+      warn: options.warn,
+      ...(options.fallbackAuthPath !== undefined ? { fallbackPath: options.fallbackAuthPath } : {}),
+    }),
     modelsPath: agentDir ? join(agentDir, AGENT_MODELS_FILE) : null,
     // MUST be set whenever modelsPath is: pi defaults this to `<dirname(modelsPath)>/models-store.json`, which would
     // write a generated cache INTO the author's agent dir.

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -9,6 +9,7 @@ import {
   type LoadedConfig,
   defaultSessionsDir,
   loadConfig,
+  resolveAuthFallback,
   resolveAuthPath,
   resolveModelSpec,
 } from "./config.ts";
@@ -60,6 +61,9 @@ export interface AgentAssembly {
   stateRoot: string;
   /** Absolute credentials file (--auth-path/authPath option > FASTAGENT_AUTH_PATH > <agentDir>/.secrets/auth.json). */
   authPath: string;
+  /** Where a provider `authPath` does not have is read from instead ({@link resolveAuthFallback}); unset when an
+   *  explicit path was named. */
+  fallbackAuthPath?: string;
   /** The full mounted tool surface (all coding tools + config.tools + discovered tools/, search_tools applied). */
   tools: MountedTool[];
   toolNames: string[];
@@ -103,6 +107,7 @@ export async function resolveAgentAssembly(
   const stateRoot = resolveStateRoot(agentDir);
   // The credentials file: project-level by default (under `<agentDir>/.secrets`).
   const authPath = resolveAuthPath(agentDir, options.authPath);
+  const fallbackAuthPath = resolveAuthFallback(options.authPath);
   return {
     config,
     configPath,
@@ -111,6 +116,7 @@ export async function resolveAgentAssembly(
     workspace,
     stateRoot,
     authPath,
+    ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
     tools,
     toolNames,
     deferredToolNames,
@@ -168,6 +174,7 @@ export async function createPiAgentFromDir(
     workspace,
     stateRoot,
     authPath,
+    fallbackAuthPath,
     tools,
     toolNames,
     deferredToolNames,
@@ -186,6 +193,7 @@ export async function createPiAgentFromDir(
     cwd: workspace,
     tools: mountedTools,
     authPath,
+    ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
     // Skills are definition-only (the agent is its directory), so dev mirrors deployment exactly.
     sessions,
   });

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -150,6 +150,9 @@ export async function createPiAgentFromDir(
   sessionsDir: string;
   /** Absolute credentials file in use (for the startup report). */
   authPath: string;
+  /** The second layer that file reads through ({@link AgentAssembly.fallbackAuthPath}) — the startup report names
+   *  whichever layer the credential came from, so it needs both. */
+  fallbackAuthPath?: string;
   sessions: PiSessionRecordStore;
   /** The observation plane over this agent's sessions; present iff `options.sessionControl`. */
   sessionControl?: SessionControl;
@@ -255,6 +258,7 @@ export async function createPiAgentFromDir(
     stateRoot,
     sessionsDir,
     authPath,
+    ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
     toolNames,
     deferredToolNames,
     toolCollisions,

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -41,12 +41,19 @@ export async function buildAgentSessionRuntime(
   async function resolveAssembly(cwd: string) {
     // The shared front half — the SAME placement/config/model-spec/tool/auth resolution the serving opener uses
     // (open.ts).
-    const { config, modelSpec, agentDir, authPath, stateRoot, tools, toolCollisions, toolFailures } =
+    const { config, modelSpec, agentDir, authPath, fallbackAuthPath, stateRoot, tools, toolCollisions, toolFailures } =
       await resolveAgentAssembly(cwd, options);
     reportToolCollisions(toolCollisions);
     reportModuleLoadFailures(toolFailures);
     // ONE hub owns model resolution AND per-request auth.
-    const modelRuntime = await createPiModelRuntime({ authPath, agentDir, stateRoot });
+    // The fallback layer travels too: `chat` resolving credentials differently from dev/start/invoke is exactly the
+    // divergence the layer exists to remove.
+    const modelRuntime = await createPiModelRuntime({
+      authPath,
+      agentDir,
+      stateRoot,
+      ...(fallbackAuthPath !== undefined ? { fallbackAuthPath } : {}),
+    });
     const env = new NodeExecutionEnv({ cwd });
     const definition = await loadAgentDefinition(agentDir, { cwd, env });
     reportFindingsIfChanged(definition.dir, definition);

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -191,3 +191,58 @@ describe("fastagentCredentialStore (read-write credential file; fail-visibly dis
     expect(await readFile(present, "utf8")).toBe(before); // unchanged (no write)
   });
 });
+
+describe("fastagentCredentialStore: the global fallback layer", () => {
+  const oauth = (access: string) => ({ type: "oauth" as const, access, refresh: "r", expires: Date.now() + 3_600_000 });
+  const layered = async (project: Record<string, unknown>, global: Record<string, unknown>) => {
+    const projectPath = await authPath(JSON.stringify(project));
+    const globalPath = await authPath(JSON.stringify(global));
+    return { projectPath, globalPath, store: fastagentCredentialStore(projectPath, { fallbackPath: globalPath }) };
+  };
+
+  it("falls back PER PROVIDER, so one project login does not hide the rest", async () => {
+    // The reason this is not per FILE: `fastagent login anthropic` inside a project creates a project auth.json,
+    // and a file-level fallback would make every other provider the person has globally disappear at that moment.
+    const { store } = await layered(
+      { anthropic: oauth("project") },
+      { anthropic: oauth("global"), openai: oauth("g") },
+    );
+    const access = async (id: string) => {
+      const credential = await store.read(id);
+      return credential?.type === "oauth" ? credential.access : undefined;
+    };
+    expect(await access("anthropic")).toBe("project"); // the project's own wins
+    expect(await access("openai")).toBe("g"); // still reachable
+    expect((await store.list()).map((c) => c.providerId).sort()).toEqual(["anthropic", "openai"]);
+  });
+
+  it("writes a refresh back to the layer it was READ from", async () => {
+    // Anything else conjures a second holder of the same OAuth grant — both providers rotate refresh tokens, so
+    // whichever copy refreshes first invalidates the other.
+    const { projectPath, globalPath, store } = await layered({ anthropic: oauth("project") }, { openai: oauth("g") });
+    await store.modify("openai", async () => oauth("rotated"));
+    expect(JSON.parse(await readFile(globalPath, "utf8")).openai.access).toBe("rotated");
+    expect(JSON.parse(await readFile(projectPath, "utf8")).openai).toBeUndefined();
+
+    await store.modify("anthropic", async () => oauth("rotated-too"));
+    expect(JSON.parse(await readFile(projectPath, "utf8")).anthropic.access).toBe("rotated-too");
+    expect(JSON.parse(await readFile(globalPath, "utf8")).anthropic).toBeUndefined();
+  });
+
+  it("a provider in neither layer is new, and belongs to the primary", async () => {
+    const { projectPath, globalPath, store } = await layered({}, { openai: oauth("g") });
+    await store.modify("anthropic", async () => oauth("fresh"));
+    expect(JSON.parse(await readFile(projectPath, "utf8")).anthropic.access).toBe("fresh");
+    expect(JSON.parse(await readFile(globalPath, "utf8")).anthropic).toBeUndefined();
+  });
+
+  it("deletes from the owning layer, and no fallback path means no second layer", async () => {
+    const { projectPath, globalPath, store } = await layered({ anthropic: oauth("p") }, { openai: oauth("g") });
+    await store.delete("openai");
+    expect(JSON.parse(await readFile(globalPath, "utf8")).openai).toBeUndefined();
+
+    // An explicitly named path is an instruction, not a preference: no layering at all.
+    const plain = fastagentCredentialStore(projectPath);
+    expect(await plain.read("openai")).toBeUndefined();
+  });
+});

--- a/test/cli-shared.test.ts
+++ b/test/cli-shared.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { enterAgentCommand, loginWithKeyCheck, reportAssembly } from "../src/cli/shared.ts";
+import { enterAgentCommand, loginWithKeyCheck, reportAssembly, reportAuth } from "../src/cli/shared.ts";
 import { setLogLevel } from "../src/log.ts";
 import { LoginCancelled, type LoginMethod } from "../src/engines/pi/login.ts";
 import * as models from "../src/engines/pi/models.ts";
@@ -176,5 +176,57 @@ describe("enterAgentCommand: --no-input never reaches the picker", () => {
 
     expect(placement.agentDir).toBe(dir);
     expect(runtime).not.toHaveBeenCalled();
+  });
+});
+
+describe("reportAuth (which layer the line names)", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  /** A primary + fallback auth file pair; `where` (if given) gets the stored credential for provider `p`. */
+  const layers = (where?: "primary" | "fallback") => {
+    const dir = mkdtempSync(join(tmpdir(), "fastagent-auth-layer-"));
+    dirs.push(dir);
+    const primary = join(dir, "project.json");
+    const fallback = join(dir, "global.json");
+    writeFileSync(primary, "{}\n");
+    writeFileSync(fallback, "{}\n");
+    if (where)
+      writeFileSync(
+        where === "primary" ? primary : fallback,
+        `${JSON.stringify({ p: { type: "api_key", key: "k" } })}\n`,
+      );
+    return { dir, primary, fallback };
+  };
+
+  /** The single `auth:` line, at the default `info` level. */
+  const authLine = async (agentDir: string, primary: string, fallback: string): Promise<string> => {
+    const out: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: unknown) => void out.push(String(m)));
+    try {
+      await reportAuth(agentDir, "p/m", primary, fallback);
+    } finally {
+      spy.mockRestore();
+    }
+    return out.find((l) => l.includes("auth:")) ?? "";
+  };
+
+  it("names the fallback only when the fallback is the layer holding the credential", async () => {
+    // Provider "p" is not a real pi provider, so nothing satisfies auth and the line reports what is STORED —
+    // which is the read this test is about.
+    const held = layers("fallback");
+    expect(await authLine(held.dir, held.primary, held.fallback)).toContain(held.fallback);
+
+    const mine = layers("primary");
+    expect(await authLine(mine.dir, mine.primary, mine.fallback)).toContain(mine.primary);
+
+    // Neither layer: the file to edit is the one `fastagent login` writes — the primary.
+    const none = layers();
+    const line = await authLine(none.dir, none.primary, none.fallback);
+    expect(line).toContain("(none found)");
+    expect(line).toContain(none.primary);
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -144,6 +144,11 @@ describe("config: resolveAuthPath (auth-file precedence)", () => {
     expect(resolveAuthFallback(undefined, {} as NodeJS.ProcessEnv)).toBe(GLOBAL_AUTH_PATH);
     expect(resolveAuthFallback("flagauth.json", {} as NodeJS.ProcessEnv)).toBeUndefined();
     expect(resolveAuthFallback(undefined, { FASTAGENT_AUTH_PATH: "env.json" } as NodeJS.ProcessEnv)).toBeUndefined();
+    // FASTAGENT_SECRETS_DIR names the file just as explicitly, and is what the Fly/Railway/AgentCore artifacts set:
+    // a deployed container reads its mounted credentials, never a second layer under its own $HOME.
+    expect(
+      resolveAuthFallback(undefined, { FASTAGENT_SECRETS_DIR: "/data/.secrets" } as NodeJS.ProcessEnv),
+    ).toBeUndefined();
   });
 
   it("resolveAuthPath falls back to the workspace project auth file (not the global default)", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -5,10 +5,12 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import { createPiAgentFromDir, createPiModels, listModels, probeAuthSource, resolveModel } from "../src/index.ts";
+import { GLOBAL_AUTH_PATH } from "../src/engines/pi/auth.ts";
 import {
   defaultAuthPath,
   defaultSessionsDir,
   loadConfig,
+  resolveAuthFallback,
   resolveAuthPath,
   resolveModelSpec,
   resolveSessionsDirOverride,
@@ -134,6 +136,14 @@ describe("config: resolveAuthPath (auth-file precedence)", () => {
     expect(resolveAuthPath("/app", undefined, env)).toBe(resolve("envauth.json")); // env when no flag
     expect(resolveAuthPath("/app", undefined, {} as NodeJS.ProcessEnv)).toBe("/app/.secrets/auth.json"); // neither
     expect(resolveAuthPath("/app", "/abs/auth.json", {} as NodeJS.ProcessEnv)).toBe("/abs/auth.json"); // absolute kept
+  });
+
+  it("resolveAuthFallback layers the global store under the DEFAULT path only", () => {
+    // "Use this file" is an instruction, so an explicitly named path gets no second layer; the default location is
+    // a preference, so it reads the user-global store for providers it does not have.
+    expect(resolveAuthFallback(undefined, {} as NodeJS.ProcessEnv)).toBe(GLOBAL_AUTH_PATH);
+    expect(resolveAuthFallback("flagauth.json", {} as NodeJS.ProcessEnv)).toBeUndefined();
+    expect(resolveAuthFallback(undefined, { FASTAGENT_AUTH_PATH: "env.json" } as NodeJS.ProcessEnv)).toBeUndefined();
   });
 
   it("resolveAuthPath falls back to the workspace project auth file (not the global default)", () => {


### PR DESCRIPTION
Step 3 of [docs/design/configuration.md §12](../blob/main/docs/design/configuration.md).

## The problem

`fastagent login` wrote the project's `auth.json` and nothing read anything else, so every agent directory needed its own login. Logging in from outside an agent produced a global file the CLI then told you no agent would read:

> `logging in GLOBALLY (…). An agent reads its own .secrets/auth.json: cd into one first`

A login is a **person on a machine**, not a project.

## The shape

npm's, and asymmetric on purpose:

```
read:   <agent>/.secrets/auth.json  >  ~/.fastagent/.secrets/auth.json
write:  <agent>/.secrets/auth.json  (`-g` for the global one)
```

One `fastagent login -g openai-codex` now serves every agent on the machine. Writing still defaults to the project so that giving *one* agent a different account stays an explicit act, and so a `login` cannot silently rewrite a credential another agent depends on.

Two properties that are not negotiable:

- **The fallback is per provider, not per file.** A file-level fallback would mean that `fastagent login anthropic` inside a project — which creates a project `auth.json` — makes every other provider you have globally disappear at that moment. Silently.
- **A refresh is written back to the layer it was read from.** Both providers rotate refresh tokens on every refresh (verified in pi's flows), so two copies of one grant each invalidate the other. FastAgent never creates the second copy.

An explicitly named path (`--auth-path` / `FASTAGENT_AUTH_PATH`, or an embedder's `authPath`) gets **no** second layer: "use this file" is an instruction, not a preference. `resolveAuthFallback` is the one place that decides this.

## Changes

- `fastagentCredentialStore(path, { fallbackPath })` — per-provider read/list, and `modify`/`delete` route to the layer that owns the provider (a provider in neither is new and belongs to the primary).
- `resolveAuthFallback(flag, env)` in `config.ts`, threaded beside `authPath` through the opener and the model runtime.
- `fastagent login -g`, and the out-of-agent message reframed from "no agent will read this" to "this is usually what you want".
- The startup auth line names the layer the credential actually came from — "which file do I edit" is the question it answers.

## Verification

Four cases in `test/auth.test.ts` pin the store's rules (per-provider fallback, write-back to the owning layer, new credentials to the primary, no layering without a fallback path) and one in `test/config.test.ts` pins where the layer comes from. `npm run lint && npm run typecheck && npm test` pass (1673 passed).
