### PR TITLE
refactor(config): one config filename, not a family

### DIFF
--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -40,7 +40,7 @@ Preserve existing code, context, credentials, and deployment ownership.
 | Deterministic operations and external-system access | `tools/<name>.ts` | Expose a small typed capability with runtime input validation, useful results, and visible failures. |
 | Event ingress and conversational replies | `channels/` | Start with a first-party channel. It owns protocol verification and routing; chat integrations also deliver normal replies. GitHub is ingress-only. |
 | Clock triggers and deliberate follow-ups | `schedules/` and the opt-in `wake` tool | State the work and its recipient. A timer triggers a turn; it does not deliver the reply. |
-| Model, serving, and deployment choices | `fastagent.config.*` | Keep configuration declarative. Use [supported keys](configuration.md#config-file). |
+| Model, serving, and deployment choices | `fastagent.config.ts` | Keep configuration declarative. Use [supported keys](configuration.md#config-file). |
 | Credentials and machine state | `.secrets/`, `.state/`, or their configured roots | Let FastAgent manage auth, journals, channel state, and scheduling records. Preserve them according to the host. |
 | Business notes and decisions | Existing working files or an explicitly chosen durable store | Record sources, approval decisions, outcomes, and pending work. A session journal is not a business database. |
 
@@ -58,7 +58,7 @@ network, and credentials. Constrain the whole process when isolation is required
 ## 2. Choose placement and initialize once
 
 The **workspace** is the directory passed to FastAgent: the agent's working directory and deployment
-build context. The **agent directory** holds `fastagent.config.*` and the definition. They can be different
+build context. The **agent directory** holds `fastagent.config.ts` and the definition. They can be different
 directories or the same directory.
 
 | Situation | Placement |
@@ -68,7 +68,7 @@ directories or the same directory.
 | An existing application embeds the agent | Keep the application's layout. A nested definition is convenient; the app retains auth, routes, database, and deployment. See [embedding](#8-embed-only-what-the-application-needs). |
 
 A config file identifies an agent, not its directory name. Check the workspace itself and its direct
-children for `fastagent.config.ts`, `.js`, or `.mjs` before running `init`. Reuse an existing definition.
+children for `fastagent.config.ts` before running `init`. Reuse an existing definition.
 `--agent-dir bot` selects another name; multiple sibling agents are selected with `FASTAGENT_AGENT`.
 See [Configuration](configuration.md#more-than-one-agent). Optional directories remain optional.
 
@@ -89,7 +89,7 @@ my-agent/                         # workspace; run FastAgent commands here
     ├── persona.md
     ├── skills/writing-great-skills/
     ├── tools/fetch-url.ts
-    ├── fastagent.config.mjs
+    ├── fastagent.config.ts
     ├── package.json              # type: module; FastAgent is a local dependency
     ├── .secrets/.env.example
     └── .gitignore
@@ -106,10 +106,11 @@ For a flat agent, omit the `fastagent/` path prefix and npm's `--prefix fastagen
 
 ## 3. Use TypeScript for new authored code
 
-Prefer **TypeScript for tools, channels, schedules, library helpers, and tests**. Runtime discovery also
-supports JavaScript (`.js` and `.mjs`); existing JavaScript remains valid. Keep the generated
-`fastagent.config.mjs`, Dockerfile, YAML/JSON host configuration, and generated deployment JavaScript in
-their generated formats. Those artifacts do not set the language for business code.
+Prefer **TypeScript for tools, channels, schedules, library helpers, and tests**. Runtime discovery of
+*your* code also supports JavaScript (`.js` and `.mjs`); existing JavaScript remains valid. The config
+file is the exception with no choice: it is always `fastagent.config.ts`, because fastagent generates it.
+Keep the generated Dockerfile, YAML/JSON host configuration, and generated deployment JavaScript in their
+generated formats. Those artifacts do not set the language for business code.
 
 Use **Node >= 22.19** (`node --version`) and ESM (`"type": "module"` in the agent's `package.json`, already
 set by the default scaffold). Node runs erasable TypeScript directly. It removes types without checking
@@ -265,7 +266,7 @@ Ask the owner to run `fastagent login` in this workspace's terminal, or have the
 provider key in `fastagent/.secrets/.env`. Keep credentials out of chat transcripts, issue comments,
 source files, and logs. The CLI reads the agent's `.secrets/.env`, not a workspace-root `.env`.
 
-Set `model: "provider/model-id"` in the existing `fastagent.config.mjs`, preserving its export. A terminal
+Set `model: "provider/model-id"` in the existing `fastagent.config.ts`, preserving its export. A terminal
 picker can also set the model; unattended invocations require an explicit model. A deployment resolves
 from two sources only — that config value, or `FASTAGENT_MODEL` in `fastagent/.secrets/.env`, which
 `deploy` reads from the file and records in the release manifest. A `--model` flag is local to the run
@@ -284,7 +285,7 @@ fastagent dev
 
 `dev` is a long-running server. Edits to `persona.md`, `AGENTS.md`, and skills are read on the next turn.
 With watching enabled, changes under the agent's `tools/`, `channels/`, `schedules/`, and `extensions/`
-restart the worker, as do changes to its `fastagent.config.*`, `package.json`, `models.json`, and resolved
+restart the worker, as do changes to its `fastagent.config.ts`, `package.json`, `models.json`, and resolved
 `.env` (only when that file is inside the agent directory).
 
 **After editing `fastagent/lib/batches.ts` or another imported helper outside those watched directories,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -732,7 +732,7 @@ callers already know):
 import { createAgentService } from "@fastagent-sh/fastagent";
 import { connectSessionControl } from "@fastagent-sh/fastagent/core";
 
-// Set `sessionControl: true` in fastagent.config.*; the plane is then mounted on the service's
+// Set `sessionControl: true` in fastagent.config.ts; the plane is then mounted on the service's
 // handler, owning the /control prefix — routes, preflight, 404/405 and a failing handler all carry
 // CORS headers, so a browser client can read every reply. SSE at /control/sessions/{id}/events.
 const service = await createAgentService("./my-agent");

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,11 +47,11 @@ fastagent init [dir] [--minimal] [--no-install] [--agent-dir <name>|--flat]
 
 Creates a self-iterating agent — it can edit its own definition (persona.md and skills are re-read every turn). A fresh agent has `persona.md` (the agent's identity: how to improve yourself), a `writing-great-skills` example skill (from [mattpocock/skills](https://github.com/mattpocock/skills) — the guide to authoring skills), a `fetch-url` example code tool, config, `.secrets/.env.example`, and `.gitignore`. No `AGENTS.md` is scaffolded (it is project context, not identity); an existing one is kept untouched. Everything is written offline; by default it also writes `package.json` and runs `npm install`. Ignore hygiene is two scaffolded files: the agent `.gitignore` (`node_modules/`, `.state/`, a stray `.env`) and `.secrets/.gitignore` (everything but `.env.example`). fastagent writes both once, at `init` — no later command reads, rewrites or verifies them, so they are yours. They are separate on purpose: the root one is the file you will edit, and a nested `.gitignore` outranks it, so the credentials stay protected either way.
 
-**Where the files land** — no detection and no prompt. By default the WHOLE agent — definition, config, `.secrets/`, `.state/` — goes into `./fastagent/`; the directory around it gets zero writes and becomes the agent's WORKSPACE when you point fastagent there. The agent self-contains its `package.json`, so the workspace's manifest and lockfile are never touched. `init` refuses when the target already holds a `fastagent.config.*` (already an agent) or any other content.
+**Where the files land** — no detection and no prompt. By default the WHOLE agent — definition, config, `.secrets/`, `.state/` — goes into `./fastagent/`; the directory around it gets zero writes and becomes the agent's WORKSPACE when you point fastagent there. The agent self-contains its `package.json`, so the workspace's manifest and lockfile are never touched. `init` refuses when the target already holds a `fastagent.config.ts` (already an agent) or any other content.
 
-`--agent-dir <name>` names that directory anything you like: **the name never decides what IS an agent** — a `fastagent.config.*` does, so `./bot/` and `./fastagent/` are equally agents. The name carries weight in exactly one place, and only among agents already identified: when a workspace holds several and nothing selects, the one named `fastagent` answers (see `FASTAGENT_AGENT` below). It must be a single directory name (a path would put the agent where fastagent's one-level lookup could not find it). To deploy it, keep the name to letters, digits, `-` and `_`: the release manifest carries it into the container, and `deploy` refuses anything else by name.
+`--agent-dir <name>` names that directory anything you like: **the name never decides what IS an agent** — a `fastagent.config.ts` does, so `./bot/` and `./fastagent/` are equally agents. The name carries weight in exactly one place, and only among agents already identified: when a workspace holds several and nothing selects, the one named `fastagent` answers (see `FASTAGENT_AGENT` below). It must be a single directory name (a path would put the agent where fastagent's one-level lookup could not find it). To deploy it, keep the name to letters, digits, `-` and `_`: the release manifest carries it into the container, and `deploy` refuses anything else by name.
 
-`--agent-dir .` (spelled `--flat`) puts the identical shape in the directory itself — for a standalone agent repo or a monorepo package, where the agent's tools operate on its own definition. Adopting a directory is the point, so **every file that already exists is kept** (reported, never overwritten); only a `fastagent.config.*` refuses, because that means it is already an agent. `deploy` does not accept this layout — it needs a workspace containing the agent, because a release replaces the agent directory and nothing else.
+`--agent-dir .` (spelled `--flat`) puts the identical shape in the directory itself — for a standalone agent repo or a monorepo package, where the agent's tools operate on its own definition. Adopting a directory is the point, so **every file that already exists is kept** (reported, never overwritten); only a `fastagent.config.ts` refuses, because that means it is already an agent. `deploy` does not accept this layout — it needs a workspace containing the agent, because a release replaces the agent directory and nothing else.
 
 What a served agent's workspace turns out to be is not decided here: it is whatever directory you later point fastagent at (see `dev`/`start` below). `init`'s one placement duty is to refuse a target the lookup could never SELECT — an agent already resolving AT `dir`, which wins over anything inside it and would hide the new one. A second agent BESIDE an existing one is fine and supported: several agents can share one workspace (an engineer's, a PM's, a content owner's, all driving the same repository), and `FASTAGENT_AGENT=<name>` picks between them — the one named `fastagent` answers by default. `init` prints the note when a workspace crosses into that shape. The config is a DECLARATION, not configuration: its contents may be `export default {}` (a model can come from `--model`), but a directory has to SAY it is an agent — the job `package.json` and `Cargo.toml` do for their tools. A directory holding nothing else is already a complete agent.
 
@@ -93,7 +93,7 @@ fastagent models [search]
 
 Lists available model specs in `provider/modelId` form. Pass a search string to filter.
 
-Use a listed spec with `--model`, `FASTAGENT_MODEL`, or `fastagent.config.*`.
+Use a listed spec with `--model`, `FASTAGENT_MODEL`, or `fastagent.config.ts`.
 
 ## `fastagent login`
 
@@ -135,7 +135,7 @@ fastagent dev [dir] [--port N] [--bind addr] [--model provider/modelId] [--no-wa
 
 Assembles the agent and serves it locally. persona.md/AGENTS.md/`skills/` are re-read every turn (edits go
 live next turn, no restart); a supervisor restarts the worker on edits to the code inputs —
-`tools/`, `channels/`, `schedules/`, `fastagent.config.*`, `package.json`, `.secrets/.env`.
+`tools/`, `channels/`, `schedules/`, `fastagent.config.ts`, `package.json`, `.secrets/.env`.
 
 With no model set and a terminal attached, `dev` first shows the full model catalog — models whose
 provider already has credentials are listed first and annotated with the source (e.g. `ready —
@@ -157,7 +157,7 @@ Options:
 Model precedence:
 
 ```txt
---model > FASTAGENT_MODEL > fastagent.config.* model
+--model > FASTAGENT_MODEL > fastagent.config.ts model
 ```
 
 ## `fastagent attach`
@@ -318,13 +318,13 @@ Runs the agent in production posture: no watch, same assembly as `dev`.
 Port precedence:
 
 ```txt
---port > PORT > fastagent.config.* http.port > 8787
+--port > PORT > fastagent.config.ts http.port > 8787
 ```
 
 Bind precedence:
 
 ```txt
---bind > fastagent.config.* http.host > all interfaces
+--bind > fastagent.config.ts http.host > all interfaces
 ```
 
 `dev` reads the same chain but ends it at `127.0.0.1` — see [Bind address](configuration.md#bind-address).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: "Configure a FastAgent agent: model selection, auth, ports, sessions, tools, channels, state paths, and deploy options in fastagent.config.*."
+description: "Configure a FastAgent agent: model selection, auth, ports, sessions, tools, channels, state paths, and deploy options in fastagent.config.ts."
 status: current
 ---
 
@@ -9,18 +9,19 @@ status: current
 FastAgent keeps behavior and deployment choices separate:
 
 - agent behavior lives in `persona.md` (identity), `skills/`, `tools/`, and `AGENTS.md` project context,
-- deployment choices live in `fastagent.config.*`, CLI flags, and environment variables,
+- deployment choices live in `fastagent.config.ts`, CLI flags, and environment variables,
 - secrets live in `<agent dir>/.secrets/` (`.env` + the project-level `auth.json`) or provider env vars.
 
 ## Config file
 
-An agent may contain exactly one config file:
+An agent is identified by exactly one filename:
 
 ```txt
 fastagent.config.ts
-fastagent.config.js
-fastagent.config.mjs
 ```
+
+One spelling, not a family — fastagent generates this file, so an extension to choose from would buy
+nothing. (Your own `tools/`, `channels/`, and `schedules/` still accept `.ts`, `.js`, or `.mjs`.)
 
 Example:
 
@@ -70,7 +71,7 @@ fastagent models gpt
 Precedence:
 
 ```txt
-CLI --model > FASTAGENT_MODEL > fastagent.config.* model
+CLI --model > FASTAGENT_MODEL > fastagent.config.ts model
 ```
 
 With none of these set, a serving command (`dev` / `start` / `invoke`) run in a terminal prompts you
@@ -237,13 +238,13 @@ Run `fastagent info` or `fastagent dev` to see the resolved auth source for the 
 Port precedence for `dev`:
 
 ```txt
---port > fastagent.config.* http.port > 8787
+--port > fastagent.config.ts http.port > 8787
 ```
 
 Port precedence for `start`:
 
 ```txt
---port > PORT > fastagent.config.* http.port > 8787
+--port > PORT > fastagent.config.ts http.port > 8787
 ```
 
 Use `PORT` in hosted environments that inject a port.
@@ -251,8 +252,8 @@ Use `PORT` in hosted environments that inject a port.
 ## Bind address
 
 ```txt
-dev:   --bind > fastagent.config.* http.host > 127.0.0.1
-start: --bind > fastagent.config.* http.host > all interfaces
+dev:   --bind > fastagent.config.ts http.host > 127.0.0.1
+start: --bind > fastagent.config.ts http.host > all interfaces
 ```
 
 `localhost` is accepted and resolved to `127.0.0.1` as it is read, so what binds, what the startup
@@ -448,7 +449,7 @@ built for serving, and it is concurrency-safe.
 ### When the repo already owns `tools/` or `channels/`
 
 Nothing to do — the agent lives in `./fastagent/`, so FastAgent scans the agent's own directories,
-never the workspace's names. `fastagent.config.*` identifies the agent directory; `fastagent/` is its
+never the workspace's names. `fastagent.config.ts` identifies the agent directory; `fastagent/` is its
 default name. Within the agent, a broken tool is reported and skipped, while
 a broken declared channel fails serving — an inbound endpoint must not silently disappear. If you want
 programmatic tools outside the agent, declare them with `config.tools`.
@@ -479,7 +480,7 @@ Share code through packages or real files, not symlinks in code-input directorie
 
 ## Channels
 
-Channels are not configured in `fastagent.config.*`. A channel needs glue code, so its file is the
+Channels are not configured in `fastagent.config.ts`. A channel needs glue code, so its file is the
 enable switch: `.ts` / `.js` / `.mjs` files under `channels/` are enabled; rename one to
 `<name>.ts.disabled` to disable it without introducing a second config source.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -204,7 +204,7 @@ AgentCore differs from the resident-box hosts in kind — the platform has **no 
 
 What to know before choosing it:
 
-- **The idle tail is the standing cost, and you set it.** Compute is reclaimed after `deploy.agentcore.idleTimeoutSeconds` (default 180 s, AWS bounds 60–1209600) of idle, and memory bills for that whole tail; a session past it cold-starts on the next message. A chat agent talked to in bursts is cheaper to keep warm than to restart, a schedule-only agent is not — raise or lower it in `fastagent.config.*`. A turn in flight is never cut short: `/ping` reports `HealthyBusy` while work is running.
+- **The idle tail is the standing cost, and you set it.** Compute is reclaimed after `deploy.agentcore.idleTimeoutSeconds` (default 180 s, AWS bounds 60–1209600) of idle, and memory bills for that whole tail; a session past it cold-starts on the next message. A chat agent talked to in bursts is cheaper to keep warm than to restart, a schedule-only agent is not — raise or lower it in `fastagent.config.ts`. A turn in flight is never cut short: `/ping` reports `HealthyBusy` while work is running.
 - **A deploy resets the state.** Storage is the platform's managed SessionStorage at `/mnt/data`. It keeps the workspace, `.state` and `.secrets` across compute stop/resume — an idle-reclaimed agent resumes with its memory — and AWS **wipes it on every runtime version update, i.e. on every deploy**, and after 14 idle days. So sessions, channel state and pending wake-ups start blank after each deploy. Cross-deploy memory would need EFS or S3 Files, both VPC-only and therefore a NAT gateway for model/channel egress (~$33/mo standing); if you need it, use `deploy fly` or `deploy railway` and their real volumes. The S3 bucket here holds only the forwarder deployment package.
 - **Deploying is re-authenticating.** The credential seed is absent-only, so a restart keeps an `auth.json` the box rotated and a deploy re-seeds from `FASTAGENT_AUTH_SEED`. Caveat for OAuth: a refresh token is single-use and shared with your machine, so the box can lose model access between deploys — deploy again, or use a provider API key.
 - **Nothing opens before the first invocation.** Runtime filesystems appear on invoke, so `/ping` answers immediately while the definition, credentials and channels wait for the first envelope. `deploy --run` probes exactly that path, so a bad credential or a broken `channels/` module fails at deploy time with the runtime's own error text.
@@ -247,7 +247,7 @@ The generated `Dockerfile` runs the directory on any container platform; `fastag
 
 `config.deploy.apt` bakes extra apt packages into the image; a package needing a custom apt repo or a different base image means providing your own `Dockerfile` (`deploy` keeps an existing one). See [Configuration](configuration.md#config-file).
 
-`.git` ships in the image by default (the agent's pull/push loop needs it); for a smaller image with no git needs, add a `.git` line to the generated `.dockerignore`. The git **binary** is baked in exactly when the workspace ships a `.git`; a non-git workspace that still needs git declares `deploy: { apt: ["git"] }` in `fastagent.config.*`.
+`.git` ships in the image by default (the agent's pull/push loop needs it); for a smaller image with no git needs, add a `.git` line to the generated `.dockerignore`. The git **binary** is baked in exactly when the workspace ships a `.git`; a non-git workspace that still needs git declares `deploy: { apt: ["git"] }` in `fastagent.config.ts`.
 
 ## Single-machine tier
 

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -206,7 +206,7 @@ Dropped from the RFC, and from earlier drafts of this document:
 | Moving `.env` out of `.secrets/` | `.secrets/` is the one directory the `.gitignore` and the image excludes already cover |
 | Removing `FASTAGENT_SECRETS_DIR` / `FASTAGENT_STATE_DIR` / `FASTAGENT_AUTH_PATH` | The fly/railway/agentcore plans point them at the mounted volume, and the deployed container locates `auth.json` through that chain. Only the corresponding CLI flags can go |
 | A `--profile` selector, a current-environment switch, arbitrary credential-path options, a custom encryption/key-distribution framework | Orchestration or scope creep |
-| Reading back deployed state to diff it, moving generated artifacts into `.state/`, narrowing `AGENT_CONFIG_NAMES` to `fastagent.config.ts` | None is needed for anything above, and each is unrelated to env or credential ownership |
+| Reading back deployed state to diff it, moving generated artifacts into `.state/` | Neither is needed for anything above, and each is unrelated to env or credential ownership |
 
 ## 12. Implementation sketch and sequencing
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -41,7 +41,7 @@ One agent shape, one marker:
 ├── persona.md              # optional identity
 ├── AGENTS.md               # optional project context
 ├── skills/  tools/  channels/  schedules/
-├── fastagent.config.ts    # THE marker
+├── fastagent.config.ts     # THE marker
 ├── models.json             # optional custom model endpoints (pi's schema, definition-local so it
 │                           # travels into the image; pi's machine-global ~/.pi one stays unread)
 ├── .gitignore              # scaffolded once by init, yours after

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -41,7 +41,7 @@ One agent shape, one marker:
 ├── persona.md              # optional identity
 ├── AGENTS.md               # optional project context
 ├── skills/  tools/  channels/  schedules/
-├── fastagent.config.mjs    # THE marker
+├── fastagent.config.ts    # THE marker
 ├── models.json             # optional custom model endpoints (pi's schema, definition-local so it
 │                           # travels into the image; pi's machine-global ~/.pi one stays unread)
 ├── .gitignore              # scaffolded once by init, yours after
@@ -60,7 +60,7 @@ repo/                       # `fastagent dev` here  → agent = repo/agent, work
 ├── src/
 └── agent/                  # `fastagent dev` here  → agent = repo/agent, workspace = repo/agent
     ├── persona.md  skills/  tools/  channels/  schedules/
-    ├── fastagent.config.mjs
+    ├── fastagent.config.ts
     └── .secrets/  .state/
 ```
 
@@ -71,7 +71,7 @@ standalone agent repo, a monorepo package) is the same rule with the two directo
 
 | `dir` | Result |
 |---|---|
-| holds a `fastagent.config.*` | `{ agentDir: dir, workspace: dir }` |
+| holds a `fastagent.config.ts` | `{ agentDir: dir, workspace: dir }` |
 | exactly one directory inside it holds one | `{ agentDir: <that dir>, workspace: dir }` |
 | several do | `FASTAGENT_AGENT` names one, else the one named `fastagent` — else throws, naming them |
 | none | throws: not a fastagent agent, with the exit that fits the position |

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -369,7 +369,7 @@ subpaths. Within a serving process, they share the mounted channel's credentials
 token cache, bounded retries, and UTF-8 text splitting. Feishu and Lark remain isolated even in one
 workspace. With no channel mounted (`fire`, `invoke`, `tool`, or an embedded agent), the transport
 reads the matching `FEISHU_*` / `LARK_*` environment credentials and uses that cloud's default gateway.
-Standalone sending requires no `fastagent.config.*`; an embedded agent can use a bare definition
+Standalone sending requires no `fastagent.config.ts`; an embedded agent can use a bare definition
 directory or an independent `cwd`.
 
 `tools/feishu-send.ts` / `tools/lark-send.ts` are the package's, not authored glue: re-running

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,7 +22,7 @@ agent/
 ├── extensions/         # optional pi extension modules (chat only — see configuration.md)
 ├── AGENTS.md           # optional project context (yours, or a host repo's)
 ├── reference.md        # optional markdown context (any file layout)
-└── fastagent.config.mjs # optional deployment choices
+└── fastagent.config.ts # optional deployment choices
 ```
 
 ## What FastAgent provides
@@ -123,7 +123,7 @@ fastagent add feishu   # 飞书; Lark international: fastagent add lark
 Implemented today:
 
 - Agent Handler v0.1 reference implementation over pi.
-- Directory assembly from `persona.md`, `AGENTS.md` project context, `skills/`, discovered `tools/`, and `fastagent.config.*`.
+- Directory assembly from `persona.md`, `AGENTS.md` project context, `skills/`, discovered `tools/`, and `fastagent.config.ts`.
 - HTTP/SSE invoke channel.
 - GitHub, Telegram, Slack, and Feishu channel adapters (Lark international rides the same engine as a compatibility profile).
 - Cron schedules (`schedules/` files) and opt-in agent self-scheduling (the `wake` tool), with a per-run audit.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ my-agent/                              # the workspace — the agent's cwd, unto
     ├── persona.md                     # its identity — how to improve yourself
     ├── skills/writing-great-skills/   # the example skill: how to author skills well
     ├── tools/fetch-url.ts             # an example code tool
-    ├── fastagent.config.mjs
+    ├── fastagent.config.ts
     ├── package.json
     ├── .secrets/.env.example          # secrets live here, never committed
     └── .gitignore
@@ -57,22 +57,22 @@ fastagent info
 
 `info` is read-only. It prints the model, persona, context files (`AGENTS.md`), skills, discovered tools, channels, diagnostics, and session path without starting a server.
 
-**Initializing inside an existing project?** Same command, same result: `init` puts the WHOLE agent into `./fastagent/` — zero writes elsewhere, so the project's build and the agent's surface never sweep each other, and the repo's own `AGENTS.md` is read as project context. A `fastagent.config.*` file identifies the agent; `fastagent/` is only the default directory name.
+**Initializing inside an existing project?** Same command, same result: `init` puts the WHOLE agent into `./fastagent/` — zero writes elsewhere, so the project's build and the agent's surface never sweep each other, and the repo's own `AGENTS.md` is read as project context. A `fastagent.config.ts` file identifies the agent; `fastagent/` is only the default directory name.
 
-**The repository IS the agent?** (A standalone agent repo, or a monorepo package.) `fastagent init . --flat` puts the same shape at the root instead. Existing files are kept untouched, and the agent's workspace is its own directory, so its tools operate on its own definition. Note that `fastagent deploy` needs a workspace that CONTAINS the agent, so a flat agent has to move into one before it can be deployed. **Want a different directory name?** `fastagent init . --agent-dir bot` — the `fastagent.config.*` inside is what makes a directory an agent, never its name.
+**The repository IS the agent?** (A standalone agent repo, or a monorepo package.) `fastagent init . --flat` puts the same shape at the root instead. Existing files are kept untouched, and the agent's workspace is its own directory, so its tools operate on its own definition. Note that `fastagent deploy` needs a workspace that CONTAINS the agent, so a flat agent has to move into one before it can be deployed. **Want a different directory name?** `fastagent init . --agent-dir bot` — the `fastagent.config.ts` inside is what makes a directory an agent, never its name.
 
 A fresh agent presets no model. On the first `fastagent dev` (or `start` / `invoke`) in a
 terminal, FastAgent shows the full model catalog — models whose provider already has credentials (a
 stored login, or a provider API key in your env/`.env`) come first, annotated with the source; picking
 one that needs auth runs the login flow right there — and writes your pick back to
-`fastagent.config.mjs`. Credentials are stored per project (`<agent dir>/.secrets/auth.json`, no global
+`fastagent.config.ts`. Credentials are stored per project (`<agent dir>/.secrets/auth.json`, no global
 fallback), so a login from another directory is invisible here. To set the model non-interactively
 (or in CI/deploy, where there is no prompt):
 
 ```bash
 fastagent dev --model provider/model-id
 FASTAGENT_MODEL=provider/model-id fastagent dev
-# or edit fastagent.config.mjs
+# or edit fastagent.config.ts
 ```
 
 ## 3. Run locally
@@ -219,7 +219,7 @@ On resident hosts, the cron fires while `dev`/`start` is serving; keep the proce
 `fastagent schedule history <name>` answers "did last night's run silently fail?", and
 `fastagent schedule list` shows the selected local state's pending work. Agents can
 also schedule **themselves** (a built-in `wake` tool — "check the deploy in 10 minutes") — opt in with
-`selfSchedule: true` in `fastagent.config.*`. See the [CLI reference](cli.md) and
+`selfSchedule: true` in `fastagent.config.ts`. See the [CLI reference](cli.md) and
 [API reference](api-reference.md#schedule-authoring).
 
 ## Where next

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,13 +26,13 @@ Set one with any of:
 ```bash
 fastagent dev --model provider/modelId
 FASTAGENT_MODEL=provider/modelId fastagent dev
-# or fastagent.config.mjs: { model: "provider/modelId" }
+# or fastagent.config.ts: { model: "provider/modelId" }
 ```
 
 Precedence:
 
 ```txt
---model > FASTAGENT_MODEL > fastagent.config.* model
+--model > FASTAGENT_MODEL > fastagent.config.ts model
 ```
 
 ## `auth: (none found)`
@@ -93,7 +93,7 @@ For `start`, hosted environments can set `PORT`.
 
 - **persona.md, AGENTS.md, and `skills/`** are re-read on every turn — edits go live on the next turn
   with no restart (and no watcher involvement).
-- **Code inputs** (`tools/`, `channels/`, `fastagent.config.*`, `package.json`, `.secrets/.env`) restart the
+- **Code inputs** (`tools/`, `channels/`, `fastagent.config.ts`, `package.json`, `.secrets/.env`) restart the
   dev worker — a new process is the only way to drop the ESM module cache.
 
 Nothing else is watched: files the agent itself writes into the workspace (its work product) never
@@ -284,7 +284,7 @@ A broken `schedules/<name>.ts` file is reported by `fastagent info` before it ev
 
 `deploy` resolves the model in **the environment being deployed**, not in yours. That environment is
 declared by `.secrets/.env`, so its `FASTAGENT_MODEL` is recorded in the release manifest
-(`fastagent.release.json`), with `model` in `fastagent.config.*` as the fallback (the config file ships
+(`fastagent.release.json`), with `model` in `fastagent.config.ts` as the fallback (the config file ships
 too). A `FASTAGENT_MODEL` exported in your shell belongs to this machine's environment and never
 reaches the box, and `deploy` has no `--model` flag. Set a source and redeploy — `deploy` prints the
 effective model and where it read it. Note the manifest's value outranks the deployed box's own

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 Key facts:
 
 - Install: `npm i -g @fastagent-sh/fastagent` (CLI) or `npm i @fastagent-sh/fastagent` (library). Requires Node >= 22.19 (also runs under Bun).
-- The directory is the agent: optional `persona.md` (identity), `skills/`, `tools/`, `channels/`, `schedules/` (cron triggers), `AGENTS.md` (project context, not identity), markdown context, and `fastagent.config.*`. No framework rewrite, no build step.
+- The directory is the agent: optional `persona.md` (identity), `skills/`, `tools/`, `channels/`, `schedules/` (cron triggers), `AGENTS.md` (project context, not identity), markdown context, and `fastagent.config.ts`. No framework rewrite, no build step.
 - The contract is `invoke(scope, prompt) => AsyncIterable<AgentEvent>` (the Agent Handler SPEC).
 - Core CLI: `fastagent init | info | models | login | dev | chat | invoke | tool | fire | schedule | start | add | deploy`.
 - Channels: HTTP/SSE (default), GitHub, Telegram, plus custom adapters.

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -84,7 +84,7 @@ export async function runDeploy(host: DeployHost, dirArg: string, opts: DeployOp
     // A flag/host combination the parser cannot see (host is an argument) — usage class, exit 2.
     failUsage(`deploy stopped: --tunnel is supported only by the local Docker target`);
   }
-  // The picker's write-back lands the model in fastagent.config.*.
+  // The picker's write-back lands the model in fastagent.config.ts.
   const placement = await enterAgentCommand(dirArg, opts);
   // ONE deploy semantic: bake the WORKSPACE (WYSIWYG).
   const { agentDir, workspace } = placement;

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -39,7 +39,7 @@ export async function runLogin(provider: string | undefined, opts: LoginOptions)
   // lands somewhere no agent will read.
   if (!agentDir && !opts.global && !process.env.FASTAGENT_AUTH_PATH) {
     console.error(
-      `[fastagent] no agent here (no fastagent.config.*, here or one level inside) — ` +
+      `[fastagent] no agent here (no fastagent.config.ts, here or one level inside) — ` +
         `logging in GLOBALLY (${authPath}). Every agent on this machine reads this file for providers its own ` +
         `.secrets/auth.json does not have, so this is usually what you want; \`cd\` into an agent to give that ` +
         `one its own account instead.`,

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -64,7 +64,7 @@ const init: CommandSpec = {
     { cmd: "fastagent init . --flat", note: "this repo IS the agent" },
   ],
   notes:
-    "An agent is a directory holding a fastagent.config.* — never its NAME, so --agent-dir can call it " +
+    "An agent is a directory holding a fastagent.config.ts — never its NAME, so --agent-dir can call it " +
     "anything (the name decides only which agent answers when a workspace holds several: see " +
     "FASTAGENT_AGENT). What the agent works ON (its cwd, where its AGENTS.md context is read from) is " +
     "whatever directory you later point fastagent at: point at the project and the agent inside it " +
@@ -85,7 +85,7 @@ const dev: CommandSpec = {
   description:
     "Assemble the agent in dir (default .) and serve a local HTTP channel. persona.md/AGENTS.md/skills " +
     "are re-read every turn (edits go live next turn); edits to code inputs — tools/, channels/, " +
-    "fastagent.config.*, package.json, .secrets/.env — restart the worker. Files the agent writes as " +
+    "fastagent.config.ts, package.json, .secrets/.env — restart the worker. Files the agent writes as " +
     "work product never trigger a restart.",
   args: [DIR_ARG],
   flags: [PORT, BIND, MODEL, { flags: "--no-watch", description: "serve once, no file-watching" }, TUNNEL, NO_INPUT],

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -23,7 +23,7 @@ export function assertTunnelBindable(host: string | undefined, tunnel: boolean, 
   const fix =
     source === "flag"
       ? "bind 0.0.0.0 (or 127.0.0.1), or drop --tunnel"
-      : "set http.host to 0.0.0.0 (or 127.0.0.1) in fastagent.config.*, override it with --bind, or drop --tunnel";
+      : "set http.host to 0.0.0.0 (or 127.0.0.1) in fastagent.config.ts, override it with --bind, or drop --tunnel";
   const message = `--tunnel reaches the serve by dialing localhost, which the bind address ${host} does not answer — ${fix}`;
   if (source === "flag") failUsage(message);
   failStartup(new Error(message));

--- a/src/deploy/preflight.ts
+++ b/src/deploy/preflight.ts
@@ -129,7 +129,7 @@ export async function preflightDeploy(input: {
       ok: false,
       gate:
         `the agent directory "${basename(agentDir)}" cannot be deployed — a deployed agent directory ` +
-        `may use only letters, digits, "-" and "_"; rename it (the fastagent.config.* inside is what ` +
+        `may use only letters, digits, "-" and "_"; rename it (the fastagent.config.ts inside is what ` +
         `makes it an agent, never its name)`,
     };
   }
@@ -151,7 +151,7 @@ export async function preflightDeploy(input: {
   }
   if (!model.spec) {
     const issue =
-      `no model resolves for this deployment — set \`model: "provider/id"\` in fastagent.config.* (it travels ` +
+      `no model resolves for this deployment — set \`model: "provider/id"\` in fastagent.config.ts (it travels ` +
       `in the image), or FASTAGENT_MODEL in ${valueFile} (deploy records that one in the release manifest)` +
       // Whoever has the variable set right here sees `fastagent info` report a model, so "no model resolves" reads
       // like a bug until the message says which environment was read. It states that fact WITHOUT attributing the
@@ -513,7 +513,7 @@ export async function preflightDeploy(input: {
       const issue =
         `your Dockerfile does not set FASTAGENT_RELEASE_FILE, and the model comes from ${valueFile} — it travels ` +
         `in the release manifest, which is only read when that ENV points at it. Add it (see a generated ` +
-        `Dockerfile), or set \`model\` in fastagent.config.* so it ships in the config instead.`;
+        `Dockerfile), or set \`model\` in fastagent.config.ts so it ships in the config instead.`;
       if (run) return { ok: false, gate: issue };
       messages.push({ level: "warn", text: issue });
     }

--- a/src/dev-supervisor.ts
+++ b/src/dev-supervisor.ts
@@ -5,13 +5,7 @@
 import { spawn } from "node:child_process";
 import { relative, sep } from "node:path";
 import { watch as watchTree } from "chokidar";
-import {
-  AGENT_CONFIG_NAMES,
-  AGENT_MODELS_FILE,
-  type ResolvedPlacement,
-  resolveStateRoot,
-  isUnderDir,
-} from "./paths.ts";
+import { AGENT_CONFIG_FILE, AGENT_MODELS_FILE, type ResolvedPlacement, resolveStateRoot, isUnderDir } from "./paths.ts";
 import { dotEnvPath } from "./env.ts";
 import { log } from "./log.ts";
 import { openExternalUrl } from "./open-url.ts";
@@ -22,7 +16,7 @@ import { type Tunnel, announceWebhooks, startCloudflareTunnel } from "./tunnel.t
 /** The agent-dir directories loaded ONCE per worker: a restart is their only re-read. */
 const CODE_INPUT_DIRS = ["tools", "channels", "schedules", "extensions"] as const;
 
-const WATCHED_HINT = `${CODE_INPUT_DIRS.map((dir) => `${dir}/`).join(", ")}, package.json, fastagent.config.*, models.json, .secrets/.env`;
+const WATCHED_HINT = `${CODE_INPUT_DIRS.map((dir) => `${dir}/`).join(", ")}, package.json, fastagent.config.ts, models.json, .secrets/.env`;
 
 /** chokidar `ignored` matcher for the narrow watch scope (true = ignore), rooted at the AGENT DIR. */
 export function devWatchIgnored(root: string, envFile: string): (path: string) => boolean {
@@ -33,7 +27,7 @@ export function devWatchIgnored(root: string, envFile: string): (path: string) =
     const rel = relative(root, path);
     // Code inputs at the agent dir root: config, package.json, and the dirs loaded once per worker (a restart is
     // their only re-read).
-    if ((AGENT_CONFIG_NAMES as readonly string[]).includes(rel)) return false;
+    if (rel === AGENT_CONFIG_FILE) return false;
     if (rel === "package.json") return false;
     // models.json is read ONCE per worker (the model hub is built during assembly), so an edit needs a restart like
     // any other code input.

--- a/src/engines/pi/config.ts
+++ b/src/engines/pi/config.ts
@@ -3,7 +3,7 @@
  * resolveModelSpec).
  */
 import { existsSync, statSync } from "node:fs";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { FastagentTool } from "./tool.ts";
@@ -14,7 +14,7 @@ import { GLOBAL_AUTH_PATH } from "./auth.ts";
 import { readSecretDeclaration } from "../../declared-secrets.ts";
 import { isBindAddress } from "../../bind.ts";
 import { moduleLoadHint } from "../../loader.ts";
-import { AGENT_CONFIG_NAMES, resolveOverridePath, resolveSecretsDir } from "../../paths.ts";
+import { AGENT_CONFIG_FILE, resolveOverridePath, resolveSecretsDir } from "../../paths.ts";
 
 // pi's thinking levels as a runtime value live in session-settings.ts (THE single source, with the exhaustiveness
 // anchor against pi's union).
@@ -89,18 +89,10 @@ function validateStringList(value: unknown, key: string, shape: RegExp, desc: st
   }
 }
 
-/** Load `<dir>/fastagent.config.ts|.js|.mjs`. */
+/** Load `<dir>/fastagent.config.ts`. */
 export async function loadConfig(dir: string): Promise<LoadedConfig> {
-  const found = AGENT_CONFIG_NAMES.map((name) => join(dir, name)).filter((path) => existsSync(path));
-  if (found.length === 0) return { config: {} };
-  if (found.length > 1) {
-    throw new Error(
-      `${dir}: multiple fastagent config files found; keep exactly one (${found.map((p) => basename(p)).join(", ")})`,
-    );
-  }
-
-  // biome-ignore lint/style/noNonNullAssertion: length checked above — exactly one element here
-  const path = found[0]!;
+  const path = join(dir, AGENT_CONFIG_FILE);
+  if (!existsSync(path)) return { config: {} };
   let mod: { default?: unknown };
   try {
     // Cache-bust on file change: ESM `import()` caches by URL, so a config REWRITTEN in this process (the first-run
@@ -116,8 +108,9 @@ export async function loadConfig(dir: string): Promise<LoadedConfig> {
     throw new Error(`${path}: must default-export defineConfig({...})`);
   }
   const c = config as FastagentConfig;
-  // Unknown keys throw: defineConfig only type-protects .ts authors; a typo in a .js/.mjs config (`modle:`) must not
-  // silently degrade to defaults.
+  // Unknown keys throw. This is NOT redundant with `defineConfig`'s types: Node strips types without checking them,
+  // so `modle:` reaches here whatever the editor said, and silently degrading to defaults is the failure it would
+  // otherwise cause.
   for (const key of Object.keys(c)) {
     if (
       key !== "model" &&

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -24,8 +24,12 @@ export const SECRETS_DIRNAME = ".secrets";
 /** The state segment inside an agent dir — same rule and same template caveat as {@link SECRETS_DIRNAME}. */
 export const STATE_DIRNAME = ".state";
 
-/** The config filenames, in load precedence. */
-export const AGENT_CONFIG_NAMES = ["fastagent.config.ts", "fastagent.config.js", "fastagent.config.mjs"] as const;
+/**
+ * THE config filename. One spelling, not a family: fastagent generates this file, so a choice of extension buys
+ * an author nothing and costs a precedence order plus a "you have two of them" failure path. Everything else an
+ * author writes (`tools/`, `channels/`, `schedules/`) still accepts `.ts`/`.js`/`.mjs` — that is THEIR code.
+ */
+export const AGENT_CONFIG_FILE = "fastagent.config.ts";
 
 /** The optional custom-model-endpoint file inside an agent dir (pi's models.json schema). */
 export const AGENT_MODELS_FILE = "models.json";
@@ -50,9 +54,9 @@ function isDir(p: string): boolean {
   return statSync(p, { throwIfNoEntry: false })?.isDirectory() === true;
 }
 
-/** THE marker: a directory that declares itself an agent with a `fastagent.config.*`. */
+/** THE marker: a directory that declares itself an agent with a {@link AGENT_CONFIG_FILE}. */
 function hasConfig(p: string): boolean {
-  return isDir(p) && AGENT_CONFIG_NAMES.some((name) => existsSync(join(p, name)));
+  return isDir(p) && existsSync(join(p, AGENT_CONFIG_FILE));
 }
 
 /** The agent directories DIRECTLY inside `dir` — the one-level scan that finds an agent without knowing its name. */
@@ -168,7 +172,7 @@ export function resolvePlacement(dir: string, env: NodeJS.ProcessEnv = process.e
     const base = resolve(dir);
     throw new Error(
       placementDeadEnd(base, env) ??
-        `${base} is not a fastagent agent — no fastagent.config.* here, and no directory holding one ` +
+        `${base} is not a fastagent agent — no fastagent.config.ts here, and no directory holding one ` +
           `directly inside; run \`fastagent init\` to scaffold one`,
     );
   }

--- a/src/scaffold/init.ts
+++ b/src/scaffold/init.ts
@@ -2,7 +2,7 @@
 import { lstat, mkdir, readdir, rm, rmdir, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import {
-  AGENT_CONFIG_NAMES,
+  AGENT_CONFIG_FILE,
   DEFAULT_AGENT_DIRNAME,
   SECRETS_DIRNAME,
   agentDefinitionOwner,
@@ -74,7 +74,7 @@ export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}):
     skill("SKILL.md"),
     skill("GLOSSARY.md"),
     skill("LICENSE"),
-    { rel: join(root, "fastagent.config.mjs"), content: baseTemplate("fastagent.config.mjs") },
+    { rel: join(root, AGENT_CONFIG_FILE), content: baseTemplate(AGENT_CONFIG_FILE) },
     // Two ignore files, scaffolded ONCE and owned by the author from then on — no command rewrites, reads or verifies
     // them.
     { rel: join(root, ".gitignore"), content: baseTemplate("gitignore") },
@@ -146,9 +146,8 @@ export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}):
   // ONE coordinate system for both refusals — `displayPath` is the shared policy (relative inside the cwd, absolute
   // when it climbs out).
   const target = displayPath(process.cwd(), join(dir, root)) ?? join(dir, root);
-  const config = occupants.filter((f) => (AGENT_CONFIG_NAMES as readonly string[]).includes(f));
-  if (config.length > 0) {
-    throw new Error(`"${target}" already has ${config.join(", ")} — already a fastagent agent`);
+  if (occupants.includes(AGENT_CONFIG_FILE)) {
+    throw new Error(`"${target}" already has ${AGENT_CONFIG_FILE} — already a fastagent agent`);
   }
   // Only a SUBDIRECTORY target must be empty.
   if (!flat && occupants.length > 0) {

--- a/src/scaffold/templates/fastagent.config.ts
+++ b/src/scaffold/templates/fastagent.config.ts
@@ -1,4 +1,4 @@
-// fastagent.config.mjs — deployment choices only (model / http; code tools auto-discover from tools/).
+// fastagent.config.ts — deployment choices only (model / http; code tools auto-discover from tools/).
 // Your agent's identity lives in persona.md; its capabilities in skills/ + tools/ — never here.
 // An AGENTS.md in the WORKSPACE (the directory the agent is started in) is read as project context.
 // Model precedence: `--model` flag > FASTAGENT_MODEL env > this default.

--- a/test/agentcore-service.test.ts
+++ b/test/agentcore-service.test.ts
@@ -9,7 +9,7 @@ import { openPreparedStartService } from "../src/cli/commands/start.ts";
 
 async function agentDir(files: Record<string, string> = {}, config = `{ model: "openai-codex/gpt-5.5" }`) {
   const dir = await mkdtemp(join(tmpdir(), "fa-agentcore-"));
-  await writeFile(join(dir, "fastagent.config.mjs"), `export default ${config};\n`);
+  await writeFile(join(dir, "fastagent.config.ts"), `export default ${config};\n`);
   await writeFile(join(dir, "persona.md"), "You are a test agent.\n");
   for (const [rel, body] of Object.entries(files)) {
     await mkdir(join(dir, rel, ".."), { recursive: true });

--- a/test/ai-start.test.ts
+++ b/test/ai-start.test.ts
@@ -26,7 +26,7 @@ it("the agent development guide's copied files typecheck, run, and reject a mist
   const cli = (args: string[]) => node([join(root, "src/cli.ts"), ...args]);
   try {
     await cli(["init", ".", "--no-install"]);
-    const config = await readFile(join(agentDir, "fastagent.config.mjs"), "utf8");
+    const config = await readFile(join(agentDir, "fastagent.config.ts"), "utf8");
     for (const file of [
       "tsconfig.json",
       "persona.md",
@@ -71,7 +71,7 @@ it("the agent development guide's copied files typecheck, run, and reject a mist
       scheduleFailures: [],
       diagnostics: [],
     });
-    expect(await readFile(join(agentDir, "fastagent.config.mjs"), "utf8")).toBe(config);
+    expect(await readFile(join(agentDir, "fastagent.config.ts"), "utf8")).toBe(config);
 
     const testFile = join(agentDir, "test/batches.test.ts");
     const valid = await readFile(testFile, "utf8");

--- a/test/cli-kernel.test.ts
+++ b/test/cli-kernel.test.ts
@@ -321,7 +321,7 @@ async function agentWorkspace(prefix: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), prefix));
   await mkdir(join(dir, "fastagent"));
   await writeFile(join(dir, "fastagent", "persona.md"), "You are terse.\n");
-  await writeFile(join(dir, "fastagent", "fastagent.config.mjs"), "export default {};\n"); // THE marker
+  await writeFile(join(dir, "fastagent", "fastagent.config.ts"), "export default {};\n"); // THE marker
   return dir;
 }
 

--- a/test/cli-shared.test.ts
+++ b/test/cli-shared.test.ts
@@ -126,7 +126,7 @@ describe("reportAssembly (the startup report dev and start share)", () => {
   });
 
   it("places each command's extras where that command puts them", async () => {
-    const dev = await lines({ beforeModel: [["config", "/w/agent/fastagent.config.mjs"]] });
+    const dev = await lines({ beforeModel: [["config", "/w/agent/fastagent.config.ts"]] });
     expect(dev.indexOf("config")).toBe(2); // after agent/workspace, before model
     expect(dev.indexOf("config")).toBeLessThan(dev.indexOf("model"));
 
@@ -156,7 +156,7 @@ describe("enterAgentCommand: --no-input never reaches the picker", () => {
   const modellessAgent = (): string => {
     const dir = mkdtempSync(join(tmpdir(), "fastagent-prelude-"));
     dirs.push(dir);
-    writeFileSync(join(dir, "fastagent.config.mjs"), "export default {};\n");
+    writeFileSync(join(dir, "fastagent.config.ts"), "export default {};\n");
     return dir;
   };
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -16,7 +16,7 @@ async function agentWorkspace(prefix: string, files: Record<string, string> = {}
   const dir = await mkdtemp(join(tmpdir(), prefix));
   await mkdir(join(dir, "fastagent", ".secrets"), { recursive: true });
   await writeFile(join(dir, "fastagent", "persona.md"), "You are terse.\n");
-  await writeFile(join(dir, "fastagent", "fastagent.config.mjs"), "export default {};\n"); // THE marker
+  await writeFile(join(dir, "fastagent", "fastagent.config.ts"), "export default {};\n"); // THE marker
   await writeFile(join(dir, "fastagent", ".secrets", "auth.json"), "{}\n"); // a real credential to leak
   for (const [name, content] of Object.entries(files)) {
     await mkdir(join(dir, "fastagent", dirname(name)), { recursive: true });
@@ -47,7 +47,7 @@ describe("cli papercuts", () => {
     // test/deploy-artifacts.test.ts; eight spawns proving it here made this the slowest and only flaky
     // test in the suite. What a subprocess is for is the WIRING: that the command actually consults it.
     const dir = await agentWorkspace("fa-deploy-ignore-", {
-      "fastagent.config.mjs": `export default { model: "openai-codex/gpt-5.5" };\n`,
+      "fastagent.config.ts": `export default { model: "openai-codex/gpt-5.5" };\n`,
       "package.json": `{"type":"module"}`,
     });
     expect((await run(["deploy", "fly", dir])).code).toBe(0);
@@ -69,7 +69,7 @@ describe("cli papercuts", () => {
 
   it("deploy: generate mode succeeds with the WYSIWYG note; the agentDir config key is retired", async () => {
     const dir = await agentWorkspace("fa-deploy-gen-", {
-      "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n`,
+      "fastagent.config.ts": `export default { model: "openai/gpt-4o-mini" };\n`,
     });
     const result = await run(["deploy", "fly", dir]);
     expect(result.code).toBe(0);
@@ -78,7 +78,7 @@ describe("cli papercuts", () => {
 
     // The retired config key fails visibly — placement is structural now, never configured.
     const legacy = await agentWorkspace("fa-deploy-legacy-", {
-      "fastagent.config.mjs": `export default { agentDir: "./agent" };\n`,
+      "fastagent.config.ts": `export default { agentDir: "./agent" };\n`,
     });
     const rejected = await run(["deploy", "fly", legacy]);
     expect(rejected.code).toBe(1);
@@ -87,7 +87,7 @@ describe("cli papercuts", () => {
 
   it("deploy docker generates app-only Compose and keeps user-owned Dockerfile/Compose on re-run", async () => {
     const dir = await agentWorkspace("fa-deploy-docker-", {
-      "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n`,
+      "fastagent.config.ts": `export default { model: "openai/gpt-4o-mini" };\n`,
     });
     await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
 
@@ -115,7 +115,7 @@ describe("cli papercuts", () => {
 
   it("deploy docker --tunnel keeps an existing app-only topology and prints an actionable runbook", async () => {
     const dir = await agentWorkspace("fa-deploy-kept-no-tunnel-", {
-      "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n`,
+      "fastagent.config.ts": `export default { model: "openai/gpt-4o-mini" };\n`,
     });
     expect((await run(["deploy", "docker", dir])).code).toBe(0);
     const composePath = join(dir, "fastagent", "fastagent.compose.yml");
@@ -137,7 +137,7 @@ describe("cli papercuts", () => {
     // one file while the container reads another: every declared value is silently absent. Deterministic, so `--run`
     // refuses before Docker is touched; generating artifacts only warns.
     const dir = await agentWorkspace("fa-deploy-secrets-dir-", {
-      "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n`,
+      "fastagent.config.ts": `export default { model: "openai/gpt-4o-mini" };\n`,
     });
     const elsewhere = await mkdtemp(join(tmpdir(), "fa-secrets-elsewhere-"));
     const env = { ...process.env, FASTAGENT_SECRETS_DIR: elsewhere };
@@ -157,7 +157,7 @@ describe("cli papercuts", () => {
     // determinate mismatch between what ships and what the definition says — so it stops before Docker is touched.
     // (writeArtifacts owns WHICH files are stale; this is the dispatcher's wiring of that fact to an exit code.)
     const dir = await agentWorkspace("fa-deploy-stale-", {
-      "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n`,
+      "fastagent.config.ts": `export default { model: "openai/gpt-4o-mini" };\n`,
     });
     expect((await run(["deploy", "docker", dir])).code).toBe(0);
     const compose = join(dir, "fastagent", "fastagent.compose.yml");
@@ -179,7 +179,7 @@ describe("cli papercuts", () => {
 
   it("deploy docker --tunnel shapes Compose but does not run Docker without --run", async () => {
     const dir = await agentWorkspace("fa-deploy-tunnel-", {
-      "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n`,
+      "fastagent.config.ts": `export default { model: "openai/gpt-4o-mini" };\n`,
     });
     const result = await run(["deploy", "docker", dir, "--tunnel"]);
     expect(result.code).toBe(0);
@@ -266,7 +266,7 @@ describe("cli papercuts", () => {
 
   it("start fails when a declared channel cannot load instead of exposing the default /invoke route", async () => {
     const dir = await agentWorkspace("fa-cli-channel-fail-", {
-      "fastagent.config.mjs": `export default { model: "openai/gpt-5.5" };\n`,
+      "fastagent.config.ts": `export default { model: "openai/gpt-5.5" };\n`,
       "channels/telegram.mjs": `export default () => { throw new Error("TELEGRAM_SECRET_TOKEN required"); };\n`,
     });
 
@@ -403,7 +403,7 @@ describe("cli papercuts", () => {
     // apply). An up-to-date generated one is kept quietly. Marker/predicate come from container.ts (single source).
     const setup = async (dockerfileContent: string) => {
       const dir = await agentWorkspace("fa-apt-", {
-        "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini", deploy: { apt: ["git"] } };\n`,
+        "fastagent.config.ts": `export default { model: "openai/gpt-4o-mini", deploy: { apt: ["git"] } };\n`,
         Dockerfile: dockerfileContent,
       });
       await writeFile(join(dir, "AGENTS.md"), "You are terse.\n");
@@ -440,7 +440,7 @@ describe("cli papercuts", () => {
 
   it("info reports the assembled surface as JSON (incl. load diagnostics), read-only (no sessions dir)", async () => {
     const dir = await agentWorkspace("fa-info-", {
-      "fastagent.config.mjs": "export default {};\n",
+      "fastagent.config.ts": "export default {};\n",
       "skills/greet/SKILL.md": "---\nname: greet\ndescription: Greet warmly.\n---\nHi.\n",
       "skills/bad/SKILL.md": "---\nname: bad\n---\nno description.\n", // malformed
       "tools/lookup.mjs":
@@ -582,7 +582,7 @@ describe("cli papercuts", () => {
     const { code, stderr } = await run(["login", "no-such-provider"], cwd, env);
     expect(code).not.toBe(0);
     // The marker names itself, at both positions the lookup checks.
-    expect(stderr).toMatch(/no agent here \(no fastagent\.config\.\*, here or one level inside\)/);
+    expect(stderr).toMatch(/no agent here \(no fastagent\.config\.ts, here or one level inside\)/);
     await expect(stat(join(cwd, ".secrets"))).rejects.toThrow(); // nothing created in the non-agent dir
 
     // …and it is silent when FASTAGENT_AUTH_PATH outranks the fallback: an announcement naming a file the
@@ -598,7 +598,7 @@ describe("cli papercuts", () => {
     // switching scope.
     const inside = join(cwd, "agent", "tools");
     await mkdir(inside, { recursive: true });
-    await writeFile(join(cwd, "agent", "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(cwd, "agent", "fastagent.config.ts"), "export default {};\n");
     const nested = await run(["login", "no-such-provider"], inside, env);
     expect(nested.stderr).toMatch(/is inside the agent .*but is not its root/);
     expect(nested.stderr).not.toMatch(/logging in GLOBALLY/);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -34,7 +34,7 @@ describe("config: resolveSessionsDirOverride (start's sessions precedence)", () 
 describe("config: loadConfig rereads a config rewritten in-process (ESM cache-bust)", () => {
   it("a write-back (the first-run picker) is visible to the next loadConfig — not the cached module", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-fresh-"));
-    const path = join(dir, "fastagent.config.mjs");
+    const path = join(dir, "fastagent.config.ts");
     await writeFile(path, "export default {\n};\n");
     expect((await loadConfig(dir)).config.model).toBeUndefined();
     // Simulate persistModelChoice: rewrite the file AFTER it was imported once. Without the mtime
@@ -54,7 +54,7 @@ describe("config: loadConfig validation", () => {
   it("refuses an unknown key BY NAME — typo, nested typo, retired, or never-a-config-entry", async () => {
     const load = async (body: string) => {
       const dir = await mkdtemp(join(tmpdir(), "fa-config-unknown-"));
-      await writeFile(join(dir, "fastagent.config.mjs"), body);
+      await writeFile(join(dir, "fastagent.config.ts"), body);
       return loadConfig(dir);
     };
     await expect(load(`export default { modle: "openai-codex/gpt-5.5" };`)).rejects.toThrow(/unknown key "modle"/);
@@ -68,11 +68,11 @@ describe("config: loadConfig validation", () => {
 
   it("selfSchedule: accepts a boolean (opt-in to the wake tool), rejects a non-boolean", async () => {
     const ok = await mkdtemp(join(tmpdir(), "fa-selfsched-ok-"));
-    await writeFile(join(ok, "fastagent.config.mjs"), `export default { selfSchedule: true };\n`);
+    await writeFile(join(ok, "fastagent.config.ts"), `export default { selfSchedule: true };\n`);
     expect((await loadConfig(ok)).config.selfSchedule).toBe(true);
 
     const bad = await mkdtemp(join(tmpdir(), "fa-selfsched-bad-"));
-    await writeFile(join(bad, "fastagent.config.mjs"), `export default { selfSchedule: "yes" };\n`);
+    await writeFile(join(bad, "fastagent.config.ts"), `export default { selfSchedule: "yes" };\n`);
     await expect(loadConfig(bad)).rejects.toThrow(/selfSchedule.*must be a boolean/);
   });
 });
@@ -213,28 +213,28 @@ describe("config: loadConfig", () => {
 
   it("a config SYNTAX error names the file (not a raw SyntaxError + ESM stack)", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: `); // truncated = parse error
-    await expect(loadConfig(dir)).rejects.toThrow(/fastagent\.config\.mjs: /);
+    await writeFile(join(dir, "fastagent.config.ts"), `export default { model: `); // truncated = parse error
+    await expect(loadConfig(dir)).rejects.toThrow(/fastagent\.config\.ts: /);
   });
 
   it("a config that imports a missing dep gets the same npm-install hint as tools/channels", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-    await writeFile(join(dir, "fastagent.config.mjs"), `import "totally-not-installed-pkg";\nexport default {};`);
-    await expect(loadConfig(dir)).rejects.toThrow(/fastagent\.config\.mjs: .*npm install/s);
+    await writeFile(join(dir, "fastagent.config.ts"), `import "totally-not-installed-pkg";\nexport default {};`);
+    await expect(loadConfig(dir)).rejects.toThrow(/fastagent\.config\.ts: .*npm install/s);
   });
 
   it("validates http shape as well: non-numeric/out-of-range http.port throws", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { http: { port: "oops" } };`);
+    await writeFile(join(dir, "fastagent.config.ts"), `export default { http: { port: "oops" } };`);
     await expect(loadConfig(dir)).rejects.toThrow(/"http\.port" must be an integer/);
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { http: { port: 99999 } };`);
+    await writeFile(join(dir, "fastagent.config.ts"), `export default { http: { port: 99999 } };`);
     await expect(loadConfig(dir)).rejects.toThrow(/"http\.port" must be an integer/);
   });
 
   it("http.host: an IP literal loads, an unbindable string throws at load (not at listen time)", async () => {
     const load = async (body: string) => {
       const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-      await writeFile(join(dir, "fastagent.config.mjs"), body);
+      await writeFile(join(dir, "fastagent.config.ts"), body);
       return loadConfig(dir);
     };
     expect((await load(`export default { http: { host: "127.0.0.1" } };`)).config.http?.host).toBe("127.0.0.1");
@@ -246,7 +246,7 @@ describe("config: loadConfig", () => {
   it("thinkingLevel: a valid pi level loads; an invalid value throws (fail visibly, not a silent default)", async () => {
     const load = async (body: string) => {
       const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-      await writeFile(join(dir, "fastagent.config.mjs"), body);
+      await writeFile(join(dir, "fastagent.config.ts"), body);
       return loadConfig(dir);
     };
     const { config } = await load(`export default { thinkingLevel: "high" };`);
@@ -261,7 +261,7 @@ describe("config: loadConfig", () => {
     // A fresh dir per case: ESM caches a module by URL, so re-writing one file wouldn't re-import.
     const load = async (body: string) => {
       const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-      await writeFile(join(dir, "fastagent.config.mjs"), body);
+      await writeFile(join(dir, "fastagent.config.ts"), body);
       return loadConfig(dir);
     };
     const { config } = await load(`export default { deploy: { secrets: ["GH_TOKEN"], apt: ["git", "ripgrep"] } };`);
@@ -280,7 +280,7 @@ describe("config: loadConfig", () => {
   it("validates deploy.agentcore.idleTimeoutSeconds against AWS's own bounds", async () => {
     const load = async (body: string) => {
       const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-      await writeFile(join(dir, "fastagent.config.mjs"), body);
+      await writeFile(join(dir, "fastagent.config.ts"), body);
       return loadConfig(dir);
     };
     const { config } = await load(`export default { deploy: { agentcore: { idleTimeoutSeconds: 900 } } };`);
@@ -299,23 +299,16 @@ describe("config: loadConfig", () => {
     );
   });
 
-  it("multiple config files throw instead of silently choosing one", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-    await writeFile(join(dir, "fastagent.config.js"), `export default { model: "openai-codex/gpt-5.5" };`);
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.4" };`);
-    await expect(loadConfig(dir)).rejects.toThrow(/multiple fastagent config files/);
-  });
-
   it("invalid custom tool entries throw during config load", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-config-"));
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { tools: [{}] };`);
+    await writeFile(join(dir, "fastagent.config.ts"), `export default { tools: [{}] };`);
     await expect(loadConfig(dir)).rejects.toThrow(/tools\[0\].*name.*execute/);
 
     // A malformed `secrets` on a config tool is a CONFIG error, refused here with the entry named —
     // not a fault thrown out of tool resolution later, where it would take `info`'s other reporting
     // down with it. A `tools/x.ts` file with the same mistake stays that one file's load failure.
     await writeFile(
-      join(dir, "fastagent.config.mjs"),
+      join(dir, "fastagent.config.ts"),
       `export default { tools: [{ name: "gh", execute: async () => ({}), secrets: "GH_TOKEN" }] };`,
     );
     await expect(loadConfig(dir)).rejects.toThrow(/"tools\[0\]": secrets must be an array of env-var names/);
@@ -339,7 +332,7 @@ async function agentWorkspace(): Promise<{ host: string; agent: string }> {
   const agent = join(host, "fastagent");
   await mkdir(agent);
   await writeFile(join(agent, "persona.md"), "You are terse.\n");
-  await writeFile(join(agent, "fastagent.config.mjs"), "export default {};\n"); // THE marker
+  await writeFile(join(agent, "fastagent.config.ts"), "export default {};\n"); // THE marker
   return { host, agent };
 }
 
@@ -348,13 +341,13 @@ describe("L3: createPiAgentFromDir (config-driven assembly boundary on the engin
     const { host, agent } = await agentWorkspace();
     await writeFile(join(host, "AGENTS.md"), "# Test Agent\nBe concise.\n");
     await writeFile(
-      join(agent, "fastagent.config.mjs"),
+      join(agent, "fastagent.config.ts"),
       `export default { model: "openai-codex/gpt-5.5", http: { port: 9999 } };`,
     );
 
     const ws = await createPiAgentFromDir(host);
     expect(ws.modelSpec).toBe("openai-codex/gpt-5.5"); // from config
-    expect(ws.configPath).toMatch(/fastagent\.config\.mjs$/);
+    expect(ws.configPath).toMatch(/fastagent\.config\.ts$/);
     expect(ws.config.http?.port).toBe(9999);
     expect(typeof ws.agent.invoke).toBe("function");
     expect(ws.definition.dir).toBe(agent);
@@ -369,7 +362,7 @@ describe("L3: createPiAgentFromDir (config-driven assembly boundary on the engin
     // library caller's directory got edited behind its back — and an author's own edit could abort
     // the command. Opening resolves paths; it does not have opinions about the user's repo.
     const { host, agent } = await agentWorkspace();
-    await writeFile(join(agent, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };`);
+    await writeFile(join(agent, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };`);
     await createPiAgentFromDir(host);
     expect(existsSync(join(agent, ".state", ".gitignore"))).toBe(false);
     expect(existsSync(join(agent, ".secrets", ".gitignore"))).toBe(false);
@@ -380,7 +373,7 @@ describe("L3: createPiAgentFromDir (config-driven assembly boundary on the engin
     // volume) so a redeploy that replaces the dir does not wipe conversations. Lock that the override
     // wins and the default lands under .state (the single opener both commands drive).
     const { host, agent } = await agentWorkspace();
-    await writeFile(join(agent, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };`);
+    await writeFile(join(agent, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };`);
     const ext = await mkdtemp(join(tmpdir(), "fa-sessions-"));
     const overridden = await createPiAgentFromDir(host, { sessionsDir: ext });
     expect(overridden.sessionsDir).toBe(ext);
@@ -393,7 +386,7 @@ describe("L3: createPiAgentFromDir (config-driven assembly boundary on the engin
     // global file. Lock that the opener defaults project-level and an explicit path (e.g. the shared
     // global one) overrides — the same precedence shape as sessionsDir.
     const { host, agent } = await agentWorkspace();
-    await writeFile(join(agent, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };`);
+    await writeFile(join(agent, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };`);
     const defaulted = await createPiAgentFromDir(host);
     expect(defaulted.authPath).toBe(join(agent, ".secrets", "auth.json"));
     const shared = join(tmpdir(), "shared-auth.json");

--- a/test/declared-secrets.test.ts
+++ b/test/declared-secrets.test.ts
@@ -19,7 +19,7 @@ async function agent(files: Record<string, string>): Promise<string> {
   await mkdir(join(dir, "tools"), { recursive: true });
   await mkdir(join(dir, "schedules"), { recursive: true });
   await mkdir(join(dir, "channels"), { recursive: true });
-  await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai/gpt-4o-mini" };\n`);
+  await writeFile(join(dir, "fastagent.config.ts"), `export default { model: "openai/gpt-4o-mini" };\n`);
   for (const [name, content] of Object.entries(files)) await writeFile(join(dir, name), content);
   return dir;
 }

--- a/test/definition-extensions.test.ts
+++ b/test/definition-extensions.test.ts
@@ -146,7 +146,7 @@ describe("definition: chat runs the definition's extensions in full", () => {
     const dir = join(workspace, "fastagent");
     await mkdir(join(dir, "extensions"), { recursive: true });
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    await writeFile(join(dir, "fastagent.config.ts"), 'export default { model: "openai-codex/gpt-5.5" };\n');
     await writeFile(join(dir, "extensions", "marker.ts"), markerExtension("chat_extension_marker"));
 
     const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
@@ -213,7 +213,7 @@ export default async function (pi) {
     const dir = join(workspace, "fastagent");
     await mkdir(join(dir, "extensions"), { recursive: true });
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    await writeFile(join(dir, "fastagent.config.ts"), 'export default { model: "openai-codex/gpt-5.5" };\n');
     for (const [rel, content] of Object.entries(files)) await writeFile(join(dir, rel), content);
     const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
     await rt.dispose?.();
@@ -225,7 +225,7 @@ export default async function (pi) {
     const dir = join(workspace, "fastagent");
     await mkdir(join(dir, "extensions"), { recursive: true });
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    await writeFile(join(dir, "fastagent.config.ts"), 'export default { model: "openai-codex/gpt-5.5" };\n');
     for (const [rel, content] of Object.entries(files)) await writeFile(join(dir, rel), content);
     const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
     try {
@@ -270,7 +270,7 @@ describe("definition: an extension can define the model chat runs on", () => {
     const dir = join(workspace, "fastagent");
     await mkdir(join(dir, "extensions"), { recursive: true });
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "acme-proxy/acme-1" };\n');
+    await writeFile(join(dir, "fastagent.config.ts"), 'export default { model: "acme-proxy/acme-1" };\n');
     await writeFile(
       join(dir, "extensions", "provider.ts"),
       `
@@ -314,7 +314,7 @@ describe("definition: chat rebuilds extensions when pi replaces the session", ()
     const dir = join(workspace, "fastagent");
     await mkdir(join(dir, "extensions"), { recursive: true });
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    await writeFile(join(dir, "fastagent.config.ts"), 'export default { model: "openai-codex/gpt-5.5" };\n');
     await writeFile(
       join(dir, "extensions", "count.ts"),
       `

--- a/test/deploy-preflight.test.ts
+++ b/test/deploy-preflight.test.ts
@@ -14,7 +14,7 @@ async function workspace(files: Record<string, string> = {}): Promise<string> {
   const dir = join(host, "fastagent");
   await mkdir(join(dir, ".secrets"), { recursive: true });
   await writeFile(join(dir, "persona.md"), "You are terse.\n");
-  await writeFile(join(dir, "fastagent.config.mjs"), "export default {};\n"); // THE marker
+  await writeFile(join(dir, "fastagent.config.ts"), "export default {};\n"); // THE marker
   // Real credential files: the leak gate only fires on paths that EXIST (nothing else can be baked).
   await writeFile(join(dir, ".secrets", "auth.json"), "{}\n");
   await writeFile(join(dir, ".secrets", ".env"), "K=v\n");
@@ -41,7 +41,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
     const host = await mkdtemp(join(tmpdir(), "fa-preflight-"));
     const dir = join(host, "my.agent");
     await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(dir, "fastagent.config.ts"), "export default {};\n");
     const pre = await call(dir, { model: "openai/gpt-4o-mini" });
     expect(pre.ok).toBe(false);
     if (!pre.ok) expect(pre.gate).toContain('"my.agent"');
@@ -153,7 +153,7 @@ describe("deploy/preflight: the host-neutral pre-flight", () => {
 
   it("container facts come from the AGENT DIR; git auto-baked when the workspace ships .git", async () => {
     const agentDir = await workspace({
-      "fastagent.config.mjs": `export default { model: "openai/gpt-4o-mini" };\n`,
+      "fastagent.config.ts": `export default { model: "openai/gpt-4o-mini" };\n`,
       "package.json": `{"type":"module","dependencies":{"@fastagent-sh/fastagent":"^1"}}`,
     });
     await mkdir(join(dirname(agentDir), ".git")); // the workspace is a git repo — the image gets the git binary

--- a/test/deployment-start.test.ts
+++ b/test/deployment-start.test.ts
@@ -64,7 +64,7 @@ it("retries interrupted installs, opens the workspace's runtime and preserves to
     );
     await mkdir(join(agent, "node_modules/.bin"));
     await writeFile(join(agent, "package.json"), '{"type":"module"}');
-    await writeFile(join(agent, "fastagent.config.mjs"), 'export default { model: "local/test" };');
+    await writeFile(join(agent, "fastagent.config.ts"), 'export default { model: "local/test" };');
     await writeFile(join(agent, "persona.md"), "Use the context tool.");
     await writeFile(
       join(agent, "models.json"),

--- a/test/dev-supervisor.test.ts
+++ b/test/dev-supervisor.test.ts
@@ -19,7 +19,6 @@ describe("dev-supervisor: devWatchIgnored (the narrow watch scope)", () => {
     expect(ignored(join(root, "extensions", "notify.ts"))).toBe(false);
     expect(ignored(join(root, "extensions", "notify", "index.ts"))).toBe(false);
     expect(ignored(join(root, "package.json"))).toBe(false);
-    expect(ignored(join(root, "fastagent.config.mjs"))).toBe(false);
     expect(ignored(join(root, "fastagent.config.ts"))).toBe(false);
     // models.json is loaded once per worker (the model hub is built during assembly) AND a malformed one
     // fails that assembly — unwatched, the edit that repairs a dead worker would not be the edit that

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -104,7 +104,7 @@ describe("env: a stray .env at the agent root is announced, not silently ignored
 
     const agent = join(await mkdtemp(join(tmpdir(), "fa-stray-")), "fastagent");
     await mkdir(agent);
-    await writeFile(join(agent, "fastagent.config.mjs"), "export default {};\n"); // THE marker
+    await writeFile(join(agent, "fastagent.config.ts"), "export default {};\n"); // THE marker
     await writeFile(join(agent, ".env"), "FASTAGENT_MODEL=prov/m\n"); // NOT the file fastagent reads
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
     try {

--- a/test/feishu-send-tool.test.ts
+++ b/test/feishu-send-tool.test.ts
@@ -57,7 +57,7 @@ function cloudFixture(kind: "feishu" | "lark", prefix: "FEISHU" | "LARK") {
   });
   beforeEach(async () => {
     state.cwd = await mkdtemp(join(tmpdir(), `fa-${kind}-send-`));
-    await writeFile(join(state.cwd, "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(state.cwd, "fastagent.config.ts"), "export default {};\n");
     vi.stubEnv("FASTAGENT_STATE_DIR", "");
     vi.stubEnv("FASTAGENT_AGENT", "");
     vi.stubEnv(`${prefix}_APP_ID`, "");

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -48,7 +48,7 @@ describe("init: scaffoldAgent", () => {
         agentPath("skills", "writing-great-skills", "GLOSSARY.md"),
         agentPath("skills", "writing-great-skills", "LICENSE"),
         agentPath("tools", "fetch-url.ts"),
-        agentPath("fastagent.config.mjs"),
+        agentPath("fastagent.config.ts"),
         agentPath("package.json"),
         agentPath(".gitignore"),
         agentPath(".secrets", ".env.example"),
@@ -106,7 +106,7 @@ describe("init: scaffoldAgent", () => {
     const persona = await readFile(join(dir, "fastagent", "persona.md"), "utf8");
     expect(persona).toContain("Use only the tools actually listed in your system prompt");
     expect(persona).not.toContain("where your `read` / `write` / `edit` / `bash` tools operate");
-    const configTemplate = await readFile(join(dir, "fastagent", "fastagent.config.mjs"), "utf8");
+    const configTemplate = await readFile(join(dir, "fastagent", "fastagent.config.ts"), "utf8");
     expect(configTemplate).not.toContain("codingTools");
 
     // The scaffolded agent ASSEMBLES: ① persona + tools from fastagent/, ② context walked from the workspace.
@@ -131,7 +131,7 @@ describe("init: scaffoldAgent", () => {
         agentPath(".gitignore"),
         agentPath(".secrets", ".env.example"),
         agentPath(".secrets", ".gitignore"),
-        agentPath("fastagent.config.mjs"),
+        agentPath("fastagent.config.ts"),
       ].sort(),
     );
     expect(await exists(join(dir, "fastagent", "package.json"))).toBe(false);
@@ -185,7 +185,7 @@ describe("init: scaffoldAgent", () => {
   it("refuses an occupied ./fastagent/: a config means already-an-agent, anything else means don't mix", async () => {
     const dir = await freshDir();
     await mkdir(join(dir, "fastagent"), { recursive: true });
-    await writeFile(join(dir, "fastagent", "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(dir, "fastagent", "fastagent.config.ts"), "export default {};\n");
     await expect(scaffoldAgent(dir)).rejects.toThrow(/already a fastagent agent/);
 
     const dir2 = await freshDir();
@@ -208,7 +208,7 @@ describe("init: scaffoldAgent", () => {
 
     const nestedAlready = await freshDir();
     await mkdir(join(nestedAlready, "fastagent"), { recursive: true });
-    await writeFile(join(nestedAlready, "fastagent", "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(nestedAlready, "fastagent", "fastagent.config.ts"), "export default {};\n");
     await expect(scaffoldAgent(nestedAlready, { agentDir: "." })).rejects.toThrow(/never served/);
 
     // …but a SIBLING is a supported shape, not a collision: several agents on ONE workspace is how
@@ -219,7 +219,7 @@ describe("init: scaffoldAgent", () => {
   it("refuses init inside an agent's own LOADED surface — the outer agent would load it as content", async () => {
     const inside = join(await freshDir(), "fastagent");
     await mkdir(inside);
-    await writeFile(join(inside, "fastagent.config.mjs"), "export default {};\n"); // a real agent
+    await writeFile(join(inside, "fastagent.config.ts"), "export default {};\n"); // a real agent
     // Its skills/tools/channels/schedules are what it LOADS: an agent scaffolded there becomes part of
     // that definition rather than an agent of its own. Every other command refuses this position too.
     const surface = join(inside, "skills");
@@ -260,7 +260,7 @@ describe("init: scaffoldAgent", () => {
     expect(out).toMatch(/agent in \.\/fastagent\//);
     expect(out).not.toMatch(/found tsconfig/); // no detection chatter
     expect(await exists(join(host, "fastagent", "persona.md"))).toBe(true);
-    expect(await exists(join(host, "fastagent.config.mjs"))).toBe(false); // zero writes around the agent
+    expect(await exists(join(host, "fastagent.config.ts"))).toBe(false); // zero writes around the agent
 
     // --embedded stayed deleted: "embedded" means using fastagent as a library, nothing else.
     const gone = await freshDir();
@@ -270,7 +270,7 @@ describe("init: scaffoldAgent", () => {
     // An agent already here → refuse.
     const done = await freshDir();
     await mkdir(join(done, "fastagent"), { recursive: true });
-    await writeFile(join(done, "fastagent", "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(done, "fastagent", "fastagent.config.ts"), "export default {};\n");
     expect(await cliInit(["init"], done)).toMatch(/already a fastagent agent/);
   });
 
@@ -329,7 +329,7 @@ describe("init: scaffoldAgent", () => {
     await writeFile(join(host, "AGENTS.md"), "# Host repo context\n"); // ② at the workspace
     const root = join(host, "fastagent");
     await mkdir(join(root, "tools"), { recursive: true });
-    await writeFile(join(root, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+    await writeFile(join(root, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };\n`);
     await writeFile(join(root, "persona.md"), "You are the Repo Bot.\n"); // ① in the agent dir
     await writeFile(
       join(root, "tools", "foo.mjs"),
@@ -372,7 +372,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     const dir = join(await freshDir(), "fastagent");
     await mkdir(dir);
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), "export default {};\n"); // THE marker
+    await writeFile(join(dir, "fastagent.config.ts"), "export default {};\n"); // THE marker
     await writeFile(
       join(dir, "package.json"),
       `${JSON.stringify({ type: "module", dependencies: { "@fastagent-sh/fastagent": "^0.4.0" } }, null, 2)}\n`,
@@ -384,7 +384,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
     const dir = await freshDir();
     const root = join(dir, "fastagent");
     await mkdir(join(root, ".secrets"), { recursive: true });
-    await writeFile(join(root, "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(root, "fastagent.config.ts"), "export default {};\n");
     await writeFile(join(root, ".secrets", ".env.example"), "# env\n");
     await writeFile(
       join(root, "package.json"),
@@ -551,7 +551,7 @@ describe("add: fastagent add <channel> (github / telegram)", () => {
       const d = join(await freshDir(), "fastagent");
       await mkdir(d);
       await writeFile(join(d, "persona.md"), "You are terse.\n");
-      await writeFile(join(d, "fastagent.config.mjs"), "export default {};\n"); // THE marker
+      await writeFile(join(d, "fastagent.config.ts"), "export default {};\n"); // THE marker
       if (pkg) await writeFile(join(d, "package.json"), `${JSON.stringify(pkg, null, 2)}\n`);
       return d;
     };
@@ -625,7 +625,7 @@ describe("add: fastagent add skill (vendor)", () => {
     );
     const dir = await freshDir();
     await mkdir(join(dir, "fastagent"), { recursive: true });
-    await writeFile(join(dir, "fastagent", "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(dir, "fastagent", "fastagent.config.ts"), "export default {};\n");
 
     const out = await cliInit(["add", "skill", join(srcRoot, "greeter")], dir);
     expect(out).toMatch(/vendored skill "greeter"/);

--- a/test/live/agentcore-deploy.live.test.ts
+++ b/test/live/agentcore-deploy.live.test.ts
@@ -75,7 +75,7 @@ beforeAll(async () => {
   const agentDir = join(workspace, "fastagent");
   await mkdir(agentDir, { recursive: true });
   await writeFile(join(agentDir, "persona.md"), "You are terse. Answer in as few words as possible.\n");
-  await writeFile(join(agentDir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+  await writeFile(join(agentDir, "fastagent.config.ts"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
   await writeFile(
     join(agentDir, "package.json"),
     `${JSON.stringify(

--- a/test/live/agentcore-wake.live.test.ts
+++ b/test/live/agentcore-wake.live.test.ts
@@ -97,7 +97,7 @@ beforeAll(async () => {
   // container (open.ts, serving + selfSchedule), and it puts the forwarder, its Function URL and the
   // wake/scheduler IAM into the template. Without it there is no chain to test.
   await writeFile(
-    join(agentDir, "fastagent.config.mjs"),
+    join(agentDir, "fastagent.config.ts"),
     `export default { model: ${JSON.stringify(MODEL)}, selfSchedule: true };\n`,
   );
   await writeFile(

--- a/test/live/agentcore.live.test.ts
+++ b/test/live/agentcore.live.test.ts
@@ -63,7 +63,7 @@ describe("aws CLI output still matches what the AgentCore driver reads", () => {
     // Function URL, the two Lambda permissions, the wake/scheduler IAM roles or an
     // `AWS::Scheduler::Schedule`. This fixture emits all of them and still creates nothing.
     await writeFile(
-      join(agentDir, "fastagent.config.mjs"),
+      join(agentDir, "fastagent.config.ts"),
       `export default { model: "openai-codex/gpt-5.5", selfSchedule: true };\n`,
     );
     // A plain default export, not `defineSchedule(...)`: loadSchedules validates the SHAPE, and this

--- a/test/live/docker.live.test.ts
+++ b/test/live/docker.live.test.ts
@@ -47,7 +47,7 @@ beforeAll(async () => {
   await mkdir(agent, { recursive: true });
   await writeFile(join(agent, "persona.md"), "You are terse. Answer in as few words as possible.\n");
   await writeFile(
-    join(agent, "fastagent.config.mjs"),
+    join(agent, "fastagent.config.ts"),
     `export default { model: ${JSON.stringify(MODEL)}, http: { port: ${port} } };\n`,
   );
   // The agent declares the fastagent version it runs, so the image installs the SAME artifact the

--- a/test/live/feishu.live.test.ts
+++ b/test/live/feishu.live.test.ts
@@ -58,7 +58,7 @@ describe("feishu: registering an event URL the platform verifies by calling it",
   it("the platform's challenge reaches our route and the subscription is stored", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-live-feishu-"));
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+    await writeFile(join(dir, "fastagent.config.ts"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
     await mkdir(join(dir, "channels"), { recursive: true });
     // The scaffold's own import is the package name, which resolves through the agent dir's
     // node_modules; a throwaway directory has none. Importing this checkout by path loads the same

--- a/test/live/fly-deploy.live.test.ts
+++ b/test/live/fly-deploy.live.test.ts
@@ -42,7 +42,7 @@ beforeAll(async () => {
   const agentDir = join(workspace, "fastagent");
   await mkdir(agentDir, { recursive: true });
   await writeFile(join(agentDir, "persona.md"), "You are terse. Answer in as few words as possible.\n");
-  await writeFile(join(agentDir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+  await writeFile(join(agentDir, "fastagent.config.ts"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
   await writeFile(
     join(agentDir, "package.json"),
     `${JSON.stringify(

--- a/test/live/model.live.test.ts
+++ b/test/live/model.live.test.ts
@@ -53,7 +53,7 @@ afterAll(async () => {
 async function agentDirectory(model: string, files: Record<string, string> = {}): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "fa-live-model-"));
   await writeFile(join(dir, "persona.md"), "You are terse. Answer in as few words as possible.\n");
-  await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(model)} };\n`);
+  await writeFile(join(dir, "fastagent.config.ts"), `export default { model: ${JSON.stringify(model)} };\n`);
   for (const [name, content] of Object.entries(files)) {
     await mkdir(join(dir, name, ".."), { recursive: true });
     await writeFile(join(dir, name), content);

--- a/test/live/railway-deploy.live.test.ts
+++ b/test/live/railway-deploy.live.test.ts
@@ -49,7 +49,7 @@ beforeAll(async () => {
   const agentDir = join(workspace, "fastagent");
   await mkdir(agentDir, { recursive: true });
   await writeFile(join(agentDir, "persona.md"), "You are terse. Answer in as few words as possible.\n");
-  await writeFile(join(agentDir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+  await writeFile(join(agentDir, "fastagent.config.ts"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
   await writeFile(
     join(agentDir, "package.json"),
     `${JSON.stringify(

--- a/test/live/registry.live.test.ts
+++ b/test/live/registry.live.test.ts
@@ -36,7 +36,7 @@ describe(`published ${PACKAGE}@${VERSION}`, () => {
     // --no-install: the scaffold's own npm install would re-fetch the same package for nothing.
     await run(cli, ["init", "demo", "--no-install"], { cwd: dir });
     const agent = join(dir, "demo", "fastagent");
-    for (const file of ["persona.md", "fastagent.config.mjs", "package.json", "tools/fetch-url.ts"]) {
+    for (const file of ["persona.md", "fastagent.config.ts", "package.json", "tools/fetch-url.ts"]) {
       expect(await exists(join(agent, file)), `init did not produce ${file}`).toBe(true);
     }
     // The skill is a DIRECTORY in the payload — the shape most likely to be lost by a copy step.

--- a/test/live/schedule.live.test.ts
+++ b/test/live/schedule.live.test.ts
@@ -40,7 +40,7 @@ describe("schedules: a cron fire reaches the agent and the audit log", () => {
   it("catches up an overdue slot, runs the turn, and records the outcome", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-live-schedule-"));
     await writeFile(join(dir, "persona.md"), "You are terse. Answer in as few words as possible.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+    await writeFile(join(dir, "fastagent.config.ts"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
     await mkdir(join(dir, "schedules"), { recursive: true });
     // A plain default export: `defineSchedule` is an identity function, so this is the shape the
     // loader gets either way, and the file stays what an author's `schedules/*.ts` looks like rather

--- a/test/live/telegram.live.test.ts
+++ b/test/live/telegram.live.test.ts
@@ -77,7 +77,7 @@ describe("telegram: registering a webhook against a live tunnel", () => {
 
     const dir = await mkdtemp(join(tmpdir(), "fa-live-telegram-"));
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
+    await writeFile(join(dir, "fastagent.config.ts"), `export default { model: ${JSON.stringify(MODEL)} };\n`);
 
     const service = await createAgentService(dir);
     const server = serveNode(service.handler, { port: 0, host: "127.0.0.1" });

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -12,7 +12,7 @@ import { displayPath, readTextIfExists, resolvePlacement, workspaceHint } from "
 describe("paths: resolvePlacement — one marker, and the directory you point at", () => {
   const config = async (dir: string): Promise<void> => {
     await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, "fastagent.config.mjs"), "export default {};\n");
+    await writeFile(join(dir, "fastagent.config.ts"), "export default {};\n");
   };
 
   it("the agent is the config holder one level inside; the workspace is what you pointed at", async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -19,7 +19,7 @@ async function agentDir(
   config = `{ model: "openai-codex/gpt-5.5" }`,
 ): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "fa-surface-"));
-  await writeFile(join(dir, "fastagent.config.mjs"), `export default ${config};\n`);
+  await writeFile(join(dir, "fastagent.config.ts"), `export default ${config};\n`);
   await writeFile(join(dir, "persona.md"), "You are a test agent.\n");
   for (const [rel, body] of Object.entries(files)) {
     await mkdir(join(dir, rel, ".."), { recursive: true });
@@ -64,7 +64,7 @@ describe("createAgentService", () => {
     // repo shipped a version where they did not — /control/* 404'd while control.json advertised it.
     const dir = await mkdtemp(join(tmpdir(), "fa-surface-ctl-"));
     await writeFile(
-      join(dir, "fastagent.config.mjs"),
+      join(dir, "fastagent.config.ts"),
       `export default { model: "openai-codex/gpt-5.5", sessionControl: true };\n`,
     );
     await writeFile(join(dir, "persona.md"), "You are a test agent.\n");
@@ -84,7 +84,7 @@ describe("createAgentService", () => {
     // access at all (the CLI's discovery file is `announceControl`'s, in cli/serve.ts).
     const dir = await mkdtemp(join(tmpdir(), "fa-surface-token-"));
     await writeFile(
-      join(dir, "fastagent.config.mjs"),
+      join(dir, "fastagent.config.ts"),
       `export default { model: "openai-codex/gpt-5.5", sessionControl: true };\n`,
     );
     await writeFile(join(dir, "persona.md"), "You are a test agent.\n");
@@ -102,7 +102,7 @@ describe("createAgentService", () => {
   it("honours an injected control token — the deployed case, where a minted one is unreadable", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-surface-injected-"));
     await writeFile(
-      join(dir, "fastagent.config.mjs"),
+      join(dir, "fastagent.config.ts"),
       `export default { model: "openai-codex/gpt-5.5", sessionControl: true };\n`,
     );
     await writeFile(join(dir, "persona.md"), "You are a test agent.\n");

--- a/test/session-builder.test.ts
+++ b/test/session-builder.test.ts
@@ -27,7 +27,7 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
     const piUrl = new URL("../src/pi.ts", import.meta.url).href;
     try {
       await writeFile(
-        join(dir, "fastagent.config.mjs"),
+        join(dir, "fastagent.config.ts"),
         `import { defineTool, z } from ${JSON.stringify(piUrl)};
          export default {
            model: "openai-codex/gpt-5.5",
@@ -74,7 +74,7 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
     const dir = await freshAgentDir("fa-chat-defer-");
     try {
       await writeFile(
-        join(dir, "fastagent.config.mjs"),
+        join(dir, "fastagent.config.ts"),
         `export default {
            model: "openai-codex/gpt-5.5",
            tools: [{
@@ -147,7 +147,7 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
     try {
       await writeFile(join(dir, "AGENTS.md"), "# Test Agent\nMAGIC_CHAT_MARKER_91. Be terse.\n");
       await writeFile(
-        join(dir, "fastagent.config.mjs"),
+        join(dir, "fastagent.config.ts"),
         `export default {
            model: "openai-codex/gpt-5.5",
            tools: [{
@@ -240,7 +240,7 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
       await writeFile(join(dir, "AGENTS.md"), "HOST_CTX_MARKER. Repo conventions.\n"); // ② at the workspace
       const root = join(dir, "fastagent");
       await mkdir(join(root, "tools"), { recursive: true });
-      await writeFile(join(root, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(join(root, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };\n`);
       await writeFile(join(root, "persona.md"), "You are PERSONA_MARKER bot.\n"); // ① in the workspace root
       await writeFile(
         join(root, "tools", "foo.mjs"),
@@ -269,7 +269,7 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
     const prev = process.env.PI_CODING_AGENT_DIR;
     try {
       await writeFile(join(dir, "AGENTS.md"), "# Agent\nDEFN_ONLY_MARKER.\n");
-      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(join(dir, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };\n`);
       await writeFile(join(agentDir, "APPEND_SYSTEM.md"), "GLOBAL_APPEND_LEAK_MARKER must not reach chat.\n");
       process.env.PI_CODING_AGENT_DIR = agentDir;
 
@@ -292,7 +292,7 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
   it("wires auth to the agent's credential file (not ~/.pi), touching no .gitignore", async () => {
     const dir = await freshAgentDir("fa-sb-auth-");
     try {
-      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(join(dir, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };\n`);
       // A credential in the PROJECT-level auth.json — the same file dev/start/login use.
       await mkdir(join(dir, ".secrets"), { recursive: true });
       await writeFile(
@@ -320,7 +320,7 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
     const dir = await freshAgentDir("fa-sb-think-");
     try {
       await writeFile(
-        join(dir, "fastagent.config.mjs"),
+        join(dir, "fastagent.config.ts"),
         `export default { model: "openai-codex/gpt-5.5", thinkingLevel: "high" };\n`,
       );
       const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
@@ -348,9 +348,9 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
       await mkdir(dir, { recursive: true });
       await mkdir(other, { recursive: true });
       await writeFile(join(dir, "AGENTS.md"), "# Agent A\n");
-      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(join(dir, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };\n`);
       await writeFile(join(other, "AGENTS.md"), "# Agent B\n");
-      await writeFile(join(other, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(join(other, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };\n`);
       const imported = join(root, "other-session.jsonl");
       await writeFile(
         imported,
@@ -387,7 +387,7 @@ describe("session builder: buildAgentSessionRuntime injects fastagent's assemble
     try {
       await mkdir(dir, { recursive: true });
       await writeFile(join(dir, "AGENTS.md"), "# Agent\n");
-      await writeFile(join(dir, "fastagent.config.mjs"), `export default { model: "openai-codex/gpt-5.5" };\n`);
+      await writeFile(join(dir, "fastagent.config.ts"), `export default { model: "openai-codex/gpt-5.5" };\n`);
       // A legacy session: a header with NO cwd, plus one user message entry to fork at.
       const legacy = join(root, "legacy-session.jsonl");
       await writeFile(
@@ -429,7 +429,7 @@ describe("session builder: a tool sees one spelling of the workspace", () => {
       await mkdir(dir, { recursive: true });
       await writeFile(join(dir, "persona.md"), "You are terse.\n");
       await writeFile(
-        join(dir, "fastagent.config.mjs"),
+        join(dir, "fastagent.config.ts"),
         `import { defineTool, z } from ${JSON.stringify(piUrl)};
          export default {
            model: "openai-codex/gpt-5.5",
@@ -504,7 +504,7 @@ describe("session builder: the credential hint belongs to the runtime, not to ea
     const dir = join(workspace, "fastagent");
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    await writeFile(join(dir, "fastagent.config.ts"), 'export default { model: "openai-codex/gpt-5.5" };\n');
     const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
     const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
     try {
@@ -531,7 +531,7 @@ describe("session builder: chat offers the model the same tool set serving does"
     // so a version of this that stated the active set explicitly offered the model two of each.
     const dir = await mkdtemp(join(tmpdir(), "fa-active-"));
     await writeFile(join(dir, "persona.md"), "You are terse.\n");
-    await writeFile(join(dir, "fastagent.config.mjs"), 'export default { model: "openai-codex/gpt-5.5" };\n');
+    await writeFile(join(dir, "fastagent.config.ts"), 'export default { model: "openai-codex/gpt-5.5" };\n');
     const rt = await buildAgentSessionRuntime(dir, {}, SessionManager.inMemory());
     try {
       const active = rt.session.getActiveToolNames().sort();

--- a/test/session-control.test.ts
+++ b/test/session-control.test.ts
@@ -318,7 +318,7 @@ describe("session control: observation plane", () => {
     try {
       await mkdir(join(dir, "fastagent"), { recursive: true });
       await writeFile(
-        join(dir, "fastagent", "fastagent.config.mjs"),
+        join(dir, "fastagent", "fastagent.config.ts"),
         `export default { model: "openai-codex/gpt-5.5" };\n`,
       );
       const opened = await createPiAgentFromDir(dir, { sessionControl: true });
@@ -350,7 +350,7 @@ describe("session control: observation plane", () => {
       const { mkdir } = await import("node:fs/promises");
       await mkdir(join(dir, "fastagent"));
       await writeFile(
-        join(dir, "fastagent", "fastagent.config.mjs"),
+        join(dir, "fastagent", "fastagent.config.ts"),
         `export default { model: "openai-codex/gpt-5.5" };\n`,
       );
       const opened = await createPiAgentFromDir(dir, { sessionControl: true });
@@ -380,7 +380,7 @@ describe("session control: observation plane", () => {
     try {
       await mkdir(join(dir, "fastagent"));
       await writeFile(
-        join(dir, "fastagent", "fastagent.config.mjs"),
+        join(dir, "fastagent", "fastagent.config.ts"),
         `export default { model: "openai-codex/gpt-5.5" };\n`,
       );
       const opened = await createPiAgentFromDir(dir, { sessionControl: true });
@@ -2287,7 +2287,7 @@ describe("session control: boundary mutations", () => {
       const { mkdir } = await import("node:fs/promises");
       await mkdir(join(dir, "fastagent"));
       await writeFile(
-        join(dir, "fastagent", "fastagent.config.mjs"),
+        join(dir, "fastagent", "fastagent.config.ts"),
         `export default { model: "openai-codex/gpt-5.5" };\n`,
       );
       const seen: string[] = [];


### PR DESCRIPTION
`AGENT_CONFIG_NAMES` accepted `fastagent.config.ts`, `.js`, and `.mjs` in precedence order, and `init` generated the `.mjs`. The choice bought an author nothing — fastagent generates this file — and cost a precedence chain plus a "you have two of them" failure path. It is now `AGENT_CONFIG_FILE = "fastagent.config.ts"`, and `loadConfig` is an `existsSync` on one path.

**Only the config file is locked.** `tools/`, `channels/`, and `schedules/` still accept `.ts`/`.js`/`.mjs`: that is the author's code, and narrowing it would lock a JavaScript project out of writing tools. The docs say which rule applies where.

## Two things this does not buy, stated so nobody assumes them

**Not type checking.** Node strips types without checking them, so `modle:` reaches the loader whatever the editor said. `loadConfig`'s unknown-key check is therefore not redundant with `defineConfig` — the comment claiming it existed to compensate `.js`/`.mjs` authors was wrong and is fixed.

**Not a slower CLI.** Measured, because the first measurement was misleading: `import()` of a lone `.ts` costs ~370 ms more than a `.mjs` (type stripping loads amaro on first use). In a real agent that cost is already paid by `tools/*.ts`, and the marginal cost of the config file being `.ts` is 168 ms vs 167 ms.

The template keeps its bare `export default { … }` rather than wrapping in `defineConfig`: `init --minimal` writes no `package.json`, so a bare-specifier import would fail to resolve at runtime.

## Verification

`npm run lint && npm run typecheck && npm test` pass; the full suite ran clean twice after the rename (two earlier 30 s timeouts were load-related flakes, confirmed by the measurement above and by both clean runs). The `multiple config files throw` case is gone with the condition it tested.