### PR TITLE
ci(live): carry a refreshed credential back, and correct the day-one coverage claim

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -123,13 +123,15 @@ jobs:
       # refresh, so any file sharing this grant goes stale the moment another one refreshes it — a
       # maintainer's laptop and this workflow must not be the same grant.
       #
-      # The secret is a SNAPSHOT, and rotation makes it single-use: OpenAI returns a NEW refresh token on
-      # every refresh and voids the old one, while CI's copy dies with the runner. So runs succeed for as
-      # long as the stored ACCESS token lasts (no refresh needed), and the first run past its expiry
-      # spends the stored refresh token — every run after that fails `refresh_token_reused`. Re-run the
-      # login above and re-set the secret. An API-key credential in the same variable has no refresh at
-      # all and avoids the question entirely.
+      # An OAuth grant here is SINGLE-USE unless it is carried back: the provider returns a new refresh
+      # token on every refresh and voids the old one, while the runner's copy dies with the job. Runs
+      # therefore succeed for as long as the stored ACCESS token lasts, and the first run past its
+      # expiry spends the stored refresh token — after which every run fails `refresh_token_reused`.
+      # The "Persist a refreshed credential" step below closes that loop; the digest recorded here is
+      # how it knows a refresh happened. (An API-key credential in the same variable has no refresh at
+      # all, and needs neither step.)
       - name: Stage the model credential
+        id: stage
         env:
           FASTAGENT_AUTH_JSON: ${{ secrets.FASTAGENT_AUTH_JSON }}
         run: |
@@ -139,6 +141,7 @@ jobs:
           test -n "$FASTAGENT_AUTH_JSON" || { echo "secrets.FASTAGENT_AUTH_JSON is not set for this environment"; exit 1; }
           install -d -m 700 "$RUNNER_TEMP/secrets"
           umask 077 && printf '%s' "$FASTAGENT_AUTH_JSON" > "$RUNNER_TEMP/secrets/auth.json"
+          echo "digest=$(sha256sum "$RUNNER_TEMP/secrets/auth.json" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       # The ONE version both probes land on, resolved here so they cannot land on two. `latest`
       # rather than this checkout's version: between a `chore(release)` merge and the Release that
@@ -207,6 +210,44 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: npm run test:live
+
+      # THE OTHER HALF of staging: a refresh that happened during this run exists only on this runner,
+      # and the token it consumed is already void at the provider. Not writing it back is what makes the
+      # stored grant single-use.
+      #
+      # `always()`, because a refresh that already happened must be kept even when a later probe failed
+      # or the job was cancelled — the alternative is a secret whose refresh token the provider has
+      # already voided. Only when the file CHANGED, so an ordinary run (access token still valid, no
+      # refresh) touches nothing.
+      #
+      # This is safe here for one reason worth stating: the `live` concurrency group serializes runs, so
+      # there is never a second job holding the same grant. Two concurrent runs would each refresh and
+      # void the other's token, which is why this pattern belongs to a serialized workflow and not to a
+      # matrix. A LOCAL run against the same grant is the case nothing here can prevent — mint CI its
+      # own (`FASTAGENT_AUTH_PATH=… fastagent login`), never share a developer's.
+      #
+      # The PAT needs exactly one permission: write access to this repository's secrets. It cannot be
+      # GITHUB_TOKEN, which has no secrets scope at all. A failure here FAILS THE RUN rather than
+      # warning: the next run would break with a `refresh_token_reused` that points at the provider
+      # instead of at this step.
+      - name: Persist a refreshed credential
+        if: always() && steps.stage.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.LIVE_AUTH_WRITEBACK_TOKEN }}
+        run: |
+          test -n "$GH_TOKEN" || {
+            echo "secrets.LIVE_AUTH_WRITEBACK_TOKEN is not set — a refreshed credential cannot be kept," \
+                 "and this grant becomes single-use (see the staging step)"
+            exit 1
+          }
+          after=$(sha256sum "$RUNNER_TEMP/secrets/auth.json" | cut -d' ' -f1)
+          if [ "$after" = "${{ steps.stage.outputs.digest }}" ]; then
+            echo "credential unchanged (no refresh this run)"
+            exit 0
+          fi
+          gh secret set FASTAGENT_AUTH_JSON --env live --repo "$GITHUB_REPOSITORY" \
+            < "$RUNNER_TEMP/secrets/auth.json"
+          echo "refreshed credential written back to secrets.FASTAGENT_AUTH_JSON"
 
       # The deploy probe destroys its own app in afterAll, which a job timeout or a cancelled run
       # never reaches — and what it leaves behind is a running Fly app holding the model credential

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -226,10 +226,25 @@ jobs:
       # matrix. A LOCAL run against the same grant is the case nothing here can prevent — mint CI its
       # own (`FASTAGENT_AUTH_PATH=… fastagent login`), never share a developer's.
       #
