### PR TITLE
docs(design)+cli: record what landed, drop --auth-path, stop auditing remote variables

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,7 +21,7 @@ Most commands take an optional workspace directory (the agent is there, or in it
 | `init [dir]` | Scaffold a runnable agent. |
 | `info [dir]` | Inspect what an agent assembles into without serving. |
 | `models [search]` | List model specs. |
-| `login [provider]` | Store provider credentials in the project-level `<agent dir>/.secrets/auth.json` (override: `--auth-path` / `FASTAGENT_AUTH_PATH`, dir: `FASTAGENT_SECRETS_DIR`). |
+| `login [provider]` | Store provider credentials in the project-level `<agent dir>/.secrets/auth.json` (override: `FASTAGENT_AUTH_PATH`, dir: `FASTAGENT_SECRETS_DIR`). |
 | `dev [dir]` | Serve locally with watch/reload. |
 | `chat [dir]` | Open the same assembled agent in pi's interactive TUI. |
 | `invoke <message> [dir]` | Run one agent turn and exit. |
@@ -67,7 +67,7 @@ Options:
 ## `fastagent info`
 
 ```bash
-fastagent info [dir] [--json] [--model provider/modelId] [--auth-path file] [--sessions-dir dir]
+fastagent info [dir] [--json] [--model provider/modelId] [--sessions-dir dir]
 ```
 
 Prints the assembled surface without starting a server:
@@ -98,16 +98,16 @@ Use a listed spec with `--model`, `FASTAGENT_MODEL`, or `fastagent.config.*`.
 ## `fastagent login`
 
 ```bash
-fastagent login [provider] [-g|--global] [--auth-path file] [--no-input]
+fastagent login [provider] [-g|--global] [--no-input]
 ```
 
-Authenticates a model provider and **writes** to the project-level `<agent dir>/.secrets/auth.json` (dir override: `FASTAGENT_SECRETS_DIR`; file override: `--auth-path` / `FASTAGENT_AUTH_PATH`). `-g` writes the user-global `~/.fastagent/.secrets/auth.json` instead, as does running outside any agent (announced on stderr). Inside an agent but not at its root (`fastagent/tools/`), it refuses and tells you where to `cd`. FastAgent uses its own credential file, separate from pi's CLI state.
+Authenticates a model provider and **writes** to the project-level `<agent dir>/.secrets/auth.json` (dir override: `FASTAGENT_SECRETS_DIR`; file override: `FASTAGENT_AUTH_PATH`). `-g` writes the user-global `~/.fastagent/.secrets/auth.json` instead, as does running outside any agent (announced on stderr). Inside an agent but not at its root (`fastagent/tools/`), it refuses and tells you where to `cd`. FastAgent uses its own credential file, separate from pi's CLI state.
 
 **Writing and reading are deliberately asymmetric**, the shape npm uses for `-g`. An agent READS the global file for any provider its own file does not have, so one `fastagent login -g openai-codex` serves every agent on the machine. Writing defaults to the project so that giving *one* agent a different account is the explicit act, and so a `login` cannot silently rewrite a credential another agent depends on.
 
 The fallback is **per provider, not per file**: logging Anthropic into a project does not hide the OpenAI credential you have globally. And a refresh is written back to the layer it was read from — a global credential stays global. That matters because both providers rotate refresh tokens: two copies of one grant each invalidate the other, so FastAgent never creates a second copy.
 
-**`deploy` does not read the global file.** A deployment carries the project-level `auth.json` only — the artifact is the truth, never the builder machine's state — so after a `login -g` a `deploy … --run` still reports `no model credential`. Carry the global one explicitly with `--auth-path ~/.fastagent/.secrets/auth.json`, or `fastagent login` (no `-g`) in the agent dir. Note this moves an OAuth grant into a second file: see the warning at the end of this section.
+**`deploy` does not read the global file.** A deployment carries the project-level `auth.json` only — the artifact is the truth, never the builder machine's state — so after a `login -g` a `deploy … --run` still reports `no model credential`. Carry the global one explicitly with `FASTAGENT_AUTH_PATH=~/.fastagent/.secrets/auth.json fastagent deploy … --run`, or `fastagent login` (no `-g`) in the agent dir. Note this moves an OAuth grant into a second file: see the warning at the end of this section.
 
 An API-key login is verified immediately with one minimal request (OAuth needs no check — completing
 the flow proves the credential): a definitive rejection (HTTP 401) removes the bad key and prompts
@@ -118,15 +118,15 @@ prints the provider's message.
 **The directory holding `auth.json` is managed as a secrets directory**, whichever knob named it:
 every credential write (including an OAuth refresh mid-run) re-applies `0700` to it, and where the
 process cannot chmod it the write fails instead of leaving the credential readable. Point
-`--auth-path` / `FASTAGENT_AUTH_PATH` inside a directory this process owns, not a shared one others
+`FASTAGENT_AUTH_PATH` inside a directory this process owns, not a shared one others
 need to read.
 
-**Running several agents off one account on your dev machine?** Point them all at the one global file: set `FASTAGENT_AUTH_PATH=~/.fastagent/.secrets/auth.json` (a `.env` entry, a shell env var, or `--auth-path`), or just `login` from outside any agent. A leading `~` is expanded to your home dir in `--auth-path` and `FASTAGENT_AUTH_PATH` (shell variables like `$HOME` are not — use `~` or an absolute path). Sharing **one file** is safe — a single cross-process lock serializes OAuth refresh, so concurrent instances always read the latest token. (What is *not* safe is copying the file around: two files over one grant each rotate the single-use refresh token and break the other.)
+**Running several agents off one account on your dev machine?** Point them all at the one global file: set `FASTAGENT_AUTH_PATH=~/.fastagent/.secrets/auth.json` (a `.env` entry or a shell env var), or just `login` from outside any agent. A leading `~` is expanded to your home dir in `FASTAGENT_AUTH_PATH` (shell variables like `$HOME` are not — use `~` or an absolute path). Sharing **one file** is safe — a single cross-process lock serializes OAuth refresh, so concurrent instances always read the latest token. (What is *not* safe is copying the file around: two files over one grant each rotate the single-use refresh token and break the other.)
 
 ## `fastagent dev`
 
 ```bash
-fastagent dev [dir] [--port N] [--bind addr] [--model provider/modelId] [--auth-path file] [--no-watch] [--tunnel] [--no-input]
+fastagent dev [dir] [--port N] [--bind addr] [--model provider/modelId] [--no-watch] [--tunnel] [--no-input]
 ```
 
 Assembles the agent and serves it locally. persona.md/AGENTS.md/`skills/` are re-read every turn (edits go
@@ -146,7 +146,6 @@ Options:
 |---|---|
 | `--port N` | Override `http.port` / default `8787`. |
 | `--model spec` | Override model selection. |
-| `--auth-path file` | Override the credential file (default `<agent dir>/.secrets/auth.json`). |
 | `--no-watch` | Serve once without the watch supervisor. |
 | `--tunnel` | Open a Cloudflare quick tunnel for webhook testing. |
 | `--no-input` | Never prompt (CI/scripts) — e.g. the first-run model pick becomes an actionable error instead of a question. |
@@ -175,12 +174,12 @@ Web panel or desktop app uses (`connectSessionControl`).
 ## `fastagent chat`
 
 ```bash
-fastagent chat [dir] [--model provider/modelId] [--auth-path file]
+fastagent chat [dir] [--model provider/modelId]
 ```
 
 Opens the same assembled agent in pi's interactive TUI. This is useful for trying the agent before serving it through channels.
 
-Auth is fastagent's, same as every other command: `--auth-path` > `FASTAGENT_AUTH_PATH` > the
+Auth is fastagent's, same as every other command: `FASTAGENT_AUTH_PATH` > the
 agent `auth.json`. Log in with `fastagent login` (or pi's `/login` inside the TUI, which writes
 to the same file). With no model set, `chat` runs the same first-run picker as the serving commands
 (credential-annotated catalog, inline login) and writes the choice back to the config.
@@ -188,7 +187,7 @@ to the same file). With no model set, `chat` runs the same first-run picker as t
 ## `fastagent invoke`
 
 ```bash
-fastagent invoke <message> [dir] [--model provider/modelId] [--auth-path file] [--no-input]
+fastagent invoke <message> [dir] [--model provider/modelId] [--no-input]
 ```
 
 Runs one turn through the same agent assembly and exits:
@@ -202,7 +201,7 @@ Use this for smoke tests and scripts.
 ## `fastagent fire`
 
 ```bash
-fastagent fire <name> [dir] [--model provider/modelId] [--auth-path file] [--no-input]
+fastagent fire <name> [dir] [--model provider/modelId] [--no-input]
 ```
 
 Runs ONE schedule's turn immediately — the authoring loop for schedules (like `invoke` is for a
@@ -307,7 +306,7 @@ Use `--update` to overwrite an existing vendored skill. Review the result with `
 ## `fastagent start`
 
 ```bash
-fastagent start [dir] [--port N] [--bind addr] [--model provider/modelId] [--sessions-dir dir] [--auth-path file] [--tunnel] [--no-input]
+fastagent start [dir] [--port N] [--bind addr] [--model provider/modelId] [--sessions-dir dir] [--tunnel] [--no-input]
 ```
 
 Runs the agent in production posture: no watch, same assembly as `dev`.
@@ -370,7 +369,6 @@ Recurring per-command options (same meaning everywhere they appear):
 | `--bind <addr>` | `dev`, `start` | Bind address — an IP literal, or `localhost` (read as `127.0.0.1`). Default: `127.0.0.1` for `dev`, all interfaces for `start` (containers need it); `--bind 0.0.0.0` opens a dev serve to the LAN. Prefer this flag over `http.host` for a non-wildcard bind — that value travels into a deployed image, where `deploy` gates it. See [Bind address](configuration.md#bind-address). |
 | `--no-input` | `dev`, `start`, `invoke`, `fire`, `login`, `deploy` | Never prompt; missing information becomes an error with the flag to pass (`deploy` plan mode only warns on a missing model — `--run` gates). |
 | `--model <provider/modelId>` | assembly commands (not `deploy`) | Model override for THIS local run (`--model > FASTAGENT_MODEL > config`). `deploy` has no such flag: it resolves the deployed model from `.secrets/.env`'s `FASTAGENT_MODEL` over `config.model`, so the choice is reproducible from what travels. |
-| `--auth-path <file>` | assembly commands, `login` | Credentials file override. |
 | `--json` | `info`, `schedule history`, `schedule list` | Machine-readable output. |
 
 ## Exit codes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,7 +309,7 @@ The finer knobs still override their specific path on top:
 state root: FASTAGENT_STATE_DIR                          > <agent dir>/.state
 secrets:    FASTAGENT_SECRETS_DIR                        > <agent dir>/.secrets
 sessions:   --sessions-dir > FASTAGENT_SESSIONS_DIR      > <state root>/sessions
-auth:       FASTAGENT_AUTH_PATH                             > <secrets>/auth.json
+auth:       FASTAGENT_AUTH_PATH                          > <secrets>/auth.json
 ```
 
 A leading `~` in any of these is expanded to your home dir.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,7 +224,7 @@ FastAgent resolves model credentials through the model provider layer. Common op
 
 | Source | Use case |
 |---|---|
-| `fastagent login` | Writes OAuth/API-key credentials to the project-level `<agent dir>/.secrets/auth.json` (override: `--auth-path` / `FASTAGENT_AUTH_PATH`, a leading `~` is expanded); `-g` (or running outside any agent) writes the user-global `~/.fastagent/.secrets/auth.json`. An agent **reads** that global file for any provider its own lacks, per provider, and writes a refresh back to the layer it read from. |
+| `fastagent login` | Writes OAuth/API-key credentials to the project-level `<agent dir>/.secrets/auth.json` (override: `FASTAGENT_AUTH_PATH`, a leading `~` is expanded); `-g` (or running outside any agent) writes the user-global `~/.fastagent/.secrets/auth.json`. An agent **reads** that global file for any provider its own lacks, per provider, and writes a refresh back to the layer it read from. |
 | Provider env vars | Good for servers and CI, e.g. `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`. |
 | Agent `.env` | Local development secrets at `<agent dir>/.secrets/.env`, loaded by CLI commands. Excluded by the `.secrets/.gitignore` that `init` scaffolds. |
 
@@ -309,7 +309,7 @@ The finer knobs still override their specific path on top:
 state root: FASTAGENT_STATE_DIR                          > <agent dir>/.state
 secrets:    FASTAGENT_SECRETS_DIR                        > <agent dir>/.secrets
 sessions:   --sessions-dir > FASTAGENT_SESSIONS_DIR      > <state root>/sessions
-auth:       --auth-path    > FASTAGENT_AUTH_PATH         > <secrets>/auth.json
+auth:       FASTAGENT_AUTH_PATH                             > <secrets>/auth.json
 ```
 
 A leading `~` in any of these is expanded to your home dir.

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -1,14 +1,16 @@
 ---
 title: Configuration, deployment environments, and credential ownership
 description: "Where each configuration fact lives and why: the convention boundary (FastAgent does not own deployment orchestration), the two tiers a single agent moves through, the three resolution chains, and what deliberately does not exist."
-status: proposed
+status: partially implemented
 ---
 
 # Configuration, deployment environments, and credential ownership
 
-**Status: proposed.** This is the design conclusion for [#482](https://github.com/fastagent-sh/fastagent/issues/482). It replaces that RFC's file layout and command surface with a smaller one; §11 lists what was dropped and why. Nothing here is implemented yet — the code truth is `src/`, and §12 is the sequencing.
+**Status: partially implemented.** This is the design conclusion for [#482](https://github.com/fastagent-sh/fastagent/issues/482). It replaces that RFC's file layout and command surface with a smaller one; §11 lists what was dropped and why. The code truth is `src/`; §12 is the sequencing and carries what has landed.
 
-The user-facing document for what exists today is [configuration.md](../configuration.md). Landing this proposal updates its *Secrets and credentials* chain (`FASTAGENT_AUTH_PATH` keeps its place, the `--auth-path` flag goes, a global store is added below the project one) and its *Model resolution* section (`FASTAGENT_MODEL` is read from the selected value file). The config-file and artifact-location sections stay as they are.
+**The day-one tier is built (steps 1–3). The env dimension (§2's day two, step 4) is not, and is deliberately not scheduled** — it is a pure addition with no demand behind it yet, so every `--env` sentence below describes a design that is ready rather than code that exists. §12 also lists the three day-one leftovers that are still open.
+
+The user-facing document for what exists today is [configuration.md](../configuration.md).
 
 ## 1. Decision
 
@@ -90,9 +92,16 @@ persona.md  skills/  tools/  channels/  schedules/
 |---|---|
 | Model | `--model` (local runs only) > the selected value file's `FASTAGENT_MODEL` > `config.model`. The operator's shell variable is not a source: the chain reads the value file, never `process.env` |
 | Values | `--env` given → **only** `.secrets/<env>/.env`; omitted → `.secrets/.env`. No fallback between them |
-| Credentials | `FASTAGENT_AUTH_PATH` > `.secrets/auth.json` > `~/.fastagent/.secrets/auth.json` |
+| Credentials | `FASTAGENT_AUTH_PATH` > `.secrets/auth.json` > `~/.fastagent/.secrets/auth.json`, **per provider** — and only when the project path is the default one |
 
 The defaults live in different places for exactly one reason: one can be committed and the other cannot. `config` is the committed application default; the global auth file is "this person's" default. **Another environment's values are never a default** — the local `.env` holds one person's values on one machine, so falling back to it would make a deployment's result depend on who ran it and where.
+
+Two properties of the credential chain are not free choices, and both were paid for:
+
+- **The fallback is per provider, not per file.** A file-level fallback would make every other provider in the global store vanish the instant `login anthropic` created a project `auth.json`.
+- **An explicitly named path takes no second layer.** `--auth-path`, `FASTAGENT_AUTH_PATH`, and `FASTAGENT_SECRETS_DIR` are instructions, not preferences (`resolveAuthFallback` in `src/engines/pi/config.ts`). The deployed artifacts set the third one, and a container must read its mounted credentials and nothing else — otherwise a fly/railway/agentcore box would quietly mount `$HOME/.fastagent/.secrets/auth.json` as a second layer.
+
+`deploy` reads the project file only: the artifact is the truth, so a credential that exists only in the global store is not carried. `fastagent login` inside the agent directory, or `--auth-path` naming the global file, are the two ways to hand it one — and the second makes one grant have two holders (§13).
 
 Two rules follow:
 
@@ -215,16 +224,28 @@ Dropped from the RFC, and from earlier drafts of this document:
 | Per-env artifact names (`fly.<env>.toml`) under `--env` | `src/deploy/container.ts` + each host's `plan.ts` |
 | Unchanged | `FASTAGENT_AUTH_SEED` + chunking + `collectAuthSeed` + `authSeedBytes`, `.secrets/` 0700, `secrets-gate`, `deploy.secrets` / `deploy.apt` |
 
-| # | Step | Independent value |
-|---|---|---|
-| 1 | Deployment phase ordering: no entrance opens before credential + readiness | A correctness fix unrelated to env; worth having today |
-| 2 | `config.name` + one model chain (`FASTAGENT_MODEL` travels with the value file; delete `modelTravelIssue`) | All of day one; the single-instance path is unchanged |
-| 2b | class D reads the value file only — the same rule the model already follows | Removes the last path by which the builder's environment reaches a deployment |
-| 2c | literal-`apiKey` **warning** + `$NAME` references treated as declared secrets | Reports the second route by which a credential enters the image, without the framework deciding what is one |
-| 3 | Credential project > global fallback (per provider, refresh written back to the layer read) + `login -g` | One global login serves every project |
-| 4 | The env addition: `--env` + `.secrets/<env>/.env` + `<name>-<env>` prefix | Pure addition; day-two capability |
+| # | Step | Independent value | State |
+|---|---|---|---|
+| 1 | Deployment phase ordering: no entrance opens before credential + readiness | A correctness fix unrelated to env; worth having today | [#518](https://github.com/fastagent-sh/fastagent/pull/518) |
+| 2 | One model chain (`FASTAGENT_MODEL` travels with the value file; delete `modelTravelIssue`) | All of day one; the single-instance path is unchanged | [#520](https://github.com/fastagent-sh/fastagent/pull/520) |
+| 2b | class D reads the value file only — the same rule the model already follows | Removes the last path by which the builder's environment reaches a deployment | [#524](https://github.com/fastagent-sh/fastagent/pull/524) |
+| 2c | literal-`apiKey` **warning** + `$NAME` references treated as declared secrets | Reports the second route by which a credential enters the image, without the framework deciding what is one | [#523](https://github.com/fastagent-sh/fastagent/pull/523) |
+| 3 | Credential project > global fallback (per provider, refresh written back to the layer read) + `login -g` | One global login serves every project | [#525](https://github.com/fastagent-sh/fastagent/pull/525), [#526](https://github.com/fastagent-sh/fastagent/pull/526) |
+| 4 | The env addition: `--env` + `.secrets/<env>/.env` + `<name>-<env>` prefix, and `config.name` with it | Pure addition; day-two capability | **not scheduled** — no demand yet |
 
 Each step is usable on its own and is its own PR. 1 and 3 are small, 2 and 4 are medium.
+
+`config.name` moved from step 2 to step 4: its only consumer is the `<name>-<env>` prefix, so on its own it is a config field nothing reads.
+
+### Still open from day one
+
+These are inside §6 and §9 but outside any step above, and none of them blocks anything:
+
+| Left | Where it is written | Why it is still open |
+|---|---|---|
+| Drop the `--auth-path` flag from all eight commands (`FASTAGENT_AUTH_PATH` stays) | §6 | The flag now has one use the env var does not cover: pointing `deploy` at the global store. Deciding it means deciding whether that route should exist at all (§13's "two holders of one grant") |
+| `deploy` lists remote variable names and reports the ones outside the ownership union as **unmanaged** | §9 | Nothing reads back remote state today; this is the one piece of §9 that needs a per-host call |
+| Every supported host has an end-to-end check | §14 | `test/live/` probes exist, but no host is covered end to end |
 
 ## 13. Known costs
 
@@ -239,14 +260,16 @@ Each step is usable on its own and is its own PR. 1 and 3 are small, 2 and 4 are
 
 ## 14. Acceptance
 
+Checked boxes are covered by a test in the offline suite. The unchecked ones are either day two (`--env`) or need a real host.
+
 - [ ] A freshly generated small agent never encounters the env concept; `fastagent deploy fly --run` works end to end.
 - [ ] `.secrets/production/.env` and `.secrets/alpha/.env` can select different models; preflight, generated configuration, runtime, and diagnostics agree on the effective model and its credential provider.
 - [ ] With `--env`, neither `.secrets/.env` nor the operator's shell `FASTAGENT_MODEL` affects resolution.
 - [ ] A typoed env or a missing declared variable fails visibly and names the declaring file, with no other environment's values substituted.
 - [ ] A deploy delivers the full allowed key set, reports partial failure, deletes no remote key implicitly, and lists remote names outside its ownership union as unmanaged.
 - [ ] Value files, secret values, and credentials appear in no build context, image, manifest, command argument, or log.
-- [ ] With no project credential, the global one is used and its source is printed; a credential read from the global store refreshes back into it and leaves no project copy.
-- [ ] Concurrent local projects share the global credential file safely.
-- [ ] With no usable credential, **no public entrance is activated**; a redeploy against a host that already holds one does not overwrite it.
+- [x] With no project credential, the global one is used and its source is printed; a credential read from the global store refreshes back into it and leaves no project copy.
+- [x] Concurrent local projects share the global credential file safely.
+- [x] With no usable credential, **no public entrance is activated**; a redeploy against a host that already holds one does not overwrite it.
 - [ ] Redeploy, rollback, restart, and session-snapshot restore all preserve the latest credentials.
 - [ ] Every supported host has an end-to-end check for the above; unsupported capability combinations fail explicitly.

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -99,9 +99,9 @@ The defaults live in different places for exactly one reason: one can be committ
 Two properties of the credential chain are not free choices, and both were paid for:
 
 - **The fallback is per provider, not per file.** A file-level fallback would make every other provider in the global store vanish the instant `login anthropic` created a project `auth.json`.
-- **An explicitly named path takes no second layer.** `--auth-path`, `FASTAGENT_AUTH_PATH`, and `FASTAGENT_SECRETS_DIR` are instructions, not preferences (`resolveAuthFallback` in `src/engines/pi/config.ts`). The deployed artifacts set the third one, and a container must read its mounted credentials and nothing else — otherwise a fly/railway/agentcore box would quietly mount `$HOME/.fastagent/.secrets/auth.json` as a second layer.
+- **An explicitly named path takes no second layer.** `FASTAGENT_AUTH_PATH` and `FASTAGENT_SECRETS_DIR` are instructions, not preferences (`resolveAuthFallback` in `src/engines/pi/config.ts`). The deployed artifacts set the third one, and a container must read its mounted credentials and nothing else — otherwise a fly/railway/agentcore box would quietly mount `$HOME/.fastagent/.secrets/auth.json` as a second layer.
 
-`deploy` reads the project file only: the artifact is the truth, so a credential that exists only in the global store is not carried. `fastagent login` inside the agent directory, or `--auth-path` naming the global file, are the two ways to hand it one — and the second makes one grant have two holders (§13).
+`deploy` reads the project file only: the artifact is the truth, so a credential that exists only in the global store is not carried. `fastagent login` inside the agent directory, or `FASTAGENT_AUTH_PATH` naming the global file, are the two ways to hand it one — and the second makes one grant have two holders (§13).
 
 Two rules follow:
 
@@ -127,7 +127,7 @@ fastagent logs agentcore --env production
 |---|---|
 | `deploy <host> [dir]` | add `--env <name>`; drop `--model` (§5: it never reaches the box) and `--auth-path`; `host` stays a required positional (unambiguous, so it does not move) |
 | `logs <host> [dir]` | add `--env <name>` |
-| `login [provider]` | add `-g`; drop the `--auth-path` flag (SDK store injection stays) |
+| `login [provider]` | add `-g`; drop the `--auth-path` flag (the SDK's `authPath` option stays) |
 | `dev`, `chat`, `info`, `invoke`, `fire`, `start` | drop the `--auth-path` flag; `FASTAGENT_AUTH_PATH` stays (§11) |
 | the other six commands | unchanged |
 
@@ -179,7 +179,7 @@ No `secret push` / `env sync` prerequisite lifecycle (the lesson Kamal 2 encodes
 
 **Ownership is derived, not tracked remotely**: the keys FastAgent owns are every `{ secrets }` declaration ∪ the keys in the selected value file. Nothing outside that union is written, so platform-owned variables survive.
 
-That union describes the *current* intent and cannot say which remote key a past deploy set, so **nothing is deleted implicitly**. The plan lists the remote key names (names only — every supported host allows listing names without values) and reports the ones outside the union as unmanaged; removing them is the operator's call. Tracking a "previously managed" set would mean either a remote registry or local state that CI does not have, and the whole point of §9 is that neither exists.
+That union describes the *current* intent and cannot say which remote key a past deploy set, so **nothing is deleted implicitly** — and nothing outside it is reported either. What else lives in the platform's variable storage is the platform's business and the operator's: a tool that writes a subset has no standing to audit the rest, and saying "unmanaged" about a variable someone set on purpose is a warning with no action behind it. Tracking a "previously managed" set would need either a remote registry or local state CI does not have, and the whole point of §9 is that neither exists.
 
 Values are redacted in every output; write-only platform secrets are never read back to build a plan; a plaintext value file never enters an image, a command-line argument, a generated manifest, or a log; framework-owned storage/ingress/bootstrap names are refused.
 
@@ -202,6 +202,7 @@ Dropped from the RFC, and from earlier drafts of this document:
 | `login --env`, `auth push`, per-host credential management, per-provider merge | Day two uses API keys; day one has no choice to make |
 | A credential account/alias dimension, `config.accounts` | `--env` plus the two credential layers already covers "different account per environment" |
 | Cross-env value fallback, importing pi's credentials, copying an OAuth grant between local and remote | §5 |
+| Reporting remote variables outside the ownership union as **unmanaged** | §9: writing a subset gives no standing to audit the rest |
 | Moving `.env` out of `.secrets/` | Plaintext credentials in a 0755 directory; see the `ensureSecretsDir` note in `AGENTS.md` |
 | Removing `FASTAGENT_SECRETS_DIR` / `FASTAGENT_STATE_DIR` / `FASTAGENT_AUTH_PATH` | The fly/railway/agentcore plans point them at the mounted volume, and the deployed container locates `auth.json` through that chain. Only the corresponding CLI flags can go |
 | A `--profile` selector, a current-environment switch, arbitrary credential-path options, a custom encryption/key-distribution framework | Orchestration or scope creep |
@@ -239,12 +240,10 @@ Each step is usable on its own and is its own PR. 1 and 3 are small, 2 and 4 are
 
 ### Still open from day one
 
-These are inside §6 and §9 but outside any step above, and none of them blocks anything:
+One item is outside every step above, and it blocks nothing:
 
 | Left | Where it is written | Why it is still open |
 |---|---|---|
-| Drop the `--auth-path` flag from all eight commands (`FASTAGENT_AUTH_PATH` stays) | §6 | The flag now has one use the env var does not cover: pointing `deploy` at the global store. Deciding it means deciding whether that route should exist at all (§13's "two holders of one grant") |
-| `deploy` lists remote variable names and reports the ones outside the ownership union as **unmanaged** | §9 | Nothing reads back remote state today; this is the one piece of §9 that needs a per-host call |
 | Every supported host has an end-to-end check | §14 | `test/live/` probes exist, but no host is covered end to end |
 
 ## 13. Known costs
@@ -266,7 +265,7 @@ Checked boxes are covered by a test in the offline suite. The unchecked ones are
 - [ ] `.secrets/production/.env` and `.secrets/alpha/.env` can select different models; preflight, generated configuration, runtime, and diagnostics agree on the effective model and its credential provider.
 - [ ] With `--env`, neither `.secrets/.env` nor the operator's shell `FASTAGENT_MODEL` affects resolution.
 - [ ] A typoed env or a missing declared variable fails visibly and names the declaring file, with no other environment's values substituted.
-- [ ] A deploy delivers the full allowed key set, reports partial failure, deletes no remote key implicitly, and lists remote names outside its ownership union as unmanaged.
+- [ ] A deploy delivers the full allowed key set, reports partial failure, and deletes no remote key implicitly.
 - [ ] Value files, secret values, and credentials appear in no build context, image, manifest, command argument, or log.
 - [x] With no project credential, the global one is used and its source is printed; a credential read from the global store refreshes back into it and leaves no project copy.
 - [x] Concurrent local projects share the global credential file safely.

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -8,7 +8,7 @@ status: partially implemented
 
 **Status: partially implemented.** This is the design conclusion for [#482](https://github.com/fastagent-sh/fastagent/issues/482). It replaces that RFC's file layout and command surface with a smaller one; §11 lists what was dropped and why. The code truth is `src/`; §12 is the sequencing and carries what has landed.
 
-**The day-one tier is built (steps 1–3). The env dimension (§2's day two, step 4) is not, and is deliberately not scheduled** — it is a pure addition with no demand behind it yet, so every `--env` sentence below describes a design that is ready rather than code that exists. §12 also lists the three day-one leftovers that are still open.
+**The day-one tier is built (steps 1–3). The env dimension (§2's day two, step 4) is not, and is deliberately not scheduled** — it is a pure addition with no demand behind it yet, so every `--env` sentence below describes a design that is ready rather than code that exists. §12 also lists the day-one leftover that is still open.
 
 The user-facing document for what exists today is [configuration.md](../configuration.md).
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -129,7 +129,7 @@ Implemented today:
 - Cron schedules (`schedules/` files) and opt-in agent self-scheduling (the `wake` tool), with a per-run audit.
 - `dev`, `chat`, `invoke`, `tool`, `info`, `fire`, `schedule`, `start`, and `deploy docker` / `deploy fly` / `deploy railway` / `deploy agentcore` (`--run` drives Docker Compose or the host CLI end-to-end).
 - jsonl session persistence with restart continuity.
-- CLI login backed by a project-level `<agent dir>/.secrets/auth.json` (override: `--auth-path` / `FASTAGENT_AUTH_PATH`, dir: `FASTAGENT_SECRETS_DIR`).
+- CLI login backed by a project-level `<agent dir>/.secrets/auth.json` (override: `FASTAGENT_AUTH_PATH`, dir: `FASTAGENT_SECRETS_DIR`).
 
 Not implemented yet:
 

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -2,7 +2,7 @@
 import { failStartup } from "../fail.ts";
 import { enterAgentCommand } from "../shared.ts";
 
-export async function runChat(dirArg: string, opts: { model?: string; authPath?: string }): Promise<void> {
+export async function runChat(dirArg: string, opts: { model?: string }): Promise<void> {
   // Chat authenticates through fastagent's credential store like every other command (the shared session builder
   // injects it — see engines/pi/session-builder.ts), so the first-run picker and its inline login apply here too.
   const placement = await enterAgentCommand(dirArg, opts);
@@ -11,5 +11,5 @@ export async function runChat(dirArg: string, opts: { model?: string; authPath?:
   process.chdir(placement.workspace);
   // Lazy-import: chat pulls pi's interactive TUI module graph; headless start/dev never need it.
   const { runPiChat } = await import("../../engines/pi/chat.ts");
-  await runPiChat(placement.workspace, { model: opts.model, authPath: opts.authPath }).catch(failStartup);
+  await runPiChat(placement.workspace, { model: opts.model }).catch(failStartup);
 }

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -97,7 +97,6 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
     run: !!opts.run,
     force: !!opts.force,
     externalClock: host === "agentcore", // cron rides EventBridge there — the resident-host notes don't apply
-    authPathFlag: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by preflight (one owner)
   }).catch(failStartup);
   if (!pre.ok) failStartup(new Error(`deploy stopped: ${pre.gate}`));
   for (const m of pre.messages) console.error(`[fastagent] ${m.level}: ${m.text}`);

--- a/src/cli/commands/deploy/shared.ts
+++ b/src/cli/commands/deploy/shared.ts
@@ -27,7 +27,6 @@ export interface DeployOptions {
   /** false ⇔ `--no-scale-to-zero`. */
   scaleToZero?: boolean;
   intoLinked?: boolean;
-  authPath?: string;
   /** false ⇔ `--no-input`. */
   input?: boolean;
 }

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -30,7 +30,6 @@ export interface DevOptions {
   port?: string;
   bind?: string;
   model?: string;
-  authPath?: string;
   /** false ⇔ `--no-watch`. */
   watch?: boolean;
   tunnel?: boolean;
@@ -60,7 +59,6 @@ async function serveOnce(placement: ResolvedPlacement, opts: DevOptions): Promis
   const tunnel = opts.tunnel ?? false;
   const a = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
-    authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
     serving: true, // long-running serve: the scheduler poller runs (wake mounts iff config.selfSchedule)
   }).catch(failStartup);
   // The same report `start` prints; `config:` is dev's own extra (see reportAssembly on the asymmetry).

--- a/src/cli/commands/fire.ts
+++ b/src/cli/commands/fire.ts
@@ -14,7 +14,6 @@ import { enterAgentCommand, reportAuth } from "../shared.ts";
 
 export interface FireOptions {
   model?: string;
-  authPath?: string;
   /** false ⇔ `--no-input`. */
   input?: boolean;
 }
@@ -50,7 +49,6 @@ export async function runFire(name: string, dirArg: string, opts: FireOptions): 
   gateSecretsOrExit({ declared: secrets, failures, owner: name });
   const { agent, modelSpec, authPath, fallbackAuthPath } = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
-    authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
   }).catch(failStartup);
   console.error(`[fastagent] fire: ${name} (${modelSpec})`);
   await reportAuth(placement.agentDir, modelSpec, authPath, fallbackAuthPath);

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -26,7 +26,6 @@ import { failStartup, placementOrExit } from "../fail.ts";
 export interface InfoOptions {
   json?: boolean;
   model?: string;
-  authPath?: string;
   sessionsDir?: string;
 }
 
@@ -92,10 +91,10 @@ export async function runInfo(dirArg: string, opts: InfoOptions): Promise<void> 
   // info must not).
   const stateRoot = resolveStateRoot(agentDir);
   const sessionsDir = resolveSessionsDirOverride(opts.sessionsDir) ?? defaultSessionsDir(stateRoot);
-  const authPath = resolveAuthPath(agentDir, opts.authPath); // flag > FASTAGENT_AUTH_PATH > default — the one owner
+  const authPath = resolveAuthPath(agentDir); // FASTAGENT_AUTH_PATH > default — the one owner
   // The second layer this agent reads through: "what is this agent's state" is the question `info` answers, and a
   // credential it runs on can live in a file the agent dir does not contain.
-  const fallbackAuthPath = resolveAuthFallback(opts.authPath);
+  const fallbackAuthPath = resolveAuthFallback();
 
   // RESOLVE the spec, do not just echo it: a spec is only real once its provider/model exist in the agent's own
   // surface (built-ins + its models.json), which is exactly what a custom endpoint changes.

--- a/src/cli/commands/invoke.ts
+++ b/src/cli/commands/invoke.ts
@@ -7,7 +7,6 @@ import { enterAgentCommand, reportAuth } from "../shared.ts";
 
 export interface InvokeOptions {
   model?: string;
-  authPath?: string;
   /** false ⇔ `--no-input`. */
   input?: boolean;
 }
@@ -16,7 +15,6 @@ export async function runInvoke(message: string, dirArg: string, opts: InvokeOpt
   const placement = await enterAgentCommand(dirArg, opts);
   const { agent, modelSpec, authPath, fallbackAuthPath } = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
-    authPath: opts.authPath, // flag > FASTAGENT_AUTH_PATH > default — resolved by the opener (one owner)
   }).catch(failStartup);
   // BOTH directories, like dev/start: from the workspace, `placement.workspace` alone equals the dir you typed, so it
   // cannot tell you which agent actually ran.

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -13,7 +13,6 @@ import { failStartup, placementOrExit } from "../fail.ts";
 import { isInteractive, loginWithKeyCheck } from "../shared.ts";
 
 export interface LoginOptions {
-  authPath?: string;
   /** `-g`: store in the user-global file every agent on this machine falls back to. */
   global?: boolean;
   /** false ⇔ `--no-input`. */
@@ -31,14 +30,14 @@ export async function runLogin(provider: string | undefined, opts: LoginOptions)
   // FASTAGENT_AUTH_PATH and a proxy may both be configured in the project .env, and the OAuth token exchange must go
   // through that proxy (region-locked providers).
   enterAgentEnv(loginDir);
-  // `-g` names the global file outright. Otherwise: flag > FASTAGENT_AUTH_PATH > default — the one owner. The
+  // `-g` names the global file outright. Otherwise: FASTAGENT_AUTH_PATH > default — the one owner. The
   // store built here is deliberately UNLAYERED: reading falls back to the global file, but writing must land
   // exactly where the operator said, or a second `login` for a provider they already have globally would silently
   // rewrite the global credential instead of creating the project-level override they asked for.
-  const authPath = opts.global ? GLOBAL_AUTH_PATH : resolveAuthPath(loginDir, opts.authPath);
+  const authPath = opts.global ? GLOBAL_AUTH_PATH : resolveAuthPath(loginDir);
   // Announce when the FALLBACK is what decided the target: outside an agent with no explicit path, the credential
   // lands somewhere no agent will read.
-  if (!agentDir && !opts.global && !opts.authPath && !process.env.FASTAGENT_AUTH_PATH) {
+  if (!agentDir && !opts.global && !process.env.FASTAGENT_AUTH_PATH) {
     console.error(
       `[fastagent] no agent here (no fastagent.config.*, here or one level inside) — ` +
         `logging in GLOBALLY (${authPath}). Every agent on this machine reads this file for providers its own ` +

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,6 +1,6 @@
 /**
  * `fastagent login [provider]`: authenticate a model provider into the project-level auth file
- * (`<agentDir>/.secrets/auth.json`) by default, or `--auth-path`/`FASTAGENT_AUTH_PATH`.
+ * (`<agentDir>/.secrets/auth.json`) by default, or `FASTAGENT_AUTH_PATH`.
  */
 import { homedir } from "node:os";
 import { join } from "node:path";

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -35,7 +35,6 @@ export interface StartOptions {
   bind?: string;
   model?: string;
   sessionsDir?: string;
-  authPath?: string;
   tunnel?: boolean;
   input?: boolean;
 }
@@ -177,11 +176,10 @@ export async function openStartService(dirArg: string, opts: StartOptions): Prom
 /** Internal entry loaded from the active workspace's installed package after storage initialization. */
 export async function openPreparedStartService(dirArg: string, opts: StartOptions): Promise<StartedService> {
   const placement = await enterAgentCommand(dirArg, opts);
-  await maybeSeedAuth(resolveAuthPath(placement.agentDir, opts.authPath));
+  await maybeSeedAuth(resolveAuthPath(placement.agentDir));
   const opened = await createPiAgentFromDir(placement.workspace, {
     model: opts.model,
     sessionsDir: resolveSessionsDirOverride(opts.sessionsDir),
-    authPath: opts.authPath,
     serving: true,
   });
   const { agent, agentDir, config, stateRoot, sessionsDir } = opened;

--- a/src/cli/kernel.ts
+++ b/src/cli/kernel.ts
@@ -11,7 +11,7 @@ interface ArgSpec {
   choices?: string[];
 }
 
-/** One flag, in the flag DSL: `--json`, or `--auth-path <file>` for a value-taking flag. */
+/** One flag, in the flag DSL: `--json`, or `--sessions-dir <dir>` for a value-taking flag. */
 export interface FlagSpec {
   flags: string;
   description: string;
@@ -63,7 +63,7 @@ export interface ProgramOptions {
 
 /**
  * The option key a flag string yields on the parsed-flags record — the naming rule specs rely on: camelCase of the
- * long name (`--auth-path` → `authPath`); a `--no-x` flag negates and stores under `x` (absent ⇒ `x !== false`).
+ * long name (`--sessions-dir` → `sessionsDir`); a `--no-x` flag negates and stores under `x` (absent ⇒ `x !== false`).
  */
 export function optionKey(flags: string): string {
   const long = flags

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -16,10 +16,6 @@ const MODEL: FlagSpec = {
   flags: "--model <provider/modelId>",
   description: "model override (precedence: --model > FASTAGENT_MODEL > config)",
 };
-const AUTH_PATH: FlagSpec = {
-  flags: "--auth-path <file>",
-  description: "credentials file (default: <agent dir>/.secrets/auth.json; env: FASTAGENT_AUTH_PATH)",
-};
 const JSON_FLAG: FlagSpec = { flags: "--json", description: "machine-readable JSON output" };
 const NO_INPUT: FlagSpec = {
   flags: "--no-input",
@@ -92,15 +88,7 @@ const dev: CommandSpec = {
     "fastagent.config.*, package.json, .secrets/.env — restart the worker. Files the agent writes as " +
     "work product never trigger a restart.",
   args: [DIR_ARG],
-  flags: [
-    PORT,
-    BIND,
-    MODEL,
-    AUTH_PATH,
-    { flags: "--no-watch", description: "serve once, no file-watching" },
-    TUNNEL,
-    NO_INPUT,
-  ],
+  flags: [PORT, BIND, MODEL, { flags: "--no-watch", description: "serve once, no file-watching" }, TUNNEL, NO_INPUT],
   examples: [
     { cmd: "fastagent dev" },
     { cmd: "fastagent dev --tunnel", note: "public URL + registered/guided webhooks" },
@@ -110,7 +98,6 @@ const dev: CommandSpec = {
       port: f.port as string | undefined,
       bind: f.bind as string | undefined,
       model: f.model as string | undefined,
-      authPath: f.authPath as string | undefined,
       watch: f.watch !== false,
       tunnel: f.tunnel === true,
       input: f.input !== false,
@@ -147,12 +134,11 @@ const chat: CommandSpec = {
     "try it locally before serving. Same model/tool/skill/auth resolution as dev; pi handles " +
     "rendering, sessions, and /resume natively (its /login writes to the same fastagent auth file).",
   args: [DIR_ARG],
-  flags: [MODEL, AUTH_PATH],
+  flags: [MODEL],
   examples: [{ cmd: "fastagent chat" }],
   run: async (args, f) =>
     (await import("./commands/chat.ts")).runChat(args[0] as string, {
       model: f.model as string | undefined,
-      authPath: f.authPath as string | undefined,
     }),
 };
 
@@ -165,13 +151,12 @@ const info: CommandSpec = {
     "Read-only (never creates sessions / writes .gitignore); an unset model is reported, not fatal. " +
     "Run it first when something looks off.",
   args: [DIR_ARG],
-  flags: [JSON_FLAG, MODEL, AUTH_PATH, { flags: "--sessions-dir <dir>", description: "sessions directory override" }],
+  flags: [JSON_FLAG, MODEL, { flags: "--sessions-dir <dir>", description: "sessions directory override" }],
   examples: [{ cmd: "fastagent info" }, { cmd: "fastagent info --json", note: "for CI" }],
   run: async (args, f) =>
     (await import("./commands/info.ts")).runInfo(args[0] as string, {
       json: f.json === true,
       model: f.model as string | undefined,
-      authPath: f.authPath as string | undefined,
       sessionsDir: f.sessionsDir as string | undefined,
     }),
 };
@@ -203,12 +188,11 @@ const invoke: CommandSpec = {
     "stdout, tool/diagnostics to stderr, a failed turn exits non-zero. The all-agent counterpart of " +
     "`tool`, for CI smoke and quick checks. Same model resolution as dev.",
   args: [{ name: "<message>", description: "the user message for the turn" }, DIR_ARG],
-  flags: [MODEL, AUTH_PATH, NO_INPUT],
+  flags: [MODEL, NO_INPUT],
   examples: [{ cmd: `fastagent invoke "summarize today's inbox"` }],
   run: async (args, f) =>
     (await import("./commands/invoke.ts")).runInvoke(args[0] as string, args[1] as string, {
       model: f.model as string | undefined,
-      authPath: f.authPath as string | undefined,
       input: f.input !== false,
     }),
 };
@@ -220,12 +204,11 @@ const fire: CommandSpec = {
     "Run ONE schedule's turn immediately (authoring loop, like invoke) — fires schedules/<name>.ts now " +
     "without waiting for its cron. Reply→stdout; does NOT advance the schedule's fire state.",
   args: [{ name: "<name>", description: "the schedule name (schedules/<name>.ts)" }, DIR_ARG],
-  flags: [MODEL, AUTH_PATH, NO_INPUT],
+  flags: [MODEL, NO_INPUT],
   examples: [{ cmd: "fastagent fire daily-digest" }],
   run: async (args, f) =>
     (await import("./commands/fire.ts")).runFire(args[0] as string, args[1] as string, {
       model: f.model as string | undefined,
-      authPath: f.authPath as string | undefined,
       input: f.input !== false,
     }),
 };
@@ -256,7 +239,6 @@ const start: CommandSpec = {
     BIND,
     MODEL,
     { flags: "--sessions-dir <dir>", description: "sessions directory override" },
-    AUTH_PATH,
     TUNNEL,
     NO_INPUT,
   ],
@@ -273,7 +255,7 @@ const start: CommandSpec = {
     "            volume so a redeploy that replaces the directory never wipes it\n" +
     "  secrets:  FASTAGENT_SECRETS_DIR > <agent dir>/.secrets — .env + auth.json\n" +
     "  sessions: --sessions-dir > FASTAGENT_SESSIONS_DIR > <state>/sessions\n" +
-    "  auth:     --auth-path > FASTAGENT_AUTH_PATH > <secrets>/auth.json\n" +
+    "  auth:     FASTAGENT_AUTH_PATH > <secrets>/auth.json\n" +
     "            (project-level; point it at ~/.fastagent/.secrets/auth.json to\n" +
     "            share one credential across projects)",
   run: async (args, f) =>
@@ -282,7 +264,6 @@ const start: CommandSpec = {
       bind: f.bind as string | undefined,
       model: f.model as string | undefined,
       sessionsDir: f.sessionsDir as string | undefined,
-      authPath: f.authPath as string | undefined,
       tunnel: f.tunnel === true,
       input: f.input !== false,
     }),
@@ -455,7 +436,6 @@ const deploy: CommandSpec = {
         "(railway --run) provision INTO the project this dir is already linked to (skip create); by " +
         "default --run refuses a pre-existing link (could be unrelated/production)",
     },
-    AUTH_PATH,
     NO_INPUT,
   ],
   examples: [
@@ -476,7 +456,6 @@ const deploy: CommandSpec = {
       stop: f.stop === true,
       scaleToZero: f.scaleToZero !== false,
       intoLinked: f.intoLinked === true,
-      authPath: f.authPath as string | undefined,
       input: f.input !== false,
     }),
 };
@@ -578,14 +557,12 @@ const login: CommandSpec = {
       flags: "-g, --global",
       description: `store in ~/.fastagent/.secrets/auth.json — every agent here reads it for providers its own file lacks`,
     },
-    AUTH_PATH,
     NO_INPUT,
   ],
   examples: [{ cmd: "fastagent login" }, { cmd: "fastagent login openai" }, { cmd: "fastagent login openai -g" }],
   notes: "The positional is the PROVIDER (not a dir) — `cd` into your agent before logging in.",
   run: async (args, f) =>
     (await import("./commands/login.ts")).runLogin(args[0], {
-      authPath: f.authPath as string | undefined,
       global: f.global === true,
       input: f.input !== false,
     }),

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -43,7 +43,7 @@ import { failStartup, failUsage, placementOrExit } from "./fail.ts";
 /** How every command that runs the model enters its agent directory, in the one order that works. */
 export async function enterAgentCommand(
   dirArg: string,
-  opts: { model?: string; authPath?: string; input?: boolean },
+  opts: { model?: string; input?: boolean },
 ): Promise<ResolvedPlacement> {
   const placement = placementOrExit(resolve(dirArg));
   enterAgentEnv(placement.agentDir);
@@ -174,15 +174,15 @@ export async function reportAuth(
  */
 async function resolveFirstRunModel(
   agentDir: string,
-  options: { model?: string; authPath?: string; input?: boolean } = {},
+  options: { model?: string; input?: boolean } = {},
 ): Promise<void> {
   const { config, path: configPath } = await loadConfig(agentDir).catch(failStartup);
   if (resolveModelSpec(options.model, config)) return; // already set (flag > FASTAGENT_MODEL > config)
   if (options.input === false) return; // --no-input: never prompt (clig) — the opener raises the clear error
   if (!isInteractive()) return; // CI/deploy: the opener throws the actionable missing-model error
 
-  const authPath = resolveAuthPath(agentDir, options.authPath);
-  const fallbackAuthPath = resolveAuthFallback(options.authPath);
+  const authPath = resolveAuthPath(agentDir);
+  const fallbackAuthPath = resolveAuthFallback();
   // The picker lists the AGENT's surface: built-ins plus whatever its models.json declares, so a self-hosted endpoint
   // is pickable on first run instead of being invisible until hand-set.
   const models = await createPiModelRuntime({

--- a/src/deploy/agentcore/plan.ts
+++ b/src/deploy/agentcore/plan.ts
@@ -702,7 +702,7 @@ export function planAgentcoreDeploy(input: AgentcorePlanInput): AgentcorePlan {
     runbook.push(
       ``,
       input.modelAuth === undefined
-        ? `# Model auth: none found at the local auth path — pass --auth-path <file>, or \`--run\` carries it`
+        ? `# Model auth: none found at the local auth path — set FASTAGENT_AUTH_PATH, or \`--run\` carries it`
         : `# Model auth: your local auth is "${input.modelAuth}" — the plan can't read its value; \`--run\` carries it`,
       `#   as the FastagentAuthSeed parameter (base64 of auth.json), materialized on first boot.`,
     );

