### PR TITLE
refactor(init): one layout — the definition always lands in a subdirectory

### DIFF
--- a/docs/ai-start.md
+++ b/docs/ai-start.md
@@ -64,7 +64,7 @@ directories or the same directory.
 | Situation | Placement |
 |---|---|
 | New agent or an agent for an existing project | `fastagent init [workspace]` creates `workspace/fastagent/`; existing workspace files stay untouched. |
-| A standalone agent repository or an existing package that is itself the agent | `fastagent init . --flat` puts the definition in the current directory and keeps existing files. Review retained package and ignore files. Not deployable as-is: `deploy` requires the agent to sit inside a workspace. |
+| A standalone agent repository or an existing package that is itself the agent | Run `fastagent init` in it: that repository is the WORKSPACE and the definition lands in `./fastagent/`. This is also the shape `deploy` requires. |
 | An existing application embeds the agent | Keep the application's layout. A nested definition is convenient; the app retains auth, routes, database, and deployment. See [embedding](#8-embed-only-what-the-application-needs). |
 
 A config file identifies an agent, not its directory name. Check the workspace itself and its direct
@@ -96,7 +96,7 @@ my-agent/                         # workspace; run FastAgent commands here
 ```
 
 `init` installs dependencies in `fastagent/`. If installation fails, run `npm --prefix fastagent install`
-before continuing. `--no-install` defers that install; `--minimal` omits the code tool and package manifest.
+before continuing. `--no-install` defers that install.
 A global CLI installation alone does not make package imports available to authored tools.
 
 **Working-directory convention for the rest of this guide:** stay in `my-agent/`, the workspace.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,16 +42,16 @@ Most commands take an optional workspace directory (the agent is there, or in it
 ## `fastagent init`
 
 ```bash
-fastagent init [dir] [--minimal] [--no-install] [--agent-dir <name>|--flat]
+fastagent init [dir] [--no-install] [--agent-dir <name>]
 ```
 
 Creates a self-iterating agent — it can edit its own definition (persona.md and skills are re-read every turn). A fresh agent has `persona.md` (the agent's identity: how to improve yourself), a `writing-great-skills` example skill (from [mattpocock/skills](https://github.com/mattpocock/skills) — the guide to authoring skills), a `fetch-url` example code tool, config, `.secrets/.env.example`, and `.gitignore`. No `AGENTS.md` is scaffolded (it is project context, not identity); an existing one is kept untouched. Everything is written offline; by default it also writes `package.json` and runs `npm install`. Ignore hygiene is two scaffolded files: the agent `.gitignore` (`node_modules/`, `.state/`, a stray `.env`) and `.secrets/.gitignore` (everything but `.env.example`). fastagent writes both once, at `init` — no later command reads, rewrites or verifies them, so they are yours. They are separate on purpose: the root one is the file you will edit, and a nested `.gitignore` outranks it, so the credentials stay protected either way.
 
-**Where the files land** — no detection and no prompt. By default the WHOLE agent — definition, config, `.secrets/`, `.state/` — goes into `./fastagent/`; the directory around it gets zero writes and becomes the agent's WORKSPACE when you point fastagent there. The agent self-contains its `package.json`, so the workspace's manifest and lockfile are never touched. `init` refuses when the target already holds a `fastagent.config.ts` (already an agent) or any other content.
+**Where the files land** — no detection, no prompt, no choice. The WHOLE agent — definition, config, `.secrets/`, `.state/` — goes into `./fastagent/`; the directory around it gets zero writes and becomes the agent's WORKSPACE when you point fastagent there. The agent self-contains its `package.json`, so the workspace's manifest and lockfile are never touched. `init` refuses when the target already holds a `fastagent.config.ts` (already an agent) or any other content.
 
 `--agent-dir <name>` names that directory anything you like: **the name never decides what IS an agent** — a `fastagent.config.ts` does, so `./bot/` and `./fastagent/` are equally agents. The name carries weight in exactly one place, and only among agents already identified: when a workspace holds several and nothing selects, the one named `fastagent` answers (see `FASTAGENT_AGENT` below). It must be a single directory name (a path would put the agent where fastagent's one-level lookup could not find it). To deploy it, keep the name to letters, digits, `-` and `_`: the release manifest carries it into the container, and `deploy` refuses anything else by name.
 
-`--agent-dir .` (spelled `--flat`) puts the identical shape in the directory itself — for a standalone agent repo or a monorepo package, where the agent's tools operate on its own definition. Adopting a directory is the point, so **every file that already exists is kept** (reported, never overwritten); only a `fastagent.config.ts` refuses, because that means it is already an agent. `deploy` does not accept this layout — it needs a workspace containing the agent, because a release replaces the agent directory and nothing else.
+**A standalone agent repository is still a supported shape** — that repository is the WORKSPACE, and the definition lives in `./fastagent/` inside it. `init` will not write a definition INTO a directory that already holds other files, which is why `--agent-dir .` is refused: the agent would inherit that directory's `package.json`, and a `fastagent.config.ts` under a CommonJS manifest does not load at all. A scaffolded subdirectory carries its own `type: module`. (Placement still *resolves* an agent sitting at a directory — a deployed container is shipped the agent directory alone — so an existing layout of that shape keeps serving.)
 
 What a served agent's workspace turns out to be is not decided here: it is whatever directory you later point fastagent at (see `dev`/`start` below). `init`'s one placement duty is to refuse a target the lookup could never SELECT — an agent already resolving AT `dir`, which wins over anything inside it and would hide the new one. A second agent BESIDE an existing one is fine and supported: several agents can share one workspace (an engineer's, a PM's, a content owner's, all driving the same repository), and `FASTAGENT_AGENT=<name>` picks between them — the one named `fastagent` answers by default. `init` prints the note when a workspace crosses into that shape. The config is a DECLARATION, not configuration: its contents may be `export default {}` (a model can come from `--model`), but a directory has to SAY it is an agent — the job `package.json` and `Cargo.toml` do for their tools. A directory holding nothing else is already a complete agent.
 
@@ -59,10 +59,8 @@ Options:
 
 | Option | Meaning |
 |---|---|
-| `--minimal` | persona.md + the example skill + config only — no code tool, package.json, or install. |
 | `--no-install` | Scaffold everything but skip `npm install`. |
-| `--agent-dir <name>` | Name the agent directory (default `fastagent`; `.` = `dir` itself). |
-| `--flat` | Alias for `--agent-dir .` — the directory IS the agent; existing files are kept. Not deployable (see above). |
+| `--agent-dir <name>` | Name the agent directory (default `fastagent`). One directory name — not a path, and not `.`. |
 
 ## `fastagent info`
 

--- a/docs/design/core.md
+++ b/docs/design/core.md
@@ -66,8 +66,10 @@ repo/                       # `fastagent dev` here  → agent = repo/agent, work
 
 Point at the project and its agent serves with the project as its workspace (what `init` sets up).
 Point at the agent directory — all a deployed box may have been shipped — and it works on itself; a
-rule insisting the workspace is always the parent would hand that container `/`. `init --flat` (a
-standalone agent repo, a monorepo package) is the same rule with the two directories equal.
+rule insisting the workspace is always the parent would hand that container `/`. That shape still
+RESOLVES (the two directories are simply equal), but `init` no longer creates it: a definition written
+into a directory that already holds other files inherits that directory's `package.json`, and a
+`fastagent.config.ts` under a CommonJS manifest does not load.
 
 | `dir` | Result |
 |---|---|

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,11 +43,7 @@ my-agent/                              # the workspace — the agent's cwd, unto
     └── .gitignore
 ```
 