-      # The PAT needs exactly one permission: write access to this repository's secrets. It cannot be
-      # GITHUB_TOKEN, which has no secrets scope at all. A failure here FAILS THE RUN rather than
-      # warning: the next run would break with a `refresh_token_reused` that points at the provider
-      # instead of at this step.
+      # The PAT needs exactly one fine-grained permission: **Environments: Read and write**. Not
+      # "Secrets" — that one governs REPOSITORY secrets, while this writes an ENVIRONMENT secret, and
+      # GitHub says so itself in the `x-accepted-github-permissions` response header
+      # (`environments=read` for the public key, `environments=write` for the PUT). It cannot be
+      # GITHUB_TOKEN, which cannot write secrets at all.
+      #
+      # Verify a replacement token WITHOUT waiting for a refresh — this step only runs when the
+      # credential actually changed, so a wrong permission would otherwise surface on the one night it
+      # matters, after the stored refresh token has already been spent:
+      #
+      #   curl -sS -D- -o/dev/null -X PUT -H "Authorization: Bearer $PAT" \
+      #     -d '{"encrypted_value":"x","key_id":"1"}' \
+      #     https://api.github.com/repos/$GITHUB_REPOSITORY/environments/live/secrets/PROBE
+      #
+      # 403 with `x-accepted-github-permissions: environments=write` means the permission is missing;
+      # 422 means it is present and only the payload was junk.
+      #
+      # A failure here FAILS THE RUN rather than warning: the next run would break with a
+      # `refresh_token_reused` that points at the provider instead of at this step.
       - name: Persist a refreshed credential
         if: always() && steps.stage.outcome == 'success'
         env:

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -8,7 +8,7 @@ status: partially implemented
 
 **Status: partially implemented.** This is the design conclusion for [#482](https://github.com/fastagent-sh/fastagent/issues/482). It replaces that RFC's file layout and command surface with a smaller one; §11 lists what was dropped and why. The code truth is `src/`; §12 is the sequencing and carries what has landed.
 
-**The day-one tier is built (steps 1–3). The env dimension (§2's day two, step 4) is not, and is deliberately not scheduled** — it is a pure addition with no demand behind it yet, so every `--env` sentence below describes a design that is ready rather than code that exists. §12 also lists the day-one leftover that is still open.
+**The day-one tier is built and complete (steps 1–3). The env dimension (§2's day two, step 4) is not, and is deliberately not scheduled** — it is a pure addition with no demand behind it yet, so every `--env` sentence below describes a design that is ready rather than code that exists.
 
 The user-facing document for what exists today is [configuration.md](../configuration.md).
 
@@ -238,13 +238,10 @@ Each step is usable on its own and is its own PR. 1 and 3 are small, 2 and 4 are
 
 `config.name` moved from step 2 to step 4: its only consumer is the `<name>-<env>` prefix, so on its own it is a config field nothing reads.
 
-### Still open from day one
-
-One item is outside every step above, and it blocks nothing:
-
-| Left | Where it is written | Why it is still open |
-|---|---|---|
-| Every supported host has an end-to-end check | §14 | `test/live/` probes exist, but no host is covered end to end |
+Nothing from day one is left open. The host coverage §14 asks for exists: `docker`, `fly-deploy`,
+`railway-deploy`, and `agentcore-deploy` in `test/live/` each provision a real deployment, serve a turn
+through it, and tear it down. What they do NOT cover is the part of §14 that presumes `--env`, which is
+step 4.
 
 ## 13. Known costs
 
@@ -271,4 +268,4 @@ Checked boxes are covered by a test in the offline suite. The unchecked ones are
 - [x] Concurrent local projects share the global credential file safely.
 - [x] With no usable credential, **no public entrance is activated**; a redeploy against a host that already holds one does not overwrite it.
 - [ ] Redeploy, rollback, restart, and session-snapshot restore all preserve the latest credentials.
-- [ ] Every supported host has an end-to-end check for the above; unsupported capability combinations fail explicitly.
+- [x] Every supported host has an end-to-end check (`test/live/{docker,fly-deploy,railway-deploy,agentcore-deploy}`: provision, serve a turn, destroy) — of deployment itself, not of the `--env` items above.

--- a/test/live/README.md
+++ b/test/live/README.md
@@ -8,6 +8,10 @@ Excluded from `npm test`. `npm run test:live` (`vitest.live.config.ts`) opts in,
 credential **fails** rather than skips — you asked for them. Credentials arrive the product's way
 (`FASTAGENT_AUTH_PATH` → an `auth.json`), which is what lets an OAuth-only provider be the model.
 
+Running these LOCALLY against the same grant CI holds will break CI: an OAuth refresh voids the token
+the other copy still has. Give a local run its own (`FASTAGENT_AUTH_PATH=… fastagent login`), which is
+also what `.github/workflows/live.yml` does for CI.
+
 ## Two rules
 
 **Drive a product entry, observe from outside it.** `createPiAgentFromDir`, `deploy docker --run`,


### PR DESCRIPTION
Two things that both amount to "make live's state accurate".

## 1. The stored OAuth grant was effectively single-use

The provider returns a new refresh token on every refresh and voids the old one, while the runner's copy dies with the job. So runs succeeded for as long as the stored ACCESS token lasted, and the first run past its expiry spent the stored refresh token — after which every run failed `refresh_token_reused`. That is exactly how live broke: the nightly refreshed once, and a manual re-run an hour later was already dead.

`Persist a refreshed credential` closes the loop. Three properties worth stating:

- **`if: always()`** — a refresh that already happened must be kept even when a later probe failed or the job was cancelled. The alternative is a secret whose refresh token the provider has already voided.
- **Only when the file changed**, compared against a digest the staging step records. An ordinary run (access token still valid, no refresh) touches nothing.
- **Failure fails the run**, not a warning. The next run would otherwise break with a `refresh_token_reused` that points at the provider instead of at this step.

This is safe *here* because `concurrency: group: live` already serializes runs, so no second job holds the same grant. The pattern belongs to a serialized workflow, not a matrix — the comment says so, because two concurrent runs would each void the other's token.

The PAT needs **Environments: Read and write**, not "Secrets" (that governs *repository* secrets). GitHub states this in the `x-accepted-github-permissions` response header, and the comment carries a `curl` that verifies a replacement token without waiting for a refresh — this step only runs when the credential actually changed, so a wrong permission would otherwise surface on the one night it matters, after the refresh token has been spent.

`test/live/README.md` gains the corollary: running these probes locally against the grant CI holds will break CI.

## 2. Day one was already complete

`docs/design/configuration.md` listed "every supported host has an end-to-end check" as the last day-one leftover, with "`test/live/` probes exist, but no host is covered end to end". Wrong: `docker`, `fly-deploy`, `railway-deploy`, and `agentcore-deploy` each provision a real deployment, serve a turn through it, and destroy it. What they genuinely do not cover is the part of §14 that presumes `--env` — which is step 4, not scheduled. The acceptance item now says both halves, and the "Still open from day one" table is gone because nothing is.