--- a/src/deploy/fly/plan.ts
+++ b/src/deploy/fly/plan.ts
@@ -184,7 +184,7 @@ export function planFlyDeploy(input: FlyPlanInput): FlyPlan {
     runbook.push(
       ``,
       modelAuth === undefined
-        ? `# Model auth: none found at the local auth path — a global \`fastagent login\` isn't read here; pass --auth-path <file> (e.g. ~/.fastagent/.secrets/auth.json), or \`--run\` carries it automatically.`
+        ? `# Model auth: none found at the local auth path — a global \`fastagent login\` isn't read here; set FASTAGENT_AUTH_PATH (e.g. ~/.fastagent/.secrets/auth.json), or \`--run\` carries it automatically.`
         : `# Model auth: your local auth is "${modelAuth}" — the plan can't read its value to set as a secret.`,
       `#   Set your provider API key as a Fly secret (fly secrets set KEY=...), OR place auth.json at /data/.secrets/ on the volume.`,
     );

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -106,11 +106,6 @@ export async function preflightDeploy(input: {
   force: boolean;
   /** The target delivers cron slots from an external clock and holds no resident process (AgentCore). */
   externalClock?: boolean;
-  /**
-   * The raw `--auth-path` flag; the chain (flag > FASTAGENT_AUTH_PATH > `<agentDir>/.secrets/auth.json`) is resolved
-   * HERE via {@link resolveAuthPath}.
-   */
-  authPathFlag: string | undefined;
 }): Promise<DeployPreflight> {
   const {
     placement: { agentDir, workspace },
@@ -118,7 +113,6 @@ export async function preflightDeploy(input: {
     run,
     force,
     externalClock,
-    authPathFlag,
   } = input;
   // The ONE derived placement fact every host plan needs: where the agent's files sit relative to the build context
   // (the workspace).
@@ -245,7 +239,7 @@ export async function preflightDeploy(input: {
   }
 
   // Probe auth from the SAME project-level file the opener/login use.
-  const authPath = resolveAuthPath(agentDir, authPathFlag);
+  const authPath = resolveAuthPath(agentDir);
   const models = await createPiModelRuntime({ agentDir, authPath });
   let modelAuth = modelSpec ? await probeAuthSource(models, modelSpec) : undefined;
   let modelKeyInDefinition = false;

--- a/src/deploy/railway/plan.ts
+++ b/src/deploy/railway/plan.ts
@@ -134,7 +134,7 @@ export function planRailwayDeploy(input: RailwayPlanInput): RailwayPlan {
   if (!isEnvKey(modelAuth)) {
     runbook.push(
       modelAuth === undefined
-        ? `# Model auth: none found at the local auth path — a global \`fastagent login\` isn't read here; pass --auth-path <file> (e.g. ~/.fastagent/.secrets/auth.json), or \`--run\` carries it automatically.`
+        ? `# Model auth: none found at the local auth path — a global \`fastagent login\` isn't read here; set FASTAGENT_AUTH_PATH (e.g. ~/.fastagent/.secrets/auth.json), or \`--run\` carries it automatically.`
         : `# Model auth: your local auth is "${modelAuth}" — the plan can't read its value to set as a variable.`,
       `#   Set your provider API key as a variable (railway variables set KEY=...), OR place auth.json on the ${MOUNT} volume.`,
     );

--- a/src/engines/pi/auth.ts
+++ b/src/engines/pi/auth.ts
@@ -59,7 +59,7 @@ async function withLockedAuthFile<T>(
   authPath: string,
   fn: (current: string | undefined) => Promise<LockResult<T>>,
 ): Promise<T> {
-  // 0700 unconditionally, including on a directory an operator named with `--auth-path`.
+  // 0700 unconditionally, including on a directory an operator named with FASTAGENT_AUTH_PATH.
   await ensureSecretsDir(dirname(authPath));
   if (!existsSync(authPath)) {
     try {

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -281,8 +281,9 @@ export function resolveSessionsDirOverride(
 }
 
 /**
- * The auth-file override: `--auth-path` flag > `FASTAGENT_AUTH_PATH` env > undefined (the opener then falls back to
- * {@link defaultAuthPath} under the {@link resolveSecretsDir} dir).
+ * The auth-file override: the SDK's `authPath` option > `FASTAGENT_AUTH_PATH` env > undefined (the opener then falls
+ * back to {@link defaultAuthPath} under the {@link resolveSecretsDir} dir). The CLI has no flag for it: a second
+ * spelling of one environment variable buys nothing, and the variable is what a deployed container reads anyway.
  */
 function resolveAuthPathOverride(flag: string | undefined, env: NodeJS.ProcessEnv = process.env): string | undefined {
   return resolveOverridePath(flag ?? env.FASTAGENT_AUTH_PATH);
@@ -294,7 +295,7 @@ export function defaultAuthPath(secretsDir: string): string {
 }
 
 /** The effective auth file for an agent: override if present, else `<secrets dir>/auth.json`. */
-export function resolveAuthPath(dir: string, flag: string | undefined, env: NodeJS.ProcessEnv = process.env): string {
+export function resolveAuthPath(dir: string, flag?: string, env: NodeJS.ProcessEnv = process.env): string {
   return resolveAuthPathOverride(flag, env) ?? defaultAuthPath(resolveSecretsDir(dir, env));
 }
 
@@ -307,10 +308,7 @@ export function resolveAuthPath(dir: string, flag: string | undefined, env: Node
  * the Fly/Railway/AgentCore artifacts set, and a deployed container must read its mounted credentials and nothing
  * else (the artifact is the truth).
  */
-export function resolveAuthFallback(
-  flag: string | undefined,
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
+export function resolveAuthFallback(flag?: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
   const explicit = resolveAuthPathOverride(flag, env) ?? resolveOverridePath(env.FASTAGENT_SECRETS_DIR);
   return explicit === undefined ? GLOBAL_AUTH_PATH : undefined;
 }

--- a/src/engines/pi/login.ts
+++ b/src/engines/pi/login.ts
@@ -1,6 +1,6 @@
 /**
  * `fastagent login`: authenticate a MODEL PROVIDER into the resolved auth file (project-level
- * `<root>/.secrets/auth.json` by default, or `--auth-path`/`FASTAGENT_AUTH_PATH`) via the same {@link
+ * `<root>/.secrets/auth.json` by default, or `FASTAGENT_AUTH_PATH`) via the same {@link
  * fastagentCredentialStore} the runtime uses (one writer, one lock/corruption semantics).
  */
 import type {

--- a/src/engines/pi/open.ts
+++ b/src/engines/pi/open.ts
@@ -59,7 +59,7 @@ export interface AgentAssembly {
   workspace: string;
   /** Absolute state root (FASTAGENT_STATE_DIR > <agentDir>/.state). */
   stateRoot: string;
-  /** Absolute credentials file (--auth-path/authPath option > FASTAGENT_AUTH_PATH > <agentDir>/.secrets/auth.json). */
+  /** Absolute credentials file (`authPath` option > FASTAGENT_AUTH_PATH > <agentDir>/.secrets/auth.json). */
   authPath: string;
   /** Where a provider `authPath` does not have is read from instead ({@link resolveAuthFallback}); unset when an
    *  explicit path was named. */

--- a/src/engines/pi/session-builder.ts
+++ b/src/engines/pi/session-builder.ts
@@ -25,7 +25,7 @@ import { resolveAgentAssembly } from "./open.ts";
 export interface BuildSessionRuntimeOptions {
   /** Model spec override (the CLI --model flag). */
   model?: string;
-  /** Credentials file override (the CLI --auth-path flag). */
+  /** Credentials file override (the SDK `authPath` option; the CLI has only `FASTAGENT_AUTH_PATH`). */
   authPath?: string;
 }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -250,7 +250,7 @@ export async function ensureSecretsDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true, mode: SECRETS_DIR_MODE });
   await chmod(dir, SECRETS_DIR_MODE).catch((e: Error) => {
     throw new Error(
-      `cannot secure secrets dir ${dir} (fastagent keeps it 0700): ${e.message} — point --auth-path/FASTAGENT_SECRETS_DIR at a directory this process owns`,
+      `cannot secure secrets dir ${dir} (fastagent keeps it 0700): ${e.message} — point FASTAGENT_AUTH_PATH/FASTAGENT_SECRETS_DIR at a directory this process owns`,
       { cause: e },
     );
   });

--- a/test/cli-kernel.test.ts
+++ b/test/cli-kernel.test.ts
@@ -175,7 +175,7 @@ describe("cli kernel: help styling — bold headings, NO colors; errors carry th
 describe("cli kernel: the option-key naming rule", () => {
   it("optionKey: camelCase of the long name; --no-x negates and stores under x", () => {
     expect(optionKey("--json")).toBe("json");
-    expect(optionKey("--auth-path <file>")).toBe("authPath");
+    expect(optionKey("--sessions-dir <dir>")).toBe("sessionsDir");
     expect(optionKey("--no-input")).toBe("input");
     expect(optionKey("--no-scale-to-zero")).toBe("scaleToZero");
     expect(optionKey("-h, --help")).toBe("help");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -585,9 +585,12 @@ describe("cli papercuts", () => {
     expect(stderr).toMatch(/no agent here \(no fastagent\.config\.\*, here or one level inside\)/);
     await expect(stat(join(cwd, ".secrets"))).rejects.toThrow(); // nothing created in the non-agent dir
 
-    // …and it is silent when --auth-path outranks the fallback: an announcement naming a file the run
-    // does not write would be worse than none.
-    const directed = await run(["login", "no-such-provider", "--auth-path", join(cwd, "auth.json")], cwd, env);
+    // …and it is silent when FASTAGENT_AUTH_PATH outranks the fallback: an announcement naming a file the
+    // run does not write would be worse than none.
+    const directed = await run(["login", "no-such-provider"], cwd, {
+      ...env,
+      FASTAGENT_AUTH_PATH: join(cwd, "auth.json"),
+    });
     expect(directed.stderr).not.toMatch(/logging in GLOBALLY/);
 
     // Standing INSIDE an agent is NOT "outside an agent" — resolvePlacement refuses that position with
@@ -601,16 +604,16 @@ describe("cli papercuts", () => {
     expect(nested.stderr).not.toMatch(/logging in GLOBALLY/);
   });
 
-  it("login --auth-path at the user-global credential is the documented sharing path, not a leak", async () => {
-    // `--auth-path ~/.fastagent/.secrets/auth.json` from inside an agent is how docs/cli.md says to run
-    // several agents off one account. Warning about it would be advice against our own documentation:
+  it("FASTAGENT_AUTH_PATH at the user-global credential is the documented sharing path, not a leak", async () => {
+    // `FASTAGENT_AUTH_PATH=~/.fastagent/.secrets/auth.json` from inside an agent is how docs/cli.md says to
+    // pin every agent to one account. Warning about it would be advice against our own documentation:
     // that directory is fastagent's own machinery home and needs no .gitignore.
     const home = await mkdtemp(join(tmpdir(), "fa-share-home-"));
     const cwd = join(await agentWorkspace("fa-share-agent-"), "fastagent");
     const env: NodeJS.ProcessEnv = { ...process.env, HOME: home };
     delete env.FASTAGENT_AUTH_PATH;
     const shared = join(home, ".fastagent", ".secrets", "auth.json");
-    const { stderr } = await run(["login", "no-such-provider", "--auth-path", shared], cwd, env);
+    const { stderr } = await run(["login", "no-such-provider"], cwd, { ...env, FASTAGENT_AUTH_PATH: shared });
     expect(stderr).not.toMatch(/cannot be committed/);
   });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -128,7 +128,7 @@ describe("models: createPiModels honors authPath (the project-level credential s
 });
 
 describe("config: resolveAuthPath (auth-file precedence)", () => {
-  it("precedence --auth-path > FASTAGENT_AUTH_PATH > the agent default; a given value goes absolute", () => {
+  it("precedence: the authPath option > FASTAGENT_AUTH_PATH > the agent default; a given value goes absolute", () => {
     // Asserted through the ONE function commands call, not its internal override step: same coverage,
     // one less export existing only for a test.
     const env = { FASTAGENT_AUTH_PATH: "envauth.json" } as NodeJS.ProcessEnv;

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -28,7 +28,6 @@ const call = (target: string, config: FastagentConfig, over: Partial<Parameters<
     config,
     run: false,
     force: false,
-    authPathFlag: undefined,
     ...over,
   });
 
@@ -322,7 +321,6 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
         config: { model: "openai/gpt-4o-mini" },
         run: false,
         force: false,
-        authPathFlag: undefined,
         ...over,
       });
     const saved = process.env.FASTAGENT_SECRETS_DIR;

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -194,7 +194,7 @@ describe("paths: the secrets directory carries a mode", () => {
     denyChmod.armed = true;
     try {
       await expect(ensureSecretsDir(dir)).rejects.toThrow(
-        /cannot secure secrets dir .*\.secrets \(fastagent keeps it 0700\): EPERM.*--auth-path\/FASTAGENT_SECRETS_DIR/,
+        /cannot secure secrets dir .*\.secrets \(fastagent keeps it 0700\): EPERM.*FASTAGENT_AUTH_PATH\/FASTAGENT_SECRETS_DIR/,
       );
     } finally {
       denyChmod.armed = false;


### PR DESCRIPTION
Three things, all from one pass over `docs/design/configuration.md` against `src/`.

## 1. The design doc said nothing was implemented

It still read "Nothing here is implemented yet" after five of its six steps had merged.

- **Status** `proposed` → `partially implemented`, with the day-one/day-two split stated up front so a reader knows which `--env` sentences are design rather than code.
- **§5** now states the two properties of the credential chain that were actually built and that a linear three-layer description hides: the fallback is per **provider** (a file-level one would hide every other provider the moment `login anthropic` runs), and an explicitly named path takes **no** second layer (otherwise a deployed container would mount the builder's home as one). Also records that `deploy` reads the project file only.
- **§12** carries the PR that landed each step. `config.name` moves from step 2 to step 4 — its only consumer is the `<name>-<env>` prefix, so alone it is a field nothing reads.
- **§14** checks the three acceptance items the offline suite covers.

## 2. `--auth-path` is gone

§6 always called for this; it had no owning step. The flag was a second spelling of `FASTAGENT_AUTH_PATH` on eight commands, and the env var is what a deployed container reads anyway. Removed from the CLI, including `preflight`'s `authPathFlag` parameter and the now-dead `authPath` option on each command's type.

The SDK's `authPath` option is untouched — `createPiAgentFromDir`, `createPiModels`, and `resolveAuthPath` still take it. Only the CLI surface shrank.

Two e2e tests moved to the env var; the runbook lines in the fly/railway/agentcore plans and every doc mention now name `FASTAGENT_AUTH_PATH`.

## 3. `deploy` no longer plans to audit remote variables

§9 said the plan would list remote variable names and report the ones outside the ownership union as `unmanaged`. Moved to §11 (Not doing): a tool that writes a subset has no standing to audit the rest, and "unmanaged" about a variable someone set on purpose is a warning with no action behind it. Nothing outside the union is written, which is the property that mattered.

`npm run lint && npm run typecheck && npm test` pass (1677 passed).