-`persona.md` teaches the agent to capture durable improvements as new skills; `writing-great-skills` (vendored from [mattpocock/skills](https://github.com/mattpocock/skills)) is the guide it consults to write them. No `AGENTS.md` is scaffolded — that file is *project context* the agent reads (yours, or a host repo's), not its identity. Add more skills with `fastagent add skill <owner/repo/path>`. For a agent with no code tool or dependencies (persona.md + the skill + config only):
-
-```bash
-fastagent init my-agent --minimal
-```
+`persona.md` teaches the agent to capture durable improvements as new skills; `writing-great-skills` (vendored from [mattpocock/skills](https://github.com/mattpocock/skills)) is the guide it consults to write them. No `AGENTS.md` is scaffolded — that file is *project context* the agent reads (yours, or a host repo's), not its identity. Add more skills with `fastagent add skill <owner/repo/path>`. Don't want the code tool? Delete `tools/fetch-url.ts` — the scaffold is one shape, and everything in it is yours after `init`.
 
 ## 2. Inspect it
 
@@ -59,7 +55,7 @@ fastagent info
 
 **Initializing inside an existing project?** Same command, same result: `init` puts the WHOLE agent into `./fastagent/` — zero writes elsewhere, so the project's build and the agent's surface never sweep each other, and the repo's own `AGENTS.md` is read as project context. A `fastagent.config.ts` file identifies the agent; `fastagent/` is only the default directory name.
 
-**The repository IS the agent?** (A standalone agent repo, or a monorepo package.) `fastagent init . --flat` puts the same shape at the root instead. Existing files are kept untouched, and the agent's workspace is its own directory, so its tools operate on its own definition. Note that `fastagent deploy` needs a workspace that CONTAINS the agent, so a flat agent has to move into one before it can be deployed. **Want a different directory name?** `fastagent init . --agent-dir bot` — the `fastagent.config.ts` inside is what makes a directory an agent, never its name.
+**The repository IS the agent?** (A standalone agent repo, or a monorepo package.) Run `fastagent init` in it: that repository becomes the WORKSPACE and the definition lands in `./fastagent/`, which is also the shape `fastagent deploy` needs. **Want a different directory name?** `fastagent init . --agent-dir bot` — the `fastagent.config.ts` inside is what makes a directory an agent, never its name.
 
 A fresh agent presets no model. On the first `fastagent dev` (or `start` / `invoke`) in a
 terminal, FastAgent shows the full model catalog — models whose provider already has credentials (a

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,16 +1,14 @@
 /** `fastagent init [dir]`: scaffold a runnable agent and install its dependencies. */
 import { spawn } from "node:child_process";
-import { basename, join, resolve } from "node:path";
-import { DEFAULT_AGENT_DIRNAME, SECRETS_DIRNAME, agentsAt, displayPath } from "../../paths.ts";
-import { detectRuntime, readPackageJson } from "../../runtime.ts";
+import { basename, resolve } from "node:path";
+import { DEFAULT_AGENT_DIRNAME, agentsAt, displayPath } from "../../paths.ts";
 import { agentDirName, agentDirNameError, scaffoldAgent } from "../../scaffold/init.ts";
 import { failStartup, failUsage } from "../fail.ts";
 
 export interface InitOptions {
-  minimal: boolean;
   /** false ⇔ `--no-install`. */
   install: boolean;
-  /** The agent directory's name inside `dir` — undefined = the default, `"."` = `dir` itself (`--flat`). */
+  /** The agent directory's name inside `dir` — undefined = the default. */
   agentDir?: string;
 }
 
@@ -20,22 +18,11 @@ export async function runInit(dirArg: string, opts: InitOptions): Promise<void> 
   const requested = agentDirName(opts.agentDir);
   const invalid = agentDirNameError(requested);
   if (invalid) failUsage(`--agent-dir "${requested}" ${invalid}`);
-  const {
-    complete,
-    agentDir: rel,
-    created,
-    kept,
-  } = await scaffoldAgent(dir, {
-    minimal: opts.minimal,
-    agentDir: requested,
-  }).catch(failStartup);
-  const flat = rel === ".";
-  // The agent dir is where the manifest lives, so any install runs there — never against a surrounding workspace's
+  const { agentDir: rel, created } = await scaffoldAgent(dir, { agentDir: requested }).catch(failStartup);
+  // The agent dir is where the manifest lives, so the install runs there — never against a surrounding workspace's
   // package.json (its deps are its own concern).
   const agentDir = resolve(dir, rel);
-  console.error(
-    `[fastagent] initialized ${dir}${complete ? "" : " (minimal)"} — ${flat ? "the directory IS the agent" : `agent in ./${rel}/`}`,
-  );
+  console.error(`[fastagent] initialized ${dir} — agent in ./${rel}/`);
   console.error(`  created: ${created.join(", ")}`);
   // A second agent beside an existing one is a supported shape, not an accident (an engineer's, a PM's and a content
   // owner's agent can drive one repository), but it changes how this workspace resolves from now on — so say it HERE,
@@ -47,38 +34,9 @@ export async function runInit(dirArg: string, opts: InitOptions): Promise<void> 
       : `set FASTAGENT_AGENT=<name> (in your shell or .envrc) to pick one`;
     console.error(`[fastagent] note: ${dir} now holds ${siblings.length} agents (${siblings.join(", ")}) — ${pick}`);
   }
-  if (kept.length > 0) {
-    // Adopting a directory: its own files win, always.
-    console.error(`  kept your existing: ${kept.join(", ")}`);
-    if (kept.includes(join(rel, "package.json")) && complete) {
-      const add =
-        detectRuntime(agentDir, await readPackageJson(agentDir)).runtime === "bun" ? "bun add" : "npm install";
-      console.error(
-        `[fastagent] note: your package.json is untouched, so it does not list @fastagent-sh/fastagent — ` +
-          `run \`${add} @fastagent-sh/fastagent\` there or the scaffolded tools/ cannot resolve`,
-      );
-    }
-    const keptSecretsIgnore = kept.includes(join(rel, SECRETS_DIRNAME, ".gitignore"));
-    if (kept.includes(join(rel, ".gitignore"))) {
-      // The "credentials are covered either way" reassurance holds only when `.secrets/.gitignore` is OURS.
-      console.error(
-        `[fastagent] note: your .gitignore is untouched — make sure it ignores node_modules, .state ` +
-          `and .cache` +
-          (keptSecretsIgnore ? `` : ` (.secrets/ carries its own .gitignore, so credentials are covered either way)`),
-      );
-    }
-    if (keptSecretsIgnore) {
-      console.error(
-        `[fastagent] note: your ${join(rel, SECRETS_DIRNAME, ".gitignore")} is untouched — verify it ignores ` +
-          `everything but .env.example, because credentials land in that directory`,
-      );
-    }
-  }
-
-  const willInstall = complete && opts.install && !kept.includes(join(rel, "package.json"));
   let installFailed = false;
-  if (willInstall) {
-    console.error(`[fastagent] installing dependencies (npm install${flat ? "" : ` in ${rel}`})…`);
+  if (opts.install) {
+    console.error(`[fastagent] installing dependencies (npm install in ${rel})…`);
     installFailed = (await npmInstall(agentDir)) !== 0;
     if (installFailed)
       console.error(`[fastagent] warn: npm install failed — run it manually in ${agentDir} before \`fastagent dev\``);
@@ -87,9 +45,7 @@ export async function runInit(dirArg: string, opts: InitOptions): Promise<void> 
   console.error(`  next steps:`);
   const cdTarget = displayPath(process.cwd(), dir);
   if (cdTarget) console.error(`    cd ${cdTarget}`);
-  if (complete && (!willInstall || installFailed)) {
-    console.error(`    ${flat ? "npm install" : `(cd ${rel} && npm install)`}`);
-  }
+  if (!opts.install || installFailed) console.error(`    (cd ${rel} && npm install)`);
   console.error(`    fastagent dev   # serve locally and iterate`);
   console.error(`    fastagent add skill <owner/repo/path>   # vendor more skills from GitHub`);
 }

--- a/src/cli/kernel.ts
+++ b/src/cli/kernel.ts
@@ -15,8 +15,6 @@ interface ArgSpec {
 export interface FlagSpec {
   flags: string;
   description: string;
-  /** Mutually exclusive with these {@link optionKey} values — validated at build time. */
-  conflicts?: string[];
 }
 
 interface ExampleSpec {
@@ -118,15 +116,6 @@ export function buildProgram(specs: readonly CommandSpec[], options: ProgramOpti
 }
 
 function register(parent: Command, spec: CommandSpec): void {
-  // Validate the spec's option references BEFORE handing anything to commander.
-  const keys = new Set((spec.flags ?? []).map((f) => optionKey(f.flags)));
-  for (const f of spec.flags ?? []) {
-    for (const target of f.conflicts ?? []) {
-      if (!keys.has(target)) {
-        throw new Error(`command "${spec.name}": "${f.flags}" conflicts with unknown option key "${target}"`);
-      }
-    }
-  }
   const cmd = parent.command(spec.name);
   specOf.set(cmd, spec);
   cmd.summary(spec.summary);
@@ -144,11 +133,7 @@ function register(parent: Command, spec: CommandSpec): void {
     }
     cmd.addArgument(arg);
   }
-  for (const f of spec.flags ?? []) {
-    const opt = new Option(f.flags, f.description);
-    if (f.conflicts) opt.conflicts(f.conflicts);
-    cmd.addOption(opt);
-  }
+  for (const f of spec.flags ?? []) cmd.addOption(new Option(f.flags, f.description));
   for (const sub of spec.subcommands ?? []) register(cmd, sub);
   const run = spec.run;
   if (run) {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -38,30 +38,21 @@ const init: CommandSpec = {
   name: "init",
   summary: "scaffold a runnable agent and install its dependencies",
   description:
-    "Scaffold a runnable agent and run npm install. By default the agent goes into ./fastagent/ in dir " +
-    "(default .; --agent-dir names it otherwise) — the rest of the directory gets zero writes, and it is " +
-    "the WORKSPACE the agent works ON when you point fastagent there. Default content is a " +
+    "Scaffold a runnable agent and run npm install. The agent ALWAYS goes into a subdirectory of dir " +
+    "(default .): ./fastagent/, or --agent-dir <name> — the rest of the directory gets zero writes, and " +
+    "it is the WORKSPACE the agent works ON when you point fastagent there. Content is a " +
     "self-iterating agent: persona.md (its identity), a writing-great-skills " +
     "example skill, a fetch-url code tool, config, package.json, .gitignore. An existing AGENTS.md is " +
     "kept as project context.",
   args: [DIR_ARG],
   flags: [
-    { flags: "--minimal", description: "persona.md + the example skill + config only (no code tool / package.json)" },
     { flags: "--no-install", description: "scaffold everything but skip npm install" },
-    { flags: "--agent-dir <name>", description: "name the agent directory (default fastagent; . = dir itself)" },
-    {
-      flags: "--flat",
-      description: "alias for --agent-dir . — the directory IS the agent; keeps existing files",
-      // Two spellings of ONE knob: `--flat --agent-dir bot` names the same thing twice with different values, which
-      // is a usage error, not a precedence question to settle silently.
-      conflicts: ["agentDir"],
-    },
+    { flags: "--agent-dir <name>", description: "name the agent directory (default fastagent)" },
   ],
   examples: [
     { cmd: "fastagent init", note: "the agent lands in ./fastagent/" },
     { cmd: "fastagent init my-project", note: "my-project/fastagent/ (created)" },
     { cmd: "fastagent init . --agent-dir bot", note: "./bot/ — any name works" },
-    { cmd: "fastagent init . --flat", note: "this repo IS the agent" },
   ],
   notes:
     "An agent is a directory holding a fastagent.config.ts — never its NAME, so --agent-dir can call it " +
@@ -72,10 +63,8 @@ const init: CommandSpec = {
     "hold) and it works on itself. A directory resolves to ONE agent, at it or one level inside.",
   run: async (args, f) =>
     (await import("./commands/init.ts")).runInit(args[0] as string, {
-      minimal: f.minimal === true,
       install: f.install !== false,
-      // `--flat` is the spelling for the common case of the same knob (they conflict, so only one is ever set).
-      agentDir: f.flat === true ? "." : typeof f.agentDir === "string" ? f.agentDir : undefined,
+      agentDir: typeof f.agentDir === "string" ? f.agentDir : undefined,
     }),
 };
 

--- a/src/scaffold/add-channel.ts
+++ b/src/scaffold/add-channel.ts
@@ -405,7 +405,7 @@ export async function assertChannelReady(dir: string): Promise<void> {
       // `dir` is the AGENT dir, so `fastagent init` here would nest a second agent inside it.
       throw new Error(
         `${dir}: no package.json — a channel adapter is code and needs the agent's own manifest. ` +
-          `Add a package.json declaring @fastagent-sh/fastagent there (a --minimal init writes none), ` +
+          `Add a package.json declaring @fastagent-sh/fastagent there (\`init\` scaffolds one), ` +
           `or run \`fastagent init\` in the workspace for a fresh agent`,
       );
     }

--- a/src/scaffold/init.ts
+++ b/src/scaffold/init.ts
@@ -25,42 +25,38 @@ export function agentDirName(raw: string | undefined): string {
   return trimmed === "" ? raw : trimmed;
 }
 
-/** Why `name` cannot be an agent directory name, or undefined when it can. */
+/**
+ * Why `name` cannot be an agent directory name, or undefined when it can.
+ *
+ * `"."` is refused along with every path: the definition always lands in a SUBDIRECTORY, and the directory around it
+ * is the workspace. Scaffolding into a directory that already holds someone else's files is what made the layout a
+ * choice, and it made the agent inherit that directory's `package.json` — under which a `fastagent.config.ts` is
+ * only loadable if the host repo happens to be ESM.
+ */
 export function agentDirNameError(name: string): string | undefined {
-  if (name === "." || (name !== "" && name !== ".." && name === basename(name))) return undefined;
+  if (name !== "" && name !== "." && name !== ".." && name === basename(name)) return undefined;
   return (
-    `must be a single directory name (or "." for the target itself) — a path would put the agent outside ` +
-    `the target directory, where fastagent would not find it`
+    `must be a single directory name — the definition lives in a subdirectory, and the directory around it is ` +
+    `the workspace the agent works on (a path, or ".", would put it elsewhere)`
   );
 }
 
 export interface ScaffoldOptions {
-  /** Scaffold the markdown-only unit (no package.json, no tool, no install) instead of a complete agent. */
-  minimal?: boolean;
-  /** The agent directory's name inside `dir` — default {@link DEFAULT_AGENT_DIRNAME}, `"."` for `dir` itself. */
+  /** The agent directory's name inside `dir` — default {@link DEFAULT_AGENT_DIRNAME}. */
   agentDir?: string;
 }
 
 export interface ScaffoldResult {
   dir: string;
-  /** Whether a complete (code-tool) agent was scaffolded (false for --minimal). */
-  complete: boolean;
   /** The agent dir relative to `dir`: the {@link ScaffoldOptions.agentDir} that was used. */
   agentDir: string;
   /** Files written by this run (relative to `dir`). */
   created: string[];
-  /** Files that already existed and were KEPT untouched. */
-  kept: string[];
 }
 
-/**
- * Scaffold a runnable agent into `<dir>/<agentDir>/` — or into `dir` itself when `agentDir` is `"."` (both created if
- * missing).
- */
+/** Scaffold a runnable agent into `<dir>/<agentDir>/` (both created if missing). */
 export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}): Promise<ScaffoldResult> {
-  const minimal = options.minimal ?? false;
   const root = agentDirName(options.agentDir);
-  const flat = root === ".";
   const invalid = agentDirNameError(root);
   if (invalid) throw new Error(`agentDir "${root}" ${invalid}`);
   const skill = (name: string) => ({
@@ -80,18 +76,14 @@ export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}):
     { rel: join(root, ".gitignore"), content: baseTemplate("gitignore") },
     { rel: join(root, SECRETS_DIRNAME, ".gitignore"), content: baseTemplate("secrets.gitignore") },
     { rel: join(root, SECRETS_DIRNAME, ".env.example"), content: baseTemplate("env.example") },
+    { rel: join(root, "tools", "fetch-url.ts"), content: baseTemplate("tools/fetch-url.ts") },
+    // The agent's own manifest, named after the directory it serves. Its `type: module` is why the definition gets a
+    // subdirectory of its own: a config file under a host repo's CommonJS manifest does not load.
+    {
+      rel: join(root, "package.json"),
+      content: packageJson(`${toPackageName(dir)}-agent`, await fastagentVersion()),
+    },
   ];
-  if (!minimal) {
-    files.push(
-      { rel: join(root, "tools", "fetch-url.ts"), content: baseTemplate("tools/fetch-url.ts") },
-      // The agent's own manifest, named after the directory it serves (`<dir>-agent`) — except when it IS that
-      // directory, where it takes the name straight.
-      {
-        rel: join(root, "package.json"),
-        content: packageJson(flat ? toPackageName(dir) : `${toPackageName(dir)}-agent`, await fastagentVersion()),
-      },
-    );
-  }
 
   // Inside another agent's DEFINITION (its `skills/`, `tools/`, `channels/` or `schedules/`): the outer agent would
   // load the new one as its own content.
@@ -131,13 +123,11 @@ export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}):
   ).filter((f) => ![".DS_Store", ".gitkeep", ".keep"].includes(f));
   // Could `dir` still SELECT the agent this run creates?
   const existing = agentsAt(dir).filter((a) => a !== resolve(dir, root));
-  const shadowed = flat
-    ? existing // the new agent lands AT `dir` and hides everything inside it
-    : existing.filter((a) => a === resolve(dir)); // an agent AT `dir` hides the new one inside it
+  const shadowed = existing.filter((a) => a === resolve(dir)); // an agent AT `dir` hides the new one inside it
   if (shadowed.length > 0) {
     throw new Error(
       `"${dir}" already resolves to ${shadowed.map((a) => displayPath(process.cwd(), a) ?? a).join(", ")} — ` +
-        `an agent scaffolded ${flat ? "here" : `in ./${root}/`} would be hidden by it and never served ` +
+        `an agent scaffolded in ./${root}/ would be hidden by it and never served ` +
         `from "${dir}" (an agent AT a directory wins over any inside it). Use that agent, move it away, ` +
         `or init in a different directory.`,
     );
@@ -149,8 +139,7 @@ export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}):
   if (occupants.includes(AGENT_CONFIG_FILE)) {
     throw new Error(`"${target}" already has ${AGENT_CONFIG_FILE} — already a fastagent agent`);
   }
-  // Only a SUBDIRECTORY target must be empty.
-  if (!flat && occupants.length > 0) {
+  if (occupants.length > 0) {
     throw new Error(
       `"${target}" already holds ${occupants.join(", ")} — move it away first, or run ` +
         `\`fastagent init\` in a different directory`,
@@ -163,19 +152,14 @@ export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}):
   const agentDirExisted = await exists(join(dir, root));
   await mkdir(dir, { recursive: true });
   const created: string[] = [];
-  const kept: string[] = [];
   // ONE rollback scope: any failure removes what THIS run created — files AND the directories it made for them.
+  // `wx` so a collision is a failure: the target was checked empty above, so anything here appeared mid-run.
   try {
     for (const file of files) {
       const abs = join(dir, file.rel);
       await mkdir(dirname(abs), { recursive: true });
-      try {
-        await writeFile(abs, file.content, { flag: "wx" });
-        created.push(file.rel);
-      } catch (e) {
-        if (!flat || (e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
-        kept.push(file.rel);
-      }
+      await writeFile(abs, file.content, { flag: "wx" });
+      created.push(file.rel);
     }
   } catch (error) {
     // Best-effort rollback of a partial scaffold.
@@ -186,5 +170,5 @@ export async function scaffoldAgent(dir: string, options: ScaffoldOptions = {}):
     if (!agentDirExisted) await rmdir(join(dir, root)).catch(() => {});
     throw error;
   }
-  return { dir, complete: !minimal, agentDir: root, created, kept };
+  return { dir, agentDir: root, created };
 }

--- a/test/cli-kernel.test.ts
+++ b/test/cli-kernel.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { buildProgram, type CommandSpec, optionKey } from "../src/cli/kernel.ts";
+import { type CommandSpec, optionKey } from "../src/cli/kernel.ts";
 import { buildCliProgram, specs } from "../src/cli/program.ts";
 
 /**
@@ -78,7 +78,7 @@ describe("cli kernel: spec conformance", () => {
       [["dev"], "work product never trigger a restart"],
       [["dev"], "the quick-tunnel URL is ephemeral, not for production"],
       [["init"], "never its NAME, so --agent-dir"],
-      [["init"], "the agent goes into ./fastagent/"],
+      [["init"], "ALWAYS goes into a subdirectory"],
       [["invoke"], "counterpart of `tool`, for CI smoke and quick checks"],
       [["fire"], "does NOT advance the schedule's fire state"],
       [["schedule", "history"], "did last night's run silently fail"],
@@ -182,21 +182,6 @@ describe("cli kernel: the option-key naming rule", () => {
     expect(() => optionKey("-x")).toThrow(/no long form/);
   });
 
-  it("a conflicts reference to an unknown key fails at BUILD time, not silently at parse time", () => {
-    const bad: CommandSpec = {
-      name: "x",
-      summary: "s",
-      flags: [
-        { flags: "--flat", description: "d", conflicts: ["agentDirTypo"] },
-        { flags: "--agent-dir <name>", description: "d" },
-      ],
-      run: () => {},
-    };
-    expect(() => buildProgram([bad])).toThrow(/unknown option key "agentDirTypo"/);
-  });
-});
-
-describe("cli kernel: help", () => {
   it("per-command help shows usage, arguments, and the Examples section (exit 0)", async () => {
     const r = await parse(["models", "--help"]);
     expect(r.code).toBe(0);
@@ -378,15 +363,13 @@ describe("cli end to end: the thin entry", () => {
     expect(env.stderr).toMatch(/invalid PORT env/);
   });
 
-  it("--flat and --agent-dir name ONE knob, so passing both is a usage error (exit 2), not a precedence", async () => {
+  it("an --agent-dir value that is not one directory name is a usage error (exit 2), not a runtime fault", async () => {
     const dir = await mkdtemp(join(tmpdir(), "fa-kernel-agentdir-"));
-    const both = await run(["init", dir, "--no-install", "--flat", "--agent-dir", "bot"]);
-    expect(both.code).toBe(2);
-    expect(both.stderr).toMatch(/cannot be used with/);
-    // …and a value that is not one directory name is the same class: a rejected VALUE, not a runtime fault.
-    const path = await run(["init", dir, "--no-install", "--agent-dir", join("nested", "bot")]);
-    expect(path.code).toBe(2);
-    expect(path.stderr).toMatch(/must be a single directory name/);
+    for (const bad of [join("nested", "bot"), "."]) {
+      const out = await run(["init", dir, "--no-install", "--agent-dir", bad]);
+      expect(out.code).toBe(2);
+      expect(out.stderr).toMatch(/must be a single directory name/);
+    }
   });
 
   it("tool with malformed JSON args exits 2 (usage class); an unknown tool stays a runtime miss (1)", async () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -39,8 +39,7 @@ describe("init: scaffoldAgent", () => {
     await writeFile(join(dir, "AGENTS.md"), "# Project spec\n"); // ② context, must survive untouched
     await writeFile(join(dir, "tsconfig.json"), "{}");
     const before = (await readdir(dir)).sort();
-    const { complete, created } = await scaffoldAgent(dir);
-    expect(complete).toBe(true);
+    const { created } = await scaffoldAgent(dir);
     expect(created.sort()).toEqual(
       [
         agentPath("persona.md"),
@@ -118,35 +117,6 @@ describe("init: scaffoldAgent", () => {
     expect(a.definition.contextFiles.map((f) => f.content).join("\n")).toContain("Project spec");
   });
 
-  it("--minimal keeps persona.md + the example skill + config (no package.json/tool) and assembles fully offline", async () => {
-    const dir = await freshDir();
-    const { complete, created } = await scaffoldAgent(dir, { minimal: true });
-    expect(complete).toBe(false);
-    expect(created.sort()).toEqual(
-      [
-        agentPath("persona.md"),
-        agentPath("skills", "writing-great-skills", "SKILL.md"),
-        agentPath("skills", "writing-great-skills", "GLOSSARY.md"),
-        agentPath("skills", "writing-great-skills", "LICENSE"),
-        agentPath(".gitignore"),
-        agentPath(".secrets", ".env.example"),
-        agentPath(".secrets", ".gitignore"),
-        agentPath("fastagent.config.ts"),
-      ].sort(),
-    );
-    expect(await exists(join(dir, "fastagent", "package.json"))).toBe(false);
-    expect(await exists(join(dir, "fastagent", "tools"))).toBe(false);
-    // the bundled skill still mounts in the minimal unit
-    const def = await loadAgentDefinition(join(dir, "fastagent"));
-    expect(def.skills.map((s) => s.name)).toEqual(["writing-great-skills"]);
-
-    // No tool to import → dev assembles with zero edits and zero network. The scaffold presets no
-    // model (first-run pick writes it back), so assembly is exercised with an explicit spec.
-    const { agent, modelSpec } = await createPiAgentFromDir(dir, { model: "openai-codex/gpt-5.5" });
-    expect(typeof agent.invoke).toBe("function");
-    expect(modelSpec).toBe("openai-codex/gpt-5.5");
-  });
-
   it("creates a non-existent target dir (both levels)", async () => {
     const base = await freshDir();
     const target = join(base, "some", "project");
@@ -206,14 +176,12 @@ describe("init: scaffoldAgent", () => {
     await writeFile(join(flatAlready, "fastagent.config.ts"), "export default {};\n");
     await expect(scaffoldAgent(flatAlready)).rejects.toThrow(/already resolves to .*never served/s);
 
+    // …but a SIBLING is a supported shape, not a collision: several agents on ONE workspace is how
+    // different roles drive the same repository, and the lookup selects between them.
     const nestedAlready = await freshDir();
     await mkdir(join(nestedAlready, "fastagent"), { recursive: true });
     await writeFile(join(nestedAlready, "fastagent", "fastagent.config.ts"), "export default {};\n");
-    await expect(scaffoldAgent(nestedAlready, { agentDir: "." })).rejects.toThrow(/never served/);
-
-    // …but a SIBLING is a supported shape, not a collision: several agents on ONE workspace is how
-    // different roles drive the same repository, and the lookup selects between them.
-    expect((await scaffoldAgent(nestedAlready, { agentDir: "releaser", minimal: true })).agentDir).toBe("releaser");
+    expect((await scaffoldAgent(nestedAlready, { agentDir: "releaser" })).agentDir).toBe("releaser");
   });
 
   it("refuses init inside an agent's own LOADED surface — the outer agent would load it as content", async () => {
@@ -229,14 +197,12 @@ describe("init: scaffoldAgent", () => {
 
     // The rest of an agent's directory is the AUTHOR's tree — a second agent there is legitimate (the
     // monorepo case), so ownership stops at the loaded surface instead of claiming the whole subtree.
-    expect((await scaffoldAgent(join(inside, "packages", "sub"), { minimal: true })).created).toContain(
-      agentPath("persona.md"),
-    );
+    expect((await scaffoldAgent(join(inside, "packages", "sub"))).created).toContain(agentPath("persona.md"));
   });
 
   it("--agentDir names the agent directory — the name is never a rule, the config is the marker", async () => {
     const host = await freshDir();
-    const { agentDir, created } = await scaffoldAgent(host, { agentDir: "bot", minimal: true });
+    const { agentDir, created } = await scaffoldAgent(host, { agentDir: "bot" });
     expect(agentDir).toBe("bot");
     expect(created).toContain(join("bot", "persona.md"));
     // …and it resolves under that name, with the surrounding tree as its workspace.
@@ -249,7 +215,7 @@ describe("init: scaffoldAgent", () => {
     }
     // …but `./bot` is not a path in any meaningful sense — basename already says it means `bot`, so
     // refusing the spelling would be pedantry rather than a guard.
-    expect((await scaffoldAgent(await freshDir(), { agentDir: "./bot", minimal: true })).agentDir).toBe("bot");
+    expect((await scaffoldAgent(await freshDir(), { agentDir: "./bot" })).agentDir).toBe("bot");
   });
 
   it("`init` nests by DEFAULT — no detection, no prompt; the choice is a flag or nothing", async () => {
@@ -274,25 +240,20 @@ describe("init: scaffoldAgent", () => {
     expect(await cliInit(["init"], done)).toMatch(/already a fastagent agent/);
   });
 
-  it("--flat: the directory IS the agent, existing files are KEPT, and it resolves end to end", async () => {
-    // Case this exists for: a standalone agent repo, or a monorepo package. Agent and workspace are the
-    // same directory, so the agent's tools operate on its own definition — the point of the mode.
+  it("refuses `--agent-dir .` — the definition goes in a subdirectory, the directory around it is the workspace", async () => {
+    // The mode this replaces kept every existing file, so the agent inherited the host repo's package.json — and a
+    // `fastagent.config.ts` under a CommonJS manifest does not load at all. A scaffolded subdirectory carries its
+    // own `type: module`, which removes that failure class rather than pre-checking for it.
     const dir = await freshDir();
-    await writeFile(join(dir, ".gitignore"), "dist\n"); // the author's file: adopted, never rewritten
-    await writeFile(join(dir, "AGENTS.md"), "# House rules\n");
-    const { created, kept, agentDir } = await scaffoldAgent(dir, { agentDir: "." });
-    expect(agentDir).toBe(".");
-    expect(created).toContain("persona.md"); // at the root, no fastagent/ level
-    expect(created).toContain(join(".secrets", ".gitignore")); // credentials still self-protected
-    expect(kept).toEqual([".gitignore"]); // theirs wins
-    expect(await readFile(join(dir, ".gitignore"), "utf8")).toBe("dist\n"); // …verbatim
-    expect(await exists(join(dir, "fastagent"))).toBe(false); // no nested level anywhere
+    await writeFile(join(dir, ".gitignore"), "dist\n");
+    await expect(scaffoldAgent(dir, { agentDir: "." })).rejects.toThrow(/single directory name/);
+    expect(await readFile(join(dir, ".gitignore"), "utf8")).toBe("dist\n"); // side-effect-free refusal
+    expect(await exists(join(dir, "persona.md"))).toBe(false);
 
-    // Resolution: agent === workspace, and the definition + ② context load from the same directory.
-    const a = await createPiAgentFromDir(dir, { model: "openai-codex/gpt-5.5" });
-    expect([a.agentDir, a.workspace]).toEqual([dir, dir]);
-    expect(a.definition.persona).toContain("Persona");
-    expect(a.definition.contextFiles.map((f) => f.content).join("\n")).toContain("House rules");
+    // The CLI rejects it as USAGE (exit 2), before any scaffold work.
+    expect(await cliInit(["init", "--agent-dir", ".", "--no-install"], dir)).toMatch(/single directory name/);
+    // …and `--flat` is gone with it.
+    expect(await cliInit(["init", "--flat", "--no-install"], dir)).toMatch(/unknown option/);
   });
 
   it("a package inside an agent's own repository is a legitimate init target", async () => {
@@ -300,13 +261,15 @@ describe("init: scaffoldAgent", () => {
     // definition is its loaded surface only, so `packages/foo/` is the author's tree — refusing there
     // would make "an agent inside an agent's repository" unreachable.
     const root = await freshDir();
-    await scaffoldAgent(root, { agentDir: ".", minimal: true });
+    // Written by hand: placement still RESOLVES an agent at a directory (a deployed box is shipped the agent
+    // directory alone), `init` merely no longer creates that shape.
+    await writeFile(join(root, "fastagent.config.ts"), "export default {};\n");
     const pkg = join(root, "packages", "reviewer");
     await mkdir(pkg, { recursive: true });
-    expect((await scaffoldAgent(pkg, { minimal: true })).created).toContain(agentPath("persona.md"));
+    expect((await scaffoldAgent(pkg)).created).toContain(agentPath("persona.md"));
 
     // …but the flat agent's OWN surfaces are still off limits: it would load the new agent as content.
-    await expect(scaffoldAgent(join(root, "skills", "mine"), { minimal: true })).rejects.toThrow(
+    await expect(scaffoldAgent(join(root, "skills", "mine"))).rejects.toThrow(
       /is inside the definition of the agent at/,
     );
   });
@@ -316,12 +279,12 @@ describe("init: scaffoldAgent", () => {
     // parent as its workspace). With the config as the only marker there is nothing to trap.
     const named = join(await freshDir(), "fastagent");
     await mkdir(named);
-    expect((await scaffoldAgent(named, { agentDir: ".", minimal: true })).agentDir).toBe(".");
+    await writeFile(join(named, "fastagent.config.ts"), "export default {};\n");
     const a = await createPiAgentFromDir(named, { model: "openai-codex/gpt-5.5" });
     expect([a.agentDir, a.workspace]).toEqual([named, named]);
 
-    // Already an agent → refuse rather than double-initialize.
-    await expect(scaffoldAgent(named, { agentDir: "." })).rejects.toThrow(/already a fastagent agent/);
+    // Already an agent → refuse rather than double-initialize (the config at `named` shadows a nested one).
+    await expect(scaffoldAgent(named)).rejects.toThrow(/already resolves to .*never served/s);
   });
 
   it("createPiAgentFromDir wires the placement end-to-end: persona/tools from the agent dir, ② context from the workspace", async () => {


### PR DESCRIPTION
Closes #531.

`init` always scaffolds the complete kit into a subdirectory (`./fastagent/`, renamed by `--agent-dir <name>`). `--flat`, `--agent-dir .`, and `--minimal` are gone.

**A standalone agent repository is still supported** — that repository is the *workspace*, and the definition lives in `./fastagent/` inside it. Placement still *resolves* an agent sitting at a directory (a deployed container is shipped the agent directory alone, so that row is a runtime fact), which is why `src/paths.ts` is untouched. Only `init`'s ability to *create* that shape goes away.

## Why the flat mode had to go rather than get a pre-check

It kept every existing file, so the agent inherited the host repo's `package.json` — and since the config file is now always `fastagent.config.ts` (#530), its module type comes from that manifest. In a CommonJS repo the scaffold succeeded and then every command failed:

```
Error: …/fastagent.config.ts: Unexpected token 'export'
```

With a `type`-less manifest it loaded but Node printed `[MODULE_TYPELESS_PACKAGE_JSON] … Reparsing as ES module` on **every** config load. A scaffolded subdirectory carries its own `type: module`, so fixing the layout removes the failure class at the source. An ESM pre-check in `init` would only have existed to serve the mode being deleted.

Verified after the change, in a repo with `{"type":"commonjs"}`: `init` writes only `fastagent/`, the agent's manifest is `module`, and `info` resolves the config. `--agent-dir .` exits 2 with the usage message; `--flat` and `--minimal` are `unknown option`.

## What the deletion took with it

- **`ScaffoldResult.kept` and every branch reading it.** With no adoption mode the target must be empty, so `writeFile(…, "wx")`'s `EEXIST` is a failure again rather than a "kept yours" report — and the four `init` notes about inherited `package.json`/`.gitignore` files describe a situation that can no longer arise.
- **`ScaffoldOptions.minimal` / `ScaffoldResult.complete`.** One scaffold shape; the file list is unconditional. Don't want the example tool? Delete it — everything is yours after `init`.
- **`FlagSpec.conflicts` and its now-unused `optionKey` helper (`src/cli/kernel.ts`).** `--flat` was the only conflicts user, so removing it left the field, its build-time validation, its commander binding, and its test with nothing to guard. Restoring conflicts is three lines over commander's native `.conflicts()` if a mutually exclusive pair ever shows up.
